### PR TITLE
fix(ui): remove redundant size props and clean up button chips

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/AccountSunflowersCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountSunflowersCard.tsx
@@ -49,7 +49,7 @@ export async function AccountSunflowersCard({ accountId }: { accountId: string }
                                         { value: 'gift', label: 'Poklon' }
                                     ]} />
                             </div>
-                            <Button size="sm" type="submit" startDecorator={<Add className="size-5" />}>Dodjeli</Button>
+                            <Button type="submit" startDecorator={<Add className="size-5" />}>Dodjeli</Button>
                         </Stack>
                     </form>
                 </div>

--- a/apps/app/app/admin/accounts/page.tsx
+++ b/apps/app/app/admin/accounts/page.tsx
@@ -21,7 +21,7 @@ export default async function AccountsPage() {
         <Stack spacing={2}>
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>{"Računi"}</Typography>
-                <Chip color="primary" size="sm">{accounts.length}</Chip>
+                <Chip color="primary">{accounts.length}</Chip>
             </Row>
             <Card>
                 <CardOverflow>

--- a/apps/app/app/admin/feedback/page.tsx
+++ b/apps/app/app/admin/feedback/page.tsx
@@ -19,7 +19,7 @@ export default async function FeedbackPage() {
         <Stack spacing={2}>
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>Povratne informacije</Typography>
-                <Chip color="primary" size="sm">{feedbacks.length}</Chip>
+                <Chip color="primary">{feedbacks.length}</Chip>
             </Row>
             <Card>
                 <CardOverflow>

--- a/apps/app/app/admin/gardens/page.tsx
+++ b/apps/app/app/admin/gardens/page.tsx
@@ -21,7 +21,7 @@ export default async function GardensPage() {
         <Stack spacing={2}>
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>Vrtovi</Typography>
-                <Chip color="primary" size="sm">{gardens.length}</Chip>
+                <Chip color="primary">{gardens.length}</Chip>
             </Row>
             <Card>
                 <CardOverflow>

--- a/apps/app/app/admin/invoices/shared/InvoiceForm.tsx
+++ b/apps/app/app/admin/invoices/shared/InvoiceForm.tsx
@@ -395,7 +395,6 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                                 <Button
                                                     type="button"
                                                     variant="outlined"
-                                                    size="sm"
                                                     onClick={() => {
                                                         setShowTransactionModal(true);
                                                         fetchTransactions();
@@ -406,7 +405,6 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                                 <Button
                                                     type="button"
                                                     variant="outlined"
-                                                    size="sm"
                                                     onClick={() => {
                                                         if (!formData.accountId.trim()) {
                                                             alert('Molimo unesite Account ID prije odabira košarice');
@@ -532,7 +530,6 @@ export default function InvoiceForm({ mode, invoice, onSuccess }: InvoiceFormPro
                                         {isAccountReadOnly && mode === 'create' && (
                                             <Button
                                                 variant="outlined"
-                                                size="sm"
                                                 onClick={() => setIsAccountReadOnly(false)}
                                             >
                                                 Ručno uređivanje

--- a/apps/app/app/admin/receipts/page.tsx
+++ b/apps/app/app/admin/receipts/page.tsx
@@ -47,7 +47,7 @@ export default async function ReceiptsPage() {
         <Stack spacing={2}>
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>{"Fiskalni računi"}</Typography>
-                <Chip color="primary" size="sm">{receipts.length}</Chip>
+                <Chip color="primary">{receipts.length}</Chip>
             </Row>
             <Card>
                 <CardOverflow>

--- a/apps/app/app/admin/sensors/page.tsx
+++ b/apps/app/app/admin/sensors/page.tsx
@@ -85,7 +85,7 @@ export default async function SensorsPage() {
         <Stack spacing={2}>
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>{"Senzori"}</Typography>
-                <Chip color="primary" size="sm">{totalSensors}</Chip>
+                <Chip color="primary">{totalSensors}</Chip>
             </Row>
             <Stack spacing={2}>
                 {sensorsByPhysicalId.length === 0 ? (

--- a/apps/app/app/admin/transactions/page.tsx
+++ b/apps/app/app/admin/transactions/page.tsx
@@ -24,9 +24,9 @@ export default async function TransactionsPage() {
         <Stack spacing={2}>
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>{"Transakcije"}</Typography>
-                <Chip color="primary" size="sm">{transactions.length}</Chip>
+                <Chip color="primary">{transactions.length}</Chip>
                 {transactionsWithoutInvoices.length > 0 && (
-                    <Chip color="success" size="sm">
+                    <Chip color="success">
                         ✨ {transactionsWithoutInvoices.length} bez računa
                     </Chip>
                 )}

--- a/apps/app/app/admin/users/page.tsx
+++ b/apps/app/app/admin/users/page.tsx
@@ -24,7 +24,7 @@ export default async function UsersPage() {
 
             <Row spacing={1}>
                 <Typography level="h1" className="text-2xl" semiBold>{"Korisnici"}</Typography>
-                <Chip color="primary" size="sm">{users.length}</Chip>
+                <Chip color="primary">{users.length}</Chip>
             </Row>
             <Card>
                 <CardOverflow>

--- a/apps/app/components/operations/OperationCancelButton.tsx
+++ b/apps/app/components/operations/OperationCancelButton.tsx
@@ -27,7 +27,6 @@ export function OperationCancelButton({ operation, operationLabel }: OperationCa
             trigger={
                 <Button
                     variant="plain"
-                    size="sm"
                     className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
                     title="Otkaži operaciju"
                 >

--- a/apps/app/components/operations/OperationRescheduleButton.tsx
+++ b/apps/app/components/operations/OperationRescheduleButton.tsx
@@ -27,7 +27,6 @@ export function OperationRescheduleButton({ operation, operationLabel }: Operati
             trigger={
                 <Button
                     variant="plain"
-                    size="sm"
                     className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
                     title={operation.scheduledDate ? "Prerasporedi operaciju" : "Zakaži operaciju"}
                 >

--- a/apps/app/components/shared/attributes/typed/BarcodeScanButton.tsx
+++ b/apps/app/components/shared/attributes/typed/BarcodeScanButton.tsx
@@ -421,13 +421,13 @@ export function BarcodeScanButton({
                     {/* Camera Controls */}
                     <div className="flex gap-2 justify-center">
                         {scanState === "scanning" && (
-                            <Button onClick={stopCameraScanning} size="sm">
+                            <Button onClick={stopCameraScanning}>
                                 <Stop className="size-4 mr-2" />
                                 Stop Scanning
                             </Button>
                         )}
 
-                        <Button onClick={closeCamera} variant="outlined" size="sm">
+                        <Button onClick={closeCamera} variant="outlined">
                             Cancel
                         </Button>
                     </div>


### PR DESCRIPTION
Remove unnecessary size="sm" props from several MUI/UIButton components and
Chip usages across admin pages and components. This simplifies styling by
letting the components use their default size or CSS-based sizing, reducing
prop clutter.

Key changes:
- Remove size="sm" from Chip components on admin listing headers (accounts,
  sensors, gardens, users, feedback) so Chips rely on default sizing.
- Remove size="sm" from various Button elements (AccountSunflowersCard,
  OperationCancelButton, OperationRescheduleButton, InvoiceForm) to
  standardize button dimensions and avoid inconsistent small sizes.
- Minor whitespace/format cleanup around affected JSX.

This reduces visual inconsistencies and simplifies component props for
easier maintenance.