### PR TITLE
refactor(storage): remove unused getReceByBusinessPin

### DIFF
--- a/packages/storage/src/repositories/invoicesRepo.ts
+++ b/packages/storage/src/repositories/invoicesRepo.ts
@@ -668,16 +668,6 @@ export async function getReceiptsByStatus(cisStatus: string) {
     });
 }
 
-export async function getReceiptsByBusinessPin(businessPin: string) {
-    return storage().query.receipts.findMany({
-        where: and(eq(receipts.businessPin, businessPin), eq(receipts.isDeleted, false)),
-        with: {
-            invoice: true,
-        },
-        orderBy: desc(receipts.issuedAt),
-    });
-}
-
 async function generateReceiptNumber(): Promise<string> {
     const firstDateOfYear = new Date(new Date().getFullYear(), 0, 1);
 


### PR DESCRIPTION
Remove the now-unused getReceiptsByBusinessPin function from the invoices
repository. The function duplicated query logic that is not referenced
anywhere in the codebase, and its removal reduces dead code and potential
maintenance overhead. No behavioral changes expected; related receipt
queries remain available via other repository methods.