### PR TITLE
feat(checkout): add cartItemId metadata for reliable cart item matching

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -272,6 +272,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         imageUrls,
                         // TODO: Construct/deconstruct functions
                         metadata: {
+                            cartItemId: item.id.toString(),
                             entityId: item.entityId,
                             entityTypeName: item.entityTypeName,
                             accountId: account.id,


### PR DESCRIPTION
Include cartItemId in product metadata during checkout session creation
and extract it when processing the session. Update validation to require
cartItemId and use it to find the corresponding cart item directly,
improving accuracy and preventing duplicate payment processing. Add
additional entity consistency checks and enhance error logging for
better traceability.