### PR TITLE
feat(ui): add emoji to delivery mode labels

### DIFF
--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsTable.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsTable.tsx
@@ -56,9 +56,9 @@ export async function DeliveryRequestsTable() {
     function getModeLabel(mode: string) {
         switch (mode) {
             case 'delivery':
-                return 'Dostava';
+                return '🛻 Dostava';
             case 'pickup':
-                return 'Preuzimanje';
+                return '🚶 Preuzimanje';
             default:
                 return mode || '-';
         }


### PR DESCRIPTION
Update DeliveryRequestsTable to prepend emojis to the delivery
mode labels so that "delivery" shows a truck emoji and "pickup"
shows a walking person emoji. This improves the visual
scannability of request rows and makes mode types easier to
distinguish at a glance.

Keep fallback behavior unchanged for unknown or empty modes.