### PR TITLE
feat: add cancel operation modal and refund reason handling

### DIFF
--- a/apps/app/app/admin/schedule/CancelOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CancelOperationModal.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@signalco/ui-primitives/Modal";
+import { Button } from "@signalco/ui-primitives/Button";
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { Row } from "@signalco/ui-primitives/Row";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { Close } from "@signalco/ui-icons";
+import { cancelOperationAction } from "../../(actions)/operationActions";
+
+interface CancelOperationModalProps {
+    operation: {
+        id: number;
+        entityId: number;
+        scheduledDate?: Date;
+        status: string;
+    };
+    operationLabel: string;
+    trigger: React.ReactElement;
+}
+
+export function CancelOperationModal({
+    operation,
+    operationLabel,
+    trigger
+}: CancelOperationModalProps) {
+    const [open, setOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        setIsLoading(true);
+        try {
+            await cancelOperationAction(formData);
+            setOpen(false);
+        } catch (error) {
+            console.error('Error canceling operation:', error);
+            alert('Greška pri otkazivanju operacije: ' + (error as Error).message);
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    return (
+        <Modal
+            className="border border-tertiary border-b-4"
+            trigger={trigger}
+            title={`Otkaži: ${operationLabel}`}
+            open={open}
+            onOpenChange={setOpen}>
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="h5">
+                        Otkazivanje operacije
+                    </Typography>
+                    <Typography>
+                        Operacija će biti otkazana i korisnik će biti obaviješten o otkazivanju.
+                        {operation.status === 'planned' && ' Ako je operacija plaćena suncokretima, oni će biti refundirani.'}
+                    </Typography>
+
+                    <input type="hidden" name="operationId" value={operation.id} />
+
+                    <Stack spacing={1}>
+                        <Typography level="body2">Razlog otkazivanja</Typography>
+                        <textarea
+                            name="reason"
+                            placeholder="Unesite razlog otkazivanja operacije..."
+                            className="w-full bg-card border border-muted rounded p-2"
+                            disabled={isLoading}
+                            required
+                            rows={3}
+                        />
+                    </Stack>
+
+                    <Row spacing={1}>
+                        <Button
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={isLoading}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            color="danger"
+                            disabled={isLoading}
+                            loading={isLoading}
+                            startDecorator={<Close className="size-5 shrink-0" />}
+                        >
+                            Otkaži operaciju
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -14,9 +14,10 @@ import { Divider } from "@signalco/ui-primitives/Divider";
 import Link from "next/link";
 import { KnownPages } from "../../../src/KnownPages";
 import { CopyTasksButton } from "./CopyTasksButton";
-import { Tally3, Calendar } from "@signalco/ui-icons";
+import { Tally3, Calendar, Close } from "@signalco/ui-icons";
 import { Button } from "@signalco/ui-primitives/Button";
 import { RescheduleOperationModal } from "./RescheduleOperationModal";
+import { CancelOperationModal } from "./CancelOperationModal";
 
 export const dynamic = 'force-dynamic';
 
@@ -200,7 +201,26 @@ async function ScheduleDay({ isToday, date, allRaisedBeds, operations, plantSort
                                                             className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
                                                             title={op.scheduledDate ? "Prerasporedi operaciju" : "Zakaži operaciju"}
                                                         >
-                                                            <Calendar className="size-3" />
+                                                            <Calendar className="size-4 shrink-0" />
+                                                        </Button>
+                                                    }
+                                                />
+                                                <CancelOperationModal
+                                                    operation={{
+                                                        id: op.id,
+                                                        entityId: op.entityId,
+                                                        scheduledDate: op.scheduledDate,
+                                                        status: op.status
+                                                    }}
+                                                    operationLabel={operationData?.information?.label ?? op.entityId.toString()}
+                                                    trigger={
+                                                        <Button
+                                                            variant="plain"
+                                                            size="sm"
+                                                            className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                                                            title="Otkaži operaciju"
+                                                        >
+                                                            <Close className="size-4 shrink-0" />
                                                         </Button>
                                                     }
                                                 />

--- a/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
+++ b/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
@@ -211,7 +211,7 @@ export default async function ShoppingCartDetailsPage({ params }: { params: { ca
                                     <Table.Cell>
                                         {item.gardenId ? <Link href={KnownPages.Garden(item.gardenId)}>Vrt {item.gardenId}</Link> : ''}
                                         {item.raisedBedId ? <> | <Link href={KnownPages.RaisedBed(item.raisedBedId)}>Gr {item.raisedBedId}</Link></> : ''}
-                                        {typeof item.positionIndex === 'number' ? ` | Pozicija ${item.positionIndex}` : ''}
+                                        {typeof item.positionIndex === 'number' ? ` | Pozicija ${item.positionIndex + 1}` : ''}
                                     </Table.Cell>
                                     <Table.Cell>
                                         <LocaleDateTime time={false}>

--- a/apps/app/components/operations/OperationCancelButton.tsx
+++ b/apps/app/components/operations/OperationCancelButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Button } from "@signalco/ui-primitives/Button";
+import { Close } from "@signalco/ui-icons";
+import { CancelOperationModal } from "../../app/admin/schedule/CancelOperationModal";
+
+interface OperationCancelButtonProps {
+    operation: {
+        id: number;
+        entityId: number;
+        scheduledDate?: Date;
+        status: string;
+    };
+    operationLabel: string;
+}
+
+export function OperationCancelButton({ operation, operationLabel }: OperationCancelButtonProps) {
+    // Only show cancel button for new and planned operations
+    if (operation.status === 'completed' || operation.status === 'failed' || operation.status === 'canceled') {
+        return null;
+    }
+
+    return (
+        <CancelOperationModal
+            operation={operation}
+            operationLabel={operationLabel}
+            trigger={
+                <Button
+                    variant="plain"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                    title="Otkaži operaciju"
+                >
+                    <Close className="size-3" />
+                </Button>
+            }
+        />
+    );
+}

--- a/apps/app/components/operations/OperationsTable.tsx
+++ b/apps/app/components/operations/OperationsTable.tsx
@@ -8,6 +8,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Calendar, Tally3 } from '@signalco/ui-icons';
 import { OperationRescheduleButton } from './OperationRescheduleButton';
+import { OperationCancelButton } from './OperationCancelButton';
 
 export async function OperationsTable() {
     const [operationsData, operations, accounts, gardens, raisedBeds] = await Promise.all([
@@ -61,7 +62,9 @@ export async function OperationsTable() {
                                 <Stack>
                                     <Chip
                                         className='w-fit'
-                                        color={operation.status === 'completed' ? 'success' : (operation.status === 'planned' ? 'info' : 'warning')}>
+                                        color={operation.status === 'completed' ? 'success' :
+                                            operation.status === 'planned' ? 'info' :
+                                                operation.status === 'canceled' ? 'neutral' : 'warning'}>
                                         {operation.status}
                                     </Chip>
                                     {operation.status === 'planned' && (
@@ -107,15 +110,26 @@ export async function OperationsTable() {
                                 </LocaleDateTime>
                             </Table.Cell>
                             <Table.Cell>
-                                <OperationRescheduleButton
-                                    operation={{
-                                        id: operation.id,
-                                        entityId: operation.entityId,
-                                        scheduledDate: operation.scheduledDate,
-                                        status: operation.status
-                                    }}
-                                    operationLabel={operation.details.label || operation.entityId.toString()}
-                                />
+                                <Row spacing={1}>
+                                    <OperationRescheduleButton
+                                        operation={{
+                                            id: operation.id,
+                                            entityId: operation.entityId,
+                                            scheduledDate: operation.scheduledDate,
+                                            status: operation.status
+                                        }}
+                                        operationLabel={operation.details.label || operation.entityId.toString()}
+                                    />
+                                    <OperationCancelButton
+                                        operation={{
+                                            id: operation.id,
+                                            entityId: operation.entityId,
+                                            scheduledDate: operation.scheduledDate,
+                                            status: operation.status
+                                        }}
+                                        operationLabel={operation.details.label || operation.entityId.toString()}
+                                    />
+                                </Row>
                             </Table.Cell>
                         </Table.Row>
                     );

--- a/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
+++ b/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
@@ -40,6 +40,9 @@ function sunflowerReasonToDescription(reason: string) {
     if (reason.startsWith('shoppingCartItem')) {
         return { icon: <span className="text-4xl text-center size-10">🛒</span>, label: 'Kupnja' };
     }
+    if (reason.startsWith('refund:operation')) {
+        return { icon: <span className="text-4xl text-center size-10">↩️</span>, label: 'Povrat sredstava za radnju' };
+    }
 
     console.warn('Unknown sunflower reason:', reason);
     return { icon: <Empty className="size-10" />, label: 'Nepoznato' };

--- a/packages/storage/src/repositories/eventsRepo.ts
+++ b/packages/storage/src/repositories/eventsRepo.ts
@@ -51,6 +51,7 @@ export const knownEventTypes = {
         schedule: "operation.schedule",
         complete: "operation.complete",
         fail: "operation.fail",
+        cancel: "operation.cancel",
     }
 }
 
@@ -199,6 +200,12 @@ export const knownEvents = {
         }),
         failedV1: (aggregateId: string, data: { error: string, errorCode: string }) => ({
             type: knownEventTypes.operations.fail,
+            version: 1,
+            aggregateId,
+            data
+        }),
+        canceledV1: (aggregateId: string, data: { canceledBy: string, reason: string }) => ({
+            type: knownEventTypes.operations.cancel,
             version: 1,
             aggregateId,
             data

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -9,6 +9,7 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
         knownEventTypes.operations.schedule,
         knownEventTypes.operations.complete,
         knownEventTypes.operations.fail,
+        knownEventTypes.operations.cancel,
     ], aggregateIds, 0, 10000);
 
     return operations.map(op => {
@@ -20,6 +21,9 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
         let completedBy: string | undefined = undefined;
         let error: string | undefined = undefined;
         let errorCode: string | undefined = undefined;
+        let canceledBy: string | undefined = undefined;
+        let canceledAt: Date | undefined = undefined;
+        let cancelReason: string | undefined = undefined;
 
         for (const event of events) {
             const data = event.data as Record<string, any> | undefined;
@@ -31,6 +35,11 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
                 status = 'failed';
                 error = data?.error;
                 errorCode = data?.errorCode;
+            } else if (event.type === knownEventTypes.operations.cancel) {
+                status = 'canceled';
+                canceledBy = data?.canceledBy;
+                cancelReason = data?.reason;
+                canceledAt = event.createdAt ? new Date(event.createdAt) : undefined;
             } else if (event.type === knownEventTypes.operations.schedule) {
                 status = 'planned';
                 scheduledDate = data?.scheduledDate ? new Date(data.scheduledDate) : undefined;
@@ -44,7 +53,10 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
             completedBy,
             error,
             errorCode,
-            scheduledDate
+            scheduledDate,
+            canceledBy,
+            canceledAt,
+            cancelReason
         };
     });
 }


### PR DESCRIPTION
Add a CancelOperationModal component for admins to cancel scheduled
operations. The modal submits a cancel action, shows loading state,
disables inputs while submitting, reports errors, and closes on success.
It includes a required "reason" textarea and hidden operationId field,
and uses existing UI primitives for consistent styling.

Handle sunflower refund reason display in SunflowersList by recognizing
'refund:operation' and showing a return icon with a localized label so
refunded sunflowers are clearly identified.

Update operation actions imports to include earnSunflowers and
getEntitiesFormatted from storage for refund / entity formatting logic.