### PR TITLE
feat: show images in diary entries

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -1,3 +1,4 @@
+import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Alert } from '@signalco/ui/Alert';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { List } from '@signalco/ui-primitives/List';
@@ -23,6 +24,7 @@ function DiaryList({
               description: string | undefined;
               status: string | null;
               timestamp: Date;
+              imageUrls?: string[] | null;
           }>
         | undefined;
 }) {
@@ -59,17 +61,31 @@ function DiaryList({
                     label={
                         <Row
                             spacing={2}
-                            justifyContent="space-between"
-                            className="font-normal"
+                            className="justify-between font-normal"
                         >
-                            <Stack>
-                                <Typography level="body1" semiBold>
-                                    {entry.name}
-                                </Typography>
-                                <Typography level="body2">
-                                    {entry.description}
-                                </Typography>
-                            </Stack>
+                            <Row spacing={2} className="items-start flex-1">
+                                {entry.imageUrls?.length ? (
+                                    <Row spacing={1} className="items-start">
+                                        {entry.imageUrls.map((url) => (
+                                            <ImageViewer
+                                                key={url}
+                                                src={url}
+                                                alt={entry.name}
+                                                previewWidth={80}
+                                                previewHeight={80}
+                                            />
+                                        ))}
+                                    </Row>
+                                ) : null}
+                                <Stack>
+                                    <Typography level="body1" semiBold>
+                                        {entry.name}
+                                    </Typography>
+                                    <Typography level="body2">
+                                        {entry.description}
+                                    </Typography>
+                                </Stack>
+                            </Row>
                             <Stack>
                                 {entry.status && (
                                     <Chip

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -511,16 +511,26 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
     ]);
 
     const raisedBedsEventDiaryEntries = events
-        .map((event) => ({
-            id: event.id,
-            name:
-                event.type === knownEventTypes.raisedBeds.create
-                    ? 'Gredica stvorena'
-                    : 'Gredica obrisana',
-            description: '',
-            status: null,
-            timestamp: event.createdAt,
-        }))
+        .map((event) => {
+            const data = event.data as Record<string, unknown> | undefined;
+            return {
+                id: event.id,
+                name:
+                    event.type === knownEventTypes.raisedBeds.create
+                        ? 'Gredica stvorena'
+                        : 'Gredica obrisana',
+                description: '',
+                status: null,
+                timestamp: event.createdAt,
+                imageUrls: Array.isArray(data?.imageUrls)
+                    ? data.imageUrls.filter(
+                          (url: unknown) => typeof url === 'string',
+                      )
+                    : typeof data?.imageUrl === 'string'
+                      ? [data.imageUrl]
+                      : undefined,
+            };
+        })
         .filter((op) => op.name);
     const operationsDiaryEntries = operations
         .filter((op) => !op.raisedBedFieldId) // Filter out operations with raisedBedFieldId
@@ -534,6 +544,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
             timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
+            imageUrls: op.imageUrls,
         }))
         .filter((op) => op.name)
         .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
@@ -608,6 +619,7 @@ export async function getRaisedBedFieldDiaryEntries(
 
     const raisedBedsEventDiaryEntries = events
         .map((event) => {
+            const data = event.data as Record<string, unknown> | undefined;
             let name = 'Nepoznato';
             let description = '';
             switch (event.type) {
@@ -651,6 +663,13 @@ export async function getRaisedBedFieldDiaryEntries(
                 description,
                 status: null,
                 timestamp: event.createdAt,
+                imageUrls: Array.isArray(data?.imageUrls)
+                    ? data.imageUrls.filter(
+                          (url: unknown) => typeof url === 'string',
+                      )
+                    : typeof data?.imageUrl === 'string'
+                      ? [data.imageUrl]
+                      : undefined,
             };
         })
         .filter((event) => event.name);
@@ -666,6 +685,7 @@ export async function getRaisedBedFieldDiaryEntries(
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
             timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
+            imageUrls: op.imageUrls,
         }))
         .filter((op) => op.name)
         .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -35,6 +35,7 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
         let canceledBy: string | undefined;
         let canceledAt: Date | undefined;
         let cancelReason: string | undefined;
+        let imageUrls: string[] | undefined;
 
         for (const event of events) {
             const data = event.data as Record<string, any> | undefined;
@@ -44,6 +45,13 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
                 completedAt = data?.completedAt
                     ? new Date(data.completedAt)
                     : undefined;
+                if (Array.isArray(data?.imageUrls)) {
+                    imageUrls = data.imageUrls.filter(
+                        (url: unknown) => typeof url === 'string',
+                    );
+                } else if (typeof data?.imageUrl === 'string') {
+                    imageUrls = [data.imageUrl];
+                }
             } else if (event.type === knownEventTypes.operations.fail) {
                 status = 'failed';
                 error = data?.error;
@@ -74,6 +82,7 @@ async function fillOperationAggregares(operations: SelectOperation[]) {
             canceledBy,
             canceledAt,
             cancelReason,
+            imageUrls,
         };
     });
 }


### PR DESCRIPTION
## Summary
- display attached images next to diary entries using existing ImageViewer component
- expose optional `imageUrls` on diary entries from events and operations

## Testing
- `pnpm --filter @gredice/storage lint`
- `pnpm --filter @gredice/game run lint --max-diagnostics=200`
- `pnpm --filter @gredice/storage test` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ca28bb88832fa16bd28b5e4f67b9