### PR TITLE
chore(ci): move Node setup after pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,15 +101,15 @@ jobs:
             with:
               fetch-depth: 2
 
-          - name: ✨ Setup Node
-            uses: actions/setup-node@v5
-            with:
-              node-version: "22.19.0"
-    
           - uses: pnpm/action-setup@v3
             name: ✨ Install pnpm
             with:
               version: 10.15.1
+
+          - name: ✨ Setup Node
+            uses: actions/setup-node@v5
+            with:
+              node-version: "22.19.0"
     
           - name: ✨ Get pnpm store directory
             shell: bash

--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -31,16 +31,16 @@ jobs:
             - uses: actions/checkout@v5
               with:
                 fetch-depth: 2
-  
-            - name: ✨ Setup Node
-              uses: actions/setup-node@v5
-              with:
-                node-version: "22.19.0"
-      
+            
             - uses: pnpm/action-setup@v3
               name: ✨ Install pnpm
               with:
                 version: 10.15.1
+
+            - name: ✨ Setup Node
+              uses: actions/setup-node@v5
+              with:
+                node-version: "22.19.0"
       
             - name: ✨ Get pnpm store directory
               shell: bash


### PR DESCRIPTION
Move the actions/setup-node step to run after pnpm/action-setup in
both CI workflows. This reorders steps in .github/workflows/ci.yml
and .github/workflows/nextjs_ci_reusable.yml so pnpm is installed
before the Node version is configured.

This change simplifies the workflow ordering and ensures the pnpm
action runs prior to Node setup, keeping setup steps grouped and
consistent across reusable and repo-specific CI configs.