### PR TITLE
fix(next-config): add types and semicolon, annotate NextConfig

### DIFF
--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -1,9 +1,8 @@
-// @ts-check
-import vercelToolbar from '@vercel/toolbar/plugins/next'
+import vercelToolbar from '@vercel/toolbar/plugins/next';
 import { withAxiom } from 'next-axiom';
+import type { NextConfig } from 'next';
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
     reactStrictMode: true,
     experimental: {
         reactCompiler: true,

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -1,8 +1,8 @@
-import vercelToolbar from '@vercel/toolbar/plugins/next'
+import vercelToolbar from '@vercel/toolbar/plugins/next';
 import { withAxiom } from 'next-axiom';
+import type { NextConfig } from 'next';
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
     experimental: {
         reactCompiler: true,
         // Scope hoisting is disabled as a workaround for current compatibility issues with Turbopack and our codebase.


### PR DESCRIPTION
Update Next.js config files for apps/garden and apps/www:
- add explicit NextConfig type annotation to improve TypeScript
  type checking and editor inference.
- add missing semicolons on vercelToolbar imports for consistent
  code style.
- remove JSDoc import type comment in favor of direct TypeScript type.

These changes clarify types and enforce consistent formatting to
reduce editor/compile-time warnings and improve developer ergonomics.