### PR TITLE
feat(ui): update schedule layout and remove unused columns

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -65,7 +65,6 @@ export default async function RaisedBedPage({ params }: { params: Promise<{ rais
                                     <Table.Head>Status</Table.Head>
                                     <Table.Head>Planirani datum sadnje</Table.Head>
                                     <Table.Head>Datum kreiranja</Table.Head>
-                                    <Table.Head>Datum zadnje promjene</Table.Head>
                                 </Table.Row>
                             </Table.Header>
                             <Table.Body>
@@ -92,7 +91,6 @@ export default async function RaisedBedPage({ params }: { params: Promise<{ rais
                                             </Table.Cell>
                                             <Table.Cell>{field.plantScheduledDate ? <LocaleDateTime time={false}>{new Date(field.plantScheduledDate)}</LocaleDateTime> : '-'}</Table.Cell>
                                             <Table.Cell><LocaleDateTime time={false}>{field.createdAt}</LocaleDateTime></Table.Cell>
-                                            <Table.Cell><LocaleDateTime time={false}>{field.updatedAt}</LocaleDateTime></Table.Cell>
                                         </Table.Row>
                                     );
                                 })}

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -234,20 +234,23 @@ export default async function AdminSchedulePage() {
 
     return (
         <Stack spacing={2}>
-            <Typography level="h4" component="h1">Rasprored operacija</Typography>
+            <Typography level="h4" component="h1">Rasprored</Typography>
             <Stack spacing={2}>
                 {dates.map((date, dateIndex) => {
                     return (
                         <Fragment key={date.toISOString()}>
-                            <Row spacing={4} alignItems="start">
-                                <Stack className="pt-[18px]">
-                                    <Typography level="body2">
-                                        <LocaleDateTime time={false}>{date}</LocaleDateTime>
-                                    </Typography>
-                                    <Typography level="body1" uppercase semiBold={dateIndex !== 0} bold={dateIndex === 0}>
-                                        {dateIndex === 0 ? 'Danas' : new Intl.DateTimeFormat('hr-HR', { weekday: 'long' }).format(date).substring(0, 3)}
-                                    </Typography>
-                                </Stack>
+                            <div className="flex flex-col md:flex-row gap-x-4 gap-y-2">
+                                <Row spacing={1}>
+                                    <Calendar className="size-5 shrink-0 ml-2 mb-1" />
+                                    <Stack>
+                                        <Typography level="body2">
+                                            <LocaleDateTime time={false}>{date}</LocaleDateTime>
+                                        </Typography>
+                                        <Typography level="body1" uppercase semiBold={dateIndex !== 0} bold={dateIndex === 0}>
+                                            {dateIndex === 0 ? 'Danas' : new Intl.DateTimeFormat('hr-HR', { weekday: 'long' }).format(date).substring(0, 3)}
+                                        </Typography>
+                                    </Stack>
+                                </Row>
                                 <ScheduleDay
                                     isToday={dateIndex === 0}
                                     date={date}
@@ -255,7 +258,7 @@ export default async function AdminSchedulePage() {
                                     operations={operations}
                                     plantSorts={plantSorts}
                                     operationsData={operationsData} />
-                            </Row>
+                            </div>
                             <Divider />
                         </Fragment>
                     );


### PR DESCRIPTION
Shorten schedule page title and improve day row layout by adding a
calendar icon and responsive flex wrapping. Replace the old stacked
layout with a horizontal Row containing the Calendar + date text, and
wrap the entire day block in a responsive div so the schedule day and
divider align better on small and medium screens. This clarifies the
date presentation and improves spacing.

Remove "Datum zadnje promjene" column and its values from the raised
beds table since the last-updated timestamp is not required in the
current admin view, simplifying the table.