### PR TITLE
feat(garden): filter and display only active sensors

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -807,9 +807,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Raised bed not found' }, 404);
             }
 
-            // Take only sensors that have a Signalco ID assigned (are installed and configured)
+            // Take only sensors that have a Signalco ID assigned (are installed and configured - eg. status = 'active')
             const sensors = (await getRaisedBedSensors(raisedBedIdNumber))
-                .filter(sensor => Boolean(sensor.sensorSignalcoId))
+                .filter(sensor => Boolean(sensor.sensorSignalcoId) && sensor.status === 'active')
                 .map(sensor => ({
                     ...sensor,
                     sensorSignalcoId: sensor.sensorSignalcoId!

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -296,7 +296,7 @@ function SensorInfoModal({ icon, header, unit, yDomain, colors, positiveTrend, r
                         </div>
                     )}
                 </div>
-                {(status === 'new' || !sensorId) && (
+                {(status !== 'active' || !sensorId) && (
                     <div className="absolute inset-0 bg-background/20 backdrop-blur-md -m-6">
                         {!status && !isSensorInShoppingCart && (
                             <div className="flex flex-col items-center justify-center h-full gap-4 p-6">
@@ -321,7 +321,7 @@ function SensorInfoModal({ icon, header, unit, yDomain, colors, positiveTrend, r
                                 </Button>
                             </div>
                         )}
-                        {status === 'new' && (
+                        {(status === 'new' || status === 'installed') && (
                             <div className="flex flex-col items-center justify-center h-full gap-4 p-6">
                                 <Typography level="body1">
                                     Senzor je u procesu instalacije...

--- a/packages/storage/src/schema/gardenSchema.ts
+++ b/packages/storage/src/schema/gardenSchema.ts
@@ -172,7 +172,7 @@ export type SelectRaisedBedField = typeof raisedBedFields.$inferSelect;
 export const raisedBedSensors = pgTable('raised_bed_sensors', {
     id: serial('id').primaryKey(),
     raisedBedId: integer('raised_bed_id').notNull().references(() => raisedBeds.id),
-    status: text('status').notNull().default('new'), // Possible values: 'new', 'installed'
+    status: text('status').notNull().default('new'), // Possible values: 'new', 'installed', 'active'
     sensorSignalcoId: text('sensor_signalco_id'),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().$onUpdate(() => new Date()),


### PR DESCRIPTION
Update raised bed sensors to include a new 'active' status alongside
'existing' statuses. Modify API to return only sensors with a valid
Signalco ID and status set to 'active', ensuring only properly installed
and configured sensors are considered. Adjust UI to reflect sensor
status changes by hiding sensor info for non-active sensors and showing
installation progress for sensors with 'new' or 'installed' status. This
improves accuracy and clarity in sensor management and display.