### PR TITLE
feat(admin): display scheduled date in operation list

### DIFF
--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -141,6 +141,11 @@ async function ScheduleDay({ isToday, date, allRaisedBeds, operations, plantSort
                                             <Row spacing={1}>
                                                 <Checkbox type="submit" />
                                                 <Typography>{`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}`}</Typography>
+                                                {op.scheduledDate && (
+                                                    <Typography level="body2" className="select-none">
+                                                        <LocaleDateTime time={false}>{op.scheduledDate}</LocaleDateTime>
+                                                    </Typography>
+                                                )}
                                             </Row>
                                         </form>
                                     </div>


### PR DESCRIPTION
Add scheduled date display next to each operation in the schedule
admin page. This improves clarity by showing when operations are
planned, helping users better understand the schedule at a glance.