### PR TITLE
feat(og-image): standardize OG image API and metadata

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -37,14 +37,6 @@ export const metadata: Metadata = {
         title: "Gredice - vrt po tvom",
         url: "https://www.gredice.com",
         siteName: "Gredice - vrt po tvom",
-        images: [
-            {
-                url: "/og",
-                width: 1200,
-                height: 630,
-                alt: "Gredice - vrt po tvom",
-            },
-        ],
     }
 };
 

--- a/apps/www/app/opengraph-image.tsx
+++ b/apps/www/app/opengraph-image.tsx
@@ -1,7 +1,14 @@
 import { ImageResponse } from 'next/og'
-import { Logotype } from '../../components/Logotype'
- 
-export async function GET() {
+import { Logotype } from '../components/Logotype'
+
+export const alt = 'Gredice'
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = 'image/png'
+
+export default async function Image() {
   return new ImageResponse(
     (
       <div
@@ -20,8 +27,7 @@ export async function GET() {
       </div>
     ),
     {
-      width: 1200,
-      height: 630,
+      ...size
     }
   )
 }


### PR DESCRIPTION
Remove hardcoded images entry from page metadata and OG image
generation to new Next.js App Router export conventions.

- Delete images array from layout metadata to avoid duplication and rely
  on canonical OG image exports.
- Move Logotype import path to app-scoped component and switch GET handler
  to default async Image export.
- alt, size andType constants and use size spread for the
  ImageResponse options to centralize image configuration.

This simplifies OG image handling, ensures compatibility with Next.js
App Router expected exports, and centralizes image metadata for reuse.