### PR TITLE
test(storage): close DB connections after tests

### DIFF
--- a/apps/farm/test-results/.last-run.json
+++ b/apps/farm/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/packages/storage/tests/testDb.ts
+++ b/packages/storage/tests/testDb.ts
@@ -1,9 +1,8 @@
-// This file sets up an in-memory SQLite database for testing Drizzle ORM repositories.
-// It is used to mock the database for integration tests without mocking repositories themselves.
-
+// Initialize a shared Node Postgres Drizzle client for tests using the storage() factory.
 import 'dotenv/config';
-import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
-import * as schema from '../src/schema';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type * as schema from '../src/schema';
+import { storage } from '../src/storage';
 
 let db: NodePgDatabase<typeof schema> | undefined;
 
@@ -13,7 +12,8 @@ export function createTestDb() {
         if (!dbUrl) {
             throw new Error('POSTGRES_URL environment variable is not set');
         }
-        db = drizzle<typeof schema>(dbUrl, { schema });
+        // storage() uses TEST_ENV to create a NodePgDatabase backed by a pg Pool
+        db = storage() as NodePgDatabase<typeof schema>;
     }
     return db;
 }

--- a/packages/storage/tests/testSetup.ts
+++ b/packages/storage/tests/testSetup.ts
@@ -1,0 +1,7 @@
+import { after } from 'node:test';
+import { closeStorage } from '../src/storage';
+
+// Ensure DB connections are closed before the test process exits
+after(async () => {
+    await closeStorage();
+});


### PR DESCRIPTION
Ensure storage connections are closed when the Node test process
exits by registering an after hook in tests/testSetup.ts that calls
closeStorage(). This prevents dangling DB connections and resource
leaks that can cause the test runner or CI to hang.