### PR TITLE
feat(app): filter archived delivery slots

### DIFF
--- a/apps/app/app/admin/delivery/slots/TimeSlotsFilters.tsx
+++ b/apps/app/app/admin/delivery/slots/TimeSlotsFilters.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export function TimeSlotsFilters() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const status = searchParams.get('status') || 'active';
+
+    const handleChange = (value: string) => {
+        const params = new URLSearchParams(searchParams.toString());
+        if (value === 'active') {
+            params.delete('status');
+        } else {
+            params.set('status', value);
+        }
+        const query = params.toString();
+        router.push(`/admin/delivery/slots${query ? `?${query}` : ''}`);
+    };
+
+    return (
+        <SelectItems
+            variant="outlined"
+            placeholder="Filtriraj po statusu"
+            value={status}
+            onValueChange={handleChange}
+            items={[
+                { value: 'active', label: 'Aktivni' },
+                { value: 'all', label: 'Svi' },
+            ]}
+        />
+    );
+}

--- a/apps/app/app/admin/delivery/slots/TimeSlotsTable.tsx
+++ b/apps/app/app/admin/delivery/slots/TimeSlotsTable.tsx
@@ -1,4 +1,8 @@
-import { getAllTimeSlots, getPickupLocations } from '@gredice/storage';
+import {
+    getAllTimeSlots,
+    getPickupLocations,
+    TimeSlotStatuses,
+} from '@gredice/storage';
 import { TimeRange } from '@gredice/ui/LocalDateTime';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Table } from '@signalco/ui-primitives/Table';
@@ -6,11 +10,22 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { SlotActionButtons } from './SlotActionButtons';
 
-export async function TimeSlotsTable() {
+export async function TimeSlotsTable({
+    status = 'active',
+}: {
+    status?: 'active' | 'all';
+}) {
     const [timeSlots, pickupLocations] = await Promise.all([
         getAllTimeSlots(),
         getPickupLocations(),
     ]);
+
+    const filteredSlots =
+        status === 'all'
+            ? timeSlots
+            : timeSlots.filter(
+                  (slot) => slot.status !== TimeSlotStatuses.ARCHIVED,
+              );
 
     function getStatusColor(status: string) {
         switch (status) {
@@ -61,7 +76,7 @@ export async function TimeSlotsTable() {
                 </Table.Row>
             </Table.Header>
             <Table.Body>
-                {timeSlots.length === 0 && (
+                {filteredSlots.length === 0 && (
                     <Table.Row>
                         <Table.Cell colSpan={5}>
                             <NoDataPlaceholder>
@@ -70,7 +85,7 @@ export async function TimeSlotsTable() {
                         </Table.Cell>
                     </Table.Row>
                 )}
-                {timeSlots.map((slot) => {
+                {filteredSlots.map((slot) => {
                     const location = pickupLocations.find(
                         (loc) => loc.id === slot.locationId,
                     );

--- a/apps/app/app/admin/delivery/slots/page.tsx
+++ b/apps/app/app/admin/delivery/slots/page.tsx
@@ -8,14 +8,20 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { auth } from '../../../../lib/auth/auth';
 import { BulkGenerateModal } from './BulkGenerateModal';
 import { CreateTimeSlotModal } from './CreateTimeSlotModal';
+import { TimeSlotsFilters } from './TimeSlotsFilters';
 import { TimeSlotsTable } from './TimeSlotsTable';
 
 export const dynamic = 'force-dynamic';
 
-export default async function AdminTimeSlotsPage() {
+export default async function AdminTimeSlotsPage({
+    searchParams,
+}: {
+    searchParams: { [key: string]: string | string[] | undefined };
+}) {
     await auth(['admin']);
 
     const pickupLocations = await getPickupLocations();
+    const statusParam = searchParams.status === 'all' ? 'all' : 'active';
 
     return (
         <Stack spacing={4}>
@@ -49,9 +55,11 @@ export default async function AdminTimeSlotsPage() {
                 </Row>
             </Row>
 
+            <TimeSlotsFilters />
+
             <Card>
                 <CardOverflow>
-                    <TimeSlotsTable />
+                    <TimeSlotsTable status={statusParam} />
                 </CardOverflow>
             </Card>
         </Stack>


### PR DESCRIPTION
## Summary
- hide archived delivery slots by default
- add status filter to show active or all slots

## Testing
- `pnpm --filter app lint`
- `pnpm --filter app test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b440a2d9cc832f992f855847d9aaed