### PR TITLE
fix(schedule): "Danas" when scheduledDate is missing

### DIFF
--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -344,18 +344,20 @@ export function ScheduleDay({
                                                 justifyContent="space-between"
                                                 className="grow"
                                             >
-                                                {op.scheduledDate && (
-                                                    <Typography
-                                                        level="body2"
-                                                        className="select-none"
-                                                    >
+                                                <Typography
+                                                    level="body2"
+                                                    className="select-none"
+                                                >
+                                                    {op.scheduledDate ? (
                                                         <LocalDateTime
                                                             time={false}
                                                         >
                                                             {op.scheduledDate}
                                                         </LocalDateTime>
-                                                    </Typography>
-                                                )}
+                                                    ) : (
+                                                        <span>Danas</span>
+                                                    )}
+                                                </Typography>
                                                 <Row>
                                                     <RescheduleOperationModal
                                                         operation={{


### PR DESCRIPTION
Replace a conditional wrapper around LocalDateTime with an inline
ternary so the Typography element always renders. When op.scheduledDate
is present, render LocalDateTime inside Typography; otherwise render a
Typography containing the placeholder text "Danas".

This simplifies the JSX structure, avoids conditional omission of the
Typography node, and ensures consistent layout and spacing for schedule
rows when the date is absent.