### PR TITLE
feat: allow updating sensor service info

### DIFF
--- a/apps/app/app/(actions)/sensorActions.ts
+++ b/apps/app/app/(actions)/sensorActions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { updateRaisedBedSensor } from '@gredice/storage';
+import { revalidatePath } from 'next/cache';
+import { auth } from '../../lib/auth/auth';
+import { KnownPages } from '../../src/KnownPages';
+
+export async function updateSensor(
+    sensorId: number,
+    sensorSignalcoId: string | null,
+    status: string,
+) {
+    await auth(['admin']);
+
+    await updateRaisedBedSensor({
+        id: sensorId,
+        sensorSignalcoId,
+        status,
+    });
+
+    revalidatePath(KnownPages.Sensors);
+}

--- a/apps/app/app/admin/sensors/SensorServiceForm.tsx
+++ b/apps/app/app/admin/sensors/SensorServiceForm.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { SelectRaisedBedSensor } from '@gredice/storage';
+import { Input } from '@signalco/ui-primitives/Input';
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { useState } from 'react';
+import { updateSensor } from '../../(actions)/sensorActions';
+
+const statusOptions = [
+    { value: 'new', label: 'Novi' },
+    { value: 'installed', label: 'Instaliran' },
+    { value: 'active', label: 'Aktivan' },
+];
+
+export function SensorServiceForm({
+    sensor,
+}: {
+    sensor: SelectRaisedBedSensor;
+}) {
+    const [signalcoId, setSignalcoId] = useState(sensor.sensorSignalcoId ?? '');
+    const [status, setStatus] = useState(sensor.status);
+
+    const handleBlur = async () => {
+        await updateSensor(
+            sensor.id,
+            signalcoId.trim().length ? signalcoId.trim() : null,
+            status,
+        );
+    };
+
+    const handleStatusChange = async (newStatus: string) => {
+        setStatus(newStatus);
+        await updateSensor(
+            sensor.id,
+            signalcoId.trim().length ? signalcoId.trim() : null,
+            newStatus,
+        );
+    };
+
+    return (
+        <Stack spacing={1}>
+            <Input
+                label="Signalco ID"
+                value={signalcoId}
+                onChange={(e) => setSignalcoId(e.target.value)}
+                onBlur={handleBlur}
+            />
+            <SelectItems
+                value={status}
+                onValueChange={handleStatusChange}
+                items={statusOptions}
+            />
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/sensors/page.tsx
+++ b/apps/app/app/admin/sensors/page.tsx
@@ -11,6 +11,13 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { Suspense } from 'react';
+import { SensorServiceForm } from './SensorServiceForm';
+
+const statusLabels: Record<string, string> = {
+    new: 'Novi',
+    installed: 'Instaliran',
+    active: 'Aktivan',
+};
 
 async function SensorCard({ sensor }: { sensor: SelectRaisedBedSensor }) {
     const data = sensor.sensorSignalcoId
@@ -45,7 +52,9 @@ async function SensorCard({ sensor }: { sensor: SelectRaisedBedSensor }) {
                             <Typography level="h2" className="text-lg">
                                 {sensor.id}
                             </Typography>
-                            <Chip>{sensor.status}</Chip>
+                            <Chip>
+                                {statusLabels[sensor.status] ?? sensor.status}
+                            </Chip>
                         </Row>
                         <Typography level="body3">
                             {sensor.sensorSignalcoId}
@@ -81,6 +90,7 @@ async function SensorCard({ sensor }: { sensor: SelectRaisedBedSensor }) {
                             </Typography>
                         </Stack>
                     </Stack>
+                    <SensorServiceForm sensor={sensor} />
                 </Stack>
             </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- allow admins to link a sensor to a Signalco ID and change its status
- show sensor status labels in Croatian

## Testing
- `pnpm --filter app lint`
- `pnpm --filter app test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...; run `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68b43bd476b8832f82f7f6d73fd92c86