### PR TITLE
feat(biljke): prefer shortDescription for sort meta description

### DIFF
--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -37,7 +37,10 @@ export async function generateMetadata(
     }
     return {
         title: sort.information.name,
-        description: sort.information.description,
+        description:
+            sort.information.shortDescription ??
+            sort.information.description ??
+            sort.information.plant.information?.description,
     };
 }
 


### PR DESCRIPTION
Update page metadata generation to select a more concise description
for sort pages. The code now uses sort.information.shortDescription
if present, falling back to sort.information.description and then to
the parent plant's description. This prevents overly long or less
targeted descriptions from being used in page metadata and improves
SEO and sharing previews.