### PR TITLE
feat(app): add entities filtering

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/page.tsx
@@ -1,14 +1,23 @@
-import { getEntityTypeByName } from '@gredice/storage';
+import {
+    getAttributeDefinitions,
+    getEntitiesRaw,
+    getEntityTypeByName,
+} from '@gredice/storage';
 import { Add } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { EntityTypeMenu } from '../../../../components/admin/directories';
+import { FilterProvider } from '../../../../components/admin/providers';
+import { SearchInput } from '../../../../components/admin/SearchInput';
 import { EntitiesTable } from '../../../../components/admin/tables';
 import { ServerActionIconButton } from '../../../../components/shared/ServerActionIconButton';
 import { auth } from '../../../../lib/auth/auth';
-import { createEntity } from '../../../(actions)/entityActions';
+import {
+    createEntity,
+    duplicateEntity,
+} from '../../../(actions)/entityActions';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,29 +30,44 @@ export default async function EntitiesPage({
     const { entityType: entityTypeName } = await params;
     const entityType = await getEntityTypeByName(entityTypeName);
     const createEntityBound = createEntity.bind(null, entityTypeName);
+    const duplicateEntityBound = duplicateEntity.bind(null, entityTypeName);
+    const [entities, attributeDefinitions] = await Promise.all([
+        getEntitiesRaw(entityTypeName),
+        getAttributeDefinitions(entityTypeName),
+    ]);
 
     return (
-        <Stack spacing={2}>
-            <Row spacing={1} justifyContent="space-between">
-                <Typography level="h1" className="text-2xl" semiBold>
-                    {entityType?.label}
-                </Typography>
-                <Row>
-                    <ServerActionIconButton
-                        variant="plain"
-                        title="Dodaj zapis"
-                        onClick={createEntityBound}
-                    >
-                        <Add className="size-5" />
-                    </ServerActionIconButton>
-                    {entityType && <EntityTypeMenu entityType={entityType} />}
+        <FilterProvider>
+            <Stack spacing={2}>
+                <Row spacing={1} justifyContent="space-between">
+                    <Typography level="h1" className="text-2xl" semiBold>
+                        {entityType?.label}
+                    </Typography>
+                    <Row spacing={1}>
+                        <SearchInput />
+                        <ServerActionIconButton
+                            variant="plain"
+                            title="Dodaj zapis"
+                            onClick={createEntityBound}
+                        >
+                            <Add className="size-5" />
+                        </ServerActionIconButton>
+                        {entityType && (
+                            <EntityTypeMenu entityType={entityType} />
+                        )}
+                    </Row>
                 </Row>
-            </Row>
-            <Card>
-                <CardOverflow>
-                    <EntitiesTable entityTypeName={entityTypeName} />
-                </CardOverflow>
-            </Card>
-        </Stack>
+                <Card>
+                    <CardOverflow>
+                        <EntitiesTable
+                            entityTypeName={entityTypeName}
+                            entities={entities}
+                            attributeDefinitions={attributeDefinitions}
+                            onDuplicate={duplicateEntityBound}
+                        />
+                    </CardOverflow>
+                </Card>
+            </Stack>
+        </FilterProvider>
     );
 }

--- a/apps/app/components/admin/SearchInput.tsx
+++ b/apps/app/components/admin/SearchInput.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { Close, Search } from '@signalco/ui-icons';
-import { cx } from '@signalco/ui-primitives/cx';
-import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Search } from '@signalco/ui-icons';
 import { Input } from '@signalco/ui-primitives/Input';
 import { useFilter } from './providers';
 
@@ -14,23 +12,7 @@ export function SearchInput() {
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             placeholder="Pretraži..."
-            startDecorator={<Search className="size-5" />}
-            endDecorator={
-                <IconButton
-                    className={cx(
-                        'hover:bg-neutral-300 mr-1 rounded-full aspect-square',
-                        filter ? 'visible' : 'invisible',
-                    )}
-                    title="Očisti pretragu"
-                    onClick={() => setFilter('')}
-                    size="sm"
-                    variant="plain"
-                >
-                    <Close className="size-5" />
-                </IconButton>
-            }
-            className="min-w-60"
-            variant="soft"
+            startDecorator={<Search className="size-5 shrink-0 ml-3" />}
         />
     );
 }

--- a/apps/app/components/admin/SearchInput.tsx
+++ b/apps/app/components/admin/SearchInput.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Close, Search } from '@signalco/ui-icons';
+import { cx } from '@signalco/ui-primitives/cx';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Input } from '@signalco/ui-primitives/Input';
+import { useFilter } from './providers';
+
+export function SearchInput() {
+    const { filter, setFilter } = useFilter();
+
+    return (
+        <Input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Pretraži..."
+            startDecorator={<Search className="size-5" />}
+            endDecorator={
+                <IconButton
+                    className={cx(
+                        'hover:bg-neutral-300 mr-1 rounded-full aspect-square',
+                        filter ? 'visible' : 'invisible',
+                    )}
+                    title="Očisti pretragu"
+                    onClick={() => setFilter('')}
+                    size="sm"
+                    variant="plain"
+                >
+                    <Close className="size-5" />
+                </IconButton>
+            }
+            className="min-w-60"
+            variant="soft"
+        />
+    );
+}

--- a/apps/app/components/admin/directories/EntityAttributeProgress.tsx
+++ b/apps/app/components/admin/directories/EntityAttributeProgress.tsx
@@ -1,4 +1,5 @@
-import { getAttributeDefinitions, type getEntitiesRaw } from '@gredice/storage';
+'use client';
+
 import { cx } from '@signalco/ui-primitives/cx';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -8,18 +9,25 @@ import {
     TooltipTrigger,
 } from '@signalco/ui-primitives/Tooltip';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { cache } from 'react';
 
-const definitionsCache = cache(getAttributeDefinitions);
+type AttributeDefinition = {
+    id: number;
+    label: string;
+    required: boolean;
+    defaultValue: string | null;
+};
 
-export async function EntityAttributeProgress({
-    entityTypeName,
+type Entity = {
+    attributes: { attributeDefinitionId: number; value: string | null }[];
+};
+
+export function EntityAttributeProgress({
     entity,
+    definitions,
 }: {
-    entityTypeName: string;
-    entity: Awaited<ReturnType<typeof getEntitiesRaw>>[0];
+    entity: Entity;
+    definitions: AttributeDefinition[];
 }) {
-    const definitions = await definitionsCache(entityTypeName);
     const numberOfRequiredAttributes = definitions.filter(
         (d) => d.required,
     ).length;

--- a/apps/app/components/admin/providers/FilterProvider.tsx
+++ b/apps/app/components/admin/providers/FilterProvider.tsx
@@ -1,10 +1,16 @@
 'use client';
 
-import { createContext, useContext, useState } from 'react';
+import {
+    createContext,
+    type Dispatch,
+    type SetStateAction,
+    useContext,
+    useState,
+} from 'react';
 
 export type FilterContextType = {
     filter: string;
-    setFilter: (value: string) => void;
+    setFilter: Dispatch<SetStateAction<string>>;
 };
 
 const FilterContext = createContext<FilterContextType | undefined>(undefined);

--- a/apps/app/components/admin/providers/FilterProvider.tsx
+++ b/apps/app/components/admin/providers/FilterProvider.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+export type FilterContextType = {
+    filter: string;
+    setFilter: (value: string) => void;
+};
+
+const FilterContext = createContext<FilterContextType | undefined>(undefined);
+
+export function FilterProvider({ children }: { children: React.ReactNode }) {
+    const [filter, setFilter] = useState('');
+
+    return (
+        <FilterContext.Provider value={{ filter, setFilter }}>
+            {children}
+        </FilterContext.Provider>
+    );
+}
+
+export function useFilter() {
+    const context = useContext(FilterContext);
+    if (!context) {
+        throw new Error('useFilter must be used within a FilterProvider');
+    }
+    return context;
+}

--- a/apps/app/components/admin/providers/index.ts
+++ b/apps/app/components/admin/providers/index.ts
@@ -1,1 +1,2 @@
 export { AdminClientProvider } from './AdminClientProvider';
+export { FilterProvider, useFilter } from './FilterProvider';

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -28,7 +28,7 @@ type EntityAttribute = {
 type Entity = {
     id: number;
     state: string;
-    updatedAt: string;
+    updatedAt: Date;
     entityType: { label: string };
     attributes: EntityAttribute[];
 };

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -1,23 +1,56 @@
-import { getEntitiesRaw } from '@gredice/storage';
+'use client';
+
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Duplicate } from '@signalco/ui-icons';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
-import { duplicateEntity } from '../../../app/(actions)/entityActions';
-import { entityDisplayName } from '../../../src/entities/entityAttributes';
 import { KnownPages } from '../../../src/KnownPages';
 import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
 import { ServerActionIconButton } from '../../shared/ServerActionIconButton';
 import { EntityAttributeProgress } from '../directories/EntityAttributeProgress';
+import { useFilter } from '../providers';
 
-export async function EntitiesTable({
-    entityTypeName,
-}: {
+type AttributeDefinition = {
+    id: number;
+    label: string;
+    required: boolean;
+    defaultValue: string | null;
+};
+
+type EntityAttribute = {
+    attributeDefinitionId: number;
+    attributeDefinition: { category: string; name: string };
+    value: string | null;
+};
+
+type Entity = {
+    id: number;
+    state: string;
+    updatedAt: string;
+    entityType: { label: string };
+    attributes: EntityAttribute[];
+};
+
+type EntitiesTableProps = {
     entityTypeName: string;
-}) {
-    const entities = await getEntitiesRaw(entityTypeName);
+    entities: Entity[];
+    attributeDefinitions: AttributeDefinition[];
+    onDuplicate: (entityId: number) => Promise<void>;
+};
+
+export function EntitiesTable({
+    entityTypeName,
+    entities,
+    attributeDefinitions,
+    onDuplicate,
+}: EntitiesTableProps) {
+    const { filter } = useFilter();
+    const normalized = filter.toLowerCase();
+    const filteredEntities = entities.filter((entity) =>
+        entityDisplayName(entity).toLowerCase().includes(normalized),
+    );
 
     return (
         <Table>
@@ -31,76 +64,90 @@ export async function EntitiesTable({
                 </Table.Row>
             </Table.Header>
             <Table.Body>
-                {!entities.length && (
+                {!filteredEntities.length && (
                     <Table.Row>
                         <Table.Cell colSpan={4}>
                             <NoDataPlaceholder />
                         </Table.Cell>
                     </Table.Row>
                 )}
-                {entities.map((entity) => {
-                    return (
-                        <Table.Row key={entity.id} className="group">
-                            <Table.Cell>
-                                <Link
-                                    href={KnownPages.DirectoryEntity(
-                                        entityTypeName,
-                                        entity.id,
-                                    )}
-                                >
-                                    <Typography>
-                                        {entityDisplayName(entity)}
-                                    </Typography>
-                                </Link>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <div className="w-24">
-                                    <EntityAttributeProgress
-                                        entityTypeName={entityTypeName}
-                                        entity={entity}
-                                    />
-                                </div>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <div className="flex">
-                                    <Chip
-                                        color={
-                                            entity.state === 'draft'
-                                                ? 'neutral'
-                                                : 'success'
-                                        }
-                                    >
-                                        {entity.state === 'draft'
-                                            ? 'U izradi'
-                                            : 'Objavljeno'}
-                                    </Chip>
-                                </div>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <Typography secondary>
-                                    <LocalDateTime time={false}>
-                                        {entity.updatedAt}
-                                    </LocalDateTime>
+                {filteredEntities.map((entity) => (
+                    <Table.Row key={entity.id} className="group">
+                        <Table.Cell>
+                            <Link
+                                href={KnownPages.DirectoryEntity(
+                                    entityTypeName,
+                                    entity.id,
+                                )}
+                            >
+                                <Typography>
+                                    {entityDisplayName(entity)}
                                 </Typography>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <ServerActionIconButton
-                                    variant="plain"
-                                    title="Dupliciraj zapis"
-                                    className="group-hover:opacity-100 opacity-0 transition-opacity"
-                                    onClick={duplicateEntity.bind(
-                                        null,
-                                        entityTypeName,
-                                        entity.id,
-                                    )}
+                            </Link>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <div className="w-24">
+                                <EntityAttributeProgress
+                                    entity={entity}
+                                    definitions={attributeDefinitions}
+                                />
+                            </div>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <div className="flex">
+                                <Chip
+                                    color={
+                                        entity.state === 'draft'
+                                            ? 'neutral'
+                                            : 'success'
+                                    }
                                 >
-                                    <Duplicate className="size-5" />
-                                </ServerActionIconButton>
-                            </Table.Cell>
-                        </Table.Row>
-                    );
-                })}
+                                    {entity.state === 'draft'
+                                        ? 'U izradi'
+                                        : 'Objavljeno'}
+                                </Chip>
+                            </div>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <Typography secondary>
+                                <LocalDateTime time={false}>
+                                    {entity.updatedAt}
+                                </LocalDateTime>
+                            </Typography>
+                        </Table.Cell>
+                        <Table.Cell>
+                            <ServerActionIconButton
+                                variant="plain"
+                                title="Dupliciraj zapis"
+                                className="group-hover:opacity-100 opacity-0 transition-opacity"
+                                onClick={onDuplicate.bind(null, entity.id)}
+                            >
+                                <Duplicate className="size-5" />
+                            </ServerActionIconButton>
+                        </Table.Cell>
+                    </Table.Row>
+                ))}
             </Table.Body>
         </Table>
     );
+}
+
+function entityDisplayName(entity: Entity) {
+    return (
+        entityAttributeValue(entity, 'information', 'label') ??
+        entityAttributeValue(entity, 'information', 'name') ??
+        `${entity.entityType.label} ${entity.id}`
+    );
+}
+
+function entityAttributeValue(
+    entity: Entity,
+    categoryName: string,
+    attributeName: string,
+) {
+    return entity.attributes.find(
+        (a) =>
+            a.attributeDefinition.category === categoryName &&
+            a.attributeDefinition.name === attributeName,
+    )?.value;
 }


### PR DESCRIPTION
## Summary
- add reusable client-side search input and filtering context
- refactor entities table to client component and use filter context
- wire up filter provider and search on entities page

## Testing
- `pnpm lint --filter app`
- `pnpm test --filter app` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1893934c4832f8cc601f362ed66c4