### PR TITLE
feat(viewport): centralize viewport config in layouts

### DIFF
--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { AxiomWebVitals } from 'next-axiom';
 import "./globals.css";
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   description: "Gredice admin - upravljanje gredicama",
 };
 
+export const viewport: Viewport = {
+  initialScale: 1,
+  width: "device-width"
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -19,7 +24,6 @@ export default function RootLayout({
   return (
     <html lang="hr" suppressHydrationWarning={true}>
       <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="apple-mobile-web-app-title" content="Gredice" />
         <meta name="theme-color" content="#2e6f40" />
         <title>Admin | Gredice</title>

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -1,15 +1,20 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { AxiomWebVitals } from 'next-axiom';
 import "./globals.css";
 import Head from "next/head";
 import { ClientAppProvider } from "../components/providers/ClientAppProvider";
-import {ReactNode} from "react";
+import { ReactNode } from "react";
 
 export const metadata: Metadata = {
   title: "Farma | Gredice",
   description: "Gredice farma - upravljanje farmom.",
 };
+
+export const viewport: Viewport = {
+  initialScale: 1,
+  width: "device-width"
+}
 
 export default function RootLayout({
   children,

--- a/apps/garden/app/layout.tsx
+++ b/apps/garden/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { AxiomWebVitals } from 'next-axiom';
 import "./globals.css";
@@ -11,6 +11,13 @@ export const metadata: Metadata = {
   title: "Vrt | Gredice",
   description: "Gredice vrt - vrt po tvom",
 };
+
+export const viewport: Viewport = {
+  maximumScale: 1,
+  initialScale: 1,
+  userScalable: false,
+  width: "device-width"
+}
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
Add explicit Viewport imports and export a viewport object in three
app layout files (apps/app, apps/garden, apps/farm) and remove the
inline meta viewport tag in the admin layout. This standardizes viewport
settings across the apps, enabling consistent mobile scaling and control
over user-scalability where needed (garden disables user scaling).
Also tidy minor formatting (ReactNode import spacing) and keep existing
metadata unchanged.