### PR TITLE
feat(ui+apihooks): add field hook and localize plant status

### DIFF
--- a/packages/game/src/hooks/useRaisedBedFieldDiaryEntries.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldDiaryEntries.ts
@@ -1,0 +1,56 @@
+import { client } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+
+export const queryKeys = {
+    byId: (raisedBedId: number, positionIndex: number) => [
+        'raisedBeds',
+        raisedBedId,
+        'fields',
+        positionIndex,
+        'diary',
+    ],
+};
+
+export function useRaisedBedFieldDiaryEntries(
+    gardenId: number,
+    raisedBedId: number,
+    positionIndex: number,
+) {
+    return useQuery({
+        queryKey: queryKeys.byId(raisedBedId, positionIndex),
+        queryFn: async () => {
+            const entries = await client().api.gardens[':gardenId'][
+                'raised-beds'
+            ][':raisedBedId'].fields[':positionIndex']['diary-entries'].$get({
+                param: {
+                    gardenId: gardenId.toString(),
+                    raisedBedId: raisedBedId.toString(),
+                    positionIndex: positionIndex.toString(),
+                },
+            });
+            if (entries.status === 400) {
+                console.error(
+                    'Failed to fetch diary entries - bad request',
+                    entries,
+                );
+                return [];
+            }
+            if (entries.status === 404) {
+                console.error(
+                    'Raised bed not found or no diary entries available',
+                    entries,
+                );
+                return [];
+            }
+            return (await entries.json()).map((entry) => ({
+                ...entry,
+                timestamp: new Date(entry.timestamp),
+            }));
+        },
+        staleTime: 5 * 60 * 1000, // 5 minutes
+        enabled:
+            Boolean(gardenId) &&
+            Boolean(raisedBedId) &&
+            typeof positionIndex === 'number',
+    });
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -7,6 +7,121 @@ import { Spinner } from '@signalco/ui-primitives/Spinner';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
+import { useRaisedBedFieldDiaryEntries } from '../../hooks/useRaisedBedFieldDiaryEntries';
+
+function DiaryList({
+    error,
+    isLoading,
+    entries,
+}: {
+    error: Error | null;
+    isLoading: boolean;
+    entries:
+        | Array<{
+              id: number;
+              name: string;
+              description: string | undefined;
+              status: string | null;
+              timestamp: Date;
+          }>
+        | undefined;
+}) {
+    return (
+        <List>
+            {error && (
+                <Alert color="danger">
+                    <Typography level="body2">
+                        {
+                            'Došlo je do pogreške prilikom učitavanja dnevnika. Pokušaj ponovno.'
+                        }
+                    </Typography>
+                </Alert>
+            )}
+            {isLoading && (
+                <Spinner
+                    loading
+                    loadingLabel="Učitavanje dnevnika..."
+                    className="mx-auto my-8 flex items-center justify-center"
+                />
+            )}
+            {!isLoading && !entries?.length && (
+                <ListItem
+                    label={
+                        <Typography level="body2" className="px-2 py-4">
+                            Nema unosa u dnevniku.
+                        </Typography>
+                    }
+                />
+            )}
+            {entries?.map((entry) => (
+                <ListItem
+                    key={entry.id}
+                    label={
+                        <Row
+                            spacing={2}
+                            justifyContent="space-between"
+                            className="font-normal"
+                        >
+                            <Stack>
+                                <Typography level="body1" semiBold>
+                                    {entry.name}
+                                </Typography>
+                                <Typography level="body2">
+                                    {entry.description}
+                                </Typography>
+                            </Stack>
+                            <Stack>
+                                {entry.status && (
+                                    <Chip
+                                        color={
+                                            entry.status === 'Novo'
+                                                ? 'warning'
+                                                : entry.status === 'Završeno'
+                                                  ? 'success'
+                                                  : entry.status === 'Planirano'
+                                                    ? 'info'
+                                                    : entry.status ===
+                                                            'Neuspješno' ||
+                                                        entry.status ===
+                                                            'Otkazano'
+                                                      ? 'error'
+                                                      : 'neutral'
+                                        }
+                                        className="shrink-0 w-fit self-end"
+                                    >
+                                        {entry.status}
+                                    </Chip>
+                                )}
+                                <Typography level="body2" noWrap>
+                                    {entry.timestamp.toLocaleDateString(
+                                        'hr-HR',
+                                    )}
+                                </Typography>
+                            </Stack>
+                        </Row>
+                    }
+                />
+            ))}
+        </List>
+    );
+}
+
+export function RaisedBedFieldDiary({
+    gardenId,
+    raisedBedId,
+    positionIndex,
+}: {
+    gardenId: number;
+    raisedBedId: number;
+    positionIndex: number;
+}) {
+    const {
+        data: entries,
+        isLoading,
+        error,
+    } = useRaisedBedFieldDiaryEntries(gardenId, raisedBedId, positionIndex);
+    return <DiaryList error={error} isLoading={isLoading} entries={entries} />;
+}
 
 export function RaisedBedDiary({
     gardenId,
@@ -20,70 +135,5 @@ export function RaisedBedDiary({
         isLoading,
         error,
     } = useRaisedBedDiaryEntries(gardenId, raisedBedId);
-    return (
-        <List>
-            {error && (
-                <Alert color="danger">
-                    <Typography level="body2">
-                        Došlo je do pogreške prilikom učitavanja dnevnika
-                        gredice. Pokušaj ponovno.
-                    </Typography>
-                </Alert>
-            )}
-            {isLoading && (
-                <Spinner
-                    loading
-                    loadingLabel="Učitavanje dnevnika gredice..."
-                    className="w-full my-8 flex items-center justify-center"
-                />
-            )}
-            {!isLoading && !entries?.length && (
-                <ListItem
-                    label={
-                        <Typography level="body2">
-                            Nema unosa u dnevniku gredice.
-                        </Typography>
-                    }
-                />
-            )}
-            {entries?.map((entry) => (
-                <ListItem
-                    key={entry.id}
-                    label={
-                        <Row spacing={2} justifyContent="space-between">
-                            <Stack>
-                                <Typography level="body1">
-                                    {entry.name}
-                                </Typography>
-                                <Typography level="body2">
-                                    {entry.description}
-                                </Typography>
-                            </Stack>
-                            {entry.status && (
-                                <Stack>
-                                    <Chip
-                                        color={
-                                            entry.status === 'Završeno'
-                                                ? 'success'
-                                                : entry.status === 'Planirano'
-                                                  ? 'info'
-                                                  : 'neutral'
-                                        }
-                                        className="shrink-0"
-                                    >
-                                        {entry.status}
-                                    </Chip>
-                                    <Typography level="body2">
-                                        {entry.timestamp.toLocaleDateString(
-                                            'hr-HR',
-                                        )}
-                                    </Typography>
-                                </Stack>
-                            )}
-                        </Row>
-                    }
-                />
-            ))}
-        </List>
-    );
+    return <DiaryList error={error} isLoading={isLoading} entries={entries} />;
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,5 +1,6 @@
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
-import { Hammer, Sprout, Warning } from '@signalco/ui-icons';
+import { Book, Hammer, Sprout, Warning } from '@signalco/ui-icons';
+import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -13,6 +14,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Image from 'next/image';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
+import { RaisedBedFieldDiary } from './RaisedBedDiary';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import {
     RaisedBedFieldLifecycleTab,
@@ -150,6 +152,12 @@ export function RaisedBedFieldItemPlanted({
                                 <Typography>Biljka</Typography>
                             </Row>
                         </TabsTrigger>
+                        <TabsTrigger value="diary">
+                            <Row spacing={1}>
+                                <Book className="size-4 shrink-0" />
+                                <Typography>Dnevnik</Typography>
+                            </Row>
+                        </TabsTrigger>
                         <TabsTrigger value="operations">
                             <Row spacing={1}>
                                 <Hammer className="size-4 shrink-0" />
@@ -165,6 +173,19 @@ export function RaisedBedFieldItemPlanted({
                                 positionIndex={positionIndex}
                                 plantSortId={field.plantSortId}
                             />
+                        )}
+                    </TabsContent>
+                    <TabsContent value="diary">
+                        {garden && (
+                            <Card>
+                                <CardOverflow className="overflow-auto max-h-96">
+                                    <RaisedBedFieldDiary
+                                        gardenId={garden.id}
+                                        raisedBedId={raisedBed.id}
+                                        positionIndex={positionIndex}
+                                    />
+                                </CardOverflow>
+                            </Card>
                         )}
                     </TabsContent>
                     <TabsContent value="lifecycle">

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -1,3 +1,4 @@
+import { plantFieldStatusLabel } from '@gredice/js/plants';
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Chip } from '@signalco/ui-primitives/Chip';
@@ -218,45 +219,31 @@ export function RaisedBedFieldLifecycleTab({
         : null;
 
     let icon: ReactNode | null = null;
-    let localizedStatus = field.plantStatus;
-    switch (localizedStatus) {
+    const localizedStatus = plantFieldStatusLabel(field.plantStatus);
+    switch (field.plantStatus) {
         case 'new':
             icon = <span className="mr-0.5">{'🌟'}</span>;
-            localizedStatus = 'Čeka sijanje';
             break;
         case 'planned':
             icon = <span className="mr-0.5">{'⌛'}</span>;
-            localizedStatus = 'Planirana';
             break;
         case 'sowed':
             icon = <span className="mr-0.5">{'𓇢'}</span>;
-            localizedStatus = 'Posijana';
             break;
         case 'notSprouted':
             icon = <span className="mr-0.5">{'😢'}</span>;
-            localizedStatus = 'Nije proklijala';
             break;
         case 'sprouted':
             icon = <span className="mr-0.5">{'🌱'}</span>;
-            localizedStatus = 'Proklijala';
             break;
         case 'ready':
             icon = <span className="mr-0.5">{'🌿'}</span>;
-            localizedStatus = 'Spremna za berbu';
             break;
         case 'harvested':
             icon = <span className="mr-0.5">{'✅'}</span>;
-            localizedStatus = 'Ubrana';
             break;
         case 'died':
             icon = <span className="mr-0.5">{'😢'}</span>;
-            localizedStatus = 'Neuspjela';
-            break;
-        case 'uprooted':
-            localizedStatus = 'Uklonjena';
-            break;
-        default:
-            localizedStatus = 'Nepoznato';
             break;
     }
 
@@ -326,7 +313,7 @@ export function RaisedBedFieldLifecycleTab({
                             className="text-center"
                             semiBold
                         >
-                            {localizedStatus}
+                            {localizedStatus.shortLabel}
                         </Typography>
                     </Stack>
                 </SegmentedCircularProgress>

--- a/packages/js/src/plants/index.ts
+++ b/packages/js/src/plants/index.ts
@@ -1,1 +1,2 @@
 export * from './isPlantRecommended';
+export * from './plantFieldStatusLabel';

--- a/packages/js/src/plants/plantFieldStatusLabel.ts
+++ b/packages/js/src/plants/plantFieldStatusLabel.ts
@@ -1,0 +1,68 @@
+export function plantFieldStatusLabel(status: string | undefined) {
+    switch (status) {
+        case 'new':
+            return {
+                shortLabel: 'Čeka sijanje',
+                label: 'Biljka čeka na sijanje',
+                description:
+                    'Sijanje biljke će biti odrađeno u što kraćem roku.',
+            };
+        case 'planned':
+            return {
+                shortLabel: 'Planirana',
+                label: 'Biljka je planirana za sijanje',
+                description:
+                    'Termin sijanja je određen i biljka čeka svoj red.',
+            };
+        case 'sowed':
+            return {
+                shortLabel: 'Posijana',
+                label: 'Biljka je posijana',
+                description: 'Sjeme je posijano i čeka klijanje.',
+            };
+        case 'notSprouted':
+            return {
+                shortLabel: 'Nije proklijala',
+                label: 'Biljka nije proklijala',
+                description: 'Sjeme nije proklijalo u očekivanom vremenu.',
+            };
+        case 'sprouted':
+            return {
+                shortLabel: 'Proklijala',
+                label: 'Biljka je proklijala',
+                description:
+                    'Sjeme je uspješno proklijalo i biljka je krenula rasti.',
+            };
+        case 'ready':
+            return {
+                shortLabel: 'Spremna za berbu',
+                label: 'Biljka je spremna za berbu',
+                description:
+                    'Biljka i/ili plodovi su dozreli i mogu se ubirati.',
+            };
+        case 'harvested':
+            return {
+                shortLabel: 'Ubrana',
+                label: 'Biljka je ubrana',
+                description: 'Svi plodovi su ubrani i biljka se može ukloniti.',
+            };
+        case 'died':
+            return {
+                shortLabel: 'Neuspjela',
+                label: 'Biljka je neuspjela',
+                description: 'Iako je proklijala, biljka je neuspjela.',
+            };
+        case 'removed':
+            return {
+                shortLabel: 'Uklonjena',
+                label: 'Biljka je uklonjena',
+                description: 'Biljka je uklonjena iz polja.',
+            };
+        default:
+            return {
+                shortLabel: 'Nepoznato',
+                label: `Nepoznato stanje: ${status}`,
+                description: 'Stanje biljke nije definirano.',
+            };
+    }
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -22,6 +22,7 @@
         "@biomejs/biome": "2.2.2",
         "@neondatabase/serverless": "1.0.1",
         "@signalco/js": "0.1.0",
+        "@gredice/js": "workspace:*",
         "@upstash/redis": "1.35.3",
         "dotenv": "17.2.1",
         "drizzle-kit": "0.31.4",

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -1,36 +1,49 @@
-import { and, desc, eq } from "drizzle-orm";
-import { storage } from "../storage";
-import { InsertOperation, operations, SelectOperation } from "../schema";
-import { getEvents, knownEventTypes } from "./eventsRepo";
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import {
+    type InsertOperation,
+    operations,
+    type SelectOperation,
+} from '../schema';
+import { storage } from '../storage';
+import { getEvents, knownEventTypes } from './eventsRepo';
 
 async function fillOperationAggregares(operations: SelectOperation[]) {
-    const aggregateIds = operations.map(op => op.id.toString());
-    const aggregaresEvents = await getEvents([
-        knownEventTypes.operations.schedule,
-        knownEventTypes.operations.complete,
-        knownEventTypes.operations.fail,
-        knownEventTypes.operations.cancel,
-    ], aggregateIds, 0, 10000);
+    const aggregateIds = operations.map((op) => op.id.toString());
+    const aggregaresEvents = await getEvents(
+        [
+            knownEventTypes.operations.schedule,
+            knownEventTypes.operations.complete,
+            knownEventTypes.operations.fail,
+            knownEventTypes.operations.cancel,
+        ],
+        aggregateIds,
+        0,
+        10000,
+    );
 
-    return operations.map(op => {
-        const events = aggregaresEvents.filter(event => event.aggregateId === op.id.toString());
+    return operations.map((op) => {
+        const events = aggregaresEvents.filter(
+            (event) => event.aggregateId === op.id.toString(),
+        );
 
         let status = 'new';
-        let scheduledDate: Date | undefined = undefined;
-        let completedAt: Date | undefined = undefined;
-        let completedBy: string | undefined = undefined;
-        let error: string | undefined = undefined;
-        let errorCode: string | undefined = undefined;
-        let canceledBy: string | undefined = undefined;
-        let canceledAt: Date | undefined = undefined;
-        let cancelReason: string | undefined = undefined;
+        let scheduledDate: Date | undefined;
+        let completedAt: Date | undefined;
+        let completedBy: string | undefined;
+        let error: string | undefined;
+        let errorCode: string | undefined;
+        let canceledBy: string | undefined;
+        let canceledAt: Date | undefined;
+        let cancelReason: string | undefined;
 
         for (const event of events) {
             const data = event.data as Record<string, any> | undefined;
             if (event.type === knownEventTypes.operations.complete) {
                 status = 'completed';
                 completedBy = data?.completedBy;
-                completedAt = data?.completedAt ? new Date(data.completedAt) : undefined;
+                completedAt = data?.completedAt
+                    ? new Date(data.completedAt)
+                    : undefined;
             } else if (event.type === knownEventTypes.operations.fail) {
                 status = 'failed';
                 error = data?.error;
@@ -39,10 +52,14 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
                 status = 'canceled';
                 canceledBy = data?.canceledBy;
                 cancelReason = data?.reason;
-                canceledAt = event.createdAt ? new Date(event.createdAt) : undefined;
+                canceledAt = event.createdAt
+                    ? new Date(event.createdAt)
+                    : undefined;
             } else if (event.type === knownEventTypes.operations.schedule) {
                 status = 'planned';
-                scheduledDate = data?.scheduledDate ? new Date(data.scheduledDate) : undefined;
+                scheduledDate = data?.scheduledDate
+                    ? new Date(data.scheduledDate)
+                    : undefined;
             }
         }
 
@@ -56,21 +73,28 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
             scheduledDate,
             canceledBy,
             canceledAt,
-            cancelReason
+            cancelReason,
         };
     });
 }
 
-export async function getOperations(accountId: string, gardenId?: number, raisedBedId?: number, raisedBedFieldId?: number) {
+export async function getOperations(
+    accountId: string,
+    gardenId?: number,
+    raisedBedId?: number,
+    raisedBedFieldIds?: number[],
+) {
     const query = await storage().query.operations.findMany({
         where: and(
             eq(operations.accountId, accountId),
             eq(operations.isDeleted, false),
             gardenId ? eq(operations.gardenId, gardenId) : undefined,
             raisedBedId ? eq(operations.raisedBedId, raisedBedId) : undefined,
-            raisedBedFieldId ? eq(operations.raisedBedFieldId, raisedBedFieldId) : undefined
+            raisedBedFieldIds && raisedBedFieldIds.length > 0
+                ? inArray(operations.raisedBedFieldId, raisedBedFieldIds)
+                : undefined,
         ),
-        orderBy: desc(operations.timestamp)
+        orderBy: desc(operations.timestamp),
     });
 
     return await fillOperationAggregares(query);
@@ -79,17 +103,14 @@ export async function getOperations(accountId: string, gardenId?: number, raised
 export async function getAllOperations() {
     const operationsList = await storage().query.operations.findMany({
         where: eq(operations.isDeleted, false),
-        orderBy: desc(operations.timestamp)
+        orderBy: desc(operations.timestamp),
     });
     return await fillOperationAggregares(operationsList);
 }
 
 export async function getOperationById(id: number) {
     const operation = await storage().query.operations.findFirst({
-        where: and(
-            eq(operations.id, id),
-            eq(operations.isDeleted, false)
-        )
+        where: and(eq(operations.id, id), eq(operations.isDeleted, false)),
     });
     if (!operation) {
         throw new Error(`Operation with id ${id} not found`);
@@ -97,19 +118,33 @@ export async function getOperationById(id: number) {
     return (await fillOperationAggregares([operation]))[0];
 }
 
-export async function createOperation({ entityId, entityTypeName, accountId, gardenId, raisedBedId, raisedBedFieldId, timestamp }: InsertOperation) {
-    const [result] = await storage().insert(operations).values({
-        entityId,
-        entityTypeName,
-        accountId,
-        gardenId,
-        raisedBedId,
-        raisedBedFieldId,
-        timestamp: timestamp ?? new Date(),
-    }).returning({ id: operations.id });
+export async function createOperation({
+    entityId,
+    entityTypeName,
+    accountId,
+    gardenId,
+    raisedBedId,
+    raisedBedFieldId,
+    timestamp,
+}: InsertOperation) {
+    const [result] = await storage()
+        .insert(operations)
+        .values({
+            entityId,
+            entityTypeName,
+            accountId,
+            gardenId,
+            raisedBedId,
+            raisedBedFieldId,
+            timestamp: timestamp ?? new Date(),
+        })
+        .returning({ id: operations.id });
     return result.id;
 }
 
 export async function deleteOperation(id: number) {
-    await storage().update(operations).set({ isDeleted: true }).where(eq(operations.id, id));
+    await storage()
+        .update(operations)
+        .set({ isDeleted: true })
+        .where(eq(operations.id, id));
 }

--- a/packages/storage/src/repositories/usersRepo.ts
+++ b/packages/storage/src/repositories/usersRepo.ts
@@ -1,21 +1,30 @@
 import 'server-only';
-import { and, desc, eq, sql } from "drizzle-orm";
-import { createAccount, getFarms, storage } from "..";
-import { accountUsers, UpdateUserInfo, userLogins, users } from "../schema";
-import { createGarden } from "./gardensRepo";
-import { randomUUID, randomBytes as cryptoRandomBytes, pbkdf2Sync } from 'node:crypto';
+import {
+    randomBytes as cryptoRandomBytes,
+    pbkdf2Sync,
+    randomUUID,
+} from 'node:crypto';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import { createAccount, getFarms, storage } from '..';
+import {
+    accountUsers,
+    type UpdateUserInfo,
+    userLogins,
+    users,
+} from '../schema';
 import { createEvent, knownEvents } from './eventsRepo';
+import { createGarden } from './gardensRepo';
 
 export interface OAuthUserData {
-    name: string
-    email: string
-    providerUserId: string
-    provider: "google" | "facebook"
+    name: string;
+    email: string;
+    providerUserId: string;
+    provider: 'google' | 'facebook';
 }
 
 export function getUsers() {
     return storage().query.users.findMany({
-        orderBy: desc(users.createdAt)
+        orderBy: desc(users.createdAt),
     });
 }
 
@@ -25,10 +34,10 @@ export function getUser(userId: string) {
         with: {
             accounts: {
                 with: {
-                    account: true
-                }
-            }
-        }
+                    account: true,
+                },
+            },
+        },
     });
 }
 
@@ -36,7 +45,7 @@ export function updateUser(user: { id: string } & Partial<UpdateUserInfo>) {
     return storage()
         .update(users)
         .set({
-            ...user
+            ...user,
         })
         .where(eq(users.id, user.id));
 }
@@ -45,15 +54,18 @@ export function getUserWithLogins(userName: string) {
     return storage().query.users.findFirst({
         where: eq(users.userName, userName),
         with: {
-            usersLogins: true
-        }
+            usersLogins: true,
+        },
     });
 }
 
 export function loginSuccessful(userLoginId: number) {
-    return storage().update(userLogins).set({
-        lastLogin: new Date()
-    }).where(eq(userLogins.id, userLoginId));
+    return storage()
+        .update(userLogins)
+        .set({
+            lastLogin: new Date(),
+        })
+        .where(eq(userLogins.id, userLoginId));
 }
 
 async function createUser(userName: string, displayName?: string) {
@@ -64,7 +76,7 @@ async function createUser(userName: string, displayName?: string) {
             id: randomUUID(),
             userName,
             displayName,
-            role: 'user'
+            role: 'user',
         })
         .returning({ id: users.id });
     const userId = createdUsers[0].id;
@@ -76,9 +88,11 @@ async function createUser(userName: string, displayName?: string) {
 }
 
 async function ensureUserNameIsUnique(userName: string) {
-    const userNameExists = Boolean(await storage().query.users.findFirst({
-        where: eq(users.userName, userName)
-    }));
+    const userNameExists = Boolean(
+        await storage().query.users.findFirst({
+            where: eq(users.userName, userName),
+        }),
+    );
     if (userNameExists) {
         throw new Error('User with provided user name already exists');
     }
@@ -99,13 +113,18 @@ async function createDefaultGarden(accountId: string) {
     const gardenId = await createGarden({
         farmId: farm.id,
         accountId,
-        name: 'Moj vrt'
+        name: 'Moj vrt',
     });
 
     // Assign 4x3 grid of grass blocks and two raised beds at center
     // Grid: x = 0..3, y = 0..2
     // Center positions for raised beds: (1,1) and (2,1)
-    const { createGardenBlock, createGardenStack, updateGardenStack, createRaisedBed } = await import('./gardensRepo');
+    const {
+        createGardenBlock,
+        createGardenStack,
+        updateGardenStack,
+        createRaisedBed,
+    } = await import('./gardensRepo');
     const grassBlockIds: string[][] = [];
     for (let x = -1; x < 3; x++) {
         grassBlockIds[x] = [];
@@ -118,13 +137,16 @@ async function createDefaultGarden(accountId: string) {
             await createGardenStack(gardenId, { x, y });
 
             const blockIds = [blockId];
-            if (x === 0 && y === 0 || x === 1 && y === 0) {
-                const raisedBedBlockId = await createGardenBlock(gardenId, 'Raised_Bed');
+            if ((x === 0 && y === 0) || (x === 1 && y === 0)) {
+                const raisedBedBlockId = await createGardenBlock(
+                    gardenId,
+                    'Raised_Bed',
+                );
                 await createRaisedBed({
                     accountId,
                     gardenId,
                     blockId: raisedBedBlockId,
-                    status: 'new'
+                    status: 'new',
                 });
                 blockIds.push(raisedBedBlockId);
             }
@@ -143,9 +165,11 @@ async function createUserAndAccount(userName: string, displayName?: string) {
     // Link user to account
     await storage().insert(accountUsers).values({
         accountId,
-        userId
+        userId,
     });
-    await createEvent(knownEvents.accounts.assignedUserV1(accountId, { userId }));
+    await createEvent(
+        knownEvents.accounts.assignedUserV1(accountId, { userId }),
+    );
 
     return userId;
 }
@@ -154,18 +178,28 @@ function passwordHash(password: string) {
     const salt = cryptoRandomBytes(128).toString('base64');
     return {
         salt,
-        hash: pbkdf2Sync(password, salt, 10000, 512, 'sha512').toString('hex')
-    }
+        hash: pbkdf2Sync(password, salt, 10000, 512, 'sha512').toString('hex'),
+    };
 }
 
-export async function createUserPasswordLogin(userId: string, userName: string, password: string) {
+export async function createUserPasswordLogin(
+    userId: string,
+    userName: string,
+    password: string,
+) {
     const { salt, hash } = passwordHash(password);
-    await storage().insert(userLogins).values({
-        userId,
-        loginType: 'password',
-        loginId: userName,
-        loginData: JSON.stringify({ salt, password: hash, isVerified: false }),
-    });
+    await storage()
+        .insert(userLogins)
+        .values({
+            userId,
+            loginType: 'password',
+            loginId: userName,
+            loginData: JSON.stringify({
+                salt,
+                password: hash,
+                isVerified: false,
+            }),
+        });
 }
 
 /**
@@ -174,96 +208,126 @@ export async function createUserPasswordLogin(userId: string, userName: string, 
  * @param password The password
  * @returns The user id
  */
-export async function createUserWithPassword(userName: string, password: string) {
+export async function createUserWithPassword(
+    userName: string,
+    password: string,
+) {
     const userId = await createUserAndAccount(userName);
     await createUserPasswordLogin(userId, userName, password);
     return userId;
 }
 
-export async function createOrUpdateUserWithOauth(data: OAuthUserData, loggedInUserId?: string) {
+export async function createOrUpdateUserWithOauth(
+    data: OAuthUserData,
+    loggedInUserId?: string,
+) {
     // Fast return if user has login provider with given loginId
     const existingLogin = await storage().query.userLogins.findFirst({
         where: and(
             eq(userLogins.loginType, data.provider),
-            eq(userLogins.loginId, data.providerUserId)),
+            eq(userLogins.loginId, data.providerUserId),
+        ),
         with: {
-            user: true
+            user: true,
         },
     });
     if (existingLogin) {
         return {
             userId: existingLogin.userId,
-            loginId: existingLogin.id
-        }
+            loginId: existingLogin.id,
+        };
     }
 
     // If user with given email doesn't exist, create a new user
     let existingUser = await storage().query.users.findFirst({
         where: eq(users.userName, data.email),
         with: {
-            usersLogins: true
-        }
+            usersLogins: true,
+        },
     });
     if (!existingUser) {
         const createdUserId = await createUserAndAccount(data.email, data.name);
         existingUser = await storage().query.users.findFirst({
             where: eq(users.id, createdUserId),
             with: {
-                usersLogins: true
-            }
+                usersLogins: true,
+            },
         });
     }
 
-    if (!existingUser || // If we failed to create the user by email or retreive existing one
+    if (
+        !existingUser || // If we failed to create the user by email or retreive existing one
         (loggedInUserId && loggedInUserId !== existingUser.id) || // If current user does not match the user
-        (loggedInUserId && existingUser.usersLogins.length !== 0)) { // If current user is logged in and it does not match the user or user already has logins
-        throw new Error("Provider not assigned to the user.");
+        (loggedInUserId && existingUser.usersLogins.length !== 0)
+    ) {
+        // If current user is logged in and it does not match the user or user already has logins
+        throw new Error('Provider not assigned to the user.');
     }
 
-    const loginId = (await storage()
-        .insert(userLogins)
-        .values({
-            userId: existingUser.id,
-            loginType: data.provider,
-            loginId: data.providerUserId,
-            loginData: JSON.stringify({ isVerified: true }),
-        })
-        .returning({ id: userLogins.id }))[0].id;
+    const loginId = (
+        await storage()
+            .insert(userLogins)
+            .values({
+                userId: existingUser.id,
+                loginType: data.provider,
+                loginId: data.providerUserId,
+                loginData: JSON.stringify({ isVerified: true }),
+            })
+            .returning({ id: userLogins.id })
+    )[0].id;
     return {
         userId: existingUser.id,
-        loginId
+        loginId,
     };
 }
 
 export async function updateUserRole(userId: string, newRole: string) {
-    await storage().update(users).set({ role: newRole }).where(eq(users.id, userId));
+    await storage()
+        .update(users)
+        .set({ role: newRole })
+        .where(eq(users.id, userId));
 }
 
 export async function incLoginFailedAttempts(loginId: number) {
-    await storage().update(userLogins).set({
-        failedAttempts: sql`${userLogins.failedAttempts} + 1`,
-        lastFailedAttempt: new Date()
-    }).where(eq(userLogins.id, loginId));
+    await storage()
+        .update(userLogins)
+        .set({
+            failedAttempts: sql`${userLogins.failedAttempts} + 1`,
+            lastFailedAttempt: new Date(),
+        })
+        .where(eq(userLogins.id, loginId));
 }
 
 export async function blockLogin(loginId: number, blockedUntil: Date) {
-    await storage().update(userLogins).set({
-        blockedUntil
-    }).where(eq(userLogins.id, loginId));
+    await storage()
+        .update(userLogins)
+        .set({
+            blockedUntil,
+        })
+        .where(eq(userLogins.id, loginId));
 }
 
 export async function clearLoginFailedAttempts(loginId: number) {
-    await storage().update(userLogins).set({
-        failedAttempts: 0,
-        lastFailedAttempt: null,
-        blockedUntil: null
-    }).where(eq(userLogins.id, loginId));
+    await storage()
+        .update(userLogins)
+        .set({
+            failedAttempts: 0,
+            lastFailedAttempt: null,
+            blockedUntil: null,
+        })
+        .where(eq(userLogins.id, loginId));
 }
 
-export async function updateLoginData(loginId: number, data: Record<string, any>) {
-    await storage().update(userLogins).set({
-        loginData: JSON.stringify(data)
-    }).where(eq(userLogins.id, loginId));
+export async function updateLoginData(
+    loginId: number,
+    data: Record<string, any>,
+) {
+    await storage()
+        .update(userLogins)
+        .set({
+            loginData: JSON.stringify(data),
+        })
+        .where(eq(userLogins.id, loginId));
 }
 
 export async function changePassword(loginId: number, newPassword: string) {

--- a/packages/storage/src/repositories/usersRepo.ts
+++ b/packages/storage/src/repositories/usersRepo.ts
@@ -320,7 +320,7 @@ export async function clearLoginFailedAttempts(loginId: number) {
 
 export async function updateLoginData(
     loginId: number,
-    data: Record<string, any>,
+    data: Record<string, unknown>,
 ) {
     await storage()
         .update(userLogins)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,6 +910,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.2
         version: 2.2.2
+      '@gredice/js':
+        specifier: workspace:*
+        version: link:../js
       '@neondatabase/serverless':
         specifier: 1.0.1
         version: 1.0.1


### PR DESCRIPTION
Add a new hook useRaisedBedFieldDiaryEntries to fetch and cache
diary entries for a specific raised bed field. The hook uses the
generated client, react-query, and normalizes entry timestamps to
Date objects. It includes basic error handling and a 5-minute stale
time.

Expose plantFieldStatusLabel from the shared js package and replace
manual, hard-coded localized status strings in RaisedBedFieldLifecycleTab
with the label function. Also show the shortLabel returned by the
helper in the UI and keep existing icons per status. This centralizes
localization and avoids duplicate translations.

Update API routes import order to include getRaisedBedFieldDiaryEntries
and fix authContext usage ordering in gardensRoutes handler.

Closes #857 and #858