### PR TITLE
feat(api): expose raised bed validity

### DIFF
--- a/apps/api/lib/garden/raisedBedsService.ts
+++ b/apps/api/lib/garden/raisedBedsService.ts
@@ -1,0 +1,79 @@
+import type { SelectGardenStack, SelectRaisedBed } from '@gredice/storage';
+
+/**
+ * Calculates validity of raised beds based on their configuration.
+ * A valid configuration consists of exactly two adjacent raised beds
+ * placed next to each other horizontally or vertically on the same height.
+ *
+ * Returns a map of raised bed id to a boolean indicating if the configuration is valid.
+ */
+export function calculateRaisedBedsValidity(
+    raisedBeds: Pick<SelectRaisedBed, 'id' | 'blockId'>[],
+    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
+): Map<number, boolean> {
+    // Map blockId -> position and index
+    const blockPositions = new Map<string, { x: number; y: number; index: number }>();
+    for (const stack of stacks) {
+        stack.blocks.forEach((blockId, index) => {
+            blockPositions.set(blockId, {
+                x: stack.positionX,
+                y: stack.positionY,
+                index,
+            });
+        });
+    }
+
+    // Build adjacency list of raised beds
+    const adjacency = new Map<number, number[]>();
+    for (const bed of raisedBeds) {
+        adjacency.set(bed.id, []);
+    }
+
+    for (let i = 0; i < raisedBeds.length; i++) {
+        const bedA = raisedBeds[i];
+        const posA = blockPositions.get(bedA.blockId);
+        if (!posA) continue;
+        for (let j = i + 1; j < raisedBeds.length; j++) {
+            const bedB = raisedBeds[j];
+            const posB = blockPositions.get(bedB.blockId);
+            if (!posB) continue;
+            if (posA.index !== posB.index) continue;
+            const adjacent =
+                (posA.x === posB.x && Math.abs(posA.y - posB.y) === 1) ||
+                (posA.y === posB.y && Math.abs(posA.x - posB.x) === 1);
+            if (adjacent) {
+                adjacency.get(bedA.id)?.push(bedB.id);
+                adjacency.get(bedB.id)?.push(bedA.id);
+            }
+        }
+    }
+
+    // Traverse connected components and determine validity
+    const visited = new Set<number>();
+    const validity = new Map<number, boolean>();
+
+    for (const bed of raisedBeds) {
+        if (visited.has(bed.id)) continue;
+        const stack: number[] = [bed.id];
+        const component: number[] = [];
+        while (stack.length > 0) {
+            const current = stack.pop()!;
+            if (visited.has(current)) continue;
+            visited.add(current);
+            component.push(current);
+            const neighbors = adjacency.get(current) ?? [];
+            for (const neighbor of neighbors) {
+                if (!visited.has(neighbor)) {
+                    stack.push(neighbor);
+                }
+            }
+        }
+        const isValid = component.length === 2;
+        for (const id of component) {
+            validity.set(id, isValid);
+        }
+    }
+
+    return validity;
+}
+

--- a/apps/api/lib/garden/raisedBedsService.ts
+++ b/apps/api/lib/garden/raisedBedsService.ts
@@ -12,7 +12,10 @@ export function calculateRaisedBedsValidity(
     stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
 ): Map<number, boolean> {
     // Map blockId -> position and index
-    const blockPositions = new Map<string, { x: number; y: number; index: number }>();
+    const blockPositions = new Map<
+        string,
+        { x: number; y: number; index: number }
+    >();
     for (const stack of stacks) {
         stack.blocks.forEach((blockId, index) => {
             blockPositions.set(blockId, {
@@ -31,10 +34,12 @@ export function calculateRaisedBedsValidity(
 
     for (let i = 0; i < raisedBeds.length; i++) {
         const bedA = raisedBeds[i];
+        if (!bedA.blockId) continue;
         const posA = blockPositions.get(bedA.blockId);
         if (!posA) continue;
         for (let j = i + 1; j < raisedBeds.length; j++) {
             const bedB = raisedBeds[j];
+            if (!bedB.blockId) continue;
             const posB = blockPositions.get(bedB.blockId);
             if (!posB) continue;
             if (posA.index !== posB.index) continue;
@@ -57,7 +62,8 @@ export function calculateRaisedBedsValidity(
         const stack: number[] = [bed.id];
         const component: number[] = [];
         while (stack.length > 0) {
-            const current = stack.pop()!;
+            const current = stack.pop();
+            if (current === undefined) continue;
             if (visited.has(current)) continue;
             visited.add(current);
             component.push(current);
@@ -76,4 +82,3 @@ export function calculateRaisedBedsValidity(
 
     return validity;
 }
-

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -159,6 +159,7 @@ function mockGarden() {
                 status: 'new',
                 updatedAt: new Date().toISOString(),
                 createdAt: new Date().toISOString(),
+                isValid: true,
             },
             {
                 id: 2,
@@ -169,6 +170,7 @@ function mockGarden() {
                 status: 'new',
                 updatedAt: new Date().toISOString(),
                 createdAt: new Date().toISOString(),
+                isValid: true,
             },
         ],
     };

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -80,7 +80,7 @@ export function RaisedBedFieldHud(_props: {
                     />
                 )}
             </div>
-            {currentGarden && raisedBed && (
+            {currentGarden && raisedBed && raisedBed.isValid && (
                 <>
                     <div className="absolute top-[calc(50%+160px)] left-[calc(50%-156.5px)] md:left-[calc(50%+210px)] md:top-[calc(50%+74px)]">
                         <Stack spacing={0.5}>

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -91,10 +91,9 @@ export function RaisedBedField({
     gardenId: number;
     raisedBedId: number;
 }) {
-    // Check neighboring fields to determine if there is exactly one raised bed in the area next to this one
-    // if not, display a warning and illustrate the issue
-    const neighboringRaisedBeds = useNeighboringRaisedBeds(raisedBedId);
-    if (neighboringRaisedBeds?.length !== 1) {
+    const { data: garden } = useCurrentGarden();
+    const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
+    if (!raisedBed?.isValid) {
         return (
             <div className="flex flex-col mt-4 items-center h-full">
                 <Stack spacing={1}>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -22,6 +22,9 @@ export function RaisedBedFieldSuggestions({
     const setCartItem = useSetShoppingCartItem();
     if (!currentGarden || !raisedBed || !shoppingCart) return null;
 
+    // Only show suggestions if the raised bed is valid
+    if (!raisedBed.isValid) return null;
+
     // Check if there are already 9 plants in the cart or planted for this raised bed
     const cartItems = shoppingCart?.items.filter(
         (item) => item.raisedBedId === raisedBedId,

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -215,6 +215,8 @@ function SensorInfoModal({
     const currentStatus = getStatus(currentMoisture);
     const absoluteStatus = getStatus(avgMoisture);
 
+    // Determine whether the sensor is in the shopping cart
+    // If the sensor is in the cart for this raised bed or any neighboring raised bed, consider it in the cart
     const neighboringRaisedBeds = useNeighboringRaisedBeds(raisedBedId);
     const isSensorInShoppingCart = shoppingCart?.items.some(
         (item) =>


### PR DESCRIPTION
## Summary
- compute validity for connected raised beds on the API
- return `isValid` flag in raised bed DTOs
- consume server-side validity on the game client and mock data

## Testing
- `pnpm test` *(fails: garden#build exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1b2be890832f8c3241ca9043160e