### PR TITLE
ci: increase lint job timeout to 10 minutes

### DIFF
--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
     lint:
-        timeout-minutes: 5
+        timeout-minutes: 10
         runs-on: ubuntu-latest
         if: github.event_name == 'pull_request'
         steps:
@@ -61,7 +61,7 @@ jobs:
             - name: 🔎 Lint app
               run: pnpm lint --filter=${{ inputs.name }}
     test:
-        timeout-minutes: 5
+        timeout-minutes: 10
         runs-on: ubuntu-latest
         needs: lint
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Increase GitHub Actions lint job timeout from 5 to 10 minutes to
reduce intermittent CI failures caused by longer linting runs. This
provides more headroom for slower runners and network-dependent steps,
improving CI reliability for pull requests.