### PR TITLE
feat: addRaisedBed and SelectRaisedBedField components

### DIFF
--- a/apps/app/app/(actions)/gardenDataActions.ts
+++ b/apps/app/app/(actions)/gardenDataActions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { auth } from "../../lib/auth/auth";
+import { getRaisedBeds, getRaisedBedFieldsWithEvents } from "@gredice/storage";
+
+export async function getGardenRaisedBeds(gardenId: number, accountId?: string) {
+    await auth(["admin"]);
+
+    if (!gardenId) {
+        throw new Error("Garden ID is required");
+    }
+
+    // Get all raised beds for the garden
+    const raisedBeds = await getRaisedBeds(gardenId);
+
+    // Filter by accountId if provided
+    if (accountId) {
+        return raisedBeds.filter(bed => bed.accountId === accountId);
+    }
+
+    return raisedBeds;
+}
+
+export async function getRaisedBedFields(raisedBedId: number) {
+    await auth(["admin"]);
+
+    if (!raisedBedId) {
+        throw new Error("Raised bed ID is required");
+    }
+
+    const fields = await getRaisedBedFieldsWithEvents(raisedBedId);
+    return fields;
+}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/OperationCreateModal.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/OperationCreateModal.tsx
@@ -9,6 +9,9 @@ import { Typography } from "@signalco/ui-primitives/Typography";
 import { Stack } from "@signalco/ui-primitives/Stack";
 import { createOperationAction } from "../../../(actions)/operationActions";
 import { SelectEntity } from "./SelectEntity";
+import { SelectRaisedBed } from "./SelectRaisedBed";
+import { SelectRaisedBedField } from "./SelectRaisedBedField";
+import { useState } from "react";
 
 type OperationCreateModalProps = {
     accountId: string;
@@ -18,6 +21,8 @@ type OperationCreateModalProps = {
 };
 
 export function OperationCreateModal({ accountId, gardenId, raisedBedId, raisedBedFieldId }: OperationCreateModalProps) {
+    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<string | null>(raisedBedId?.toString() ?? null);
+
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
@@ -33,8 +38,8 @@ export function OperationCreateModal({ accountId, gardenId, raisedBedId, raisedB
         <Modal
             title={"Nova operacija"}
             trigger={(
-                <IconButton title="Nova operacija">
-                    <Add className="size-5" />
+                <IconButton title="Nova operacija" variant="outlined">
+                    <Add className="size-4" />
                 </IconButton>
             )}>
             <Stack spacing={4}>
@@ -51,8 +56,23 @@ export function OperationCreateModal({ accountId, gardenId, raisedBedId, raisedB
                             />
                             <Input name="accountId" defaultValue={accountId} label="Account ID" required />
                             <Input name="gardenId" defaultValue={gardenId} label="Vrt ID (opcionalno)" type="number" />
-                            <Input name="raisedBedId" defaultValue={raisedBedId} label="Gredica ID (opcionalno)" />
-                            <Input name="raisedBedFieldId" defaultValue={raisedBedFieldId} label="Polje gredice ID (opcionalno)" />
+                            <SelectRaisedBed
+                                name="raisedBedId"
+                                label="Gredica"
+                                accountId={accountId}
+                                gardenId={gardenId}
+                                value={selectedRaisedBedId}
+                                onChange={setSelectedRaisedBedId}
+                                disabled={!gardenId}
+                            />
+                            <SelectRaisedBedField
+                                name="raisedBedFieldId"
+                                label="Polje gredice"
+                                raisedBedId={selectedRaisedBedId ? parseInt(selectedRaisedBedId) : undefined}
+                                gardenId={gardenId}
+                                defaultValue={raisedBedFieldId?.toString()}
+                                disabled={!selectedRaisedBedId}
+                            />
                             <Input name="timestamp" type="datetime-local" label="Datum kreiranja (opcionalno)" />
                             <Input name="scheduledDate" type="datetime-local" label="Planirani datum (opcionalno)" />
                         </div>

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/OperationsTableCard.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/OperationsTableCard.tsx
@@ -4,64 +4,7 @@ import { Table } from "@signalco/ui-primitives/Table";
 import { LocaleDateTime } from "../../../../components/shared/LocaleDateTime";
 import { Row } from "@signalco/ui-primitives/Row";
 import { OperationCreateModal } from "./OperationCreateModal";
-
-async function OperationsTable({ accountId, gardenId, raisedBedId, raisedBedFieldId }: {
-    accountId: string;
-    gardenId?: number;
-    raisedBedId?: number;
-    raisedBedFieldId?: number;
-}) {
-    const operations = await getOperations(accountId, gardenId, raisedBedId, raisedBedFieldId);
-
-    return (
-        <Table>
-            <Table.Header>
-                <Table.Row>
-                    <Table.Head>ID</Table.Head>
-                    <Table.Head>Entity ID</Table.Head>
-                    <Table.Head>Entity Type</Table.Head>
-                    <Table.Head>Account ID</Table.Head>
-                    <Table.Head>Garden ID</Table.Head>
-                    <Table.Head>Raised Bed ID</Table.Head>
-                    <Table.Head>Raised Bed Field ID</Table.Head>
-                    <Table.Head>Created At</Table.Head>
-                    <Table.Head>Status</Table.Head>
-                    <Table.Head>Completed By</Table.Head>
-                    <Table.Head>Error</Table.Head>
-                    <Table.Head>Error Code</Table.Head>
-                    <Table.Head>Scheduled Date</Table.Head>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {operations.map((operation) => (
-                    <Table.Row key={operation.id}>
-                        <Table.Cell>{operation.id}</Table.Cell>
-                        <Table.Cell>{operation.entityId}</Table.Cell>
-                        <Table.Cell>{operation.entityTypeName}</Table.Cell>
-                        <Table.Cell>{operation.accountId}</Table.Cell>
-                        <Table.Cell>{operation.gardenId}</Table.Cell>
-                        <Table.Cell>{operation.raisedBedId}</Table.Cell>
-                        <Table.Cell>{operation.raisedBedFieldId}</Table.Cell>
-                        <Table.Cell>
-                            <LocaleDateTime>
-                                {operation.createdAt}
-                            </LocaleDateTime>
-                        </Table.Cell>
-                        <Table.Cell>{operation.status}</Table.Cell>
-                        <Table.Cell>{operation.completedBy}</Table.Cell>
-                        <Table.Cell>{operation.error}</Table.Cell>
-                        <Table.Cell>{operation.errorCode}</Table.Cell>
-                        <Table.Cell>
-                            <LocaleDateTime time={false}>
-                                {operation.scheduledDate}
-                            </LocaleDateTime>
-                        </Table.Cell>
-                    </Table.Row>
-                ))}
-            </Table.Body>
-        </Table>
-    );
-}
+import { OperationsTable } from "../../../../components/operations/OperationsTable";
 
 export function OperationsTableCard({ accountId, gardenId, raisedBedId, raisedBedFieldId }: {
     accountId: string;
@@ -78,7 +21,11 @@ export function OperationsTableCard({ accountId, gardenId, raisedBedId, raisedBe
                 </Row>
             </CardHeader>
             <CardContent>
-                <OperationsTable accountId={accountId} gardenId={gardenId} raisedBedId={raisedBedId} raisedBedFieldId={raisedBedFieldId} />
+                <OperationsTable
+                    accountId={accountId}
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                    raisedBedFieldId={raisedBedFieldId} />
             </CardContent>
         </Card>
     );

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/SelectRaisedBed.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/SelectRaisedBed.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { useEffect, useState } from 'react';
+import { useControllableState } from '@signalco/hooks/useControllableState';
+import { getGardenRaisedBeds } from '../../../(actions)/gardenDataActions';
+
+export type SelectRaisedBedProps = {
+    value?: string | null;
+    defaultValue?: string | null;
+    onChange?: (value: string | null) => void;
+    accountId: string;
+    gardenId?: number;
+    name?: string;
+    label?: string;
+    required?: boolean;
+    disabled?: boolean;
+}
+
+export function SelectRaisedBed({
+    value,
+    defaultValue,
+    onChange,
+    accountId,
+    gardenId,
+    name,
+    label,
+    required,
+    disabled
+}: SelectRaisedBedProps) {
+    const [internalValue, setValue] = useControllableState(value, defaultValue, onChange);
+    const [raisedBeds, setRaisedBeds] = useState<Awaited<ReturnType<typeof getGardenRaisedBeds>>>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        if (!gardenId) {
+            setRaisedBeds([]);
+            return;
+        }
+
+        const fetchRaisedBeds = async () => {
+            setIsLoading(true);
+            try {
+                const data = await getGardenRaisedBeds(gardenId, accountId);
+                setRaisedBeds(data);
+            } catch (error) {
+                console.error('Error fetching raised beds:', error);
+                setRaisedBeds([]);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchRaisedBeds();
+    }, [gardenId, accountId]);
+
+    const items = [
+        { value: '-', label: disabled ? 'Odaberite vrt prvo' : 'Odaberite gredicu...' },
+        ...(raisedBeds?.map((raisedBed) => ({
+            value: raisedBed.id.toString(),
+            label: raisedBed.name || `Gredica ${raisedBed.id}`,
+        })) ?? []),
+    ]
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue !== '-' ? newValue : null);
+    }
+
+    return (
+        <>
+            <input type="hidden" name={name} value={internalValue ?? ''} />
+            <SelectItems
+                items={items}
+                value={internalValue ?? '-'}
+                onValueChange={handleOnChange}
+                label={label}
+                required={required}
+                disabled={disabled || isLoading || !gardenId}
+            />
+        </>
+    );
+}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/SelectRaisedBedField.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/SelectRaisedBedField.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { useEffect, useState } from 'react';
+import { useControllableState } from '@signalco/hooks/useControllableState';
+import { getRaisedBedFields } from '../../../(actions)/gardenDataActions';
+
+export type SelectRaisedBedFieldProps = {
+    value?: string | null;
+    defaultValue?: string | null;
+    onChange?: (value: string | null) => void;
+    raisedBedId?: number;
+    gardenId?: number;
+    name?: string;
+    label?: string;
+    required?: boolean;
+    disabled?: boolean;
+}
+
+export function SelectRaisedBedField({
+    value,
+    defaultValue,
+    onChange,
+    raisedBedId,
+    gardenId,
+    name,
+    label,
+    required,
+    disabled
+}: SelectRaisedBedFieldProps) {
+    const [internalValue, setValue] = useControllableState(value, defaultValue, onChange);
+    const [raisedBedFields, setRaisedBedFields] = useState<Awaited<ReturnType<typeof getRaisedBedFields>>>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        if (!raisedBedId || !gardenId) {
+            setRaisedBedFields([]);
+            return;
+        }
+
+        const fetchRaisedBedFields = async () => {
+            setIsLoading(true);
+            try {
+                const fields = await getRaisedBedFields(raisedBedId);
+                setRaisedBedFields(fields);
+            } catch (error) {
+                console.error('Error fetching raised bed fields:', error);
+                setRaisedBedFields([]);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchRaisedBedFields();
+    }, [raisedBedId, gardenId]);
+
+    const items = [
+        { value: '-', label: disabled ? 'Odaberite gredicu prvo' : 'Odaberite polje...' },
+        ...(raisedBedFields?.map((field) => ({
+            value: field.id.toString(),
+            label: `Polje ${field.positionIndex + 1}`,
+        })) ?? []),
+    ]
+
+    const handleOnChange = (newValue: string) => {
+        setValue(newValue !== '-' ? newValue : null);
+    }
+
+    return (
+        <>
+            <input type="hidden" name={name} value={internalValue ?? ''} />
+            <SelectItems
+                items={items}
+                value={internalValue ?? '-'}
+                onValueChange={handleOnChange}
+                label={label}
+                required={required}
+                disabled={disabled || isLoading || !raisedBedId || !gardenId}
+            />
+        </>
+    );
+}

--- a/apps/app/components/operations/OperationsTable.tsx
+++ b/apps/app/components/operations/OperationsTable.tsx
@@ -10,7 +10,14 @@ import { Calendar, Tally3 } from '@signalco/ui-icons';
 import { OperationRescheduleButton } from './OperationRescheduleButton';
 import { OperationCancelButton } from './OperationCancelButton';
 
-export async function OperationsTable() {
+export async function OperationsTable({
+    accountId, gardenId, raisedBedId, raisedBedFieldId
+}: {
+    accountId?: string;
+    gardenId?: number;
+    raisedBedId?: number;
+    raisedBedFieldId?: number;
+}) {
     const [operationsData, operations, accounts, gardens, raisedBeds] = await Promise.all([
         getEntitiesFormatted<EntityStandardized>('operation'),
         getAllOperations(),
@@ -18,7 +25,14 @@ export async function OperationsTable() {
         getGardens(),
         getAllRaisedBeds()
     ]);
-    const operationsWithDetails = operations.map(operation => {
+    const filteredOperations = operations.filter(op => {
+        if (accountId && op.accountId !== accountId) return false;
+        if (gardenId && op.gardenId !== gardenId) return false;
+        if (raisedBedId && op.raisedBedId !== raisedBedId) return false;
+        if (raisedBedFieldId && op.raisedBedFieldId !== raisedBedFieldId) return false;
+        return true;
+    });
+    const operationsWithDetails = filteredOperations.map(operation => {
         const operationDetails = operationsData?.find(op => op.id === operation.entityId);
         return {
             ...operation,
@@ -50,6 +64,13 @@ export async function OperationsTable() {
                     </Table.Row>
                 )}
                 {operationsWithDetails.map(operation => {
+                    const operationRaisedBed = operation.raisedBedId
+                        ? raisedBeds.find(rb => rb.id === operation.raisedBedId)
+                        : null;
+                    const operationRaisedBedField = operationRaisedBed && operation.raisedBedFieldId
+                        ? operationRaisedBed.fields.find(field => field.id === operation.raisedBedFieldId)
+                        : null;
+
                     return (
                         <Table.Row key={operation.id} className='group'>
                             <Table.Cell>
@@ -94,8 +115,8 @@ export async function OperationsTable() {
                                     {operation.raisedBedId && (
                                         <span><Tally3 className="size-4 shrink-0 rotate-90 mt-1 inline" /> Gr {raisedBeds.find(rb => rb.id === operation.raisedBedId)?.physicalId ?? 'N/A'}</span>
                                     )}
-                                    {operation.raisedBedFieldId && (
-                                        <span>{operation.raisedBedFieldId}</span>
+                                    {operationRaisedBedField && (
+                                        <span>{operationRaisedBedField.positionIndex + 1}</span>
                                     )}
                                 </Stack>
                             </Table.Cell>


### PR DESCRIPTION
Introduce two client-side reusable select components for admin raised
bed UI: SelectRaisedBed and SelectRaisedBedField. Each component:

- Implements a controllable value API (value, defaultValue, onChange)
  backed by useControllableState so forms can be both controlled and
  uncontrolled.
- Fetches options from server actions (getGardenRaisedBeds and
  getRaisedBedFields) in useEffect and exposes loading/disabled handling.
- Renders a hidden input for form submissions and a SelectItems UI
  component for interactive selection, mapping fetched data to items.
- Provides a fallback placeholder option ('-') and converts that to
  null for external consumers. Errors during fetch log and clear items.

These components are added to support selecting a garden's raised beds
and selecting fields within a raised bed in the admin area, enabling
clean form integration and async data loading.