### PR TITLE
feat(storage): improve attribute value upsert and default handling

### DIFF
--- a/gredice.code-workspace
+++ b/gredice.code-workspace
@@ -74,6 +74,7 @@
 		}
 	],
 	"settings": {
-		"typescript.tsdk": "📦 @gredice/game/node_modules/typescript/lib"
+		"typescript.tsdk": "📦 @gredice/game/node_modules/typescript/lib",
+		"powershell.cwd": "✨ gredice-monorepo"
 	}
 }


### PR DESCRIPTION
Refactor upsertAttributeValue to correctly assign default values when no
value is provided, ensuring attribute values are inserted or updated
with the proper value. Simplify cache busting logic to trigger only
when an existing attribute value is updated.

Enhance entity attribute processing by removing redundant map usage and
checking for existing attributes more efficiently. Add missing default
attributes based on entity type definitions and sort attributes by
their defined order to maintain consistent attribute ordering.