### PR TITLE
feat(admin): improve auth UI and layout structure

### DIFF
--- a/apps/app/app/(actions)/sharedActions.ts
+++ b/apps/app/app/(actions)/sharedActions.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidatePath } from "next/cache";
+
+export async function invalidatePage() {
+    revalidatePath('/');
+}

--- a/apps/app/app/admin/LoginDialog.tsx
+++ b/apps/app/app/admin/LoginDialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from "@signalco/ui-primitives/Card";
 import { Input } from "@signalco/ui-primitives/Input";
 import { Button } from "@signalco/ui-primitives/Button";
 import { Stack } from "@signalco/ui-primitives/Stack";
@@ -9,6 +8,9 @@ import { authCurrentUserQueryKeys } from "@signalco/auth-client";
 import { queryClient } from "../../components/providers/ClientAppProvider";
 import { useActionState } from "react";
 import { Warning } from "@signalco/ui-icons";
+import { Modal } from "@signalco/ui-primitives/Modal";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { invalidatePage } from "../(actions)/sharedActions";
 
 export function LoginDialog() {
     const [error, submitAction, isPending] = useActionState(async (_previousState: unknown, formData: FormData) => {
@@ -32,16 +34,14 @@ export function LoginDialog() {
         localStorage.setItem('gredice-token', token);
 
         await queryClient.invalidateQueries({ queryKey: authCurrentUserQueryKeys });
-        window.location.reload();
+        await invalidatePage();
     }, null);
 
     return (
         <div className="h-[100vh] flex items-center justify-center">
-            <Card className="p-8 shadow-2xl">
-                <CardHeader className="mb-4">
-                    <CardTitle>Prijava</CardTitle>
-                </CardHeader>
-                <CardContent className="min-w-96">
+            <Modal open dismissible={false} hideClose title="Prijava" className="max-w-96">
+                <Stack spacing={4}>
+                    <Typography level="h4" component="p">Prijava</Typography>
                     <form action={submitAction}>
                         <Stack spacing={4}>
                             <Stack spacing={1}>
@@ -56,8 +56,8 @@ export function LoginDialog() {
                             )}
                         </Stack>
                     </form>
-                </CardContent>
-            </Card>
+                </Stack>
+            </Modal>
         </div>
     )
 }

--- a/apps/app/app/admin/Nav.tsx
+++ b/apps/app/app/admin/Nav.tsx
@@ -7,8 +7,10 @@ import { EntityTypeCreateModal } from "./EntityTypeCreateModal";
 import { getEntityTypes } from "@gredice/storage";
 import { ProfileNavItem } from "./ProfileNavItem";
 import { File, ShoppingCart } from "@signalco/ui-icons";
+import { auth } from "../../lib/auth/auth";
 
 export async function Nav() {
+    auth(['admin']);
     const entityTypes = await getEntityTypes();
 
     return (

--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -13,22 +13,26 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
         <AuthAppProvider>
             <div className="grow bg-secondary">
                 <main className="relative h-full">
-                    <AuthProtectedSection auth={authAdmin}>
-                        <div className="flex flex-row min-h-full">
-                            <div className="p-4 min-w-64">
+                    <div className="flex flex-row min-h-full">
+                        <div className="p-4 min-w-64">
+                            <AuthProtectedSection auth={authAdmin}>
                                 <Nav />
-                            </div>
-                            <div className="min-h-full grow pt-2">
-                                <div className="p-4 bg-white border-l border-t rounded-tl-xl min-h-full">
-                                <Suspense>
-                                    {children}
-                                </Suspense>
-                                </div>
+                            </AuthProtectedSection>
+                        </div>
+                        <div className="min-h-full grow pt-2">
+                            <div className="p-4 bg-white border-l border-t rounded-tl-xl min-h-full">
+                                <AuthProtectedSection auth={authAdmin}>
+                                    <Suspense>
+                                        {children}
+                                    </Suspense>
+                                </AuthProtectedSection>
                             </div>
                         </div>
-                    </AuthProtectedSection>
+                    </div>
                     <SignedOut auth={authAdmin}>
-                        <LoginDialog />
+                        <div className="absolute inset-0 bg-white/10 backdrop-blur">
+                            <LoginDialog />
+                        </div>
                     </SignedOut>
                 </main>
             </div>

--- a/apps/app/app/admin/logout/LogoutForm.tsx
+++ b/apps/app/app/admin/logout/LogoutForm.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Card } from "@signalco/ui-primitives/Card";
 import { Alert } from "@signalco/ui/Alert";
 import { authCurrentUserQueryKeys } from "@signalco/auth-client";
 import { useActionState } from "react";
@@ -34,22 +33,20 @@ export function LogoutForm() {
     }, null);
 
     return (
-        <Card className="p-12">
-            <form ref={autoSubmitForm} action={submitAction}>
-                <Stack spacing={4}>
-                    {!error && (
-                        <Row spacing={1} className="flex justify-center">
-                            <Spinner loadingLabel={"Odjava..."} loading />
-                            <Typography level="h6" semiBold>Odjva u tijeku...</Typography>
-                        </Row>
-                    )}
-                    {error && (
-                        <Alert color="danger" startDecorator={<Warning />}>
-                            Došlo je do greške prilikom odjave.
-                        </Alert>
-                    )}
-                </Stack>
-            </form>
-        </Card>
+        <form ref={autoSubmitForm} action={submitAction}>
+            <Stack spacing={4}>
+                {!error && (
+                    <Row spacing={1} className="flex justify-center">
+                        <Spinner loadingLabel={"Odjava..."} loading />
+                        <Typography level="h6" semiBold>Odjva u tijeku...</Typography>
+                    </Row>
+                )}
+                {error && (
+                    <Alert color="danger" startDecorator={<Warning />}>
+                        Došlo je do greške prilikom odjave.
+                    </Alert>
+                )}
+            </Stack>
+        </form>
     );
 }


### PR DESCRIPTION
Remove unnecessary Card wrapper from LogoutForm to simplify markup.
Wrap Nav and main content separately with AuthProtectedSection in admin layout
to enforce auth checks on both navigation and page content independently.
Add backdrop blur and semi-transparent background behind LoginDialog for better
visual focus when signed out.
Replace window reload with invalidatePage in LoginDialog to update state more
efficiently after login.