### PR TITLE
feat(schedule): add operation rescheduling UI and action

### DIFF
--- a/apps/app/app/admin/schedule/RescheduleOperationModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleOperationModal.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@signalco/ui-primitives/Modal";
+import { Button } from "@signalco/ui-primitives/Button";
+import { Input } from "@signalco/ui-primitives/Input";
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { Row } from "@signalco/ui-primitives/Row";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { Calendar } from "@signalco/ui-icons";
+import { rescheduleOperationAction } from "../../(actions)/operationActions";
+
+function formatLocalDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+interface RescheduleOperationModalProps {
+    operation: {
+        id: number;
+        entityId: number;
+        scheduledDate?: Date;
+    };
+    operationLabel: string;
+    trigger: React.ReactElement;
+}
+
+export function RescheduleOperationModal({
+    operation,
+    operationLabel,
+    trigger
+}: RescheduleOperationModalProps) {
+    const [open, setOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const isRescheduling = !!operation.scheduledDate;
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        setIsLoading(true);
+        try {
+            await rescheduleOperationAction(formData);
+            setOpen(false);
+        } catch (error) {
+            console.error('Error rescheduling operation:', error);
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    const today = new Date();
+    const tomorrow = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+    const threeMonthsFromTomorrow = new Date(tomorrow.getFullYear(), tomorrow.getMonth() + 3, tomorrow.getDate());
+
+    const currentScheduledDate = operation.scheduledDate
+        ? formatLocalDate(operation.scheduledDate)
+        : formatLocalDate(tomorrow);
+    const min = formatLocalDate(tomorrow);
+    const max = formatLocalDate(threeMonthsFromTomorrow);
+
+    return (
+        <Modal
+            className="border border-tertiary border-b-4"
+            trigger={trigger}
+            title={`${isRescheduling ? 'Prerasporedi' : 'Zakaži'}: ${operationLabel}`}
+            open={open}
+            onOpenChange={setOpen}>
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="h5">
+                        {isRescheduling ? 'Preraspoređivanje operacije' : 'Zakazivanje operacije'}
+                    </Typography>
+                    <Typography>
+                        Operacija će biti {isRescheduling ? 'preraspoređena' : 'zakazana'} na odabrani datum.
+                    </Typography>
+
+                    <input type="hidden" name="operationId" value={operation.id} />
+
+                    <Input
+                        type="date"
+                        label={isRescheduling ? "Novi datum operacije" : "Datum operacije"}
+                        name="scheduledDate"
+                        className="w-full bg-card"
+                        disabled={isLoading}
+                        defaultValue={currentScheduledDate}
+                        min={min}
+                        max={max}
+                        required
+                    />
+
+                    <Row spacing={1}>
+                        <Button
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={isLoading}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            disabled={isLoading}
+                            loading={isLoading}
+                            startDecorator={<Calendar className="size-5 shrink-0" />}
+                        >
+                            {isRescheduling ? 'Prerasporedi' : 'Zakaži'}
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -14,7 +14,9 @@ import { Divider } from "@signalco/ui-primitives/Divider";
 import Link from "next/link";
 import { KnownPages } from "../../../src/KnownPages";
 import { CopyTasksButton } from "./CopyTasksButton";
-import { Tally3 } from "@signalco/ui-icons";
+import { Tally3, Calendar } from "@signalco/ui-icons";
+import { Button } from "@signalco/ui-primitives/Button";
+import { RescheduleOperationModal } from "./RescheduleOperationModal";
 
 export const dynamic = 'force-dynamic';
 
@@ -165,23 +167,45 @@ async function ScheduleDay({ isToday, date, allRaisedBeds, operations, plantSort
                                 const operationData = operationsData?.find(data => data.id === op.entityId);
                                 return (
                                     <div key={op.id}>
-                                        <form action={completeOperationAction} className="w-fit">
-                                            <input type="hidden" name="operationId" value={op.id} />
-                                            <input type="hidden" name="completedBy" value={userId} />
-                                            <Row spacing={1}>
-                                                <Checkbox type="submit" />
-                                                <Link
-                                                    href={operationData?.information?.label ? KnownPages.GrediceOperation(operationData?.information?.label) : KnownPages.GrediceOperations}
-                                                    target="_blank">
-                                                    <Typography>{`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}`}</Typography>
-                                                </Link>
+                                        <Row spacing={1} alignItems="start">
+                                            <form action={completeOperationAction} className="w-fit">
+                                                <input type="hidden" name="operationId" value={op.id} />
+                                                <input type="hidden" name="completedBy" value={userId} />
+                                                <Row spacing={1}>
+                                                    <Checkbox type="submit" />
+                                                    <Link
+                                                        href={operationData?.information?.label ? KnownPages.GrediceOperation(operationData?.information?.label) : KnownPages.GrediceOperations}
+                                                        target="_blank">
+                                                        <Typography>{`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}`}</Typography>
+                                                    </Link>
+                                                </Row>
+                                            </form>
+                                            <Row spacing={1} alignItems="center">
                                                 {op.scheduledDate && (
                                                     <Typography level="body2" className="select-none">
                                                         <LocaleDateTime time={false}>{op.scheduledDate}</LocaleDateTime>
                                                     </Typography>
                                                 )}
+                                                <RescheduleOperationModal
+                                                    operation={{
+                                                        id: op.id,
+                                                        entityId: op.entityId,
+                                                        scheduledDate: op.scheduledDate
+                                                    }}
+                                                    operationLabel={operationData?.information?.label ?? op.entityId.toString()}
+                                                    trigger={
+                                                        <Button
+                                                            variant="plain"
+                                                            size="sm"
+                                                            className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                                                            title={op.scheduledDate ? "Prerasporedi operaciju" : "Zakaži operaciju"}
+                                                        >
+                                                            <Calendar className="size-3" />
+                                                        </Button>
+                                                    }
+                                                />
                                             </Row>
-                                        </form>
+                                        </Row>
                                     </div>
                                 );
                             })}

--- a/apps/app/components/operations/OperationRescheduleButton.tsx
+++ b/apps/app/components/operations/OperationRescheduleButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Button } from "@signalco/ui-primitives/Button";
+import { Calendar } from "@signalco/ui-icons";
+import { RescheduleOperationModal } from "../../app/admin/schedule/RescheduleOperationModal";
+
+interface OperationRescheduleButtonProps {
+    operation: {
+        id: number;
+        entityId: number;
+        scheduledDate?: Date;
+        status: string;
+    };
+    operationLabel: string;
+}
+
+export function OperationRescheduleButton({ operation, operationLabel }: OperationRescheduleButtonProps) {
+    // Only show reschedule button for new and planned operations
+    if (operation.status === 'completed' || operation.status === 'failed') {
+        return null;
+    }
+
+    return (
+        <RescheduleOperationModal
+            operation={operation}
+            operationLabel={operationLabel}
+            trigger={
+                <Button
+                    variant="plain"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                    title={operation.scheduledDate ? "Prerasporedi operaciju" : "Zakaži operaciju"}
+                >
+                    <Calendar className="size-3" />
+                </Button>
+            }
+        />
+    );
+}

--- a/apps/app/components/operations/OperationsTable.tsx
+++ b/apps/app/components/operations/OperationsTable.tsx
@@ -7,6 +7,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Calendar, Tally3 } from '@signalco/ui-icons';
+import { OperationRescheduleButton } from './OperationRescheduleButton';
 
 export async function OperationsTable() {
     const [operationsData, operations, accounts, gardens, raisedBeds] = await Promise.all([
@@ -36,12 +37,13 @@ export async function OperationsTable() {
                     <Table.Head>Mjesto</Table.Head>
                     <Table.Head>Datum</Table.Head>
                     <Table.Head>Datum stvaranja</Table.Head>
+                    <Table.Head>Akcije</Table.Head>
                 </Table.Row>
             </Table.Header>
             <Table.Body>
                 {!operationsWithDetails.length && (
                     <Table.Row>
-                        <Table.Cell colSpan={4}>
+                        <Table.Cell colSpan={7}>
                             <NoDataPlaceholder />
                         </Table.Cell>
                     </Table.Row>
@@ -103,6 +105,17 @@ export async function OperationsTable() {
                                 <LocaleDateTime time={false}>
                                     {operation.createdAt ? new Date(operation.createdAt) : null}
                                 </LocaleDateTime>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <OperationRescheduleButton
+                                    operation={{
+                                        id: operation.id,
+                                        entityId: operation.entityId,
+                                        scheduledDate: operation.scheduledDate,
+                                        status: operation.status
+                                    }}
+                                    operationLabel={operation.details.label || operation.entityId.toString()}
+                                />
                             </Table.Cell>
                         </Table.Row>
                     );


### PR DESCRIPTION
Add server action rescheduleOperationAction to validate auth and inputs,
lookup the operation, emit a scheduled event and revalidate relevant
pagesschedule, account, garden, raised bed). This enables backend
processing of reschedule requests and keeps pages up to date.

Add OperationRescheduleButton client component that displays a calendar
button for non-completed/non-failed operations and opens the existing
RescheduleOperationModal. Integrate the button into OperationsTable:
add an "Actions" column, increase no-data colspan, and render the
reschedule button with the operation details and label.

These changes allow users with admin privileges to reschedule operations
from the operations table and ensure the UI reflects schedule updates.