### PR TITLE
feat: improve JSON import form and enhance hypertune flag queries

### DIFF
--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -394,45 +394,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/entities/test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * /entities/test
-         * @description Get all entities of type test.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["entity-test"][];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -571,6 +532,9 @@ export interface components {
             };
             image: {
                 cover: components["schemas"]["image"];
+            };
+            store: {
+                availableInStore: boolean;
             };
             /** Format: date-time */
             createdAt: string;
@@ -714,6 +678,9 @@ export interface components {
                     image?: {
                         cover: components["schemas"]["image"];
                     };
+                    store?: {
+                        availableInStore: boolean;
+                    };
                 };
                 name: string;
                 description?: string;
@@ -729,6 +696,9 @@ export interface components {
             };
             image: {
                 cover?: components["schemas"]["image"];
+            };
+            store: {
+                availableInStore: boolean;
             };
             /** Format: date-time */
             createdAt: string;
@@ -897,6 +867,9 @@ export interface components {
                     image?: {
                         cover: components["schemas"]["image"];
                     };
+                    store?: {
+                        availableInStore: boolean;
+                    };
                 };
                 plantSort: {
                     id?: number;
@@ -1027,6 +1000,9 @@ export interface components {
                             image?: {
                                 cover: components["schemas"]["image"];
                             };
+                            store?: {
+                                availableInStore: boolean;
+                            };
                         };
                         name: string;
                         description?: string;
@@ -1043,6 +1019,9 @@ export interface components {
                     image?: {
                         cover?: components["schemas"]["image"];
                     };
+                    store?: {
+                        availableInStore: boolean;
+                    };
                 };
                 countryOfOrigin?: string;
             };
@@ -1051,6 +1030,8 @@ export interface components {
             };
             attributes: {
                 germinationPercentage?: number;
+                /** @description (cijena pakiranja u EUR) */
+                price: number;
                 /** @description (težina pakiranja u gramima) */
                 weight: number;
             };
@@ -1066,7 +1047,7 @@ export interface components {
                 id: number;
                 /** @default brand */
                 name: string;
-                /** @default Brend */
+                /** @default Brend sjemena */
                 label: string;
             };
             information: {
@@ -1137,7 +1118,7 @@ export interface components {
                 id: number;
                 /** @default operationFrequency */
                 name: string;
-                /** @default Učestalost operacije */
+                /** @default Učestalost radnje */
                 label: string;
             };
             /** Format: date-time */
@@ -1224,21 +1205,6 @@ export interface components {
                 raisedBed: boolean;
                 /** @description Blokovi koji mogu reciklirati druge blokove */
                 recycler: boolean;
-            };
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-        };
-        "entity-test": {
-            id: number;
-            entityType: {
-                /** @default 9 */
-                id: number;
-                /** @default test */
-                name: string;
-                /** @default Test */
-                label: string;
             };
             /** Format: date-time */
             createdAt: string;

--- a/apps/app/app/(actions)/entityActions.ts
+++ b/apps/app/app/(actions)/entityActions.ts
@@ -106,7 +106,7 @@ export async function handleValueSave(
 
     const newAttributeValueValue = (newValue?.length ?? 0) <= 0 ? null : newValue;
     await upsertAttributeValue({
-        id: attributeValueId,
+        id: !attributeValueId ? undefined : attributeValueId,
         attributeDefinitionId: attributeDefinition.id,
         entityTypeName: entityTypeName,
         entityId: entityId,

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -67,7 +67,7 @@ export default async function EntityDetailsPage(props: { params: Promise<{ entit
                     </Row>
                 </div>
                 {/* Import JSON form */}
-                <form action={importAction} className="mb-4 flex items-center gap-2" encType="multipart/form-data">
+                <form action={importAction} className="mb-4 flex items-center gap-2">
                     <input type="file" name="entityJson" accept="application/json" required />
                     <button type="submit" className="btn btn-primary">Import JSON</button>
                 </form>

--- a/apps/app/components/shared/attributes/AttributeInput.tsx
+++ b/apps/app/components/shared/attributes/AttributeInput.tsx
@@ -34,15 +34,19 @@ export function AttributeInput({
     attributeValue: SelectAttributeValue | undefined | null
 }) {
     const handleChange = async (value: string | null) => {
+        console.debug('AttributeInput handleChange', value, attributeValue?.entityTypeName, attributeValue?.entityId);
+
         // Ignore if not changed or empty/null value
         if (value === attributeValue?.value ||
             (value === '' && !attributeValue?.value)) {
+            console.debug('AttributeInput handleChange: no change');
             return;
         }
 
         try {
             await handleValueSave(entityType, entityId, attributeDefinition, attributeValue?.id, value);
-        } catch {
+        } catch (error) {
+            console.error('AttributeInput handleChange error', error);
             // TODO: Display error notification
         }
     }

--- a/apps/app/lib/flags/generated/hypertune.ts
+++ b/apps/app/lib/flags/generated/hypertune.ts
@@ -80,7 +80,11 @@ export class RootNode extends sdk.Node {
   }
 
   get({ fallback = rootFallback as Root}: { fallback?: Root } = {}): Root {
-    const getQuery = null;
+    const getQuery = sdk.mergeFieldQueryAndArgs(
+      query.fragmentDefinitions,
+      sdk.getFieldQueryForPath(query.fragmentDefinitions, query.fieldQuery, ["Query", "root"]), 
+      null,
+    );
     return this.getValue({ query: getQuery, fallback }) as Root;
   }
 

--- a/apps/farm/lib/flags/generated/hypertune.ts
+++ b/apps/farm/lib/flags/generated/hypertune.ts
@@ -80,7 +80,11 @@ export class RootNode extends sdk.Node {
   }
 
   get({ fallback = rootFallback as Root}: { fallback?: Root } = {}): Root {
-    const getQuery = null;
+    const getQuery = sdk.mergeFieldQueryAndArgs(
+      query.fragmentDefinitions,
+      sdk.getFieldQueryForPath(query.fragmentDefinitions, query.fieldQuery, ["Query", "root"]), 
+      null,
+    );
     return this.getValue({ query: getQuery, fallback }) as Root;
   }
 

--- a/apps/garden/lib/flags/generated/hypertune.ts
+++ b/apps/garden/lib/flags/generated/hypertune.ts
@@ -108,7 +108,11 @@ export class RootNode extends sdk.Node {
   }
 
   get({ fallback = rootFallback as Root}: { fallback?: Root } = {}): Root {
-    const getQuery = null;
+    const getQuery = sdk.mergeFieldQueryAndArgs(
+      query.fragmentDefinitions,
+      sdk.getFieldQueryForPath(query.fragmentDefinitions, query.fieldQuery, ["Query", "root"]), 
+      null,
+    );
     return this.getValue({ query: getQuery, fallback }) as Root;
   }
 

--- a/apps/www/lib/flags/generated/hypertune.ts
+++ b/apps/www/lib/flags/generated/hypertune.ts
@@ -73,7 +73,11 @@ export class RootNode extends sdk.Node {
   }
 
   get({ fallback = rootFallback as Root}: { fallback?: Root } = {}): Root {
-    const getQuery = null;
+    const getQuery = sdk.mergeFieldQueryAndArgs(
+      query.fragmentDefinitions,
+      sdk.getFieldQueryForPath(query.fragmentDefinitions, query.fieldQuery, ["Query", "root"]), 
+      null,
+    );
     return this.getValue({ query: getQuery, fallback }) as Root;
   }
 

--- a/packages/client/src/lib/directories-api/v1.d.ts
+++ b/packages/client/src/lib/directories-api/v1.d.ts
@@ -394,45 +394,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/entities/test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * /entities/test
-         * @description Get all entities of type test.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["entity-test"][];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -571,6 +532,9 @@ export interface components {
             };
             image: {
                 cover: components["schemas"]["image"];
+            };
+            store: {
+                availableInStore: boolean;
             };
             /** Format: date-time */
             createdAt: string;
@@ -714,6 +678,9 @@ export interface components {
                     image?: {
                         cover: components["schemas"]["image"];
                     };
+                    store?: {
+                        availableInStore: boolean;
+                    };
                 };
                 name: string;
                 description?: string;
@@ -729,6 +696,9 @@ export interface components {
             };
             image: {
                 cover?: components["schemas"]["image"];
+            };
+            store: {
+                availableInStore: boolean;
             };
             /** Format: date-time */
             createdAt: string;
@@ -897,6 +867,9 @@ export interface components {
                     image?: {
                         cover: components["schemas"]["image"];
                     };
+                    store?: {
+                        availableInStore: boolean;
+                    };
                 };
                 plantSort: {
                     id?: number;
@@ -1027,6 +1000,9 @@ export interface components {
                             image?: {
                                 cover: components["schemas"]["image"];
                             };
+                            store?: {
+                                availableInStore: boolean;
+                            };
                         };
                         name: string;
                         description?: string;
@@ -1043,6 +1019,9 @@ export interface components {
                     image?: {
                         cover?: components["schemas"]["image"];
                     };
+                    store?: {
+                        availableInStore: boolean;
+                    };
                 };
                 countryOfOrigin?: string;
             };
@@ -1051,6 +1030,8 @@ export interface components {
             };
             attributes: {
                 germinationPercentage?: number;
+                /** @description (cijena pakiranja u EUR) */
+                price: number;
                 /** @description (težina pakiranja u gramima) */
                 weight: number;
             };
@@ -1066,7 +1047,7 @@ export interface components {
                 id: number;
                 /** @default brand */
                 name: string;
-                /** @default Brend */
+                /** @default Brend sjemena */
                 label: string;
             };
             information: {
@@ -1137,7 +1118,7 @@ export interface components {
                 id: number;
                 /** @default operationFrequency */
                 name: string;
-                /** @default Učestalost operacije */
+                /** @default Učestalost radnje */
                 label: string;
             };
             /** Format: date-time */
@@ -1224,21 +1205,6 @@ export interface components {
                 raisedBed: boolean;
                 /** @description Blokovi koji mogu reciklirati druge blokove */
                 recycler: boolean;
-            };
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-        };
-        "entity-test": {
-            id: number;
-            entityType: {
-                /** @default 9 */
-                id: number;
-                /** @default test */
-                name: string;
-                /** @default Test */
-                label: string;
             };
             /** Format: date-time */
             createdAt: string;

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -17,9 +17,10 @@ import { cx } from "@signalco/ui-primitives/cx";
 export function PlantsSortList({ plantId, selectedSortId, onChange }: { plantId: number, selectedSortId: number | null, onChange: (plant: PlantSortData) => void }) {
     const { data: plantSorts, isLoading, isError } = usePlantSorts(plantId);
     const [search] = useSearchParam('pretraga', '');
+    const storePlants = plantSorts?.filter(sort => sort.store.availableInStore);
     const filteredPlantSorts = search.length > 0
-        ? plantSorts?.filter(sort => sort.information.name.toLowerCase().includes(search.toLowerCase()))
-        : plantSorts;
+        ? storePlants?.filter(sort => sort.information.name.toLowerCase().includes(search.toLowerCase()))
+        : storePlants;
 
     // Select first sort if only one is available
     useEffect(() => {


### PR DESCRIPTION
Remove unnecessary multipart encoding from JSON import form to simplify
file upload handling. Update hypertune flag get() methods across multiple
apps to construct and merge detailed GraphQL queries, improving data
retrieval accuracy. Clean up API types by removing deprecated test entity
endpoints and add new store availability fields to relevant schemas for
better inventory tracking.