### PR TITLE
chore(ci): reorder node setup and pnpm install in workflow

### DIFF
--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -70,16 +70,16 @@ jobs:
             with:
               fetch-depth: 2
 
-          - name: ✨ Setup Node
-            uses: actions/setup-node@v5
-            with:
-              node-version: "22.19.0"
-    
           - uses: pnpm/action-setup@v3
             name: ✨ Install pnpm
             with:
               version: 10.15.1
-    
+
+          - name: ✨ Setup Node
+            uses: actions/setup-node@v5
+            with:
+              node-version: "22.19.0"
+        
           - name: ✨ Get pnpm store directory
             shell: bash
             run: |


### PR DESCRIPTION
Move the Node setup step to occur after pnpm setup in the reusable CI workflow.
This rearrangement fixes step ordering so pnpm/action-setup runs first,
followed by actions/setup-node, matching the intended sequence and keeping
the overall job behavior unchanged. Also normalize whitespace around the
moved block for consistent formatting.