### PR TITLE
feat(controls): increase max zoom level to 500

### DIFF
--- a/packages/game/src/controls/Controls.tsx
+++ b/packages/game/src/controls/Controls.tsx
@@ -132,7 +132,7 @@ export function Controls({ debugCloseup }: { debugCloseup?: boolean }) {
                 onStart={() => setIsDragging(true)}
                 onEnd={() => setIsDragging(false)}
                 minZoom={50}
-                maxZoom={200}
+                maxZoom={500}
                 mouseButtons={{
                     LEFT: isEditMode ? undefined : MOUSE.PAN,
                     MIDDLE: MOUSE.DOLLY,


### PR DESCRIPTION
Increase the maxZoom value from 200 to 500 in the Controls component
to allow users to zoom in further. This change improves usability
by providing greater flexibility in viewing the game area, especially
in edit mode where detailed adjustments are needed.