### PR TITLE
fix(ui): show positive sunflower count in cart HUD

### DIFF
--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -161,7 +161,7 @@ export function ShoppingCart() {
                                 {(cart?.totalSunflowers ?? 0) > 0 && (
                                     <Typography level="body1" bold>
                                         {(cart?.totalSunflowers ?? 0) > 0
-                                            ? `-${cart?.totalSunflowers ?? 0}`
+                                            ? `${cart?.totalSunflowers ?? 0}`
                                             : '0'}{' '}
                                         <span className={'text-lg'}>🌻</span>
                                     </Typography>


### PR DESCRIPTION
Update ShoppingCartHud to display the total sunflower as a
positive number instead ofacing it with a minus sign. The
conditional rendering already hides zero counts, so remove the
unintended negative formatting to accurately represent the user's
sunflower balance within the HUD.