### PR TITLE
chore: tidy lockfile and format Hypert React file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,14 @@ jobs:
                 app_app:
                   - apps/app/**
                   - packages/**
+                packages_storage:
+                  - packages/storage/**
         outputs:
           app_www: ${{ steps.filter.outputs.app_www }}
           app_garden: ${{ steps.filter.outputs.app_garden }}
           app_farm: ${{ steps.filter.outputs.app_farm }}
           app_app: ${{ steps.filter.outputs.app_app }}
+          packages_storage: ${{ steps.filter.outputs.packages_storage }}
 
     ci_www:
         name: "CI - www"
@@ -84,11 +87,62 @@ jobs:
             vercelProjectIdSecretName: 'VERCEL_PROJECT_ID_APP'
         secrets: inherit
 
+    test_packages:
+        name: "CI - test @gredice/storage"
+        timeout-minutes: 5
+        runs-on: ubuntu-latest
+        needs: changes
+        if: success() && github.event_name == 'pull_request' && needs.changes.outputs.packages_storage == 'true'
+        env:
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        steps:
+          - uses: actions/checkout@v5
+            with:
+              fetch-depth: 2
+
+          - name: ✨ Setup Node
+            uses: actions/setup-node@v4
+            with:
+              node-version: "22.18.0"
+    
+          - uses: pnpm/action-setup@v3
+            name: ✨ Install pnpm
+            with:
+              version: 10.15.0
+    
+          - name: ✨ Get pnpm store directory
+            shell: bash
+            run: |
+              echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+    
+          - uses: actions/cache@v4
+            name: ✨ Setup pnpm cache
+            with:
+              path: ${{ env.STORE_PATH }}
+              key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                ${{ runner.os }}-pnpm-store-
+
+          - name: 📦️ Install dependencies
+            run: pnpm install --frozen-lockfile --filter @gredice/storage... --filter .
+
+          - name: ✨ Setup Vercel CLI
+            run: npm i --g vercel@latest
+
+          - name: ⚙️ Pull Vercel Environment Information
+            run: vercel env pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+            working-directory: ./packages/storage/
+            
+          - name: ⚒️ Test app
+            run: pnpm test --filter=@gredice/storage
+
     ci_ok:
         name: "[CI] OK"
-        needs: [changes, ci_www, ci_garden, ci_farm, ci_app]
+        needs: [changes, ci_www, ci_garden, ci_farm, ci_app, test_packages]
         if: ${{ always() }}
         runs-on: ubuntu-latest
         steps:
             - run: exit 1
               if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    

--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    '/entities/plant': {
+    "/entities/plant": {
         parameters: {
             query?: never;
             header?: never;
@@ -30,7 +30,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plant'][];
+                        "application/json": components["schemas"]["entity-plant"][];
                     };
                 };
             };
@@ -43,7 +43,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantSort': {
+    "/entities/plantSort": {
         parameters: {
             query?: never;
             header?: never;
@@ -69,7 +69,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantSort'][];
+                        "application/json": components["schemas"]["entity-plantSort"][];
                     };
                 };
             };
@@ -82,7 +82,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantStage': {
+    "/entities/plantStage": {
         parameters: {
             query?: never;
             header?: never;
@@ -108,7 +108,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantStage'][];
+                        "application/json": components["schemas"]["entity-plantStage"][];
                     };
                 };
             };
@@ -121,7 +121,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/seed': {
+    "/entities/seed": {
         parameters: {
             query?: never;
             header?: never;
@@ -147,7 +147,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-seed'][];
+                        "application/json": components["schemas"]["entity-seed"][];
                     };
                 };
             };
@@ -160,7 +160,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/brand': {
+    "/entities/brand": {
         parameters: {
             query?: never;
             header?: never;
@@ -186,7 +186,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-brand'][];
+                        "application/json": components["schemas"]["entity-brand"][];
                     };
                 };
             };
@@ -199,7 +199,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operation': {
+    "/entities/operation": {
         parameters: {
             query?: never;
             header?: never;
@@ -225,7 +225,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operation'][];
+                        "application/json": components["schemas"]["entity-operation"][];
                     };
                 };
             };
@@ -238,7 +238,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operationFrequency': {
+    "/entities/operationFrequency": {
         parameters: {
             query?: never;
             header?: never;
@@ -264,7 +264,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operationFrequency'][];
+                        "application/json": components["schemas"]["entity-operationFrequency"][];
                     };
                 };
             };
@@ -277,7 +277,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq': {
+    "/entities/faq": {
         parameters: {
             query?: never;
             header?: never;
@@ -303,7 +303,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq'][];
+                        "application/json": components["schemas"]["entity-faq"][];
                     };
                 };
             };
@@ -316,7 +316,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq-category': {
+    "/entities/faq-category": {
         parameters: {
             query?: never;
             header?: never;
@@ -342,7 +342,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq-category'][];
+                        "application/json": components["schemas"]["entity-faq-category"][];
                     };
                 };
             };
@@ -355,7 +355,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/block': {
+    "/entities/block": {
         parameters: {
             query?: never;
             header?: never;
@@ -381,7 +381,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-block'][];
+                        "application/json": components["schemas"]["entity-block"][];
                     };
                 };
             };
@@ -402,7 +402,7 @@ export interface components {
             /** Format: uri */
             url: string;
         };
-        'entity-plant': {
+        "entity-plant": {
             id: number;
             entityType: {
                 /** @default 1 */
@@ -452,7 +452,7 @@ export interface components {
                         deliverable: boolean;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     information?: {
                         /** @description (prevedeni naziv operacije) */
@@ -535,7 +535,7 @@ export interface components {
                 perPlant: number;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -545,7 +545,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantSort': {
+        "entity-plantSort": {
             id: number;
             entityType: {
                 /** @default 11 */
@@ -601,7 +601,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -684,7 +684,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -703,7 +703,7 @@ export interface components {
                 maintenance?: string;
             };
             image: {
-                cover?: components['schemas']['image'];
+                cover?: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -713,7 +713,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantStage': {
+        "entity-plantStage": {
             id: number;
             entityType: {
                 /** @default 12 */
@@ -732,7 +732,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-seed': {
+        "entity-seed": {
             id: number;
             entityType: {
                 /** @default 15 */
@@ -794,7 +794,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -877,7 +877,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -931,7 +931,7 @@ export interface components {
                                         deliverable: boolean;
                                     };
                                     image?: {
-                                        cover: components['schemas']['image'];
+                                        cover: components["schemas"]["image"];
                                     };
                                     information?: {
                                         /** @description (prevedeni naziv operacije) */
@@ -1014,7 +1014,7 @@ export interface components {
                                 perPlant: number;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             store?: {
                                 availableInStore: boolean;
@@ -1033,7 +1033,7 @@ export interface components {
                         maintenance?: string;
                     };
                     image?: {
-                        cover?: components['schemas']['image'];
+                        cover?: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -1056,7 +1056,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-brand': {
+        "entity-brand": {
             id: number;
             entityType: {
                 /** @default 16 */
@@ -1075,7 +1075,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operation': {
+        "entity-operation": {
             id: number;
             entityType: {
                 /** @default 10 */
@@ -1104,7 +1104,7 @@ export interface components {
                 deliverable: boolean;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             information: {
                 /** @description (prevedeni naziv operacije) */
@@ -1131,7 +1131,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operationFrequency': {
+        "entity-operationFrequency": {
             id: number;
             entityType: {
                 /** @default 13 */
@@ -1146,7 +1146,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq': {
+        "entity-faq": {
             id: number;
             entityType: {
                 /** @default 2 */
@@ -1176,7 +1176,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq-category': {
+        "entity-faq-category": {
             id: number;
             entityType: {
                 /** @default 14 */
@@ -1195,7 +1195,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-block': {
+        "entity-block": {
             id: number;
             entityType: {
                 /** @default 8 */

--- a/apps/app/lib/flags/generated/hypertune.react.tsx
+++ b/apps/app/lib/flags/generated/hypertune.react.tsx
@@ -215,12 +215,10 @@ export function HypertuneClientLogger({
   return null;
 }
 
-export const overrideCookieName = "hypertuneOverride";
-
 function setOverrideCookie(newOverride: any): void {
   const d = new Date();
   d.setTime(d.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days
   let expires = "expires=" + d.toUTCString();
 
-  document.cookie = `${overrideCookieName}=${JSON.stringify(newOverride)};${expires};path=/`;
+  document.cookie = `${hypertune.overrideCookieName}=${JSON.stringify(newOverride)};${expires};path=/`;
 }

--- a/apps/app/lib/flags/generated/hypertune.ts
+++ b/apps/app/lib/flags/generated/hypertune.ts
@@ -242,6 +242,8 @@ export function createSourceForServerOnly({
     : emptySource;
 }
 
+export const overrideCookieName = "hypertuneOverride";
+
 /**
  * @deprecated use createSource instead.
  */

--- a/apps/farm/lib/flags/generated/hypertune.react.tsx
+++ b/apps/farm/lib/flags/generated/hypertune.react.tsx
@@ -215,12 +215,10 @@ export function HypertuneClientLogger({
   return null;
 }
 
-export const overrideCookieName = "hypertuneOverride";
-
 function setOverrideCookie(newOverride: any): void {
   const d = new Date();
   d.setTime(d.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days
   let expires = "expires=" + d.toUTCString();
 
-  document.cookie = `${overrideCookieName}=${JSON.stringify(newOverride)};${expires};path=/`;
+  document.cookie = `${hypertune.overrideCookieName}=${JSON.stringify(newOverride)};${expires};path=/`;
 }

--- a/apps/farm/lib/flags/generated/hypertune.ts
+++ b/apps/farm/lib/flags/generated/hypertune.ts
@@ -242,6 +242,8 @@ export function createSourceForServerOnly({
     : emptySource;
 }
 
+export const overrideCookieName = "hypertuneOverride";
+
 /**
  * @deprecated use createSource instead.
  */

--- a/apps/garden/lib/flags/generated/hypertune.react.tsx
+++ b/apps/garden/lib/flags/generated/hypertune.react.tsx
@@ -215,12 +215,10 @@ export function HypertuneClientLogger({
   return null;
 }
 
-export const overrideCookieName = "hypertuneOverride";
-
 function setOverrideCookie(newOverride: any): void {
   const d = new Date();
   d.setTime(d.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days
   let expires = "expires=" + d.toUTCString();
 
-  document.cookie = `${overrideCookieName}=${JSON.stringify(newOverride)};${expires};path=/`;
+  document.cookie = `${hypertune.overrideCookieName}=${JSON.stringify(newOverride)};${expires};path=/`;
 }

--- a/apps/garden/lib/flags/generated/hypertune.ts
+++ b/apps/garden/lib/flags/generated/hypertune.ts
@@ -410,6 +410,8 @@ export function createSourceForServerOnly({
     : emptySource;
 }
 
+export const overrideCookieName = "hypertuneOverride";
+
 /**
  * @deprecated use createSource instead.
  */

--- a/apps/www/lib/flags/generated/hypertune.ts
+++ b/apps/www/lib/flags/generated/hypertune.ts
@@ -1,429 +1,246 @@
 /* eslint-disable */
 
-import * as sdk from 'hypertune';
+import * as sdk from "hypertune";
 
 export const queryCode = `query FullQuery{root{preSeason}}`;
 
-export const query: sdk.Query<sdk.ObjectValueWithVariables> = {
-    variableDefinitions: {},
-    fragmentDefinitions: {},
-    fieldQuery: {
-        Query: {
-            type: 'InlineFragment',
-            objectTypeName: 'Query',
-            selection: {
-                root: {
-                    fieldArguments: { __isPartialObject__: true },
-                    fieldQuery: {
-                        Root: {
-                            type: 'InlineFragment',
-                            objectTypeName: 'Root',
-                            selection: {
-                                preSeason: {
-                                    fieldArguments: {},
-                                    fieldQuery: null,
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-};
+export const query: sdk.Query<sdk.ObjectValueWithVariables> = {"variableDefinitions":{},"fragmentDefinitions":{},"fieldQuery":{"Query":{"type":"InlineFragment","objectTypeName":"Query","selection":{"root":{"fieldArguments":{"__isPartialObject__":true},"fieldQuery":{"Root":{"type":"InlineFragment","objectTypeName":"Root","selection":{"preSeason":{"fieldArguments":{},"fieldQuery":null}}}}}}}}};
 
-export const initData = {
-    commitId: 27865,
-    hash: '4883767446758856',
-    reducedExpression: {
-        id: 'aSYD5sRoX5E3yt1VdQu_e',
-        logs: {},
-        type: 'ObjectExpression',
-        fields: {
-            root: {
-                id: 'mVlU96bBrUq2pFr7LvmL6',
-                body: {
-                    id: 'v7OKVmigjMDLFjxa9kFxr',
-                    logs: {},
-                    type: 'ObjectExpression',
-                    fields: {
-                        preSeason: {
-                            id: 'VSyDYJcckoNeyZlz_UXNS',
-                            type: 'SwitchExpression',
-                            cases: [
-                                {
-                                    id: '5sY9FQG8YrzbTZ__9VCAC',
-                                    when: {
-                                        a: {
-                                            id: '1TrfI3vjyjLGFG5zPTVPf',
-                                            type: 'GetFieldExpression',
-                                            object: {
-                                                id: 'mNJH5yfiRvdMPd-6prq4H',
-                                                type: 'VariableExpression',
-                                                valueType: {
-                                                    type: 'ObjectValueType',
-                                                    objectTypeName:
-                                                        'Query_root_args',
-                                                },
-                                                variableId:
-                                                    'tvsyZ9Ks8fQ7w0Eze2VXz',
-                                            },
-                                            fieldPath: 'context > environment',
-                                            valueType: {
-                                                type: 'EnumValueType',
-                                                enumTypeName: 'Environment',
-                                            },
-                                        },
-                                        b: {
-                                            id: 'zoDFcBwaLaFgIGayWb4z5',
-                                            type: 'ListExpression',
-                                            items: [
-                                                {
-                                                    id: 'x_qI0aYGB5zNmB2rC_a1L',
-                                                    type: 'EnumExpression',
-                                                    value: 'development',
-                                                    valueType: {
-                                                        type: 'EnumValueType',
-                                                        enumTypeName:
-                                                            'Environment',
-                                                    },
-                                                },
-                                            ],
-                                            valueType: {
-                                                type: 'ListValueType',
-                                                itemValueType: {
-                                                    type: 'EnumValueType',
-                                                    enumTypeName: 'Environment',
-                                                },
-                                            },
-                                        },
-                                        id: '2wvd9ynKWWJP2K47Rw1R2',
-                                        type: 'ComparisonExpression',
-                                        operator: 'in',
-                                        valueType: { type: 'BooleanValueType' },
-                                    },
-                                    then: {
-                                        id: 'X3W1Zs82gQ0QdeAE9fak_',
-                                        type: 'BooleanExpression',
-                                        value: false,
-                                        valueType: { type: 'BooleanValueType' },
-                                    },
-                                },
-                            ],
-                            control: {
-                                id: 'D30yJjI-z7E_T7_49gnZM',
-                                type: 'BooleanExpression',
-                                value: true,
-                                valueType: { type: 'BooleanValueType' },
-                            },
-                            default: {
-                                id: 'NDL61LP_HqkAxksxbMyko',
-                                type: 'BooleanExpression',
-                                value: true,
-                                valueType: { type: 'BooleanValueType' },
-                            },
-                            valueType: { type: 'BooleanValueType' },
-                            logs: {
-                                evaluations: { '0ynfs6c7DzYuhe1ilcBBM': 1 },
-                            },
-                        },
-                    },
-                    valueType: {
-                        type: 'ObjectValueType',
-                        objectTypeName: 'Root',
-                    },
-                    objectTypeName: 'Root',
-                },
-                logs: {},
-                type: 'FunctionExpression',
-                valueType: {
-                    type: 'FunctionValueType',
-                    returnValueType: {
-                        type: 'ObjectValueType',
-                        objectTypeName: 'Root',
-                    },
-                    parameterValueTypes: [
-                        {
-                            type: 'ObjectValueType',
-                            objectTypeName: 'Query_root_args',
-                        },
-                    ],
-                },
-                parameters: [{ id: 'tvsyZ9Ks8fQ7w0Eze2VXz', name: 'rootArgs' }],
-            },
-        },
-        metadata: {
-            permissions: { user: {}, group: { team: { write: 'allow' } } },
-        },
-        valueType: { type: 'ObjectValueType', objectTypeName: 'Query' },
-        objectTypeName: 'Query',
-    },
-    splits: {},
-    commitConfig: { splitConfig: {} },
-};
+export const initData = {"commitId":27865,"hash":"4883767446758856","reducedExpression":{"id":"aSYD5sRoX5E3yt1VdQu_e","logs":{},"type":"ObjectExpression","fields":{"root":{"id":"mVlU96bBrUq2pFr7LvmL6","body":{"id":"v7OKVmigjMDLFjxa9kFxr","logs":{},"type":"ObjectExpression","fields":{"preSeason":{"id":"VSyDYJcckoNeyZlz_UXNS","type":"SwitchExpression","cases":[{"id":"5sY9FQG8YrzbTZ__9VCAC","when":{"a":{"id":"1TrfI3vjyjLGFG5zPTVPf","type":"GetFieldExpression","object":{"id":"mNJH5yfiRvdMPd-6prq4H","type":"VariableExpression","valueType":{"type":"ObjectValueType","objectTypeName":"Query_root_args"},"variableId":"tvsyZ9Ks8fQ7w0Eze2VXz"},"fieldPath":"context > environment","valueType":{"type":"EnumValueType","enumTypeName":"Environment"}},"b":{"id":"zoDFcBwaLaFgIGayWb4z5","type":"ListExpression","items":[{"id":"x_qI0aYGB5zNmB2rC_a1L","type":"EnumExpression","value":"development","valueType":{"type":"EnumValueType","enumTypeName":"Environment"}}],"valueType":{"type":"ListValueType","itemValueType":{"type":"EnumValueType","enumTypeName":"Environment"}}},"id":"2wvd9ynKWWJP2K47Rw1R2","type":"ComparisonExpression","operator":"in","valueType":{"type":"BooleanValueType"}},"then":{"id":"X3W1Zs82gQ0QdeAE9fak_","type":"BooleanExpression","value":false,"valueType":{"type":"BooleanValueType"}}}],"control":{"id":"D30yJjI-z7E_T7_49gnZM","type":"BooleanExpression","value":true,"valueType":{"type":"BooleanValueType"}},"default":{"id":"NDL61LP_HqkAxksxbMyko","type":"BooleanExpression","value":true,"valueType":{"type":"BooleanValueType"}},"valueType":{"type":"BooleanValueType"},"logs":{"evaluations":{"0ynfs6c7DzYuhe1ilcBBM":1}}}},"valueType":{"type":"ObjectValueType","objectTypeName":"Root"},"objectTypeName":"Root"},"logs":{},"type":"FunctionExpression","valueType":{"type":"FunctionValueType","returnValueType":{"type":"ObjectValueType","objectTypeName":"Root"},"parameterValueTypes":[{"type":"ObjectValueType","objectTypeName":"Query_root_args"}]},"parameters":[{"id":"tvsyZ9Ks8fQ7w0Eze2VXz","name":"rootArgs"}]}},"metadata":{"permissions":{"user":{},"group":{"team":{"write":"allow"}}}},"valueType":{"type":"ObjectValueType","objectTypeName":"Query"},"objectTypeName":"Query"},"splits":{},"commitConfig":{"splitConfig":{}}}
 
-export const vercelFlagDefinitions = {
-    preSeason: {
-        options: [
-            { label: 'Off', value: false },
-            { label: 'On', value: true },
-        ],
-        origin: 'https://app.hypertune.com/projects/4084/main/draft/logic?selected_field_path=root%3EpreSeason',
-    },
-};
+
+export const vercelFlagDefinitions = {"preSeason":{"options":[{"label":"Off","value":false},{"label":"On","value":true}],"origin":"https://app.hypertune.com/projects/4084/main/draft/logic?selected_field_path=root%3EpreSeason"}};
 
 export type RootFlagValues = {
-    preSeason: boolean;
-};
+  "preSeason": boolean;
+}
 
 export type FlagValues = {
-    preSeason: boolean;
-};
+  "preSeason": boolean;
+}
 
 export type FlagPaths = keyof FlagValues & string;
 
 export const flagFallbacks: FlagValues = {
-    preSeason: false,
-};
+  "preSeason": false,
+}
 
 export function decodeFlagValues<TFlagPaths extends keyof FlagValues & string>(
-    encodedValues: string,
-    flagPaths: TFlagPaths[],
+  encodedValues: string,
+  flagPaths: TFlagPaths[]
 ): Pick<FlagValues, TFlagPaths> {
-    return sdk.decodeFlagValues({ flagPaths, encodedValues });
+  return sdk.decodeFlagValues({ flagPaths, encodedValues })
 }
 
 export type VariableValues = {};
 
 export const EnvironmentEnumValues = [
-    'development',
-    'production',
-    'test',
+  "development",
+  "production",
+  "test"
 ] as const;
-export type Environment = (typeof EnvironmentEnumValues)[number];
+export type Environment = typeof EnvironmentEnumValues[number];
 
 /**
  * This `Context` input type is used for the `context` argument on your root field.
  * It contains details of the current `user` and `environment`.
- *
- * You can define other custom input types with fields that are primitives, enums
+ * 
+ * You can define other custom input types with fields that are primitives, enums 
  * or other input types.
  */
 export type Context = {
-    environment: Environment;
-};
+  environment: Environment;
+}
 
 export type RootArgs = {
-    context: Context;
-};
+  context: Context;
+}
 
 export type EmptyObject = {};
 
 export type Root = {
-    preSeason: boolean;
-};
+  preSeason: boolean;
+}
 
-const rootFallback = { preSeason: false };
+const rootFallback = {preSeason:false};
 
 export class RootNode extends sdk.Node {
-    override typeName = 'Root' as const;
+  override typeName = "Root" as const;
 
-    getRootArgs(): RootArgs {
-        const { step } = this.props;
-        return (
-            step?.type === 'GetFieldStep' ? step.fieldArguments : {}
-        ) as RootArgs;
+  getRootArgs(): RootArgs {
+    const { step } = this.props;
+    return (step?.type === 'GetFieldStep' ? step.fieldArguments : {}) as RootArgs;
+  }
+
+  get({ fallback = rootFallback as Root}: { fallback?: Root } = {}): Root {
+    const getQuery = sdk.mergeFieldQueryAndArgs(
+      query.fragmentDefinitions,
+      sdk.getFieldQueryForPath(query.fragmentDefinitions, query.fieldQuery, ["Query", "root"]), 
+      null,
+    );
+    return this.getValue({ query: getQuery, fallback }) as Root;
+  }
+
+  /**
+   * [Open in Hypertune UI]({@link https://app.hypertune.com/projects/4084/main/draft/logic?selected_field_path=root%3EpreSeason})
+   */
+  preSeason({ args = {}, fallback }: { args?: EmptyObject; fallback: boolean; }): boolean {
+    const props0 = this.getFieldNodeProps("preSeason", { fieldArguments: args });
+    const expression0 = props0.expression;
+
+    if (
+      expression0 &&
+      expression0.type === "BooleanExpression"
+    ) {
+      const node = new sdk.BooleanNode(props0);
+      return node.get({ fallback });
     }
 
-    get({ fallback = rootFallback as Root }: { fallback?: Root } = {}): Root {
-        const getQuery = sdk.mergeFieldQueryAndArgs(
-            query.fragmentDefinitions,
-            sdk.getFieldQueryForPath(
-                query.fragmentDefinitions,
-                query.fieldQuery,
-                ['Query', 'root'],
-            ),
-            null,
-        );
-        return this.getValue({ query: getQuery, fallback }) as Root;
-    }
-
-    /**
-     * [Open in Hypertune UI]({@link https://app.hypertune.com/projects/4084/main/draft/logic?selected_field_path=root%3EpreSeason})
-     */
-    preSeason({
-        args = {},
-        fallback,
-    }: {
-        args?: EmptyObject;
-        fallback: boolean;
-    }): boolean {
-        const props0 = this.getFieldNodeProps('preSeason', {
-            fieldArguments: args,
-        });
-        const expression0 = props0.expression;
-
-        if (expression0 && expression0.type === 'BooleanExpression') {
-            const node = new sdk.BooleanNode(props0);
-            return node.get({ fallback });
-        }
-
-        const node = new sdk.BooleanNode(props0);
-        node._logUnexpectedTypeError();
-        return node.get({ fallback });
-    }
+    const node = new sdk.BooleanNode(props0);
+    node._logUnexpectedTypeError();
+    return node.get({ fallback });
+  }
 }
 
 /**
  * This is your project schema expressed in GraphQL.
- *
- * Define `Boolean` fields for feature flags, custom `enum` fields for flags with
- * more than two states, `Int` fields for numeric flags like timeouts and limits,
- * `String` fields to manage in-app copy, `Void` fields for analytics events, and
- * fields with custom object and list types for more complex app configuration,
+ * 
+ * Define `Boolean` fields for feature flags, custom `enum` fields for flags with 
+ * more than two states, `Int` fields for numeric flags like timeouts and limits, 
+ * `String` fields to manage in-app copy, `Void` fields for analytics events, and 
+ * fields with custom object and list types for more complex app configuration, 
  * e.g. to use Hypertune as a CMS.
- *
+ * 
  * Once you've changed your schema, set your flag logic in the Logic view.
  */
 export type Source = {
-    /**
-     * You can add arguments to any field in your schema, which you can then use when
-     * setting its logic, including the logic of any nested fields. Your root field
-     * already has a `context` argument. Since all flags are nested under the root
-     * field, this context will be available to all of them.
-     */
-    root: Root;
-};
+  /**
+   * You can add arguments to any field in your schema, which you can then use when
+   * setting its logic, including the logic of any nested fields. Your root field 
+   * already has a `context` argument. Since all flags are nested under the root 
+   * field, this context will be available to all of them.
+   */
+  root: Root;
+}
 
-const sourceFallback = { root: { preSeason: false } };
+const sourceFallback = {root:{preSeason:false}};
 
 export type GetQueryRootArgs = {
-    args: RootArgs;
-};
+  args: RootArgs;
+}
 
 export type GetQueryArgs = {
-    root: GetQueryRootArgs;
-};
+  root: GetQueryRootArgs;
+}
 
 /**
  * This is your project schema expressed in GraphQL.
- *
- * Define `Boolean` fields for feature flags, custom `enum` fields for flags with
- * more than two states, `Int` fields for numeric flags like timeouts and limits,
- * `String` fields to manage in-app copy, `Void` fields for analytics events, and
- * fields with custom object and list types for more complex app configuration,
+ * 
+ * Define `Boolean` fields for feature flags, custom `enum` fields for flags with 
+ * more than two states, `Int` fields for numeric flags like timeouts and limits, 
+ * `String` fields to manage in-app copy, `Void` fields for analytics events, and 
+ * fields with custom object and list types for more complex app configuration, 
  * e.g. to use Hypertune as a CMS.
- *
+ * 
  * Once you've changed your schema, set your flag logic in the Logic view.
  */
 export class SourceNode extends sdk.Node {
-    override typeName = 'Query' as const;
+  override typeName = "Query" as const;
 
-    get({
-        args,
-        fallback = sourceFallback as Source,
-    }: {
-        args: GetQueryArgs;
-        fallback?: Source;
-    }): Source {
-        const getQuery = sdk.mergeFieldQueryAndArgs(
-            query.fragmentDefinitions,
-            sdk.getFieldQueryForPath(
-                query.fragmentDefinitions,
-                query.fieldQuery,
-                [],
-            ),
-            args,
-        );
-        return this.getValue({ query: getQuery, fallback }) as Source;
+  get({ args, fallback = sourceFallback as Source}: { args: GetQueryArgs; fallback?: Source }): Source {
+    const getQuery = sdk.mergeFieldQueryAndArgs(
+      query.fragmentDefinitions,
+      sdk.getFieldQueryForPath(query.fragmentDefinitions, query.fieldQuery, []), 
+      args,
+    );
+    return this.getValue({ query: getQuery, fallback }) as Source;
+  }
+
+  /**
+   * You can add arguments to any field in your schema, which you can then use when
+   * setting its logic, including the logic of any nested fields. Your root field 
+   * already has a `context` argument. Since all flags are nested under the root 
+   * field, this context will be available to all of them.
+   */
+  root({ args }: { args: RootArgs; }): RootNode {
+    const props0 = this.getFieldNodeProps("root", { fieldArguments: args });
+    const expression0 = props0.expression;
+
+    if (
+      expression0 &&
+      expression0.type === "ObjectExpression" &&
+      expression0.objectTypeName === "Root"
+    ) {
+      return new RootNode(props0);
     }
 
-    /**
-     * You can add arguments to any field in your schema, which you can then use when
-     * setting its logic, including the logic of any nested fields. Your root field
-     * already has a `context` argument. Since all flags are nested under the root
-     * field, this context will be available to all of them.
-     */
-    root({ args }: { args: RootArgs }): RootNode {
-        const props0 = this.getFieldNodeProps('root', { fieldArguments: args });
-        const expression0 = props0.expression;
-
-        if (
-            expression0 &&
-            expression0.type === 'ObjectExpression' &&
-            expression0.objectTypeName === 'Root'
-        ) {
-            return new RootNode(props0);
-        }
-
-        const node = new RootNode(props0);
-        node._logUnexpectedTypeError();
-        return node;
-    }
+    const node = new RootNode(props0);
+    node._logUnexpectedTypeError();
+    return node;
+  }
 }
 
-export type DehydratedState = sdk.DehydratedState<Source, VariableValues>;
+export type DehydratedState = sdk.DehydratedState<Source, VariableValues>
 
 const sources: { [key: string]: SourceNode } = {};
 
 export type CreateSourceOptions = {
-    token: string;
-    variableValues?: VariableValues;
-    override?: sdk.DeepPartial<Source> | null;
-    key?: string;
-} & sdk.CreateOptions;
+  token: string; 
+  variableValues?: VariableValues;
+  override?: sdk.DeepPartial<Source> | null;
+  key?: string;
+} & sdk.CreateOptions
 
 export function createSource({
-    token,
-    variableValues = {},
-    override,
-    key,
-    ...options
+  token,
+  variableValues = {},
+  override,
+  key,
+  ...options
 }: CreateSourceOptions): SourceNode {
-    const sourceKey =
-        key ?? (typeof window === 'undefined' ? 'server' : 'client');
+  const sourceKey =
+    key ?? (typeof window === "undefined" ? "server" : "client");
 
-    if (!sources[sourceKey]) {
-        sources[sourceKey] = sdk.create({
-            NodeConstructor: SourceNode,
-            token,
-            variableValues,
-            override,
-            options: {
-                initData: initData as unknown as sdk.InitData,
-                ...options,
-            },
-        });
-    }
+  if (!sources[sourceKey]) {
+    sources[sourceKey] = sdk.create({
+      NodeConstructor: SourceNode,
+      token,
+      variableValues,
+      override,
+      options: {initData: initData as unknown as sdk.InitData, ...options },
+    });
+  }
 
-    return sources[sourceKey];
+  return sources[sourceKey];
 }
 
 export const emptySource = new SourceNode({
-    context: null,
-    logger: null,
-    parent: null,
-    step: null,
-    expression: null,
-    initDataHash: null,
+  context: null,
+  logger: null,
+  parent: null,
+  step: null,
+  expression: null,
+  initDataHash: null,
 });
 
 export function createSourceForServerOnly({
-    token,
-    variableValues = {},
-    override,
-    key,
-    ...options
+  token,
+  variableValues = {},
+  override,
+  key,
+  ...options
 }: CreateSourceOptions): SourceNode {
-    return typeof window === 'undefined'
-        ? createSource({ token, variableValues, override, ...options })
-        : emptySource;
+  return typeof window === "undefined"
+    ? createSource({ token, variableValues, override, ...options })
+    : emptySource;
 }
+
+export const overrideCookieName = "hypertuneOverride";
 
 /**
  * @deprecated use createSource instead.
  */
-export const initHypertune = createSource;
+export const initHypertune = createSource
 /**
  * @deprecated use SourceNode instead.
  */

--- a/packages/apidocs/package.json
+++ b/packages/apidocs/package.json
@@ -13,7 +13,6 @@
     "@gredice/js": "workspace:*",
     "@gredice/storage": "workspace:*",
     "openapi-types": "12.1.3",
-    "tsx": "4.20.5",
     "typescript": "5.9.2"
   }
 }

--- a/packages/client/src/lib/directories-api/v1.d.ts
+++ b/packages/client/src/lib/directories-api/v1.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    '/entities/plant': {
+    "/entities/plant": {
         parameters: {
             query?: never;
             header?: never;
@@ -30,7 +30,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plant'][];
+                        "application/json": components["schemas"]["entity-plant"][];
                     };
                 };
             };
@@ -43,7 +43,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantSort': {
+    "/entities/plantSort": {
         parameters: {
             query?: never;
             header?: never;
@@ -69,7 +69,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantSort'][];
+                        "application/json": components["schemas"]["entity-plantSort"][];
                     };
                 };
             };
@@ -82,7 +82,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantStage': {
+    "/entities/plantStage": {
         parameters: {
             query?: never;
             header?: never;
@@ -108,7 +108,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantStage'][];
+                        "application/json": components["schemas"]["entity-plantStage"][];
                     };
                 };
             };
@@ -121,7 +121,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/seed': {
+    "/entities/seed": {
         parameters: {
             query?: never;
             header?: never;
@@ -147,7 +147,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-seed'][];
+                        "application/json": components["schemas"]["entity-seed"][];
                     };
                 };
             };
@@ -160,7 +160,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/brand': {
+    "/entities/brand": {
         parameters: {
             query?: never;
             header?: never;
@@ -186,7 +186,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-brand'][];
+                        "application/json": components["schemas"]["entity-brand"][];
                     };
                 };
             };
@@ -199,7 +199,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operation': {
+    "/entities/operation": {
         parameters: {
             query?: never;
             header?: never;
@@ -225,7 +225,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operation'][];
+                        "application/json": components["schemas"]["entity-operation"][];
                     };
                 };
             };
@@ -238,7 +238,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operationFrequency': {
+    "/entities/operationFrequency": {
         parameters: {
             query?: never;
             header?: never;
@@ -264,7 +264,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operationFrequency'][];
+                        "application/json": components["schemas"]["entity-operationFrequency"][];
                     };
                 };
             };
@@ -277,7 +277,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq': {
+    "/entities/faq": {
         parameters: {
             query?: never;
             header?: never;
@@ -303,7 +303,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq'][];
+                        "application/json": components["schemas"]["entity-faq"][];
                     };
                 };
             };
@@ -316,7 +316,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq-category': {
+    "/entities/faq-category": {
         parameters: {
             query?: never;
             header?: never;
@@ -342,7 +342,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq-category'][];
+                        "application/json": components["schemas"]["entity-faq-category"][];
                     };
                 };
             };
@@ -355,7 +355,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/block': {
+    "/entities/block": {
         parameters: {
             query?: never;
             header?: never;
@@ -381,7 +381,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-block'][];
+                        "application/json": components["schemas"]["entity-block"][];
                     };
                 };
             };
@@ -402,7 +402,7 @@ export interface components {
             /** Format: uri */
             url: string;
         };
-        'entity-plant': {
+        "entity-plant": {
             id: number;
             entityType: {
                 /** @default 1 */
@@ -452,7 +452,7 @@ export interface components {
                         deliverable: boolean;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     information?: {
                         /** @description (prevedeni naziv operacije) */
@@ -535,7 +535,7 @@ export interface components {
                 perPlant: number;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -545,7 +545,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantSort': {
+        "entity-plantSort": {
             id: number;
             entityType: {
                 /** @default 11 */
@@ -601,7 +601,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -684,7 +684,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -703,7 +703,7 @@ export interface components {
                 maintenance?: string;
             };
             image: {
-                cover?: components['schemas']['image'];
+                cover?: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -713,7 +713,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantStage': {
+        "entity-plantStage": {
             id: number;
             entityType: {
                 /** @default 12 */
@@ -732,7 +732,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-seed': {
+        "entity-seed": {
             id: number;
             entityType: {
                 /** @default 15 */
@@ -794,7 +794,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -877,7 +877,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -931,7 +931,7 @@ export interface components {
                                         deliverable: boolean;
                                     };
                                     image?: {
-                                        cover: components['schemas']['image'];
+                                        cover: components["schemas"]["image"];
                                     };
                                     information?: {
                                         /** @description (prevedeni naziv operacije) */
@@ -1014,7 +1014,7 @@ export interface components {
                                 perPlant: number;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             store?: {
                                 availableInStore: boolean;
@@ -1033,7 +1033,7 @@ export interface components {
                         maintenance?: string;
                     };
                     image?: {
-                        cover?: components['schemas']['image'];
+                        cover?: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -1056,7 +1056,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-brand': {
+        "entity-brand": {
             id: number;
             entityType: {
                 /** @default 16 */
@@ -1075,7 +1075,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operation': {
+        "entity-operation": {
             id: number;
             entityType: {
                 /** @default 10 */
@@ -1104,7 +1104,7 @@ export interface components {
                 deliverable: boolean;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             information: {
                 /** @description (prevedeni naziv operacije) */
@@ -1131,7 +1131,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operationFrequency': {
+        "entity-operationFrequency": {
             id: number;
             entityType: {
                 /** @default 13 */
@@ -1146,7 +1146,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq': {
+        "entity-faq": {
             id: number;
             entityType: {
                 /** @default 2 */
@@ -1176,7 +1176,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq-category': {
+        "entity-faq-category": {
             id: number;
             entityType: {
                 /** @default 14 */
@@ -1195,7 +1195,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-block': {
+        "entity-block": {
             id: number;
             entityType: {
                 /** @default 8 */

--- a/packages/signalco/src/lib/signalco-api/v1.d.ts
+++ b/packages/signalco/src/lib/signalco-api/v1.d.ts
@@ -4,14 +4,14 @@
  */
 
 export interface paths {
-    '/status': {
+    "/status": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations['HealthFunctions'];
+        get: operations["HealthFunctions"];
         put?: never;
         post?: never;
         delete?: never;
@@ -20,7 +20,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/website/newsletter-subscribe': {
+    "/website/newsletter-subscribe": {
         parameters: {
             query?: never;
             header?: never;
@@ -30,21 +30,21 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Subscribe to a newsletter. */
-        post: operations['NewsletterFunction'];
+        post: operations["NewsletterFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/stations/logging/download': {
+    "/stations/logging/download": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations['StationLoggingDownloadFunction'];
+        get: operations["StationLoggingDownloadFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -53,14 +53,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/station/logging/list': {
+    "/station/logging/list": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations['StationLoggingListFunction'];
+        get: operations["StationLoggingListFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -69,7 +69,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/station/logging/persist': {
+    "/station/logging/persist": {
         parameters: {
             query?: never;
             header?: never;
@@ -79,14 +79,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Appends logging entries. */
-        post: operations['StationLoggingPersistFunction'];
+        post: operations["StationLoggingPersistFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/station/refresh-token': {
+    "/station/refresh-token": {
         parameters: {
             query?: never;
             header?: never;
@@ -96,14 +96,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Refreshes the access token. */
-        post: operations['StationRefreshTokenFunction'];
+        post: operations["StationRefreshTokenFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/signalr/conducts/negotiate': {
+    "/signalr/conducts/negotiate": {
         parameters: {
             query?: never;
             header?: never;
@@ -113,14 +113,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Negotiates SignalR connection for conducts hub. */
-        post: operations['ConductsNegotiateFunction'];
+        post: operations["ConductsNegotiateFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/signalr/contacts/negotiate': {
+    "/signalr/contacts/negotiate": {
         parameters: {
             query?: never;
             header?: never;
@@ -130,14 +130,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Negotiates SignalR connection for entities hub. */
-        post: operations['ContactsNegotiateFunction'];
+        post: operations["ContactsNegotiateFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/share/entity': {
+    "/share/entity": {
         parameters: {
             query?: never;
             header?: never;
@@ -147,15 +147,15 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Shared the entity with users. */
-        post: operations['ShareEntityFunction'];
+        post: operations["ShareEntityFunction"];
         /** @description Un-shared the entity from users. */
-        delete: operations['UnShareEntityFunction'];
+        delete: operations["UnShareEntityFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/entity': {
+    "/entity": {
         parameters: {
             query?: never;
             header?: never;
@@ -163,18 +163,18 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves all available entities. */
-        get: operations['EntityRetrieveFunction'];
+        get: operations["EntityRetrieveFunction"];
         put?: never;
         /** @description Creates or updates entity. Will create entity if Id is not provided. */
-        post: operations['EntityUpsertFunction'];
+        post: operations["EntityUpsertFunction"];
         /** @description Deletes the entity. */
-        delete: operations['EntityDeleteFunction'];
+        delete: operations["EntityDeleteFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/entities': {
+    "/entities": {
         parameters: {
             query?: never;
             header?: never;
@@ -182,17 +182,17 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves entities. */
-        get: operations['EntityRetrieveFunction'];
+        get: operations["EntityRetrieveFunction"];
         put?: never;
         post?: never;
         /** @description Deletes the entity. */
-        delete: operations['EntityDeleteFunction'];
+        delete: operations["EntityDeleteFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/entity/{id}': {
+    "/entity/{id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -200,7 +200,7 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves single entity. */
-        get: operations['EntityRetrieveSingleFunction'];
+        get: operations["EntityRetrieveSingleFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -209,7 +209,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entity/{id}/contacts/{channelName}/{contactName}': {
+    "/entity/{id}/contacts/{channelName}/{contactName}": {
         parameters: {
             query?: never;
             header?: never;
@@ -218,16 +218,16 @@ export interface paths {
         };
         get?: never;
         /** @description Sets contact value. */
-        put: operations['EntityContactSet'];
+        put: operations["EntityContactSet"];
         post?: never;
         /** @description Deletes the contact. */
-        delete: operations['ContactDeleteFunction'];
+        delete: operations["ContactDeleteFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/contact/history': {
+    "/contact/history": {
         parameters: {
             query?: never;
             header?: never;
@@ -235,7 +235,7 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves the contact history for provided duration. */
-        get: operations['ContactHistoryRetrieveFunction'];
+        get: operations["ContactHistoryRetrieveFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -244,7 +244,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/contact/metadata': {
+    "/contact/metadata": {
         parameters: {
             query?: never;
             header?: never;
@@ -254,14 +254,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Contact metadata. */
-        post: operations['ContactMetadataFunction'];
+        post: operations["ContactMetadataFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/contact/set': {
+    "/contact/set": {
         parameters: {
             query?: never;
             header?: never;
@@ -271,14 +271,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Sets contact value. */
-        post: operations['ContactSetFunction'];
+        post: operations["ContactSetFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/conducts/request': {
+    "/conducts/request": {
         parameters: {
             query?: never;
             header?: never;
@@ -288,14 +288,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Requests conduct to be executed. */
-        post: operations['ConductRequestFunction'];
+        post: operations["ConductRequestFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/conducts/request-multiple': {
+    "/conducts/request-multiple": {
         parameters: {
             query?: never;
             header?: never;
@@ -305,14 +305,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Requests multiple conducts to be executed. */
-        post: operations['ConductRequestMultipleFunction'];
+        post: operations["ConductRequestMultipleFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/auth/pats': {
+    "/auth/pats": {
         parameters: {
             query?: never;
             header?: never;
@@ -320,10 +320,10 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieve all user PATs. */
-        get: operations['PatsRetrieveFunction'];
+        get: operations["PatsRetrieveFunction"];
         put?: never;
         /** @description Creates new PAT. */
-        post: operations['PatsCreateFunction'];
+        post: operations["PatsCreateFunction"];
         delete?: never;
         options?: never;
         head?: never;
@@ -361,7 +361,7 @@ export interface components {
             metadata?: string;
         };
         contactHistoryResponseDto: {
-            values?: components['schemas']['timeStampValuePair'][];
+            values?: components["schemas"]["timeStampValuePair"][];
         };
         contactMetadataDto: {
             entityId?: string;
@@ -389,8 +389,8 @@ export interface components {
             type: 0 | 1 | 2 | 3 | 4 | 5 | 6;
             id?: string;
             alias?: string;
-            contacts?: components['schemas']['contactDto'][];
-            sharedWith?: components['schemas']['userDto'][];
+            contacts?: components["schemas"]["contactDto"][];
+            sharedWith?: components["schemas"]["userDto"][];
         };
         entityUpsertDto: {
             id?: string;
@@ -452,7 +452,7 @@ export interface components {
         };
         stationsLoggingPersistRequestDto: {
             stationId: string;
-            entries: components['schemas']['entry'][];
+            entries: components["schemas"]["entry"][];
         };
         timeStampValuePair: {
             /** Format: date-time */
@@ -500,7 +500,7 @@ export interface operations {
             query?: never;
             header?: {
                 /** @description hCaptcha response. */
-                'HCAPTCHA-RESPONSE'?: string;
+                "HCAPTCHA-RESPONSE"?: string;
             };
             path?: never;
             cookie?: never;
@@ -508,7 +508,7 @@ export interface operations {
         /** @description Subscribe with email address. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['newsletterSubscribeDto'];
+                "application/json": components["schemas"]["newsletterSubscribeDto"];
             };
         };
         responses: {
@@ -569,7 +569,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['blobInfoDto'][];
+                    "application/json": components["schemas"]["blobInfoDto"][];
                 };
             };
             /** @description One or more required property is missing in request. */
@@ -591,7 +591,7 @@ export interface operations {
         /** @description The logging entries to persist per station. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['stationsLoggingPersistRequestDto'];
+                "application/json": components["schemas"]["stationsLoggingPersistRequestDto"];
             };
         };
         responses: {
@@ -620,7 +620,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['stationRefreshTokenRequestDto'];
+                "application/json": components["schemas"]["stationRefreshTokenRequestDto"];
             };
         };
         responses: {
@@ -630,7 +630,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['stationRefreshTokenResponseDto'];
+                    "application/json": components["schemas"]["stationRefreshTokenResponseDto"];
                 };
             };
             /** @description One or more required property is missing in request. */
@@ -657,7 +657,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['signalRConnectionInfo'];
+                    "application/json": components["schemas"]["signalRConnectionInfo"];
                 };
             };
         };
@@ -677,7 +677,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['signalRConnectionInfo'];
+                    "application/json": components["schemas"]["signalRConnectionInfo"];
                 };
             };
         };
@@ -692,7 +692,7 @@ export interface operations {
         /** @description Share one entity with one or more users. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['shareRequestDto'];
+                "application/json": components["schemas"]["shareRequestDto"];
             };
         };
         responses: {
@@ -722,7 +722,7 @@ export interface operations {
         /** @description Un-share one entity with one or more users. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['unShareRequestDto'];
+                "application/json": components["schemas"]["unShareRequestDto"];
             };
         };
         responses: {
@@ -757,7 +757,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityDetailsDto'][];
+                    "application/json": components["schemas"]["entityDetailsDto"][];
                 };
             };
         };
@@ -771,7 +771,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['entityUpsertDto'];
+                "application/json": components["schemas"]["entityUpsertDto"];
             };
         };
         responses: {
@@ -781,7 +781,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityUpsertResponseDto'];
+                    "application/json": components["schemas"]["entityUpsertResponseDto"];
                 };
             };
         };
@@ -796,7 +796,7 @@ export interface operations {
         /** @description Information about entity to delete. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['entityDeleteDto'];
+                "application/json": components["schemas"]["entityDeleteDto"];
             };
         };
         responses: {
@@ -841,7 +841,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityDetailsDto'][];
+                    "application/json": components["schemas"]["entityDetailsDto"][];
                 };
             };
         };
@@ -899,7 +899,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityDetailsDto'];
+                    "application/json": components["schemas"]["entityDetailsDto"];
                 };
             };
             /** @description No description */
@@ -927,7 +927,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['contactSetDto'];
+                "application/json": components["schemas"]["contactSetDto"];
             };
         };
         responses: {
@@ -987,7 +987,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['contactHistoryResponseDto'];
+                    "application/json": components["schemas"]["contactHistoryResponseDto"];
                 };
             };
             /** @description One or more required property is missing in request. */
@@ -1008,7 +1008,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['contactMetadataDto'];
+                "application/json": components["schemas"]["contactMetadataDto"];
             };
         };
         responses: {
@@ -1037,7 +1037,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['contactSetDto'];
+                "application/json": components["schemas"]["contactSetDto"];
             };
         };
         responses: {
@@ -1067,7 +1067,7 @@ export interface operations {
         /** @description The conduct to execute. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['conductRequestDto'];
+                "application/json": components["schemas"]["conductRequestDto"];
             };
         };
         responses: {
@@ -1097,7 +1097,7 @@ export interface operations {
         /** @description Collection of conducts to execute. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['conductRequestDto'][];
+                "application/json": components["schemas"]["conductRequestDto"][];
             };
         };
         responses: {
@@ -1132,7 +1132,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['patDto'][];
+                    "application/json": components["schemas"]["patDto"][];
                 };
             };
         };
@@ -1146,7 +1146,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['patCreateDto'];
+                "application/json": components["schemas"]["patCreateDto"];
             };
         };
         responses: {
@@ -1156,7 +1156,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['patCreateResponseDto'];
+                    "application/json": components["schemas"]["patCreateResponseDto"];
                 };
             };
         };

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,9 +13,9 @@
         "db-push": "tsx --env-file=.env ./src/migrate.ts",
         "dev": "drizzle-kit studio",
         "test": "pnpm run test:node",
-        "test:db:start": "zsh ./tests/startTestDb.sh",
+        "test:db:start": "bash ./tests/startTestDb.sh",
         "test:db:migrate": "tsx --env-file=.env.test --conditions=react-server ./src/migrate.ts",
-        "test:db:stop": "zsh ./tests/stopTestDb.sh",
+        "test:db:stop": "bash ./tests/stopTestDb.sh",
         "test:node": "pnpm run test:db:start && pnpm run test:db:migrate && tsx --test --env-file=.env.test --conditions=react-server ./tests/**/*.node.spec.ts && pnpm run test:db:stop"
     },
     "devDependencies": {

--- a/packages/storage/src/migrations/0000_tan_prima.sql
+++ b/packages/storage/src/migrations/0000_tan_prima.sql
@@ -1,516 +1,515 @@
--- -- Current sql file was generated after introspecting the database
--- -- If you want to run this migration please uncomment this code before executing migrations
--- /*
--- CREATE TABLE "attribute_definitions" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"category" text NOT NULL,
--- 	"name" text NOT NULL,
--- 	"entity_type" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"data_type" text NOT NULL,
--- 	"multiple" boolean DEFAULT false NOT NULL,
--- 	"label" text NOT NULL,
--- 	"default_value" text,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"order" text,
--- 	"required" boolean DEFAULT false NOT NULL,
--- 	"description" text
--- );
--- --> statement-breakpoint
--- CREATE TABLE "accounts" (
--- 	"id" text PRIMARY KEY NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"stripe_customer_id" text,
--- 	"address_street1" text,
--- 	"address_street2" text,
--- 	"address_city" text,
--- 	"address_zip" text
--- );
--- --> statement-breakpoint
--- CREATE TABLE "attribute_definition_categories" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"name" text NOT NULL,
--- 	"label" text NOT NULL,
--- 	"entity_type" text NOT NULL,
--- 	"order" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "user_logins" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"user_id" text NOT NULL,
--- 	"login_type" text NOT NULL,
--- 	"login_id" text NOT NULL,
--- 	"login_data" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"failed_attempts" smallint DEFAULT 0 NOT NULL,
--- 	"last_failed_attempt" timestamp,
--- 	"blocked_until" timestamp,
--- 	"last_login" timestamp
--- );
--- --> statement-breakpoint
--- CREATE TABLE "entity_types" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"name" text NOT NULL,
--- 	"label" text NOT NULL,
--- 	"order" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"category_id" integer
--- );
--- --> statement-breakpoint
--- CREATE TABLE "attribute_values" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"attribute_definition_id" integer NOT NULL,
--- 	"entity_type" text NOT NULL,
--- 	"entity_id" integer NOT NULL,
--- 	"value" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"order" text
--- );
--- --> statement-breakpoint
--- CREATE TABLE "entities" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"entity_type" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"state" text DEFAULT 'draft' NOT NULL,
--- 	"published_at" timestamp
--- );
--- --> statement-breakpoint
--- CREATE TABLE "account_users" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"account_id" text NOT NULL,
--- 	"user_id" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "garden_blocks" (
--- 	"id" text PRIMARY KEY NOT NULL,
--- 	"garden_id" integer NOT NULL,
--- 	"name" text NOT NULL,
--- 	"rotation" integer,
--- 	"variant" integer,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "events" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"type" text NOT NULL,
--- 	"version" integer NOT NULL,
--- 	"aggregate_id" text NOT NULL,
--- 	"data" jsonb,
--- 	"created_at" timestamp DEFAULT now() NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "users" (
--- 	"id" text PRIMARY KEY DEFAULT nextval('users_id_seq'::regclass) NOT NULL,
--- 	"username" text NOT NULL,
--- 	"role" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"avatar_url" text,
--- 	"display_name" text
--- );
--- --> statement-breakpoint
--- CREATE TABLE "garden_stacks" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"garden_id" integer NOT NULL,
--- 	"position_x" integer NOT NULL,
--- 	"position_y" integer NOT NULL,
--- 	"blocks" text[] DEFAULT '{""}' NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "farms" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"name" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"latitude" real NOT NULL,
--- 	"longitude" real NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "gardens" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"account_id" text NOT NULL,
--- 	"name" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"farm_id" integer NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "feedbacks" (
--- 	"id" text PRIMARY KEY NOT NULL,
--- 	"topic" text NOT NULL,
--- 	"data" json,
--- 	"score" text,
--- 	"comment" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "raised_beds" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"account_id" text,
--- 	"garden_id" integer,
--- 	"block_id" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"name" text NOT NULL,
--- 	"status" text DEFAULT 'new' NOT NULL,
--- 	"physical_id" text
--- );
--- --> statement-breakpoint
--- CREATE TABLE "transactions" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"account_id" text,
--- 	"garden_id" integer,
--- 	"stripe_payment_id" text NOT NULL,
--- 	"amount" integer NOT NULL,
--- 	"currency" text NOT NULL,
--- 	"status" text NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "notifications" (
--- 	"id" text PRIMARY KEY NOT NULL,
--- 	"header" text NOT NULL,
--- 	"content" text NOT NULL,
--- 	"image" text,
--- 	"link_url" text,
--- 	"account_id" text NOT NULL,
--- 	"user_id" text,
--- 	"garden_id" integer,
--- 	"block_id" text,
--- 	"read_at" timestamp,
--- 	"read_where" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"raised_bed_id" integer,
--- 	"timestamp" timestamp NOT NULL,
--- 	"icon_url" text
--- );
--- --> statement-breakpoint
--- CREATE TABLE "shopping_cart_items" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"cart_id" integer NOT NULL,
--- 	"entity_id" text NOT NULL,
--- 	"entity_type_name" text NOT NULL,
--- 	"garden_id" integer,
--- 	"raised_bed_id" integer,
--- 	"amount" integer NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"position_index" integer,
--- 	"additional_data" text,
--- 	"status" text DEFAULT 'new' NOT NULL,
--- 	"currency" text DEFAULT 'eur' NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "shopping_carts" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"account_id" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"status" text DEFAULT 'new' NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "raised_bed_fields" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"raised_bed_id" integer NOT NULL,
--- 	"position_index" integer NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "notification_email_log" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"user_id" text NOT NULL,
--- 	"notification_id" text NOT NULL,
--- 	"emailed_at" timestamp DEFAULT now() NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "user_notification_settings" (
--- 	"user_id" text PRIMARY KEY NOT NULL,
--- 	"email_enabled" boolean DEFAULT true NOT NULL,
--- 	"daily_digest" boolean DEFAULT true NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "raised_bed_sensors" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"raised_bed_id" integer NOT NULL,
--- 	"sensor_signalco_id" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"status" text DEFAULT 'new' NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "operations" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"entity_id" integer NOT NULL,
--- 	"entity_type_name" text NOT NULL,
--- 	"account_id" text,
--- 	"garden_id" integer,
--- 	"raised_bed_id" integer,
--- 	"raised_bed_field_id" integer,
--- 	"timestamp" timestamp DEFAULT now() NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "invoices" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"invoice_number" text NOT NULL,
--- 	"account_id" text NOT NULL,
--- 	"transaction_id" integer,
--- 	"subtotal" numeric(10, 2) NOT NULL,
--- 	"tax_amount" numeric(10, 2) DEFAULT '0.00' NOT NULL,
--- 	"total_amount" numeric(10, 2) NOT NULL,
--- 	"currency" text DEFAULT 'eur' NOT NULL,
--- 	"status" text DEFAULT 'draft' NOT NULL,
--- 	"issue_date" timestamp NOT NULL,
--- 	"due_date" timestamp NOT NULL,
--- 	"paid_date" timestamp,
--- 	"bill_to_name" text,
--- 	"bill_to_email" text NOT NULL,
--- 	"bill_to_address" text,
--- 	"bill_to_city" text,
--- 	"bill_to_state" text,
--- 	"bill_to_zip" text,
--- 	"bill_to_country" text,
--- 	"notes" text,
--- 	"terms" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	CONSTRAINT "invoices_invoice_number_unique" UNIQUE("invoice_number")
--- );
--- --> statement-breakpoint
--- CREATE TABLE "invoice_items" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"invoice_id" integer NOT NULL,
--- 	"description" text NOT NULL,
--- 	"quantity" numeric(10, 2) DEFAULT '1.00' NOT NULL,
--- 	"unit_price" numeric(10, 2) NOT NULL,
--- 	"total_price" numeric(10, 2) NOT NULL,
--- 	"entity_id" text,
--- 	"entity_type_name" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "fiscalization_pos_settings" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"name" text NOT NULL,
--- 	"pos_id" text NOT NULL,
--- 	"premise_id" text NOT NULL,
--- 	"is_active" boolean DEFAULT true NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "fiscalization_user_settings" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"pin" text NOT NULL,
--- 	"use_vat" boolean DEFAULT false NOT NULL,
--- 	"receipt_number_on_device" boolean DEFAULT false NOT NULL,
--- 	"environment" text DEFAULT 'educ' NOT NULL,
--- 	"cert_base64" text NOT NULL,
--- 	"cert_password" text NOT NULL,
--- 	"is_active" boolean DEFAULT true NOT NULL,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- CREATE TABLE "receipts" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"invoice_id" integer NOT NULL,
--- 	"receipt_number" text NOT NULL,
--- 	"subtotal" numeric(10, 2) NOT NULL,
--- 	"tax_amount" numeric(10, 2) NOT NULL,
--- 	"total_amount" numeric(10, 2) NOT NULL,
--- 	"currency" text NOT NULL,
--- 	"payment_method" text NOT NULL,
--- 	"payment_reference" text,
--- 	"jir" text,
--- 	"zki" text,
--- 	"cis_status" text DEFAULT 'pending' NOT NULL,
--- 	"cis_reference" text,
--- 	"cis_error_message" text,
--- 	"cis_timestamp" timestamp,
--- 	"issued_at" timestamp DEFAULT now() NOT NULL,
--- 	"business_pin" text,
--- 	"business_name" text,
--- 	"business_address" text,
--- 	"customer_pin" text,
--- 	"customer_name" text,
--- 	"customer_address" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL,
--- 	"year_receipt_number" text NOT NULL,
--- 	"cis_response" text,
--- 	CONSTRAINT "receipts_year_receipt_number_unique" UNIQUE("year_receipt_number")
--- );
--- --> statement-breakpoint
--- CREATE TABLE "entity_type_categories" (
--- 	"id" serial PRIMARY KEY NOT NULL,
--- 	"name" text NOT NULL,
--- 	"label" text NOT NULL,
--- 	"order" text,
--- 	"created_at" timestamp DEFAULT now() NOT NULL,
--- 	"updated_at" timestamp NOT NULL,
--- 	"is_deleted" boolean DEFAULT false NOT NULL
--- );
--- --> statement-breakpoint
--- ALTER TABLE "user_logins" ADD CONSTRAINT "user_logins_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "entity_types" ADD CONSTRAINT "entity_types_category_id_entity_type_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."entity_type_categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "attribute_values" ADD CONSTRAINT "attribute_values_attribute_definition_id_attribute_definitions_" FOREIGN KEY ("attribute_definition_id") REFERENCES "public"."attribute_definitions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "attribute_values" ADD CONSTRAINT "attribute_values_entity_id_entities_id_fk" FOREIGN KEY ("entity_id") REFERENCES "public"."entities"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "account_users" ADD CONSTRAINT "account_users_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "account_users" ADD CONSTRAINT "account_users_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "garden_blocks" ADD CONSTRAINT "garden_blocks_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "garden_stacks" ADD CONSTRAINT "garden_stacks_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "gardens" ADD CONSTRAINT "gardens_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "gardens" ADD CONSTRAINT "gardens_farm_id_farms_id_fk" FOREIGN KEY ("farm_id") REFERENCES "public"."farms"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "raised_beds" ADD CONSTRAINT "raised_beds_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "raised_beds" ADD CONSTRAINT "raised_beds_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "raised_beds" ADD CONSTRAINT "raised_beds_block_id_garden_blocks_id_fk" FOREIGN KEY ("block_id") REFERENCES "public"."garden_blocks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "transactions" ADD CONSTRAINT "transactions_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "transactions" ADD CONSTRAINT "transactions_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notifications" ADD CONSTRAINT "notifications_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notifications" ADD CONSTRAINT "notifications_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notifications" ADD CONSTRAINT "notifications_block_id_garden_blocks_id_fk" FOREIGN KEY ("block_id") REFERENCES "public"."garden_blocks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notifications" ADD CONSTRAINT "notifications_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "shopping_cart_items" ADD CONSTRAINT "shopping_cart_items_cart_id_shopping_carts_id_fk" FOREIGN KEY ("cart_id") REFERENCES "public"."shopping_carts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "shopping_cart_items" ADD CONSTRAINT "shopping_cart_items_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "shopping_cart_items" ADD CONSTRAINT "shopping_cart_items_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "shopping_carts" ADD CONSTRAINT "shopping_carts_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "raised_bed_fields" ADD CONSTRAINT "raised_bed_fields_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notification_email_log" ADD CONSTRAINT "notification_email_log_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "notification_email_log" ADD CONSTRAINT "notification_email_log_notification_id_notifications_id_fk" FOREIGN KEY ("notification_id") REFERENCES "public"."notifications"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "user_notification_settings" ADD CONSTRAINT "user_notification_settings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "raised_bed_sensors" ADD CONSTRAINT "raised_bed_sensors_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "invoices" ADD CONSTRAINT "invoices_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "invoices" ADD CONSTRAINT "invoices_transaction_id_transactions_id_fk" FOREIGN KEY ("transaction_id") REFERENCES "public"."transactions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "invoice_items" ADD CONSTRAINT "invoice_items_invoice_id_invoices_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- ALTER TABLE "receipts" ADD CONSTRAINT "receipts_invoice_id_invoices_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
--- CREATE INDEX "cms_ad_category_idx" ON "attribute_definitions" USING btree ("category" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_ad_entity_type_name_idx" ON "attribute_definitions" USING btree ("entity_type" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_ad_is_deleted_idx" ON "attribute_definitions" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "cms_ad_order_idx" ON "attribute_definitions" USING btree ("order" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_adc_entity_type_name_idx" ON "attribute_definition_categories" USING btree ("entity_type" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_adc_is_deleted_idx" ON "attribute_definition_categories" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "cms_adc_order_idx" ON "attribute_definition_categories" USING btree ("order" text_ops);--> statement-breakpoint
--- CREATE INDEX "users_ul_login_id_idx" ON "user_logins" USING btree ("login_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "users_ul_login_type_idx" ON "user_logins" USING btree ("login_type" text_ops);--> statement-breakpoint
--- CREATE INDEX "users_ul_user_id_idx" ON "user_logins" USING btree ("user_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_et_category_id_idx" ON "entity_types" USING btree ("category_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "cms_et_is_deleted_idx" ON "entity_types" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "cms_et_order_idx" ON "entity_types" USING btree ("order" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_av_attribute_definition_id_idx" ON "attribute_values" USING btree ("attribute_definition_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "cms_av_entity_id_idx" ON "attribute_values" USING btree ("entity_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "cms_av_entity_type_name_idx" ON "attribute_values" USING btree ("entity_type" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_av_is_deleted_idx" ON "attribute_values" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "cms_av_order_idx" ON "attribute_values" USING btree ("order" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_e_entity_type_name_idx" ON "entities" USING btree ("entity_type" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_e_is_deleted_idx" ON "entities" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "cms_e_state_idx" ON "entities" USING btree ("state" text_ops);--> statement-breakpoint
--- CREATE INDEX "users_au_account_id_idx" ON "account_users" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "users_au_user_id_idx" ON "account_users" USING btree ("user_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "garden_gb_garden_id_idx" ON "garden_blocks" USING btree ("garden_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "garden_gb_is_deleted_idx" ON "garden_blocks" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "events_e_aggregate_id_idx" ON "events" USING btree ("aggregate_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "events_e_created_at_idx" ON "events" USING btree ("created_at" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "events_e_type_idx" ON "events" USING btree ("type" text_ops);--> statement-breakpoint
--- CREATE INDEX "users_u_username_idx" ON "users" USING btree ("username" text_ops);--> statement-breakpoint
--- CREATE INDEX "garden_gs_garden_id_idx" ON "garden_stacks" USING btree ("garden_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "garden_gs_is_deleted_idx" ON "garden_stacks" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "farms_f_is_deleted_idx" ON "farms" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "garden_g_account_id_idx" ON "gardens" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "garden_g_farm_id_idx" ON "gardens" USING btree ("farm_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "garden_g_is_deleted_idx" ON "gardens" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "raised_beds_account_id_idx" ON "raised_beds" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "raised_beds_block_id_idx" ON "raised_beds" USING btree ("block_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "raised_beds_garden_id_idx" ON "raised_beds" USING btree ("garden_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "raised_beds_is_deleted_idx" ON "raised_beds" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "transactions_account_id_idx" ON "transactions" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "transactions_garden_id_idx" ON "transactions" USING btree ("garden_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "transactions_is_deleted_idx" ON "transactions" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "transactions_stripe_payment_id_idx" ON "transactions" USING btree ("stripe_payment_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "notifications_account_id_idx" ON "notifications" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "notifications_created_at_idx" ON "notifications" USING btree ("created_at" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "notifications_readAt_idx" ON "notifications" USING btree ("read_at" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "notifications_user_id_idx" ON "notifications" USING btree ("user_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_cart_items_cart_id_idx" ON "shopping_cart_items" USING btree ("cart_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_cart_items_entity_id_idx" ON "shopping_cart_items" USING btree ("entity_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_cart_items_garden_id_idx" ON "shopping_cart_items" USING btree ("garden_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_cart_items_is_deleted_idx" ON "shopping_cart_items" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_cart_items_raised_bed_id_idx" ON "shopping_cart_items" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_cart_items_status_idx" ON "shopping_cart_items" USING btree ("status" text_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_carts_account_id_idx" ON "shopping_carts" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_carts_is_deleted_idx" ON "shopping_carts" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "shopping_carts_status_idx" ON "shopping_carts" USING btree ("status" text_ops);--> statement-breakpoint
--- CREATE INDEX "raised_bed_fields_is_deleted_idx" ON "raised_bed_fields" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "raised_bed_fields_raised_bed_id_idx" ON "raised_bed_fields" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "raised_bed_sensors_is_deleted_idx" ON "raised_bed_sensors" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "raised_bed_sensors_raised_bed_id_idx" ON "raised_bed_sensors" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "operations_account_id_idx" ON "operations" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "operations_entity_id_idx" ON "operations" USING btree ("entity_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "operations_entity_type_name_idx" ON "operations" USING btree ("entity_type_name" text_ops);--> statement-breakpoint
--- CREATE INDEX "operations_garden_id_idx" ON "operations" USING btree ("garden_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "operations_is_deleted_idx" ON "operations" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "operations_raised_bed_field_id_idx" ON "operations" USING btree ("raised_bed_field_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "operations_raised_bed_id_idx" ON "operations" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "operations_timestamp_idx" ON "operations" USING btree ("timestamp" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_account_id_idx" ON "invoices" USING btree ("account_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_due_date_idx" ON "invoices" USING btree ("due_date" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_invoice_number_idx" ON "invoices" USING btree ("invoice_number" text_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_is_deleted_idx" ON "invoices" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_issue_date_idx" ON "invoices" USING btree ("issue_date" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_status_idx" ON "invoices" USING btree ("status" text_ops);--> statement-breakpoint
--- CREATE INDEX "invoices_transaction_id_idx" ON "invoices" USING btree ("transaction_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "invoice_items_entity_id_idx" ON "invoice_items" USING btree ("entity_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "invoice_items_entity_type_idx" ON "invoice_items" USING btree ("entity_type_name" text_ops);--> statement-breakpoint
--- CREATE INDEX "invoice_items_invoice_id_idx" ON "invoice_items" USING btree ("invoice_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "fiscalization_pos_settings_is_active_idx" ON "fiscalization_pos_settings" USING btree ("is_active" bool_ops);--> statement-breakpoint
--- CREATE INDEX "fiscalization_pos_settings_is_deleted_idx" ON "fiscalization_pos_settings" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "fiscalization_pos_settings_pos_id_idx" ON "fiscalization_pos_settings" USING btree ("pos_id" text_ops);--> statement-breakpoint
--- CREATE INDEX "fiscalization_user_settings_is_active_idx" ON "fiscalization_user_settings" USING btree ("is_active" bool_ops);--> statement-breakpoint
--- CREATE INDEX "fiscalization_user_settings_is_deleted_idx" ON "fiscalization_user_settings" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_business_pin_idx" ON "receipts" USING btree ("business_pin" text_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_cis_status_idx" ON "receipts" USING btree ("cis_status" text_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_invoice_id_idx" ON "receipts" USING btree ("invoice_id" int4_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_is_deleted_idx" ON "receipts" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_issued_at_idx" ON "receipts" USING btree ("issued_at" timestamp_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_jir_idx" ON "receipts" USING btree ("jir" text_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_receipt_number_idx" ON "receipts" USING btree ("receipt_number" text_ops);--> statement-breakpoint
--- CREATE INDEX "receipts_zki_idx" ON "receipts" USING btree ("zki" text_ops);--> statement-breakpoint
--- CREATE INDEX "cms_etc_is_deleted_idx" ON "entity_type_categories" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
--- CREATE INDEX "cms_etc_order_idx" ON "entity_type_categories" USING btree ("order" text_ops);
--- */
+-- Current sql file was generated after introspecting the database
+-- If you want to run this migration please uncomment this code before executing migrations
+
+CREATE TABLE "attribute_definitions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"category" text NOT NULL,
+	"name" text NOT NULL,
+	"entity_type" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"data_type" text NOT NULL,
+	"multiple" boolean DEFAULT false NOT NULL,
+	"label" text NOT NULL,
+	"default_value" text,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"order" text,
+	"required" boolean DEFAULT false NOT NULL,
+	"description" text
+);
+--> statement-breakpoint
+CREATE TABLE "accounts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"stripe_customer_id" text,
+	"address_street1" text,
+	"address_street2" text,
+	"address_city" text,
+	"address_zip" text
+);
+--> statement-breakpoint
+CREATE TABLE "attribute_definition_categories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"label" text NOT NULL,
+	"entity_type" text NOT NULL,
+	"order" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_logins" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"login_type" text NOT NULL,
+	"login_id" text NOT NULL,
+	"login_data" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"failed_attempts" smallint DEFAULT 0 NOT NULL,
+	"last_failed_attempt" timestamp,
+	"blocked_until" timestamp,
+	"last_login" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "entity_types" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"label" text NOT NULL,
+	"order" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"category_id" integer
+);
+--> statement-breakpoint
+CREATE TABLE "attribute_values" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"attribute_definition_id" integer NOT NULL,
+	"entity_type" text NOT NULL,
+	"entity_id" integer NOT NULL,
+	"value" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"order" text
+);
+--> statement-breakpoint
+CREATE TABLE "entities" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"entity_type" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"state" text DEFAULT 'draft' NOT NULL,
+	"published_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "account_users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "garden_blocks" (
+	"id" text PRIMARY KEY NOT NULL,
+	"garden_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"rotation" integer,
+	"variant" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"type" text NOT NULL,
+	"version" integer NOT NULL,
+	"aggregate_id" text NOT NULL,
+	"data" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"role" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"avatar_url" text,
+	"display_name" text
+);
+--> statement-breakpoint
+CREATE TABLE "garden_stacks" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"garden_id" integer NOT NULL,
+	"position_x" integer NOT NULL,
+	"position_y" integer NOT NULL,
+	"blocks" text[] DEFAULT '{""}' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "farms" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"latitude" real NOT NULL,
+	"longitude" real NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "gardens" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"farm_id" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "feedbacks" (
+	"id" text PRIMARY KEY NOT NULL,
+	"topic" text NOT NULL,
+	"data" json,
+	"score" text,
+	"comment" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "raised_beds" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"account_id" text,
+	"garden_id" integer,
+	"block_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"name" text NOT NULL,
+	"status" text DEFAULT 'new' NOT NULL,
+	"physical_id" text
+);
+--> statement-breakpoint
+CREATE TABLE "transactions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"account_id" text,
+	"garden_id" integer,
+	"stripe_payment_id" text NOT NULL,
+	"amount" integer NOT NULL,
+	"currency" text NOT NULL,
+	"status" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" text PRIMARY KEY NOT NULL,
+	"header" text NOT NULL,
+	"content" text NOT NULL,
+	"image" text,
+	"link_url" text,
+	"account_id" text NOT NULL,
+	"user_id" text,
+	"garden_id" integer,
+	"block_id" text,
+	"read_at" timestamp,
+	"read_where" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"raised_bed_id" integer,
+	"timestamp" timestamp NOT NULL,
+	"icon_url" text
+);
+--> statement-breakpoint
+CREATE TABLE "shopping_cart_items" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"cart_id" integer NOT NULL,
+	"entity_id" text NOT NULL,
+	"entity_type_name" text NOT NULL,
+	"garden_id" integer,
+	"raised_bed_id" integer,
+	"amount" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"position_index" integer,
+	"additional_data" text,
+	"status" text DEFAULT 'new' NOT NULL,
+	"currency" text DEFAULT 'eur' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "shopping_carts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"account_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"status" text DEFAULT 'new' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "raised_bed_fields" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"raised_bed_id" integer NOT NULL,
+	"position_index" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "notification_email_log" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"notification_id" text NOT NULL,
+	"emailed_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_notification_settings" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"email_enabled" boolean DEFAULT true NOT NULL,
+	"daily_digest" boolean DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "raised_bed_sensors" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"raised_bed_id" integer NOT NULL,
+	"sensor_signalco_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"status" text DEFAULT 'new' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "operations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"entity_id" integer NOT NULL,
+	"entity_type_name" text NOT NULL,
+	"account_id" text,
+	"garden_id" integer,
+	"raised_bed_id" integer,
+	"raised_bed_field_id" integer,
+	"timestamp" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "invoices" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"invoice_number" text NOT NULL,
+	"account_id" text NOT NULL,
+	"transaction_id" integer,
+	"subtotal" numeric(10, 2) NOT NULL,
+	"tax_amount" numeric(10, 2) DEFAULT '0.00' NOT NULL,
+	"total_amount" numeric(10, 2) NOT NULL,
+	"currency" text DEFAULT 'eur' NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"issue_date" timestamp NOT NULL,
+	"due_date" timestamp NOT NULL,
+	"paid_date" timestamp,
+	"bill_to_name" text,
+	"bill_to_email" text NOT NULL,
+	"bill_to_address" text,
+	"bill_to_city" text,
+	"bill_to_state" text,
+	"bill_to_zip" text,
+	"bill_to_country" text,
+	"notes" text,
+	"terms" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	CONSTRAINT "invoices_invoice_number_unique" UNIQUE("invoice_number")
+);
+--> statement-breakpoint
+CREATE TABLE "invoice_items" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"invoice_id" integer NOT NULL,
+	"description" text NOT NULL,
+	"quantity" numeric(10, 2) DEFAULT '1.00' NOT NULL,
+	"unit_price" numeric(10, 2) NOT NULL,
+	"total_price" numeric(10, 2) NOT NULL,
+	"entity_id" text,
+	"entity_type_name" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "fiscalization_pos_settings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"pos_id" text NOT NULL,
+	"premise_id" text NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "fiscalization_user_settings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pin" text NOT NULL,
+	"use_vat" boolean DEFAULT false NOT NULL,
+	"receipt_number_on_device" boolean DEFAULT false NOT NULL,
+	"environment" text DEFAULT 'educ' NOT NULL,
+	"cert_base64" text NOT NULL,
+	"cert_password" text NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "receipts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"invoice_id" integer NOT NULL,
+	"receipt_number" text NOT NULL,
+	"subtotal" numeric(10, 2) NOT NULL,
+	"tax_amount" numeric(10, 2) NOT NULL,
+	"total_amount" numeric(10, 2) NOT NULL,
+	"currency" text NOT NULL,
+	"payment_method" text NOT NULL,
+	"payment_reference" text,
+	"jir" text,
+	"zki" text,
+	"cis_status" text DEFAULT 'pending' NOT NULL,
+	"cis_reference" text,
+	"cis_error_message" text,
+	"cis_timestamp" timestamp,
+	"issued_at" timestamp DEFAULT now() NOT NULL,
+	"business_pin" text,
+	"business_name" text,
+	"business_address" text,
+	"customer_pin" text,
+	"customer_name" text,
+	"customer_address" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL,
+	"year_receipt_number" text NOT NULL,
+	"cis_response" text,
+	CONSTRAINT "receipts_year_receipt_number_unique" UNIQUE("year_receipt_number")
+);
+--> statement-breakpoint
+CREATE TABLE "entity_type_categories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"label" text NOT NULL,
+	"order" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_logins" ADD CONSTRAINT "user_logins_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "entity_types" ADD CONSTRAINT "entity_types_category_id_entity_type_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."entity_type_categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attribute_values" ADD CONSTRAINT "attribute_values_attribute_definition_id_attribute_definitions_" FOREIGN KEY ("attribute_definition_id") REFERENCES "public"."attribute_definitions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attribute_values" ADD CONSTRAINT "attribute_values_entity_id_entities_id_fk" FOREIGN KEY ("entity_id") REFERENCES "public"."entities"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "account_users" ADD CONSTRAINT "account_users_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "account_users" ADD CONSTRAINT "account_users_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "garden_blocks" ADD CONSTRAINT "garden_blocks_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "garden_stacks" ADD CONSTRAINT "garden_stacks_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gardens" ADD CONSTRAINT "gardens_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gardens" ADD CONSTRAINT "gardens_farm_id_farms_id_fk" FOREIGN KEY ("farm_id") REFERENCES "public"."farms"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raised_beds" ADD CONSTRAINT "raised_beds_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raised_beds" ADD CONSTRAINT "raised_beds_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raised_beds" ADD CONSTRAINT "raised_beds_block_id_garden_blocks_id_fk" FOREIGN KEY ("block_id") REFERENCES "public"."garden_blocks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_block_id_garden_blocks_id_fk" FOREIGN KEY ("block_id") REFERENCES "public"."garden_blocks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shopping_cart_items" ADD CONSTRAINT "shopping_cart_items_cart_id_shopping_carts_id_fk" FOREIGN KEY ("cart_id") REFERENCES "public"."shopping_carts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shopping_cart_items" ADD CONSTRAINT "shopping_cart_items_garden_id_gardens_id_fk" FOREIGN KEY ("garden_id") REFERENCES "public"."gardens"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shopping_cart_items" ADD CONSTRAINT "shopping_cart_items_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shopping_carts" ADD CONSTRAINT "shopping_carts_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raised_bed_fields" ADD CONSTRAINT "raised_bed_fields_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notification_email_log" ADD CONSTRAINT "notification_email_log_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notification_email_log" ADD CONSTRAINT "notification_email_log_notification_id_notifications_id_fk" FOREIGN KEY ("notification_id") REFERENCES "public"."notifications"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_notification_settings" ADD CONSTRAINT "user_notification_settings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raised_bed_sensors" ADD CONSTRAINT "raised_bed_sensors_raised_bed_id_raised_beds_id_fk" FOREIGN KEY ("raised_bed_id") REFERENCES "public"."raised_beds"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_transaction_id_transactions_id_fk" FOREIGN KEY ("transaction_id") REFERENCES "public"."transactions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice_items" ADD CONSTRAINT "invoice_items_invoice_id_invoices_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "receipts" ADD CONSTRAINT "receipts_invoice_id_invoices_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "cms_ad_category_idx" ON "attribute_definitions" USING btree ("category" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_ad_entity_type_name_idx" ON "attribute_definitions" USING btree ("entity_type" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_ad_is_deleted_idx" ON "attribute_definitions" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "cms_ad_order_idx" ON "attribute_definitions" USING btree ("order" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_adc_entity_type_name_idx" ON "attribute_definition_categories" USING btree ("entity_type" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_adc_is_deleted_idx" ON "attribute_definition_categories" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "cms_adc_order_idx" ON "attribute_definition_categories" USING btree ("order" text_ops);--> statement-breakpoint
+CREATE INDEX "users_ul_login_id_idx" ON "user_logins" USING btree ("login_id" text_ops);--> statement-breakpoint
+CREATE INDEX "users_ul_login_type_idx" ON "user_logins" USING btree ("login_type" text_ops);--> statement-breakpoint
+CREATE INDEX "users_ul_user_id_idx" ON "user_logins" USING btree ("user_id" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_et_category_id_idx" ON "entity_types" USING btree ("category_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "cms_et_is_deleted_idx" ON "entity_types" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "cms_et_order_idx" ON "entity_types" USING btree ("order" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_av_attribute_definition_id_idx" ON "attribute_values" USING btree ("attribute_definition_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "cms_av_entity_id_idx" ON "attribute_values" USING btree ("entity_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "cms_av_entity_type_name_idx" ON "attribute_values" USING btree ("entity_type" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_av_is_deleted_idx" ON "attribute_values" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "cms_av_order_idx" ON "attribute_values" USING btree ("order" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_e_entity_type_name_idx" ON "entities" USING btree ("entity_type" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_e_is_deleted_idx" ON "entities" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "cms_e_state_idx" ON "entities" USING btree ("state" text_ops);--> statement-breakpoint
+CREATE INDEX "users_au_account_id_idx" ON "account_users" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "users_au_user_id_idx" ON "account_users" USING btree ("user_id" text_ops);--> statement-breakpoint
+CREATE INDEX "garden_gb_garden_id_idx" ON "garden_blocks" USING btree ("garden_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "garden_gb_is_deleted_idx" ON "garden_blocks" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "events_e_aggregate_id_idx" ON "events" USING btree ("aggregate_id" text_ops);--> statement-breakpoint
+CREATE INDEX "events_e_created_at_idx" ON "events" USING btree ("created_at" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "events_e_type_idx" ON "events" USING btree ("type" text_ops);--> statement-breakpoint
+CREATE INDEX "users_u_username_idx" ON "users" USING btree ("username" text_ops);--> statement-breakpoint
+CREATE INDEX "garden_gs_garden_id_idx" ON "garden_stacks" USING btree ("garden_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "garden_gs_is_deleted_idx" ON "garden_stacks" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "farms_f_is_deleted_idx" ON "farms" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "garden_g_account_id_idx" ON "gardens" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "garden_g_farm_id_idx" ON "gardens" USING btree ("farm_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "garden_g_is_deleted_idx" ON "gardens" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "raised_beds_account_id_idx" ON "raised_beds" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "raised_beds_block_id_idx" ON "raised_beds" USING btree ("block_id" text_ops);--> statement-breakpoint
+CREATE INDEX "raised_beds_garden_id_idx" ON "raised_beds" USING btree ("garden_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "raised_beds_is_deleted_idx" ON "raised_beds" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "transactions_account_id_idx" ON "transactions" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "transactions_garden_id_idx" ON "transactions" USING btree ("garden_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "transactions_is_deleted_idx" ON "transactions" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "transactions_stripe_payment_id_idx" ON "transactions" USING btree ("stripe_payment_id" text_ops);--> statement-breakpoint
+CREATE INDEX "notifications_account_id_idx" ON "notifications" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "notifications_created_at_idx" ON "notifications" USING btree ("created_at" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "notifications_readAt_idx" ON "notifications" USING btree ("read_at" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "notifications_user_id_idx" ON "notifications" USING btree ("user_id" text_ops);--> statement-breakpoint
+CREATE INDEX "shopping_cart_items_cart_id_idx" ON "shopping_cart_items" USING btree ("cart_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "shopping_cart_items_entity_id_idx" ON "shopping_cart_items" USING btree ("entity_id" text_ops);--> statement-breakpoint
+CREATE INDEX "shopping_cart_items_garden_id_idx" ON "shopping_cart_items" USING btree ("garden_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "shopping_cart_items_is_deleted_idx" ON "shopping_cart_items" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "shopping_cart_items_raised_bed_id_idx" ON "shopping_cart_items" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "shopping_cart_items_status_idx" ON "shopping_cart_items" USING btree ("status" text_ops);--> statement-breakpoint
+CREATE INDEX "shopping_carts_account_id_idx" ON "shopping_carts" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "shopping_carts_is_deleted_idx" ON "shopping_carts" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "shopping_carts_status_idx" ON "shopping_carts" USING btree ("status" text_ops);--> statement-breakpoint
+CREATE INDEX "raised_bed_fields_is_deleted_idx" ON "raised_bed_fields" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "raised_bed_fields_raised_bed_id_idx" ON "raised_bed_fields" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "raised_bed_sensors_is_deleted_idx" ON "raised_bed_sensors" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "raised_bed_sensors_raised_bed_id_idx" ON "raised_bed_sensors" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "operations_account_id_idx" ON "operations" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "operations_entity_id_idx" ON "operations" USING btree ("entity_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "operations_entity_type_name_idx" ON "operations" USING btree ("entity_type_name" text_ops);--> statement-breakpoint
+CREATE INDEX "operations_garden_id_idx" ON "operations" USING btree ("garden_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "operations_is_deleted_idx" ON "operations" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "operations_raised_bed_field_id_idx" ON "operations" USING btree ("raised_bed_field_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "operations_raised_bed_id_idx" ON "operations" USING btree ("raised_bed_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "operations_timestamp_idx" ON "operations" USING btree ("timestamp" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "invoices_account_id_idx" ON "invoices" USING btree ("account_id" text_ops);--> statement-breakpoint
+CREATE INDEX "invoices_due_date_idx" ON "invoices" USING btree ("due_date" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "invoices_invoice_number_idx" ON "invoices" USING btree ("invoice_number" text_ops);--> statement-breakpoint
+CREATE INDEX "invoices_is_deleted_idx" ON "invoices" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "invoices_issue_date_idx" ON "invoices" USING btree ("issue_date" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "invoices_status_idx" ON "invoices" USING btree ("status" text_ops);--> statement-breakpoint
+CREATE INDEX "invoices_transaction_id_idx" ON "invoices" USING btree ("transaction_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "invoice_items_entity_id_idx" ON "invoice_items" USING btree ("entity_id" text_ops);--> statement-breakpoint
+CREATE INDEX "invoice_items_entity_type_idx" ON "invoice_items" USING btree ("entity_type_name" text_ops);--> statement-breakpoint
+CREATE INDEX "invoice_items_invoice_id_idx" ON "invoice_items" USING btree ("invoice_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "fiscalization_pos_settings_is_active_idx" ON "fiscalization_pos_settings" USING btree ("is_active" bool_ops);--> statement-breakpoint
+CREATE INDEX "fiscalization_pos_settings_is_deleted_idx" ON "fiscalization_pos_settings" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "fiscalization_pos_settings_pos_id_idx" ON "fiscalization_pos_settings" USING btree ("pos_id" text_ops);--> statement-breakpoint
+CREATE INDEX "fiscalization_user_settings_is_active_idx" ON "fiscalization_user_settings" USING btree ("is_active" bool_ops);--> statement-breakpoint
+CREATE INDEX "fiscalization_user_settings_is_deleted_idx" ON "fiscalization_user_settings" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "receipts_business_pin_idx" ON "receipts" USING btree ("business_pin" text_ops);--> statement-breakpoint
+CREATE INDEX "receipts_cis_status_idx" ON "receipts" USING btree ("cis_status" text_ops);--> statement-breakpoint
+CREATE INDEX "receipts_invoice_id_idx" ON "receipts" USING btree ("invoice_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "receipts_is_deleted_idx" ON "receipts" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "receipts_issued_at_idx" ON "receipts" USING btree ("issued_at" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "receipts_jir_idx" ON "receipts" USING btree ("jir" text_ops);--> statement-breakpoint
+CREATE INDEX "receipts_receipt_number_idx" ON "receipts" USING btree ("receipt_number" text_ops);--> statement-breakpoint
+CREATE INDEX "receipts_zki_idx" ON "receipts" USING btree ("zki" text_ops);--> statement-breakpoint
+CREATE INDEX "cms_etc_is_deleted_idx" ON "entity_type_categories" USING btree ("is_deleted" bool_ops);--> statement-breakpoint
+CREATE INDEX "cms_etc_order_idx" ON "entity_type_categories" USING btree ("order" text_ops);

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -1,7 +1,13 @@
-import { drizzle as neonDrizzle, NeonDatabase } from 'drizzle-orm/neon-serverless';
-import { drizzle as nodeDrizzle, NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool } from '@neondatabase/serverless';
+import {
+    type NeonDatabase,
+    drizzle as neonDrizzle,
+} from 'drizzle-orm/neon-serverless';
 import { migrate as neonMigrate } from 'drizzle-orm/neon-serverless/migrator';
+import {
+    type NodePgDatabase,
+    drizzle as nodeDrizzle,
+} from 'drizzle-orm/node-postgres';
 import { migrate as nodeMigrate } from 'drizzle-orm/node-postgres/migrator';
 import * as schema from './schema';
 
@@ -11,18 +17,19 @@ const isTest = process.env.TEST_ENV === '1';
 function getDbConnectionString() {
     const connectionString = process.env.POSTGRES_URL;
     if (!connectionString) {
-        throw new Error("POSTGRES_URL environment variable is not set.");
+        throw new Error('POSTGRES_URL environment variable is not set.');
     }
     return connectionString;
 }
 
 let pool: Pool | null = null;
-let client: NodePgDatabase<typeof schema> | NeonDatabase<typeof schema> | null = null;
+let client: NodePgDatabase<typeof schema> | NeonDatabase<typeof schema> | null =
+    null;
 export function storage() {
     if (isTest) {
         if (!client) {
             console.debug('Instantiating NodePgDatabase for testing');
-            client = nodeDrizzle(getDbConnectionString(), { schema }) as any
+            client = nodeDrizzle(getDbConnectionString(), { schema }) as any;
         }
         return client as NodePgDatabase<typeof schema>;
     }
@@ -33,7 +40,7 @@ export function storage() {
     if (!client) {
         client = neonDrizzle({
             client: pool,
-            schema
+            schema,
         });
     }
     return client as NeonDatabase<typeof schema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,9 +617,6 @@ importers:
       openapi-types:
         specifier: 12.1.3
         version: 12.1.3
-      tsx:
-        specifier: 4.20.5
-        version: 4.20.5
       typescript:
         specifier: 5.9.2
         version: 5.9.2


### PR DESCRIPTION
- remove duplicate tsx entries from pnpm-lock.yaml to simplify lockfile
  and avoid stale version pins
- mark tunnel-rat optional dependency as optional in lockfile
- reformat apps/www/lib/flags/generated/hypertune.react.tsx:
  - normalize quote style and indentation to project conventions
  - align parameter and type formatting for readability
  - compress noop callbacks and context defaults into single-line forms
  - adjust JSX indentation and spacing for consistent style

These changes are purely cosmetic and dependency metadata
cleanup to improve maintainability and reduce noise in diffs.