### PR TITLE
feat(schedule): support image attachments on completion

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -174,6 +174,7 @@ export async function completeOperation(
 }
 
 export async function completeOperationWithImages(formData: FormData) {
+    await auth(['admin']);
     const operationId = formData.get('operationId')
         ? Number(formData.get('operationId'))
         : undefined;

--- a/apps/app/app/admin/schedule/CompleteOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CompleteOperationModal.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useRef, useState } from 'react';
+import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
+import {
+    completeOperation,
+    completeOperationWithImages,
+} from '../../(actions)/operationActions';
+
+type CompleteOperationModalProps = {
+    operationId: number;
+    label: string;
+    userId: string;
+    conditions?: EntityStandardized['conditions'];
+};
+
+export function CompleteOperationModal({
+    operationId,
+    label,
+    userId,
+    conditions,
+}: CompleteOperationModalProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [files, setFiles] = useState<File[]>([]);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const attachImages = conditions?.completionAttachImages;
+    const attachRequired = conditions?.completionAttachImagesRequired;
+
+    const handleOpenChange = (open: boolean) => {
+        setIsOpen(open);
+        if (!open) {
+            setFiles([]);
+            if (fileInputRef.current) fileInputRef.current.value = '';
+        }
+    };
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files) {
+            setFiles(Array.from(e.target.files));
+        }
+    };
+
+    const handleConfirm = async () => {
+        if (attachImages && files.length > 0) {
+            const formData = new FormData();
+            formData.append('operationId', operationId.toString());
+            formData.append('completedBy', userId);
+            for (const file of files) {
+                formData.append('images', file);
+            }
+            await completeOperationWithImages(formData);
+        } else {
+            await completeOperation(operationId, userId);
+        }
+        handleOpenChange(false);
+    };
+
+    return (
+        <Modal
+            title="Potvrda završetka operacije"
+            open={isOpen}
+            onOpenChange={handleOpenChange}
+            trigger={<Checkbox />}
+        >
+            <Stack spacing={2}>
+                <Typography>
+                    Jeste li sigurni da želite označiti operaciju kao završenu:{' '}
+                    <strong>{label}</strong>?
+                </Typography>
+                {attachImages && (
+                    <Stack spacing={1}>
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/*"
+                            capture="environment"
+                            multiple
+                            className="hidden"
+                            onChange={handleFileChange}
+                        />
+                        <Button
+                            variant="outlined"
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                        >
+                            {files.length > 0
+                                ? 'Dodaj još slika'
+                                : 'Dodaj slike'}
+                        </Button>
+                        {files.length > 0 && (
+                            <Typography level="body2">
+                                Odabrano {files.length}{' '}
+                                {files.length === 1 ? 'slika' : 'slike'}
+                            </Typography>
+                        )}
+                    </Stack>
+                )}
+                <Row spacing={1} justifyContent="end">
+                    <Button
+                        variant="outlined"
+                        onClick={() => handleOpenChange(false)}
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        variant="solid"
+                        onClick={handleConfirm}
+                        disabled={attachRequired && files.length === 0}
+                    >
+                        Potvrdi
+                    </Button>
+                </Row>
+            </Stack>
+        </Modal>
+    );
+}

--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -10,9 +10,9 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 import { KnownPages } from '../../../src/KnownPages';
-import { completeOperation } from '../../(actions)/operationActions';
 import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
 import { CancelOperationModal } from './CancelOperationModal';
+import { CompleteOperationModal } from './CompleteOperationModal';
 import { CopyTasksButton } from './CopyTasksButton';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
 
@@ -304,11 +304,6 @@ export function ScheduleDay({
                                 const operationData = operationsData?.find(
                                     (data) => data.id === op.entityId,
                                 );
-
-                                const handleOperationConfirm = async () => {
-                                    await completeOperation(op.id, userId);
-                                };
-
                                 return (
                                     <div key={op.id}>
                                         <Row
@@ -316,22 +311,14 @@ export function ScheduleDay({
                                             className="hover:bg-muted"
                                         >
                                             <Row spacing={1}>
-                                                <ModalConfirm
-                                                    title="Potvrda završetka operacije"
-                                                    header="Označavanje operacije kao završene"
-                                                    onConfirm={
-                                                        handleOperationConfirm
+                                                <CompleteOperationModal
+                                                    operationId={op.id}
+                                                    userId={userId}
+                                                    label={`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`}
+                                                    conditions={
+                                                        operationData?.conditions
                                                     }
-                                                    trigger={<Checkbox />}
-                                                >
-                                                    <Typography>
-                                                        Jeste li sigurni da
-                                                        želite označiti
-                                                        operaciju kao završenu:{' '}
-                                                        <strong>{`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`}</strong>
-                                                        ?
-                                                    </Typography>
-                                                </ModalConfirm>
+                                                />
                                                 <a
                                                     href={
                                                         operationData

--- a/apps/app/lib/@types/EntityStandardized.ts
+++ b/apps/app/lib/@types/EntityStandardized.ts
@@ -22,4 +22,8 @@ export type EntityStandardized = {
         perPlant?: number;
         perOperation?: number;
     };
+    conditions?: {
+        completionAttachImages?: boolean;
+        completionAttachImagesRequired?: boolean;
+    };
 };

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -26,6 +26,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-email": "4.2.8",
+        "@vercel/blob": "^0.18.0",
         "server-only": "0.0.1"
     },
     "devDependencies": {

--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -25,8 +25,14 @@ const nextConfig: NextConfig = {
                 hostname: 'cdn.gredice.com',
             },
             {
+                // Garden - Vercel Blob
                 protocol: 'https',
                 hostname: 'myegtvromcktt2y7.public.blob.vercel-storage.com',
+            },
+            {
+                // Public - Vercel Blob
+                protocol: 'https',
+                hostname: '7ql7fvz1vzzo6adz.public.blob.vercel-storage.com',
             },
         ],
     },

--- a/packages/storage/src/@types/EntityStandardized.ts
+++ b/packages/storage/src/@types/EntityStandardized.ts
@@ -22,4 +22,8 @@ export type EntityStandardized = {
         perPlant?: number;
         perOperation?: number;
     };
+    conditions?: {
+        completionAttachImages?: boolean;
+        completionAttachImagesRequired?: boolean;
+    };
 };

--- a/packages/storage/src/repositories/eventsRepo.ts
+++ b/packages/storage/src/repositories/eventsRepo.ts
@@ -306,7 +306,10 @@ export const knownEvents = {
             aggregateId,
             data,
         }),
-        completedV1: (aggregateId: string, data: { completedBy: string }) => ({
+        completedV1: (
+            aggregateId: string,
+            data: { completedBy: string; images?: string[] },
+        ) => ({
             type: knownEventTypes.operations.complete,
             version: 1,
             aggregateId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@react-email/components':
         specifier: 0.5.1
         version: 0.5.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@vercel/blob':
+        specifier: ^0.18.0
+        version: 0.18.0
       hypertune:
         specifier: 2.7.3
         version: 2.7.3
@@ -1805,6 +1808,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@ffmpeg-installer/darwin-arm64@4.1.5':
     resolution: {integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==}
@@ -4069,6 +4076,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/blob@0.18.0':
+    resolution: {integrity: sha512-DKjzhGfvBIzYjAI8RLsoEWB8NYUkMXL3TQLeKO5V1qLglgckuetwtfnYPF0OeTLezklE9m//vMpBS0qkxP4RRA==}
+    engines: {node: '>=16.14'}
+
   '@vercel/edge-config-fs@0.1.0':
     resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
 
@@ -4347,6 +4358,9 @@ packages:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -4407,6 +4421,10 @@ packages:
   bufferutil@4.0.9:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
     engines: {node: '>=6.14.2'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -7232,6 +7250,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@5.28.2:
+    resolution: {integrity: sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==}
+    engines: {node: '>=14.0'}
+
   undici@7.15.0:
     resolution: {integrity: sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==}
     engines: {node: '>=20.18.1'}
@@ -8816,6 +8838,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.8':
     optional: true
+
+  '@fastify/busboy@2.1.1': {}
 
   '@ffmpeg-installer/darwin-arm64@4.1.5':
     optional: true
@@ -11700,6 +11724,12 @@ snapshots:
       vue: 3.5.17(typescript@5.9.2)
       vue-router: 4.5.1(vue@3.5.17(typescript@5.9.2))
 
+  '@vercel/blob@0.18.0':
+    dependencies:
+      async-retry: 1.3.3
+      bytes: 3.1.2
+      undici: 5.28.2
+
   '@vercel/edge-config-fs@0.1.0': {}
 
   '@vercel/edge-config@1.4.0':
@@ -11989,6 +12019,10 @@ snapshots:
 
   assign-symbols@1.0.0: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   asynckit@0.4.0: {}
 
   attr-accept@2.2.5: {}
@@ -12073,6 +12107,8 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -15297,6 +15333,10 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@5.28.2:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@7.15.0: {}
 


### PR DESCRIPTION
## Summary
- allow operations to specify completion image attachment conditions
- add modal for attaching optional or required images when completing an operation
- expose server action that accepts uploaded images with completion
- upload images to Vercel Blob storage and include their URLs in completion events and notifications
- depend on official `@vercel/blob` package instead of custom workspace shim

## Testing
- `pnpm lint --filter app --filter @gredice/storage`
- `pnpm test --filter app --filter @gredice/storage` *(fails: docker: command not found; Module not found: Can't resolve '@vercel/blob')*


------
https://chatgpt.com/codex/tasks/task_e_68b0cdf44e48832f81320444bcb16a96