### PR TITLE
feat(flags): cache SourceNode instances by key to reuse sources

### DIFF
--- a/apps/app/lib/flags/generated/hypertune.react.tsx
+++ b/apps/app/lib/flags/generated/hypertune.react.tsx
@@ -53,22 +53,14 @@ export function HypertuneSourceProvider({
   createSourceOptions: hypertune.CreateSourceOptions;
   children: React.ReactNode;
 }): React.ReactElement {
-  const hypertuneSource = React.useMemo(
-    () => {
-      return hypertune.createSource({
-        initDataProvider: typeof window === "undefined" ? null : undefined,
-        remoteLogging: {
-          mode: typeof window === "undefined" ? "off" : undefined,
-        },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        localLogger: typeof window === "undefined" ? () => {} : undefined,
-        ...createSourceOptions,
-      });
-    },
-    // Don't recreate the source even if createSourceOptions changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+  const hypertuneSource = hypertune.createSource({
+    key: typeof window === "undefined" ? "ssr" : "client",
+    initDataProvider: typeof window === "undefined" ? null : undefined,
+    remoteLogging: { mode: typeof window === "undefined" ? "off" : undefined },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    localLogger: typeof window === "undefined" ? () => {} : undefined,
+    ...createSourceOptions,
+  });
 
   const [stateHash, setStateHash] = React.useState(
     hypertuneSource.getStateHash()

--- a/apps/app/lib/flags/generated/hypertune.ts
+++ b/apps/app/lib/flags/generated/hypertune.ts
@@ -184,27 +184,37 @@ export class SourceNode extends sdk.Node {
 }
 
 export type DehydratedState = sdk.DehydratedState<Source, VariableValues>
-export type CreateSourceOptions = { 
+
+const sources: { [key: string]: SourceNode } = {};
+
+export type CreateSourceOptions = {
   token: string; 
   variableValues?: VariableValues;
   override?: sdk.DeepPartial<Source> | null;
+  key?: string;
 } & sdk.CreateOptions
 
 export function createSource({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
-  return sdk.create({
-    NodeConstructor: SourceNode,
-    token,
-    query,
-    queryCode,
-    variableValues,
-    override,
-    options: {initData: initData as unknown as sdk.InitData, ...options },
-  });
+  const sourceKey =
+    key ?? (typeof window === "undefined" ? "server" : "client");
+
+  if (!sources[sourceKey]) {
+    sources[sourceKey] = sdk.create({
+      NodeConstructor: SourceNode,
+      token,
+      variableValues,
+      override,
+      options: {initData: initData as unknown as sdk.InitData, ...options },
+    });
+  }
+
+  return sources[sourceKey];
 }
 
 export const emptySource = new SourceNode({
@@ -220,6 +230,7 @@ export function createSourceForServerOnly({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
   return typeof window === "undefined"

--- a/apps/farm/lib/flags/generated/hypertune.react.tsx
+++ b/apps/farm/lib/flags/generated/hypertune.react.tsx
@@ -53,22 +53,14 @@ export function HypertuneSourceProvider({
   createSourceOptions: hypertune.CreateSourceOptions;
   children: React.ReactNode;
 }): React.ReactElement {
-  const hypertuneSource = React.useMemo(
-    () => {
-      return hypertune.createSource({
-        initDataProvider: typeof window === "undefined" ? null : undefined,
-        remoteLogging: {
-          mode: typeof window === "undefined" ? "off" : undefined,
-        },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        localLogger: typeof window === "undefined" ? () => {} : undefined,
-        ...createSourceOptions,
-      });
-    },
-    // Don't recreate the source even if createSourceOptions changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+  const hypertuneSource = hypertune.createSource({
+    key: typeof window === "undefined" ? "ssr" : "client",
+    initDataProvider: typeof window === "undefined" ? null : undefined,
+    remoteLogging: { mode: typeof window === "undefined" ? "off" : undefined },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    localLogger: typeof window === "undefined" ? () => {} : undefined,
+    ...createSourceOptions,
+  });
 
   const [stateHash, setStateHash] = React.useState(
     hypertuneSource.getStateHash()

--- a/apps/farm/lib/flags/generated/hypertune.ts
+++ b/apps/farm/lib/flags/generated/hypertune.ts
@@ -184,27 +184,37 @@ export class SourceNode extends sdk.Node {
 }
 
 export type DehydratedState = sdk.DehydratedState<Source, VariableValues>
-export type CreateSourceOptions = { 
+
+const sources: { [key: string]: SourceNode } = {};
+
+export type CreateSourceOptions = {
   token: string; 
   variableValues?: VariableValues;
   override?: sdk.DeepPartial<Source> | null;
+  key?: string;
 } & sdk.CreateOptions
 
 export function createSource({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
-  return sdk.create({
-    NodeConstructor: SourceNode,
-    token,
-    query,
-    queryCode,
-    variableValues,
-    override,
-    options: {initData: initData as unknown as sdk.InitData, ...options },
-  });
+  const sourceKey =
+    key ?? (typeof window === "undefined" ? "server" : "client");
+
+  if (!sources[sourceKey]) {
+    sources[sourceKey] = sdk.create({
+      NodeConstructor: SourceNode,
+      token,
+      variableValues,
+      override,
+      options: {initData: initData as unknown as sdk.InitData, ...options },
+    });
+  }
+
+  return sources[sourceKey];
 }
 
 export const emptySource = new SourceNode({
@@ -220,6 +230,7 @@ export function createSourceForServerOnly({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
   return typeof window === "undefined"

--- a/apps/garden/lib/flags/generated/hypertune.react.tsx
+++ b/apps/garden/lib/flags/generated/hypertune.react.tsx
@@ -53,22 +53,14 @@ export function HypertuneSourceProvider({
   createSourceOptions: hypertune.CreateSourceOptions;
   children: React.ReactNode;
 }): React.ReactElement {
-  const hypertuneSource = React.useMemo(
-    () => {
-      return hypertune.createSource({
-        initDataProvider: typeof window === "undefined" ? null : undefined,
-        remoteLogging: {
-          mode: typeof window === "undefined" ? "off" : undefined,
-        },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        localLogger: typeof window === "undefined" ? () => {} : undefined,
-        ...createSourceOptions,
-      });
-    },
-    // Don't recreate the source even if createSourceOptions changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+  const hypertuneSource = hypertune.createSource({
+    key: typeof window === "undefined" ? "ssr" : "client",
+    initDataProvider: typeof window === "undefined" ? null : undefined,
+    remoteLogging: { mode: typeof window === "undefined" ? "off" : undefined },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    localLogger: typeof window === "undefined" ? () => {} : undefined,
+    ...createSourceOptions,
+  });
 
   const [stateHash, setStateHash] = React.useState(
     hypertuneSource.getStateHash()

--- a/apps/garden/lib/flags/generated/hypertune.ts
+++ b/apps/garden/lib/flags/generated/hypertune.ts
@@ -352,27 +352,37 @@ export class SourceNode extends sdk.Node {
 }
 
 export type DehydratedState = sdk.DehydratedState<Source, VariableValues>
-export type CreateSourceOptions = { 
+
+const sources: { [key: string]: SourceNode } = {};
+
+export type CreateSourceOptions = {
   token: string; 
   variableValues?: VariableValues;
   override?: sdk.DeepPartial<Source> | null;
+  key?: string;
 } & sdk.CreateOptions
 
 export function createSource({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
-  return sdk.create({
-    NodeConstructor: SourceNode,
-    token,
-    query,
-    queryId,
-    variableValues,
-    override,
-    options: {initData: initData as unknown as sdk.InitData, ...options },
-  });
+  const sourceKey =
+    key ?? (typeof window === "undefined" ? "server" : "client");
+
+  if (!sources[sourceKey]) {
+    sources[sourceKey] = sdk.create({
+      NodeConstructor: SourceNode,
+      token,
+      variableValues,
+      override,
+      options: {initData: initData as unknown as sdk.InitData, ...options },
+    });
+  }
+
+  return sources[sourceKey];
 }
 
 export const emptySource = new SourceNode({
@@ -388,6 +398,7 @@ export function createSourceForServerOnly({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
   return typeof window === "undefined"

--- a/apps/www/lib/flags/generated/hypertune.react.tsx
+++ b/apps/www/lib/flags/generated/hypertune.react.tsx
@@ -53,22 +53,14 @@ export function HypertuneSourceProvider({
   createSourceOptions: hypertune.CreateSourceOptions;
   children: React.ReactNode;
 }): React.ReactElement {
-  const hypertuneSource = React.useMemo(
-    () => {
-      return hypertune.createSource({
-        initDataProvider: typeof window === "undefined" ? null : undefined,
-        remoteLogging: {
-          mode: typeof window === "undefined" ? "off" : undefined,
-        },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        localLogger: typeof window === "undefined" ? () => {} : undefined,
-        ...createSourceOptions,
-      });
-    },
-    // Don't recreate the source even if createSourceOptions changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+  const hypertuneSource = hypertune.createSource({
+    key: typeof window === "undefined" ? "ssr" : "client",
+    initDataProvider: typeof window === "undefined" ? null : undefined,
+    remoteLogging: { mode: typeof window === "undefined" ? "off" : undefined },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    localLogger: typeof window === "undefined" ? () => {} : undefined,
+    ...createSourceOptions,
+  });
 
   const [stateHash, setStateHash] = React.useState(
     hypertuneSource.getStateHash()

--- a/apps/www/lib/flags/generated/hypertune.ts
+++ b/apps/www/lib/flags/generated/hypertune.ts
@@ -177,27 +177,37 @@ export class SourceNode extends sdk.Node {
 }
 
 export type DehydratedState = sdk.DehydratedState<Source, VariableValues>
-export type CreateSourceOptions = { 
+
+const sources: { [key: string]: SourceNode } = {};
+
+export type CreateSourceOptions = {
   token: string; 
   variableValues?: VariableValues;
   override?: sdk.DeepPartial<Source> | null;
+  key?: string;
 } & sdk.CreateOptions
 
 export function createSource({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
-  return sdk.create({
-    NodeConstructor: SourceNode,
-    token,
-    query,
-    queryCode,
-    variableValues,
-    override,
-    options: {initData: initData as unknown as sdk.InitData, ...options },
-  });
+  const sourceKey =
+    key ?? (typeof window === "undefined" ? "server" : "client");
+
+  if (!sources[sourceKey]) {
+    sources[sourceKey] = sdk.create({
+      NodeConstructor: SourceNode,
+      token,
+      variableValues,
+      override,
+      options: {initData: initData as unknown as sdk.InitData, ...options },
+    });
+  }
+
+  return sources[sourceKey];
 }
 
 export const emptySource = new SourceNode({
@@ -213,6 +223,7 @@ export function createSourceForServerOnly({
   token,
   variableValues = {},
   override,
+  key,
   ...options
 }: CreateSourceOptions): SourceNode {
   return typeof window === "undefined"


### PR DESCRIPTION
Add a sources cache keyed by environment (server) or custom key
to createSource in hypertune flags modules. This avoids recreating 
SourceNode instances on each call, improving performance and 
consistency.

Update React components to pass explicit keys ("ssr" or "client") when
creating sources, removing useMemo wrappers. This simplifies source
management and ensures stable source reuse across renders.