### PR TITLE
refactor(auth): centralize client env vars

### DIFF
--- a/apps/api/lib/auth/oauth.ts
+++ b/apps/api/lib/auth/oauth.ts
@@ -8,31 +8,30 @@ export interface OAuthConfig {
     userInfoUrl: string;
 }
 
-function getGoogleSecrets() {
-    const clientId = process.env.GOOGLE_CLIENT_ID;
-    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const googleClientId = process.env.GOOGLE_CLIENT_ID;
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const facebookClientId = process.env.FACEBOOK_CLIENT_ID;
+const facebookClientSecret = process.env.FACEBOOK_CLIENT_SECRET;
 
-    if (!clientId || !clientSecret) {
+function getGoogleSecrets() {
+    if (!googleClientId || !googleClientSecret) {
         throw new Error('Missing Google OAuth secrets');
     }
 
     return {
-        clientId,
-        clientSecret,
+        clientId: googleClientId,
+        clientSecret: googleClientSecret,
     };
 }
 
 function getFacebookSecrets() {
-    const clientId = process.env.FACEBOOK_CLIENT_ID;
-    const clientSecret = process.env.FACEBOOK_CLIENT_SECRET;
-
-    if (!clientId || !clientSecret) {
+    if (!facebookClientId || !facebookClientSecret) {
         throw new Error('Missing Facebook OAuth secrets');
     }
 
     return {
-        clientId,
-        clientSecret,
+        clientId: facebookClientId,
+        clientSecret: facebookClientSecret,
     };
 }
 


### PR DESCRIPTION
Google and Facebook OAuth client ID/secret reads to module-level
constants and update helper functions to use those constants. This
reduces repeated process.env lookups, clarifies where environment
variables are accessed, and makes getGoogleSecrets/getFacebookSecrets
focus on validation and returning structured secrets. Preserve the same
error messages and return shapes.