### PR TITLE
feat(ui): add Tailwind deps and improve ImageViewer interactions

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,10 @@
         "@types/node": "22.18.0",
         "@types/react": "19.1.12",
         "@types/react-dom": "19.1.12",
+        "@signalco/ui-themes-minimal": "0.1.3",
+        "@tailwindcss/typography": "0.5.16",
+        "tailwindcss": "3.4.17",
+        "tailwindcss-animate": "1.0.7",
         "typescript": "5.9.2"
     },
     "dependencies": {
@@ -27,6 +31,10 @@
     "peerDependencies": {
         "next": "15.x",
         "react": "19.x",
-        "react-dom": "19.x"
+        "react-dom": "19.x",
+        "tailwindcss": "3.x",
+        "tailwindcss-animate": "1.x",
+        "@tailwindcss/typography": "0.x",
+        "@signalco/ui-primitives": "0.x"
     }
 }

--- a/packages/ui/postcss.config.js
+++ b/packages/ui/postcss.config.js
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+    plugins: {
+        tailwindcss: {},
+    },
+};
+
+export default config;

--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { Add, Close, Remove, Save, Search } from '@signalco/ui-icons';
-import { Button } from '@signalco/ui-primitives/Button';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Modal } from '@signalco/ui-primitives/Modal';
 import Image from 'next/image';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useRef, useState } from 'react';
 
 interface ImageViewerProps {
     src: string;
@@ -21,22 +22,24 @@ export function ImageViewer({
     previewHeight = 200,
 }: ImageViewerProps) {
     const [isExpanded, setIsExpanded] = useState(false);
-    const [mounted, setMounted] = useState(false);
     const [zoomLevel, setZoomLevel] = useState(1);
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [isDragging, setIsDragging] = useState(false);
     const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
     const imageRef = useRef<HTMLDivElement>(null);
 
-    const handleZoomIn = () => {
+    const handleZoomIn = (e?: React.MouseEvent) => {
+        e?.stopPropagation();
         setZoomLevel((prev) => Math.min(prev + 0.5, 5));
     };
 
-    const handleZoomOut = () => {
+    const handleZoomOut = (e?: React.MouseEvent) => {
+        e?.stopPropagation();
         setZoomLevel((prev) => Math.max(prev - 0.5, 0.5));
     };
 
-    const handleDownload = async () => {
+    const handleDownload = async (e?: React.MouseEvent) => {
+        e?.stopPropagation();
         try {
             const response = await fetch(src);
             const blob = await response.blob();
@@ -53,22 +56,26 @@ export function ImageViewer({
         }
     };
 
+    const closeExpanded = (e?: React.MouseEvent | React.KeyboardEvent) => {
+        e?.stopPropagation();
+        setIsExpanded(false);
+        // Reset zoom and position when closing
+        setZoomLevel(1);
+        setPosition({ x: 0, y: 0 });
+    };
+
     const handleMouseDown = (e: React.MouseEvent) => {
-        if (zoomLevel > 1) {
-            e.preventDefault();
-            e.stopPropagation();
-            setIsDragging(true);
-            setDragStart({
-                x: e.clientX - position.x,
-                y: e.clientY - position.y,
-            });
-        }
+        e.stopPropagation();
+        setIsDragging(true);
+        setDragStart({
+            x: e.clientX - position.x,
+            y: e.clientY - position.y,
+        });
     };
 
     const handleMouseMove = (e: React.MouseEvent) => {
-        if (isDragging && zoomLevel > 1) {
-            e.preventDefault();
-            e.stopPropagation();
+        e.stopPropagation();
+        if (isDragging) {
             setPosition({
                 x: e.clientX - dragStart.x,
                 y: e.clientY - dragStart.y,
@@ -77,209 +84,188 @@ export function ImageViewer({
     };
 
     const handleMouseUp = (e: React.MouseEvent) => {
-        e.preventDefault();
         e.stopPropagation();
         setIsDragging(false);
     };
 
-    const handleTouchStart = (e: React.TouchEvent) => {
-        e.preventDefault();
+    const handleClick = (e: React.MouseEvent) => {
         e.stopPropagation();
-        if (zoomLevel > 1 && e.touches.length === 1) {
+        // Additional click handling if needed
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        e.stopPropagation();
+        // Key handling for image container
+    };
+
+    const handleTouchStart = (e: React.TouchEvent) => {
+        e.stopPropagation();
+        if (e.touches.length === 1) {
             setIsDragging(true);
             setDragStart({
-                x: (e.touches[0]?.clientX ?? 0) - position.x,
-                y: (e.touches[0]?.clientY ?? 0) - position.y,
+                x: e.touches[0].clientX - position.x,
+                y: e.touches[0].clientY - position.y,
             });
         }
     };
 
     const handleTouchMove = (e: React.TouchEvent) => {
-        e.preventDefault();
         e.stopPropagation();
-        if (isDragging && zoomLevel > 1 && e.touches.length === 1) {
+        if (isDragging && e.touches.length === 1) {
             setPosition({
-                x: (e.touches[0]?.clientX ?? 0) - dragStart.x,
-                y: (e.touches[0]?.clientY ?? 0) - dragStart.y,
+                x: e.touches[0].clientX - dragStart.x,
+                y: e.touches[0].clientY - dragStart.y,
             });
         }
     };
 
     const handleTouchEnd = (e: React.TouchEvent) => {
-        e.preventDefault();
         e.stopPropagation();
         setIsDragging(false);
     };
 
-    const resetZoom = () => {
-        setZoomLevel(1);
-        setPosition({ x: 0, y: 0 });
-    };
-
-    const closeExpanded = () => {
-        setIsExpanded(false);
-        resetZoom();
-    };
-
-    // Handle wheel zoom
     const handleWheel = (e: React.WheelEvent) => {
-        e.preventDefault();
         e.stopPropagation();
         const delta = e.deltaY > 0 ? -0.2 : 0.2;
-        setZoomLevel((prev) => Math.max(0.5, Math.min(5, prev + delta)));
+        setZoomLevel((prev) => Math.min(Math.max(prev + delta, 0.5), 5));
     };
 
-    // Reset position when zoom changes
-    useEffect(() => {
-        if (zoomLevel === 1) {
+    const handleModalOpenChange = (open: boolean) => {
+        setIsExpanded(open);
+        if (!open) {
+            // Reset zoom and position when closing
+            setZoomLevel(1);
             setPosition({ x: 0, y: 0 });
         }
-    }, [zoomLevel]);
-
-    useEffect(() => {
-        setMounted(true);
-        return () => setMounted(false);
-    }, []);
-
-    // Prevent body scroll when modal is open
-    useEffect(() => {
-        if (isExpanded) {
-            document.body.style.overflow = 'hidden';
-        } else {
-            document.body.style.overflow = 'unset';
-        }
-        return () => {
-            document.body.style.overflow = 'unset';
-        };
-    }, [isExpanded]);
+    };
 
     return (
         <>
             {/* Preview Image */}
-            <div className="relative inline-block group cursor-pointer">
-                <div className="relative overflow-hidden rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200">
-                    <Image
-                        src={src || '/placeholder.svg'}
-                        alt={alt}
-                        width={previewWidth}
-                        height={previewHeight}
-                        className="object-cover w-full h-full"
-                        style={{
-                            width: previewWidth,
-                            height: previewHeight,
-                        }}
-                    />
-                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-200" />
-                </div>
+            <button
+                type="button"
+                title="Otvori u punoj veličini"
+                className="group relative overflow-hidden rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200"
+                onClick={() => setIsExpanded(true)}
+            >
+                <Image
+                    src={src}
+                    alt={alt}
+                    width={previewWidth}
+                    height={previewHeight}
+                    className="object-cover rounded-lg shadow-sm shrink-0"
+                />
+                <div className="absolute inset-0 bg-white/30 opacity-0 group-hover:opacity-50 transition-opacity"></div>
+                <Search className="size-4 shrink-0 absolute bottom-1 right-1" />
+            </button>
 
-                {/* Magnifier Icon */}
-                <Button
-                    size="sm"
-                    variant="solid"
-                    className="absolute bottom-2 right-2 h-8 w-8 p-0 opacity-80 hover:opacity-100 transition-opacity duration-200"
-                    onClick={() => setIsExpanded(true)}
-                >
-                    <Search className="h-4 w-4" />
-                </Button>
-            </div>
-
-            {/* Expanded Modal */}
-            {mounted &&
-                isExpanded &&
-                createPortal(
-                    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur flex items-center justify-center p-4">
-                        {/* Controls */}
-                        <div className="absolute top-4 right-4 flex gap-2 z-10">
-                            <Button
-                                size="sm"
-                                variant="solid"
-                                onClick={handleZoomOut}
-                                disabled={zoomLevel <= 0.5}
-                            >
-                                <Remove className="h-4 w-4" />
-                            </Button>
-                            <Button
-                                size="sm"
-                                variant="solid"
-                                onClick={handleZoomIn}
-                                disabled={zoomLevel >= 5}
-                            >
-                                <Add className="h-4 w-4" />
-                            </Button>
-                            <Button
-                                size="sm"
-                                variant="solid"
-                                onClick={handleDownload}
-                            >
-                                <Save className="h-4 w-4" />
-                            </Button>
-                            <Button
-                                size="sm"
-                                variant="solid"
-                                onClick={closeExpanded}
-                            >
-                                <Close className="h-4 w-4" />
-                            </Button>
-                        </div>
-
-                        {/* Image Container */}
-                        <div
-                            ref={imageRef}
-                            role="option"
-                            tabIndex={0}
-                            className="relative max-w-full max-h-full overflow-hidden cursor-grab active:cursor-grabbing"
-                            onMouseDown={handleMouseDown}
-                            onMouseMove={handleMouseMove}
-                            onMouseUp={handleMouseUp}
-                            onMouseLeave={handleMouseUp}
-                            onTouchStart={handleTouchStart}
-                            onTouchMove={handleTouchMove}
-                            onTouchEnd={handleTouchEnd}
-                            onWheel={handleWheel}
+            {/* Modal for expanded view */}
+            <Modal
+                open={isExpanded}
+                onOpenChange={handleModalOpenChange}
+                title="Pregled slike"
+                hideClose
+                dismissible={false}
+                className="p-0 m-0 max-w-none max-h-none w-screen h-screen border-0"
+            >
+                <div className="relative w-full h-full flex items-center justify-center">
+                    {/* Controls */}
+                    <div className="absolute top-4 right-4 flex gap-2 z-10">
+                        <IconButton
+                            title="Smanji"
+                            variant="solid"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleZoomOut(e);
+                            }}
+                            disabled={zoomLevel <= 0.5}
                         >
-                            <div
-                                className="transition-transform duration-200 ease-out"
-                                style={{
-                                    transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${position.y / zoomLevel}px)`,
-                                    transformOrigin: 'center center',
-                                }}
-                            >
-                                <Image
-                                    src={src}
-                                    alt={alt}
-                                    width={800}
-                                    height={600}
-                                    className="max-w-[90vw] max-h-[90vh] object-contain select-none pointer-events-none"
-                                    draggable={false}
-                                />
-                            </div>
-                        </div>
+                            <Remove className="size-4 shrink-0" />
+                        </IconButton>
+                        <IconButton
+                            title="Uvećaj"
+                            variant="solid"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleZoomIn(e);
+                            }}
+                            disabled={zoomLevel >= 5}
+                        >
+                            <Add className="size-4 shrink-0" />
+                        </IconButton>
+                        <IconButton
+                            title="Preuzmi"
+                            variant="solid"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleDownload(e);
+                            }}
+                        >
+                            <Save className="size-4 shrink-0" />
+                        </IconButton>
+                        <IconButton
+                            title="Zatvori"
+                            variant="solid"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                closeExpanded(e);
+                            }}
+                        >
+                            <Close className="size-4 shrink-0" />
+                        </IconButton>
+                    </div>
 
-                        {/* Zoom Level Indicator */}
-                        <div className="absolute top-4 left-4 bg-black/80 backdrop-blur text-white px-3 py-1 rounded-full text-sm">
-                            {Math.round(zoomLevel * 100)}%
+                    {/* Image Container */}
+                    <div
+                        ref={imageRef}
+                        role="option"
+                        tabIndex={0}
+                        className="relative max-w-full max-h-full overflow-hidden cursor-grab active:cursor-grabbing"
+                        onMouseDown={handleMouseDown}
+                        onMouseMove={handleMouseMove}
+                        onMouseUp={handleMouseUp}
+                        onMouseLeave={handleMouseUp}
+                        onClick={handleClick}
+                        onKeyDown={handleKeyDown}
+                        onTouchStart={handleTouchStart}
+                        onTouchMove={handleTouchMove}
+                        onTouchEnd={handleTouchEnd}
+                        onWheel={handleWheel}
+                    >
+                        <div
+                            className="transition-transform duration-200 ease-out select-none pointer-events-none"
+                            style={{
+                                transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${position.y / zoomLevel}px)`,
+                                transformOrigin: 'center center',
+                            }}
+                        >
+                            <Image
+                                src={src}
+                                alt={alt}
+                                width={800}
+                                height={600}
+                                className="max-w-[90vw] max-h-[90vh] object-contain select-none pointer-events-none"
+                                draggable={false}
+                            />
                         </div>
+                    </div>
 
-                        {/* Instructions */}
-                        <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-white/70 text-sm text-center">
-                            <p className="hidden sm:block">
-                                Koristi kotač za zoom • Povuci za pomicanje
-                                slike
-                            </p>
-                            <p className="sm:hidden">
-                                Dodirni i drži za pomicanje • Uštipni za zoom
-                            </p>
-                        </div>
+                    {/* Zoom Level Indicator */}
+                    <Chip className="absolute top-4 left-4" variant="solid">
+                        {Math.round(zoomLevel * 100)}%
+                    </Chip>
 
-                        {/* Background Click to Close */}
-                        <button
-                            type="button"
-                            className="absolute inset-0 -z-10"
-                            onClick={closeExpanded}
-                        />
-                    </div>,
-                    document.body,
-                )}
+                    {/* Instructions */}
+                    <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-white/70 text-sm text-center">
+                        <p className="hidden sm:block">
+                            Koristi kotač za zoom • Povuci za pomicanje slike
+                        </p>
+                        <p className="sm:hidden">
+                            Dodirni i drži za pomicanje • Uštipni za zoom
+                        </p>
+                    </div>
+                </div>
+            </Modal>
         </>
     );
 }

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,0 +1,11 @@
+import { config } from '@signalco/ui-themes-minimal/config';
+import tailwindcssTypography from '@tailwindcss/typography';
+import type { Config } from 'tailwindcss';
+import tailwindcssAnimate from 'tailwindcss-animate';
+
+const tailwindConfig: Config = {
+    content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+    presets: [config],
+    plugins: [tailwindcssAnimate, tailwindcssTypography],
+};
+export default tailwindConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1033,6 +1033,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.2
         version: 2.2.2
+      '@signalco/ui-themes-minimal':
+        specifier: 0.1.3
+        version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
+      '@tailwindcss/typography':
+        specifier: 0.5.16
+        version: 0.5.16(tailwindcss@3.4.17)
       '@types/node':
         specifier: 22.18.0
         version: 22.18.0
@@ -1042,6 +1048,12 @@ importers:
       '@types/react-dom':
         specifier: 19.1.9
         version: 19.1.9(@types/react@19.1.12)
+      tailwindcss:
+        specifier: 3.4.17
+        version: 3.4.17
+      tailwindcss-animate:
+        specifier: 1.0.7
+        version: 1.0.7(tailwindcss@3.4.17)
       typescript:
         specifier: 5.9.2
         version: 5.9.2


### PR DESCRIPTION
Add Tailwind and related UI theme packages to the workspace and the
ui package to enable typography and animations in UI components.
- pnpm-lock.yaml: add @signalco/ui-themes-minimal, @tailwindcss/typography,
  tailwindcss, tailwindcss-animate versions.
- packages/ui/package.json: add devDependencies and peerDependencies for
  tailwindcss, tailwindcss-animate, @tailwindcss/typography and
  @signalco/ui-primitives.

Refactor ImageViewer to use primitives, stop propagation on controls,
and improve interaction handling.
- Replace direct Button import with Chip, IconButton and Modal from
  @signalco/ui-primitives.
- Simplify hooks, remove unused mounted state.
- Make zoom, download and close handlers accept events and call
  e.stopPropagation() to prevent event bubbling when interacting with
  the viewer.
- Reset zoom and position when closing expanded view.
- Always start drag on mouse down and handle dragging on mouse move,
  removing zoom gating so panning is consistent.
- Add click and keydown handlers that stop propagation and leave
  placeholders for future behavior.
- Prepare touch handler (incomplete in diff) for consistent touch UX.

These changes enable Tailwind-based styling/features and make the image
viewer interactions more predictable in nested UI contexts.