### PR TITLE
feat(admin): add cache management page with busting functionality

### DIFF
--- a/apps/app/app/admin/Nav.tsx
+++ b/apps/app/app/admin/Nav.tsx
@@ -59,6 +59,12 @@ export async function Nav() {
                     <NavItem href={KnownPages.Feedback} label="Povratne informacije" icon={<SmileHappy className="size-5" />} />
                 </List>
             </Stack>
+            <Stack spacing={1}>
+                <ListHeader header="Sustavi" />
+                <List>
+                    <NavItem href={KnownPages.Cache} label="Cache" icon={<File className="size-5" />} />
+                </List>
+            </Stack>
         </Stack>
     );
 }

--- a/apps/app/app/admin/cache/page.tsx
+++ b/apps/app/app/admin/cache/page.tsx
@@ -1,0 +1,79 @@
+import { bustGrediceCached, grediceCachedInfo, directoriesCachedInfo, bustCached } from "@gredice/storage";
+import { Card, CardContent, CardHeader, CardTitle } from "@signalco/ui-primitives/Card";
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { auth } from "../../../lib/auth/auth";
+import { Fragment } from "react";
+import { ServerActionButton } from "../../../components/shared/ServerActionButton";
+
+export const dynamic = 'force-dynamic';
+
+export default async function CachePage() {
+    await auth(['admin']);
+    const grediceInfo = await grediceCachedInfo();
+    const directoryInfo = await directoriesCachedInfo();
+
+    async function bustGredicaCacheKey(key: string) {
+        'use server';
+        await auth(['admin']);
+        await bustGrediceCached(key);
+    }
+
+    async function bustDirectoryCacheKey(key: string) {
+        'use server';
+        await auth(['admin']);
+        await bustCached(key);
+    }
+
+    return (
+        <Stack spacing={2}>
+            <Typography level="h4" component="h1">Cache</Typography>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>
+                            Gredice Cache
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="grid grid-cols-[1fr_auto] gap-2">
+                            {grediceInfo?.keys.length === 0 && (
+                                <Typography className="col-span-2">Cache je prazan</Typography>
+                            )}
+                            {grediceInfo?.keys.map((key) => (
+                                <Fragment key={key}>
+                                    <Typography>{key}</Typography>
+                                    <ServerActionButton onClick={bustGredicaCacheKey.bind(null, key)}>
+                                        Očisti
+                                    </ServerActionButton>
+                                </Fragment>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>
+                            Directory Cache
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="grid grid-cols-[1fr_auto] gap-2">
+                            {directoryInfo?.keys.length === 0 && (
+                                <Typography className="col-span-2">Cache je prazan</Typography>
+                            )}
+                            {directoryInfo?.keys.map((key) => (
+                                <Fragment key={key}>
+                                    <Typography>{key}</Typography>
+                                    <ServerActionButton onClick={bustDirectoryCacheKey.bind(null, key)}>
+                                        Očisti
+                                    </ServerActionButton>
+                                </Fragment>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </Stack>
+    )
+}

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -12,6 +12,8 @@ import { Fragment } from "react";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Divider } from "@signalco/ui-primitives/Divider";
 
+export const dynamic = 'force-dynamic';
+
 function getDaySchedule(isToday: boolean, date: Date, raisedBeds: Awaited<ReturnType<typeof getAllRaisedBeds>>, operations: Awaited<ReturnType<typeof getAllOperations>>) {
     const todaysNewFields = raisedBeds.flatMap(rb => rb.fields).filter(field =>
         (field.plantStatus === 'new' || field.plantStatus === 'planned') &&
@@ -153,6 +155,7 @@ async function ScheduleDay({ isToday, date, allRaisedBeds, operations, plantSort
 }
 
 export default async function AdminSchedulePage() {
+    await auth(['admin']);
     const [allRaisedBeds, operations, plantSorts, operationsData] = await Promise.all([
         getAllRaisedBeds(),
         getAllOperations(),

--- a/apps/app/components/shared/ServerActionButton.tsx
+++ b/apps/app/components/shared/ServerActionButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, ButtonButtonProps } from "@signalco/ui-primitives/Button";
-import { startTransition, useState } from "react";
+import { useState } from "react";
 
 export type ServerActionButtonProps = Omit<ButtonButtonProps, 'onClick'> & {
     onClick?: () => Promise<void>;
@@ -12,7 +12,8 @@ export function ServerActionButton({ onClick, loading, ...props }: ServerActionB
     const handleClick = async () => {
         setIsLoading(true);
         if (onClick)
-            startTransition(onClick);
+            await onClick();
+        setIsLoading(false);
     }
 
     return (

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -23,6 +23,7 @@ export const KnownPages = {
     Transaction: (transactionId: number) => `/admin/transactions/${transactionId}`,
     ShoppingCarts: '/admin/shopping-carts',
     ShoppingCart: (cartId: number) => `/admin/shopping-carts/${cartId}`,
+    Cache: '/admin/cache',
 
     // External links
     StripePayment: (paymentId: string) => `https://dashboard.stripe.com/payments/${paymentId}`,

--- a/apps/app/tailwind.config.ts
+++ b/apps/app/tailwind.config.ts
@@ -6,7 +6,7 @@ const tailwindConfig: Config = {
   content: [
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./node_modules/@gredice/ui/**/*.{js,ts,jsx,tsx,mdx}",
+    "./node_modules/@gredice/ui/src/*.{js,ts,jsx,tsx,mdx}",
     "./node_modules/@signalco/auth-client/**/*.{js,ts,jsx,tsx,mdx}",
     "./node_modules/@signalco/auth-server/**/*.{js,ts,jsx,tsx,mdx}",
     "./node_modules/@signalco/ui/**/*.{js,ts,jsx,tsx,mdx}",

--- a/packages/storage/src/cache/directoriesCached.ts
+++ b/packages/storage/src/cache/directoriesCached.ts
@@ -37,6 +37,27 @@ export async function directoriesCached<T>(key: string, fn: () => Promise<T>, tt
     }
 }
 
+export async function directoriesCachedInfo() {
+    try {
+        const client = cacheClient();
+        const keys: string[] = [];
+        let cursor = "0";
+
+        do {
+            const scanResult = await client.scan(cursor);
+            cursor = scanResult[0];
+            keys.push(...scanResult[1]);
+        } while (cursor !== "0");
+
+        return {
+            keys
+        }
+    } catch (error) {
+        console.error('Error fetching Redis info:', error);
+        return null;
+    }
+}
+
 export async function bustCached(key: string) {
     console.debug(`Bust cache for key: ${key}`);
     const client = cacheClient();

--- a/packages/storage/src/cache/grediceCached.ts
+++ b/packages/storage/src/cache/grediceCached.ts
@@ -47,6 +47,27 @@ export async function grediceCached<T>(key: string, fn: () => Promise<T>, ttl: n
     }
 }
 
+export async function grediceCachedInfo() {
+    try {
+        const client = cacheClient();
+        const keys: string[] = [];
+        let cursor = "0";
+
+        do {
+            const scanResult = await client.scan(cursor);
+            cursor = scanResult[0];
+            keys.push(...scanResult[1]);
+        } while (cursor !== "0");
+
+        return {
+            keys
+        }
+    } catch (error) {
+        console.error('Error fetching Redis info:', error);
+        return null;
+    }
+}
+
 export async function bustGrediceCached(key: string) {
     const client = cacheClient();
     await client.del(key);

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -16,3 +16,4 @@ export * from './repositories/shoppingCartRepo';
 export * from './repositories/notificationsRepo';
 export * from './repositories/operationsRepo';
 export * from './cache/grediceCached';
+export * from './cache/directoriesCached';


### PR DESCRIPTION
Add a new admin CachePage to display and clear cached keys for Gredice
and directory caches. Implement server actions to securely bust cache keys
with admin authentication. Update navigation to include the Cache page
under Systems. Fix tailwind config to correctly include gredice UI source
files for styling. This enables admins to monitor and manage cache state
directly from the admin interface, improving maintenance and debugging.