### PR TITLE
feat/garden-operations-tabs

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantOperations.tsx
+++ b/apps/www/app/biljke/[alias]/PlantOperations.tsx
@@ -1,14 +1,9 @@
 import { Card, CardContent } from "@signalco/ui-primitives/Card";
-import { Modal } from "@signalco/ui-primitives/Modal";
-import { Typography } from "@signalco/ui-primitives/Typography";
 import { IconButton } from "@signalco/ui-primitives/IconButton";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Stack } from "@signalco/ui-primitives/Stack";
-import { Markdown } from "../../../components/shared/Markdown";
-import { AttributeCard } from "../../../components/attributes/DetailCard";
-import { NavigatingButton } from "@signalco/ui/NavigatingButton";
 import { KnownPages } from "../../../src/KnownPages";
-import { Euro, Info } from "@signalco/ui-icons";
+import { Info } from "@signalco/ui-icons";
 import { PlantData } from "@gredice/client";
 import { OperationImage } from "../../../components/operations/OperationImage";
 import Link from "next/link";

--- a/apps/www/app/biljke/[alias]/PlantOperations.tsx
+++ b/apps/www/app/biljke/[alias]/PlantOperations.tsx
@@ -5,7 +5,7 @@ import { Stack } from "@signalco/ui-primitives/Stack";
 import { KnownPages } from "../../../src/KnownPages";
 import { Info } from "@signalco/ui-icons";
 import { PlantData } from "@gredice/client";
-import { OperationImage } from "../../../components/operations/OperationImage";
+import { OperationImage } from "@gredice/ui/OperationImage";
 import Link from "next/link";
 
 export function operationFrequencyLabel(frequency: string | undefined) {

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -7,7 +7,7 @@ import { Row } from "@signalco/ui-primitives/Row";
 import { Typography } from "@signalco/ui-primitives/Typography";
 import { FeedbackModal } from "../../../components/shared/feedback/FeedbackModal";
 import { OperationAttributesCards } from "./OperationAttributesCards";
-import { OperationImage } from "../../../components/operations/OperationImage";
+import { OperationImage } from "@gredice/ui/OperationImage";
 import { KnownPages } from "../../../src/KnownPages";
 import { Breadcrumbs } from "@signalco/ui/Breadcrumbs";
 import { Euro } from "@signalco/ui-icons";

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -2,7 +2,7 @@ import { Stack } from "@signalco/ui-primitives/Stack";
 import { PageHeader } from "../../components/shared/PageHeader";
 import { getOperationsData, OperationData } from "../../lib/plants/getOperationsData";
 import { Typography } from "@signalco/ui-primitives/Typography";
-import { OperationImage } from "../../components/operations/OperationImage";
+import { OperationImage } from "@gredice/ui/OperationImage";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Card, CardContent } from "@signalco/ui-primitives/Card";
 import { KnownPages } from "../../src/KnownPages";

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -58,11 +58,11 @@ export function GameScene({
     useThemeManager();
 
     // Prelaod all required data 
-    const { isPending: blockDataPending } = useBlockData();
-    const { data: garden, isPending: gardenPending } = useCurrentGarden();
-    const { isPending: weatherPending } = useWeatherNow();
-    const isPending = gardenPending || blockDataPending || weatherPending;
-    if (isPending) {
+    const { isLoading: blockDataPending } = useBlockData();
+    const { data: garden, isLoading: gardenPending } = useCurrentGarden();
+    const { isLoading: weatherPending } = useWeatherNow();
+    const isLoading = gardenPending || blockDataPending || weatherPending;
+    if (isLoading) {
         return (
             <GardenLoadingIndicator />
         );

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -125,7 +125,7 @@ function ProfileCard() {
 
 export function AccountHud() {
     const { data: currentUser } = useCurrentUser();
-    const { data: currentGarden, isPending } = useCurrentGarden();
+    const { data: currentGarden, isLoading } = useCurrentGarden();
     const { data: notifications } = useNotifications(currentUser?.id, false);
     const hasUnreadNotifications = notifications?.some(notification => !notification.readAt);
 
@@ -155,7 +155,7 @@ export function AccountHud() {
                     <ProfileCard />
                 </DropdownMenu>
                 <div className="hidden md:block">
-                    {isPending ? (
+                    {isLoading ? (
                         <Skeleton className="w-32 h-7" />
                     ) : (currentGarden && (
                         <SelectItems

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -7,7 +7,7 @@ import { Typography } from "@signalco/ui-primitives/Typography";
 import { Row } from "@signalco/ui-primitives/Row";
 import { RaisedBedSensorInfo } from "./raisedBed/RaisedBedSensorInfo";
 import { ButtonGreen } from "../shared-ui/ButtonGreen";
-import { RaisedBedInfo } from "../controls/components/RaisedBedInfo";
+import { RaisedBedInfo } from "./raisedBed/RaisedBedInfo";
 import { Modal } from "@signalco/ui-primitives/Modal";
 import { SVGProps } from "react";
 import { RaisedBedFieldSuggestions } from "./raisedBed/RaisedBedFieldSuggestions";
@@ -59,6 +59,8 @@ export function RaisedBedFieldHud({
                     <div className="absolute max-w-64 md:max-w-[312px] top-[calc(50%-203.5px)] left-[calc(50%-156.5px)]">
                         <Modal
                             title="Informacije o gredici"
+                            modal={false}
+                            className="md:border-tertiary md:border-b-4"
                             trigger={(
                                 <ButtonGreen fullWidth>
                                     <Row spacing={1}>

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -176,6 +176,7 @@ export function ShoppingCartHud() {
                 <Modal
                     title="Košarica"
                     className='bg-card border-tertiary border-b-4 md:max-w-2xl'
+                    modal={false}
                     trigger={(
                         <IconButton
                             title="Košarica"

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -58,10 +58,10 @@ function SunflowersCard() {
 }
 
 function SunflowersAmount() {
-    const { data: account, isPending } = useCurrentAccount();
+    const { data: account, isLoading } = useCurrentAccount();
     const sunflowerCount = account?.sunflowers.amount;
 
-    if (isPending) {
+    if (isLoading) {
         return null;
     }
 

--- a/packages/game/src/hud/raisedBed/OperationListItemSkeleton.tsx
+++ b/packages/game/src/hud/raisedBed/OperationListItemSkeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@signalco/ui-primitives/Skeleton";
+
+export function OperationListItemSkeleton() {
+    return (
+        <div className="p-2 flex flex-row gap-2">
+            <Skeleton className="w-12 h-12" />
+            <div className="flex flex-col gap-1">
+                <Skeleton className="w-32 h-6" />
+                <Skeleton className="w-44 h-5" />
+            </div>
+        </div>
+    )
+}

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -13,8 +13,84 @@ import { Row } from "@signalco/ui-primitives/Row";
 import { Button } from "@signalco/ui-primitives/Button";
 import { useEffect } from "react";
 import { cx } from "@signalco/ui-primitives/cx";
+import { AnimateFlyToItem, useAnimateFlyToShoppingCart } from "../../indicators/AnimateFlyTo";
 
-export function PlantsSortList({ plantId, selectedSortId, onChange }: { plantId: number, selectedSortId: number | null, onChange: (plant: PlantSortData) => void }) {
+type PlantsSortListProps = {
+    plantId: number;
+    selectedSortId: number | null;
+    onChange: (plant: PlantSortData) => void;
+    flyToShoppingCart?: boolean;
+};
+
+function PlantSortListItem({
+    sort,
+    selectedSortId,
+    onChange,
+    flyToShoppingCart
+}: {
+    sort: PlantSortData;
+    selectedSortId: number | null;
+    onChange: (sort: PlantSortData) => void;
+    flyToShoppingCart?: boolean;
+}) {
+    const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
+
+    useEffect(() => {
+        if (flyToShoppingCart) {
+            animateFlyToShoppingCart.run();
+        } else {
+            animateFlyToShoppingCart.reset();
+        }
+    }, [flyToShoppingCart]);
+
+    return (
+        <Stack className={cx(
+            selectedSortId === sort.id && 'bg-muted'
+        )}>
+            <Button
+                // variant={selectedSortId === sort.id ? "soft" : "plain"}
+                variant="plain"
+                className={cx(
+                    "justify-between text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
+                )}
+                onClick={() => onChange(sort)}>
+                <Row spacing={1.5}>
+                    <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
+                        <img
+                            src={'https://www.gredice.com/' + (sort.image?.cover?.url ?? sort.information.plant.image?.cover?.url)}
+                            alt={sort.information.name}
+                            width={48}
+                            height={48}
+                            className="size-12 shrink-0 min-w-12"
+                        />
+                    </AnimateFlyToItem>
+                    <Stack>
+                        <Typography level="body1" semiBold>{sort.information.name}</Typography>
+                        <Typography level="body2" className="font-normal line-clamp-2 break-words">{sort.information.shortDescription ?? sort.information.plant.information?.description}</Typography>
+                    </Stack>
+                </Row>
+                {selectedSortId === sort.id && (
+                    <Check
+                        className="size-5 shrink-0"
+                        title="Odabrano"
+                    />
+                )}
+            </Button>
+            <Row justifyContent="end" className="px-4">
+                <Button
+                    title="Više informacija"
+                    href={KnownPages.GredicePlantSort(sort.information.plant.information?.name ?? 'nepoznato', sort.information.name)}
+                    variant="link"
+                    size="sm"
+                >
+                    Više informacija...
+                </Button>
+            </Row>
+        </Stack>
+    );
+}
+
+export function PlantsSortList({ plantId, selectedSortId, onChange, flyToShoppingCart }: PlantsSortListProps) {
     const { data: plantSorts, isLoading, isError } = usePlantSorts(plantId);
     const [search] = useSearchParam('pretraga', '');
     const storePlants = plantSorts?.filter(sort => sort.store.availableInStore);
@@ -46,46 +122,13 @@ export function PlantsSortList({ plantId, selectedSortId, onChange }: { plantId:
                     <PlantListItemSkeleton key={index} />
                 ))}
                 {filteredPlantSorts?.map((sort) => (
-                    <Stack key={sort.id} className={cx(
-                        selectedSortId === sort.id && 'bg-muted'
-                    )}>
-                        <Button
-                            // variant={selectedSortId === sort.id ? "soft" : "plain"}
-                            variant="plain"
-                            className={cx(
-                                "justify-between text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
-                            )}
-                            onClick={() => onChange(sort)}>
-                            <Row spacing={1.5}>
-                                <img
-                                    src={'https://www.gredice.com/' + (sort.image?.cover?.url ?? sort.information.plant.image?.cover?.url)}
-                                    alt={sort.information.name}
-                                    width={48}
-                                    height={48}
-                                    className="size-12" />
-                                <Stack>
-                                    <Typography level="body1" semiBold>{sort.information.name}</Typography>
-                                    <Typography level="body2" className="font-normal line-clamp-2 break-words">{sort.information.shortDescription ?? sort.information.plant.information?.description}</Typography>
-                                </Stack>
-                            </Row>
-                            {selectedSortId === sort.id && (
-                                <Check
-                                    className="size-5 shrink-0"
-                                    title="Odabrano"
-                                />
-                            )}
-                        </Button>
-                        <Row justifyContent="end" className="px-4">
-                            <Button
-                                title="Više informacija"
-                                href={KnownPages.GredicePlantSort(sort.information.plant.information?.name ?? 'nepoznato', sort.information.name)}
-                                variant="link"
-                                size="sm"
-                            >
-                                Više informacija...
-                            </Button>
-                        </Row>
-                    </Stack>
+                    <PlantSortListItem
+                        key={sort.id}
+                        sort={sort}
+                        selectedSortId={selectedSortId}
+                        onChange={onChange}
+                        flyToShoppingCart={flyToShoppingCart && selectedSortId === sort.id}
+                    />
                 ))}
             </List>
         </>

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -7,7 +7,7 @@ import { RaisedBedFieldItemPlanted } from "./RaisedBedFieldItemPlanted";
 import { Stack } from "@signalco/ui-primitives/Stack";
 
 function RaisedBedFieldItem({ gardenId, raisedBedId, positionIndex }: { raisedBedId: number; gardenId: number; positionIndex: number }) {
-    const { data: garden, isPending: isGardenPending } = useCurrentGarden();
+    const { data: garden, isLoading: isGardenLoading } = useCurrentGarden();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
     if (!raisedBed) {
         return null;
@@ -16,7 +16,7 @@ function RaisedBedFieldItem({ gardenId, raisedBedId, positionIndex }: { raisedBe
     const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
     const hasField = Boolean(field);
 
-    if (isGardenPending) {
+    if (isGardenLoading) {
         return (
             <RaisedBedFieldItemButton isLoading={true} />
         );

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -8,8 +8,8 @@ import { usePlantSort } from "../../hooks/usePlantSorts";
 import { RaisedBedFieldItemButton } from "./RaisedBedFieldItemButton";
 
 export function RaisedBedFieldItemEmpty({ gardenId, raisedBedId, positionIndex }: { raisedBedId: number; gardenId: number; positionIndex: number }) {
-    const { data: cart, isPending: isCartPending } = useShoppingCart();
-    const { data: garden, isPending: isGardenPending } = useCurrentGarden();
+    const { data: cart, isLoading: isCartPending } = useShoppingCart();
+    const { data: garden, isLoading: isGardenPending } = useCurrentGarden();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
     if (!raisedBed) {
         return null;
@@ -20,7 +20,7 @@ export function RaisedBedFieldItemEmpty({ gardenId, raisedBedId, positionIndex }
         item.positionIndex === positionIndex);
     const cartPlantItem = cartItems?.find(item => item.entityTypeName === 'plantSort' && item.status === 'new');
     const cartPlantSortId = cartPlantItem ? Number(cartPlantItem.entityId) : null;
-    const { data: cartPlantSort, isPending: isCartPlantSortPending } = usePlantSort(cartPlantSortId);
+    const { data: cartPlantSort, isLoading: isCartPlantSortPending } = usePlantSort(cartPlantSortId);
     const cartPlantId = cartPlantSort?.information.plant.id;
     const additionalDataRaw = cartPlantItem?.additionalData ? JSON.parse(cartPlantItem.additionalData) : null;
     const cartPlantOptions = {

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,17 +1,18 @@
 import { useCurrentGarden } from "../../hooks/useCurrentGarden";
-import { Warning } from "@signalco/ui-icons";
+import { Hammer, Sprout, Warning } from "@signalco/ui-icons";
 import { usePlantSort } from "../../hooks/usePlantSorts";
 import { Modal } from "@signalco/ui-primitives/Modal";
 import { Stack } from "@signalco/ui-primitives/Stack";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Typography } from "@signalco/ui-primitives/Typography";
-import { Chip } from "@signalco/ui-primitives/Chip";
 import { RaisedBedFieldItemButton } from "./RaisedBedFieldItemButton";
 import { SegmentedCircularProgress } from "@gredice/ui/SegmentedCircularProgress";
-import { ReactNode } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@signalco/ui-primitives/Tabs";
+import { RaisedBedFieldLifecycleTab, useRaisedBedFieldLifecycleData } from "./RaisedBedFieldLifecycleTab";
+import { RaisedBedFieldOperationsTab } from "./RaisedBedFieldOperationsTab";
 
 export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { raisedBedId: number; positionIndex: number; }) {
-    const { data: garden, isPending: isGardenPending } = useCurrentGarden();
+    const { data: garden, isLoading: isGardenLoading } = useCurrentGarden();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
     if (!raisedBed) {
         return null;
@@ -24,12 +25,17 @@ export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { rais
     }
 
     const plantSortId = field.plantSortId;
-    const plantScheduledDate = field.plantScheduledDate
-        ? new Date(field.plantScheduledDate)
-        : null;
-    const { data: plantSort, isPending: isPlantSortPending } = usePlantSort(plantSortId);
+    const { data: plantSort, isLoading: isPlantSortLoading } = usePlantSort(plantSortId);
+    const {
+        germinationValue,
+        germinationPercentage,
+        growthValue,
+        growthPercentage,
+        harvestValue,
+        harvestPercentage
+    } = useRaisedBedFieldLifecycleData(raisedBedId, positionIndex);
 
-    const isLoading = isGardenPending || (Boolean(plantSortId) && isPlantSortPending);
+    const isLoading = isGardenLoading || (Boolean(plantSortId) && isPlantSortLoading);
     if (isLoading) {
         return (
             <RaisedBedFieldItemButton isLoading={true} />
@@ -44,93 +50,11 @@ export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { rais
         );
     }
 
-    let icon: ReactNode | null = null;
-    let localizedStatus = field.plantStatus;
-    switch (localizedStatus) {
-        case 'new':
-            icon = <span className="mr-0.5">{'🌟'}</span>;
-            localizedStatus = 'Čeka sijanje';
-            break;
-        case 'planned':
-            icon = <span className="mr-0.5">{'⌛'}</span>;
-            localizedStatus = 'Planirana';
-            break;
-        case 'sowed':
-            icon = <span className="mr-0.5">{'𓇢'}</span>;
-            localizedStatus = 'Posijana';
-            break;
-        case 'sprouted':
-            icon = <span className="mr-0.5">{'🌱'}</span>;
-            localizedStatus = 'Proklijala';
-            break;
-        case 'ready':
-            icon = <span className="mr-0.5">{'🌿'}</span>;
-            localizedStatus = 'Spremna za berbu';
-            break;
-        case 'harvested':
-            icon = <span className="mr-0.5">{'✅'}</span>;
-            localizedStatus = 'Ubrana';
-            break;
-        case 'died':
-            icon = <span className="mr-0.5">{'💀'}</span>;
-            localizedStatus = 'Uginula';
-            break;
-        case 'uprooted':
-            localizedStatus = 'Uklonjena';
-            break;
-        default:
-            localizedStatus = 'Nepoznato';
-            break;
-    }
-
-    const maxDuration =
-        (plantSort.information.plant.attributes?.germinationWindowMax ?? 0) +
-        (plantSort.information.plant.attributes?.growthWindowMax ?? 0) +
-        (plantSort.information.plant.attributes?.harvestWindowMax ?? 0);
-    const germinationPercentage = plantSort.information.plant.attributes?.germinationWindowMax
-        ? Math.max(10, Math.min(100, plantSort.information.plant.attributes.germinationWindowMax / (maxDuration ?? 0) * 100))
-        : 0;
-    const harvestPercentage = plantSort.information.plant.attributes?.harvestWindowMax
-        ? Math.min(100, plantSort.information.plant.attributes.harvestWindowMax / (maxDuration ?? 0) * 100)
-        : 0;
-    const growthPercentage = 100 - germinationPercentage - harvestPercentage;
-    const germinationWindowMs = (plantSort.information.plant.attributes?.germinationWindowMax ?? 0) * 24 * 60 * 60 * 1000;
-    const growthWindowMs = (plantSort.information.plant.attributes?.growthWindowMax ?? 0) * 24 * 60 * 60 * 1000;
-    const germinationValue = field.plantGrowthDate
-        ? 100
-        : (field.plantSowDate
-            ? Math.min(100, ((Date.now() - new Date(field.plantSowDate).getTime())) / (germinationWindowMs || 1) * 100)
-            : 0);
-    const germinatingDays = Math.round(((field.plantGrowthDate
-        ? new Date(field.plantGrowthDate).getTime()
-        : Date.now()) - (field.plantSowDate
-            ? new Date(field.plantSowDate).getTime()
-            : Date.now())) / (1000 * 60 * 60 * 24));
-    const germinatingDaysDayPlural = germinatingDays === 1 ? 'dan' : 'dana';
-
-    const growthValue = field.plantReadyDate ?
-        100
-        : (field.plantGrowthDate
-            ? Math.min(100, (Date.now() - new Date(field.plantGrowthDate).getTime()) / (growthWindowMs || 1) * 100)
-            : 0);
-    const growingDays = Math.round(((field.plantReadyDate
-        ? new Date(field.plantReadyDate).getTime()
-        : Date.now()) - (field.plantGrowthDate
-            ? new Date(field.plantGrowthDate).getTime()
-            : Date.now())) / (1000 * 60 * 60 * 24));
-    const growingDaysDayPlural = growingDays === 1 ? 'dan' : 'dana';
-
-    const harvestValue = field.plantReadyDate
-        ? Math.min(100, (Date.now() - new Date(field.plantReadyDate).getTime()) / (plantSort.information.plant.attributes?.harvestWindowMax ?? 1) * 100)
-        : 0;
-    const readyDays = Math.round(((Date.now() - (field.plantReadyDate
-        ? new Date(field.plantReadyDate).getTime()
-        : Date.now())) / (1000 * 60 * 60 * 24)));
-    const readyDaysDayPlural = readyDays === 1 ? 'dan' : 'dana';
-
     return (
         <Modal
             title={`Biljka "${plantSort.information.name}"`}
+            modal={false}
+            className="md:border-tertiary md:border-b-4"
             trigger={(
                 <RaisedBedFieldItemButton>
                     <SegmentedCircularProgress
@@ -151,7 +75,7 @@ export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { rais
                     </SegmentedCircularProgress>
                 </RaisedBedFieldItemButton>
             )}>
-            <Stack spacing={4}>
+            <Stack spacing={2}>
                 <Row spacing={2}>
                     <img
                         src={`https://www.gredice.com/${plantSort.image?.cover?.url || plantSort.information.plant.image?.cover?.url}`}
@@ -161,101 +85,36 @@ export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { rais
                     />
                     <Typography level="h3">{plantSort.information.name}</Typography>
                 </Row>
-                <div className="grid grid-cols-[auto_1fr] gap-2 items-center">
-                    {plantScheduledDate && (
-                        <>
-                            <Typography level="body2">Planirani datum</Typography>
-                            <div className="flex items-start">
-                                <Chip>{plantScheduledDate?.toLocaleDateString("hr-HR") || 'Nepoznato'}</Chip>
-                            </div>
-                        </>
-                    )}
-                    <Stack spacing={1}>
-                        <Row spacing={2}>
-                            <SegmentedCircularProgress
-                                size={140}
-                                strokeWidth={3}
-                                segments={[
-                                    { value: germinationValue, percentage: germinationPercentage, color: "stroke-yellow-500", trackColor: "stroke-yellow-200 dark:stroke-yellow-50", pulse: !field.plantGrowthDate },
-                                    { value: growthValue, percentage: growthPercentage, color: "stroke-green-500", trackColor: "stroke-green-200 dark:stroke-green-50", pulse: !field.plantReadyDate },
-                                    { value: harvestValue, percentage: harvestPercentage, color: "stroke-blue-500", trackColor: "stroke-blue-200 dark:stroke-blue-50", pulse: Boolean(harvestValue) },
-                                ]}
-                            >
-                                <Stack alignItems="center" className="border bg-card rounded-full shrink-0 size-[100px] aspect-square shadow flex items-center justify-center">
-                                    <span className="text-2xl">{icon}</span>
-                                    <Typography level="body1" className="text-center" semiBold>
-                                        {localizedStatus}
-                                    </Typography>
-                                </Stack>
-                            </SegmentedCircularProgress>
-                            <Stack spacing={1}>
-                                <Stack>
-                                    <Typography level="body2" secondary>Klijanje ({plantSort.information.plant.attributes?.germinationWindowMin}-{plantSort.information.plant.attributes?.germinationWindowMax} dana)</Typography>
-                                    <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
-                                        <Typography>
-                                            {field.plantSowDate
-                                                ? new Date(field.plantSowDate).toLocaleDateString("hr-HR")
-                                                : 'Nije posijano'}
-                                        </Typography>
-                                        {field.plantSowDate && (
-                                            <>
-                                                <span>-</span>
-                                                <Typography noWrap>
-                                                    {field.plantGrowthDate
-                                                        ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
-                                                        : 'U tijeku...'}
-                                                </Typography>
-                                                <Typography>
-                                                    ({germinatingDays} {germinatingDaysDayPlural})
-                                                </Typography>
-                                            </>
-                                        )}
-                                    </div>
-                                </Stack>
-                                <Stack>
-                                    <Typography level="body2" secondary>Rast ({plantSort.information.plant.attributes?.growthWindowMin}-{plantSort.information.plant.attributes?.growthWindowMax} dana)</Typography>
-                                    <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
-                                        <Typography>
-                                            {field.plantGrowthDate
-                                                ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
-                                                : 'Nije u fazi rasta'}
-                                        </Typography>
-                                        {field.plantGrowthDate && (
-                                            <>
-                                                <span>-</span>
-                                                <Typography noWrap>
-                                                    {field.plantReadyDate
-                                                        ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
-                                                        : 'U tijeku...'}
-                                                </Typography>
-                                                <Typography>
-                                                    ({growingDays} {growingDaysDayPlural})
-                                                </Typography>
-                                            </>
-                                        )}
-                                    </div>
-                                </Stack>
-                                <Stack>
-                                    <Typography level="body2" secondary>Berba ({plantSort.information.plant.attributes?.harvestWindowMin}-{plantSort.information.plant.attributes?.harvestWindowMax} dana)</Typography>
-                                    <Row spacing={0.5}>
-                                        <Typography>
-                                            {field.plantReadyDate
-                                                ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
-                                                : 'Nije u fazi berbe'}
-                                        </Typography>
-                                        {field.plantReadyDate && (
-                                            <Typography>
-                                                ({readyDays} {readyDaysDayPlural})
-                                            </Typography>
-                                        )}
-                                    </Row>
-                                </Stack>
-                            </Stack>
-                        </Row>
-                    </Stack>
-                </div>
+                <Tabs defaultValue="lifecycle" className="flex flex-col gap-2">
+                    <TabsList className="border w-fit self-center">
+                        <TabsTrigger value="lifecycle">
+                            <Row spacing={1}>
+                                <Sprout className="size-4 shrink-0" />
+                                <Typography>Biljka</Typography>
+                            </Row>
+                        </TabsTrigger>
+                        <TabsTrigger value="operations">
+                            <Row spacing={1}>
+                                <Hammer className="size-4 shrink-0" />
+                                <Typography>Radnje</Typography>
+                            </Row>
+                        </TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="operations">
+                        {garden && (
+                            <RaisedBedFieldOperationsTab
+                                gardenId={garden.id}
+                                raisedBedId={raisedBedId}
+                                positionIndex={positionIndex}
+                                plantSortId={field.plantSortId} />
+                        )}
+                    </TabsContent>
+                    <TabsContent value="lifecycle">
+                        <RaisedBedFieldLifecycleTab raisedBedId={raisedBedId} positionIndex={positionIndex} />
+                    </TabsContent>
+                </Tabs>
             </Stack>
-        </Modal>
+        </Modal >
     );
 
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -1,0 +1,277 @@
+import { SegmentedCircularProgress } from "@gredice/ui/SegmentedCircularProgress";
+import { Row } from "@signalco/ui-primitives/Row";
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { ReactNode } from "react";
+import { usePlantSort } from "../../hooks/usePlantSorts";
+import { useCurrentGarden } from "../../hooks/useCurrentGarden";
+import { Chip } from "@signalco/ui-primitives/Chip";
+
+// TODO: Move to a separate file
+export function useRaisedBedFieldLifecycleData(raisedBedId: number, positionIndex: number) {
+    const result = {
+        germinationValue: 0,
+        germinationPercentage: 0,
+        germinatingDays: 0,
+        growthValue: 0,
+        growthPercentage: 0,
+        growingDays: 0,
+        harvestValue: 0,
+        harvestPercentage: 0,
+        readyDays: 0
+    };
+    const { data: garden } = useCurrentGarden();
+    const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
+    if (!raisedBed) {
+        return result;
+    }
+
+    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
+    if (!field || !field.plantSortId) {
+        console.error(`Field not found for raised bed ${raisedBedId} at position index ${positionIndex}`, raisedBed.fields);
+        return result;
+    }
+
+    const plantSortId = field.plantSortId;
+    const { data: plantSort } = usePlantSort(plantSortId);
+    if (!plantSort) {
+        return result;
+    }
+
+    const maxDuration =
+        (plantSort.information.plant.attributes?.germinationWindowMax ?? 0) +
+        (plantSort.information.plant.attributes?.growthWindowMax ?? 0) +
+        (plantSort.information.plant.attributes?.harvestWindowMax ?? 0);
+    result.germinationPercentage = plantSort.information.plant.attributes?.germinationWindowMax
+        ? Math.max(10, Math.min(100, plantSort.information.plant.attributes.germinationWindowMax / (maxDuration ?? 0) * 100))
+        : 0;
+    result.harvestPercentage = plantSort.information.plant.attributes?.harvestWindowMax
+        ? Math.min(100, plantSort.information.plant.attributes.harvestWindowMax / (maxDuration ?? 0) * 100)
+        : 0;
+    const germinationWindowMs = (plantSort.information.plant.attributes?.germinationWindowMax ?? 0) * 24 * 60 * 60 * 1000;
+    result.germinationValue = field.plantGrowthDate
+        ? 100
+        : (field.plantSowDate
+            ? Math.min(100, ((Date.now() - new Date(field.plantSowDate).getTime())) / (germinationWindowMs || 1) * 100)
+            : 0);
+    result.germinatingDays = Math.round(((field.plantGrowthDate
+        ? new Date(field.plantGrowthDate).getTime()
+        : Date.now()) - (field.plantSowDate
+            ? new Date(field.plantSowDate).getTime()
+            : Date.now())) / (1000 * 60 * 60 * 24));
+
+    result.growthPercentage = 100 - result.germinationPercentage - result.harvestPercentage;
+    const growthWindowMs = (plantSort.information.plant.attributes?.growthWindowMax ?? 0) * 24 * 60 * 60 * 1000;
+    result.growthValue = field.plantReadyDate ?
+        100
+        : (field.plantGrowthDate
+            ? Math.min(100, (Date.now() - new Date(field.plantGrowthDate).getTime()) / (growthWindowMs || 1) * 100)
+            : 0);
+    result.growingDays = Math.round(((field.plantReadyDate
+        ? new Date(field.plantReadyDate).getTime()
+        : Date.now()) - (field.plantGrowthDate
+            ? new Date(field.plantGrowthDate).getTime()
+            : Date.now())) / (1000 * 60 * 60 * 24));
+
+    result.harvestValue = field.plantReadyDate
+        ? Math.min(100, (Date.now() - new Date(field.plantReadyDate).getTime()) / (plantSort.information.plant.attributes?.harvestWindowMax ?? 1) * 100)
+        : 0;
+    result.readyDays = Math.round(((Date.now() - (field.plantReadyDate
+        ? new Date(field.plantReadyDate).getTime()
+        : Date.now())) / (1000 * 60 * 60 * 24)));
+
+    return result;
+}
+
+function useRaisedBedField(raisedBedId: number, positionIndex: number) {
+    const { data: garden } = useCurrentGarden();
+    const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
+    if (!raisedBed) {
+        return null;
+    }
+
+    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
+    if (!field || !field.plantSortId) {
+        console.error(`Field not found for raised bed ${raisedBedId} at position index ${positionIndex}`, raisedBed.fields);
+        return null;
+    }
+
+    return field;
+}
+
+function useRaisedBedFieldPlantSort(raisedBedId: number, positionIndex: number) {
+    const field = useRaisedBedField(raisedBedId, positionIndex);
+    if (!field) {
+        return null;
+    }
+
+    const plantSortId = field.plantSortId;
+    const { data: plantSort } = usePlantSort(plantSortId);
+    if (!plantSort) {
+        return null;
+    }
+
+    return plantSort;
+}
+
+export function RaisedBedFieldLifecycleTab({ raisedBedId, positionIndex }: { raisedBedId: number; positionIndex: number }) {
+    const {
+        germinationValue,
+        germinationPercentage,
+        germinatingDays,
+        growthValue,
+        growthPercentage,
+        growingDays,
+        harvestValue,
+        harvestPercentage,
+        readyDays
+    } = useRaisedBedFieldLifecycleData(raisedBedId, positionIndex);
+    const field = useRaisedBedField(raisedBedId, positionIndex);
+    const plantSort = useRaisedBedFieldPlantSort(raisedBedId, positionIndex);
+    if (!plantSort || !field) {
+        return null;
+    }
+
+    const plantScheduledDate = field.plantScheduledDate
+        ? new Date(field.plantScheduledDate)
+        : null;
+
+    let icon: ReactNode | null = null;
+    let localizedStatus = field.plantStatus;
+    switch (localizedStatus) {
+        case 'new':
+            icon = <span className="mr-0.5">{'🌟'}</span>;
+            localizedStatus = 'Čeka sijanje';
+            break;
+        case 'planned':
+            icon = <span className="mr-0.5">{'⌛'}</span>;
+            localizedStatus = 'Planirana';
+            break;
+        case 'sowed':
+            icon = <span className="mr-0.5">{'𓇢'}</span>;
+            localizedStatus = 'Posijana';
+            break;
+        case 'sprouted':
+            icon = <span className="mr-0.5">{'🌱'}</span>;
+            localizedStatus = 'Proklijala';
+            break;
+        case 'ready':
+            icon = <span className="mr-0.5">{'🌿'}</span>;
+            localizedStatus = 'Spremna za berbu';
+            break;
+        case 'harvested':
+            icon = <span className="mr-0.5">{'✅'}</span>;
+            localizedStatus = 'Ubrana';
+            break;
+        case 'died':
+            icon = <span className="mr-0.5">{'💀'}</span>;
+            localizedStatus = 'Uginula';
+            break;
+        case 'uprooted':
+            localizedStatus = 'Uklonjena';
+            break;
+        default:
+            localizedStatus = 'Nepoznato';
+            break;
+    }
+
+    const germinatingDaysDayPlural = germinatingDays === 1 ? 'dan' : 'dana';
+    const growingDaysDayPlural = growingDays === 1 ? 'dan' : 'dana';
+    const readyDaysDayPlural = readyDays === 1 ? 'dan' : 'dana';
+
+    return (
+        <div className="grid grid-cols-[auto_1fr] gap-2 items-center">
+            <Stack spacing={1}>
+                {plantScheduledDate && (
+                    <>
+                        <Typography level="body2">Planirani datum</Typography>
+                        <div className="flex items-start">
+                            <Chip>{plantScheduledDate?.toLocaleDateString("hr-HR") || 'Nepoznato'}</Chip>
+                        </div>
+                    </>
+                )}
+                <Row spacing={2}>
+                    <SegmentedCircularProgress
+                        size={140}
+                        strokeWidth={3}
+                        segments={[
+                            { value: germinationValue, percentage: germinationPercentage, color: "stroke-yellow-500", trackColor: "stroke-yellow-200 dark:stroke-yellow-50", pulse: !field.plantGrowthDate },
+                            { value: growthValue, percentage: growthPercentage, color: "stroke-green-500", trackColor: "stroke-green-200 dark:stroke-green-50", pulse: !field.plantReadyDate },
+                            { value: harvestValue, percentage: harvestPercentage, color: "stroke-blue-500", trackColor: "stroke-blue-200 dark:stroke-blue-50", pulse: Boolean(harvestValue) },
+                        ]}
+                    >
+                        <Stack alignItems="center" className="border bg-card rounded-full shrink-0 size-[100px] aspect-square shadow flex items-center justify-center">
+                            <span className="text-2xl">{icon}</span>
+                            <Typography level="body1" className="text-center" semiBold>
+                                {localizedStatus}
+                            </Typography>
+                        </Stack>
+                    </SegmentedCircularProgress>
+                    <Stack spacing={1}>
+                        <Stack>
+                            <Typography level="body2" secondary>Klijanje ({plantSort.information.plant.attributes?.germinationWindowMin}-{plantSort.information.plant.attributes?.germinationWindowMax} dana)</Typography>
+                            <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
+                                <Typography>
+                                    {field.plantSowDate
+                                        ? new Date(field.plantSowDate).toLocaleDateString("hr-HR")
+                                        : 'Nije posijano'}
+                                </Typography>
+                                {field.plantSowDate && (
+                                    <>
+                                        <span>-</span>
+                                        <Typography noWrap>
+                                            {field.plantGrowthDate
+                                                ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
+                                                : 'U tijeku...'}
+                                        </Typography>
+                                        <Typography>
+                                            ({germinatingDays} {germinatingDaysDayPlural})
+                                        </Typography>
+                                    </>
+                                )}
+                            </div>
+                        </Stack>
+                        <Stack>
+                            <Typography level="body2" secondary>Rast ({plantSort.information.plant.attributes?.growthWindowMin}-{plantSort.information.plant.attributes?.growthWindowMax} dana)</Typography>
+                            <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
+                                <Typography>
+                                    {field.plantGrowthDate
+                                        ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
+                                        : 'Nije u fazi rasta'}
+                                </Typography>
+                                {field.plantGrowthDate && (
+                                    <>
+                                        <span>-</span>
+                                        <Typography noWrap>
+                                            {field.plantReadyDate
+                                                ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
+                                                : 'U tijeku...'}
+                                        </Typography>
+                                        <Typography>
+                                            ({growingDays} {growingDaysDayPlural})
+                                        </Typography>
+                                    </>
+                                )}
+                            </div>
+                        </Stack>
+                        <Stack>
+                            <Typography level="body2" secondary>Berba ({plantSort.information.plant.attributes?.harvestWindowMin}-{plantSort.information.plant.attributes?.harvestWindowMax} dana)</Typography>
+                            <Row spacing={0.5}>
+                                <Typography>
+                                    {field.plantReadyDate
+                                        ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
+                                        : 'Nije u fazi berbe'}
+                                </Typography>
+                                {field.plantReadyDate && (
+                                    <Typography>
+                                        ({readyDays} {readyDaysDayPlural})
+                                    </Typography>
+                                )}
+                            </Row>
+                        </Stack>
+                    </Stack>
+                </Row>
+            </Stack>
+        </div>
+    )
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldOperationsTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldOperationsTab.tsx
@@ -1,0 +1,14 @@
+import { OperationsList } from "./shared/OperationsList";
+
+export function RaisedBedFieldOperationsTab({ gardenId, raisedBedId, positionIndex, plantSortId }: { gardenId: number; raisedBedId: number; positionIndex: number; plantSortId?: number }) {
+    return (
+        <OperationsList
+            gardenId={gardenId}
+            raisedBedId={raisedBedId}
+            positionIndex={positionIndex}
+            plantSortId={plantSortId}
+            filterFunc={(operation) =>
+                operation.attributes.application === 'plant'}
+        />
+    );
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -5,11 +5,12 @@ import { BlockImage } from "@gredice/ui/BlockImage";
 import { useCurrentGarden } from "../../hooks/useCurrentGarden";
 import { EditableInput } from "@signalco/ui/EditableInput";
 import { useUpdateRaisedBed } from "../../hooks/useUpdateRaisedBed";
-import { useAllSorts } from "../../hooks/usePlantSorts";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@signalco/ui-primitives/Tabs";
 import { Card, CardOverflow } from "@signalco/ui-primitives/Card";
-import { RaisedBedDiary } from "../../hud/raisedBed/RaisedBedDiary";
-import { Book, Info } from "@signalco/ui-icons";
+import { RaisedBedDiary } from "./RaisedBedDiary";
+import { Book, Hammer, Info } from "@signalco/ui-icons";
+import { RaisedBedInfoTab } from "./RaisedBedInfoTab";
+import { RaisedBedOperationsTab } from "./RaisedBedOperationsTab";
 
 export function RaisedBedInfo({ gardenId, raisedBed }: { gardenId: number, raisedBed: NonNullable<Awaited<ReturnType<typeof useCurrentGarden>>['data']>['raisedBeds'][0] }) {
     const updateRaisedBed = useUpdateRaisedBed(gardenId, raisedBed.id);
@@ -17,24 +18,6 @@ export function RaisedBedInfo({ gardenId, raisedBed }: { gardenId: number, raise
     function handleNameChange(newName: string) {
         updateRaisedBed.mutate({ name: newName });
     }
-
-    // Get all raised bed fields and calculate average, min and max yield based on plant sorts
-    const { data: sorts } = useAllSorts()
-    const yieldStats = raisedBed.fields.reduce(
-        (acc, field) => {
-            const sortData = sorts?.find(sort => sort.id === field.plantSortId);
-            if (!sortData) return acc;
-            const plantYieldMin = sortData.information.plant.attributes?.yieldMin ?? 0;
-            const plantYieldMax = sortData.information.plant.attributes?.yieldMax ?? 0;
-            const plantYieldAvg = (plantYieldMin + plantYieldMax) / 2;
-            return {
-                min: acc.min + plantYieldMin,
-                max: acc.max + plantYieldMax,
-                avg: acc.avg + plantYieldAvg,
-            };
-        },
-        { min: 0, max: 0, avg: 0 }
-    );
 
     return (
         <Stack spacing={2}>
@@ -53,6 +36,12 @@ export function RaisedBedInfo({ gardenId, raisedBed }: { gardenId: number, raise
                             <Typography>Dnevnik</Typography>
                         </Row>
                     </TabsTrigger>
+                    <TabsTrigger value="operations">
+                        <Row spacing={1}>
+                            <Hammer className="size-4 shrink-0" />
+                            <Typography>Radnje</Typography>
+                        </Row>
+                    </TabsTrigger>
                     <TabsTrigger value="info">
                         <Row spacing={1}>
                             <Info className="size-4 shrink-0" />
@@ -61,31 +50,7 @@ export function RaisedBedInfo({ gardenId, raisedBed }: { gardenId: number, raise
                     </TabsTrigger>
                 </TabsList>
                 <TabsContent value="info">
-                    <div className="grid grid-cols-2 gap-y-2 gap-x-6">
-                        <Stack>
-                            <Typography level="body2">Dimenzije</Typography>
-                            <Typography level="body1">2m x 1m x 20cm</Typography>
-                        </Stack>
-                        <Stack>
-                            <Typography level="body2">Površina</Typography>
-                            <Typography level="body1">1m²</Typography>
-                        </Stack>
-                        <Stack>
-                            <Typography level="body2">Broj popunjenih polja</Typography>
-                            <Typography level="body1">{raisedBed.fields.length}</Typography>
-                        </Stack>
-                        <Stack>
-                            <Typography level="body2">Očekivani prinos</Typography>
-                            <Stack>
-                                <Typography level="body1">
-                                    ~{(yieldStats.avg / 1000).toFixed(2)} kg
-                                </Typography>
-                                <Typography level="body2">
-                                    {((yieldStats.min / 1000).toFixed(2))} kg - {((yieldStats.max / 1000).toFixed(2))} kg
-                                </Typography>
-                            </Stack>
-                        </Stack>
-                    </div>
+                    <RaisedBedInfoTab gardenId={gardenId} raisedBedId={raisedBed.id} />
                 </TabsContent>
                 <TabsContent value="diary">
                     <Card>
@@ -93,6 +58,9 @@ export function RaisedBedInfo({ gardenId, raisedBed }: { gardenId: number, raise
                             <RaisedBedDiary gardenId={gardenId} raisedBedId={raisedBed.id} />
                         </CardOverflow>
                     </Card>
+                </TabsContent>
+                <TabsContent value="operations">
+                    <RaisedBedOperationsTab gardenId={gardenId} raisedBedId={raisedBed.id} />
                 </TabsContent>
             </Tabs>
         </Stack>

--- a/packages/game/src/hud/raisedBed/RaisedBedInfoTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfoTab.tsx
@@ -1,0 +1,58 @@
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { useAllSorts } from "../../hooks/usePlantSorts";
+import { useCurrentGarden } from "../../hooks/useCurrentGarden";
+
+export function RaisedBedInfoTab({ gardenId, raisedBedId }: { gardenId: number, raisedBedId: number }) {
+    const { data: currentGarden } = useCurrentGarden();
+    if (currentGarden?.id !== gardenId) return null;
+    const raisedBed = currentGarden?.raisedBeds.find(bed => bed.id === raisedBedId);
+
+    // Get all raised bed fields and calculate average, min and max yield based on plant sorts
+    const { data: sorts } = useAllSorts()
+    const yieldStats = raisedBed?.fields.reduce(
+        (acc, field) => {
+            const sortData = sorts?.find(sort => sort.id === field.plantSortId);
+            if (!sortData) return acc;
+            const plantYieldMin = sortData.information.plant.attributes?.yieldMin ?? 0;
+            const plantYieldMax = sortData.information.plant.attributes?.yieldMax ?? 0;
+            const plantYieldAvg = (plantYieldMin + plantYieldMax) / 2;
+            return {
+                min: acc.min + plantYieldMin,
+                max: acc.max + plantYieldMax,
+                avg: acc.avg + plantYieldAvg,
+            };
+        },
+        { min: 0, max: 0, avg: 0 }
+    ) ?? { min: 0, max: 0, avg: 0 };
+
+    if (!raisedBed) return null;
+
+    return (
+        <div className="grid grid-cols-2 gap-y-2 gap-x-6">
+            <Stack>
+                <Typography level="body2">Dimenzije</Typography>
+                <Typography level="body1">2m x 1m x 20cm</Typography>
+            </Stack>
+            <Stack>
+                <Typography level="body2">Površina</Typography>
+                <Typography level="body1">1m²</Typography>
+            </Stack>
+            <Stack>
+                <Typography level="body2">Broj popunjenih polja</Typography>
+                <Typography level="body1">{raisedBed.fields.length}</Typography>
+            </Stack>
+            <Stack>
+                <Typography level="body2">Očekivani prinos</Typography>
+                <Stack>
+                    <Typography level="body1">
+                        ~{(yieldStats.avg / 1000).toFixed(2)} kg
+                    </Typography>
+                    <Typography level="body2">
+                        {((yieldStats.min / 1000).toFixed(2))} kg - {((yieldStats.max / 1000).toFixed(2))} kg
+                    </Typography>
+                </Stack>
+            </Stack>
+        </div>
+    );
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationsTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationsTab.tsx
@@ -1,0 +1,13 @@
+import { OperationsList } from "./shared/OperationsList";
+
+export function RaisedBedOperationsTab({ gardenId, raisedBedId }: { gardenId: number; raisedBedId?: number }) {
+    return (
+        <OperationsList
+            gardenId={gardenId}
+            raisedBedId={raisedBedId}
+            filterFunc={(operation) =>
+                operation.attributes.application === 'raisedBedFull' ||
+                operation.attributes.application === 'raisedBed1m'}
+        />
+    )
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -56,6 +56,7 @@ export function PlantPicker({
     const [selectedPlantId, setSelectedPlantId] = useState<number | null>(preselectedPlantId ?? null);
     const [selectedSortId, setSelectedSortId] = useState<number | null>(preselectedSortId ?? null);
     const [plantOptions, setPlantOptions] = useState<{ scheduledDate: Date | null | undefined } | null>(preselectedPlantOptions ?? null);
+    const [flyToShoppingCart, setFlyToShoppingCart] = useState(false);
 
     let currentStep = 0;
     if (selectedPlantId) {
@@ -107,6 +108,7 @@ export function PlantPicker({
         }
 
         // Add new item to cart
+        setFlyToShoppingCart(true);
         await setCartItem.mutateAsync({
             entityTypeName: "plantSort",
             entityId: selectedSortId?.toString(),
@@ -118,7 +120,9 @@ export function PlantPicker({
                 scheduledDate: plantOptions?.scheduledDate?.toISOString(),
             })
         });
+        await new Promise(resolve => setTimeout(resolve, 800)); // Wait for animation to finish
         setOpen(false);
+        setFlyToShoppingCart(false);
     }
 
     function handleOpenChange(open: boolean) {
@@ -148,6 +152,7 @@ export function PlantPicker({
             open={open}
             onOpenChange={handleOpenChange}
             title={"Sijanje biljke"}
+            modal={false}
             className="md:border-tertiary md:border-b-4 md:max-w-2xl">
             <Stack spacing={2}>
                 <SegmentedProgress
@@ -196,7 +201,9 @@ export function PlantPicker({
                                 onChange={(sort) => {
                                     handleSortSelect(sort);
                                     setSearch(undefined);
-                                }} />
+                                }}
+                                flyToShoppingCart={flyToShoppingCart}
+                            />
                             <Input
                                 type="date"
                                 label="Datum sijanja"

--- a/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
@@ -1,132 +1,21 @@
-import { Popper } from "@signalco/ui-primitives/Popper";
 import { ButtonGreen } from "../../shared-ui/ButtonGreen";
 import { BlockImage } from "@gredice/ui/BlockImage";
-import { useOperations } from "../../hooks/useOperations";
-import { useSetShoppingCartItem } from "../../hooks/useSetShoppingCartItem";
-import { Button } from "@signalco/ui-primitives/Button";
-import { Row } from "@signalco/ui-primitives/Row";
 import { Modal } from "@signalco/ui-primitives/Modal";
-import { Calendar } from "@signalco/ui-icons";
-import { IconButton } from "@signalco/ui-primitives/IconButton";
-import { Input } from "@signalco/ui-primitives/Input";
 import { Stack } from "@signalco/ui-primitives/Stack";
 import { Typography } from "@signalco/ui-primitives/Typography";
-import { Card } from "@signalco/ui-primitives/Card";
-import { formatLocalDate } from "./RaisedBedPlantPicker";
 import { useState } from "react";
+import { OperationsList } from "./shared/OperationsList";
 
-function OperationScheduleModal({ operationId, onConfirm, disabled }: { operationId: number; onConfirm: (date: Date) => Promise<void>, disabled?: boolean }) {
+export function RaisedBedWatering({ gardenId, raisedBedId }: { gardenId: number; raisedBedId: number }) {
     const [open, setOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-    const operations = useOperations();
-    const op = operations.data?.find(op => op.id === operationId);
-
-    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        const date = formData.get("scheduledDate") as string;
-        if (date) {
-            const scheduledDate = new Date(date);
-            setIsLoading(true);
-            await onConfirm(scheduledDate);
-            setOpen(false);
-            setIsLoading(false);
-        }
-    }
-
-    const today = new Date();
-    const tomorrow = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
-    const threeMonthsFromTomorrow = new Date(tomorrow.getFullYear(), tomorrow.getMonth() + 3, tomorrow.getDate());
-    const operationDefaultDate = formatLocalDate(tomorrow);
-    const min = formatLocalDate(tomorrow);
-    const max = formatLocalDate(threeMonthsFromTomorrow);
 
     return (
         <Modal
             className="border border-tertiary border-b-4"
-            trigger={(
-                <IconButton
-                    title={`Zakaži zalijevanje: ${op?.information.label}`}
-                    variant="soft"
-                    disabled={disabled}>
-                    <Calendar className="size-5 shrink-0" />
-                </IconButton>
-            )}
-            title={`Zakaži zalijevanje: ${op?.information.label}`}
+            title="Zalijevanje"
             open={open}
-            onOpenChange={setOpen}>
-            <form onSubmit={handleSubmit}>
-                <Stack spacing={2}>
-                    <Typography level="h5">
-                        Zakazivanje radnje
-                    </Typography>
-                    <Typography>Ova radnja će biti zakazana za odabrani datum.</Typography>
-                    <Card>
-                        <Row spacing={2}>
-                            <img
-                                src={op?.image?.cover?.url ?? "https://www.gredice.com/assets/plants/placeholder.png"}
-                                alt={op?.information.label}
-                                className="size-20 object-cover border rounded bg-card" />
-                            <Stack>
-                                <Typography className="mt-2" noWrap>
-                                    {op?.information.label}
-                                </Typography>
-                                <Typography level="body2">
-                                    {op?.information.shortDescription}
-                                </Typography>
-                            </Stack>
-                        </Row>
-                    </Card>
-                    <Input
-                        type="date"
-                        label="Željeni datum radnje"
-                        name="scheduledDate"
-                        className="w-full bg-card"
-                        disabled={isLoading}
-                        defaultValue={operationDefaultDate}
-                        min={min}
-                        max={max}
-                        required
-                    />
-                    <Button
-                        type="submit"
-                        variant="solid"
-                        disabled={isLoading}
-                        loading={isLoading}
-                        startDecorator={<Calendar className="size-5 shrink-0" />}
-                    >
-                        Potvrdi
-                    </Button>
-                </Stack>
-            </form>
-        </Modal>
-    );
-}
-
-export function RaisedBedWatering({ gardenId, raisedBedId }: { gardenId: number; raisedBedId: number }) {
-    const operations = useOperations();
-    const wateringOperations = operations.data?.filter(op => op.attributes.stage.information?.name === 'watering' && op.attributes.application === 'raisedBed1m');
-    const setShoppingCartItem = useSetShoppingCartItem();
-
-    async function handleWateringOperation(operationId: number, scheduledDate?: Date) {
-        await setShoppingCartItem.mutateAsync({
-            amount: 1,
-            entityId: operationId.toString(),
-            entityTypeName: 'operation',
-            gardenId: gardenId,
-            raisedBedId: raisedBedId,
-            additionalData: scheduledDate
-                ? JSON.stringify({
-                    scheduledDate: scheduledDate ? scheduledDate.toISOString() : undefined,
-                })
-                : undefined,
-            forceCreate: true
-        });
-    }
-
-    return (
-        <Popper
-            className="border border-tertiary border-b-4"
+            modal={false}
+            onOpenChange={setOpen}
             trigger={(
                 <ButtonGreen
                     className="rounded-full p-0 pr-4 gap-0">
@@ -140,29 +29,21 @@ export function RaisedBedWatering({ gardenId, raisedBedId }: { gardenId: number;
                     <span className="-ml-2">Zalijevanje</span>
                 </ButtonGreen>
             )}>
-            <div className="flex flex-col gap-2 p-2">
-                {wateringOperations?.length ? (
-                    wateringOperations.map(op => (
-                        <Row key={op.id} spacing={1}>
-                            <Button
-                                variant="soft"
-                                fullWidth
-                                disabled={setShoppingCartItem.isPending}
-                                onClick={() => handleWateringOperation(op.id)}>
-                                {op.information.label}
-                            </Button>
-                            <OperationScheduleModal
-                                operationId={op.id}
-                                disabled={setShoppingCartItem.isPending}
-                                onConfirm={async (date) => {
-                                    await handleWateringOperation(op.id, date);
-                                }} />
-                        </Row>
-                    ))
-                ) : (
-                    <span>Nema dostupnih operacija zalijevanja</span>
-                )}
-            </div>
-        </Popper>
+            <Stack spacing={2}>
+                <Typography level="h5">
+                    Radnje zalijevanja
+                </Typography>
+                <Typography>
+                    Odaberite radnju zalijevanja za ovu gredicu.
+                </Typography>
+                <OperationsList
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                    filterFunc={(operation) =>
+                        operation.attributes.stage.information?.name === 'watering' &&
+                        operation.attributes.application === 'raisedBed1m'}
+                />
+            </Stack>
+        </Modal>
     );
 }

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -179,7 +179,7 @@ function OperationsListItem({
     return (
         <Stack key={operation.id}>
             {operationButton}
-            <div className="flex flex-wrap gap-y-1 gap-x-2 px-4 items-center justify-between">
+            <div className="flex flex-wrap gap-y-1 gap-x-2 pr-4 items-center justify-between">
                 <OperationScheduleModal
                     operation={operation}
                     gardenId={gardenId}

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -1,0 +1,282 @@
+import { OperationData } from "@gredice/client";
+import { Button } from "@signalco/ui-primitives/Button";
+import { List } from "@signalco/ui-primitives/List";
+import { Row } from "@signalco/ui-primitives/Row";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { NoDataPlaceholder } from "@signalco/ui/NoDataPlaceholder";
+import { KnownPages } from "../../../knownPages";
+import { OperationListItemSkeleton } from "../OperationListItemSkeleton";
+import { useOperations } from "../../../hooks/useOperations";
+import { Alert } from "@signalco/ui/Alert";
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { usePlantSort } from "../../../hooks/usePlantSorts";
+import { useSetShoppingCartItem } from "../../../hooks/useSetShoppingCartItem";
+import { useState, useCallback, useRef } from "react"
+import { useSprings, config, animated, to, SpringValue } from "@react-spring/web"
+
+interface AnimationOptions {
+    duration?: number
+    bounceScale?: number
+    shrinkScale?: number
+}
+
+export function useAnimateFlyTo(targetX: number, targetY: number, options: AnimationOptions = {}) {
+    const { duration = 800, bounceScale = 1.2, shrinkScale = 0.3 } = options
+
+    const [animations, setAnimations] = useState<number[]>([]);
+    const elementRef = useRef<HTMLDivElement | null>(null)
+
+    const [springs, api] = useSprings(animations.length, (index) => {
+        if (!elementRef.current) {
+            console.warn("Element reference is not set for animation");
+            return {
+                from: { x: 0, y: 0, scale: 1, opacity: 1 },
+                to: { x: 0, y: 0, scale: 1, opacity: 0 }
+            };
+        }
+
+        // Get current position accounting for scroll offset and document positioning
+        const rect = elementRef.current.getBoundingClientRect()
+        const scrollX = window.pageXOffset || document.documentElement.scrollLeft
+        const scrollY = window.pageYOffset || document.documentElement.scrollTop
+
+        const startX = rect.left + scrollX + rect.width / 2
+        const startY = rect.top + scrollY + rect.height / 2
+
+        return {
+            from: {
+                x: startX,
+                y: startY,
+                scale: 1,
+                opacity: 1,
+            },
+            to: async (next) => {
+                // await next({
+                //     immediate: true,
+                //     x: startX,
+                //     y: startY,
+                //     scale: 1,
+                //     opacity: 1
+                // });
+                await next({
+                    x: startX,
+                    y: startY - 10,
+                    scale: bounceScale,
+                    config: { ...config.wobbly, duration: duration },
+                });
+                // await next({
+                //     x: targetX,
+                //     y: targetY,
+                //     scale: 1,
+                //     config: { ...config.gentle, duration: duration * 0.6 },
+                // });
+                // await next({
+                //     x: 0,
+                //     y: 0,
+                //     scale: shrinkScale,
+                //     opacity: 0,
+                //     config: { ...config.slow, duration: duration * 0.7 },
+                // });
+
+                // Wait for the animation to finish before removing it
+                setAnimations(prev => {
+                    // Remove the first item (the one that just finished)
+                    const newAnimations = [...prev];
+                    newAnimations.splice(index, 1);
+                    return newAnimations;
+                });
+            },
+        };
+    })
+
+    const run = useCallback(async () => {
+        setAnimations(prev => [...prev, Date.now()]); // Use timestamp as unique ID
+    }, []);
+
+    const reset = useCallback(() => {
+        api.stop()
+        setAnimations([])
+    }, [api])
+
+    return {
+        run,
+        reset,
+        isAnimating: animations.length > 0,
+        props: {
+            ref: elementRef,
+            animations,
+            springs,
+        },
+    }
+}
+
+import type React from "react"
+import { createPortal } from "react-dom"
+
+interface AnimateFlyToItemProps {
+    children: React.ReactNode
+    className?: string
+    style?: React.CSSProperties
+    ref?: React.Ref<HTMLDivElement>
+    animations?: Array<number>,
+    springs?: Array<{
+        x: SpringValue<number>
+        y: SpringValue<number>
+        scale: SpringValue<number>
+        opacity: SpringValue<number>
+    }>
+}
+
+export const AnimateFlyToItem: React.FC<AnimateFlyToItemProps> = ({
+    children,
+    className = "",
+    style = {},
+    ref,
+    animations = [],
+    springs = [],
+    ...props
+}) => {
+    return (
+        <>
+            {/* Original element */}
+            <div ref={ref} className={`inline-block ${className}`} style={style} {...props}>
+                {children}
+            </div>
+
+            {/* Render animated elements in portal to document.body */}
+            {typeof document !== "undefined" &&
+                createPortal(
+                    <>
+                        {animations.map((animationId, index) => {
+                            const spring = springs[index]
+                            if (!spring) return null;
+
+                            return (
+                                <animated.div
+                                    key={animationId}
+                                    className={`absolute inset-0 inline-block pointer-events-none ${className}`}
+                                    style={{
+                                        transformOrigin: "center center",
+                                        willChange: "transform, opacity",
+                                        transform:
+                                            to(
+                                                [spring.x, spring.y, spring.scale],
+                                                (x: number, y: number, scale: number) => `translate(${x ?? 0}px, ${y ?? 0}px) scale(${scale ?? 1})`
+                                            ),
+                                        opacity: spring.opacity ?? 1,
+                                        zIndex: 1000,
+                                        ...style,
+                                    }}
+                                >
+                                    {children}
+                                </animated.div>
+                            )
+                        })}
+                    </>,
+                    document.body
+                )}
+        </>
+    )
+}
+
+export function OperationsList({
+    gardenId,
+    raisedBedId,
+    positionIndex,
+    plantSortId,
+    filterFunc
+}: {
+    gardenId: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+    plantSortId?: number;
+    filterFunc: (operation: OperationData) => boolean;
+}) {
+    const setShoppingCartItem = useSetShoppingCartItem();
+    const { data: operations, isLoading: isLoadingOperations, isError } = useOperations();
+    const { data: plantSort, isLoading: isPlantSortLoading } = usePlantSort(plantSortId);
+    const isLoading = isLoadingOperations || (Boolean(plantSortId) && isPlantSortLoading);
+    const filteredOperations = operations
+        ?.filter(filterFunc)
+        .filter(op => plantSortId ? plantSort?.information.plant.information?.operations?.map(op => op.information?.name).includes(op.information.name) : true)
+
+    async function handleOperationPicked(operation: OperationData) {
+        setShoppingCartItem.mutate({
+            amount: 1,
+            entityId: operation.id.toString(),
+            entityTypeName: operation.entityType.name,
+            gardenId,
+            raisedBedId,
+            positionIndex,
+            additionalData: null // TODO: Implement scheduling for operations
+        });
+        animateFlyToShoppingCart.run();
+    }
+
+    const shoppingCartPositionX = window.innerWidth < 768 ? 30 : 20;
+    const shoppingCartPositionY = window.innerWidth < 768 ? 90 : 70;
+    const animateFlyToShoppingCart = useAnimateFlyTo(shoppingCartPositionX, shoppingCartPositionY);
+
+    return (
+        <>
+            {isError && (
+                <Alert color="danger">
+                    Greška prilikom učitavanja radnji
+                </Alert>
+            )}
+            <List variant="outlined" className="bg-card max-h-96 overflow-y-auto">
+                {!isLoading && filteredOperations?.length === 0 && (
+                    <NoDataPlaceholder className="p-4">
+                        Nema dostupnih radnji
+                    </NoDataPlaceholder>
+                )}
+                {isLoading && Array.from({ length: 3 }).map((_, index) => (
+                    <OperationListItemSkeleton key={index} />
+                ))}
+                {filteredOperations?.map((operation) => {
+                    const price = operation.prices?.perOperation ? operation.prices.perOperation.toFixed(2) : 'Nepoznato';
+                    return (
+                        <Stack key={operation.id}>
+                            <Button
+                                variant="plain"
+                                className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
+                                onClick={() => handleOperationPicked(operation)}>
+                                {/* <img
+                                    src={'https://www.gredice.com/' + operation.image?.cover?.url}
+                                    alt={operation.information.label}
+                                    width={48}
+                                    height={48}
+                                    className="size-12" /> */}
+                                <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
+                                    <span className="size-8 text-3xl">🪏</span>
+                                </AnimateFlyToItem>
+                                <Stack className="w-full">
+                                    <Row spacing={1} justifyContent="space-between">
+                                        <Typography level="body1" semiBold>
+                                            {operation.information.label}
+                                        </Typography>
+                                        <Typography level="body1" semiBold>{price} €</Typography>
+                                    </Row>
+                                    {operation.information.shortDescription && (
+                                        <Typography level="body2" className="line-clamp-2 break-words">
+                                            {operation.information.shortDescription}
+                                        </Typography>
+                                    )}
+                                </Stack>
+                            </Button>
+                            <div className="flex flex-wrap gap-y-1 gap-x-2 px-4 items-center justify-end">
+                                <Button
+                                    title="Više informacija"
+                                    variant="link"
+                                    size="sm"
+                                    href={KnownPages.GrediceOperation(operation.information.label)}>
+                                    Više informacija...
+                                </Button>
+                            </div>
+                        </Stack>
+                    );
+                })}
+            </List>
+        </>
+    )
+}

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -11,172 +11,77 @@ import { Alert } from "@signalco/ui/Alert";
 import { Stack } from "@signalco/ui-primitives/Stack";
 import { usePlantSort } from "../../../hooks/usePlantSorts";
 import { useSetShoppingCartItem } from "../../../hooks/useSetShoppingCartItem";
-import { useState, useCallback, useRef } from "react"
-import { useSprings, config, animated, to, SpringValue } from "@react-spring/web"
+import { AnimateFlyToItem, useAnimateFlyToShoppingCart } from "../../../indicators/AnimateFlyTo";
 
-interface AnimationOptions {
-    duration?: number
-    bounceScale?: number
-    shrinkScale?: number
-}
+function OperationsListItem({
+    operation,
+    gardenId,
+    raisedBedId,
+    positionIndex
+}: {
+    gardenId: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+    operation: OperationData;
+}) {
+    const setShoppingCartItem = useSetShoppingCartItem();
+    const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
 
-export function useAnimateFlyTo(targetX: number, targetY: number, options: AnimationOptions = {}) {
-    const { duration = 800, bounceScale = 1.2, shrinkScale = 0.3 } = options
+    const price = operation.prices?.perOperation ? operation.prices.perOperation.toFixed(2) : 'Nepoznato';
 
-    const [animations, setAnimations] = useState<number[]>([]);
-    const elementRef = useRef<HTMLDivElement | null>(null)
-
-    const [springs, api] = useSprings(animations.length, (index) => {
-        if (!elementRef.current) {
-            console.warn("Element reference is not set for animation");
-            return {
-                from: { x: 0, y: 0, scale: 1, opacity: 1 },
-                to: { x: 0, y: 0, scale: 1, opacity: 0 }
-            };
-        }
-
-        // Get current position accounting for scroll offset and document positioning
-        const rect = elementRef.current.getBoundingClientRect()
-        const scrollX = window.pageXOffset || document.documentElement.scrollLeft
-        const scrollY = window.pageYOffset || document.documentElement.scrollTop
-
-        const startX = rect.left + scrollX + rect.width / 2
-        const startY = rect.top + scrollY + rect.height / 2
-
-        return {
-            from: {
-                x: startX,
-                y: startY,
-                scale: 1,
-                opacity: 1,
-            },
-            to: async (next) => {
-                // await next({
-                //     immediate: true,
-                //     x: startX,
-                //     y: startY,
-                //     scale: 1,
-                //     opacity: 1
-                // });
-                await next({
-                    x: startX,
-                    y: startY - 10,
-                    scale: bounceScale,
-                    config: { ...config.wobbly, duration: duration },
-                });
-                // await next({
-                //     x: targetX,
-                //     y: targetY,
-                //     scale: 1,
-                //     config: { ...config.gentle, duration: duration * 0.6 },
-                // });
-                // await next({
-                //     x: 0,
-                //     y: 0,
-                //     scale: shrinkScale,
-                //     opacity: 0,
-                //     config: { ...config.slow, duration: duration * 0.7 },
-                // });
-
-                // Wait for the animation to finish before removing it
-                setAnimations(prev => {
-                    // Remove the first item (the one that just finished)
-                    const newAnimations = [...prev];
-                    newAnimations.splice(index, 1);
-                    return newAnimations;
-                });
-            },
-        };
-    })
-
-    const run = useCallback(async () => {
-        setAnimations(prev => [...prev, Date.now()]); // Use timestamp as unique ID
-    }, []);
-
-    const reset = useCallback(() => {
-        api.stop()
-        setAnimations([])
-    }, [api])
-
-    return {
-        run,
-        reset,
-        isAnimating: animations.length > 0,
-        props: {
-            ref: elementRef,
-            animations,
-            springs,
-        },
+    async function handleOperationPicked(operation: OperationData) {
+        setShoppingCartItem.mutate({
+            amount: 1,
+            entityId: operation.id.toString(),
+            entityTypeName: operation.entityType.name,
+            gardenId,
+            raisedBedId,
+            positionIndex,
+            additionalData: null // TODO: Implement scheduling for operations
+        });
+        animateFlyToShoppingCart.run();
     }
-}
 
-import type React from "react"
-import { createPortal } from "react-dom"
-
-interface AnimateFlyToItemProps {
-    children: React.ReactNode
-    className?: string
-    style?: React.CSSProperties
-    ref?: React.Ref<HTMLDivElement>
-    animations?: Array<number>,
-    springs?: Array<{
-        x: SpringValue<number>
-        y: SpringValue<number>
-        scale: SpringValue<number>
-        opacity: SpringValue<number>
-    }>
-}
-
-export const AnimateFlyToItem: React.FC<AnimateFlyToItemProps> = ({
-    children,
-    className = "",
-    style = {},
-    ref,
-    animations = [],
-    springs = [],
-    ...props
-}) => {
     return (
-        <>
-            {/* Original element */}
-            <div ref={ref} className={`inline-block ${className}`} style={style} {...props}>
-                {children}
+        <Stack key={operation.id}>
+            <Button
+                variant="plain"
+                className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
+                onClick={() => handleOperationPicked(operation)}>
+                {/* <img
+                                    src={'https://www.gredice.com/' + operation.image?.cover?.url}
+                                    alt={operation.information.label}
+                                    width={48}
+                                    height={48}
+                                    className="size-12" /> */}
+                <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
+                    <span className="size-8 text-3xl">🪏</span>
+                </AnimateFlyToItem>
+                <Stack className="w-full">
+                    <Row spacing={1} justifyContent="space-between">
+                        <Typography level="body1" semiBold>
+                            {operation.information.label}
+                        </Typography>
+                        <Typography level="body1" semiBold>{price} €</Typography>
+                    </Row>
+                    {operation.information.shortDescription && (
+                        <Typography level="body2" className="line-clamp-2 break-words">
+                            {operation.information.shortDescription}
+                        </Typography>
+                    )}
+                </Stack>
+            </Button>
+            <div className="flex flex-wrap gap-y-1 gap-x-2 px-4 items-center justify-end">
+                <Button
+                    title="Više informacija"
+                    variant="link"
+                    size="sm"
+                    href={KnownPages.GrediceOperation(operation.information.label)}>
+                    Više informacija...
+                </Button>
             </div>
-
-            {/* Render animated elements in portal to document.body */}
-            {typeof document !== "undefined" &&
-                createPortal(
-                    <>
-                        {animations.map((animationId, index) => {
-                            const spring = springs[index]
-                            if (!spring) return null;
-
-                            return (
-                                <animated.div
-                                    key={animationId}
-                                    className={`absolute inset-0 inline-block pointer-events-none ${className}`}
-                                    style={{
-                                        transformOrigin: "center center",
-                                        willChange: "transform, opacity",
-                                        transform:
-                                            to(
-                                                [spring.x, spring.y, spring.scale],
-                                                (x: number, y: number, scale: number) => `translate(${x ?? 0}px, ${y ?? 0}px) scale(${scale ?? 1})`
-                                            ),
-                                        opacity: spring.opacity ?? 1,
-                                        zIndex: 1000,
-                                        ...style,
-                                    }}
-                                >
-                                    {children}
-                                </animated.div>
-                            )
-                        })}
-                    </>,
-                    document.body
-                )}
-        </>
-    )
+        </Stack>
+    );
 }
 
 export function OperationsList({
@@ -192,30 +97,12 @@ export function OperationsList({
     plantSortId?: number;
     filterFunc: (operation: OperationData) => boolean;
 }) {
-    const setShoppingCartItem = useSetShoppingCartItem();
     const { data: operations, isLoading: isLoadingOperations, isError } = useOperations();
     const { data: plantSort, isLoading: isPlantSortLoading } = usePlantSort(plantSortId);
     const isLoading = isLoadingOperations || (Boolean(plantSortId) && isPlantSortLoading);
     const filteredOperations = operations
         ?.filter(filterFunc)
         .filter(op => plantSortId ? plantSort?.information.plant.information?.operations?.map(op => op.information?.name).includes(op.information.name) : true)
-
-    async function handleOperationPicked(operation: OperationData) {
-        setShoppingCartItem.mutate({
-            amount: 1,
-            entityId: operation.id.toString(),
-            entityTypeName: operation.entityType.name,
-            gardenId,
-            raisedBedId,
-            positionIndex,
-            additionalData: null // TODO: Implement scheduling for operations
-        });
-        animateFlyToShoppingCart.run();
-    }
-
-    const shoppingCartPositionX = window.innerWidth < 768 ? 30 : 20;
-    const shoppingCartPositionY = window.innerWidth < 768 ? 90 : 70;
-    const animateFlyToShoppingCart = useAnimateFlyTo(shoppingCartPositionX, shoppingCartPositionY);
 
     return (
         <>
@@ -233,49 +120,15 @@ export function OperationsList({
                 {isLoading && Array.from({ length: 3 }).map((_, index) => (
                     <OperationListItemSkeleton key={index} />
                 ))}
-                {filteredOperations?.map((operation) => {
-                    const price = operation.prices?.perOperation ? operation.prices.perOperation.toFixed(2) : 'Nepoznato';
-                    return (
-                        <Stack key={operation.id}>
-                            <Button
-                                variant="plain"
-                                className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
-                                onClick={() => handleOperationPicked(operation)}>
-                                {/* <img
-                                    src={'https://www.gredice.com/' + operation.image?.cover?.url}
-                                    alt={operation.information.label}
-                                    width={48}
-                                    height={48}
-                                    className="size-12" /> */}
-                                <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
-                                    <span className="size-8 text-3xl">🪏</span>
-                                </AnimateFlyToItem>
-                                <Stack className="w-full">
-                                    <Row spacing={1} justifyContent="space-between">
-                                        <Typography level="body1" semiBold>
-                                            {operation.information.label}
-                                        </Typography>
-                                        <Typography level="body1" semiBold>{price} €</Typography>
-                                    </Row>
-                                    {operation.information.shortDescription && (
-                                        <Typography level="body2" className="line-clamp-2 break-words">
-                                            {operation.information.shortDescription}
-                                        </Typography>
-                                    )}
-                                </Stack>
-                            </Button>
-                            <div className="flex flex-wrap gap-y-1 gap-x-2 px-4 items-center justify-end">
-                                <Button
-                                    title="Više informacija"
-                                    variant="link"
-                                    size="sm"
-                                    href={KnownPages.GrediceOperation(operation.information.label)}>
-                                    Više informacija...
-                                </Button>
-                            </div>
-                        </Stack>
-                    );
-                })}
+                {filteredOperations?.map((operation) => (
+                    <OperationsListItem
+                        key={operation.id}
+                        operation={operation}
+                        gardenId={gardenId}
+                        raisedBedId={raisedBedId}
+                        positionIndex={positionIndex}
+                    />
+                ))}
             </List>
         </>
     )

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -19,6 +19,13 @@ import { Calendar } from "@signalco/ui-icons";
 import { formatLocalDate } from "../RaisedBedPlantPicker";
 import { useState } from "react";
 
+function formatPrice(price?: number | null): string {
+    if (price == null || price === undefined) {
+        return 'Nepoznato';
+    }
+    return `${price.toFixed(2)} €`;
+}
+
 function OperationScheduleModal({
     operation,
     onConfirm,
@@ -129,7 +136,7 @@ function OperationsListItem({
     const setShoppingCartItem = useSetShoppingCartItem();
     const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
 
-    const price = operation.prices?.perOperation ? operation.prices.perOperation.toFixed(2) : 'Nepoznato';
+    const price = formatPrice(operation.prices?.perOperation);
 
     async function handleOperationPicked(operation: OperationData, scheduledDate?: Date) {
         setShoppingCartItem.mutate({
@@ -161,7 +168,7 @@ function OperationsListItem({
                     <Typography level="body1" semiBold>
                         {operation.information.label}
                     </Typography>
-                    <Typography level="body1" semiBold>{price} €</Typography>
+                    <Typography level="body1" semiBold>{price}</Typography>
                 </Row>
                 {operation.information.shortDescription && (
                     <Typography level="body2" className="line-clamp-2 break-words">

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -12,6 +12,112 @@ import { Stack } from "@signalco/ui-primitives/Stack";
 import { usePlantSort } from "../../../hooks/usePlantSorts";
 import { useSetShoppingCartItem } from "../../../hooks/useSetShoppingCartItem";
 import { AnimateFlyToItem, useAnimateFlyToShoppingCart } from "../../../indicators/AnimateFlyTo";
+import { Modal } from "@signalco/ui-primitives/Modal";
+import { Input } from "@signalco/ui-primitives/Input";
+import { Card } from "@signalco/ui-primitives/Card";
+import { Calendar } from "@signalco/ui-icons";
+import { formatLocalDate } from "../RaisedBedPlantPicker";
+import { useState } from "react";
+
+function OperationScheduleModal({
+    operation,
+    onConfirm,
+    trigger
+}: {
+    operation: OperationData;
+    gardenId: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+    onConfirm: (date: Date) => Promise<void>;
+    disabled?: boolean;
+    trigger: React.ReactElement;
+}) {
+    const [open, setOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        const date = formData.get("scheduledDate") as string;
+        if (date) {
+            const scheduledDate = new Date(date);
+            setIsLoading(true);
+            await onConfirm(scheduledDate);
+            setOpen(false);
+            setIsLoading(false);
+        }
+    }
+
+    const today = new Date();
+    const tomorrow = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+    const threeMonthsFromTomorrow = new Date(tomorrow.getFullYear(), tomorrow.getMonth() + 3, tomorrow.getDate());
+    const operationDefaultDate = formatLocalDate(tomorrow);
+    const min = formatLocalDate(tomorrow);
+    const max = formatLocalDate(threeMonthsFromTomorrow);
+
+    return (
+        <Modal
+            className="border border-tertiary border-b-4"
+            trigger={trigger}
+            title={`Zakaži radnju: ${operation.information.label}`}
+            open={open}
+            onOpenChange={setOpen}>
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="h5">
+                        Zakazivanje radnje
+                    </Typography>
+                    <Typography>Ova radnja će biti zakazana za odabrani datum.</Typography>
+                    <Card>
+                        <Row spacing={2}>
+                            <span className="size-20 text-4xl flex items-center justify-center border rounded bg-card">🪏</span>
+                            <Stack>
+                                <Typography className="mt-2" noWrap>
+                                    {operation.information.label}
+                                </Typography>
+                                <Typography level="body2">
+                                    {operation.information.shortDescription}
+                                </Typography>
+                                <Typography level="body2" semiBold>
+                                    {operation.prices?.perOperation ? `${operation.prices.perOperation.toFixed(2)} €` : 'Nepoznato'}
+                                </Typography>
+                            </Stack>
+                        </Row>
+                    </Card>
+                    <Input
+                        type="date"
+                        label="Željeni datum radnje"
+                        name="scheduledDate"
+                        className="w-full bg-card"
+                        disabled={isLoading}
+                        defaultValue={operationDefaultDate}
+                        min={min}
+                        max={max}
+                        required
+                    />
+                    <Row spacing={1}>
+                        <Button
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={isLoading}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            disabled={isLoading}
+                            loading={isLoading}
+                            startDecorator={<Calendar className="size-5 shrink-0" />}
+                        >
+                            Potvrdi
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}
 
 function OperationsListItem({
     operation,
@@ -29,7 +135,7 @@ function OperationsListItem({
 
     const price = operation.prices?.perOperation ? operation.prices.perOperation.toFixed(2) : 'Nepoznato';
 
-    async function handleOperationPicked(operation: OperationData) {
+    async function handleOperationPicked(operation: OperationData, scheduledDate?: Date) {
         setShoppingCartItem.mutate({
             amount: 1,
             entityId: operation.id.toString(),
@@ -37,41 +143,63 @@ function OperationsListItem({
             gardenId,
             raisedBedId,
             positionIndex,
-            additionalData: null // TODO: Implement scheduling for operations
+            additionalData: scheduledDate
+                ? JSON.stringify({
+                    scheduledDate: scheduledDate.toISOString(),
+                })
+                : null
         });
         animateFlyToShoppingCart.run();
     }
 
+    const operationButton = (
+        <Button
+            variant="plain"
+            className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
+            onClick={() => handleOperationPicked(operation)}>
+            <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
+                <span className="size-8 text-3xl">🪏</span>
+            </AnimateFlyToItem>
+            <Stack className="w-full">
+                <Row spacing={1} justifyContent="space-between">
+                    <Typography level="body1" semiBold>
+                        {operation.information.label}
+                    </Typography>
+                    <Typography level="body1" semiBold>{price} €</Typography>
+                </Row>
+                {operation.information.shortDescription && (
+                    <Typography level="body2" className="line-clamp-2 break-words">
+                        {operation.information.shortDescription}
+                    </Typography>
+                )}
+            </Stack>
+        </Button>
+    );
+
     return (
         <Stack key={operation.id}>
-            <Button
-                variant="plain"
-                className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
-                onClick={() => handleOperationPicked(operation)}>
-                {/* <img
-                                    src={'https://www.gredice.com/' + operation.image?.cover?.url}
-                                    alt={operation.information.label}
-                                    width={48}
-                                    height={48}
-                                    className="size-12" /> */}
-                <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
-                    <span className="size-8 text-3xl">🪏</span>
-                </AnimateFlyToItem>
-                <Stack className="w-full">
-                    <Row spacing={1} justifyContent="space-between">
-                        <Typography level="body1" semiBold>
-                            {operation.information.label}
-                        </Typography>
-                        <Typography level="body1" semiBold>{price} €</Typography>
-                    </Row>
-                    {operation.information.shortDescription && (
-                        <Typography level="body2" className="line-clamp-2 break-words">
-                            {operation.information.shortDescription}
-                        </Typography>
-                    )}
-                </Stack>
-            </Button>
-            <div className="flex flex-wrap gap-y-1 gap-x-2 px-4 items-center justify-end">
+            {operationButton}
+            <div className="flex flex-wrap gap-y-1 gap-x-2 px-4 items-center justify-between">
+                <OperationScheduleModal
+                    operation={operation}
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                    positionIndex={positionIndex}
+                    disabled={setShoppingCartItem.isPending}
+                    onConfirm={async (date) => {
+                        await handleOperationPicked(operation, date);
+                    }}
+                    trigger={
+                        <Button
+                            title="Zakaži radnju"
+                            variant="plain"
+                            size="sm"
+                            startDecorator={<Calendar className="size-4 shrink-0" />}
+                            disabled={setShoppingCartItem.isPending}>
+                            Zakaži
+                        </Button>
+                    }
+                />
                 <Button
                     title="Više informacija"
                     variant="link"

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -18,6 +18,7 @@ import { Card } from "@signalco/ui-primitives/Card";
 import { Calendar } from "@signalco/ui-icons";
 import { formatLocalDate } from "../RaisedBedPlantPicker";
 import { useState } from "react";
+import { OperationImage } from "@gredice/ui/OperationImage";
 
 function formatPrice(price?: number | null): string {
     if (price == null || price === undefined) {
@@ -161,7 +162,7 @@ function OperationsListItem({
             className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
             onClick={() => handleOperationPicked(operation)}>
             <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
-                <span className="size-8 text-3xl">🪏</span>
+                <OperationImage operation={operation} size={32} />
             </AnimateFlyToItem>
             <Stack className="w-full">
                 <Row spacing={1} justifyContent="space-between">

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -75,7 +75,7 @@ function OperationScheduleModal({
                                     {operation.information.shortDescription}
                                 </Typography>
                                 <Typography level="body2" semiBold>
-                                    {operation.prices?.perOperation ? `${operation.prices.perOperation.toFixed(2)} €` : 'Nepoznato'}
+                                    {formatPrice(operation.prices?.perOperation)}
                                 </Typography>
                             </Stack>
                         </Row>

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -25,11 +25,7 @@ function OperationScheduleModal({
     trigger
 }: {
     operation: OperationData;
-    gardenId: number;
-    raisedBedId?: number;
-    positionIndex?: number;
     onConfirm: (date: Date) => Promise<void>;
-    disabled?: boolean;
     trigger: React.ReactElement;
 }) {
     const [open, setOpen] = useState(false);
@@ -182,10 +178,6 @@ function OperationsListItem({
             <div className="flex flex-wrap gap-y-1 gap-x-2 pr-4 items-center justify-between">
                 <OperationScheduleModal
                     operation={operation}
-                    gardenId={gardenId}
-                    raisedBedId={raisedBedId}
-                    positionIndex={positionIndex}
-                    disabled={setShoppingCartItem.isPending}
                     onConfirm={async (date) => {
                         await handleOperationPicked(operation, date);
                     }}

--- a/packages/game/src/indicators/AnimateFlyTo/AnimateFlyToItem.tsx
+++ b/packages/game/src/indicators/AnimateFlyTo/AnimateFlyToItem.tsx
@@ -1,0 +1,70 @@
+
+import type React from "react"
+import { createPortal } from "react-dom"
+import { cx } from "@signalco/ui-primitives/cx";
+import { animated, SpringValue, to } from "@react-spring/web";
+
+export type AnimateFlyToItemProps = {
+    children: React.ReactNode
+    className?: string
+    style?: React.CSSProperties
+    ref?: React.Ref<HTMLDivElement>
+    animations?: Array<number>,
+    springs?: Array<{
+        x: SpringValue<number>
+        y: SpringValue<number>
+        scale: SpringValue<number>
+        opacity: SpringValue<number>
+    }>
+}
+
+export const AnimateFlyToItem: React.FC<AnimateFlyToItemProps> = ({
+    children,
+    className,
+    style,
+    ref,
+    animations = [],
+    springs = [],
+    ...props
+}) => {
+    return (
+        <>
+            {/* Original element */}
+            <div ref={ref} className={cx('inline-block', className)} style={style} {...props}>
+                {children}
+            </div>
+
+            {/* Render animated elements in portal to document.body */}
+            {typeof document !== "undefined" &&
+                createPortal(
+                    <>
+                        {animations.map((animationId, index) => {
+                            const spring = springs[index]
+                            if (!spring) return null;
+
+                            return (
+                                <animated.div
+                                    key={animationId}
+                                    className={cx('absolute left-0 top-0 inline-block pointer-events-none', className)}
+                                    style={{
+                                        willChange: "transform, opacity",
+                                        transform:
+                                            to(
+                                                [spring.x, spring.y, spring.scale],
+                                                (x, y, scale) => `translate(${x ?? 0}px, ${y ?? 0}px) scale(${scale ?? 1})`
+                                            ),
+                                        opacity: spring.opacity ?? 1,
+                                        zIndex: 1000,
+                                        ...style,
+                                    }}
+                                >
+                                    {children}
+                                </animated.div>
+                            )
+                        })}
+                    </>,
+                    document.body
+                )}
+        </>
+    )
+}

--- a/packages/game/src/indicators/AnimateFlyTo/index.tsx
+++ b/packages/game/src/indicators/AnimateFlyTo/index.tsx
@@ -1,0 +1,3 @@
+export * from './useAnimateFlyTo';
+export * from './useAnimateFlyToShoppingCart';
+export * from './AnimateFlyToItem';

--- a/packages/game/src/indicators/AnimateFlyTo/useAnimateFlyTo.ts
+++ b/packages/game/src/indicators/AnimateFlyTo/useAnimateFlyTo.ts
@@ -1,0 +1,75 @@
+import { useState, useCallback, useRef } from "react"
+import { useSprings, config } from "@react-spring/web"
+
+export type AnimationOptions = {
+    duration?: number
+    bounceScale?: number
+    shrinkScale?: number
+}
+
+export function useAnimateFlyTo(targetX: number, targetY: number, options: AnimationOptions = {}) {
+    const { duration = 800, bounceScale = 1.3, shrinkScale = 0.3 } = options
+
+    const [animations, setAnimations] = useState<number[]>([]);
+    const elementRef = useRef<HTMLDivElement | null>(null)
+
+    const [springs, api] = useSprings(animations.length, () => {
+        if (!elementRef.current) {
+            console.warn("Element reference is not set for animation");
+            return {
+                from: { x: 0, y: 0, scale: 1, opacity: 1 },
+                to: { x: 0, y: 0, scale: 1, opacity: 0 }
+            };
+        }
+
+        const rect = elementRef.current.getBoundingClientRect();
+
+        return {
+            from: {
+                x: rect.left,
+                y: rect.top,
+                scale: 1,
+                opacity: 1
+            },
+            to: async (next) => {
+                await next({
+                    x: rect.left,
+                    y: rect.top - 10,
+                    scale: bounceScale,
+                    config: { ...config.wobbly, duration: duration * 0.2 },
+                });
+                await next({
+                    x: targetX,
+                    y: targetY,
+                    scale: 1,
+                    config: { ...config.gentle, duration: duration * 0.7 },
+                });
+                await next({
+                    scale: shrinkScale,
+                    opacity: 0,
+                    config: { ...config.slow, duration: duration * 0.1 },
+                });
+            },
+        };
+    });
+
+    const run = useCallback(async () => {
+        setAnimations(prev => [...prev, Date.now()]);
+    }, []);
+
+    const reset = useCallback(() => {
+        api.stop()
+        setAnimations([])
+    }, [api])
+
+    return {
+        run,
+        reset,
+        isAnimating: animations.length > 0,
+        props: {
+            ref: elementRef,
+            animations,
+            springs,
+        },
+    }
+}

--- a/packages/game/src/indicators/AnimateFlyTo/useAnimateFlyToShoppingCart.ts
+++ b/packages/game/src/indicators/AnimateFlyTo/useAnimateFlyToShoppingCart.ts
@@ -1,0 +1,7 @@
+import { AnimationOptions, useAnimateFlyTo } from "./useAnimateFlyTo";
+
+export function useAnimateFlyToShoppingCart(options: AnimationOptions = {}) {
+    const shoppingCartPositionX = window.innerWidth < 768 ? 30 : 20;
+    const shoppingCartPositionY = window.innerWidth < 768 ? 90 : 70;
+    return useAnimateFlyTo(shoppingCartPositionX, shoppingCartPositionY, options);
+}

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -83,7 +83,7 @@ export function OverviewModal() {
     const markAllNotificationsRead = useMarkAllNotificationsRead();
 
     // Security
-    const { data: userLogins, isPending: userLoginsLoading } = useUserLogins(currentUser.data?.id);
+    const { data: userLogins, isLoading: userLoginsLoading } = useUserLogins(currentUser.data?.id);
     const token = getAuthToken();
     const passwordLoginConnected = userLogins?.methods?.some(login => login.provider === 'password');
     const googleConnected = userLogins?.methods?.some(login => login.provider === 'google');

--- a/packages/ui/src/OperationImage/OperationImage.tsx
+++ b/packages/ui/src/OperationImage/OperationImage.tsx
@@ -1,8 +1,21 @@
 import Image from "next/image";
-import { OperationData } from "../../lib/plants/getOperationsData";
 import { Hammer } from "@signalco/ui-icons";
 
-export function OperationImage({ operation, size }: { operation: Partial<Pick<OperationData, "image" | "information">>, size?: number }) {
+export type OperationImageProps = {
+    operation: {
+        image?: {
+            cover?: {
+                url?: string;
+            };
+        };
+        information?: {
+            label?: string;
+        };
+    };
+    size?: number;
+};
+
+export function OperationImage({ operation, size }: OperationImageProps) {
     if (!operation.image?.cover?.url) {
         return (
             <Hammer

--- a/packages/ui/src/OperationImage/index.ts
+++ b/packages/ui/src/OperationImage/index.ts
@@ -1,0 +1,1 @@
+export * from './OperationImage';


### PR DESCRIPTION
### Description

- Add detailed lifecycle and info tabs for raised beds, including dimensions, filled fields count, expected yield, and plant growth lifecycle visualization.
- Introduce RaisedBedFieldOperationsTab to list planting operations filtered by application type.
- Replace custom animation hook in OperationsList with centralized useAnimateFlyToShoppingCart hook and AnimateFlyToItem component for consistent fly-to-cart animation.
- Add OperationScheduleModal to schedule garden operations within a 3-month window from the raised bed HUD.
- Simplify RaisedBedWatering component by removing unused imports and obsolete scheduling modal code, focusing on watering functionality with a streamlined modal.