### PR TITLE
feat(schedule): add copy-tasks button and external links

### DIFF
--- a/apps/app/app/admin/schedule/CopyTasksButton.tsx
+++ b/apps/app/app/admin/schedule/CopyTasksButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from "react";
+import { Duplicate } from "@signalco/ui-icons";
+import { Row } from "@signalco/ui-primitives/Row";
+
+type TaskItem = {
+    id: string;
+    text: string;
+    link?: string;
+};
+
+type CopyTasksButtonProps = {
+    physicalId: string;
+    tasks: TaskItem[];
+};
+
+export function CopyTasksButton({ physicalId, tasks }: CopyTasksButtonProps) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Create formatted text with links
+        const taskText = tasks.map(task => {
+            // TODO: Not working for WhatsApp
+            // if (task.link) {
+            //     return `• [${task.text}](${task.link})`;
+            // }
+            return `• ${task.text}`;
+        }).join('\n');
+
+        const fullText = `Gr ${physicalId}\n${taskText}`;
+
+        try {
+            await navigator.clipboard.writeText(fullText);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (error) {
+            console.error('Failed to copy to clipboard:', error);
+        }
+    };
+
+    return (
+        <Row spacing={1}>
+            <a onClick={handleCopy} className="hover:opacity-60">
+                <Duplicate className="size-4" />
+            </a>
+            {copied && <span className="text-sm text-green-500">Kopirano!</span>}
+        </Row>
+    );
+}

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -11,6 +11,10 @@ import { Accordion } from "@signalco/ui/Accordion";
 import { Fragment } from "react";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Divider } from "@signalco/ui-primitives/Divider";
+import Link from "next/link";
+import { KnownPages } from "../../../src/KnownPages";
+import { CopyTasksButton } from "./CopyTasksButton";
+import { Tally3 } from "@signalco/ui-icons";
 
 export const dynamic = 'force-dynamic';
 
@@ -102,11 +106,37 @@ async function ScheduleDay({ isToday, date, allRaisedBeds, operations, plantSort
                     })
                     .sort((a, b) => a.physicalPositionIndex.localeCompare(b.physicalPositionIndex, undefined, { numeric: true }));
 
+                // Prepare tasks for copy functionality
+                const copyTasks = [
+                    ...dayFields.map((field) => {
+                        const sortData = plantSorts?.find(ps => ps.id === field.plantSortId);
+                        const numberOfPlants = Math.pow(Math.floor(30 / (sortData?.information?.plant?.attributes?.seedingDistance || 30)), 2);
+                        return {
+                            id: `field-${field.id}`,
+                            text: `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : '?'}`,
+                        };
+                    }),
+                    ...dayOperations.map((op) => {
+                        const operationData = operationsData?.find(data => data.id === op.entityId);
+                        return {
+                            id: `operation-${op.id}`,
+                            text: `${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}`,
+                            link: operationData?.information?.label ? KnownPages.GrediceOperation(operationData?.information?.label) : KnownPages.GrediceOperations,
+                        };
+                    })
+                ];
+
                 return (
                     <Accordion key={physicalId} defaultOpen={isToday} variant="plain" className="hover:bg-muted">
                         <Row spacing={1}>
-                            <div className="rounded-full border-2 bg-background border-neutral-500 size-[19px]" />
-                            <Typography level="body1" className="text-lg"><strong>Gr {physicalId}</strong></Typography>
+                            <Tally3 className="size-5 rotate-90 mt-1" />
+                            <Typography level="h5" component="p"><strong>Gr {physicalId}</strong></Typography>
+                            {copyTasks.length > 0 && (
+                                <CopyTasksButton
+                                    physicalId={physicalId.toString()}
+                                    tasks={copyTasks}
+                                />
+                            )}
                         </Row>
                         <Stack spacing={1}>
                             {(!dayFields.length && !dayOperations.length) && (
@@ -140,7 +170,11 @@ async function ScheduleDay({ isToday, date, allRaisedBeds, operations, plantSort
                                             <input type="hidden" name="completedBy" value={userId} />
                                             <Row spacing={1}>
                                                 <Checkbox type="submit" />
-                                                <Typography>{`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}`}</Typography>
+                                                <Link
+                                                    href={operationData?.information?.label ? KnownPages.GrediceOperation(operationData?.information?.label) : KnownPages.GrediceOperations}
+                                                    target="_blank">
+                                                    <Typography>{`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}`}</Typography>
+                                                </Link>
                                                 {op.scheduledDate && (
                                                     <Typography level="body2" className="select-none">
                                                         <LocaleDateTime time={false}>{op.scheduledDate}</LocaleDateTime>

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -38,4 +38,6 @@ export const KnownPages = {
 
     // External links
     StripePayment: (paymentId: string) => `https://dashboard.stripe.com/payments/${paymentId}`,
+    GrediceOperations: `https://www.gredice.com/radnje`,
+    GrediceOperation: (operationAlias: string) => `https://www.gredice.com/radnje/${encodeURIComponent(operationAlias)}`,
 }


### PR DESCRIPTION
Add a CopyTasksButton component to the schedule admin UI that copies
a prepared list of tasks (fields and operations) to the clipboard with
a "Gr <physicalId>" header. Integrate the button into the schedule
page, prepare task text (including optional operation links), and show
a brief "Kopirano!" confirmation after successful copy. Replace the
small circular indicator with a rotated Tally3 icon and standardize
the group title typography.

Also export GrediceOperations and GrediceOperation helpers in
KnownPages so operation links can be generated.

This enables quick copying of daily tasks for sharing or pasting into
other tools and centralizes operation link generation.