### PR TITLE
Show last login provider and expose login history

### DIFF
--- a/apps/api/app/api/[...route]/authRoutes.ts
+++ b/apps/api/app/api/[...route]/authRoutes.ts
@@ -416,7 +416,6 @@ const app = new Hono()
 
             return context.json({
                 provider: login.loginType,
-                lastLogin: login.lastLogin?.toISOString() ?? null,
             });
         },
     )

--- a/apps/app/app/admin/users/[userId]/page.tsx
+++ b/apps/app/app/admin/users/[userId]/page.tsx
@@ -233,6 +233,56 @@ export default async function UserPage({
                         </Table>
                     </CardOverflow>
                 </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Prijave</CardTitle>
+                    </CardHeader>
+                    <CardOverflow>
+                        <Table>
+                            <Table.Header>
+                                <Table.Row>
+                                    <Table.Head>Vrsta</Table.Head>
+                                    <Table.Head>Zadnja prijava</Table.Head>
+                                </Table.Row>
+                            </Table.Header>
+                            <Table.Body>
+                                {logins?.usersLogins.filter((l) => l.lastLogin)
+                                    .length === 0 && (
+                                    <Table.Row>
+                                        <Table.Cell colSpan={2}>
+                                            <NoDataPlaceholder>
+                                                Nema prijava
+                                            </NoDataPlaceholder>
+                                        </Table.Cell>
+                                    </Table.Row>
+                                )}
+                                {logins?.usersLogins
+                                    .filter((l) => l.lastLogin)
+                                    .sort(
+                                        (a, b) =>
+                                            (b.lastLogin?.getTime() ?? 0) -
+                                            (a.lastLogin?.getTime() ?? 0),
+                                    )
+                                    .map((userLogin) => (
+                                        <Table.Row key={userLogin.id}>
+                                            <Table.Cell>
+                                                {userLogin.loginType}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {userLogin.lastLogin ? (
+                                                    <LocalDateTime>
+                                                        {userLogin.lastLogin}
+                                                    </LocalDateTime>
+                                                ) : (
+                                                    'Nikad'
+                                                )}
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    ))}
+                            </Table.Body>
+                        </Table>
+                    </CardOverflow>
+                </Card>
             </div>
         </Stack>
     );

--- a/apps/garden/components/auth/FacebookLoginButton.tsx
+++ b/apps/garden/components/auth/FacebookLoginButton.tsx
@@ -9,7 +9,7 @@ export function FacebookLoginButton({
         <Button
             type="button"
             variant="outlined"
-            className="bg-white dark:bg-blue-900"
+            className="bg-white dark:bg-blue-900 dark:hover:bg-blue-800"
             fullWidth
             endDecorator={
                 lastUsed && (

--- a/apps/garden/components/auth/FacebookLoginButton.tsx
+++ b/apps/garden/components/auth/FacebookLoginButton.tsx
@@ -1,12 +1,26 @@
 import { Button, type ButtonProps } from '@signalco/ui-primitives/Button';
+import { Chip } from '@signalco/ui-primitives/Chip';
 
-export function FacebookLoginButton({ ...props }: ButtonProps) {
+export function FacebookLoginButton({
+    lastUsed,
+    ...props
+}: ButtonProps & { lastUsed?: boolean }) {
     return (
         <Button
             type="button"
             variant="outlined"
             className="bg-white dark:bg-blue-900"
             fullWidth
+            endDecorator={
+                lastUsed && (
+                    <Chip
+                        className="absolute right-8 hidden sm:inline-block"
+                        size="sm"
+                    >
+                        Zadnje korišteno
+                    </Chip>
+                )
+            }
             {...props}
         >
             <svg

--- a/apps/garden/components/auth/GoogleLoginButton.tsx
+++ b/apps/garden/components/auth/GoogleLoginButton.tsx
@@ -9,7 +9,7 @@ export function GoogleLoginButton({
         <Button
             type="button"
             variant="outlined"
-            className="bg-white dark:text-black"
+            className="bg-white dark:text-black dark:hover:bg-white/80"
             fullWidth
             endDecorator={
                 lastUsed && (

--- a/apps/garden/components/auth/GoogleLoginButton.tsx
+++ b/apps/garden/components/auth/GoogleLoginButton.tsx
@@ -1,12 +1,26 @@
 import { Button, type ButtonProps } from '@signalco/ui-primitives/Button';
+import { Chip } from '@signalco/ui-primitives/Chip';
 
-export function GoogleLoginButton({ ...props }: ButtonProps) {
+export function GoogleLoginButton({
+    lastUsed,
+    ...props
+}: ButtonProps & { lastUsed?: boolean }) {
     return (
         <Button
             type="button"
             variant="outlined"
-            className="bg-white dark:bg-black"
+            className="bg-white dark:text-black"
             fullWidth
+            endDecorator={
+                lastUsed && (
+                    <Chip
+                        className="absolute right-8 hidden sm:inline-block"
+                        size="sm"
+                    >
+                        Zadnje korišteno
+                    </Chip>
+                )
+            }
             {...props}
         >
             <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -4,7 +4,6 @@ import { client } from '@gredice/client';
 import { Alert } from '@signalco/ui/Alert';
 import { Divider } from '@signalco/ui-primitives/Divider';
 import { Modal } from '@signalco/ui-primitives/Modal';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import {
     Tabs,
@@ -12,7 +11,6 @@ import {
     TabsList,
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
-import { Typography } from '@signalco/ui-primitives/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -123,31 +121,24 @@ export default function LoginModal() {
             open
             title="Prijava"
             className="bg-card border-tertiary border-b-4 rounded-lg shadow-2xl"
-            hideClose
             dismissible={false}
         >
-            <Stack spacing={2}>
-                <Row spacing={2} justifyContent="start">
+            <Tabs defaultValue="login" className="w-full">
+                <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 w-full">
                     <Image
                         src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/GrediceLogomark-v1LQ0bdzsonOf0SXkAUHj0h4G36mGB.svg"
                         alt="Gredice Logo"
-                        width={48}
-                        height={48}
+                        width={32}
+                        height={32}
                         priority
                         className="dark:mix-blend-plus-lighter"
                     />
-                    <Typography
-                        level="h3"
-                        className="text-[#2f6e40] dark:mix-blend-plus-lighter"
-                    >
-                        Prijava
-                    </Typography>
-                </Row>
-                <Tabs defaultValue="login" className="w-full">
-                    <TabsList className="grid w-full grid-cols-2 border">
+                    <TabsList className="grid w-full grid-cols-2">
                         <TabsTrigger value="login">Prijava</TabsTrigger>
                         <TabsTrigger value="register">Registracija</TabsTrigger>
                     </TabsList>
+                </div>
+                <Stack spacing={2}>
                     <TabsContent value="login" className="mt-4">
                         <div className="space-y-4 px-1">
                             <Stack spacing={2}>
@@ -167,44 +158,6 @@ export default function LoginModal() {
                                     </span>
                                 </div>
                             </div>
-                            <Stack spacing={1}>
-                                <Row
-                                    justifyContent="between"
-                                    alignItems="center"
-                                >
-                                    <FacebookLoginButton
-                                        onClick={() =>
-                                            handleOAuthLogin('facebook')
-                                        }
-                                    />
-                                    {lastLoginProvider === 'facebook' && (
-                                        <Typography
-                                            level="body3"
-                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
-                                        >
-                                            Last used
-                                        </Typography>
-                                    )}
-                                </Row>
-                                <Row
-                                    justifyContent="between"
-                                    alignItems="center"
-                                >
-                                    <GoogleLoginButton
-                                        onClick={() =>
-                                            handleOAuthLogin('google')
-                                        }
-                                    />
-                                    {lastLoginProvider === 'google' && (
-                                        <Typography
-                                            level="body3"
-                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
-                                        >
-                                            Last used
-                                        </Typography>
-                                    )}
-                                </Row>
-                            </Stack>
                         </div>
                     </TabsContent>
                     <TabsContent value="register" className="mt-4">
@@ -227,48 +180,20 @@ export default function LoginModal() {
                                     </span>
                                 </div>
                             </div>
-                            <Stack spacing={1}>
-                                <Row
-                                    justifyContent="between"
-                                    alignItems="center"
-                                >
-                                    <FacebookLoginButton
-                                        onClick={() =>
-                                            handleOAuthLogin('facebook')
-                                        }
-                                    />
-                                    {lastLoginProvider === 'facebook' && (
-                                        <Typography
-                                            level="body3"
-                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
-                                        >
-                                            Last used
-                                        </Typography>
-                                    )}
-                                </Row>
-                                <Row
-                                    justifyContent="between"
-                                    alignItems="center"
-                                >
-                                    <GoogleLoginButton
-                                        onClick={() =>
-                                            handleOAuthLogin('google')
-                                        }
-                                    />
-                                    {lastLoginProvider === 'google' && (
-                                        <Typography
-                                            level="body3"
-                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
-                                        >
-                                            Last used
-                                        </Typography>
-                                    )}
-                                </Row>
-                            </Stack>
                         </div>
                     </TabsContent>
-                </Tabs>
-            </Stack>
+                    <Stack spacing={1}>
+                        <FacebookLoginButton
+                            onClick={() => handleOAuthLogin('facebook')}
+                            lastUsed={lastLoginProvider === 'facebook'}
+                        />
+                        <GoogleLoginButton
+                            onClick={() => handleOAuthLogin('google')}
+                            lastUsed={lastLoginProvider === 'google'}
+                        />
+                    </Stack>
+                </Stack>
+            </Tabs>
         </Modal>
     );
 }

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -16,7 +16,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { EmailPasswordForm } from './EmailPasswordForm';
 import { FacebookLoginButton } from './FacebookLoginButton';
 import { GoogleLoginButton } from './GoogleLoginButton';
@@ -25,6 +25,22 @@ export default function LoginModal() {
     const router = useRouter();
     const queryClient = useQueryClient();
     const [error, setError] = useState<string>();
+    const [lastLoginProvider, setLastLoginProvider] = useState<string>();
+
+    useEffect(() => {
+        const token = localStorage.getItem('gredice-token');
+        if (!token) return;
+        client()
+            .api.auth['last-login'].$get({ query: { token } })
+            .then(async (response) => {
+                if (response.status !== 200) return;
+                const data = await response.json();
+                if (data?.provider) setLastLoginProvider(data.provider);
+            })
+            .catch(() => {
+                /* ignore */
+            });
+    }, []);
 
     const handleLogin = async (email: string, password: string) => {
         setError(undefined);
@@ -152,12 +168,42 @@ export default function LoginModal() {
                                 </div>
                             </div>
                             <Stack spacing={1}>
-                                <FacebookLoginButton
-                                    onClick={() => handleOAuthLogin('facebook')}
-                                />
-                                <GoogleLoginButton
-                                    onClick={() => handleOAuthLogin('google')}
-                                />
+                                <Row
+                                    justifyContent="between"
+                                    alignItems="center"
+                                >
+                                    <FacebookLoginButton
+                                        onClick={() =>
+                                            handleOAuthLogin('facebook')
+                                        }
+                                    />
+                                    {lastLoginProvider === 'facebook' && (
+                                        <Typography
+                                            level="body3"
+                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
+                                        >
+                                            Last used
+                                        </Typography>
+                                    )}
+                                </Row>
+                                <Row
+                                    justifyContent="between"
+                                    alignItems="center"
+                                >
+                                    <GoogleLoginButton
+                                        onClick={() =>
+                                            handleOAuthLogin('google')
+                                        }
+                                    />
+                                    {lastLoginProvider === 'google' && (
+                                        <Typography
+                                            level="body3"
+                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
+                                        >
+                                            Last used
+                                        </Typography>
+                                    )}
+                                </Row>
                             </Stack>
                         </div>
                     </TabsContent>
@@ -182,12 +228,42 @@ export default function LoginModal() {
                                 </div>
                             </div>
                             <Stack spacing={1}>
-                                <FacebookLoginButton
-                                    onClick={() => handleOAuthLogin('facebook')}
-                                />
-                                <GoogleLoginButton
-                                    onClick={() => handleOAuthLogin('google')}
-                                />
+                                <Row
+                                    justifyContent="between"
+                                    alignItems="center"
+                                >
+                                    <FacebookLoginButton
+                                        onClick={() =>
+                                            handleOAuthLogin('facebook')
+                                        }
+                                    />
+                                    {lastLoginProvider === 'facebook' && (
+                                        <Typography
+                                            level="body3"
+                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
+                                        >
+                                            Last used
+                                        </Typography>
+                                    )}
+                                </Row>
+                                <Row
+                                    justifyContent="between"
+                                    alignItems="center"
+                                >
+                                    <GoogleLoginButton
+                                        onClick={() =>
+                                            handleOAuthLogin('google')
+                                        }
+                                    />
+                                    {lastLoginProvider === 'google' && (
+                                        <Typography
+                                            level="body3"
+                                            className="px-2 py-0.5 rounded bg-muted text-muted-foreground"
+                                        >
+                                            Last used
+                                        </Typography>
+                                    )}
+                                </Row>
                             </Stack>
                         </div>
                     </TabsContent>

--- a/packages/storage/src/repositories/usersRepo.ts
+++ b/packages/storage/src/repositories/usersRepo.ts
@@ -59,6 +59,13 @@ export function getUserWithLogins(userName: string) {
     });
 }
 
+export function getLastUserLogin(userId: string) {
+    return storage().query.userLogins.findFirst({
+        where: eq(userLogins.userId, userId),
+        orderBy: desc(userLogins.lastLogin),
+    });
+}
+
 export function loginSuccessful(userLoginId: number) {
     return storage()
         .update(userLogins)


### PR DESCRIPTION
## Summary
- track last user login and expose it via `/auth/last-login`
- highlight last used provider on the garden login screen
- show recent login list on admin user details page

## Testing
- `pnpm lint --filter @gredice/api --filter garden`
- `pnpm lint --filter app`
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/api --filter @gredice/storage --filter garden --filter app` *(fails: app#test)*

------
https://chatgpt.com/codex/tasks/task_e_68b8335f963c832fa4f9e98aca474e7c