### PR TITLE
fix(auth): prevent LoginModal from being dismissible

### DIFF
--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -88,7 +88,8 @@ export default function LoginModal() {
             open
             title="Prijava"
             className='bg-card border-tertiary border-b-4 rounded-lg shadow-2xl'
-            hideClose>
+            hideClose
+            dismissible={false}>
             <Stack spacing={2}>
                 <Row spacing={2} justifyContent='start'>
                     <Image


### PR DESCRIPTION
Add dismissible={false} to LoginModal to ensure users cannot
dismiss the modal by clicking outside or pressing escape. This
change improves the login flow by forcing users to complete the
authentication process without accidental closure.