### PR TITLE
fix(ui): remove redundant Input className overrides

### DIFF
--- a/apps/garden/components/auth/EmailPasswordForm.tsx
+++ b/apps/garden/components/auth/EmailPasswordForm.tsx
@@ -45,7 +45,6 @@ export function EmailPasswordForm({
                     id="email"
                     type="email"
                     label='Email'
-                    className='[&_input]:text-base sm:[&_input]:text-[16px]'
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     required
@@ -53,7 +52,6 @@ export function EmailPasswordForm({
                 <Input
                     id="password"
                     type="password"
-                    className='[&_input]:text-base sm:[&_input]:text-[16px]'
                     label="Zaporka"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -64,7 +62,6 @@ export function EmailPasswordForm({
                         <Input
                             id="repeatPassword"
                             type="password"
-                            className='sm:[&_input]:text-base [&_input]:text-[16px]'
                             label="Ponovi zaporku"
                             value={repeatPassword}
                             onChange={(e) => setRepeatPassword(e.target.value)}

--- a/packages/game/src/modals/components/UserProfileCard.tsx
+++ b/packages/game/src/modals/components/UserProfileCard.tsx
@@ -69,7 +69,6 @@ export function UserProfileCard() {
                                 <Input
                                     name="displayName"
                                     label="Prikazano ime"
-                                    className='[&_input]:text-base sm:[&_input]:text-[16px]'
                                     defaultValue={currentUser.data?.displayName}
                                     type="text"
                                     placeholder="Unesite ime..."


### PR DESCRIPTION
Remove duplicated className props that force input font-size on several
Input usages across the app. The class overrides in UserProfileCard and
EmailPasswordForm were unnecessary and conflicted with global or
component-level styling, so they are deleted to rely on the default
styles. This simplifies the markup and prevents inconsistent font-size
behavior across breakpoints.