### PR TITLE
feat(garden): active fields and show removal state

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -179,11 +179,11 @@ export async function processItem(itemData: {
                 return;
             }
 
-            // Try to resolve field ID from position index
+            // Try to resolve field ID from position index (only active fields)
             let fieldId: number | undefined = undefined;
             if (typeof itemData.positionIndex === 'number' && itemData.raisedBedId) {
                 const raisedBedFields = await getRaisedBedFieldsWithEvents(itemData.raisedBedId);
-                fieldId = raisedBedFields.find(field => field.positionIndex === itemData.positionIndex)?.id;
+                fieldId = raisedBedFields.find(field => field.positionIndex === itemData.positionIndex && field.active)?.id;
             }
 
             // Try to extract scheduled date from additional data

--- a/packages/game/src/hooks/useRaisedBedFieldRemove.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldRemove.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { currentGardenKeys, useCurrentGarden } from "./useCurrentGarden";
+import { handleOptimisticUpdate } from "../helpers/queryHelpers";
+import { client } from "@gredice/client";
+
+const mutationKey = ['gardens', 'current', 'raisedBedFieldRemove'];
+
+export function useRaisedBedFieldRemove() {
+    const queryClient = useQueryClient();
+    const { data: garden } = useCurrentGarden();
+
+    return useMutation({
+        mutationKey,
+        mutationFn: async ({ raisedBedId, positionIndex }: { raisedBedId: number; positionIndex: number }) => {
+            if (!garden) {
+                throw new Error('No garden selected');
+            }
+
+            // Find the field to validate it can be removed
+            const raisedBed = garden.raisedBeds.find(bed => bed.id === raisedBedId);
+            if (!raisedBed) {
+                throw new Error('Raised bed not found');
+            }
+
+            const field = raisedBed.fields.find(field => field.positionIndex === positionIndex && field.active);
+            if (!field) {
+                throw new Error('Field not found');
+            }
+
+            // Check if the field is marked for removal (toBeRemoved)
+            if (!field.toBeRemoved) {
+                throw new Error('Plant cannot be removed at this time. Only plants that are dead, harvested, or failed to sprout can be removed.');
+            }
+
+            // Call the backend API to update the plant status to 'removed'
+            const response = await client().api.gardens[":gardenId"]["raised-beds"][":raisedBedId"].fields[":positionIndex"].$patch({
+                param: {
+                    gardenId: garden.id.toString(),
+                    raisedBedId: raisedBedId.toString(),
+                    positionIndex: positionIndex.toString()
+                },
+                json: {
+                    status: 'removed'
+                }
+            });
+
+            if (response.status !== 200) {
+                const errorData = await response.text();
+                throw new Error(`Failed to remove plant: ${errorData}`);
+            }
+        },
+        onMutate: async ({ raisedBedId, positionIndex }) => {
+            if (!garden) {
+                return;
+            }
+
+            // Optimistically update the garden data
+            const updatedRaisedBeds = garden.raisedBeds.map(raisedBed => {
+                if (raisedBed.id === raisedBedId) {
+                    return {
+                        ...raisedBed,
+                        fields: raisedBed.fields.map(field => {
+                            if (field.positionIndex === positionIndex && field.active) {
+                                return {
+                                    ...field,
+                                    plantStatus: 'removed',
+                                    active: false,
+                                    plantRemovedDate: new Date().toISOString()
+                                };
+                            }
+                            return field;
+                        })
+                    };
+                }
+                return raisedBed;
+            });
+
+            const previousItem = await handleOptimisticUpdate(queryClient, currentGardenKeys, {
+                ...garden,
+                raisedBeds: updatedRaisedBeds
+            });
+
+            return {
+                previousItem
+            };
+        },
+        onError: (error, _variables, context) => {
+            console.error('Error removing plant from field:', error);
+            if (context?.previousItem) {
+                queryClient.setQueryData(currentGardenKeys, context.previousItem);
+            }
+        },
+        onSettled: async () => {
+            // Invalidate queries to refetch fresh data
+            if (queryClient.isMutating({ mutationKey }) === 1) {
+                await queryClient.invalidateQueries({ queryKey: currentGardenKeys });
+            }
+        }
+    });
+}

--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -96,7 +96,7 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
 
 export function NotificationList({ read, short }: NotificationProps) {
     const { data: currentUser } = useCurrentUser();
-    const { data: notifications, error } = useNotifications(currentUser?.id, read, 0, short ? 10 : undefined);
+    const { data: notifications, error } = useNotifications(currentUser?.id, read, 0, short ? 10 : 1000);
     const isLoading = false;
     if (isLoading) {
         return (

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -13,7 +13,7 @@ function RaisedBedFieldItem({ gardenId, raisedBedId, positionIndex }: { raisedBe
         return null;
     }
 
-    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
+    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex && field.active);
     const hasField = Boolean(field);
 
     if (isGardenLoading) {

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -16,6 +16,7 @@ export function RaisedBedFieldItemEmpty({ gardenId, raisedBedId, positionIndex }
     }
 
     const cartItems = cart?.items.filter(item =>
+        item.gardenId === gardenId &&
         item.raisedBedId === raisedBedId &&
         item.positionIndex === positionIndex);
     const cartPlantItem = cartItems?.find(item => item.entityTypeName === 'plantSort' && item.status === 'new');

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -18,7 +18,7 @@ export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { rais
         return null;
     }
 
-    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
+    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex && field.active);
     if (!field || !field.plantSortId) {
         console.error(`Field not found for raised bed ${raisedBedId} at position index ${positionIndex}`, raisedBed.fields);
         return null;
@@ -50,21 +50,27 @@ export function RaisedBedFieldItemPlanted({ raisedBedId, positionIndex }: { rais
         );
     }
 
+    const segments = field.toBeRemoved ?
+        [
+            { value: 100, percentage: 100, color: "stroke-red-500", trackColor: "stroke-red-50 dark:stroke-red-50/80" },
+        ] :
+        [
+            { value: germinationValue, percentage: germinationPercentage, color: "stroke-yellow-500", trackColor: "stroke-yellow-50 dark:stroke-yellow-50/80", pulse: !field.plantGrowthDate },
+            { value: growthValue, percentage: growthPercentage, color: "stroke-green-500", trackColor: "stroke-green-50 dark:stroke-green-50/80", pulse: !field.plantReadyDate },
+            { value: harvestValue, percentage: harvestPercentage, color: "stroke-blue-500", trackColor: "stroke-blue-50 dark:stroke-blue-50/80", pulse: Boolean(harvestValue) },
+        ];
+
     return (
         <Modal
             title={`Biljka "${plantSort.information.name}"`}
             modal={false}
-            className="md:border-tertiary md:border-b-4"
+            className="md:border-tertiary md:border-b-4 max-w-xl"
             trigger={(
                 <RaisedBedFieldItemButton>
                     <SegmentedCircularProgress
                         size={80}
                         strokeWidth={4}
-                        segments={[
-                            { value: germinationValue, percentage: germinationPercentage, color: "stroke-yellow-500", trackColor: "stroke-yellow-50 dark:stroke-yellow-50/80", pulse: !field.plantGrowthDate },
-                            { value: growthValue, percentage: growthPercentage, color: "stroke-green-500", trackColor: "stroke-green-50 dark:stroke-green-50/80", pulse: !field.plantReadyDate },
-                            { value: harvestValue, percentage: harvestPercentage, color: "stroke-blue-500", trackColor: "stroke-blue-50 dark:stroke-blue-50/80", pulse: Boolean(harvestValue) },
-                        ]}
+                        segments={segments}
                     >
                         <img
                             src={`https://www.gredice.com/${plantSort.image?.cover?.url || plantSort.information.plant.image?.cover?.url}`}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -6,6 +6,9 @@ import { ReactNode } from "react";
 import { usePlantSort } from "../../hooks/usePlantSorts";
 import { useCurrentGarden } from "../../hooks/useCurrentGarden";
 import { Chip } from "@signalco/ui-primitives/Chip";
+import { Button } from "@signalco/ui-primitives/Button";
+import { ShovelIcon } from "../../icons/Shovel";
+import { useRaisedBedFieldRemove } from "../../hooks/useRaisedBedFieldRemove";
 
 // TODO: Move to a separate file
 export function useRaisedBedFieldLifecycleData(raisedBedId: number, positionIndex: number) {
@@ -18,25 +21,18 @@ export function useRaisedBedFieldLifecycleData(raisedBedId: number, positionInde
         growingDays: 0,
         harvestValue: 0,
         harvestPercentage: 0,
-        readyDays: 0
+        readyDays: 0,
     };
     const { data: garden } = useCurrentGarden();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
-    if (!raisedBed) {
-        return result;
-    }
-
-    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
-    if (!field || !field.plantSortId) {
-        console.error(`Field not found for raised bed ${raisedBedId} at position index ${positionIndex}`, raisedBed.fields);
-        return result;
-    }
-
-    const plantSortId = field.plantSortId;
+    const field = raisedBed?.fields.find(field => field.positionIndex === positionIndex && field.active);
+    const plantSortId = field?.plantSortId;
     const { data: plantSort } = usePlantSort(plantSortId);
-    if (!plantSort) {
+    if (!raisedBed || !field || !plantSort) {
         return result;
     }
+
+    const targetDateNow = (field.stoppedDate ? new Date(field.stoppedDate) : new Date()).getTime();
 
     const maxDuration =
         (plantSort.information.plant.attributes?.germinationWindowMax ?? 0) +
@@ -52,33 +48,33 @@ export function useRaisedBedFieldLifecycleData(raisedBedId: number, positionInde
     result.germinationValue = field.plantGrowthDate
         ? 100
         : (field.plantSowDate
-            ? Math.min(100, ((Date.now() - new Date(field.plantSowDate).getTime())) / (germinationWindowMs || 1) * 100)
+            ? Math.min(100, ((targetDateNow - new Date(field.plantSowDate).getTime())) / (germinationWindowMs || 1) * 100)
             : 0);
     result.germinatingDays = Math.round(((field.plantGrowthDate
         ? new Date(field.plantGrowthDate).getTime()
-        : Date.now()) - (field.plantSowDate
+        : targetDateNow) - (field.plantSowDate
             ? new Date(field.plantSowDate).getTime()
-            : Date.now())) / (1000 * 60 * 60 * 24));
+            : targetDateNow)) / (1000 * 60 * 60 * 24));
 
     result.growthPercentage = 100 - result.germinationPercentage - result.harvestPercentage;
     const growthWindowMs = (plantSort.information.plant.attributes?.growthWindowMax ?? 0) * 24 * 60 * 60 * 1000;
     result.growthValue = field.plantReadyDate ?
         100
         : (field.plantGrowthDate
-            ? Math.min(100, (Date.now() - new Date(field.plantGrowthDate).getTime()) / (growthWindowMs || 1) * 100)
+            ? Math.min(100, (targetDateNow - new Date(field.plantGrowthDate).getTime()) / (growthWindowMs || 1) * 100)
             : 0);
     result.growingDays = Math.round(((field.plantReadyDate
         ? new Date(field.plantReadyDate).getTime()
-        : Date.now()) - (field.plantGrowthDate
+        : targetDateNow) - (field.plantGrowthDate
             ? new Date(field.plantGrowthDate).getTime()
-            : Date.now())) / (1000 * 60 * 60 * 24));
+            : targetDateNow)) / (1000 * 60 * 60 * 24));
 
     result.harvestValue = field.plantReadyDate
-        ? Math.min(100, (Date.now() - new Date(field.plantReadyDate).getTime()) / (plantSort.information.plant.attributes?.harvestWindowMax ?? 1) * 100)
+        ? Math.min(100, (targetDateNow - new Date(field.plantReadyDate).getTime()) / (plantSort.information.plant.attributes?.harvestWindowMax ?? 1) * 100)
         : 0;
-    result.readyDays = Math.round(((Date.now() - (field.plantReadyDate
+    result.readyDays = Math.round(((targetDateNow - (field.plantReadyDate
         ? new Date(field.plantReadyDate).getTime()
-        : Date.now())) / (1000 * 60 * 60 * 24)));
+        : targetDateNow)) / (1000 * 60 * 60 * 24)));
 
     return result;
 }
@@ -90,9 +86,8 @@ function useRaisedBedField(raisedBedId: number, positionIndex: number) {
         return null;
     }
 
-    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex);
+    const field = raisedBed.fields.find(field => field.positionIndex === positionIndex && field.active);
     if (!field || !field.plantSortId) {
-        console.error(`Field not found for raised bed ${raisedBedId} at position index ${positionIndex}`, raisedBed.fields);
         return null;
     }
 
@@ -101,11 +96,7 @@ function useRaisedBedField(raisedBedId: number, positionIndex: number) {
 
 function useRaisedBedFieldPlantSort(raisedBedId: number, positionIndex: number) {
     const field = useRaisedBedField(raisedBedId, positionIndex);
-    if (!field) {
-        return null;
-    }
-
-    const plantSortId = field.plantSortId;
+    const plantSortId = field?.plantSortId;
     const { data: plantSort } = usePlantSort(plantSortId);
     if (!plantSort) {
         return null;
@@ -128,9 +119,27 @@ export function RaisedBedFieldLifecycleTab({ raisedBedId, positionIndex }: { rai
     } = useRaisedBedFieldLifecycleData(raisedBedId, positionIndex);
     const field = useRaisedBedField(raisedBedId, positionIndex);
     const plantSort = useRaisedBedFieldPlantSort(raisedBedId, positionIndex);
+    const removeFieldMutation = useRaisedBedFieldRemove();
+
     if (!plantSort || !field) {
         return null;
     }
+
+    const handleRemovePlant = async () => {
+        if (!field.toBeRemoved) {
+            return;
+        }
+
+        try {
+            await removeFieldMutation.mutateAsync({
+                raisedBedId,
+                positionIndex
+            });
+        } catch (error) {
+            console.error('Failed to remove plant:', error);
+            // TODO: Show error message to user
+        }
+    };
 
     const plantScheduledDate = field.plantScheduledDate
         ? new Date(field.plantScheduledDate)
@@ -151,6 +160,10 @@ export function RaisedBedFieldLifecycleTab({ raisedBedId, positionIndex }: { rai
             icon = <span className="mr-0.5">{'𓇢'}</span>;
             localizedStatus = 'Posijana';
             break;
+        case 'notSprouted':
+            icon = <span className="mr-0.5">{'😢'}</span>;
+            localizedStatus = 'Nije proklijala';
+            break;
         case 'sprouted':
             icon = <span className="mr-0.5">{'🌱'}</span>;
             localizedStatus = 'Proklijala';
@@ -164,7 +177,7 @@ export function RaisedBedFieldLifecycleTab({ raisedBedId, positionIndex }: { rai
             localizedStatus = 'Ubrana';
             break;
         case 'died':
-            icon = <span className="mr-0.5">{'💀'}</span>;
+            icon = <span className="mr-0.5">{'😢'}</span>;
             localizedStatus = 'Uginula';
             break;
         case 'uprooted':
@@ -179,99 +192,116 @@ export function RaisedBedFieldLifecycleTab({ raisedBedId, positionIndex }: { rai
     const growingDaysDayPlural = growingDays === 1 ? 'dan' : 'dana';
     const readyDaysDayPlural = readyDays === 1 ? 'dan' : 'dana';
 
+    const segments = field.toBeRemoved ?
+        [
+            { value: 100, percentage: 100, color: "stroke-red-500", trackColor: "stroke-red-50 dark:stroke-red-50/80" },
+        ]
+        : [
+            { value: germinationValue, percentage: germinationPercentage, color: "stroke-yellow-500", trackColor: "stroke-yellow-200 dark:stroke-yellow-50", pulse: !field.plantGrowthDate },
+            { value: growthValue, percentage: growthPercentage, color: "stroke-green-500", trackColor: "stroke-green-200 dark:stroke-green-50", pulse: !field.plantReadyDate },
+            { value: harvestValue, percentage: harvestPercentage, color: "stroke-blue-500", trackColor: "stroke-blue-200 dark:stroke-blue-50", pulse: Boolean(harvestValue) },
+        ];
+
     return (
-        <div className="grid grid-cols-[auto_1fr] gap-2 items-center">
-            <Stack spacing={1}>
-                {plantScheduledDate && (
-                    <>
-                        <Typography level="body2">Planirani datum</Typography>
-                        <div className="flex items-start">
-                            <Chip>{plantScheduledDate?.toLocaleDateString("hr-HR") || 'Nepoznato'}</Chip>
-                        </div>
-                    </>
-                )}
+        <Stack spacing={2}>
+            {plantScheduledDate && (
                 <Row spacing={2}>
-                    <SegmentedCircularProgress
-                        size={140}
-                        strokeWidth={3}
-                        segments={[
-                            { value: germinationValue, percentage: germinationPercentage, color: "stroke-yellow-500", trackColor: "stroke-yellow-200 dark:stroke-yellow-50", pulse: !field.plantGrowthDate },
-                            { value: growthValue, percentage: growthPercentage, color: "stroke-green-500", trackColor: "stroke-green-200 dark:stroke-green-50", pulse: !field.plantReadyDate },
-                            { value: harvestValue, percentage: harvestPercentage, color: "stroke-blue-500", trackColor: "stroke-blue-200 dark:stroke-blue-50", pulse: Boolean(harvestValue) },
-                        ]}
-                    >
-                        <Stack alignItems="center" className="border bg-card rounded-full shrink-0 size-[100px] aspect-square shadow flex items-center justify-center">
-                            <span className="text-2xl">{icon}</span>
-                            <Typography level="body1" className="text-center" semiBold>
-                                {localizedStatus}
-                            </Typography>
-                        </Stack>
-                    </SegmentedCircularProgress>
-                    <Stack spacing={1}>
-                        <Stack>
-                            <Typography level="body2" secondary>Klijanje ({plantSort.information.plant.attributes?.germinationWindowMin}-{plantSort.information.plant.attributes?.germinationWindowMax} dana)</Typography>
-                            <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
-                                <Typography>
-                                    {field.plantSowDate
-                                        ? new Date(field.plantSowDate).toLocaleDateString("hr-HR")
-                                        : 'Nije posijano'}
-                                </Typography>
-                                {field.plantSowDate && (
-                                    <>
-                                        <span>-</span>
-                                        <Typography noWrap>
-                                            {field.plantGrowthDate
-                                                ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
-                                                : 'U tijeku...'}
-                                        </Typography>
-                                        <Typography>
-                                            ({germinatingDays} {germinatingDaysDayPlural})
-                                        </Typography>
-                                    </>
-                                )}
-                            </div>
-                        </Stack>
-                        <Stack>
-                            <Typography level="body2" secondary>Rast ({plantSort.information.plant.attributes?.growthWindowMin}-{plantSort.information.plant.attributes?.growthWindowMax} dana)</Typography>
-                            <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
-                                <Typography>
-                                    {field.plantGrowthDate
-                                        ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
-                                        : 'Nije u fazi rasta'}
-                                </Typography>
-                                {field.plantGrowthDate && (
-                                    <>
-                                        <span>-</span>
-                                        <Typography noWrap>
-                                            {field.plantReadyDate
-                                                ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
-                                                : 'U tijeku...'}
-                                        </Typography>
-                                        <Typography>
-                                            ({growingDays} {growingDaysDayPlural})
-                                        </Typography>
-                                    </>
-                                )}
-                            </div>
-                        </Stack>
-                        <Stack>
-                            <Typography level="body2" secondary>Berba ({plantSort.information.plant.attributes?.harvestWindowMin}-{plantSort.information.plant.attributes?.harvestWindowMax} dana)</Typography>
-                            <Row spacing={0.5}>
-                                <Typography>
-                                    {field.plantReadyDate
-                                        ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
-                                        : 'Nije u fazi berbe'}
-                                </Typography>
-                                {field.plantReadyDate && (
-                                    <Typography>
-                                        ({readyDays} {readyDaysDayPlural})
-                                    </Typography>
-                                )}
-                            </Row>
-                        </Stack>
-                    </Stack>
+                    <Typography level="body2">Planirani datum</Typography>
+                    <div className="flex items-start">
+                        <Chip>{plantScheduledDate?.toLocaleDateString("hr-HR") || 'Nepoznato'}</Chip>
+                    </div>
                 </Row>
-            </Stack>
-        </div>
+            )}
+            <Row spacing={2}>
+                <SegmentedCircularProgress
+                    size={140}
+                    strokeWidth={3}
+                    segments={segments}
+                >
+                    <Stack alignItems="center" className="border bg-card rounded-full shrink-0 size-[100px] aspect-square shadow flex items-center justify-center">
+                        <span className="text-2xl">{icon}</span>
+                        <Typography level="body1" className="text-center" semiBold>
+                            {localizedStatus}
+                        </Typography>
+                    </Stack>
+                </SegmentedCircularProgress>
+                <Stack spacing={1}>
+                    <Stack>
+                        <Typography level="body2" secondary>Klijanje ({plantSort.information.plant.attributes?.germinationWindowMin}-{plantSort.information.plant.attributes?.germinationWindowMax} dana)</Typography>
+                        <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
+                            <Typography>
+                                {field.plantSowDate
+                                    ? new Date(field.plantSowDate).toLocaleDateString("hr-HR")
+                                    : 'Nije posijano'}
+                            </Typography>
+                            {field.plantSowDate && (
+                                <>
+                                    <span>-</span>
+                                    <Typography noWrap>
+                                        {field.plantGrowthDate
+                                            ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
+                                            : (field.stoppedDate ? new Date(field.stoppedDate).toLocaleDateString("hr-HR") : 'U tijeku...')}
+                                    </Typography>
+                                    <Typography>
+                                        ({germinatingDays} {germinatingDaysDayPlural})
+                                    </Typography>
+                                </>
+                            )}
+                        </div>
+                    </Stack>
+                    <Stack>
+                        <Typography level="body2" secondary>Rast ({plantSort.information.plant.attributes?.growthWindowMin}-{plantSort.information.plant.attributes?.growthWindowMax} dana)</Typography>
+                        <div className="grid gap-x-2 items-center grid-cols-[auto_auto_auto] md:grid-cols-[repeat(4,auto)]">
+                            <Typography>
+                                {field.plantGrowthDate
+                                    ? new Date(field.plantGrowthDate).toLocaleDateString("hr-HR")
+                                    : 'Nije u fazi rasta'}
+                            </Typography>
+                            {field.plantGrowthDate && (
+                                <>
+                                    <span>-</span>
+                                    <Typography noWrap>
+                                        {field.plantReadyDate
+                                            ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
+                                            : (field.stoppedDate ? new Date(field.stoppedDate).toLocaleDateString("hr-HR") : 'U tijeku...')}
+                                    </Typography>
+                                    <Typography>
+                                        ({growingDays} {growingDaysDayPlural})
+                                    </Typography>
+                                </>
+                            )}
+                        </div>
+                    </Stack>
+                    <Stack>
+                        <Typography level="body2" secondary>Berba ({plantSort.information.plant.attributes?.harvestWindowMin}-{plantSort.information.plant.attributes?.harvestWindowMax} dana)</Typography>
+                        <Row spacing={0.5}>
+                            <Typography>
+                                {field.plantReadyDate
+                                    ? new Date(field.plantReadyDate).toLocaleDateString("hr-HR")
+                                    : 'Nije u fazi berbe'}
+                            </Typography>
+                            {field.plantReadyDate && (
+                                <Typography>
+                                    ({readyDays} {readyDaysDayPlural})
+                                </Typography>
+                            )}
+                        </Row>
+                    </Stack>
+                </Stack>
+            </Row>
+            {field.toBeRemoved && (
+                <Row>
+                    <Button
+                        variant="solid"
+                        fullWidth
+                        loading={removeFieldMutation.isPending}
+                        disabled={removeFieldMutation.isPending}
+                        onClick={handleRemovePlant}
+                        startDecorator={<ShovelIcon className="size-5 shrink-0" />}>
+                        Ukloni biljku
+                    </Button>
+                </Row>
+            )}
+        </Stack>
     )
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -27,7 +27,7 @@ export function RaisedBedFieldSuggestions({ gardenId, raisedBedId }: { gardenId:
 
         await Promise.all(Array.from({ length: 9 }).map(async (_, index) => {
             if (!raisedBed || !shoppingCart) return;
-            if (raisedBed.fields.find(field => field.positionIndex === index)) return;
+            if (raisedBed.fields.find(field => field.positionIndex === index && field.active)) return;
             if (shoppingCart.items.find(item => item.raisedBedId === raisedBedId && item.positionIndex === index && item.entityTypeName === 'plantSort' && item.status === 'new')) return;
             return setCartItem.mutateAsync({
                 entityTypeName: "plantSort",

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -311,7 +311,7 @@ export function OverviewModal() {
                                     </Row>
                                 </Card>
                                 <div className="overflow-y-auto max-h-[calc(100dvh-18rem)] md:max-h-[calc(100dvh-24rem)] rounded-lg text-card-foreground bg-card shadow-sm p-0">
-                                    <NotificationList read={notificationsFilter === 'all'} short />
+                                    <NotificationList read={notificationsFilter === 'all'} />
                                 </div>
                             </Stack>
                         </Stack>

--- a/packages/storage/src/repositories/eventsRepo.ts
+++ b/packages/storage/src/repositories/eventsRepo.ts
@@ -45,7 +45,6 @@ export const knownEventTypes = {
         delete: "raisedBedField.delete",
         plantPlace: "raisedBedField.plantPlace",
         plantUpdate: "raisedBedField.plantUpdate",
-        plantAbandon: "raisedBedField.plantAbandon",
     },
     operations: {
         schedule: "operation.schedule",
@@ -165,12 +164,6 @@ export const knownEvents = {
             type: knownEventTypes.raisedBedFields.delete,
             version: 1,
             aggregateId,
-        }),
-        plantAbandonV1: (aggregateId: string) => ({
-            type: knownEventTypes.raisedBedFields.plantAbandon,
-            version: 1,
-            aggregateId,
-            data: { status: "abandoned" },
         }),
         plantPlaceV1: (aggregateId: string, data: { plantSortId: string, scheduledDate: string | null | undefined }) => ({
             type: knownEventTypes.raisedBedFields.plantPlace,


### PR DESCRIPTION
- Ensure raised bed field lookup only matches active fields in UI and API
  (RaisedBedFieldItemPlanted.tsx, processCheckoutSession.ts). This avoids
  rendering or resolving fields that have been deactivated and prevents
  operations from targeting inactive positions.

- Add explicit "to be removed" visualization for planted field progress by
  computing a single red segment when field.toBeRemoved is true and moving
  progress segment construction into a local `segments` variable. Also limit
  modal width (max-w-xl) to improve layout.

- Wire new event creation imports and begin adding a PATCH route scaffold to
  gardensRoutes to support updating a plant in a raised bed field. This
  prepares the API for field update operations and event creation handling.