### PR TITLE
Sort delivery requests by upcoming time slot

### DIFF
--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsTable.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsTable.tsx
@@ -14,7 +14,7 @@ export async function DeliveryRequestsTable() {
     ]);
 
     const now = new Date();
-    deliveryRequests.sort((a, b) => {
+    const sortedDeliveryRequests = deliveryRequests.toSorted((a, b) => {
         const aSlot = a.slot?.startAt;
         const bSlot = b.slot?.startAt;
 
@@ -100,7 +100,7 @@ export async function DeliveryRequestsTable() {
                 </Table.Row>
             </Table.Header>
             <Table.Body>
-                {deliveryRequests.length === 0 && (
+                {sortedDeliveryRequests.length === 0 && (
                     <Table.Row>
                         <Table.Cell colSpan={7}>
                             <NoDataPlaceholder>
@@ -109,7 +109,7 @@ export async function DeliveryRequestsTable() {
                         </Table.Cell>
                     </Table.Row>
                 )}
-                {deliveryRequests.map((request) => {
+                {sortedDeliveryRequests.map((request) => {
                     const { slot, address, location } = request;
                     const addressString = address
                         ? [

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsTable.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsTable.tsx
@@ -13,6 +13,28 @@ export async function DeliveryRequestsTable() {
         getAllTimeSlots(),
     ]);
 
+    const now = new Date();
+    deliveryRequests.sort((a, b) => {
+        const aSlot = a.slot?.startAt;
+        const bSlot = b.slot?.startAt;
+
+        if (!aSlot && !bSlot) return 0;
+        if (!aSlot) return 1;
+        if (!bSlot) return -1;
+
+        const aFuture = aSlot >= now;
+        const bFuture = bSlot >= now;
+
+        if (aFuture && !bFuture) return -1;
+        if (!aFuture && bFuture) return 1;
+
+        if (aFuture && bFuture) {
+            return aSlot.getTime() - bSlot.getTime();
+        }
+
+        return bSlot.getTime() - aSlot.getTime();
+    });
+
     function getStatusColor(
         status: string,
     ): 'primary' | 'warning' | 'info' | 'success' | 'neutral' | 'error' {


### PR DESCRIPTION
## Summary
- sort admin delivery requests so upcoming time slots appear first and past ones last

## Testing
- `pnpm --filter app lint`
- `pnpm --filter app test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4406f5e48832f8692846b3a7935c7