### PR TITLE
feat: add plant status options and notifications

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -49,7 +49,11 @@ export async function raisedBedFieldUpdatePlant({ raisedBedId, positionIndex, st
             // Create sprouted notification
             let header: string | null = null;
             let content: string | null = null;
-            if (status === 'sowed') {
+            if (status === 'planned') {
+                // TODO: Add not sprouted image
+                header = `📅 Biljka ${sortData.information?.name} je na rasporedu!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je na rasporedu za sijanje.`;
+            } else if (status === 'sowed') {
                 // TODO: Add seed image
                 header = `Biljka ${sortData.information?.name} je posijana!`;
                 content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** posijana je biljka **${sortData.information?.name}**.`;
@@ -57,6 +61,25 @@ export async function raisedBedFieldUpdatePlant({ raisedBedId, positionIndex, st
                 // TODO: Add sprouted image
                 header = `🌱 Proklijala je biljka ${sortData.information?.name}!`;
                 content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** proklijala je biljka **${sortData.information?.name}**.`;
+            } else if (status === 'notSprouted') {
+                // TODO: Add not sprouted image
+                header = `😢 Biljka ${sortData.information?.name} nije proklijala!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** nije proklijala. Polje je spremno za nove biljke.`;
+            } else if (status === 'died') {
+                // TODO: Add died image
+                header = `😢 Biljka ${sortData.information?.name} je uginula!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je uginula. Veselimo se novim biljkama koje će rasti na ovom mestu.`;
+            } else if (status === 'ready') {
+                // TODO: Add ready image
+                header = `🌿 Biljka ${sortData.information?.name} je spremna za berbu!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je spremna za berbu.`;
+            } else if (status === 'harvested') {
+                // TODO: Add harvested image
+                header = `🌾 Biljka ${sortData.information?.name} je ubrana!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je ubrana. Polje je spremno za nove biljke.`;
+            } else if (status === 'removed') {
+                header = `🧹 Biljka ${sortData.information?.name} je uklonjena!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je uklonjena. Polje je spremno za nove biljke.`;
             }
 
             if (header && content && raisedBed.accountId) {

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector.tsx
@@ -17,14 +17,15 @@ export function RaisedBedFieldPlantStatusSelector({ raisedBedId, positionIndex, 
                 raisedBedFieldUpdatePlant({ raisedBedId, positionIndex, status: newValue });
             }}
             items={[
-                { value: 'new', label: 'Novo' },
-                { value: 'planned', label: 'Planirano' },
-                { value: 'sowed', label: 'Sijano' },
-                { value: 'sprouted', label: 'Proklijalo' },
-                { value: 'ready', label: 'Spremno' },
-                { value: 'harvesting', label: 'Berba' },
-                { value: 'harvested', label: 'Ubrane' },
-                { value: 'removed', label: 'Uklonjene' }
+                { value: 'new', label: 'Novo', icon: '🆕' },
+                { value: 'planned', label: 'Planirano', icon: '🗓️' },
+                { value: 'sowed', label: 'Sijano', icon: '🫘' },
+                { value: 'sprouted', label: 'Proklijalo', icon: '🌱' },
+                { value: 'notSprouted', label: 'Nije proklijalo', icon: '❌' },
+                { value: 'died', label: 'Uginulo', icon: '💀' },
+                { value: 'ready', label: 'Spremno', icon: '🥕' },
+                { value: 'harvested', label: 'Ubrane', icon: '🌾' },
+                { value: 'removed', label: 'Uklonjene', icon: '🗑️' }
             ]}
         />
     );


### PR DESCRIPTION
Add new plant status options to the raised bed field selector,
including icons and additional states: notSprouted and died. Update
the selector items to include icons for better UX and expand the
status set to cover non-germination and plant death.

Extend raised bed field actions to handle the new statuses and
improve notification coverage. Create notifications for planned,
notSprouted, died, ready, harvested, and removed states (in
addition to existing sowed and sprouted), providing localized
headers and content for each state. Add TODOs for images to be
included later.

This allows more precise status tracking and user feedback for
all lifecycle events of plants.