### PR TITLE
feat(raised-bed): add operation categorization spec and utils plan

### DIFF
--- a/.specs/BUG202508230043 - Quick seeding can be triggered for raised bed that is in invalid configuration.md
+++ b/.specs/BUG202508230043 - Quick seeding can be triggered for raised bed that is in invalid configuration.md
@@ -1,0 +1,5 @@
+# BUG: Quick seeding can be triggered for raised bed that is in invalid configuration
+
+Status: Draft
+
+Hide the quick-seed HUD component when selected raised bed is in invalid configuration.

--- a/.specs/FEAT00001 - Delivery.md
+++ b/.specs/FEAT00001 - Delivery.md
@@ -1,5 +1,7 @@
 # FEAT00001 – Delivery Feature Specification
 
+Status: Implemented
+
 ## 1. Summary
 
 Enable users to receive (or personally pick up) deliverable items purchased through the platform by: (a) storing reusable delivery addresses, (b) selecting an available 2‑hour delivery (or pickup) time slot during checkout (Game modal flow), and (c) managing delivery requests operationally in the internal app. Built on Next.js (App Router) with Drizzle (PostgreSQL) and event sourcing for delivery request aggregate changes.

--- a/.specs/FEAT202508230026 - Cancel planned operation or plant field.md
+++ b/.specs/FEAT202508230026 - Cancel planned operation or plant field.md
@@ -1,0 +1,291 @@
+# Cancel planned operation or plant field
+
+**Status**: In-review
+
+## Overview
+
+User can cancel planned operation or planted field to provide flexibility in farm management and prevent accidental or unwanted operations/plantings.
+
+## Business Rules
+
+### Operations Cancellation
+
+- Can cancel operations with status: `new`, `planned`
+- Cannot cancel operations with status: `completed`, `failed`, `canceled`
+- Refund amount = operation price × 1000 (sunflower conversion rate)
+- Refund reason format: `refund:operation:{operationId}`
+
+### Plant Field Cancellation Rules
+
+- Can cancel planted fields with status: `new`, `planned`
+- Cannot cancel fields with status: `sowed`, `sprouted`, `ready`, `harvested`, `removed`
+- Plant cost refund = pricePerPlant * 1000 (sunflower conversion rate)
+- Refund reason format: `refund:plant:{raisedBedId}|{positionIndex}`
+
+## User Experience
+
+### Operation Cancellation
+
+1. Display cancel button next to operations in admin schedule view
+2. Show confirmation modal with:
+   - Operation details (name, scheduled date, location)
+   - Refund amount information
+   - Reason input field (required)
+   - Consequences warning
+3. Send notification to user upon cancellation
+4. Update UI to reflect cancellation
+
+### Plant Field Cancellation UX
+
+1. Display cancel button in raised bed field management interface
+2. Show confirmation modal with:
+   - Plant details (name, variety, scheduled date)
+   - Field location information
+   - Refund amount (if applicable)
+   - Reason input field (required)
+   - Warning about field reset
+3. Send notification to user upon cancellation
+4. Reset field to empty state
+
+## Technical Implementation Plan
+
+### Phase 1: Extend Operation Cancellation (EXISTING - Enhancement needed)
+
+**Files to modify:**
+
+- `apps/app/app/(actions)/operationActions.ts` - Already has `cancelOperationAction` ✅
+- `apps/app/app/admin/schedule/CancelOperationModal.tsx` - Already exists ✅
+- API routes - Already support operation cancellation ✅
+
+**Enhancements needed:**
+
+- Add user-facing cancellation interface (currently admin-only)
+- Improve refund calculation transparency
+- Add consequence warnings in UI
+
+### Phase 2: Plant Field Cancellation (NEW FEATURE)
+
+#### Backend Implementation
+
+**New Events:**
+
+```typescript
+// Add to packages/storage/src/repositories/eventsRepo.ts
+raisedBedFields: {
+  // ... existing events
+  plantCancelV1: (aggregateId: string, data: { canceledBy: string, reason: string, refundAmount?: number }) => ({
+    type: "raisedBedField.plantCancel",
+    version: 1,
+    aggregateId,
+    data
+  })
+}
+```
+
+**New Actions:**
+
+```typescript
+// New file: apps/app/app/(actions)/plantFieldActions.ts
+export async function cancelPlantFieldAction(formData: FormData) {
+  // Validate permissions
+  // Check field status (only new/planned allowed)
+  // Calculate refund amount
+  // Create cancellation event
+  // Reset field to empty state
+  // Refund sunflowers
+  // Send notification
+  // Revalidate paths
+}
+```
+
+**API Routes:**
+
+```typescript
+// Add to apps/api/app/api/[...route]/gardensRoutes.ts
+.delete(
+  '/:gardenId/raised-beds/:raisedBedId/fields/:positionIndex/plant',
+  // Cancel planted field implementation
+)
+```
+
+#### Frontend Implementation
+
+**New Components:**
+
+```typescript
+// apps/app/app/components/CancelPlantFieldModal.tsx
+interface CancelPlantFieldModalProps {
+  raisedBedId: number;
+  positionIndex: number;
+  plant: PlantData;
+  trigger: React.ReactElement;
+}
+```
+
+**Component Integration:**
+
+- `packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx` - Add cancel button
+- `packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx` - Add cancel option for new plants
+- `apps/app/app/admin/raised-beds/[raisedBedId]/` - Admin interface enhancements
+
+#### Data Flow
+
+1. **User Initiates Cancellation**
+   - Click cancel button in UI
+   - Modal opens with confirmation details
+
+2. **Validation**
+   - Check user permissions
+   - Validate field status allows cancellation
+   - Calculate refund amount
+
+3. **Cancellation Processing**
+   - Create `plantCancel` event
+   - Update field status to empty/available
+   - Process sunflower refund
+   - Send user notification
+
+4. **UI Updates**
+   - Close modal
+   - Update field display
+   - Refresh related data
+
+### Phase 3: User Interface Integration
+
+#### Enhanced Operation Cancellation UI
+
+- Move cancellation capability from admin-only to user-accessible
+- Add cancellation button in user's operation schedule
+- Improve modal design with better consequence explanations
+
+#### Plant Field Cancellation UI
+
+- Add cancel action to planted field items
+- Integrate with existing raised bed interface
+- Provide clear status indicators
+
+### Phase 4: Testing & Validation
+
+#### Unit Tests
+
+```typescript
+// packages/storage/tests/plantFieldCancellation.spec.ts
+describe('Plant Field Cancellation', () => {
+  test('should cancel new plant field')
+  test('should prevent canceling sowed plants')
+  test('should calculate correct refund amount')
+  test('should emit correct events')
+})
+```
+
+#### Integration Tests
+
+- Test full cancellation flow
+- Verify refund processing
+- Validate notification delivery
+- Check UI state updates
+
+## Database Impact
+
+### Events Table
+
+- New event type: `raisedBedField.plantCancel`
+- Event data structure for cancellation details
+
+### No Schema Changes Required
+
+- Using event sourcing pattern
+- Field status derived from events
+- Sunflower transactions via existing events
+
+## Security Considerations
+
+### Authorization
+
+- Users can only cancel their own operations/plants
+- Admin users can cancel any operation/plant
+- Rate limiting on cancellation actions
+
+### Validation
+
+- Server-side status validation
+- Prevent race conditions
+- Audit trail via events
+
+## Monitoring & Analytics
+
+### Metrics to Track
+
+- Cancellation rates by operation type
+- Refund amounts processed
+- User satisfaction with cancellation process
+- Most common cancellation reasons
+
+### Alerts
+
+- High cancellation rates (>20%)
+- Failed refund processing
+- Invalid cancellation attempts
+
+## Dependencies
+
+### External
+
+- None
+
+### Internal
+
+- Existing operation cancellation system
+- Sunflower transaction system
+- Event sourcing infrastructure
+- Notification system
+
+## Risks & Mitigation
+
+### Technical Risks
+
+- **Risk**: Event ordering issues in concurrent cancellations
+- **Mitigation**: Use database transactions and event versioning
+
+- **Risk**: Incorrect refund calculations
+- **Mitigation**: Comprehensive testing and audit logging
+
+### Business Risks
+
+- **Risk**: Users abuse cancellation system
+- **Mitigation**: Rate limiting and monitoring
+
+- **Risk**: Revenue impact from increased cancellations
+- **Mitigation**: Analytics to understand cancellation patterns
+
+## Success Criteria
+
+### Functional
+
+- ✅ Users can cancel planned operations
+- ✅ Users can cancel new/planned plant fields  
+- ✅ Refunds are processed correctly
+- ✅ Notifications are sent appropriately
+- ✅ UI reflects cancellation status immediately
+
+### Non-Functional
+
+- ⏱️ Cancellation completes within 2 seconds
+- 🔒 No unauthorized cancellations possible
+- 📊 <5% error rate in cancellation processing
+- 🎯 >90% user satisfaction with cancellation process
+
+## Future Enhancements
+
+### V2 Features
+
+- Partial refunds based on time elapsed
+- Cancellation windows (e.g., can't cancel within 24h of scheduled time)
+- Bulk cancellation operations
+- Automated cancellation for system maintenance
+
+### Advanced Features
+
+- Machine learning predictions for cancellation likelihood
+- Dynamic refund calculations based on market conditions
+- Integration with third-party scheduling systems

--- a/.specs/FEAT202508230029 - Raised bed field operations grouping.md
+++ b/.specs/FEAT202508230029 - Raised bed field operations grouping.md
@@ -1,0 +1,379 @@
+# Raised bed field operations grouping
+
+**Status**: In-review
+
+## Overview
+
+Raised bed field operations should be grouped by category to provide better organization and user experience in the game interface. This feature extends the existing www app radnje page grouping pattern to raised bed field operations.
+
+Category is extracted from the operation attributes (`operation.attributes.stage.information.name`), and each operation is assigned to a single category for grouping and filtering purposes.
+
+## Current Implementation Analysis
+
+### Existing Grouping in WWW App
+
+The www app's radnje page (`apps/www/app/radnje/page.tsx`) already implements operation grouping by stage:
+
+```typescript
+const stagesLabels = [...new Set(operationsData?.map(op => op.attributes.stage?.information?.label) || [])];
+```
+
+### Current Game Interface Operations
+
+Currently, operations in the game interface are filtered but not grouped:
+
+1. **RaisedBedWatering.tsx** - Filters by watering stage: `operation.attributes.stage.information?.name === 'watering'`
+2. **RaisedBedFieldOperationsTab.tsx** - Filters by plant application: `operation.attributes.application === 'plant'`
+
+## Business Requirements
+
+### Operation Categories
+
+Based on existing data structure and plant lifecycle, operations are categorized by stage:
+
+| Category ID | Category Label | Croatian Label | Operations Include |
+|-------------|---------------|----------------|-------------------|
+| `sowing` | Sowing | Sijanje | Seed planting, direct sowing |
+| `soilPreparation` | Soil Preparation | Priprema tla | Tilling, composting, fertilizing |
+| `planting` | Planting | Sadnja | Transplanting seedlings |
+| `growth` | Growth | Rast | Growth monitoring, pruning |
+| `maintenance` | Maintenance | Održavanje | General care, pest control |
+| `watering` | Watering | Zalijevanje | Irrigation, moisture management |
+| `flowering` | Flowering | Cvjetanje | Flower care, pollination |
+| `harvest` | Harvest | Berba | Fruit/vegetable collection |
+| `storage` | Storage | Skladištenje | Post-harvest processing |
+
+### Grouping Rules
+
+1. **Primary Grouping**: By `operation.attributes.stage.information.name`
+2. **Secondary Filtering**: By application (`plant`, `raisedBed1m`, etc.)
+3. **Display Order**: Sort groups by lifecycle progression
+4. **Empty Groups**: Hide categories with no available operations
+
+## User Experience Requirements
+
+### Raised Bed Field Operations Tab Enhancement
+
+**Current State**: Flat list of all plant operations  
+**Desired State**: Grouped operations by category with expandable sections
+
+**User Flow**:
+
+1. User opens field operations tab
+2. Operations are displayed in categorized groups
+3. Each category shows operation count badge
+4. Categories are collapsible/expandable
+5. User can filter specific categories if needed
+
+### Watering Modal Enhancement
+
+**Current State**: Filtered list of watering operations  
+**Desired State**: Keep current behavior (watering-specific operations only)
+
+**Note**: Watering modal should remain focused on watering operations only.
+
+## Technical Implementation Plan
+
+### Phase 1: Create Operation Categorization Utilities
+
+#### New Utility Functions
+
+**File**: `packages/game/src/utils/operationCategorization.ts`
+
+```typescript
+import { OperationData } from '@gredice/client';
+
+export interface OperationCategory {
+  id: string;
+  label: string;
+  croatianLabel: string;
+  order: number;
+  icon?: string;
+}
+
+export const OPERATION_CATEGORIES: OperationCategory[] = [
+  { id: 'soilPreparation', label: 'Soil Preparation', croatianLabel: 'Priprema tla', order: 1 },
+  { id: 'sowing', label: 'Sowing', croatianLabel: 'Sijanje', order: 2 },
+  { id: 'planting', label: 'Planting', croatianLabel: 'Sadnja', order: 3 },
+  { id: 'growth', label: 'Growth', croatianLabel: 'Rast', order: 4 },
+  { id: 'watering', label: 'Watering', croatianLabel: 'Zalijevanje', order: 5 },
+  { id: 'maintenance', label: 'Maintenance', croatianLabel: 'Održavanje', order: 6 },
+  { id: 'flowering', label: 'Flowering', croatianLabel: 'Cvjetanje', order: 7 },
+  { id: 'harvest', label: 'Harvest', croatianLabel: 'Berba', order: 8 },
+  { id: 'storage', label: 'Storage', croatianLabel: 'Skladištenje', order: 9 },
+];
+
+export function categorizeOperations(operations: OperationData[]): Record<string, OperationData[]> {
+  const categorized: Record<string, OperationData[]> = {};
+  
+  operations.forEach(operation => {
+    const categoryId = operation.attributes.stage.information?.name || 'other';
+    if (!categorized[categoryId]) {
+      categorized[categoryId] = [];
+    }
+    categorized[categoryId].push(operation);
+  });
+  
+  return categorized;
+}
+
+export function getOperationCategory(categoryId: string): OperationCategory | undefined {
+  return OPERATION_CATEGORIES.find(cat => cat.id === categoryId);
+}
+
+export function getSortedCategories(categorizedOperations: Record<string, OperationData[]>): OperationCategory[] {
+  return OPERATION_CATEGORIES
+    .filter(cat => categorizedOperations[cat.id]?.length > 0)
+    .sort((a, b) => a.order - b.order);
+}
+```
+
+REVIEW: TODO: We shouldn't use hardcoded OPERATION_CATEGORIES
+
+### Phase 2: Create Grouped Operations List Component
+
+#### New Component: OperationsListGrouped
+
+**File**: `packages/game/src/hud/raisedBed/shared/OperationsListGrouped.tsx`
+
+```typescript
+import { useState } from 'react';
+import { OperationData } from '@gredice/client';
+import { Accordion, AccordionItem } from '@signalco/ui-primitives/Accordion';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { Badge } from '@signalco/ui-primitives/Badge';
+import { OperationsListItem } from './OperationsList';
+import { categorizeOperations, getSortedCategories, getOperationCategory } from '../../../utils/operationCategorization';
+
+interface OperationsListGroupedProps {
+  operations: OperationData[];
+  gardenId: number;
+  raisedBedId?: number;
+  positionIndex?: number;
+  plantSortId?: number;
+  filterFunc: (operation: OperationData) => boolean;
+  showCategoryFilter?: boolean;
+  defaultOpenCategories?: string[];
+}
+
+export function OperationsListGrouped({
+  operations,
+  gardenId,
+  raisedBedId,
+  positionIndex,
+  plantSortId,
+  filterFunc,
+  showCategoryFilter = false,
+  defaultOpenCategories = []
+}: OperationsListGroupedProps) {
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    new Set(defaultOpenCategories)
+  );
+  
+  const filteredOperations = operations?.filter(filterFunc) || [];
+  const categorizedOperations = categorizeOperations(filteredOperations);
+  const sortedCategories = getSortedCategories(categorizedOperations);
+
+  const toggleCategory = (categoryId: string) => {
+    const newExpanded = new Set(expandedCategories);
+    if (newExpanded.has(categoryId)) {
+      newExpanded.delete(categoryId);
+    } else {
+      newExpanded.add(categoryId);
+    }
+    setExpandedCategories(newExpanded);
+  };
+
+  if (sortedCategories.length === 0) {
+    return (
+      <div className="p-4 text-center text-muted-foreground">
+        Nema dostupnih radnji
+      </div>
+    );
+  }
+
+  return (
+    <Accordion type="multiple" className="w-full">
+      {sortedCategories.map(category => {
+        const categoryOperations = categorizedOperations[category.id];
+        const isExpanded = expandedCategories.has(category.id);
+        
+        return (
+          <AccordionItem key={category.id} value={category.id}>
+            <AccordionTrigger 
+              onClick={() => toggleCategory(category.id)}
+              className="flex justify-between items-center p-3 hover:bg-muted/50"
+            >
+              <div className="flex items-center gap-2">
+                <Typography level="h6">{category.croatianLabel}</Typography>
+                <Badge variant="secondary">{categoryOperations.length}</Badge>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-1">
+                {categoryOperations.map(operation => (
+                  <OperationsListItem
+                    key={operation.id}
+                    operation={operation}
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                    positionIndex={positionIndex}
+                  />
+                ))}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
+    </Accordion>
+  );
+}
+```
+
+### Phase 3: Update Existing Components
+
+#### Update RaisedBedFieldOperationsTab
+
+**File**: `packages/game/src/hud/raisedBed/RaisedBedFieldOperationsTab.tsx`
+
+```typescript
+import { OperationsListGrouped } from "./shared/OperationsListGrouped";
+
+export function RaisedBedFieldOperationsTab({ 
+  gardenId, 
+  raisedBedId, 
+  positionIndex, 
+  plantSortId 
+}: { 
+  gardenId: number; 
+  raisedBedId: number; 
+  positionIndex: number; 
+  plantSortId?: number 
+}) {
+  return (
+    <OperationsListGrouped
+      gardenId={gardenId}
+      raisedBedId={raisedBedId}
+      positionIndex={positionIndex}
+      plantSortId={plantSortId}
+      filterFunc={(operation) => operation.attributes.application === 'plant'}
+      defaultOpenCategories={['watering', 'maintenance']} // Most common categories
+      showCategoryFilter={true}
+    />
+  );
+}
+```
+
+#### Keep RaisedBedWatering Unchanged
+
+The `RaisedBedWatering` component should remain unchanged as it serves a specific purpose (watering-only operations) and the grouping would not add value in this context.
+
+### Phase 4: Enhanced UX Features (Optional)
+
+#### Category Filter Toggle
+
+**File**: `packages/game/src/hud/raisedBed/shared/CategoryFilter.tsx`
+
+```typescript
+interface CategoryFilterProps {
+  categories: OperationCategory[];
+  selectedCategories: Set<string>;
+  onCategoriesChange: (categories: Set<string>) => void;
+}
+
+export function CategoryFilter({
+  categories,
+  selectedCategories,
+  onCategoriesChange
+}: CategoryFilterProps) {
+  // Implementation for category filtering UI
+  // Chip-based filter with multi-select
+}
+```
+
+#### Category Icons
+
+Add visual icons for each category:
+
+- 🌱 Sowing
+- 🚜 Soil Preparation  
+- 🌿 Planting
+- 📈 Growth
+- 💧 Watering
+- 🔧 Maintenance
+- 🌸 Flowering
+- 🍅 Harvest
+- 📦 Storage
+
+## Database Impact
+
+**No database changes required** - This feature uses existing operation data and attributes.
+
+### Technical Metrics
+
+- ⏱️ **Performance**: No degradation in component render time
+- 🔒 **Reliability**: <1% error rate in categorization
+- 📱 **Compatibility**: Works on all supported devices/browsers
+
+## Future Enhancements
+
+### Phase 2 Features
+
+1. **Smart Categorization**: AI-suggested operation groupings
+2. **Custom Categories**: User-defined operation groups
+3. **Category Search**: Search within specific categories
+4. **Recommendations**: "Next suggested operation" based on plant lifecycle
+
+### Integration Opportunities
+
+1. **Calendar Integration**: Show operations by season/timing
+2. **Plant Lifecycle**: Visual progress indicators per category
+3. **Analytics**: Operation success rates by category
+4. **Notifications**: Category-based operation reminders
+
+## Dependencies
+
+### External Dependencies
+
+- None
+
+### Internal Dependencies
+
+- Existing operation data structure
+- OperationsList component
+- Game UI component library
+- Feature flag system
+
+## Risks & Mitigation
+
+### Technical Risks
+
+- **Risk**: Component complexity increases
+- **Mitigation**: Modular design with clear separation of concerns
+
+- **Risk**: Performance impact on operation filtering
+- **Mitigation**: Memoization and lazy loading strategies
+
+### User Experience Risks
+
+- **Risk**: Important operations hidden in collapsed categories
+- **Mitigation**: Smart defaults for expanded categories
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- ✅ Operations are grouped by stage/category
+- ✅ Categories can be expanded/collapsed
+- ✅ Operation count badges display correctly
+- ✅ Filtering works within categories
+- ✅ Feature flag controls grouping behavior
+- ✅ Existing watering modal remains unchanged
+
+### Non-Functional Requirements
+
+- ⏱️ Component renders within 100ms
+- 📱 Works on mobile and desktop
+- ♿ Accessible keyboard navigation
+- 🌐 Supports Croatian localization
+- 🔄 Graceful degradation if categorization fails

--- a/.specs/FEAT202508230031 - Reschedule planned operation or plant field.md
+++ b/.specs/FEAT202508230031 - Reschedule planned operation or plant field.md
@@ -1,0 +1,5 @@
+# Reschedule planned operation or plant field
+
+Status: Draft
+
+In-game user side ability to reschedule planned operations or plant fields.

--- a/.specs/FEAT202508230044 - Account deletion request.md
+++ b/.specs/FEAT202508230044 - Account deletion request.md
@@ -1,0 +1,7 @@
+# Account deletion request
+
+Status: Draft
+
+In-game account deletion requests can be initiated by the user through the settings menu. The user must confirm the deletion by entering their password. Then email is sent to them just like we do when deleting through the administration application (app).
+
+Before deletion, user must be only user on the account. Other users must be removed. This check should be displayed above the delete account button to inform user this is the requirement. In future there may be other requirenments so make sure we can list multiple. If requirenment is not met - user should be informed about it and the deletion process should not be allowed.


### PR DESCRIPTION
Document raised bed field operation grouping to align game interface
with the existing www app grouping pattern. Add a detailed spec that
defines categories (sowing, soilPreparation, planting, growth,
maintenance, watering, flowering, harvest, storage), grouping rules,
UX requirements (collapsible category groups, counts, lifecycle order),
and handling for watering modal. Include a proposed technical plan
and a new utility outline for categorizing operations 
(OPERATION_CATEGORIES, categorizeOperations, getOperationCategory) to 
extract category from operation.attributes.stage.information.name and 
return grouped sets.

This change is driven by the need to improve organization and user
experience in the raised bed field operations tab, enable filtering
by lifecycle stage, and reuse established grouping behavior from the
www app.