### PR TITLE
chore(biome): bump schema version to 2.2.3

### DIFF
--- a/apps/api/biome.json
+++ b/apps/api/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/app/biome.json
+++ b/apps/app/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/farm/biome.json
+++ b/apps/farm/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/garden/biome.json
+++ b/apps/garden/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/www/biome.json
+++ b/apps/www/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/client/biome.json
+++ b/packages/client/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/game/biome.json
+++ b/packages/game/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/js/biome.json
+++ b/packages/js/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/signalco/biome.json
+++ b/packages/signalco/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/storage/biome.json
+++ b/packages/storage/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/stripe/biome.json
+++ b/packages/stripe/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
Update multiple package and app biome.json files to reference the
Biome schema 2.2.3 (previously 2.2.2). This aligns all workspaces with
the newer schema, ensuring consistent validation and tooling behavior
across the repository.