### PR TITLE
fix: allow vrt recycle icon

### DIFF
--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -25,6 +25,10 @@ const nextConfig: NextConfig = {
                 hostname: 'cdn.gredice.com',
             },
             {
+                protocol: 'https',
+                hostname: 'vrt.gredice.com',
+            },
+            {
                 // Garden - Vercel Blob
                 protocol: 'https',
                 hostname: 'myegtvromcktt2y7.public.blob.vercel-storage.com',


### PR DESCRIPTION
## Summary
- allow vrt.gredice.com as an image source for garden app

## Testing
- `pnpm --filter garden lint`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b833bcaec4832f88077f9d8735a9dd