### PR TITLE
fix(game): add scrollable container to NotificationList

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -42,7 +42,9 @@ function NotificationsCard() {
                 </IconButton>
             </Row>
             <Divider />
-            <NotificationList short />
+            <div className=" overflow-y-auto max-h-96">
+                <NotificationList short />
+            </div>
             <Divider />
             <Stack>
                 <Button


### PR DESCRIPTION
Wrap NotificationList in a div with max height and overflow-y-auto
to enable scrolling when notifications exceed the visible area. This
prevents the HUD from growing too large and improves usability.