### PR TITLE
feat(delivery): auto-select default address and improve UI

### DIFF
--- a/packages/game/src/shared-ui/delivery/DeliveryAddressesSection.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryAddressesSection.tsx
@@ -4,6 +4,7 @@ import { Add, Delete, Edit } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card, CardContent } from '@signalco/ui-primitives/Card';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Chip } from '@signalco/ui-primitives/Chip';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
@@ -203,7 +204,13 @@ function AddressForm({
     );
 }
 
-function AddressCard({ address }: { address: DeliveryAddressData }) {
+export function AddressCard({
+    address,
+    readonly,
+}: {
+    address: DeliveryAddressData;
+    readonly?: boolean;
+}) {
     const [isEditing, setIsEditing] = useState(false);
     const updateAddress = useUpdateDeliveryAddress();
     const deleteAddress = useDeleteDeliveryAddress();
@@ -244,62 +251,63 @@ function AddressCard({ address }: { address: DeliveryAddressData }) {
     }
 
     return (
-        <Card className={address.isDefault ? 'border-primary/30 border-2' : ''}>
+        <Card>
             <CardContent>
                 <Stack spacing={2}>
                     <Row justifyContent="space-between" alignItems="start">
                         <Stack spacing={1}>
-                            <Row spacing={1}>
+                            <Row spacing={2}>
                                 <Typography level="h6">
                                     {address.label}
                                 </Typography>
                                 {address.isDefault && (
-                                    <Typography
-                                        level="body3"
-                                        className="text-primary"
-                                    >
-                                        (Zadana)
-                                    </Typography>
+                                    <Chip className="text-primary">
+                                        ⭐ Zadana
+                                    </Chip>
                                 )}
                             </Row>
-                            <Typography level="body2">
-                                {address.contactName}
-                            </Typography>
-                            <Typography level="body3" secondary>
-                                {address.phone}
-                            </Typography>
-                        </Stack>
-                        <Row spacing={1}>
-                            <IconButton
-                                title="Uredi adresu"
-                                variant="outlined"
-                                size="sm"
-                                onClick={() => setIsEditing(true)}
-                            >
-                                <Edit className="size-4" />
-                            </IconButton>
-                            <ModalConfirm
-                                title="Potvrdi brisanje adrese"
-                                header="Brisanje adrese"
-                                onConfirm={handleDelete}
-                                trigger={
-                                    <IconButton
-                                        title="Obriši adresu"
-                                        variant="outlined"
-                                        size="sm"
-                                        className="text-red-600"
-                                        loading={deleteAddress.isPending}
-                                    >
-                                        <Delete className="size-4" />
-                                    </IconButton>
-                                }
-                            >
-                                <Typography>
-                                    Jeste li sigurni da želite obrisati adresu "
-                                    {address.label}"?
+                            <Stack>
+                                <Typography level="body2">
+                                    {address.contactName}
                                 </Typography>
-                            </ModalConfirm>
-                        </Row>
+                                <Typography level="body3">
+                                    {address.phone}
+                                </Typography>
+                            </Stack>
+                        </Stack>
+                        {!readonly && (
+                            <Row spacing={1}>
+                                <IconButton
+                                    title="Uredi adresu"
+                                    variant="outlined"
+                                    size="sm"
+                                    onClick={() => setIsEditing(true)}
+                                >
+                                    <Edit className="size-4" />
+                                </IconButton>
+                                <ModalConfirm
+                                    title="Potvrdi brisanje adrese"
+                                    header="Brisanje adrese"
+                                    onConfirm={handleDelete}
+                                    trigger={
+                                        <IconButton
+                                            title="Obriši adresu"
+                                            variant="outlined"
+                                            size="sm"
+                                            className="text-red-600"
+                                            loading={deleteAddress.isPending}
+                                        >
+                                            <Delete className="size-4" />
+                                        </IconButton>
+                                    }
+                                >
+                                    <Typography>
+                                        Jeste li sigurni da želite obrisati
+                                        adresu "{address.label}"?
+                                    </Typography>
+                                </ModalConfirm>
+                            </Row>
+                        )}
                     </Row>
                     <Stack spacing={0.5}>
                         <Typography level="body3" secondary>

--- a/packages/storage/src/repositories/deliveryAddressesRepo.ts
+++ b/packages/storage/src/repositories/deliveryAddressesRepo.ts
@@ -156,12 +156,13 @@ export function validateDeliveryAddress(
         errors.push('Contact name is required');
     }
 
-    if (
-        data.phone &&
-        !/^\+?[1-9]\d{1,14}$/.test(data.phone.replace(/\s/g, ''))
-    ) {
-        errors.push('Phone number must be in E.164 format');
-    }
+    // TODO: Removed for now, re-add if needed
+    // if (
+    //     data.phone &&
+    //     !/^\+?[1-9]\d{1,14}$/.test(data.phone.replace(/\s/g, ''))
+    // ) {
+    //     errors.push('Phone number must be in E.164 format');
+    // }
 
     if (data.street1 && data.street1.trim().length < 1) {
         errors.push('Street address is required');


### PR DESCRIPTION
- Automatically set a default delivery address when addresses finish
  loading and no address is selected. This prevents an empty selection
  state and ensures time slot queries use a valid address.
- Add loading flag for delivery addresses (isLoadingAddresses) and use
  it in the effect that applies the default address.
- Expose selectedAddress for later UI/logic use.
- Replace the "Manage addresses" header layout: add a back IconButton
  with a rotated Navigate icon and move the section title next to it.
- Wrap DeliveryAddressesSection in a scrollable container to constrain
  its height (max-h 50vh) when managing addresses.
- Rename heading "Informacije o dostavi" to "Način dostave" and remove
  an extra subheading in the mode selection to tighten the UI.
- Import IconButton and Skeleton and add Navigate icon to imports.

These changes improve UX by ensuring a sensible initial address
selection, making the address management UI more compact and navigable,
and preparing selected address state for further UI updates.