### PR TITLE
feat: add operation acceptance workflow

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -5,6 +5,7 @@ import {
     createEvent,
     createNotification,
     createOperation,
+    acceptOperation,
     earnSunflowers,
     getEntityFormatted,
     getOperationById,
@@ -106,6 +107,22 @@ export async function rescheduleOperationAction(formData: FormData) {
     return { success: true };
 }
 
+export async function acceptOperationAction(operationId: number) {
+    await auth(['admin']);
+    const operation = await getOperationById(operationId);
+    if (!operation) {
+        throw new Error(`Operation with ID ${operationId} not found.`);
+    }
+    await acceptOperation(operationId);
+    revalidatePath(KnownPages.Schedule);
+    if (operation.accountId)
+        revalidatePath(KnownPages.Account(operation.accountId));
+    if (operation.gardenId)
+        revalidatePath(KnownPages.Garden(operation.gardenId));
+    if (operation.raisedBedId)
+        revalidatePath(KnownPages.RaisedBed(operation.raisedBedId));
+}
+
 export async function completeOperation(
     operationId: number,
     completedBy: string,
@@ -115,6 +132,9 @@ export async function completeOperation(
     const operation = await getOperationById(operationId);
     if (!operation) {
         throw new Error(`Operation with ID ${operationId} not found.`);
+    }
+    if (!operation.isAccepted) {
+        throw new Error('Operation must be accepted before completion');
     }
 
     const operationData = await getEntityFormatted<EntityStandardized>(

--- a/apps/app/app/admin/schedule/AcceptOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptOperationModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ModalConfirm } from '@signalco/ui/ModalConfirm';
+import { Check } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { acceptOperationAction } from '../../(actions)/operationActions';
+
+interface AcceptOperationModalProps {
+    operationId: number;
+    label: string;
+}
+
+export function AcceptOperationModal({ operationId, label }: AcceptOperationModalProps) {
+    const handleConfirm = async () => {
+        try {
+            await acceptOperationAction(operationId);
+        } catch (error) {
+            console.error('Error accepting operation:', error);
+        }
+    };
+
+    return (
+        <ModalConfirm
+            title="Potvrda operacije"
+            onConfirm={handleConfirm}
+            trigger={
+                <Button
+                    variant="plain"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                    title="Potvrdi operaciju"
+                >
+                    <Check className="size-4 shrink-0" />
+                </Button>
+            }
+        >
+            <Typography>
+                Jeste li sigurni da želite potvrditi operaciju: <strong>{label}</strong>?
+            </Typography>
+        </ModalConfirm>
+    );
+}
+

--- a/apps/app/app/admin/schedule/ScheduleClient.tsx
+++ b/apps/app/app/admin/schedule/ScheduleClient.tsx
@@ -48,6 +48,7 @@ type Operation = {
     completedBy?: string;
     timestamp: Date;
     createdAt: Date;
+    isAccepted: boolean;
     isDeleted: boolean;
 };
 

--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -12,6 +12,7 @@ import type { EntityStandardized } from '../../../lib/@types/EntityStandardized'
 import { KnownPages } from '../../../src/KnownPages';
 import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
 import { CancelOperationModal } from './CancelOperationModal';
+import { AcceptOperationModal } from './AcceptOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { CopyTasksButton } from './CopyTasksButton';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
@@ -54,6 +55,7 @@ type Operation = {
     completedBy?: string;
     timestamp: Date;
     createdAt: Date;
+    isAccepted: boolean;
     isDeleted: boolean;
 };
 
@@ -306,6 +308,7 @@ export function ScheduleDay({
                                 const operationData = operationsData?.find(
                                     (data) => data.id === op.entityId,
                                 );
+                                const operationLabel = `${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`;
                                 return (
                                     <div key={op.id}>
                                         <Row
@@ -313,14 +316,21 @@ export function ScheduleDay({
                                             className="hover:bg-muted"
                                         >
                                             <Row spacing={1}>
-                                                <CompleteOperationModal
-                                                    operationId={op.id}
-                                                    userId={userId}
-                                                    label={`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`}
-                                                    conditions={
-                                                        operationData?.conditions
-                                                    }
-                                                />
+                                                {op.isAccepted ? (
+                                                    <CompleteOperationModal
+                                                        operationId={op.id}
+                                                        userId={userId}
+                                                        label={operationLabel}
+                                                        conditions={
+                                                            operationData?.conditions
+                                                        }
+                                                    />
+                                                ) : (
+                                                    <AcceptOperationModal
+                                                        operationId={op.id}
+                                                        label={operationLabel}
+                                                    />
+                                                )}
                                                 <a
                                                     href={
                                                         operationData
@@ -336,9 +346,17 @@ export function ScheduleDay({
                                                     rel="noopener noreferrer"
                                                 >
                                                     <Typography>
-                                                        {`${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`}
+                                                        {operationLabel}
                                                     </Typography>
                                                 </a>
+                                                <Typography
+                                                    level="body2"
+                                                    className={`ml-1 italic ${op.isAccepted ? 'text-green-600' : 'text-muted-foreground'}`}
+                                                >
+                                                    {op.isAccepted
+                                                        ? 'Potvrđeno'
+                                                        : 'Nije potvrđeno'}
+                                                </Typography>
                                             </Row>
                                             <Row
                                                 justifyContent="space-between"

--- a/packages/storage/src/migrations/0002_add_is_accepted_to_operations.sql
+++ b/packages/storage/src/migrations/0002_add_is_accepted_to_operations.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "operations" ADD COLUMN "is_accepted" boolean NOT NULL DEFAULT false;
+CREATE INDEX "operations_is_accepted_idx" ON "operations" USING btree ("is_accepted");

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -151,6 +151,13 @@ export async function createOperation({
     return result.id;
 }
 
+export async function acceptOperation(id: number) {
+    await storage()
+        .update(operations)
+        .set({ isAccepted: true })
+        .where(eq(operations.id, id));
+}
+
 export async function deleteOperation(id: number) {
     await storage()
         .update(operations)

--- a/packages/storage/src/schema/operationsSchema.ts
+++ b/packages/storage/src/schema/operationsSchema.ts
@@ -24,6 +24,7 @@ export const operations = pgTable(
         raisedBedFieldId: integer('raised_bed_field_id'),
         timestamp: timestamp('timestamp').notNull().defaultNow(),
         createdAt: timestamp('created_at').notNull().defaultNow(),
+        isAccepted: boolean('is_accepted').notNull().default(false),
         isDeleted: boolean('is_deleted').notNull().default(false),
     },
     (table) => [
@@ -35,6 +36,7 @@ export const operations = pgTable(
         index('operations_raised_bed_field_id_idx').on(table.raisedBedFieldId),
         index('operations_timestamp_idx').on(table.timestamp),
         index('operations_is_deleted_idx').on(table.isDeleted),
+        index('operations_is_accepted_idx').on(table.isAccepted),
     ],
 );
 


### PR DESCRIPTION
## Summary
- allow operations to be marked as accepted before completion
- display acceptance state and accept button on schedule
- add migration and repo logic for new acceptance flag

## Testing
- `pnpm test` *(fails: Build error occurred: Failed to collect page data for /biljke/[alias]/sorte/[sortAlias])*

------
https://chatgpt.com/codex/tasks/task_e_68b4ccf38f10832f9e9168e48ca3e221