### PR TITLE
fix(hud/raised-bed): update 'died' status text to Croatian/Bosnian

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -67,8 +67,8 @@ export async function raisedBedFieldUpdatePlant({ raisedBedId, positionIndex, st
                 content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** nije proklijala. Polje je spremno za nove biljke.`;
             } else if (status === 'died') {
                 // TODO: Add died image
-                header = `😢 Biljka ${sortData.information?.name} je uginula!`;
-                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je uginula. Veselimo se novim biljkama koje će rasti na ovom mestu.`;
+                header = `😢 Biljka ${sortData.information?.name} nije uspjela!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** nije uspjela. Veselimo se novim biljkama koje će rasti na ovom mestu.`;
             } else if (status === 'ready') {
                 // TODO: Add ready image
                 header = `🌿 Biljka ${sortData.information?.name} je spremna za berbu!`;

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -178,7 +178,7 @@ export function RaisedBedFieldLifecycleTab({ raisedBedId, positionIndex }: { rai
             break;
         case 'died':
             icon = <span className="mr-0.5">{'😢'}</span>;
-            localizedStatus = 'Uginula';
+            localizedStatus = 'Neuspjela';
             break;
         case 'uprooted':
             localizedStatus = 'Uklonjena';


### PR DESCRIPTION
Change the displayed and notification text for the 'died' lifecycle
status of raised bed plants from "Uginula" / "je uginula" to
"Neuspjela" / "nije uspjela". Also adjust the notification header to
match the new wording.

This aligns the UI wording with the preferred localized term and
ensures consistency between the HUD status label and the app's action
notifications.