### PR TITLE
fix(viewer): use viewport units for full-screen image modal

### DIFF
--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -166,7 +166,7 @@ export function ImageViewer({
                 title="Pregled slike"
                 hideClose
                 dismissible={false}
-                className="p-0 m-0 max-w-none max-h-none w-screen h-screen border-0"
+                className="p-0 m-0 max-w-none max-h-none w-[100dvw] h-[100dvh] border-0"
             >
                 <div className="relative w-full h-full flex items-center justify-center">
                     {/* Controls */}


### PR DESCRIPTION
- Replace w-screen/h-screen with explicit 100dvw/100dvh for the image viewer overlay
- Update className to use 100dvw/100dvh to avoid clipping and ensure full-screen coverage across mobile and browser UI variations