### PR TITLE
feat(garden): update displayName input font size

### DIFF
--- a/packages/game/src/modals/components/UserProfileCard.tsx
+++ b/packages/game/src/modals/components/UserProfileCard.tsx
@@ -69,6 +69,7 @@ export function UserProfileCard() {
                                 <Input
                                     name="displayName"
                                     label="Prikazano ime"
+                                    className='[&_input]:text-base sm:[&_input]:text-[16px]'
                                     defaultValue={currentUser.data?.displayName}
                                     type="text"
                                     placeholder="Unesite ime..."


### PR DESCRIPTION
Add responsive font size classes to the displayName input field in the
UserProfileCard component. This improves readability by setting the 
input text to base size on smaller screens and 16px on larger screens.