### PR TITLE
chore(html): add translate="no" to root html elements

### DIFF
--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
     children: ReactNode;
 }>) {
     return (
-        <html lang="hr" suppressHydrationWarning={true}>
+        <html lang="hr" translate="no" suppressHydrationWarning={true}>
             <Head>
                 <meta name="apple-mobile-web-app-title" content="Gredice" />
                 <meta name="theme-color" content="#2e6f40" />

--- a/apps/app/playwright/index.html
+++ b/apps/app/playwright/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="hr">
+<html lang="hr" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
     children: ReactNode;
 }>) {
     return (
-        <html lang="hr">
+        <html lang="hr" translate="no">
             <Head>
                 <meta name="apple-mobile-web-app-title" content="Gredice" />
                 <meta name="theme-color" content="#2e6f40" />

--- a/apps/farm/playwright/index.html
+++ b/apps/farm/playwright/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="hr">
+<html lang="hr" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/garden/app/layout.tsx
+++ b/apps/garden/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
 
     return (
-        <html lang="hr" suppressHydrationWarning={true}>
+        <html lang="hr" translate="no" suppressHydrationWarning={true}>
             <Head>
                 <meta name="theme-color" content="#2e6f40" />
                 <meta name="apple-mobile-web-app-title" content="Gredice" />

--- a/apps/garden/playwright/index.html
+++ b/apps/garden/playwright/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="hr">
+<html lang="hr" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -65,7 +65,7 @@ export default async function RootLayout({
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
 
     return (
-        <html lang="hr">
+        <html lang="hr" translate="no">
             <Head>
                 <title>Gredice</title>
                 <meta name="apple-mobile-web-app-title" content="Gredice" />

--- a/apps/www/playwright/index.html
+++ b/apps/www/playwright/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="hr">
+<html lang="hr" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Update multiple and playwright HTML/layout files to set
translate="no" on <html> element. This prevents automated
translation tools from altering app UI strings and attributes
in the Croatian (hr) pages, preserving layout, metadata and
accessibility behavior. Apply change consistently across:
- apps/*/playwright/index.html
- apps/*/app/layout.tsx

No functional behavior is otherwise changed; hydration and
development-toolbar flags are left intact.