### PR TITLE
feat(fiscalization): handle CIS responses and show confirmed state

### DIFF
--- a/apps/app/app/admin/invoices/InvoicesTable.tsx
+++ b/apps/app/app/admin/invoices/InvoicesTable.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { NoDataPlaceholder } from "../../../components/shared/placeholders/NoDataPlaceholder";
 import { LocaleDateTime } from "../../../components/shared/LocaleDateTime";
 import { ExternalLink } from "@signalco/ui-icons";
+import { Typography } from "@signalco/ui-primitives/Typography";
 
 function getStatusColor(status: string) {
     switch (status) {
@@ -66,8 +67,8 @@ export async function InvoicesTable({ transactionId }: { transactionId?: number 
                         </Table.Cell>
                         <Table.Cell>
                             <div>
-                                <div className="font-medium">{invoice.billToName}</div>
-                                <div className="text-sm text-gray-500">{invoice.billToEmail}</div>
+                                <Typography>{invoice.billToName}</Typography>
+                                <Typography level="body2">{invoice.billToEmail}</Typography>
                             </div>
                         </Table.Cell>
                         <Table.Cell>
@@ -98,7 +99,7 @@ export async function InvoicesTable({ transactionId }: { transactionId?: number 
                                     </Chip>
                                 </Link>
                             ) : (
-                                <span className="text-gray-500">Nema transakcije</span>
+                                <NoDataPlaceholder>Nema transakcije</NoDataPlaceholder>
                             )}
                         </Table.Cell>
                     </Table.Row>

--- a/apps/app/app/admin/invoices/[invoiceId]/InvoiceActions.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/InvoiceActions.tsx
@@ -9,7 +9,6 @@ import { Edit, Delete, Send, Check, Clear, FileText } from "@signalco/ui-icons";
 import { useState, useTransition, useEffect } from "react";
 import { changeInvoiceStatusAction, cancelInvoiceAction, deleteInvoiceAction, createReceiptAction, getInvoiceReceiptAction } from "./actions";
 import { canEditInvoice, canDeleteInvoice, canCancelInvoice, InvoiceStatus } from "./invoiceUtils";
-import Link from "next/link";
 import { KnownPages } from "../../../../src/KnownPages";
 
 type Invoice = {
@@ -98,17 +97,16 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
                         variant="outlined"
                         startDecorator={<Edit className="size-4" />}
                         disabled={isPending}
+                        href={`${KnownPages.Invoice(invoice.id)}/edit`}
                     >
-                        <Link href={`${KnownPages.Invoice(invoice.id)}/edit`}>
-                            Uredi
-                        </Link>
+                        Uredi
                     </Button>
                 )}
 
                 {/* Status Transition Buttons */}
                 {status === 'draft' && (
                     <Button
-                        variant="soft"
+                        variant="solid"
                         startDecorator={<FileText className="size-4" />}
                         disabled={isPending}
                         onClick={() => handleStatusChange('pending')}
@@ -119,19 +117,18 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
 
                 {status === 'pending' && (
                     <Button
-                        variant="soft"
-                        color="primary"
+                        variant="solid"
                         startDecorator={<Send className="size-4" />}
                         disabled={isPending}
                         onClick={() => handleStatusChange('sent')}
                     >
-                        Pošalji
+                        Zaključaj
                     </Button>
                 )}
 
                 {status === 'sent' && (
                     <Button
-                        variant="soft"
+                        variant="solid"
                         color="success"
                         startDecorator={<Check className="size-4" />}
                         disabled={isPending}
@@ -144,7 +141,7 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
                 {/* Create Receipt Button - only when invoice is paid */}
                 {status === 'paid' && receiptChecked && !existingReceipt && (
                     <Button
-                        variant="soft"
+                        variant="solid"
                         color="primary"
                         startDecorator={<FileText className="size-4" />}
                         disabled={isPending}
@@ -160,10 +157,9 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
                         variant="outlined"
                         startDecorator={<FileText className="size-4" />}
                         disabled={isPending}
+                        href={KnownPages.Receipt(existingReceipt.id)}
                     >
-                        <Link href={KnownPages.Receipt(existingReceipt.id)}>
-                            Prikaži račun
-                        </Link>
+                        Prikaži račun
                     </Button>
                 )}
 

--- a/apps/app/app/admin/invoices/[invoiceId]/page.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/page.tsx
@@ -13,6 +13,7 @@ import { LocaleDateTime } from "../../../../components/shared/LocaleDateTime";
 import { InvoiceActions } from "./InvoiceActions";
 import { isOverdue } from "./invoiceUtils";
 import { Breadcrumbs } from "@signalco/ui/Breadcrumbs";
+import { NoDataPlaceholder } from "../../../../components/shared/placeholders/NoDataPlaceholder";
 
 export const dynamic = 'force-dynamic';
 
@@ -178,6 +179,9 @@ export default async function InvoicePage({ params }: { params: { invoiceId: str
                             </CardHeader>
                             <CardContent>
                                 <Stack spacing={2}>
+                                    {!invoice.transactionId && (
+                                        <NoDataPlaceholder>Nema povezanih stavki</NoDataPlaceholder>
+                                    )}
                                     {invoice.transactionId && (
                                         <Row spacing={2} alignItems="center">
                                             <Typography level="body2" className="w-20">Transakcija:</Typography>
@@ -218,10 +222,10 @@ export default async function InvoicePage({ params }: { params: { invoiceId: str
                                                 <Typography>{item.quantity} kom</Typography>
                                             </Table.Cell>
                                             <Table.Cell className="text-right">
-                                                <Typography>{item.unitPrice}{invoice.currency === 'eur' ? '€' : invoice.currency}</Typography>
+                                                <Typography>{Number(item.unitPrice).toFixed(2)}{invoice.currency === 'eur' ? '€' : invoice.currency}</Typography>
                                             </Table.Cell>
                                             <Table.Cell className="text-right">
-                                                <Typography>{item.totalPrice}{invoice.currency === 'eur' ? '€' : invoice.currency}</Typography>
+                                                <Typography>{Number(item.totalPrice).toFixed(2)}{invoice.currency === 'eur' ? '€' : invoice.currency}</Typography>
                                             </Table.Cell>
                                         </Table.Row>
                                     ))}

--- a/apps/app/app/admin/invoices/create/actions.ts
+++ b/apps/app/app/admin/invoices/create/actions.ts
@@ -206,7 +206,7 @@ export async function getShoppingCartItemsWithEntityNamesAction(shoppingCartItem
         return {
             ...item,
             entityName: entity?.information?.label || entity?.information?.name || `${item.entityTypeName} ${item.entityId}`,
-            price: entity?.prices?.perPlant || entity?.prices?.perOperation || 0,
+            price: entity?.prices?.perPlant || entity?.information?.plant?.prices?.perPlant || entity?.prices?.perOperation || entity?.information?.plant?.prices?.perOperation || 0,
         };
     });
 

--- a/apps/app/app/admin/invoices/create/page.tsx
+++ b/apps/app/app/admin/invoices/create/page.tsx
@@ -8,10 +8,10 @@ export default async function CreateInvoicePage() {
     await auth(['admin']);
 
     return (
-        <Stack spacing={4}>
+        <Stack spacing={2}>
             <Breadcrumbs items={[
-                { label: 'Računi', href: KnownPages.Invoices },
-                { label: 'Kreiraj novi račun' }
+                { label: 'Ponude', href: KnownPages.Invoices },
+                { label: 'Kreiraj novu ponudu' }
             ]} />
             <InvoiceForm mode="create" />
         </Stack>

--- a/apps/app/app/admin/invoices/shared/InvoiceForm.tsx
+++ b/apps/app/app/admin/invoices/shared/InvoiceForm.tsx
@@ -11,13 +11,15 @@ import { Input } from "@signalco/ui-primitives/Input";
 import { Chip } from "@signalco/ui-primitives/Chip";
 import { KnownPages } from "../../../../src/KnownPages";
 import { IconButton } from "@signalco/ui-primitives/IconButton";
-import { Delete } from "@signalco/ui-icons";
+import { Add, Delete } from "@signalco/ui-icons";
 import { DotIndicator } from '@signalco/ui-primitives/DotIndicator';
 
 // Import actions based on mode
 import { createInvoiceAction, getTransactionsAction, getShoppingCartsAction, getAccountDetailsAction, getShoppingCartItemsWithEntityNamesAction } from "../create/actions";
 import { updateInvoiceAction } from "../[invoiceId]/edit/actions";
 import { getInvoice } from "@gredice/storage";
+import { Checkbox } from "@signalco/ui-primitives/Checkbox";
+import { SelectItems } from "@signalco/ui-primitives/SelectItems";
 
 const statusOptions = [
     { value: 'draft', label: 'Nacrt' },
@@ -356,7 +358,7 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
     return (
         <>
             <form onSubmit={handleSubmit}>
-                <Stack spacing={4}>
+                <Stack spacing={2}>
                     <Row spacing={2} justifyContent="space-between" alignItems="center">
                         <Typography level="h1" className="text-2xl" semiBold>
                             {mode === 'create' ? 'Nova ponuda' : `Uredi ponudu ${invoice?.invoiceNumber}`}
@@ -372,8 +374,8 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                             </Button>
                             <Button
                                 type="submit"
+                                variant="solid"
                                 disabled={isSubmitting}
-                                color="primary"
                             >
                                 {isSubmitting
                                     ? (mode === 'create' ? 'Kreiranje...' : 'Ažuriranje...')
@@ -383,8 +385,8 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                         </Row>
                     </Row>
 
-                    <Row spacing={4} alignItems="stretch">
-                        <Stack spacing={4} className="flex-1">
+                    <Row spacing={2} alignItems="stretch">
+                        <Stack spacing={2} className="flex-1">
                             {/* Invoice Information */}
                             <Card>
                                 <CardHeader>
@@ -428,97 +430,72 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                     </Row>
                                 </CardHeader>
                                 <CardContent>
-                                    <Stack spacing={3}>
+                                    <Stack spacing={1}>
                                         {mode === 'create' && (
-                                            <Row spacing={3}>
-                                                <Stack spacing={1} className="flex-1">
-                                                    <Typography level="body2" className="text-gray-600">Account ID</Typography>
-                                                    <Input
-                                                        value={formData.accountId}
-                                                        onChange={(e) => handleInputChange('accountId', e.target.value)}
-                                                        placeholder="Unesite account ID"
-                                                        required
-                                                    />
-                                                </Stack>
-                                                <Stack spacing={1} className="flex-1">
-                                                    <Typography level="body2" className="text-gray-600">Transaction ID (neobavezno)</Typography>
-                                                    <Input
-                                                        value={formData.transactionId}
-                                                        onChange={(e) => handleInputChange('transactionId', e.target.value)}
-                                                        placeholder="ID povezane transakcije"
-                                                        type="number"
-                                                    />
-                                                </Stack>
+                                            <Row spacing={2}>
+                                                <Input
+                                                    label="Account ID"
+                                                    value={formData.accountId}
+                                                    onChange={(e) => handleInputChange('accountId', e.target.value)}
+                                                    placeholder="Unesite account ID"
+                                                    required
+                                                />
+                                                <Input
+                                                    label="Transaction ID (neobavezno)"
+                                                    value={formData.transactionId}
+                                                    onChange={(e) => handleInputChange('transactionId', e.target.value)}
+                                                    placeholder="ID povezane transakcije"
+                                                    type="number"
+                                                />
                                             </Row>
                                         )}
-                                        <Row spacing={3}>
-                                            <Stack spacing={1} className="flex-1">
-                                                <Typography level="body2" className="text-gray-600">Valuta</Typography>
-                                                <select
-                                                    value={formData.currency}
-                                                    onChange={(e) => handleInputChange('currency', e.target.value)}
-                                                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                                >
-                                                    {currencyOptions.map(option => (
-                                                        <option key={option.value} value={option.value}>
-                                                            {option.label}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            </Stack>
-                                            <Stack spacing={1} className="flex-1">
-                                                <Typography level="body2" className="text-gray-600">Status</Typography>
-                                                <select
-                                                    value={formData.status}
-                                                    onChange={(e) => handleInputChange('status', e.target.value)}
-                                                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                                >
-                                                    {availableStatusOptions.map(option => (
-                                                        <option key={option.value} value={option.value}>
-                                                            {option.label}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            </Stack>
+                                        <Row spacing={2}>
+                                            <SelectItems
+                                                label="Valuta"
+                                                className="w-full"
+                                                value={formData.currency}
+                                                items={currencyOptions}
+                                                onValueChange={(value) => handleInputChange('currency', value)}
+                                            />
+                                            <SelectItems
+                                                label="Status"
+                                                className="w-full"
+                                                value={formData.status}
+                                                items={availableStatusOptions}
+                                                onValueChange={(value) => handleInputChange('status', value)}
+                                            />
                                         </Row>
-                                        <Row spacing={3}>
-                                            <Stack spacing={1} className="flex-1">
-                                                <Typography level="body2" className="text-gray-600">Datum izdavanja</Typography>
-                                                <Input
-                                                    type="date"
-                                                    value={formData.issueDate}
-                                                    onChange={(e) => handleInputChange('issueDate', e.target.value)}
-                                                    required
-                                                />
-                                            </Stack>
-                                            <Stack spacing={1} className="flex-1">
-                                                <Typography level="body2" className="text-gray-600">Datum dospijeća</Typography>
-                                                <Input
-                                                    type="date"
-                                                    value={formData.dueDate}
-                                                    onChange={(e) => handleInputChange('dueDate', e.target.value)}
-                                                    required
-                                                />
-                                            </Stack>
+                                        <Row spacing={2}>
+                                            <Input
+                                                label="Datum izdavanja"
+                                                type="date"
+                                                fullWidth
+                                                value={formData.issueDate}
+                                                onChange={(e) => handleInputChange('issueDate', e.target.value)}
+                                                required
+                                            />
+                                            <Input
+                                                label="Datum dospijeća"
+                                                type="date"
+                                                fullWidth
+                                                value={formData.dueDate}
+                                                onChange={(e) => handleInputChange('dueDate', e.target.value)}
+                                                required
+                                            />
                                         </Row>
-                                        <Row spacing={3}>
-                                            <Stack spacing={1} className="flex-1">
-                                                <Typography level="body2" className="text-gray-600">PDV</Typography>
-                                                <label className="flex items-center space-x-2 p-3 border border-gray-300 rounded-md cursor-pointer hover:bg-gray-50">
-                                                    <input
-                                                        type="checkbox"
+                                        <Row spacing={2}>
+                                            <div className="flex-1">
+                                                <label className="flex items-center space-x-2 p-3 border border-input bg-background rounded-md cursor-pointer">
+                                                    <Checkbox
+                                                        label={formData.vatEnabled ? 'PDV uključen (25%)' : 'PDV isključen'}
                                                         checked={formData.vatEnabled}
-                                                        onChange={(e) => handleInputChange('vatEnabled', e.target.checked.toString())}
-                                                        className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                                                        onCheckedChange={(checked: boolean) => handleInputChange('vatEnabled', checked.toString())}
                                                     />
-                                                    <span className="text-sm">
-                                                        {formData.vatEnabled ? 'PDV uključen (25%)' : 'PDV isključen'}
-                                                    </span>
                                                 </label>
-                                            </Stack>
-                                            <Stack spacing={1} className="flex-1">
+                                            </div>
+                                            <div className="flex-1">
                                                 {/* Empty column for alignment */}
-                                            </Stack>
+                                            </div>
                                         </Row>
                                     </Stack>
                                 </CardContent>
@@ -541,44 +518,46 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                     </Row>
                                 </CardHeader>
                                 <CardContent>
-                                    <Stack spacing={3}>
+                                    <Stack spacing={1}>
+                                        <Row spacing={2}>
+                                            <Stack spacing={1} className="w-full">
+                                                <Input
+                                                    label="Naziv *"
+                                                    value={formData.billToName}
+                                                    onChange={(e) => handleInputChange('billToName', e.target.value)}
+                                                    placeholder="Naziv kupca"
+                                                    required
+                                                    disabled={isAccountReadOnly}
+                                                />
+                                                {isAccountReadOnly && (
+                                                    <Typography level="body3">
+                                                        Automatski ispunjeno iz podataka ponude
+                                                    </Typography>
+                                                )}
+                                            </Stack>
+                                            <Stack spacing={1} className="w-full">
+                                                <Input
+                                                    label="Email"
+                                                    type="email"
+                                                    value={formData.billToEmail}
+                                                    onChange={(e) => handleInputChange('billToEmail', e.target.value)}
+                                                    placeholder="email@example.com"
+                                                    disabled={isAccountReadOnly}
+                                                />
+                                                {isAccountReadOnly && (
+                                                    <Typography level="body3">
+                                                        Automatski ispunjeno iz podataka ponude
+                                                    </Typography>
+                                                )}
+                                            </Stack>
+                                        </Row>
                                         <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Naziv *</Typography>
-                                            <Input
-                                                value={formData.billToName}
-                                                onChange={(e) => handleInputChange('billToName', e.target.value)}
-                                                placeholder="Naziv kupca"
-                                                required
-                                                disabled={isAccountReadOnly}
-                                            />
-                                            {isAccountReadOnly && (
-                                                <Typography level="body3" className="text-gray-500">
-                                                    Automatski ispunjeno iz podataka ponude
-                                                </Typography>
-                                            )}
-                                        </Stack>
-                                        <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Email</Typography>
-                                            <Input
-                                                type="email"
-                                                value={formData.billToEmail}
-                                                onChange={(e) => handleInputChange('billToEmail', e.target.value)}
-                                                placeholder="email@example.com"
-                                                disabled={isAccountReadOnly}
-                                            />
-                                            {isAccountReadOnly && (
-                                                <Typography level="body3" className="text-gray-500">
-                                                    Automatski ispunjeno iz podataka ponude
-                                                </Typography>
-                                            )}
-                                        </Stack>
-                                        <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Adresa</Typography>
+                                            <Typography level="body2">Adresa</Typography>
                                             <textarea
                                                 value={formData.billToAddress}
                                                 onChange={(e) => handleInputChange('billToAddress', e.target.value)}
-                                                placeholder="Ulica i broj&#10;Poštanski broj Grad&#10;Država"
-                                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                                                placeholder="Ulica i broj, Poštanski broj Grad, Država..."
+                                                className="w-full text-base px-3 py-2 border border-input bg-background rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                                                 rows={3}
                                             />
                                         </Stack>
@@ -587,7 +566,7 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                             </Card>
                         </Stack>
 
-                        <Stack spacing={4} className="flex-1">
+                        <Stack spacing={2} className="flex-1">
                             {/* Summary and Invoice Details */}
                             <Card>
                                 <CardHeader>
@@ -596,12 +575,12 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                 <CardContent>
                                     <Stack spacing={2}>
                                         <Row justifyContent="space-between">
-                                            <Typography level="body2" className="text-gray-600">Osnovica</Typography>
+                                            <Typography level="body2">Osnovica</Typography>
                                             <Typography>€{subtotal}</Typography>
                                         </Row>
                                         {formData.vatEnabled && (
                                             <Row justifyContent="space-between">
-                                                <Typography level="body2" className="text-gray-600">PDV (25%)</Typography>
+                                                <Typography level="body2">PDV (25%)</Typography>
                                                 <Typography>€{taxAmount}</Typography>
                                             </Row>
                                         )}
@@ -619,24 +598,24 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                     <CardTitle>Napomene i uvjeti</CardTitle>
                                 </CardHeader>
                                 <CardContent>
-                                    <Stack spacing={3}>
+                                    <Stack spacing={1}>
                                         <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Napomene</Typography>
+                                            <Typography level="body2">Napomene</Typography>
                                             <textarea
                                                 value={formData.notes}
                                                 onChange={(e) => handleInputChange('notes', e.target.value)}
                                                 placeholder="Dodatne napomene..."
-                                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                                                className="w-full text-base px-3 py-2 border border-input bg-background rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                                                 rows={3}
                                             />
                                         </Stack>
                                         <Stack spacing={1}>
-                                            <Typography level="body2" className="text-gray-600">Uvjeti</Typography>
+                                            <Typography level="body2">Uvjeti</Typography>
                                             <textarea
                                                 value={formData.terms}
                                                 onChange={(e) => handleInputChange('terms', e.target.value)}
                                                 placeholder="Uvjeti plaćanja..."
-                                                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                                                className="w-full text-base px-3 py-2 border border-input bg-background rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                                                 rows={3}
                                             />
                                         </Stack>
@@ -651,17 +630,17 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                         <CardHeader>
                             <Row justifyContent="space-between" alignItems="center">
                                 <CardTitle>Stavke ponude</CardTitle>
-                                <Button type="button" variant="link" onClick={addItem}>
-                                    + Dodaj stavku
+                                <Button variant="solid" onClick={addItem} startDecorator={<Add className="size-4 shrink-0" />}>
+                                    Dodaj stavku
                                 </Button>
                             </Row>
                         </CardHeader>
                         <CardContent>
                             <Stack spacing={2}>
                                 {items.map((item, index) => (
-                                    <Card key={index} className="border-l-4 border-l-blue-200">
+                                    <Card key={index} className="border-l-4 border-l-primary">
                                         <CardContent className="pt-4">
-                                            <Stack spacing={3}>
+                                            <Stack spacing={2}>
                                                 <Row spacing={2} alignItems="start">
                                                     <Stack spacing={1} className="flex-1">
                                                         <Typography level="body2">Opis *</Typography>
@@ -687,7 +666,7 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                                         <Input
                                                             type="number"
                                                             step="0.01"
-                                                            min="0"
+                                                            min="1"
                                                             value={item.quantity}
                                                             onChange={(e) => handleItemChange(index, 'quantity', e.target.value)}
                                                             required
@@ -698,7 +677,6 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                                         <Input
                                                             type="number"
                                                             step="0.01"
-                                                            min="0"
                                                             value={item.unitPrice}
                                                             onChange={(e) => handleItemChange(index, 'unitPrice', e.target.value)}
                                                             required
@@ -709,7 +687,7 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                                         <Input
                                                             value={item.totalPrice}
                                                             disabled
-                                                            className="bg-gray-50"
+                                                            readOnly
                                                         />
                                                     </Stack>
                                                 </Row>
@@ -725,8 +703,8 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
 
             {/* Transaction Selection Modal - Only for create mode */}
             {mode === 'create' && showTransactionModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] overflow-hidden">
+                <div className="fixed inset-0 bg-black backdrop-blur bg-opacity-50 flex items-center justify-center z-50">
+                    <div className="bg-card rounded-lg max-w-2xl w-full max-h-[80vh] overflow-hidden">
                         <div className="p-6 border-b">
                             <Row spacing={2} justifyContent="space-between" alignItems="center">
                                 <Typography level="h3" semiBold>Odaberite transakciju</Typography>
@@ -744,15 +722,15 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                             ) : (
                                 <Stack spacing={2}>
                                     {transactions.map((transaction) => (
-                                        <Card key={transaction.id} className="cursor-pointer hover:bg-gray-50" onClick={() => populateFromTransaction(transaction)}>
+                                        <Card key={transaction.id} onClick={() => populateFromTransaction(transaction)}>
                                             <CardContent>
                                                 <Row spacing={2} justifyContent="space-between">
                                                     <Stack spacing={1}>
                                                         <Typography semiBold>#{transaction.id}</Typography>
-                                                        <Typography level="body2" className="text-gray-600">
+                                                        <Typography level="body2">
                                                             Account: {transaction.accountId}
                                                         </Typography>
-                                                        <Typography level="body2" className="text-gray-600">
+                                                        <Typography level="body2">
                                                             {transaction.stripePaymentId}
                                                         </Typography>
                                                     </Stack>
@@ -777,14 +755,14 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
 
             {/* Shopping Cart Selection Modal - Only for create mode */}
             {mode === 'create' && showShoppingCartModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] overflow-hidden">
+                <div className="fixed inset-0 bg-black backdrop-blur bg-opacity-50 flex items-center justify-center z-50">
+                    <div className="bg-card rounded-lg max-w-2xl w-full max-h-[80vh] overflow-hidden">
                         <div className="p-6 border-b">
                             <Row spacing={2} justifyContent="space-between" alignItems="center">
                                 <Stack spacing={1}>
                                     <Typography level="h3" semiBold>Odaberite košaricu</Typography>
                                     {formData.accountId && (
-                                        <Typography level="body2" className="text-gray-600">
+                                        <Typography level="body2">
                                             Košarice za korisnički račun: {formData.accountId}
                                         </Typography>
                                     )}
@@ -803,21 +781,21 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                             ) : (
                                 <Stack spacing={2}>
                                     {shoppingCarts.map((cart) => (
-                                        <Card key={cart.id} className="cursor-pointer hover:bg-gray-50" onClick={() => populateFromShoppingCart(cart)}>
+                                        <Card key={cart.id} onClick={() => populateFromShoppingCart(cart)}>
                                             <CardContent>
                                                 <Row spacing={2} justifyContent="space-between">
                                                     <Stack spacing={1}>
                                                         <Typography semiBold>Košarica #{cart.id}</Typography>
-                                                        <Typography level="body2" className="text-gray-600">
+                                                        <Typography level="body2">
                                                             Account: {cart.accountId}
                                                         </Typography>
-                                                        <Typography level="body2" className="text-gray-600">
+                                                        <Typography level="body2">
                                                             Stavki: {cart.items?.length || 0}
                                                         </Typography>
                                                     </Stack>
                                                     <Stack spacing={1} alignItems="start">
                                                         <Typography semiBold>
-                                                            {((cart.items?.reduce((sum: number, item) => sum + (item.amount || 0), 0) || 0) / 100).toFixed(2)}€
+                                                            {((cart.items?.reduce((sum: number, item) => sum + (item.amount || 0), 0) || 0)).toFixed(2)}€
                                                         </Typography>
                                                         <Chip className="w-fit" color={cart.status === 'paid' ? 'success' : 'neutral'}>
                                                             {cart.status === 'paid' ? 'Plaćena' : (cart.status === 'new' ? 'Nova' : cart.status)}

--- a/packages/fiscalization/src/clients/shared.ts
+++ b/packages/fiscalization/src/clients/shared.ts
@@ -30,12 +30,12 @@ export async function sendSoapRequest(signedXml: string, endpoint: string) {
         if (responseText.includes("<tns:PorukaGreske>")) {
             const errorMatch = responseText.match(/<tns:PorukaGreske>([^<]+)<\/tns:PorukaGreske>/)
             if (errorMatch) {
-                return { errors: [{ errorMessage: errorMatch[1] }] }
+                return { responseText, errors: [{ errorMessage: errorMatch[1] }] }
             }
         }
 
         throw new Error(`Error! Status: ${response.statusCode}. Response: ${responseText}`);
     }
 
-    return responseText;
+    return { responseText };
 }

--- a/packages/storage/src/migrations/0056_pretty_nextwave.sql
+++ b/packages/storage/src/migrations/0056_pretty_nextwave.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "receipts" ADD COLUMN "cis_response" text;

--- a/packages/storage/src/migrations/meta/0056_snapshot.json
+++ b/packages/storage/src/migrations/meta/0056_snapshot.json
@@ -1,0 +1,4130 @@
+{
+  "id": "c68b6922-a938-4e9e-a595-a8671fd7e6c2",
+  "prevId": "ec9a5247-056d-4dea-a253-3dcf86a22743",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attribute_definition_categories": {
+      "name": "attribute_definition_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_adc_entity_type_name_idx": {
+          "name": "cms_adc_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_order_idx": {
+          "name": "cms_adc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_is_deleted_idx": {
+          "name": "cms_adc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definitions": {
+      "name": "attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_ad_category_idx": {
+          "name": "cms_ad_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_entity_type_name_idx": {
+          "name": "cms_ad_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_order_idx": {
+          "name": "cms_ad_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_is_deleted_idx": {
+          "name": "cms_ad_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_values": {
+      "name": "attribute_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_av_attribute_definition_id_idx": {
+          "name": "cms_av_attribute_definition_id_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_type_name_idx": {
+          "name": "cms_av_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_id_idx": {
+          "name": "cms_av_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_order_idx": {
+          "name": "cms_av_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_is_deleted_idx": {
+          "name": "cms_av_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attribute_values_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "attribute_values_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attribute_values_entity_id_entities_id_fk": {
+          "name": "attribute_values_entity_id_entities_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_e_entity_type_name_idx": {
+          "name": "cms_e_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_state_idx": {
+          "name": "cms_e_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_is_deleted_idx": {
+          "name": "cms_e_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_type_categories": {
+      "name": "entity_type_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_etc_order_idx": {
+          "name": "cms_etc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_etc_is_deleted_idx": {
+          "name": "cms_etc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_et_category_id_idx": {
+          "name": "cms_et_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_order_idx": {
+          "name": "cms_et_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_deleted_idx": {
+          "name": "cms_et_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_types_category_id_entity_type_categories_id_fk": {
+          "name": "entity_types_category_id_entity_type_categories_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_type_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_users": {
+      "name": "account_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_au_account_id_idx": {
+          "name": "users_au_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_au_user_id_idx": {
+          "name": "users_au_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_users_account_id_accounts_id_fk": {
+          "name": "account_users_account_id_accounts_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_users_user_id_users_id_fk": {
+          "name": "account_users_user_id_users_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street1": {
+          "name": "address_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street2": {
+          "name": "address_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_logins": {
+      "name": "user_logins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_id": {
+          "name": "login_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_data": {
+          "name": "login_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_ul_user_id_idx": {
+          "name": "users_ul_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_type_idx": {
+          "name": "users_ul_login_type_idx",
+          "columns": [
+            {
+              "expression": "login_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_id_idx": {
+          "name": "users_ul_login_id_idx",
+          "columns": [
+            {
+              "expression": "login_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_logins_user_id_users_id_fk": {
+          "name": "user_logins_user_id_users_id_fk",
+          "tableFrom": "user_logins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_u_username_idx": {
+          "name": "users_u_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_blocks": {
+      "name": "garden_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gb_garden_id_idx": {
+          "name": "garden_gb_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gb_is_deleted_idx": {
+          "name": "garden_gb_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_blocks_garden_id_gardens_id_fk": {
+          "name": "garden_blocks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_blocks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_stacks": {
+      "name": "garden_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gs_garden_id_idx": {
+          "name": "garden_gs_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gs_is_deleted_idx": {
+          "name": "garden_gs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_stacks_garden_id_gardens_id_fk": {
+          "name": "garden_stacks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_stacks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gardens": {
+      "name": "gardens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_g_account_id_idx": {
+          "name": "garden_g_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_farm_id_idx": {
+          "name": "garden_g_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_deleted_idx": {
+          "name": "garden_g_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gardens_account_id_accounts_id_fk": {
+          "name": "gardens_account_id_accounts_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gardens_farm_id_farms_id_fk": {
+          "name": "gardens_farm_id_farms_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_fields": {
+      "name": "raised_bed_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_fields_raised_bed_id_idx": {
+          "name": "raised_bed_fields_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_fields_is_deleted_idx": {
+          "name": "raised_bed_fields_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_fields_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_fields_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_fields",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_sensors": {
+      "name": "raised_bed_sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "sensor_signalco_id": {
+          "name": "sensor_signalco_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_sensors_raised_bed_id_idx": {
+          "name": "raised_bed_sensors_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_sensors_is_deleted_idx": {
+          "name": "raised_bed_sensors_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_sensors_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_sensors_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_sensors",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_beds": {
+      "name": "raised_beds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "physical_id": {
+          "name": "physical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_beds_account_id_idx": {
+          "name": "raised_beds_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_garden_id_idx": {
+          "name": "raised_beds_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_block_id_idx": {
+          "name": "raised_beds_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_is_deleted_idx": {
+          "name": "raised_beds_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_beds_account_id_accounts_id_fk": {
+          "name": "raised_beds_account_id_accounts_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_garden_id_gardens_id_fk": {
+          "name": "raised_beds_garden_id_gardens_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_block_id_garden_blocks_id_fk": {
+          "name": "raised_beds_block_id_garden_blocks_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farms": {
+      "name": "farms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "farms_f_is_deleted_idx": {
+          "name": "farms_f_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_e_type_idx": {
+          "name": "events_e_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_aggregate_id_idx": {
+          "name": "events_e_aggregate_id_idx",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_created_at_idx": {
+          "name": "events_e_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "transactions_account_id_idx": {
+          "name": "transactions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_garden_id_idx": {
+          "name": "transactions_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_payment_id_idx": {
+          "name": "transactions_stripe_payment_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_is_deleted_idx": {
+          "name": "transactions_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_garden_id_gardens_id_fk": {
+          "name": "transactions_garden_id_gardens_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.00'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_id_idx": {
+          "name": "invoice_items_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_id_idx": {
+          "name": "invoice_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_type_idx": {
+          "name": "invoice_items_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_name": {
+          "name": "bill_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_email": {
+          "name": "bill_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_to_address": {
+          "name": "bill_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_country": {
+          "name": "bill_to_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_account_id_idx": {
+          "name": "invoices_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_transaction_id_idx": {
+          "name": "invoices_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_issue_date_idx": {
+          "name": "invoices_issue_date_idx",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_due_date_idx": {
+          "name": "invoices_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_is_deleted_idx": {
+          "name": "invoices_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_account_id_accounts_id_fk": {
+          "name": "invoices_account_id_accounts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_transaction_id_transactions_id_fk": {
+          "name": "invoices_transaction_id_transactions_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_receipt_number": {
+          "name": "year_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_reference": {
+          "name": "payment_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jir": {
+          "name": "jir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zki": {
+          "name": "zki",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_status": {
+          "name": "cis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cis_reference": {
+          "name": "cis_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_error_message": {
+          "name": "cis_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_timestamp": {
+          "name": "cis_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_response": {
+          "name": "cis_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "business_pin": {
+          "name": "business_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_address": {
+          "name": "business_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_pin": {
+          "name": "customer_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "receipts_invoice_id_idx": {
+          "name": "receipts_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_receipt_number_idx": {
+          "name": "receipts_receipt_number_idx",
+          "columns": [
+            {
+              "expression": "receipt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_jir_idx": {
+          "name": "receipts_jir_idx",
+          "columns": [
+            {
+              "expression": "jir",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_zki_idx": {
+          "name": "receipts_zki_idx",
+          "columns": [
+            {
+              "expression": "zki",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_cis_status_idx": {
+          "name": "receipts_cis_status_idx",
+          "columns": [
+            {
+              "expression": "cis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_issued_at_idx": {
+          "name": "receipts_issued_at_idx",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_business_pin_idx": {
+          "name": "receipts_business_pin_idx",
+          "columns": [
+            {
+              "expression": "business_pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_is_deleted_idx": {
+          "name": "receipts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_invoice_id_invoices_id_fk": {
+          "name": "receipts_invoice_id_invoices_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_year_receipt_number_unique": {
+          "name": "receipts_year_receipt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_cart_items": {
+      "name": "shopping_cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_cart_items_cart_id_idx": {
+          "name": "shopping_cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_entity_id_idx": {
+          "name": "shopping_cart_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_garden_id_idx": {
+          "name": "shopping_cart_items_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_raised_bed_id_idx": {
+          "name": "shopping_cart_items_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_is_deleted_idx": {
+          "name": "shopping_cart_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_status_idx": {
+          "name": "shopping_cart_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_cart_items_cart_id_shopping_carts_id_fk": {
+          "name": "shopping_cart_items_cart_id_shopping_carts_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_garden_id_gardens_id_fk": {
+          "name": "shopping_cart_items_garden_id_gardens_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_raised_bed_id_raised_beds_id_fk": {
+          "name": "shopping_cart_items_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_carts": {
+      "name": "shopping_carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_carts_account_id_idx": {
+          "name": "shopping_carts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_is_deleted_idx": {
+          "name": "shopping_carts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_status_idx": {
+          "name": "shopping_carts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_carts_account_id_accounts_id_fk": {
+          "name": "shopping_carts_account_id_accounts_id_fk",
+          "tableFrom": "shopping_carts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_email_log": {
+      "name": "notification_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_email_log_user_id_users_id_fk": {
+          "name": "notification_email_log_user_id_users_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_email_log_notification_id_notifications_id_fk": {
+          "name": "notification_email_log_notification_id_notifications_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_where": {
+          "name": "read_where",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_account_id_idx": {
+          "name": "notifications_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_readAt_idx": {
+          "name": "notifications_readAt_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_garden_id_gardens_id_fk": {
+          "name": "notifications_garden_id_gardens_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_raised_bed_id_raised_beds_id_fk": {
+          "name": "notifications_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_block_id_garden_blocks_id_fk": {
+          "name": "notifications_block_id_garden_blocks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_digest": {
+          "name": "daily_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "operations_entity_id_idx": {
+          "name": "operations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_entity_type_name_idx": {
+          "name": "operations_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_account_id_idx": {
+          "name": "operations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_garden_id_idx": {
+          "name": "operations_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_id_idx": {
+          "name": "operations_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_field_id_idx": {
+          "name": "operations_raised_bed_field_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_timestamp_idx": {
+          "name": "operations_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_deleted_idx": {
+          "name": "operations_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_pos_settings": {
+      "name": "fiscalization_pos_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_id": {
+          "name": "pos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_pos_settings_pos_id_idx": {
+          "name": "fiscalization_pos_settings_pos_id_idx",
+          "columns": [
+            {
+              "expression": "pos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_active_idx": {
+          "name": "fiscalization_pos_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_deleted_idx": {
+          "name": "fiscalization_pos_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_user_settings": {
+      "name": "fiscalization_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_vat": {
+          "name": "use_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receipt_number_on_device": {
+          "name": "receipt_number_on_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'educ'"
+        },
+        "cert_base64": {
+          "name": "cert_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cert_password": {
+          "name": "cert_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_user_settings_is_active_idx": {
+          "name": "fiscalization_user_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_user_settings_is_deleted_idx": {
+          "name": "fiscalization_user_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1754170193052,
       "tag": "0055_free_quicksilver",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1755039074777,
+      "tag": "0056_pretty_nextwave",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/eventsRepo.ts
+++ b/packages/storage/src/repositories/eventsRepo.ts
@@ -127,7 +127,7 @@ export const knownEvents = {
             version: 1,
             aggregateId,
         }),
-        fiscalizedV1: (aggregateId: string, data: { jir?: string; zki?: string; cisStatus: string }) => ({
+        fiscalizedV1: (aggregateId: string, data: { jir?: string; zki?: string; cisStatus: string, cisResponse?: string | null }) => ({
             type: knownEventTypes.receipts.fiscalize,
             version: 1,
             aggregateId,

--- a/packages/storage/src/repositories/fiscalizationRepo.ts
+++ b/packages/storage/src/repositories/fiscalizationRepo.ts
@@ -9,7 +9,7 @@ import {
 } from "../schema";
 
 // Get active fiscalization user settings for an account
-export async function getFiscalizationUserSettings(accountId: string): Promise<SelectFiscalizationUserSettings | null> {
+export async function getFiscalizationUserSettings(): Promise<SelectFiscalizationUserSettings | null> {
     const results = await storage()
         .select()
         .from(fiscalizationUserSettings)
@@ -25,7 +25,7 @@ export async function getFiscalizationUserSettings(accountId: string): Promise<S
 }
 
 // Get active fiscalization POS settings for an account
-export async function getFiscalizationPosSettings(accountId: string): Promise<SelectFiscalizationPosSettings | null> {
+export async function getFiscalizationPosSettings(): Promise<SelectFiscalizationPosSettings | null> {
     const results = await storage()
         .select()
         .from(fiscalizationPosSettings)
@@ -41,10 +41,10 @@ export async function getFiscalizationPosSettings(accountId: string): Promise<Se
 }
 
 // Get all fiscalization settings for an account (convenience function)
-export async function getAllFiscalizationSettings(accountId: string) {
+export async function getAllFiscalizationSettings() {
     const [userSettings, posSettings] = await Promise.all([
-        getFiscalizationUserSettings(accountId),
-        getFiscalizationPosSettings(accountId),
+        getFiscalizationUserSettings(),
+        getFiscalizationPosSettings(),
     ]);
 
     return {

--- a/packages/storage/src/repositories/invoicesRepo.ts
+++ b/packages/storage/src/repositories/invoicesRepo.ts
@@ -17,14 +17,14 @@ import { PgTransaction } from 'drizzle-orm/pg-core';
 
 // Receipt creation data interface
 export interface ReceiptCreationData {
-    paymentMethod: string; // 'card', 'cash', 'bank_transfer', etc.
-    paymentReference?: string; // External payment reference (e.g., Stripe payment ID)
-    businessPin?: string; // Croatian business tax number
-    businessName?: string;
-    businessAddress?: string;
-    customerPin?: string; // Customer's PIN for B2B transactions
-    customerName?: string;
-    customerAddress?: string; // Customer's address for B2B transactions
+    paymentMethod: 'card' | 'cash' | 'bank_transfer';
+    paymentReference?: string | null;
+    businessPin?: string | null;
+    businessName?: string | null;
+    businessAddress?: string | null;
+    customerPin?: string | null;
+    customerName?: string | null;
+    customerAddress?: string | null;
     // JIR and ZKI are optional - provided later during fiscalization
     jir?: string;
     zki?: string;
@@ -623,6 +623,7 @@ export async function updateReceiptFiscalization(
         cisReference?: string;
         cisErrorMessage?: string | null;
         cisTimestamp?: Date;
+        cisResponse?: string | null;
     }
 ) {
     await storage()
@@ -634,6 +635,7 @@ export async function updateReceiptFiscalization(
             cisReference: fiscalizationData.cisReference,
             cisErrorMessage: fiscalizationData.cisErrorMessage,
             cisTimestamp: fiscalizationData.cisTimestamp,
+            cisResponse: fiscalizationData.cisResponse,
             updatedAt: new Date(),
         })
         .where(
@@ -646,6 +648,7 @@ export async function updateReceiptFiscalization(
         jir: fiscalizationData.jir,
         zki: fiscalizationData.zki,
         cisStatus: fiscalizationData.cisStatus,
+        cisResponse: fiscalizationData.cisResponse,
     }) ?? {
         name: 'receipt.fiscalized.v1',
         entityId: receiptId.toString(),
@@ -654,6 +657,7 @@ export async function updateReceiptFiscalization(
             jir: fiscalizationData.jir,
             zki: fiscalizationData.zki,
             cisStatus: fiscalizationData.cisStatus,
+            cisResponse: fiscalizationData.cisResponse,
         }
     });
 }

--- a/packages/storage/src/schema/invoiceSchema.ts
+++ b/packages/storage/src/schema/invoiceSchema.ts
@@ -133,6 +133,7 @@ export const receipts = pgTable('receipts', {
     cisReference: text('cis_reference'), // Reference number from CIS system
     cisErrorMessage: text('cis_error_message'), // Error message if fiscalization failed
     cisTimestamp: timestamp('cis_timestamp'), // When receipt was processed by CIS
+    cisResponse: text('cis_response'), // Full response from CIS (for debugging)
 
     // Receipt dates
     issuedAt: timestamp('issued_at').notNull().defaultNow(),


### PR DESCRIPTION
Update fiscalization flow to handle full payloads and errorcases, and confirmed receipts in the admin UI.

- Call getAllFiscalizationSettings without account (use global
  settings) to avoid incorrect account-based lookup.
- Replace fiscalResult with a unified response variable and handle the
  unsuccessful path: persist z, mark cisStatus as failed, save
  cisErrorMessage and cisResponse when response.success is false.
- On success, persist jir, zki, cisTimestamp (dateTime), cisReference
  (receiptNumber) and cisResponse; mark cisStatus as confirmed.
- Improve error handling: include cisResponse='no response' when an
  exception occurs and ensure cisTimestamp is written.
- Update admin receipts page to show confirmed receipts:
  - Map 'confirmed' to success color and localized label.
  - Fetch receipts with status 'confirmed' and include them in the
    displayed list.
  - Reorder table columns to move "Datum izdavanja" and remove duplicate
    JIR/ZKI/extra date columns to match the new stored fields.

These changes ensure failed CIS responses are recorded for debugging,
successful fiscalizations are fully persisted, and confirmed receipts
are visible and correctly labeled in the admin interface.