### PR TITLE
chore(game): r3f-perf and usage

### DIFF
--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cx } from '@signalco/ui-primitives/cx';
-import { Perf } from 'r3f-perf';
+// import { Perf } from 'r3f-perf';
 import type { HTMLAttributes } from 'react';
 import { Controls } from './controls/Controls';
 import { EntityFactory } from './entities/EntityFactory';
@@ -109,7 +109,7 @@ export function GameScene({
                     <EntityInstances stacks={garden?.stacks} />
                 </group>
                 {!noControls && <Controls />}
-                {!hideHud && <Perf position="bottom-right" />}
+                {/* {!hideHud && <Perf position="bottom-right" />} */}
             </Scene>
             {!hideHud && <GameHud flags={flags} />}
         </div>


### PR DESCRIPTION
Comment out the r3f-perf import and its component usage in GameScene.
This removes the performance overlay (Perf) from the rendered scene and
prevents a direct dependency on r3f-perf during runtime.

Reason: hide the HUD/perf overlay by default or avoid including the
perf tool in environments where it is unnecessary or causes issues.