### PR TITLE
feat(hud conditionally show welcome on logged-in user

### DIFF
--- a/packages/game/src/hud/WelcomeMessage.tsx
+++ b/packages/game/src/hud/WelcomeMessage.tsx
@@ -7,6 +7,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Image from 'next/image';
 import { useMemo, useState } from 'react';
+import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useGameAudio } from '../hooks/useGameAudio';
 import { useGameState } from '../useGameState';
 
@@ -40,7 +41,10 @@ const messageTypes = {
 };
 
 export function WelcomeMessage() {
+    const { data: currentUser } = useCurrentUser();
     const show = useMemo(() => {
+        if (!currentUser) return false;
+
         let showWelcomeMessage = false;
         const now = new Date();
 
@@ -69,7 +73,7 @@ export function WelcomeMessage() {
         }
 
         return showWelcomeMessage;
-    }, []);
+    }, [currentUser]);
 
     const [open, setOpen] = useState(show);
     const { resumeIfNeeded } = useGameAudio();


### PR DESCRIPTION
Include current user in welcome visibility logic and hook dependencies

- Import and use useCurrentUser to determine whether a welcome message
  should be shown.
- Prevent welcome message from appearing for unauthenticated visitors
  by returning false when currentUser is absent.
- Add currentUser to the useMemo dependency array so visibility updates
  when authentication state changes.
- Keep initial open state driven by computed show value.

This fixes a bug where the welcome UI could display for anonymous
users or fail to update when the user logs in or out.