### PR TITLE
feat(js): package type to module ESM support

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -2,6 +2,7 @@
     "name": "@gredice/js",
     "version": "1.0.0",
     "private": true,
+    "type": "module",
     "exports": {
         "./*": "./src/*/index.ts"
     },


### PR DESCRIPTION
Add "type": "module" to packages/js/package.json to ensure Node
treats .js files as ECMAScript modules. This aligns package behavior
with the/ESM build output and prevents CommonJS interpretation
mismatches when importing compiled files.