### PR TITLE
refactor(flags,api): rename types and normalize strings

### DIFF
--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    '/entities/plant': {
+    "/entities/plant": {
         parameters: {
             query?: never;
             header?: never;
@@ -30,7 +30,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plant'][];
+                        "application/json": components["schemas"]["entity-plant"][];
                     };
                 };
             };
@@ -43,7 +43,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantSort': {
+    "/entities/plantSort": {
         parameters: {
             query?: never;
             header?: never;
@@ -69,7 +69,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantSort'][];
+                        "application/json": components["schemas"]["entity-plantSort"][];
                     };
                 };
             };
@@ -82,7 +82,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantStage': {
+    "/entities/plantStage": {
         parameters: {
             query?: never;
             header?: never;
@@ -108,7 +108,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantStage'][];
+                        "application/json": components["schemas"]["entity-plantStage"][];
                     };
                 };
             };
@@ -121,7 +121,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/seed': {
+    "/entities/seed": {
         parameters: {
             query?: never;
             header?: never;
@@ -147,7 +147,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-seed'][];
+                        "application/json": components["schemas"]["entity-seed"][];
                     };
                 };
             };
@@ -160,7 +160,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/brand': {
+    "/entities/brand": {
         parameters: {
             query?: never;
             header?: never;
@@ -186,7 +186,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-brand'][];
+                        "application/json": components["schemas"]["entity-brand"][];
                     };
                 };
             };
@@ -199,7 +199,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operation': {
+    "/entities/operation": {
         parameters: {
             query?: never;
             header?: never;
@@ -225,7 +225,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operation'][];
+                        "application/json": components["schemas"]["entity-operation"][];
                     };
                 };
             };
@@ -238,7 +238,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operationFrequency': {
+    "/entities/operationFrequency": {
         parameters: {
             query?: never;
             header?: never;
@@ -264,7 +264,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operationFrequency'][];
+                        "application/json": components["schemas"]["entity-operationFrequency"][];
                     };
                 };
             };
@@ -277,7 +277,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq': {
+    "/entities/faq": {
         parameters: {
             query?: never;
             header?: never;
@@ -303,7 +303,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq'][];
+                        "application/json": components["schemas"]["entity-faq"][];
                     };
                 };
             };
@@ -316,7 +316,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq-category': {
+    "/entities/faq-category": {
         parameters: {
             query?: never;
             header?: never;
@@ -342,7 +342,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq-category'][];
+                        "application/json": components["schemas"]["entity-faq-category"][];
                     };
                 };
             };
@@ -355,7 +355,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/block': {
+    "/entities/block": {
         parameters: {
             query?: never;
             header?: never;
@@ -381,7 +381,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-block'][];
+                        "application/json": components["schemas"]["entity-block"][];
                     };
                 };
             };
@@ -402,7 +402,7 @@ export interface components {
             /** Format: uri */
             url: string;
         };
-        'entity-plant': {
+        "entity-plant": {
             id: number;
             entityType: {
                 /** @default 1 */
@@ -452,7 +452,7 @@ export interface components {
                         deliverable: boolean;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     information?: {
                         /** @description (prevedeni naziv operacije) */
@@ -473,6 +473,12 @@ export interface components {
                         discounted?: number;
                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                         discountDescription?: string;
+                    };
+                    conditions?: {
+                        /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                        completionAttachImagesRequired: boolean;
+                        /** @description (da li se mogu proložiti slike za završetak radnje) */
+                        completionAttachImages: boolean;
                     };
                 }[];
                 flowering?: string;
@@ -535,7 +541,7 @@ export interface components {
                 perPlant: number;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -545,7 +551,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantSort': {
+        "entity-plantSort": {
             id: number;
             entityType: {
                 /** @default 11 */
@@ -556,7 +562,6 @@ export interface components {
                 label: string;
             };
             information: {
-                harvest?: string;
                 planting?: string;
                 flowering?: string;
                 plant: {
@@ -601,7 +606,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -622,6 +627,12 @@ export interface components {
                                 discounted?: number;
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
+                            };
+                            conditions?: {
+                                /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                                completionAttachImagesRequired: boolean;
+                                /** @description (da li se mogu proložiti slike za završetak radnje) */
+                                completionAttachImages: boolean;
                             };
                         }[];
                         flowering?: string;
@@ -684,7 +695,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -692,7 +703,6 @@ export interface components {
                 };
                 name: string;
                 description?: string;
-                shortDescription: string;
                 latinName?: string;
                 sowing?: string;
                 origin?: string;
@@ -701,9 +711,11 @@ export interface components {
                 growth?: string;
                 storage?: string;
                 maintenance?: string;
+                harvest?: string;
+                shortDescription: string;
             };
             image: {
-                cover?: components['schemas']['image'];
+                cover?: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -713,7 +725,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantStage': {
+        "entity-plantStage": {
             id: number;
             entityType: {
                 /** @default 12 */
@@ -732,7 +744,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-seed': {
+        "entity-seed": {
             id: number;
             entityType: {
                 /** @default 15 */
@@ -794,7 +806,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -815,6 +827,12 @@ export interface components {
                                 discounted?: number;
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
+                            };
+                            conditions?: {
+                                /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                                completionAttachImagesRequired: boolean;
+                                /** @description (da li se mogu proložiti slike za završetak radnje) */
+                                completionAttachImages: boolean;
                             };
                         }[];
                         flowering?: string;
@@ -877,7 +895,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -886,7 +904,6 @@ export interface components {
                 plantSort: {
                     id?: number;
                     information?: {
-                        harvest?: string;
                         planting?: string;
                         flowering?: string;
                         plant: {
@@ -931,7 +948,7 @@ export interface components {
                                         deliverable: boolean;
                                     };
                                     image?: {
-                                        cover: components['schemas']['image'];
+                                        cover: components["schemas"]["image"];
                                     };
                                     information?: {
                                         /** @description (prevedeni naziv operacije) */
@@ -952,6 +969,12 @@ export interface components {
                                         discounted?: number;
                                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                         discountDescription?: string;
+                                    };
+                                    conditions?: {
+                                        /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                                        completionAttachImagesRequired: boolean;
+                                        /** @description (da li se mogu proložiti slike za završetak radnje) */
+                                        completionAttachImages: boolean;
                                     };
                                 }[];
                                 flowering?: string;
@@ -1014,7 +1037,7 @@ export interface components {
                                 perPlant: number;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             store?: {
                                 availableInStore: boolean;
@@ -1022,7 +1045,6 @@ export interface components {
                         };
                         name: string;
                         description?: string;
-                        shortDescription: string;
                         latinName?: string;
                         sowing?: string;
                         origin?: string;
@@ -1031,9 +1053,11 @@ export interface components {
                         growth?: string;
                         storage?: string;
                         maintenance?: string;
+                        harvest?: string;
+                        shortDescription: string;
                     };
                     image?: {
-                        cover?: components['schemas']['image'];
+                        cover?: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -1056,7 +1080,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-brand': {
+        "entity-brand": {
             id: number;
             entityType: {
                 /** @default 16 */
@@ -1075,7 +1099,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operation': {
+        "entity-operation": {
             id: number;
             entityType: {
                 /** @default 10 */
@@ -1104,7 +1128,7 @@ export interface components {
                 deliverable: boolean;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             information: {
                 /** @description (prevedeni naziv operacije) */
@@ -1126,12 +1150,18 @@ export interface components {
                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                 discountDescription?: string;
             };
+            conditions: {
+                /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                completionAttachImagesRequired: boolean;
+                /** @description (da li se mogu proložiti slike za završetak radnje) */
+                completionAttachImages: boolean;
+            };
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operationFrequency': {
+        "entity-operationFrequency": {
             id: number;
             entityType: {
                 /** @default 13 */
@@ -1146,7 +1176,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq': {
+        "entity-faq": {
             id: number;
             entityType: {
                 /** @default 2 */
@@ -1176,7 +1206,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq-category': {
+        "entity-faq-category": {
             id: number;
             entityType: {
                 /** @default 14 */
@@ -1195,7 +1225,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-block': {
+        "entity-block": {
             id: number;
             entityType: {
                 /** @default 8 */

--- a/apps/app/lib/flags/generated/hypertune.react.tsx
+++ b/apps/app/lib/flags/generated/hypertune.react.tsx
@@ -196,7 +196,7 @@ export function HypertuneHydrator({
 export function HypertuneClientLogger({
   flagPaths,
 }: {
-  flagPaths: hypertune.FlagPaths[];
+  flagPaths: hypertune.FlagPath[];
 }): null {
   const hypertuneRoot = useHypertune();
   const isReady = hypertuneRoot.isReady();

--- a/apps/app/lib/flags/generated/hypertune.ts
+++ b/apps/app/lib/flags/generated/hypertune.ts
@@ -19,17 +19,17 @@ export type FlagValues = {
   "test": boolean;
 }
 
-export type FlagPaths = keyof FlagValues & string;
+export type FlagPath = keyof FlagValues & string;
 
 export const flagFallbacks: FlagValues = {
   "test": false,
 }
 
-export function decodeFlagValues<TFlagPaths extends keyof FlagValues & string>(
-  encodedValues: string,
-  flagPaths: TFlagPaths[]
-): Pick<FlagValues, TFlagPaths> {
-  return sdk.decodeFlagValues({ flagPaths, encodedValues })
+export function decodeFlagValues<TFlagPath extends keyof FlagValues & string>(
+  encodedFlagValues: string,
+  flagPaths: TFlagPath[]
+): Pick<FlagValues, TFlagPath> {
+  return sdk.decodeFlagValues({ encodedValues: encodedFlagValues, flagPaths })
 }
 
 export type VariableValues = {};

--- a/apps/farm/lib/flags/generated/hypertune.react.tsx
+++ b/apps/farm/lib/flags/generated/hypertune.react.tsx
@@ -196,7 +196,7 @@ export function HypertuneHydrator({
 export function HypertuneClientLogger({
   flagPaths,
 }: {
-  flagPaths: hypertune.FlagPaths[];
+  flagPaths: hypertune.FlagPath[];
 }): null {
   const hypertuneRoot = useHypertune();
   const isReady = hypertuneRoot.isReady();

--- a/apps/farm/lib/flags/generated/hypertune.ts
+++ b/apps/farm/lib/flags/generated/hypertune.ts
@@ -19,17 +19,17 @@ export type FlagValues = {
   "showUI": boolean;
 }
 
-export type FlagPaths = keyof FlagValues & string;
+export type FlagPath = keyof FlagValues & string;
 
 export const flagFallbacks: FlagValues = {
   "showUI": false,
 }
 
-export function decodeFlagValues<TFlagPaths extends keyof FlagValues & string>(
-  encodedValues: string,
-  flagPaths: TFlagPaths[]
-): Pick<FlagValues, TFlagPaths> {
-  return sdk.decodeFlagValues({ flagPaths, encodedValues })
+export function decodeFlagValues<TFlagPath extends keyof FlagValues & string>(
+  encodedFlagValues: string,
+  flagPaths: TFlagPath[]
+): Pick<FlagValues, TFlagPath> {
+  return sdk.decodeFlagValues({ encodedValues: encodedFlagValues, flagPaths })
 }
 
 export type VariableValues = {};

--- a/apps/garden/lib/flags/generated/hypertune.react.tsx
+++ b/apps/garden/lib/flags/generated/hypertune.react.tsx
@@ -196,7 +196,7 @@ export function HypertuneHydrator({
 export function HypertuneClientLogger({
   flagPaths,
 }: {
-  flagPaths: hypertune.FlagPaths[];
+  flagPaths: hypertune.FlagPath[];
 }): null {
   const hypertuneRoot = useHypertune();
   const isReady = hypertuneRoot.isReady();

--- a/apps/garden/lib/flags/generated/hypertune.ts
+++ b/apps/garden/lib/flags/generated/hypertune.ts
@@ -33,7 +33,7 @@ export type FlagValues = {
   "enableDebugHud": boolean;
 }
 
-export type FlagPaths = keyof FlagValues & string;
+export type FlagPath = keyof FlagValues & string;
 
 export const flagFallbacks: FlagValues = {
   "raisedBedFieldWatering": false,
@@ -46,11 +46,11 @@ export const flagFallbacks: FlagValues = {
   "enableDebugHud": false,
 }
 
-export function decodeFlagValues<TFlagPaths extends keyof FlagValues & string>(
-  encodedValues: string,
-  flagPaths: TFlagPaths[]
-): Pick<FlagValues, TFlagPaths> {
-  return sdk.decodeFlagValues({ flagPaths, encodedValues })
+export function decodeFlagValues<TFlagPath extends keyof FlagValues & string>(
+  encodedFlagValues: string,
+  flagPaths: TFlagPath[]
+): Pick<FlagValues, TFlagPath> {
+  return sdk.decodeFlagValues({ encodedValues: encodedFlagValues, flagPaths })
 }
 
 export type VariableValues = {};

--- a/apps/www/lib/flags/generated/hypertune.react.tsx
+++ b/apps/www/lib/flags/generated/hypertune.react.tsx
@@ -196,7 +196,7 @@ export function HypertuneHydrator({
 export function HypertuneClientLogger({
   flagPaths,
 }: {
-  flagPaths: hypertune.FlagPaths[];
+  flagPaths: hypertune.FlagPath[];
 }): null {
   const hypertuneRoot = useHypertune();
   const isReady = hypertuneRoot.isReady();

--- a/apps/www/lib/flags/generated/hypertune.ts
+++ b/apps/www/lib/flags/generated/hypertune.ts
@@ -19,17 +19,17 @@ export type FlagValues = {
   "preSeason": boolean;
 }
 
-export type FlagPaths = keyof FlagValues & string;
+export type FlagPath = keyof FlagValues & string;
 
 export const flagFallbacks: FlagValues = {
   "preSeason": false,
 }
 
-export function decodeFlagValues<TFlagPaths extends keyof FlagValues & string>(
-  encodedValues: string,
-  flagPaths: TFlagPaths[]
-): Pick<FlagValues, TFlagPaths> {
-  return sdk.decodeFlagValues({ flagPaths, encodedValues })
+export function decodeFlagValues<TFlagPath extends keyof FlagValues & string>(
+  encodedFlagValues: string,
+  flagPaths: TFlagPath[]
+): Pick<FlagValues, TFlagPath> {
+  return sdk.decodeFlagValues({ encodedValues: encodedFlagValues, flagPaths })
 }
 
 export type VariableValues = {};

--- a/packages/client/src/lib/directories-api/v1.d.ts
+++ b/packages/client/src/lib/directories-api/v1.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    '/entities/plant': {
+    "/entities/plant": {
         parameters: {
             query?: never;
             header?: never;
@@ -30,7 +30,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plant'][];
+                        "application/json": components["schemas"]["entity-plant"][];
                     };
                 };
             };
@@ -43,7 +43,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantSort': {
+    "/entities/plantSort": {
         parameters: {
             query?: never;
             header?: never;
@@ -69,7 +69,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantSort'][];
+                        "application/json": components["schemas"]["entity-plantSort"][];
                     };
                 };
             };
@@ -82,7 +82,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/plantStage': {
+    "/entities/plantStage": {
         parameters: {
             query?: never;
             header?: never;
@@ -108,7 +108,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-plantStage'][];
+                        "application/json": components["schemas"]["entity-plantStage"][];
                     };
                 };
             };
@@ -121,7 +121,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/seed': {
+    "/entities/seed": {
         parameters: {
             query?: never;
             header?: never;
@@ -147,7 +147,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-seed'][];
+                        "application/json": components["schemas"]["entity-seed"][];
                     };
                 };
             };
@@ -160,7 +160,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/brand': {
+    "/entities/brand": {
         parameters: {
             query?: never;
             header?: never;
@@ -186,7 +186,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-brand'][];
+                        "application/json": components["schemas"]["entity-brand"][];
                     };
                 };
             };
@@ -199,7 +199,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operation': {
+    "/entities/operation": {
         parameters: {
             query?: never;
             header?: never;
@@ -225,7 +225,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operation'][];
+                        "application/json": components["schemas"]["entity-operation"][];
                     };
                 };
             };
@@ -238,7 +238,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/operationFrequency': {
+    "/entities/operationFrequency": {
         parameters: {
             query?: never;
             header?: never;
@@ -264,7 +264,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-operationFrequency'][];
+                        "application/json": components["schemas"]["entity-operationFrequency"][];
                     };
                 };
             };
@@ -277,7 +277,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq': {
+    "/entities/faq": {
         parameters: {
             query?: never;
             header?: never;
@@ -303,7 +303,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq'][];
+                        "application/json": components["schemas"]["entity-faq"][];
                     };
                 };
             };
@@ -316,7 +316,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/faq-category': {
+    "/entities/faq-category": {
         parameters: {
             query?: never;
             header?: never;
@@ -342,7 +342,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-faq-category'][];
+                        "application/json": components["schemas"]["entity-faq-category"][];
                     };
                 };
             };
@@ -355,7 +355,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entities/block': {
+    "/entities/block": {
         parameters: {
             query?: never;
             header?: never;
@@ -381,7 +381,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        'application/json': components['schemas']['entity-block'][];
+                        "application/json": components["schemas"]["entity-block"][];
                     };
                 };
             };
@@ -402,7 +402,7 @@ export interface components {
             /** Format: uri */
             url: string;
         };
-        'entity-plant': {
+        "entity-plant": {
             id: number;
             entityType: {
                 /** @default 1 */
@@ -452,7 +452,7 @@ export interface components {
                         deliverable: boolean;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     information?: {
                         /** @description (prevedeni naziv operacije) */
@@ -473,6 +473,12 @@ export interface components {
                         discounted?: number;
                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                         discountDescription?: string;
+                    };
+                    conditions?: {
+                        /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                        completionAttachImagesRequired: boolean;
+                        /** @description (da li se mogu proložiti slike za završetak radnje) */
+                        completionAttachImages: boolean;
                     };
                 }[];
                 flowering?: string;
@@ -535,7 +541,7 @@ export interface components {
                 perPlant: number;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -545,7 +551,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantSort': {
+        "entity-plantSort": {
             id: number;
             entityType: {
                 /** @default 11 */
@@ -556,7 +562,6 @@ export interface components {
                 label: string;
             };
             information: {
-                harvest?: string;
                 planting?: string;
                 flowering?: string;
                 plant: {
@@ -601,7 +606,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -622,6 +627,12 @@ export interface components {
                                 discounted?: number;
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
+                            };
+                            conditions?: {
+                                /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                                completionAttachImagesRequired: boolean;
+                                /** @description (da li se mogu proložiti slike za završetak radnje) */
+                                completionAttachImages: boolean;
                             };
                         }[];
                         flowering?: string;
@@ -684,7 +695,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -692,7 +703,6 @@ export interface components {
                 };
                 name: string;
                 description?: string;
-                shortDescription: string;
                 latinName?: string;
                 sowing?: string;
                 origin?: string;
@@ -701,9 +711,11 @@ export interface components {
                 growth?: string;
                 storage?: string;
                 maintenance?: string;
+                harvest?: string;
+                shortDescription: string;
             };
             image: {
-                cover?: components['schemas']['image'];
+                cover?: components["schemas"]["image"];
             };
             store: {
                 availableInStore: boolean;
@@ -713,7 +725,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-plantStage': {
+        "entity-plantStage": {
             id: number;
             entityType: {
                 /** @default 12 */
@@ -732,7 +744,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-seed': {
+        "entity-seed": {
             id: number;
             entityType: {
                 /** @default 15 */
@@ -794,7 +806,7 @@ export interface components {
                                 deliverable: boolean;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             information?: {
                                 /** @description (prevedeni naziv operacije) */
@@ -815,6 +827,12 @@ export interface components {
                                 discounted?: number;
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
+                            };
+                            conditions?: {
+                                /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                                completionAttachImagesRequired: boolean;
+                                /** @description (da li se mogu proložiti slike za završetak radnje) */
+                                completionAttachImages: boolean;
                             };
                         }[];
                         flowering?: string;
@@ -877,7 +895,7 @@ export interface components {
                         perPlant: number;
                     };
                     image?: {
-                        cover: components['schemas']['image'];
+                        cover: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -886,7 +904,6 @@ export interface components {
                 plantSort: {
                     id?: number;
                     information?: {
-                        harvest?: string;
                         planting?: string;
                         flowering?: string;
                         plant: {
@@ -931,7 +948,7 @@ export interface components {
                                         deliverable: boolean;
                                     };
                                     image?: {
-                                        cover: components['schemas']['image'];
+                                        cover: components["schemas"]["image"];
                                     };
                                     information?: {
                                         /** @description (prevedeni naziv operacije) */
@@ -952,6 +969,12 @@ export interface components {
                                         discounted?: number;
                                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                         discountDescription?: string;
+                                    };
+                                    conditions?: {
+                                        /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                                        completionAttachImagesRequired: boolean;
+                                        /** @description (da li se mogu proložiti slike za završetak radnje) */
+                                        completionAttachImages: boolean;
                                     };
                                 }[];
                                 flowering?: string;
@@ -1014,7 +1037,7 @@ export interface components {
                                 perPlant: number;
                             };
                             image?: {
-                                cover: components['schemas']['image'];
+                                cover: components["schemas"]["image"];
                             };
                             store?: {
                                 availableInStore: boolean;
@@ -1022,7 +1045,6 @@ export interface components {
                         };
                         name: string;
                         description?: string;
-                        shortDescription: string;
                         latinName?: string;
                         sowing?: string;
                         origin?: string;
@@ -1031,9 +1053,11 @@ export interface components {
                         growth?: string;
                         storage?: string;
                         maintenance?: string;
+                        harvest?: string;
+                        shortDescription: string;
                     };
                     image?: {
-                        cover?: components['schemas']['image'];
+                        cover?: components["schemas"]["image"];
                     };
                     store?: {
                         availableInStore: boolean;
@@ -1056,7 +1080,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-brand': {
+        "entity-brand": {
             id: number;
             entityType: {
                 /** @default 16 */
@@ -1075,7 +1099,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operation': {
+        "entity-operation": {
             id: number;
             entityType: {
                 /** @default 10 */
@@ -1104,7 +1128,7 @@ export interface components {
                 deliverable: boolean;
             };
             image: {
-                cover: components['schemas']['image'];
+                cover: components["schemas"]["image"];
             };
             information: {
                 /** @description (prevedeni naziv operacije) */
@@ -1126,12 +1150,18 @@ export interface components {
                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                 discountDescription?: string;
             };
+            conditions: {
+                /** @description (da li je obavezno proložiti slike za završetak radnje) */
+                completionAttachImagesRequired: boolean;
+                /** @description (da li se mogu proložiti slike za završetak radnje) */
+                completionAttachImages: boolean;
+            };
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-operationFrequency': {
+        "entity-operationFrequency": {
             id: number;
             entityType: {
                 /** @default 13 */
@@ -1146,7 +1176,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq': {
+        "entity-faq": {
             id: number;
             entityType: {
                 /** @default 2 */
@@ -1176,7 +1206,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-faq-category': {
+        "entity-faq-category": {
             id: number;
             entityType: {
                 /** @default 14 */
@@ -1195,7 +1225,7 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        'entity-block': {
+        "entity-block": {
             id: number;
             entityType: {
                 /** @default 8 */

--- a/packages/signalco/src/lib/signalco-api/v1.d.ts
+++ b/packages/signalco/src/lib/signalco-api/v1.d.ts
@@ -4,14 +4,14 @@
  */
 
 export interface paths {
-    '/status': {
+    "/status": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations['HealthFunctions'];
+        get: operations["HealthFunctions"];
         put?: never;
         post?: never;
         delete?: never;
@@ -20,7 +20,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/website/newsletter-subscribe': {
+    "/website/newsletter-subscribe": {
         parameters: {
             query?: never;
             header?: never;
@@ -30,21 +30,21 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Subscribe to a newsletter. */
-        post: operations['NewsletterFunction'];
+        post: operations["NewsletterFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/stations/logging/download': {
+    "/stations/logging/download": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations['StationLoggingDownloadFunction'];
+        get: operations["StationLoggingDownloadFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -53,14 +53,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/station/logging/list': {
+    "/station/logging/list": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get: operations['StationLoggingListFunction'];
+        get: operations["StationLoggingListFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -69,7 +69,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/station/logging/persist': {
+    "/station/logging/persist": {
         parameters: {
             query?: never;
             header?: never;
@@ -79,14 +79,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Appends logging entries. */
-        post: operations['StationLoggingPersistFunction'];
+        post: operations["StationLoggingPersistFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/station/refresh-token': {
+    "/station/refresh-token": {
         parameters: {
             query?: never;
             header?: never;
@@ -96,14 +96,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Refreshes the access token. */
-        post: operations['StationRefreshTokenFunction'];
+        post: operations["StationRefreshTokenFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/signalr/conducts/negotiate': {
+    "/signalr/conducts/negotiate": {
         parameters: {
             query?: never;
             header?: never;
@@ -113,14 +113,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Negotiates SignalR connection for conducts hub. */
-        post: operations['ConductsNegotiateFunction'];
+        post: operations["ConductsNegotiateFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/signalr/contacts/negotiate': {
+    "/signalr/contacts/negotiate": {
         parameters: {
             query?: never;
             header?: never;
@@ -130,14 +130,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Negotiates SignalR connection for entities hub. */
-        post: operations['ContactsNegotiateFunction'];
+        post: operations["ContactsNegotiateFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/share/entity': {
+    "/share/entity": {
         parameters: {
             query?: never;
             header?: never;
@@ -147,15 +147,15 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Shared the entity with users. */
-        post: operations['ShareEntityFunction'];
+        post: operations["ShareEntityFunction"];
         /** @description Un-shared the entity from users. */
-        delete: operations['UnShareEntityFunction'];
+        delete: operations["UnShareEntityFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/entity': {
+    "/entity": {
         parameters: {
             query?: never;
             header?: never;
@@ -163,18 +163,18 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves all available entities. */
-        get: operations['EntityRetrieveFunction'];
+        get: operations["EntityRetrieveFunction"];
         put?: never;
         /** @description Creates or updates entity. Will create entity if Id is not provided. */
-        post: operations['EntityUpsertFunction'];
+        post: operations["EntityUpsertFunction"];
         /** @description Deletes the entity. */
-        delete: operations['EntityDeleteFunction'];
+        delete: operations["EntityDeleteFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/entities': {
+    "/entities": {
         parameters: {
             query?: never;
             header?: never;
@@ -182,17 +182,17 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves entities. */
-        get: operations['EntityRetrieveFunction'];
+        get: operations["EntityRetrieveFunction"];
         put?: never;
         post?: never;
         /** @description Deletes the entity. */
-        delete: operations['EntityDeleteFunction'];
+        delete: operations["EntityDeleteFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/entity/{id}': {
+    "/entity/{id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -200,7 +200,7 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves single entity. */
-        get: operations['EntityRetrieveSingleFunction'];
+        get: operations["EntityRetrieveSingleFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -209,7 +209,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/entity/{id}/contacts/{channelName}/{contactName}': {
+    "/entity/{id}/contacts/{channelName}/{contactName}": {
         parameters: {
             query?: never;
             header?: never;
@@ -218,16 +218,16 @@ export interface paths {
         };
         get?: never;
         /** @description Sets contact value. */
-        put: operations['EntityContactSet'];
+        put: operations["EntityContactSet"];
         post?: never;
         /** @description Deletes the contact. */
-        delete: operations['ContactDeleteFunction'];
+        delete: operations["ContactDeleteFunction"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/contact/history': {
+    "/contact/history": {
         parameters: {
             query?: never;
             header?: never;
@@ -235,7 +235,7 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieves the contact history for provided duration. */
-        get: operations['ContactHistoryRetrieveFunction'];
+        get: operations["ContactHistoryRetrieveFunction"];
         put?: never;
         post?: never;
         delete?: never;
@@ -244,7 +244,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/contact/metadata': {
+    "/contact/metadata": {
         parameters: {
             query?: never;
             header?: never;
@@ -254,14 +254,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Contact metadata. */
-        post: operations['ContactMetadataFunction'];
+        post: operations["ContactMetadataFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/contact/set': {
+    "/contact/set": {
         parameters: {
             query?: never;
             header?: never;
@@ -271,14 +271,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Sets contact value. */
-        post: operations['ContactSetFunction'];
+        post: operations["ContactSetFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/conducts/request': {
+    "/conducts/request": {
         parameters: {
             query?: never;
             header?: never;
@@ -288,14 +288,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Requests conduct to be executed. */
-        post: operations['ConductRequestFunction'];
+        post: operations["ConductRequestFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/conducts/request-multiple': {
+    "/conducts/request-multiple": {
         parameters: {
             query?: never;
             header?: never;
@@ -305,14 +305,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** @description Requests multiple conducts to be executed. */
-        post: operations['ConductRequestMultipleFunction'];
+        post: operations["ConductRequestMultipleFunction"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    '/auth/pats': {
+    "/auth/pats": {
         parameters: {
             query?: never;
             header?: never;
@@ -320,10 +320,10 @@ export interface paths {
             cookie?: never;
         };
         /** @description Retrieve all user PATs. */
-        get: operations['PatsRetrieveFunction'];
+        get: operations["PatsRetrieveFunction"];
         put?: never;
         /** @description Creates new PAT. */
-        post: operations['PatsCreateFunction'];
+        post: operations["PatsCreateFunction"];
         delete?: never;
         options?: never;
         head?: never;
@@ -361,7 +361,7 @@ export interface components {
             metadata?: string;
         };
         contactHistoryResponseDto: {
-            values?: components['schemas']['timeStampValuePair'][];
+            values?: components["schemas"]["timeStampValuePair"][];
         };
         contactMetadataDto: {
             entityId?: string;
@@ -389,8 +389,8 @@ export interface components {
             type: 0 | 1 | 2 | 3 | 4 | 5 | 6;
             id?: string;
             alias?: string;
-            contacts?: components['schemas']['contactDto'][];
-            sharedWith?: components['schemas']['userDto'][];
+            contacts?: components["schemas"]["contactDto"][];
+            sharedWith?: components["schemas"]["userDto"][];
         };
         entityUpsertDto: {
             id?: string;
@@ -452,7 +452,7 @@ export interface components {
         };
         stationsLoggingPersistRequestDto: {
             stationId: string;
-            entries: components['schemas']['entry'][];
+            entries: components["schemas"]["entry"][];
         };
         timeStampValuePair: {
             /** Format: date-time */
@@ -500,7 +500,7 @@ export interface operations {
             query?: never;
             header?: {
                 /** @description hCaptcha response. */
-                'HCAPTCHA-RESPONSE'?: string;
+                "HCAPTCHA-RESPONSE"?: string;
             };
             path?: never;
             cookie?: never;
@@ -508,7 +508,7 @@ export interface operations {
         /** @description Subscribe with email address. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['newsletterSubscribeDto'];
+                "application/json": components["schemas"]["newsletterSubscribeDto"];
             };
         };
         responses: {
@@ -569,7 +569,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['blobInfoDto'][];
+                    "application/json": components["schemas"]["blobInfoDto"][];
                 };
             };
             /** @description One or more required property is missing in request. */
@@ -591,7 +591,7 @@ export interface operations {
         /** @description The logging entries to persist per station. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['stationsLoggingPersistRequestDto'];
+                "application/json": components["schemas"]["stationsLoggingPersistRequestDto"];
             };
         };
         responses: {
@@ -620,7 +620,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['stationRefreshTokenRequestDto'];
+                "application/json": components["schemas"]["stationRefreshTokenRequestDto"];
             };
         };
         responses: {
@@ -630,7 +630,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['stationRefreshTokenResponseDto'];
+                    "application/json": components["schemas"]["stationRefreshTokenResponseDto"];
                 };
             };
             /** @description One or more required property is missing in request. */
@@ -657,7 +657,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['signalRConnectionInfo'];
+                    "application/json": components["schemas"]["signalRConnectionInfo"];
                 };
             };
         };
@@ -677,7 +677,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['signalRConnectionInfo'];
+                    "application/json": components["schemas"]["signalRConnectionInfo"];
                 };
             };
         };
@@ -692,7 +692,7 @@ export interface operations {
         /** @description Share one entity with one or more users. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['shareRequestDto'];
+                "application/json": components["schemas"]["shareRequestDto"];
             };
         };
         responses: {
@@ -722,7 +722,7 @@ export interface operations {
         /** @description Un-share one entity with one or more users. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['unShareRequestDto'];
+                "application/json": components["schemas"]["unShareRequestDto"];
             };
         };
         responses: {
@@ -757,7 +757,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityDetailsDto'][];
+                    "application/json": components["schemas"]["entityDetailsDto"][];
                 };
             };
         };
@@ -771,7 +771,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['entityUpsertDto'];
+                "application/json": components["schemas"]["entityUpsertDto"];
             };
         };
         responses: {
@@ -781,7 +781,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityUpsertResponseDto'];
+                    "application/json": components["schemas"]["entityUpsertResponseDto"];
                 };
             };
         };
@@ -796,7 +796,7 @@ export interface operations {
         /** @description Information about entity to delete. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['entityDeleteDto'];
+                "application/json": components["schemas"]["entityDeleteDto"];
             };
         };
         responses: {
@@ -841,7 +841,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityDetailsDto'][];
+                    "application/json": components["schemas"]["entityDetailsDto"][];
                 };
             };
         };
@@ -899,7 +899,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['entityDetailsDto'];
+                    "application/json": components["schemas"]["entityDetailsDto"];
                 };
             };
             /** @description No description */
@@ -927,7 +927,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['contactSetDto'];
+                "application/json": components["schemas"]["contactSetDto"];
             };
         };
         responses: {
@@ -987,7 +987,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['contactHistoryResponseDto'];
+                    "application/json": components["schemas"]["contactHistoryResponseDto"];
                 };
             };
             /** @description One or more required property is missing in request. */
@@ -1008,7 +1008,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['contactMetadataDto'];
+                "application/json": components["schemas"]["contactMetadataDto"];
             };
         };
         responses: {
@@ -1037,7 +1037,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['contactSetDto'];
+                "application/json": components["schemas"]["contactSetDto"];
             };
         };
         responses: {
@@ -1067,7 +1067,7 @@ export interface operations {
         /** @description The conduct to execute. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['conductRequestDto'];
+                "application/json": components["schemas"]["conductRequestDto"];
             };
         };
         responses: {
@@ -1097,7 +1097,7 @@ export interface operations {
         /** @description Collection of conducts to execute. */
         requestBody?: {
             content: {
-                'application/json': components['schemas']['conductRequestDto'][];
+                "application/json": components["schemas"]["conductRequestDto"][];
             };
         };
         responses: {
@@ -1132,7 +1132,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['patDto'][];
+                    "application/json": components["schemas"]["patDto"][];
                 };
             };
         };
@@ -1146,7 +1146,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                'application/json': components['schemas']['patCreateDto'];
+                "application/json": components["schemas"]["patCreateDto"];
             };
         };
         responses: {
@@ -1156,7 +1156,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    'application/json': components['schemas']['patCreateResponseDto'];
+                    "application/json": components["schemas"]["patCreateResponseDto"];
                 };
             };
         };


### PR DESCRIPTION
Rename FlagPaths -> FlagPath across generated hypertune flag
modules and update decodeFlagValues parameter names and callsite to
clarify intent and ensure consistent parameter naming. Update related
React client logger props to use the new FlagPath type.

Also normalize string quoting in the directories API typings to use
double quotes and fix formatting for JSON content schema references.
These changes improve type clarity and maintain consistent code style.