### PR TITLE
fix(ui): remove redundant text-gray-600 classes from invoice page

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -1,4 +1,4 @@
-import { getShoppingCart, setCartItemPaid, upsertRaisedBedField, createEvent, knownEvents, earnSunflowersForPayment, updateRaisedBed, markCartPaidIfAllItemsPaid, createTransaction, getTransactions, createRaisedBedSensor, createOperation, getRaisedBedFieldsWithEvents } from "@gredice/storage";
+import { getShoppingCart, setCartItemPaid, upsertRaisedBedField, createEvent, knownEvents, earnSunflowersForPayment, updateRaisedBed, markCartPaidIfAllItemsPaid, createTransaction, createRaisedBedSensor, createOperation, getRaisedBedFieldsWithEvents, getAllTransactions } from "@gredice/storage";
 import { getStripeCheckoutSession } from "@gredice/stripe/server";
 
 export async function processCheckoutSession(checkoutSessionId?: string) {
@@ -59,7 +59,7 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
         // Check if transaction was already precessed
         if (accountId) {
             // TODO: Use paginatino and retrieve last N transactions or match via date
-            const transactions = await getTransactions(accountId);
+            const transactions = await getAllTransactions({ filter: { accountId } });
             const existingTransaction = transactions.find(t =>
                 t.stripePaymentId === session.id &&
                 t.status === 'completed'

--- a/apps/app/app/admin/accounts/[accountId]/AccountShoppingCartsCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountShoppingCartsCard.tsx
@@ -1,0 +1,18 @@
+import { Card, CardHeader, CardOverflow, CardTitle } from "@signalco/ui-primitives/Card";
+import { auth } from "../../../../lib/auth/auth";
+import { ShoppingCartsTable } from "../../shopping-carts/ShoppingCartsTable";
+
+export async function AccountShoppingCartsCard({ accountId }: { accountId: string }) {
+    await auth(['admin']);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Košarice</CardTitle>
+            </CardHeader>
+            <CardOverflow>
+                <ShoppingCartsTable accountId={accountId} />
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/accounts/[accountId]/AccountSunflowersCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountSunflowersCard.tsx
@@ -61,6 +61,7 @@ export async function AccountSunflowersCard({ accountId }: { accountId: string }
                         <Table.Header>
                             <Table.Row>
                                 <Table.Head>Tip</Table.Head>
+                                <Table.Head>Podaci</Table.Head>
                                 <Table.Head>Iznos</Table.Head>
                                 <Table.Head>Datum kreiranja</Table.Head>
                             </Table.Row>
@@ -79,6 +80,9 @@ export async function AccountSunflowersCard({ accountId }: { accountId: string }
                                 <Table.Row key={sunflower.id}>
                                     <Table.Cell>
                                         {sunflower.type}
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        {JSON.stringify(sunflower.data)}
                                     </Table.Cell>
                                     <Table.Cell>
                                         {sunflower.amount}

--- a/apps/app/app/admin/accounts/[accountId]/AccountTransactionsCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountTransactionsCard.tsx
@@ -1,53 +1,14 @@
 import { Card, CardHeader, CardOverflow, CardTitle } from "@signalco/ui-primitives/Card";
-import { Table } from "@signalco/ui-primitives/Table";
-import { NoDataPlaceholder } from "../../../../components/shared/placeholders/NoDataPlaceholder";
-import { LocaleDateTime } from "../../../../components/shared/LocaleDateTime";
-import { getTransactions } from "@gredice/storage";
+import { TransactionsTable } from "../../transactions/TransactionsTable";
 
 export async function AccountTransactionsCard({ accountId }: { accountId: string }) {
-    const transactions = await getTransactions(accountId);
-
     return (
         <Card>
             <CardHeader>
                 <CardTitle>Transakcije</CardTitle>
             </CardHeader>
             <CardOverflow>
-                <Table>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.Head>ID</Table.Head>
-                            <Table.Head>Iznos</Table.Head>
-                            <Table.Head>Valuta</Table.Head>
-                            <Table.Head>Status</Table.Head>
-                            <Table.Head>Datum</Table.Head>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {transactions.length === 0 && (
-                            <Table.Row>
-                                <Table.Cell colSpan={5}>
-                                    <NoDataPlaceholder>
-                                        Nema transakcija
-                                    </NoDataPlaceholder>
-                                </Table.Cell>
-                            </Table.Row>
-                        )}
-                        {transactions.map(transaction => (
-                            <Table.Row key={transaction.id}>
-                                <Table.Cell>{transaction.id}</Table.Cell>
-                                <Table.Cell>{transaction.amount}</Table.Cell>
-                                <Table.Cell>{transaction.currency}</Table.Cell>
-                                <Table.Cell>{transaction.status}</Table.Cell>
-                                <Table.Cell>
-                                    <LocaleDateTime>
-                                        {transaction.createdAt}
-                                    </LocaleDateTime>
-                                </Table.Cell>
-                            </Table.Row>
-                        ))}
-                    </Table.Body>
-                </Table>
+                <TransactionsTable accountId={accountId} />
             </CardOverflow>
         </Card>
     );

--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -16,6 +16,7 @@ import { sendDeleteAccountEmail } from "../../../(actions)/accountsActions";
 import { Delete } from "@signalco/ui-icons";
 import { Row } from "@signalco/ui-primitives/Row";
 import { FieldSet } from "../../../../components/shared/fields/FieldSet";
+import { AccountShoppingCartsCard } from "./AccountShoppingCartsCard";
 
 export const dynamic = 'force-dynamic';
 
@@ -60,6 +61,7 @@ export default async function AccountPage({ params }: { params: Promise<{ accoun
                 <AccountTransactionsCard accountId={accountId} />
                 <RaisedBedsTableCard accountId={accountId} />
                 <NotificationsTableCard accountId={accountId} />
+                <AccountShoppingCartsCard accountId={accountId} />
             </div>
         </Stack>
     );

--- a/apps/app/app/admin/invoices/InvoicesTable.tsx
+++ b/apps/app/app/admin/invoices/InvoicesTable.tsx
@@ -1,0 +1,109 @@
+import { getAllInvoices } from "@gredice/storage";
+import { Chip } from "@signalco/ui-primitives/Chip";
+import { Table } from "@signalco/ui-primitives/Table";
+import { KnownPages } from "../../../src/KnownPages";
+import Link from "next/link";
+import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
+import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
+import { ExternalLink } from "@signalco/ui-icons";
+
+function getStatusColor(status: string) {
+    switch (status) {
+        case 'draft': return 'neutral';
+        case 'pending': return 'warning';
+        case 'sent': return 'info';
+        case 'paid': return 'success';
+        case 'overdue': return 'error';
+        case 'cancelled': return 'neutral';
+        default: return 'neutral';
+    }
+}
+
+function getStatusLabel(status: string) {
+    switch (status) {
+        case 'draft': return 'Nacrt';
+        case 'pending': return 'Na čekanju';
+        case 'sent': return 'Poslan';
+        case 'paid': return 'Plaćen';
+        case 'overdue': return 'Dospio';
+        case 'cancelled': return 'Otkazan';
+        default: return status;
+    }
+}
+
+export async function InvoicesTable({ transactionId }: { transactionId?: number }) {
+    const invoices = await getAllInvoices({ transactionId });
+
+    return (
+        <Table>
+            <Table.Header>
+                <Table.Row>
+                    <Table.Head>Broj ponude</Table.Head>
+                    <Table.Head>Klijent</Table.Head>
+                    <Table.Head>Status</Table.Head>
+                    <Table.Head>Iznos</Table.Head>
+                    <Table.Head>Datum izdavanja</Table.Head>
+                    <Table.Head>Datum dospijeća</Table.Head>
+                    <Table.Head>Transakcija</Table.Head>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {invoices.length === 0 && (
+                    <Table.Row>
+                        <Table.Cell colSpan={7}>
+                            <NoDataPlaceholder>
+                                Nema ponuda
+                            </NoDataPlaceholder>
+                        </Table.Cell>
+                    </Table.Row>
+                )}
+                {invoices.map(invoice => (
+                    <Table.Row key={invoice.id}>
+                        <Table.Cell>
+                            <Link href={KnownPages.Invoice(invoice.id)}>
+                                {invoice.invoiceNumber}
+                            </Link>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <div>
+                                <div className="font-medium">{invoice.billToName}</div>
+                                <div className="text-sm text-gray-500">{invoice.billToEmail}</div>
+                            </div>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <Chip color={getStatusColor(invoice.status)} className="w-fit">
+                                {getStatusLabel(invoice.status)}
+                            </Chip>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <Chip color="success" className="w-fit">
+                                {invoice.totalAmount}{invoice.currency === 'eur' ? '€' : invoice.currency}
+                            </Chip>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <LocaleDateTime time={false}>
+                                {invoice.issueDate}
+                            </LocaleDateTime>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <LocaleDateTime time={false}>
+                                {invoice.dueDate}
+                            </LocaleDateTime>
+                        </Table.Cell>
+                        <Table.Cell>
+                            {invoice.transactionId ? (
+                                <Link href={KnownPages.Transaction(invoice.transactionId)}>
+                                    <Chip startDecorator={<ExternalLink className="size-4 shrink-0" />} className="w-fit">
+                                        #{invoice.transactionId}
+                                    </Chip>
+                                </Link>
+                            ) : (
+                                <span className="text-gray-500">Nema transakcije</span>
+                            )}
+                        </Table.Cell>
+                    </Table.Row>
+                ))}
+            </Table.Body>
+        </Table>
+    );
+}

--- a/apps/app/app/admin/invoices/[invoiceId]/page.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/page.tsx
@@ -78,38 +78,38 @@ export default async function InvoicePage({ params }: { params: { invoiceId: str
                                 <Stack spacing={2}>
                                     <Row spacing={4}>
                                         <Stack spacing={1} className="flex-1">
-                                            <Typography level="body2" className="text-gray-600">Broj ponude</Typography>
+                                            <Typography level="body2" >Broj ponude</Typography>
                                             <Typography>{invoice.invoiceNumber}</Typography>
                                         </Stack>
                                         <Stack spacing={1} className="flex-1">
-                                            <Typography level="body2" className="text-gray-600">Valuta</Typography>
+                                            <Typography level="body2" >Valuta</Typography>
                                             <Typography>{invoice.currency}</Typography>
                                         </Stack>
                                     </Row>
                                     <Row spacing={4}>
                                         <Stack spacing={1} className="flex-1">
-                                            <Typography level="body2" className="text-gray-600">Datum izdavanja</Typography>
+                                            <Typography level="body2" >Datum izdavanja</Typography>
                                             <LocaleDateTime time={false}>{invoice.issueDate}</LocaleDateTime>
                                         </Stack>
                                         <Stack spacing={1} className="flex-1">
-                                            <Typography level="body2" className="text-gray-600">Datum dospijeća</Typography>
+                                            <Typography level="body2" >Datum dospijeća</Typography>
                                             <LocaleDateTime time={false}>{invoice.dueDate}</LocaleDateTime>
                                         </Stack>
                                     </Row>
                                     {invoice.notes && (
                                         <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Napomene</Typography>
+                                            <Typography level="body2" >Napomene</Typography>
                                             <Typography>{invoice.notes}</Typography>
                                         </Stack>
                                     )}
                                     <Stack spacing={1} className="flex-1">
-                                        <Typography level="body2" className="text-gray-600">Status</Typography>
+                                        <Typography level="body2" >Status</Typography>
                                         <Row spacing={2} alignItems="center">
-                                            <Chip color={getStatusColor(invoice.status)} size="sm">
+                                            <Chip color={getStatusColor(invoice.status)} >
                                                 {getStatusLabel(invoice.status)}
                                             </Chip>
                                             {isOverdue(invoice) && (
-                                                <Chip color="error" size="sm">
+                                                <Chip color="error" >
                                                     Dospio
                                                 </Chip>
                                             )}
@@ -127,18 +127,18 @@ export default async function InvoicePage({ params }: { params: { invoiceId: str
                             <CardContent>
                                 <Stack spacing={2}>
                                     <Stack spacing={1}>
-                                        <Typography level="body2" className="text-gray-600">Naziv</Typography>
+                                        <Typography level="body2" >Naziv</Typography>
                                         <Typography>{invoice.billToName}</Typography>
                                     </Stack>
                                     {invoice.billToEmail && (
                                         <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Email</Typography>
+                                            <Typography level="body2" >Email</Typography>
                                             <Typography>{invoice.billToEmail}</Typography>
                                         </Stack>
                                     )}
                                     {invoice.billToAddress && (
                                         <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Adresa</Typography>
+                                            <Typography level="body2" >Adresa</Typography>
                                             <Typography className="whitespace-pre-line">{invoice.billToAddress}</Typography>
                                         </Stack>
                                     )}
@@ -156,11 +156,11 @@ export default async function InvoicePage({ params }: { params: { invoiceId: str
                             <CardContent>
                                 <Stack spacing={2}>
                                     <Row justifyContent="space-between">
-                                        <Typography level="body2" className="text-gray-600">Osnovica</Typography>
+                                        <Typography level="body2" >Osnovica</Typography>
                                         <Typography>{invoice.subtotal}{invoice.currency === 'eur' ? '€' : invoice.currency}</Typography>
                                     </Row>
                                     <Row justifyContent="space-between">
-                                        <Typography level="body2" className="text-gray-600">PDV</Typography>
+                                        <Typography level="body2" >PDV</Typography>
                                         <Typography>{invoice.taxAmount}{invoice.currency === 'eur' ? '€' : invoice.currency}</Typography>
                                     </Row>
                                     <Row justifyContent="space-between" className="border-t pt-2">

--- a/apps/app/app/admin/invoices/page.tsx
+++ b/apps/app/app/admin/invoices/page.tsx
@@ -1,120 +1,14 @@
-import { getAllInvoices } from "@gredice/storage";
 import { Card, CardOverflow } from "@signalco/ui-primitives/Card";
-import { Chip } from "@signalco/ui-primitives/Chip";
-import { Table } from "@signalco/ui-primitives/Table";
 import { Button } from "@signalco/ui-primitives/Button";
 import { auth } from "../../../lib/auth/auth";
 import { KnownPages } from "../../../src/KnownPages";
-import Link from "next/link";
-import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
-import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
 import { Typography } from "@signalco/ui-primitives/Typography";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Stack } from "@signalco/ui-primitives/Stack";
-import { ExternalLink, LinkOff } from "@signalco/ui-icons";
+import { Add } from "@signalco/ui-icons";
+import { InvoicesTable } from "./InvoicesTable";
 
 export const dynamic = 'force-dynamic';
-
-function getStatusColor(status: string) {
-    switch (status) {
-        case 'draft': return 'neutral';
-        case 'pending': return 'warning';
-        case 'sent': return 'info';
-        case 'paid': return 'success';
-        case 'overdue': return 'error';
-        case 'cancelled': return 'neutral';
-        default: return 'neutral';
-    }
-}
-
-function getStatusLabel(status: string) {
-    switch (status) {
-        case 'draft': return 'Nacrt';
-        case 'pending': return 'Na čekanju';
-        case 'sent': return 'Poslan';
-        case 'paid': return 'Plaćen';
-        case 'overdue': return 'Dospio';
-        case 'cancelled': return 'Otkazan';
-        default: return status;
-    }
-}
-
-export async function InvoicesTable({ transactionId }: { transactionId?: number }) {
-    const invoices = await getAllInvoices({ transactionId });
-
-    return (
-        <Table>
-            <Table.Header>
-                <Table.Row>
-                    <Table.Head>Broj ponude</Table.Head>
-                    <Table.Head>Klijent</Table.Head>
-                    <Table.Head>Status</Table.Head>
-                    <Table.Head>Iznos</Table.Head>
-                    <Table.Head>Datum izdavanja</Table.Head>
-                    <Table.Head>Datum dospijeća</Table.Head>
-                    <Table.Head>Transakcija</Table.Head>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {invoices.length === 0 && (
-                    <Table.Row>
-                        <Table.Cell colSpan={7}>
-                            <NoDataPlaceholder>
-                                Nema ponuda
-                            </NoDataPlaceholder>
-                        </Table.Cell>
-                    </Table.Row>
-                )}
-                {invoices.map(invoice => (
-                    <Table.Row key={invoice.id}>
-                        <Table.Cell>
-                            <Link href={KnownPages.Invoice(invoice.id)}>
-                                {invoice.invoiceNumber}
-                            </Link>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <div>
-                                <div className="font-medium">{invoice.billToName}</div>
-                                <div className="text-sm text-gray-500">{invoice.billToEmail}</div>
-                            </div>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <Chip color={getStatusColor(invoice.status)} className="w-fit">
-                                {getStatusLabel(invoice.status)}
-                            </Chip>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <Chip color="success" className="w-fit">
-                                {invoice.totalAmount}{invoice.currency === 'eur' ? '€' : invoice.currency}
-                            </Chip>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <LocaleDateTime time={false}>
-                                {invoice.issueDate}
-                            </LocaleDateTime>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <LocaleDateTime time={false}>
-                                {invoice.dueDate}
-                            </LocaleDateTime>
-                        </Table.Cell>
-                        <Table.Cell>
-                            {invoice.transactionId ? (
-                                <Link href={KnownPages.Transaction(invoice.transactionId)}>
-                                    <Chip startDecorator={<ExternalLink className="size-4 shrink-0" />} className="w-fit">
-                                        #{invoice.transactionId}
-                                    </Chip>
-                                </Link>
-                            ) : (
-                                <span className="text-gray-500">Nema transakcije</span>
-                            )}
-                        </Table.Cell>
-                    </Table.Row>
-                ))}
-            </Table.Body>
-        </Table>
-    );
-}
 
 export default async function InvoicesPage() {
     await auth(['admin']);
@@ -125,86 +19,13 @@ export default async function InvoicesPage() {
                 <Row spacing={1}>
                     <Typography level="h1" className="text-2xl" semiBold>Ponude</Typography>
                 </Row>
-                <Link href={KnownPages.CreateInvoice}>
-                    <Button variant="solid" color="primary">
-                        Nova ponuda
-                    </Button>
-                </Link>
+                <Button variant="solid" startDecorator={<Add className="size-5 shrink-0" />} href={KnownPages.CreateInvoice}>
+                    Nova ponuda
+                </Button>
             </Row>
             <Card>
                 <CardOverflow>
-                    <Table>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.Head>Broj ponude</Table.Head>
-                                <Table.Head>Klijent</Table.Head>
-                                <Table.Head>Status</Table.Head>
-                                <Table.Head>Iznos</Table.Head>
-                                <Table.Head>Datum izdavanja</Table.Head>
-                                <Table.Head>Datum dospijeća</Table.Head>
-                                <Table.Head>Transakcija</Table.Head>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {invoices.length === 0 && (
-                                <Table.Row>
-                                    <Table.Cell colSpan={7}>
-                                        <NoDataPlaceholder>
-                                            Nema ponuda
-                                        </NoDataPlaceholder>
-                                    </Table.Cell>
-                                </Table.Row>
-                            )}
-                            {invoices.map(invoice => (
-                                <Table.Row key={invoice.id}>
-                                    <Table.Cell>
-                                        <Link href={KnownPages.Invoice(invoice.id)}>
-                                            {invoice.invoiceNumber}
-                                        </Link>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <div>
-                                            <div className="font-medium">{invoice.billToName}</div>
-                                            <div className="text-sm text-gray-500">{invoice.billToEmail}</div>
-                                        </div>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Chip color={getStatusColor(invoice.status)} size="sm" className="w-fit">
-                                            <Typography noWrap>
-                                                {getStatusLabel(invoice.status)}
-                                            </Typography>
-                                        </Chip>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Chip color="success" size="sm" className="w-fit">
-                                            <Typography noWrap>
-                                                {invoice.totalAmount}{invoice.currency === 'eur' ? '€' : invoice.currency}
-                                            </Typography>
-                                        </Chip>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <LocaleDateTime time={false}>
-                                            {invoice.issueDate}
-                                        </LocaleDateTime>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <LocaleDateTime time={false}>
-                                            {invoice.dueDate}
-                                        </LocaleDateTime>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        {invoice.transactionId ? (
-                                            <Link href={KnownPages.Transaction(invoice.transactionId)}>
-                                                #{invoice.transactionId}
-                                            </Link>
-                                        ) : (
-                                            <span className="text-gray-500">Nema transakcije</span>
-                                        )}
-                                    </Table.Cell>
-                                </Table.Row>
-                            ))}
-                        </Table.Body>
-                    </Table>
+                    <InvoicesTable />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/admin/receipts/[receiptId]/page.tsx
+++ b/apps/app/app/admin/receipts/[receiptId]/page.tsx
@@ -19,8 +19,8 @@ export const dynamic = 'force-dynamic';
 
 function getCisStatusColor(cisStatus: string) {
     switch (cisStatus) {
-        case 'sent': return 'success';
         case 'pending': return 'warning';
+        case 'confirmed': return 'success';
         case 'failed': return 'error';
         default: return 'neutral';
     }
@@ -28,8 +28,8 @@ function getCisStatusColor(cisStatus: string) {
 
 function getCisStatusLabel(cisStatus: string) {
     switch (cisStatus) {
-        case 'sent': return 'Poslano';
         case 'pending': return 'Na čekanju';
+        case 'confirmed': return 'Potvrđeno';
         case 'failed': return 'Neuspješno';
         default: return cisStatus;
     }
@@ -57,7 +57,7 @@ export default async function ReceiptPage({ params }: { params: Promise<{ receip
                     <Typography level="h1" className="text-2xl" semiBold>
                         Fiskalni račun #{receipt.id}
                     </Typography>
-                    <Chip color={getCisStatusColor(receipt.cisStatus)} size="sm">
+                    <Chip color={getCisStatusColor(receipt.cisStatus)}>
                         {getCisStatusLabel(receipt.cisStatus)}
                     </Chip>
                 </Row>
@@ -99,7 +99,7 @@ export default async function ReceiptPage({ params }: { params: Promise<{ receip
                                 </FieldSet>
                                 <FieldSet>
                                     <Field name="CIS Status" value={
-                                        <Chip color={getCisStatusColor(receipt.cisStatus)} size="sm" className="w-fit">
+                                        <Chip color={getCisStatusColor(receipt.cisStatus)} className="w-fit">
                                             {getCisStatusLabel(receipt.cisStatus)}
                                         </Chip>
                                     } />
@@ -145,11 +145,11 @@ export default async function ReceiptPage({ params }: { params: Promise<{ receip
                         <CardContent>
                             <Stack spacing={1}>
                                 <Row justifyContent="space-between">
-                                    <Typography level="body2" className="text-gray-600">Osnovica</Typography>
+                                    <Typography level="body2">Osnovica</Typography>
                                     <Typography>{receipt.subtotal}{receipt.currency === 'eur' ? ' €' : receipt.currency}</Typography>
                                 </Row>
                                 <Row justifyContent="space-between">
-                                    <Typography level="body2" className="text-gray-600">PDV</Typography>
+                                    <Typography level="body2">PDV</Typography>
                                     <Typography>{receipt.taxAmount}{receipt.currency === 'eur' ? ' €' : receipt.currency}</Typography>
                                 </Row>
                                 <Row justifyContent="space-between" className="border-t pt-2">
@@ -168,14 +168,14 @@ export default async function ReceiptPage({ params }: { params: Promise<{ receip
                         <CardContent>
                             <Stack spacing={1}>
                                 <Row spacing={2} alignItems="center">
-                                    <Typography level="body2" className="text-gray-600 w-20">Ponuda:</Typography>
+                                    <Typography level="body2" className="w-20">Ponuda:</Typography>
                                     <Link href={KnownPages.Invoice(receipt.invoiceId)}>
                                         {receipt.invoice?.invoiceNumber || `#${receipt.invoiceId}`}
                                     </Link>
                                 </Row>
                                 {receipt.invoice?.transactionId && (
                                     <Row spacing={2} alignItems="center">
-                                        <Typography level="body2" className="text-gray-600 w-20">Transakcija:</Typography>
+                                        <Typography level="body2" className="w-20">Transakcija:</Typography>
                                         <Link href={KnownPages.Transaction(receipt.invoice.transactionId)}>
                                             #{receipt.invoice.transactionId}
                                         </Link>

--- a/apps/app/app/admin/shopping-carts/ShoppingCartsTable.tsx
+++ b/apps/app/app/admin/shopping-carts/ShoppingCartsTable.tsx
@@ -1,0 +1,93 @@
+import { getAllShoppingCarts } from "@gredice/storage";
+import { Table } from "@signalco/ui-primitives/Table";
+import { auth } from "../../../lib/auth/auth";
+import { KnownPages } from "../../../src/KnownPages";
+import Link from "next/link";
+import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
+import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
+import { Chip } from "@signalco/ui-primitives/Chip";
+import { Typography } from "@signalco/ui-primitives/Typography";
+
+export async function ShoppingCartsTable({ accountId }: { accountId?: string }) {
+    await auth(['admin']);
+    const allShoppingCarts = await getAllShoppingCarts({ status: null, filter: { accountId } });
+
+    // Sort shopping carts by newest first (updatedAt descending)
+    const shoppingCarts = (allShoppingCarts || []).sort((a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
+    const hasAccountFilter = !!accountId;
+
+    return (
+        <Table>
+            <Table.Header>
+                <Table.Row>
+                    <Table.Head>ID</Table.Head>
+                    <Table.Head>Račun</Table.Head>
+                    {!hasAccountFilter && <Table.Head>Korisnik</Table.Head>}
+                    <Table.Head>Broj stavki</Table.Head>
+                    <Table.Head>Status</Table.Head>
+                    <Table.Head>Datum izmjene</Table.Head>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {shoppingCarts.length === 0 && (
+                    <Table.Row>
+                        <Table.Cell colSpan={3}>
+                            <NoDataPlaceholder>
+                                Nema košarica
+                            </NoDataPlaceholder>
+                        </Table.Cell>
+                    </Table.Row>
+                )}
+                {shoppingCarts.map(cart => {
+                    const user = cart.account?.accountUsers.at(0)?.user;
+                    return (
+                        <Table.Row key={cart.id}>
+                            <Table.Cell>
+                                <Link href={KnownPages.ShoppingCart(cart.id)}>
+                                    {cart.id}
+                                </Link>
+                            </Table.Cell>
+                            {!hasAccountFilter && (
+                                <Table.Cell>
+                                    {cart.accountId ? (
+                                        <Link href={KnownPages.Account(cart.accountId)}>
+                                            {cart.accountId.slice(0, 6)}...
+                                        </Link>
+                                    ) : (
+                                        <Typography level="body2">Nema računa</Typography>
+                                    )}
+                                </Table.Cell>
+                            )}
+                            <Table.Cell>
+                                {user ? (
+                                    <Link href={KnownPages.User(user.id)}>
+                                        {user.displayName || user.userName}
+                                    </Link>
+                                ) : (
+                                    <span className="text-gray-500">Nema korisnika</span>
+                                )}
+                            </Table.Cell>
+                            <Table.Cell>
+                                <Chip className="w-fit">
+                                    {cart.items.length} stavke
+                                </Chip>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <Chip className="w-fit" color={cart.status === 'paid' ? 'success' : 'neutral'}>
+                                    {cart.status === 'paid' ? 'Plaćena' : (cart.status === 'new' ? 'Nova' : cart.status)}
+                                </Chip>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <LocaleDateTime time={false}>
+                                    {cart.updatedAt}
+                                </LocaleDateTime>
+                            </Table.Cell>
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </Table>
+    );
+}

--- a/apps/app/app/admin/shopping-carts/page.tsx
+++ b/apps/app/app/admin/shopping-carts/page.tsx
@@ -1,89 +1,20 @@
-import { getAllShoppingCarts } from "@gredice/storage";
 import { Card, CardOverflow } from "@signalco/ui-primitives/Card";
-import { Table } from "@signalco/ui-primitives/Table";
 import { auth } from "../../../lib/auth/auth";
-import { KnownPages } from "../../../src/KnownPages";
-import Link from "next/link";
-import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
-import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
 import { Typography } from "@signalco/ui-primitives/Typography";
 import { Stack } from "@signalco/ui-primitives/Stack";
-import { Chip } from "@signalco/ui-primitives/Chip";
+import { ShoppingCartsTable } from "./ShoppingCartsTable";
 
 export const dynamic = 'force-dynamic';
 
 export default async function ShoppingCartsPage() {
     await auth(['admin']);
-    const allShoppingCarts = await getAllShoppingCarts({ status: null });
-
-    // Sort shopping carts by newest first (createdAt descending)
-    const shoppingCarts = (allShoppingCarts || []).sort((a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
 
     return (
         <Stack spacing={2}>
             <Typography level="h1" className="text-2xl" semiBold>Košarice</Typography>
             <Card>
                 <CardOverflow>
-                    <Table>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.Head>ID</Table.Head>
-                                <Table.Head>Račun</Table.Head>
-                                <Table.Head>Korisnik</Table.Head>
-                                <Table.Head>Broj stavki</Table.Head>
-                                <Table.Head>Status</Table.Head>
-                                <Table.Head>Datum kreiranja</Table.Head>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {shoppingCarts.length === 0 && (
-                                <Table.Row>
-                                    <Table.Cell colSpan={3}>
-                                        <NoDataPlaceholder>
-                                            Nema košarica
-                                        </NoDataPlaceholder>
-                                    </Table.Cell>
-                                </Table.Row>
-                            )}
-                            {shoppingCarts.map(cart => {
-                                const user = cart.account?.accountUsers.at(0)?.user;
-                                return (
-                                    <Table.Row key={cart.id}>
-                                        <Table.Cell>
-                                            <Link href={KnownPages.ShoppingCart(cart.id)}>
-                                                {cart.id}
-                                            </Link>
-                                        </Table.Cell>
-                                        <Table.Cell>{cart.accountId}</Table.Cell>
-                                        <Table.Cell>
-                                            {user ? (
-                                                <Link href={KnownPages.User(user.id)}>
-                                                    {user.displayName || user.userName}
-                                                </Link>
-                                            ) : (
-                                                <span className="text-gray-500">Nema korisnika</span>
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {cart.items.length}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Chip className="w-fit" color={cart.status === 'paid' ? 'success' : 'neutral'}>
-                                                {cart.status === 'paid' ? 'Plaćena' : (cart.status === 'new' ? 'Nova' : cart.status)}
-                                            </Chip>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <LocaleDateTime time={false}>
-                                                {cart.createdAt}
-                                            </LocaleDateTime>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                );
-                            })}
-                        </Table.Body>
-                    </Table>
+                    <ShoppingCartsTable />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/admin/transactions/TransactionsTable.tsx
+++ b/apps/app/app/admin/transactions/TransactionsTable.tsx
@@ -1,0 +1,122 @@
+import { getAllTransactions } from "@gredice/storage";
+import { Chip } from "@signalco/ui-primitives/Chip";
+import { Table } from "@signalco/ui-primitives/Table";
+import { auth } from "../../../lib/auth/auth";
+import { KnownPages } from "../../../src/KnownPages";
+import Link from "next/link";
+import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
+import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { Row } from "@signalco/ui-primitives/Row";
+import { ExternalLink } from "@signalco/ui-icons";
+
+export async function TransactionsTable({ accountId }: { accountId?: string }) {
+    await auth(['admin']);
+    const allTransactions = await getAllTransactions({ filter: { accountId } });
+
+    // Sort transactions by newest first (createdAt descending)
+    const transactions = (allTransactions || []).sort((a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+
+    const hasAccountFilter = !!accountId;
+
+    return (
+        <Table>
+            <Table.Header>
+                <Table.Row>
+                    <Table.Head>ID</Table.Head>
+                    {!hasAccountFilter && (
+                        <Table.Head>Račun</Table.Head>
+                    )}
+                    <Table.Head>Status</Table.Head>
+                    <Table.Head>Iznos</Table.Head>
+                    <Table.Head>Ponude</Table.Head>
+                    <Table.Head>Datum kreiranja</Table.Head>
+                    <Table.Head>Stripe Payment ID</Table.Head>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {transactions.length === 0 && (
+                    <Table.Row>
+                        <Table.Cell colSpan={7}>
+                            <NoDataPlaceholder>
+                                Nema transakcija
+                            </NoDataPlaceholder>
+                        </Table.Cell>
+                    </Table.Row>
+                )}
+                {transactions.map(transaction => {
+                    const invoiceCount = transaction.invoices?.length || 0;
+                    const hasNoInvoices = invoiceCount === 0;
+
+                    return (
+                        <Table.Row key={transaction.id} className={hasNoInvoices ? 'bg-green-50 dark:bg-green-950' : ''}>
+                            <Table.Cell>
+                                <Link href={KnownPages.Transaction(transaction.id)}>
+                                    {transaction.id}
+                                </Link>
+                            </Table.Cell>
+                            {!hasAccountFilter && (
+                                <Table.Cell>
+                                    {transaction.accountId && (
+                                        <Link href={KnownPages.Account(transaction.accountId)}>
+                                            {transaction.accountId}
+                                        </Link>
+                                    )}
+                                </Table.Cell>
+                            )}
+                            <Table.Cell>
+                                <Chip color="info" className="w-fit">
+                                    <Typography noWrap>
+                                        {transaction.status}
+                                    </Typography>
+                                </Chip>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <Chip color="success" className="w-fit">
+                                    <Typography noWrap>
+                                        €{(transaction.amount / 100).toFixed(2)}
+                                    </Typography>
+                                </Chip>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <Row spacing={1} alignItems="center">
+                                    {hasNoInvoices ? (
+                                        <Chip color="error" className="w-fit">
+                                            <Typography noWrap>
+                                                Bez ponuda
+                                            </Typography>
+                                        </Chip>
+                                    ) : (
+                                        <Chip color="success" className="w-fit">
+                                            <Typography noWrap>
+                                                📋 {invoiceCount} ponuda
+                                            </Typography>
+                                        </Chip>
+                                    )}
+                                </Row>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <LocaleDateTime time={false}>
+                                    {transaction.createdAt}
+                                </LocaleDateTime>
+                            </Table.Cell>
+                            <Table.Cell>
+                                {transaction.stripePaymentId ? (
+                                    <Link href={KnownPages.StripePayment(transaction.stripePaymentId)}>
+                                        <Chip startDecorator={<ExternalLink className="size-4" />}>
+                                            Stripe
+                                        </Chip>
+                                    </Link>
+                                ) : (
+                                    <span className="text-gray-500">Nema Stripe poveznicu</span>
+                                )}
+                            </Table.Cell>
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </Table>
+    )
+}

--- a/apps/app/app/admin/transactions/[transactionId]/page.tsx
+++ b/apps/app/app/admin/transactions/[transactionId]/page.tsx
@@ -9,7 +9,7 @@ import { Card, CardHeader, CardOverflow, CardTitle } from "@signalco/ui-primitiv
 import { Chip } from "@signalco/ui-primitives/Chip";
 import { FieldSet } from "../../../../components/shared/fields/FieldSet";
 import { Field } from "../../../../components/shared/fields/Field";
-import { InvoicesTable } from "../../invoices/page";
+import { InvoicesTable } from "../../invoices/InvoicesTable";
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/app/app/admin/transactions/page.tsx
+++ b/apps/app/app/admin/transactions/page.tsx
@@ -1,15 +1,11 @@
 import { getAllTransactions } from "@gredice/storage";
 import { Card, CardOverflow } from "@signalco/ui-primitives/Card";
 import { Chip } from "@signalco/ui-primitives/Chip";
-import { Table } from "@signalco/ui-primitives/Table";
 import { auth } from "../../../lib/auth/auth";
-import { KnownPages } from "../../../src/KnownPages";
-import Link from "next/link";
-import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
-import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
 import { Typography } from "@signalco/ui-primitives/Typography";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Stack } from "@signalco/ui-primitives/Stack";
+import { TransactionsTable } from "./TransactionsTable";
 
 export const dynamic = 'force-dynamic';
 
@@ -37,96 +33,7 @@ export default async function TransactionsPage() {
             </Row>
             <Card>
                 <CardOverflow>
-                    <Table>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.Head>ID</Table.Head>
-                                <Table.Head>Račun</Table.Head>
-                                <Table.Head>Status</Table.Head>
-                                <Table.Head>Iznos</Table.Head>
-                                <Table.Head>Računi</Table.Head>
-                                <Table.Head>Datum kreiranja</Table.Head>
-                                <Table.Head>Stripe Payment ID</Table.Head>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {transactions.length === 0 && (
-                                <Table.Row>
-                                    <Table.Cell colSpan={7}>
-                                        <NoDataPlaceholder>
-                                            Nema transakcija
-                                        </NoDataPlaceholder>
-                                    </Table.Cell>
-                                </Table.Row>
-                            )}
-                            {transactions.map(transaction => {
-                                const invoiceCount = transaction.invoices?.length || 0;
-                                const hasNoInvoices = invoiceCount === 0;
-
-                                return (
-                                    <Table.Row key={transaction.id} className={hasNoInvoices ? 'bg-green-50 dark:bg-green-950' : ''}>
-                                        <Table.Cell>
-                                            <Link href={KnownPages.Transaction(transaction.id)}>
-                                                {transaction.id}
-                                            </Link>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {transaction.accountId && (
-                                                <Link href={KnownPages.Account(transaction.accountId)}>
-                                                    {transaction.accountId}
-                                                </Link>
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Chip color="info" size="lg" className="w-fit">
-                                                <Typography noWrap>
-                                                    {transaction.status}
-                                                </Typography>
-                                            </Chip>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Chip color="success" size="lg" className="w-fit">
-                                                <Typography noWrap>
-                                                    €{(transaction.amount / 100).toFixed(2)}
-                                                </Typography>
-                                            </Chip>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Row spacing={1} alignItems="center">
-                                                {hasNoInvoices ? (
-                                                    <Chip color="success" size="sm" className="w-fit">
-                                                        <Typography noWrap className="text-xs">
-                                                            ✨ Bez računa
-                                                        </Typography>
-                                                    </Chip>
-                                                ) : (
-                                                    <Chip color="primary" size="sm" className="w-fit">
-                                                        <Typography noWrap className="text-xs">
-                                                            📋 {invoiceCount} račun{invoiceCount > 1 ? 'a' : ''}
-                                                        </Typography>
-                                                    </Chip>
-                                                )}
-                                            </Row>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <LocaleDateTime time={false}>
-                                                {transaction.createdAt}
-                                            </LocaleDateTime>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {transaction.stripePaymentId ? (
-                                                <Link href={KnownPages.StripePayment(transaction.stripePaymentId)}>
-                                                    {transaction.stripePaymentId}
-                                                </Link>
-                                            ) : (
-                                                <span className="text-gray-500">Nema Stripe ID</span>
-                                            )}
-                                        </Table.Cell>
-                                    </Table.Row>
-                                );
-                            })}
-                        </Table.Body>
-                    </Table>
+                    <TransactionsTable />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -158,11 +158,17 @@ export async function deleteShoppingCart(accountId: string) {
     }
 }
 
-export async function getAllShoppingCarts({ status = 'new' }: { status?: 'new' | 'paid' | null } = {}) {
+export async function getAllShoppingCarts({ status = 'new', filter }: {
+    status?: 'new' | 'paid' | null
+    filter?: {
+        accountId?: string
+    }
+} = {}) {
     return await storage().query.shoppingCarts.findMany({
         where: and(
             eq(shoppingCarts.isDeleted, false),
-            status ? eq(shoppingCarts.status, status) : undefined
+            status ? eq(shoppingCarts.status, status) : undefined,
+            filter?.accountId ? eq(shoppingCarts.accountId, filter.accountId) : undefined
         ),
         with: {
             account: {

--- a/packages/storage/src/repositories/transactionsRepo.ts
+++ b/packages/storage/src/repositories/transactionsRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { and, eq } from "drizzle-orm";
-import { transactions, InsertTransaction, UpdateTransaction } from "../schema";
+import { transactions, InsertTransaction, UpdateTransaction, invoices } from "../schema";
 import { storage } from "../storage";
 import { createEvent, knownEvents } from "./eventsRepo";
 
@@ -33,20 +33,16 @@ export async function getTransaction(transactionId: number) {
     });
 }
 
-export async function getTransactions(accountId: string) {
+export async function getAllTransactions({ filter }: { filter?: { accountId?: string } } = {}) {
     return storage().query.transactions.findMany({
-        where: and(eq(transactions.accountId, accountId), eq(transactions.isDeleted, false)),
+        where: and(
+            filter?.accountId ? eq(transactions.accountId, filter.accountId) : undefined,
+            eq(transactions.isDeleted, false),
+        ),
         with: {
-            invoices: true,
-        },
-    });
-}
-
-export async function getAllTransactions() {
-    return storage().query.transactions.findMany({
-        where: eq(transactions.isDeleted, false),
-        with: {
-            invoices: true,
+            invoices: {
+                where: eq(invoices.isDeleted, false),
+            },
         },
         orderBy: transactions.createdAt
     });

--- a/packages/storage/tests/transactionsRepo.node.spec.ts
+++ b/packages/storage/tests/transactionsRepo.node.spec.ts
@@ -4,7 +4,6 @@ import { createTestDb } from './testDb';
 import {
     createTransaction,
     getTransaction,
-    getTransactions,
     getAllTransactions,
     getTransactionByStripeId,
     updateTransaction,
@@ -32,12 +31,12 @@ test('createTransaction and getTransaction', async () => {
     assert.strictEqual(tx.id, txId);
 });
 
-test('getTransactions returns transactions for account', async () => {
+test('getAllTransactions with account filter returns transactions for account', async () => {
     createTestDb();
     const transaction = await baseTransaction()
     const txId = await createTransaction(transaction);
     assert.ok(transaction.accountId != null);
-    const txs = await getTransactions(transaction.accountId);
+    const txs = await getAllTransactions({ filter: { accountId: transaction.accountId } });
     assert.ok(Array.isArray(txs));
     assert.ok(txs.some(t => t.id === txId));
 });


### PR DESCRIPTION
Remove unnecessary "text-gray-600" class from Typography components
in the invoice details page to simplify styling. Also, remove size="sm"
prop from Chip components to standardize their appearance. These changes
improve code clarity and maintain consistent UI styling across the page.