### PR TITLE
feat(operations): improve operation info linking and add attribute cards

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantOperations.tsx
+++ b/apps/www/app/biljke/[alias]/PlantOperations.tsx
@@ -11,8 +11,9 @@ import { KnownPages } from "../../../src/KnownPages";
 import { Euro, Info } from "@signalco/ui-icons";
 import { PlantData } from "@gredice/client";
 import { OperationImage } from "../../../components/operations/OperationImage";
+import Link from "next/link";
 
-function operationFrequencyLabel(frequency: string) {
+export function operationFrequencyLabel(frequency: string | undefined) {
     switch (frequency) {
         case 'optional':
             return 'Opcionalno/po potrebi';
@@ -29,7 +30,7 @@ function operationFrequencyLabel(frequency: string) {
         case 'monthly':
             return 'Svakog mjeseca';
         default:
-            return frequency;
+            return "Nepoznato";
     }
 }
 
@@ -61,43 +62,15 @@ export function PlantOperations({ operations }: { operations?: PlantData["inform
                                 <span>
                                     {operation.prices?.perOperation.toFixed(2)}€
                                 </span>
-                                <Modal
-                                    title={operation.information?.label ?? 'Informacije o operaciji'}
-                                    className="border border-tertiary border-b-4 max-w-xl"
-                                    trigger={(
-                                        <IconButton
-                                            size="lg"
-                                            variant="plain"
-                                            aria-label={`Više informacija o ${operation.information?.label}`}
-                                        >
-                                            <Info />
-                                        </IconButton>
-                                    )}>
-                                    <Stack spacing={4}>
-                                        <Row spacing={2}>
-                                            <OperationImage operation={operation} />
-                                            <Stack spacing={1}>
-                                                <Typography level="h4">{operation.information?.label}</Typography>
-                                                <p>{operation.information?.shortDescription}</p>
-                                            </Stack>
-                                        </Row>
-                                        {operation.information?.description && (
-                                            <Card>
-                                                <CardContent>
-                                                    <Markdown>{operation.information.description}</Markdown>
-                                                </CardContent>
-                                            </Card>
-                                        )}
-                                        <div className="grid grid-cols-2 gap-2">
-                                            <AttributeCard header="Cijena" icon={<Euro />} value={operation.prices?.perOperation.toFixed(2)} />
-                                        </div>
-                                        <NavigatingButton
-                                            href={KnownPages.GardenApp}
-                                            className="bg-green-800 hover:bg-green-700 self-end">
-                                            Moj vrt
-                                        </NavigatingButton>
-                                    </Stack>
-                                </Modal>
+                                <Link href={operation.information?.label ? KnownPages.Operation(operation.information?.label) : KnownPages.Operations}>
+                                    <IconButton
+                                        size="lg"
+                                        variant="plain"
+                                        aria-label={`Više informacija o ${operation.information?.label}`}
+                                    >
+                                        <Info />
+                                    </IconButton>
+                                </Link>
                             </Row>
                         </CardContent>
                     </Card>

--- a/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
+++ b/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
@@ -1,0 +1,78 @@
+import { Card, CardContent } from "@signalco/ui-primitives/Card";
+import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
+import { getOperationsData } from "../../../lib/plants/getOperationsData";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { Row } from "@signalco/ui-primitives/Row";
+import { NavigatingButton } from "@signalco/ui/NavigatingButton";
+import { KnownPages } from "../../../src/KnownPages";
+import { BlockImage } from "@gredice/ui/BlockImage";
+import { getPlantsData } from "../../../lib/plants/getPlantsData";
+import { PlantImage } from "../../../components/plants/PlantImage";
+
+export async function OperationApplicationsList({ operationId }: { operationId: number }) {
+    const operationsData = await getOperationsData();
+    const operation = operationsData?.find(op => op.id === operationId);
+    if (!operation) {
+        return <NoDataPlaceholder className="text-left py-4">Nije dostupno</NoDataPlaceholder>
+    }
+
+    if (operation.attributes.application === 'garden') {
+        return (
+            <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                <Card>
+                    <CardContent noHeader>
+                        <Row justifyContent="space-between">
+                            <Typography>Dostupno u tvom vrtu</Typography>
+                            <NavigatingButton href={KnownPages.GardenApp} className="bg-green-800 hover:bg-green-700">
+                                Moj vrt
+                            </NavigatingButton>
+                        </Row>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    if (operation.attributes.application === 'raisedBedFull' ||
+        operation.attributes.application === 'raisedBed1m') {
+        return (
+            <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                <Card>
+                    <CardContent noHeader>
+                        <Row spacing={2}>
+                            <BlockImage blockName="Raised_Bed" width={42} height={42} />
+                            <Typography>
+                                Ova radnja je dostupna u svim gredicama
+                            </Typography>
+                        </Row>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    if (operation.attributes.application === 'plant') {
+        const plants = await getPlantsData();
+        const plantsWithOperation = plants?.filter(plant => plant.information.operations?.map(op => op.information?.name).includes(operation.information.name));
+        if (plantsWithOperation && (plantsWithOperation?.length ?? 0) > 0) {
+            return (
+                <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
+                    {plantsWithOperation.map(plant => (
+                        <Card key={plant.id} href={KnownPages.Plant(plant.information.name)}>
+                            <CardContent noHeader>
+                                <Row spacing={2}>
+                                    <PlantImage plant={plant} width={42} height={42} />
+                                    <Typography>
+                                        {plant.information.name ?? 'Nepoznato'}
+                                    </Typography>
+                                </Row>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            )
+        }
+    }
+
+    return <NoDataPlaceholder className="text-left py-4">Nije dostupno</NoDataPlaceholder>
+}

--- a/apps/www/app/radnje/[alias]/OperationAttributesCards.tsx
+++ b/apps/www/app/radnje/[alias]/OperationAttributesCards.tsx
@@ -1,0 +1,33 @@
+import { Sun, Sprout, Leaf, Ruler, Tally3, Hourglass } from "@signalco/ui-icons"
+import { AttributeCard } from "../../../components/attributes/DetailCard";
+import { OperationData } from "@gredice/client";
+import { JSX } from "react";
+import { operationFrequencyLabel } from "../../biljke/[alias]/PlantOperations";
+
+export function OperationAttributesCards({ attributes }: { attributes: OperationData['attributes'] | undefined }) {
+    const applicationMap: Record<string, { label: string; icon: JSX.Element }> = {
+        garden: { label: 'Vrt', icon: <Sun className="size-5 shrink-0" /> },
+        raisedBedFull: { label: 'Cijela gredica', icon: <Tally3 className="size-5 shrink-0 rotate-90 mt-1" /> },
+        raisedBed1m: { label: 'Gredica 1m²', icon: <Tally3 className="size-5 shrink-0 rotate-90 mt-1" /> },
+        plant: { label: 'Biljka', icon: <Leaf className="size-5 shrink-0" /> },
+    }
+
+    return (
+        <div className="grid grid-cols-2 gap-2">
+            {attributes?.application && (
+                <AttributeCard
+                    icon={applicationMap[attributes.application]?.icon ?? <Ruler />}
+                    header="Primjena"
+                    value={applicationMap[attributes?.application]?.label ?? '-'} />
+            )}
+            <AttributeCard
+                icon={<Hourglass />}
+                header="Učestalost"
+                value={operationFrequencyLabel(attributes?.frequency)} />
+            <AttributeCard
+                icon={<Sprout />}
+                header="Stadij"
+                value={attributes?.stage?.information?.label ?? '-'} />
+        </div>
+    )
+}

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -37,7 +37,7 @@ export default async function OperationPage({ params }: { params: Promise<{ alia
                 >
                     <Stack>
                         <Stack spacing={1} className="group">
-                            <Typography level="h2" className="text-2xl">Svojstva</Typography>
+                            <Typography level="h2" className="text-2xl">Informacije</Typography>
                             <div className="grid grid-cols-2 gap-2">
                                 <AttributeCard
                                     icon={<Euro />}

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -2,6 +2,17 @@ import { Stack } from "@signalco/ui-primitives/Stack";
 import { getOperationsData } from "../../../lib/plants/getOperationsData";
 import { PageHeader } from "../../../components/shared/PageHeader";
 import { notFound } from "next/navigation";
+import { Markdown } from "../../../components/shared/Markdown";
+import { Row } from "@signalco/ui-primitives/Row";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { FeedbackModal } from "../../../components/shared/feedback/FeedbackModal";
+import { OperationAttributesCards } from "./OperationAttributesCards";
+import { OperationImage } from "../../../components/operations/OperationImage";
+import { KnownPages } from "../../../src/KnownPages";
+import { Breadcrumbs } from "@signalco/ui/Breadcrumbs";
+import { Euro } from "@signalco/ui-icons";
+import { AttributeCard } from "../../../components/attributes/DetailCard";
+import { OperationApplicationsList } from "./OperationApplicationsList";
 
 export default async function OperationPage({ params }: { params: Promise<{ alias: string }> }) {
     const { alias: aliasUnescaped } = await params;
@@ -13,12 +24,67 @@ export default async function OperationPage({ params }: { params: Promise<{ alia
     }
 
     return (
-        <Stack>
-            <PageHeader
-                header={operation.information.label}
-                subHeader={operation.information.shortDescription}
-                padded
-            />
-        </Stack>
+        <div className="py-8">
+            <Stack spacing={4}>
+                <Breadcrumbs items={[
+                    { label: 'Radnje', href: KnownPages.Operations },
+                    { label: operation.information.label }
+                ]} />
+                <PageHeader
+                    visual={<OperationImage operation={operation} size={128} />}
+                    header={operation.information.label}
+                    subHeader={operation.information.shortDescription}
+                >
+                    <Stack>
+                        <Stack spacing={1} className="group">
+                            <Typography level="h2" className="text-2xl">Svojstva</Typography>
+                            <div className="grid grid-cols-2 gap-2">
+                                <AttributeCard
+                                    icon={<Euro />}
+                                    header="Cijena"
+                                    value={`${operation.prices.perOperation.toFixed(2)}€`} />
+                            </div>
+                            <FeedbackModal
+                                topic={"www/operations/information"}
+                                data={{
+                                    operationId: operation.id,
+                                    operationAlias: alias
+                                }}
+                                className="self-end group-hover:opacity-100 opacity-0 transition-opacity" />
+                        </Stack>
+                        <Stack spacing={1} className="group">
+                            <Typography level="h2" className="text-2xl">Svojstva</Typography>
+                            <OperationAttributesCards attributes={operation.attributes} />
+                            <FeedbackModal
+                                topic={"www/operations/attributes"}
+                                data={{
+                                    operationId: operation.id,
+                                    operationAlias: alias
+                                }}
+                                className="self-end group-hover:opacity-100 opacity-0 transition-opacity" />
+                        </Stack>
+                    </Stack>
+                </PageHeader>
+                <div className="max-w-xl">
+                    <Markdown>
+                        {operation.information.description || "Nema opisa za ovu radnju."}
+                    </Markdown>
+                </div>
+                <Stack>
+                    <Typography level="h2" className="text-2xl">Dostupno za</Typography>
+                    <OperationApplicationsList
+                        operationId={operation.id} />
+                </Stack>
+                <Row spacing={2}>
+                    <Typography level="body1">Jesu li ti informacije o ovoj radnji korisne?</Typography>
+                    <FeedbackModal
+                        topic="www/operations/details"
+                        data={{
+                            operationId: operation.id,
+                            operationAlias: alias
+                        }} />
+                </Row>
+            </Stack>
+        </div>
     );
 }

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -6,6 +6,7 @@ import { OperationImage } from "../../components/operations/OperationImage";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Card, CardContent } from "@signalco/ui-primitives/Card";
 import { KnownPages } from "../../src/KnownPages";
+import { FeedbackModal } from "../../components/shared/feedback/FeedbackModal";
 
 function OperationCard({ operation }: { operation: OperationData }) {
     return (
@@ -33,27 +34,36 @@ export default async function OperationsPage() {
     const stagesLabels = [...new Set(operationsData?.map(op => op.attributes.stage?.information?.label) || [])];
 
     return (
-        <Stack>
+        <Stack spacing={4}>
             <PageHeader
                 header="Radnje"
                 subHeader={`Sve što trebaš znati o radnjama koje možeš obavljati u svojim gredicama 🪏`}
                 padded
             />
-            <Stack spacing={2}>
+            <Stack spacing={4}>
                 {!operationsData?.length && (
                     <div>Nema dostupnih radnji.</div>
                 )}
                 {stagesLabels.map((stageLabel) => (
                     <Stack key={stageLabel} spacing={1}>
-                        <Typography level="h2">{stageLabel}</Typography>
-                        {operationsData
-                            ?.filter(op => op.attributes.stage?.information?.label === stageLabel)
-                            .map((operation) => (
-                                <OperationCard key={operation.id} operation={operation} />
-                            ))}
+                        <Typography level="h3">{stageLabel}</Typography>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                            {operationsData
+                                ?.filter(op => op.attributes.stage?.information?.label === stageLabel)
+                                .sort((a, b) => a.information.label.localeCompare(b.information.label))
+                                .map((operation) => (
+                                    <OperationCard key={operation.id} operation={operation} />
+                                ))}
+                        </div>
                     </Stack>
                 ))}
             </Stack>
+            <Row spacing={2}>
+                <Typography level="body1">Jesu li ti informacije o radnjama korisne?</Typography>
+                <FeedbackModal
+                    topic="www/operations"
+                />
+            </Row>
         </Stack>
     );
 }

--- a/apps/www/components/operations/OperationImage.tsx
+++ b/apps/www/components/operations/OperationImage.tsx
@@ -1,22 +1,27 @@
 import Image from "next/image";
 import { OperationData } from "../../lib/plants/getOperationsData";
+import { Hammer } from "@signalco/ui-icons";
 
-export function OperationImage({ operation }: { operation: Partial<Pick<OperationData, "image" | "information">> }) {
+export function OperationImage({ operation, size }: { operation: Partial<Pick<OperationData, "image" | "information">>, size?: number }) {
     if (!operation.image?.cover?.url) {
         return (
-            <span className="size-[32px] text-3xl">🪏</span>
+            <Hammer
+                style={{
+                    "--imageSize": size ? `${size}px` : '32px',
+                } as React.CSSProperties}
+                className="size-[--imageSize]">🪏</Hammer>
         );
     }
 
     return (
         <Image
             src={operation.image.cover.url}
-            width={32}
-            height={32}
+            width={size ?? 32}
+            height={size ?? 32}
             style={{
                 objectFit: 'contain',
-                width: '32px',
-                height: '32px'
+                width: `${size ?? 32}px`,
+                height: `${size ?? 32}px`
             }}
             alt={operation.information?.label ?? "Slika operacije"} />
     );

--- a/apps/www/components/operations/OperationImage.tsx
+++ b/apps/www/components/operations/OperationImage.tsx
@@ -9,7 +9,7 @@ export function OperationImage({ operation, size }: { operation: Partial<Pick<Op
                 style={{
                     "--imageSize": size ? `${size}px` : '32px',
                 } as React.CSSProperties}
-                className="size-[--imageSize]">🪏</Hammer>
+                className="size-[--imageSize]" />
         );
     }
 


### PR DESCRIPTION
Change operationFrequencyLabel to handle undefined and return a default
"Nepoznato" for unknown frequencies to improve robustness.

Replace modal-based operation info display with a Next.js Link wrapping
the info icon, enabling navigation to detailed operation pages for better
user experience and simpler UI.

Add OperationAttributesCards component to display operation attributes with
icons and labels, enhancing attribute visualization and consistency across
the app.