### PR TITLE
feat: add image attribute support

### DIFF
--- a/apps/app/components/shared/attributes/AttributeInput.tsx
+++ b/apps/app/components/shared/attributes/AttributeInput.tsx
@@ -16,6 +16,7 @@ import {
 import type { AttributeInputProps } from './AttributeInputProps';
 import { BarcodeInput } from './typed/BarcodeInput';
 import { BooleanInput } from './typed/BooleanInput';
+import { ImageInput } from './typed/ImageInput';
 import { JsonInput } from './typed/JsonInput';
 import { NumberInput } from './typed/NumberInput';
 import { SelectEntity } from './typed/SelectEntity';
@@ -93,6 +94,8 @@ export function AttributeInput({
         AttributeInputComponent = NumberInput;
     } else if (attributeDefinition.dataType === 'barcode') {
         AttributeInputComponent = BarcodeInput;
+    } else if (attributeDefinition.dataType === 'image') {
+        AttributeInputComponent = ImageInput;
     } else if (attributeDefinition.dataType.startsWith('json')) {
         AttributeInputComponent = JsonInput;
         // Extract schema from json|{schema} string

--- a/apps/app/components/shared/attributes/typed/ImageInput.tsx
+++ b/apps/app/components/shared/attributes/typed/ImageInput.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { ImageEditor } from '@gredice/ui/ImageEditor';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+import { uploadAttributeImage } from '../../../../app/(actions)/entityActions';
+import type { AttributeInputProps } from '../AttributeInputProps';
+
+export function ImageInput({
+    value,
+    onChange,
+    attributeDefinition,
+}: AttributeInputProps) {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [editorFile, setEditorFile] = useState<File | null>(null);
+    let imageUrl: string | null = null;
+    let urlText: string | null = null;
+
+    if (value) {
+        try {
+            const data = JSON.parse(value);
+            if (data && typeof data.url === 'string') {
+                imageUrl = data.url;
+            } else {
+                urlText = value;
+            }
+        } catch {
+            urlText = value;
+        }
+    }
+
+    const triggerFileInput = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        if (file.size > 3 * 1024 * 1024) {
+            alert(
+                'Slika je veća od 3MB. Razmotri smanjenje, ali možeš nastaviti.',
+            );
+        }
+        setEditorFile(file);
+    };
+
+    const handleSave = async (file: File) => {
+        const formData = new FormData();
+        formData.append('file', file);
+        const { url } = await uploadAttributeImage(formData);
+        await onChange(JSON.stringify({ url }));
+        setEditorFile(null);
+    };
+
+    return (
+        <Stack spacing={2}>
+            {imageUrl ? (
+                <Image
+                    src={imageUrl}
+                    alt={attributeDefinition?.label || 'attribute image'}
+                    width={200}
+                    height={200}
+                    className="object-contain"
+                />
+            ) : (
+                urlText && (
+                    <a href={urlText} className="text-blue-600 underline">
+                        {urlText}
+                    </a>
+                )
+            )}
+            <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                className="hidden"
+                onChange={handleFileChange}
+            />
+            <Button onClick={triggerFileInput}>
+                {imageUrl ? 'Zameni sliku' : 'Dodaj sliku'}
+            </Button>
+            {editorFile && (
+                <ImageEditor
+                    file={editorFile}
+                    onSave={handleSave}
+                    onCancel={() => setEditorFile(null)}
+                />
+            )}
+        </Stack>
+    );
+}

--- a/apps/app/components/shared/attributes/typed/ImageInput.tsx
+++ b/apps/app/components/shared/attributes/typed/ImageInput.tsx
@@ -38,11 +38,6 @@ export function ImageInput({
     const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (!file) return;
-        if (file.size > 3 * 1024 * 1024) {
-            alert(
-                'Slika je veća od 3MB. Razmotri smanjenje, ali možeš nastaviti.',
-            );
-        }
         setEditorFile(file);
     };
 
@@ -79,7 +74,7 @@ export function ImageInput({
                 onChange={handleFileChange}
             />
             <Button onClick={triggerFileInput}>
-                {imageUrl ? 'Zameni sliku' : 'Dodaj sliku'}
+                {imageUrl ? 'Zamijeni sliku' : 'Dodaj sliku'}
             </Button>
             {editorFile && (
                 <ImageEditor

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -15,6 +15,7 @@
         "regenerate:feature-flags": "hypertune"
     },
     "dependencies": {
+        "@aws-sdk/client-s3": "3.879.0",
         "@azure/communication-email": "1.0.0",
         "@gredice/transactional": "workspace:*",
         "@react-email/components": "0.5.1",

--- a/packages/ui/src/ImageEditor/ImageEditor.tsx
+++ b/packages/ui/src/ImageEditor/ImageEditor.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@signalco/ui-primitives/Button';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -97,16 +98,22 @@ export function ImageEditor({ file, onSave, onCancel }: ImageEditorProps) {
         setScale(Math.round((height / crop.height) * 100));
     };
 
+    function handleOpenChange(newOpen: boolean) {
+        if (!newOpen) {
+            onCancel();
+        }
+    }
+
     return (
         <Modal
             open
-            onClose={onCancel}
+            onOpenChange={handleOpenChange}
             title="Uredi sliku"
             className="md:max-w-lg"
         >
             <Stack spacing={3}>
                 <canvas ref={canvasRef} className="max-w-full" />
-                <Stack direction="row" spacing={2}>
+                <Row spacing={2}>
                     <div className="flex flex-col">
                         <span>X</span>
                         <Input
@@ -159,8 +166,8 @@ export function ImageEditor({ file, onSave, onCancel }: ImageEditorProps) {
                             }
                         />
                     </div>
-                </Stack>
-                <Stack direction="row" spacing={2}>
+                </Row>
+                <Row spacing={2}>
                     <div className="flex flex-col">
                         <span>Rotacija</span>
                         <Input
@@ -205,13 +212,13 @@ export function ImageEditor({ file, onSave, onCancel }: ImageEditorProps) {
                             }
                         />
                     </div>
-                </Stack>
-                <Stack direction="row" spacing={2} justifyContent="end">
+                </Row>
+                <Row spacing={2} justifyContent="end">
                     <Button variant="outlined" onClick={onCancel}>
                         Odustani
                     </Button>
                     <Button onClick={handleSave}>Spremi</Button>
-                </Stack>
+                </Row>
             </Stack>
         </Modal>
     );

--- a/packages/ui/src/ImageEditor/ImageEditor.tsx
+++ b/packages/ui/src/ImageEditor/ImageEditor.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface ImageEditorProps {
+    file: File;
+    onSave: (file: File) => void;
+    onCancel: () => void;
+}
+
+export function ImageEditor({ file, onSave, onCancel }: ImageEditorProps) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
+    const [crop, setCrop] = useState({ x: 0, y: 0, width: 0, height: 0 });
+    const [angle, setAngle] = useState(0);
+    const [scale, setScale] = useState(100);
+    const [outputSize, setOutputSize] = useState({ width: 0, height: 0 });
+
+    useEffect(() => {
+        const img = new Image();
+        const url = URL.createObjectURL(file);
+        img.src = url;
+        img.onload = () => {
+            setImageEl(img);
+            setCrop({ x: 0, y: 0, width: img.width, height: img.height });
+            setOutputSize({ width: img.width, height: img.height });
+        };
+        return () => URL.revokeObjectURL(url);
+    }, [file]);
+
+    const draw = useCallback(
+        (img: HTMLImageElement) => {
+            const canvas = canvasRef.current;
+            if (!canvas) return;
+            const scaleFactor = scale / 100;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) return;
+            canvas.width = Math.round(crop.width * scaleFactor);
+            canvas.height = Math.round(crop.height * scaleFactor);
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+            const tmpCanvas = document.createElement('canvas');
+            tmpCanvas.width = img.width;
+            tmpCanvas.height = img.height;
+            const tctx = tmpCanvas.getContext('2d');
+            if (!tctx) return;
+            tctx.translate(img.width / 2, img.height / 2);
+            tctx.rotate((angle * Math.PI) / 180);
+            tctx.drawImage(img, -img.width / 2, -img.height / 2);
+
+            ctx.drawImage(
+                tmpCanvas,
+                crop.x,
+                crop.y,
+                crop.width,
+                crop.height,
+                0,
+                0,
+                canvas.width,
+                canvas.height,
+            );
+        },
+        [angle, crop, scale],
+    );
+
+    useEffect(() => {
+        if (imageEl) {
+            draw(imageEl);
+            const scaleFactor = scale / 100;
+            setOutputSize({
+                width: Math.round(crop.width * scaleFactor),
+                height: Math.round(crop.height * scaleFactor),
+            });
+        }
+    }, [imageEl, draw, crop, scale]);
+
+    const handleSave = () => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        canvas.toBlob((blob) => {
+            if (blob) {
+                const edited = new File([blob], file.name, { type: file.type });
+                onSave(edited);
+            }
+        }, file.type);
+    };
+
+    const handleOutputWidthChange = (width: number) => {
+        setScale(Math.round((width / crop.width) * 100));
+    };
+
+    const handleOutputHeightChange = (height: number) => {
+        setScale(Math.round((height / crop.height) * 100));
+    };
+
+    return (
+        <Modal
+            open
+            onClose={onCancel}
+            title="Uredi sliku"
+            className="md:max-w-lg"
+        >
+            <Stack spacing={3}>
+                <canvas ref={canvasRef} className="max-w-full" />
+                <Stack direction="row" spacing={2}>
+                    <div className="flex flex-col">
+                        <span>X</span>
+                        <Input
+                            type="number"
+                            value={crop.x}
+                            onChange={(e) =>
+                                setCrop({
+                                    ...crop,
+                                    x: Number(e.target.value) || 0,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="flex flex-col">
+                        <span>Y</span>
+                        <Input
+                            type="number"
+                            value={crop.y}
+                            onChange={(e) =>
+                                setCrop({
+                                    ...crop,
+                                    y: Number(e.target.value) || 0,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="flex flex-col">
+                        <span>W</span>
+                        <Input
+                            type="number"
+                            value={crop.width}
+                            onChange={(e) =>
+                                setCrop({
+                                    ...crop,
+                                    width: Number(e.target.value) || 0,
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="flex flex-col">
+                        <span>H</span>
+                        <Input
+                            type="number"
+                            value={crop.height}
+                            onChange={(e) =>
+                                setCrop({
+                                    ...crop,
+                                    height: Number(e.target.value) || 0,
+                                })
+                            }
+                        />
+                    </div>
+                </Stack>
+                <Stack direction="row" spacing={2}>
+                    <div className="flex flex-col">
+                        <span>Rotacija</span>
+                        <Input
+                            type="number"
+                            value={angle}
+                            onChange={(e) =>
+                                setAngle(Number(e.target.value) || 0)
+                            }
+                        />
+                    </div>
+                    <div className="flex flex-col">
+                        <span>Skaliranje (%)</span>
+                        <Input
+                            type="number"
+                            value={scale}
+                            onChange={(e) =>
+                                setScale(Number(e.target.value) || 100)
+                            }
+                        />
+                    </div>
+                    <div className="flex flex-col">
+                        <span>Širina (px)</span>
+                        <Input
+                            type="number"
+                            value={outputSize.width}
+                            onChange={(e) =>
+                                handleOutputWidthChange(
+                                    Number(e.target.value) || 0,
+                                )
+                            }
+                        />
+                    </div>
+                    <div className="flex flex-col">
+                        <span>Visina (px)</span>
+                        <Input
+                            type="number"
+                            value={outputSize.height}
+                            onChange={(e) =>
+                                handleOutputHeightChange(
+                                    Number(e.target.value) || 0,
+                                )
+                            }
+                        />
+                    </div>
+                </Stack>
+                <Stack direction="row" spacing={2} justifyContent="end">
+                    <Button variant="outlined" onClick={onCancel}>
+                        Odustani
+                    </Button>
+                    <Button onClick={handleSave}>Spremi</Button>
+                </Stack>
+            </Stack>
+        </Modal>
+    );
+}

--- a/packages/ui/src/ImageEditor/index.ts
+++ b/packages/ui/src/ImageEditor/index.ts
@@ -1,0 +1,1 @@
+export { ImageEditor } from './ImageEditor';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
 
   apps/app:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: 3.879.0
+        version: 3.879.0
       '@azure/communication-email':
         specifier: 1.0.0
         version: 1.0.0


### PR DESCRIPTION
## Summary
- allow uploading and replacing images for image-type attributes
- add reusable ImageEditor component with crop, rotate, and scale
- support uploading attribute images to Cloudflare R2 via `@aws-sdk/client-s3`

## Testing
- `pnpm lint --filter app --filter @gredice/ui`
- `pnpm test --filter app` *(fails: Module not found: Can't resolve '@aws-sdk/client-s3')*

------
https://chatgpt.com/codex/tasks/task_e_68b1965718e4832faee1db9f80e5d7b5