### PR TITLE
feat: manage raised bed seeding requests

### DIFF
--- a/apps/app/app/admin/schedule/AcceptOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptOperationModal.tsx
@@ -1,10 +1,7 @@
-'use client';
-
-import { ModalConfirm } from '@signalco/ui/ModalConfirm';
 import { Check } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
-import { Typography } from '@signalco/ui-primitives/Typography';
 import { acceptOperationAction } from '../../(actions)/operationActions';
+import { AcceptRequestModal } from './AcceptRequestModal';
 
 interface AcceptOperationModalProps {
     operationId: number;
@@ -24,20 +21,18 @@ export function AcceptOperationModal({
     };
 
     return (
-        <ModalConfirm
-            title="Potvrda operacije"
-            header="Potvrda operacije"
+        <AcceptRequestModal
+            label={label}
             onConfirm={handleConfirm}
             trigger={
                 <IconButton variant="plain" title="Potvrdi operaciju">
                     <Check className="size-4 shrink-0" />
                 </IconButton>
             }
-        >
-            <Typography>
-                Jeste li sigurni da želite potvrditi operaciju:{' '}
-                <strong>{label}</strong>?
-            </Typography>
-        </ModalConfirm>
+            title="Potvrda operacije"
+            header="Potvrda operacije"
+        />
     );
 }
+
+export default AcceptOperationModal;

--- a/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Check } from '@signalco/ui-icons';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { acceptRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
+import { AcceptRequestModal } from './AcceptRequestModal';
+
+interface AcceptRaisedBedFieldModalProps {
+    raisedBedId: number;
+    positionIndex: number;
+    label: string;
+}
+
+export function AcceptRaisedBedFieldModal({
+    raisedBedId,
+    positionIndex,
+    label,
+}: AcceptRaisedBedFieldModalProps) {
+    const handleConfirm = async () => {
+        try {
+            await acceptRaisedBedFieldAction(raisedBedId, positionIndex);
+        } catch (error) {
+            console.error('Error accepting field request:', error);
+        }
+    };
+
+    return (
+        <AcceptRequestModal
+            label={label}
+            onConfirm={handleConfirm}
+            trigger={
+                <IconButton variant="plain" title="Potvrdi sijanje">
+                    <Check className="size-4 shrink-0" />
+                </IconButton>
+            }
+            title="Potvrda sijanja"
+            header="Potvrda sijanja"
+        />
+    );
+}
+
+export default AcceptRaisedBedFieldModal;

--- a/apps/app/app/admin/schedule/AcceptRequestModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRequestModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ModalConfirm } from '@signalco/ui/ModalConfirm';
+import { Check } from '@signalco/ui-icons';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Typography } from '@signalco/ui-primitives/Typography';
+
+interface AcceptRequestModalProps {
+    label: string;
+    onConfirm: () => Promise<void>;
+    trigger?: React.ReactElement;
+    title?: string;
+    header?: string;
+}
+
+export function AcceptRequestModal({
+    label,
+    onConfirm,
+    trigger,
+    title = 'Potvrda zadatka',
+    header = 'Potvrda zadatka',
+}: AcceptRequestModalProps) {
+    return (
+        <ModalConfirm
+            title={title}
+            header={header}
+            onConfirm={onConfirm}
+            trigger={
+                trigger ?? (
+                    <IconButton variant="plain" title="Potvrdi">
+                        <Check className="size-4 shrink-0" />
+                    </IconButton>
+                )
+            }
+        >
+            <Typography>
+                Jeste li sigurni da želite potvrditi zadatak:{' '}
+                <strong>{label}</strong>?
+            </Typography>
+        </ModalConfirm>
+    );
+}
+
+export default AcceptRequestModal;

--- a/apps/app/app/admin/schedule/CancelOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CancelOperationModal.tsx
@@ -1,13 +1,5 @@
-'use client';
-
-import { Close } from '@signalco/ui-icons';
-import { Button } from '@signalco/ui-primitives/Button';
-import { Modal } from '@signalco/ui-primitives/Modal';
-import { Row } from '@signalco/ui-primitives/Row';
-import { Stack } from '@signalco/ui-primitives/Stack';
-import { Typography } from '@signalco/ui-primitives/Typography';
-import { useState } from 'react';
 import { cancelOperationAction } from '../../(actions)/operationActions';
+import { CancelRequestModal } from './CancelRequestModal';
 
 interface CancelOperationModalProps {
     operation: {
@@ -25,87 +17,22 @@ export function CancelOperationModal({
     operationLabel,
     trigger,
 }: CancelOperationModalProps) {
-    const [open, setOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-
-    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-
-        setIsLoading(true);
-        try {
-            await cancelOperationAction(formData);
-            setOpen(false);
-        } catch (error) {
-            console.error('Error canceling operation:', error);
-            alert(
-                `Greška pri otkazivanju operacije: ${(error as Error).message}`,
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    }
-
     return (
-        <Modal
+        <CancelRequestModal
+            label={operationLabel}
             trigger={trigger}
-            title={`Otkaži: ${operationLabel}`}
-            open={open}
-            onOpenChange={setOpen}
-        >
-            <form onSubmit={handleSubmit}>
-                <Stack spacing={2}>
-                    <Typography level="h5">Otkazivanje operacije</Typography>
-                    <Typography>
-                        Operacija će biti otkazana i korisnik će biti
-                        obaviješten o otkazivanju.
-                        {operation.status === 'planned' &&
-                            ' Ako je operacija plaćena suncokretima, oni će biti refundirani.'}
-                    </Typography>
-
-                    <input
-                        type="hidden"
-                        name="operationId"
-                        value={operation.id}
-                    />
-
-                    <Stack spacing={1}>
-                        <Typography level="body2">
-                            Razlog otkazivanja
-                        </Typography>
-                        <textarea
-                            name="reason"
-                            placeholder="Unesite razlog otkazivanja operacije..."
-                            className="w-full bg-card border border-muted rounded p-2"
-                            disabled={isLoading}
-                            required
-                            rows={3}
-                        />
-                    </Stack>
-
-                    <Row spacing={1}>
-                        <Button
-                            variant="plain"
-                            onClick={() => setOpen(false)}
-                            disabled={isLoading}
-                        >
-                            Odustani
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            color="danger"
-                            disabled={isLoading}
-                            loading={isLoading}
-                            startDecorator={
-                                <Close className="size-5 shrink-0" />
-                            }
-                        >
-                            Otkaži operaciju
-                        </Button>
-                    </Row>
-                </Stack>
-            </form>
-        </Modal>
+            onSubmit={cancelOperationAction}
+            hiddenFields={
+                <input type="hidden" name="operationId" value={operation.id} />
+            }
+            description={`Operacija će biti otkazana i korisnik će biti obaviješten o otkazivanju.${
+                operation.status === 'planned'
+                    ? ' Ako je operacija plaćena suncokretima, oni će biti refundirani.'
+                    : ''
+            }`}
+            confirmLabel="Otkaži operaciju"
+        />
     );
 }
+
+export default CancelOperationModal;

--- a/apps/app/app/admin/schedule/CancelRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/CancelRaisedBedFieldModal.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { cancelRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
+import { CancelRequestModal } from './CancelRequestModal';
+
+interface CancelRaisedBedFieldModalProps {
+    field: {
+        raisedBedId: number;
+        positionIndex: number;
+    };
+    fieldLabel: string;
+    trigger: React.ReactElement;
+}
+
+export function CancelRaisedBedFieldModal({
+    field,
+    fieldLabel,
+    trigger,
+}: CancelRaisedBedFieldModalProps) {
+    return (
+        <CancelRequestModal
+            label={fieldLabel}
+            trigger={trigger}
+            onSubmit={cancelRaisedBedFieldAction}
+            hiddenFields={
+                <>
+                    <input
+                        type="hidden"
+                        name="raisedBedId"
+                        value={field.raisedBedId}
+                    />
+                    <input
+                        type="hidden"
+                        name="positionIndex"
+                        value={field.positionIndex}
+                    />
+                </>
+            }
+            description="Sijanje će biti otkazano i korisnik će biti obaviješten o otkazivanju. Ako je sijanje plaćeno suncokretima, oni će biti refundirani."
+            confirmLabel="Otkaži sijanje"
+        />
+    );
+}
+
+export default CancelRaisedBedFieldModal;

--- a/apps/app/app/admin/schedule/CancelRequestModal.tsx
+++ b/apps/app/app/admin/schedule/CancelRequestModal.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Close } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useState } from 'react';
+
+interface CancelRequestModalProps {
+    label: string;
+    trigger: React.ReactElement;
+    onSubmit: (formData: FormData) => Promise<void>;
+    hiddenFields: React.ReactNode;
+    description?: string;
+    confirmLabel?: string;
+}
+
+export function CancelRequestModal({
+    label,
+    trigger,
+    onSubmit,
+    hiddenFields,
+    description,
+    confirmLabel = 'Otkaži zadatak',
+}: CancelRequestModalProps) {
+    const [open, setOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        setIsLoading(true);
+        try {
+            await onSubmit(formData);
+            setOpen(false);
+        } catch (error) {
+            console.error('Error canceling item:', error);
+            alert(`Greška pri otkazivanju: ${(error as Error).message}`);
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    return (
+        <Modal
+            trigger={trigger}
+            title={`Otkaži: ${label}`}
+            open={open}
+            onOpenChange={setOpen}
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="h5">Otkazivanje zadatka</Typography>
+                    <Typography>
+                        {description ||
+                            'Zadatak će biti otkazan i korisnik će biti obaviješten o otkazivanju.'}
+                    </Typography>
+
+                    {hiddenFields}
+
+                    <Stack spacing={1}>
+                        <Typography level="body2">
+                            Razlog otkazivanja
+                        </Typography>
+                        <textarea
+                            name="reason"
+                            placeholder="Unesite razlog otkazivanja..."
+                            className="w-full bg-card border border-muted rounded p-2"
+                            disabled={isLoading}
+                            required
+                            rows={3}
+                        />
+                    </Stack>
+
+                    <Row spacing={1}>
+                        <Button
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={isLoading}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            color="danger"
+                            disabled={isLoading}
+                            loading={isLoading}
+                            startDecorator={
+                                <Close className="size-5 shrink-0" />
+                            }
+                        >
+                            {confirmLabel}
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}
+
+export default CancelRequestModal;

--- a/apps/app/app/admin/schedule/RescheduleModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleModal.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { Calendar } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useState } from 'react';
+
+function formatLocalDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+interface RescheduleModalProps {
+    label: string;
+    scheduledDate?: Date;
+    trigger: React.ReactElement;
+    onSubmit: (formData: FormData) => Promise<void>;
+    hiddenFields: React.ReactNode;
+}
+
+export function RescheduleModal({
+    label,
+    scheduledDate,
+    trigger,
+    onSubmit,
+    hiddenFields,
+}: RescheduleModalProps) {
+    const [open, setOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const isRescheduling = !!scheduledDate;
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+
+        setIsLoading(true);
+        try {
+            await onSubmit(formData);
+            setOpen(false);
+        } catch (error) {
+            console.error('Error rescheduling item:', error);
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    const today = new Date();
+    const tomorrow = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() + 1,
+    );
+    const threeMonthsFromTomorrow = new Date(
+        tomorrow.getFullYear(),
+        tomorrow.getMonth() + 3,
+        tomorrow.getDate(),
+    );
+
+    const currentScheduledDate = scheduledDate
+        ? formatLocalDate(scheduledDate)
+        : formatLocalDate(tomorrow);
+    const min = formatLocalDate(tomorrow);
+    const max = formatLocalDate(threeMonthsFromTomorrow);
+
+    return (
+        <Modal
+            trigger={trigger}
+            title={`${isRescheduling ? 'Prerasporedi' : 'Zakaži'}: ${label}`}
+            open={open}
+            onOpenChange={setOpen}
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="h5">
+                        {isRescheduling
+                            ? 'Preraspoređivanje zadatka'
+                            : 'Zakazivanje zadatka'}
+                    </Typography>
+                    <Typography>
+                        Zadatak će biti{' '}
+                        {isRescheduling ? 'preraspoređen' : 'zakazan'} na
+                        odabrani datum.
+                    </Typography>
+
+                    {hiddenFields}
+
+                    <Input
+                        type="date"
+                        label={isRescheduling ? 'Novi datum' : 'Datum'}
+                        name="scheduledDate"
+                        className="w-full bg-card"
+                        disabled={isLoading}
+                        defaultValue={currentScheduledDate}
+                        min={min}
+                        max={max}
+                        required
+                    />
+
+                    <Row spacing={1}>
+                        <Button
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={isLoading}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            disabled={isLoading}
+                            loading={isLoading}
+                            startDecorator={
+                                <Calendar className="size-5 shrink-0" />
+                            }
+                        >
+                            {isRescheduling ? 'Prerasporedi' : 'Zakaži'}
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}
+
+export default RescheduleModal;

--- a/apps/app/app/admin/schedule/RescheduleOperationModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleOperationModal.tsx
@@ -1,21 +1,5 @@
-'use client';
-
-import { Calendar } from '@signalco/ui-icons';
-import { Button } from '@signalco/ui-primitives/Button';
-import { Input } from '@signalco/ui-primitives/Input';
-import { Modal } from '@signalco/ui-primitives/Modal';
-import { Row } from '@signalco/ui-primitives/Row';
-import { Stack } from '@signalco/ui-primitives/Stack';
-import { Typography } from '@signalco/ui-primitives/Typography';
-import { useState } from 'react';
 import { rescheduleOperationAction } from '../../(actions)/operationActions';
-
-function formatLocalDate(date: Date): string {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-}
+import { RescheduleModal } from './RescheduleModal';
 
 interface RescheduleOperationModalProps {
     operation: {
@@ -32,108 +16,17 @@ export function RescheduleOperationModal({
     operationLabel,
     trigger,
 }: RescheduleOperationModalProps) {
-    const [open, setOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-
-    const isRescheduling = !!operation.scheduledDate;
-
-    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-
-        setIsLoading(true);
-        try {
-            await rescheduleOperationAction(formData);
-            setOpen(false);
-        } catch (error) {
-            console.error('Error rescheduling operation:', error);
-        } finally {
-            setIsLoading(false);
-        }
-    }
-
-    const today = new Date();
-    const tomorrow = new Date(
-        today.getFullYear(),
-        today.getMonth(),
-        today.getDate() + 1,
-    );
-    const threeMonthsFromTomorrow = new Date(
-        tomorrow.getFullYear(),
-        tomorrow.getMonth() + 3,
-        tomorrow.getDate(),
-    );
-
-    const currentScheduledDate = operation.scheduledDate
-        ? formatLocalDate(operation.scheduledDate)
-        : formatLocalDate(tomorrow);
-    const min = formatLocalDate(tomorrow);
-    const max = formatLocalDate(threeMonthsFromTomorrow);
-
     return (
-        <Modal
+        <RescheduleModal
+            label={operationLabel}
+            scheduledDate={operation.scheduledDate}
             trigger={trigger}
-            title={`${isRescheduling ? 'Prerasporedi' : 'Zakaži'}: ${operationLabel}`}
-            open={open}
-            onOpenChange={setOpen}
-        >
-            <form onSubmit={handleSubmit}>
-                <Stack spacing={2}>
-                    <Typography level="h5">
-                        {isRescheduling
-                            ? 'Preraspoređivanje operacije'
-                            : 'Zakazivanje operacije'}
-                    </Typography>
-                    <Typography>
-                        Operacija će biti{' '}
-                        {isRescheduling ? 'preraspoređena' : 'zakazana'} na
-                        odabrani datum.
-                    </Typography>
-
-                    <input
-                        type="hidden"
-                        name="operationId"
-                        value={operation.id}
-                    />
-
-                    <Input
-                        type="date"
-                        label={
-                            isRescheduling
-                                ? 'Novi datum operacije'
-                                : 'Datum operacije'
-                        }
-                        name="scheduledDate"
-                        className="w-full bg-card"
-                        disabled={isLoading}
-                        defaultValue={currentScheduledDate}
-                        min={min}
-                        max={max}
-                        required
-                    />
-
-                    <Row spacing={1}>
-                        <Button
-                            variant="plain"
-                            onClick={() => setOpen(false)}
-                            disabled={isLoading}
-                        >
-                            Odustani
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            disabled={isLoading}
-                            loading={isLoading}
-                            startDecorator={
-                                <Calendar className="size-5 shrink-0" />
-                            }
-                        >
-                            {isRescheduling ? 'Prerasporedi' : 'Zakaži'}
-                        </Button>
-                    </Row>
-                </Stack>
-            </form>
-        </Modal>
+            onSubmit={rescheduleOperationAction}
+            hiddenFields={
+                <input type="hidden" name="operationId" value={operation.id} />
+            }
+        />
     );
 }
+
+export default RescheduleOperationModal;

--- a/apps/app/app/admin/schedule/RescheduleRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleRaisedBedFieldModal.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { rescheduleRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
+import { RescheduleModal } from './RescheduleModal';
+
+interface RescheduleRaisedBedFieldModalProps {
+    field: {
+        raisedBedId: number;
+        positionIndex: number;
+        plantScheduledDate?: Date;
+    };
+    fieldLabel: string;
+    trigger: React.ReactElement;
+}
+
+export function RescheduleRaisedBedFieldModal({
+    field,
+    fieldLabel,
+    trigger,
+}: RescheduleRaisedBedFieldModalProps) {
+    return (
+        <RescheduleModal
+            label={fieldLabel}
+            scheduledDate={field.plantScheduledDate}
+            trigger={trigger}
+            onSubmit={rescheduleRaisedBedFieldAction}
+            hiddenFields={
+                <>
+                    <input
+                        type="hidden"
+                        name="raisedBedId"
+                        value={field.raisedBedId}
+                    />
+                    <input
+                        type="hidden"
+                        name="positionIndex"
+                        value={field.positionIndex}
+                    />
+                </>
+            }
+        />
+    );
+}
+
+export default RescheduleRaisedBedFieldModal;

--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -12,10 +12,13 @@ import type { EntityStandardized } from '../../../lib/@types/EntityStandardized'
 import { KnownPages } from '../../../src/KnownPages';
 import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
 import { AcceptOperationModal } from './AcceptOperationModal';
+import { AcceptRaisedBedFieldModal } from './AcceptRaisedBedFieldModal';
 import { CancelOperationModal } from './CancelOperationModal';
+import { CancelRaisedBedFieldModal } from './CancelRaisedBedFieldModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { CopyTasksButton } from './CopyTasksButton';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
+import { RescheduleRaisedBedFieldModal } from './RescheduleRaisedBedFieldModal';
 
 // Type definitions for the props (without importing server-side functions)
 type RaisedBed = {
@@ -281,27 +284,81 @@ export function ScheduleDay({
                                     );
                                 };
 
+                                const fieldLabel = `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`;
+
                                 return (
                                     <div key={field.id}>
-                                        <Row spacing={1}>
-                                            <ModalConfirm
-                                                title="Potvrda sijanja"
-                                                header="Označavanje kao posijano"
-                                                onConfirm={handlePlantConfirm}
-                                                trigger={
-                                                    <Checkbox className="size-5 mx-2" />
-                                                }
-                                            >
+                                        <Row
+                                            spacing={1}
+                                            className="hover:bg-muted rounded"
+                                        >
+                                            <Row spacing={1}>
+                                                {field.plantStatus === 'new' ? (
+                                                    <AcceptRaisedBedFieldModal
+                                                        raisedBedId={
+                                                            field.raisedBedId
+                                                        }
+                                                        positionIndex={
+                                                            field.positionIndex
+                                                        }
+                                                        label={fieldLabel}
+                                                    />
+                                                ) : (
+                                                    <ModalConfirm
+                                                        title="Potvrda sijanja"
+                                                        header="Označavanje kao posijano"
+                                                        onConfirm={
+                                                            handlePlantConfirm
+                                                        }
+                                                        trigger={
+                                                            <Checkbox className="size-5 mx-2" />
+                                                        }
+                                                    >
+                                                        <Typography>
+                                                            Jeste li sigurni da
+                                                            želite označiti da
+                                                            je posijavno:{' '}
+                                                            <strong>
+                                                                {fieldLabel}
+                                                            </strong>
+                                                            ?
+                                                        </Typography>
+                                                    </ModalConfirm>
+                                                )}
                                                 <Typography>
-                                                    Jeste li sigurni da želite
-                                                    označiti da je posijavno:{' '}
-                                                    <strong>{`${field.physicalPositionIndex} - ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`}</strong>
-                                                    ?
+                                                    {fieldLabel}
                                                 </Typography>
-                                            </ModalConfirm>
-                                            <Typography>
-                                                {`${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`}
-                                            </Typography>
+                                            </Row>
+                                            <Row>
+                                                <RescheduleRaisedBedFieldModal
+                                                    field={field}
+                                                    fieldLabel={fieldLabel}
+                                                    trigger={
+                                                        <IconButton
+                                                            variant="plain"
+                                                            title={
+                                                                field.plantScheduledDate
+                                                                    ? 'Prerasporedi sijanje'
+                                                                    : 'Zakaži sijanje'
+                                                            }
+                                                        >
+                                                            <Calendar className="size-4 shrink-0" />
+                                                        </IconButton>
+                                                    }
+                                                />
+                                                <CancelRaisedBedFieldModal
+                                                    field={field}
+                                                    fieldLabel={fieldLabel}
+                                                    trigger={
+                                                        <IconButton
+                                                            variant="plain"
+                                                            title="Otkaži sijanje"
+                                                        >
+                                                            <Close className="size-4 shrink-0" />
+                                                        </IconButton>
+                                                    }
+                                                />
+                                            </Row>
                                         </Row>
                                     </div>
                                 );

--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -292,7 +292,7 @@ export function ScheduleDay({
                                             spacing={1}
                                             className="hover:bg-muted rounded"
                                         >
-                                            <Row spacing={1}>
+                                            <Row spacing={1} className="grow">
                                                 {field.plantStatus === 'new' ? (
                                                     <AcceptRaisedBedFieldModal
                                                         raisedBedId={
@@ -327,6 +327,30 @@ export function ScheduleDay({
                                                 )}
                                                 <Typography>
                                                     {fieldLabel}
+                                                </Typography>
+                                                <Typography
+                                                    level="body2"
+                                                    className={`ml-1 italic ${field.plantStatus === 'new' ? 'text-muted-foreground' : 'text-green-600'}`}
+                                                >
+                                                    {field.plantStatus === 'new'
+                                                        ? 'Nije potvrđeno'
+                                                        : 'Potvrđeno'}
+                                                </Typography>
+                                                <Typography
+                                                    level="body2"
+                                                    className="select-none"
+                                                >
+                                                    {field.plantScheduledDate ? (
+                                                        <LocalDateTime
+                                                            time={false}
+                                                        >
+                                                            {
+                                                                field.plantScheduledDate
+                                                            }
+                                                        </LocalDateTime>
+                                                    ) : (
+                                                        <span>Danas</span>
+                                                    )}
                                                 </Typography>
                                             </Row>
                                             <Row>
@@ -374,7 +398,7 @@ export function ScheduleDay({
                                             spacing={1}
                                             className="hover:bg-muted rounded"
                                         >
-                                            <Row spacing={1}>
+                                            <Row spacing={1} className="grow">
                                                 {op.isAccepted ? (
                                                     <CompleteOperationModal
                                                         operationId={op.id}
@@ -416,11 +440,6 @@ export function ScheduleDay({
                                                         ? 'Potvrđeno'
                                                         : 'Nije potvrđeno'}
                                                 </Typography>
-                                            </Row>
-                                            <Row
-                                                justifyContent="space-between"
-                                                className="grow"
-                                            >
                                                 <Typography
                                                     level="body2"
                                                     className="select-none"
@@ -435,59 +454,57 @@ export function ScheduleDay({
                                                         <span>Danas</span>
                                                     )}
                                                 </Typography>
-                                                <Row>
-                                                    <RescheduleOperationModal
-                                                        operation={{
-                                                            id: op.id,
-                                                            entityId:
-                                                                op.entityId,
-                                                            scheduledDate:
-                                                                op.scheduledDate,
-                                                        }}
-                                                        operationLabel={
-                                                            operationData
-                                                                ?.information
-                                                                ?.label ??
-                                                            op.entityId.toString()
-                                                        }
-                                                        trigger={
-                                                            <IconButton
-                                                                variant="plain"
-                                                                title={
-                                                                    op.scheduledDate
-                                                                        ? 'Prerasporedi operaciju'
-                                                                        : 'Zakaži operaciju'
-                                                                }
-                                                            >
-                                                                <Calendar className="size-4 shrink-0" />
-                                                            </IconButton>
-                                                        }
-                                                    />
-                                                    <CancelOperationModal
-                                                        operation={{
-                                                            id: op.id,
-                                                            entityId:
-                                                                op.entityId,
-                                                            scheduledDate:
-                                                                op.scheduledDate,
-                                                            status: op.status,
-                                                        }}
-                                                        operationLabel={
-                                                            operationData
-                                                                ?.information
-                                                                ?.label ??
-                                                            op.entityId.toString()
-                                                        }
-                                                        trigger={
-                                                            <IconButton
-                                                                variant="plain"
-                                                                title="Otkaži operaciju"
-                                                            >
-                                                                <Close className="size-4 shrink-0" />
-                                                            </IconButton>
-                                                        }
-                                                    />
-                                                </Row>
+                                            </Row>
+                                            <Row>
+                                                <RescheduleOperationModal
+                                                    operation={{
+                                                        id: op.id,
+                                                        entityId: op.entityId,
+                                                        scheduledDate:
+                                                            op.scheduledDate,
+                                                    }}
+                                                    operationLabel={
+                                                        operationData
+                                                            ?.information
+                                                            ?.label ??
+                                                        op.entityId.toString()
+                                                    }
+                                                    trigger={
+                                                        <IconButton
+                                                            variant="plain"
+                                                            title={
+                                                                op.scheduledDate
+                                                                    ? 'Prerasporedi operaciju'
+                                                                    : 'Zakaži operaciju'
+                                                            }
+                                                        >
+                                                            <Calendar className="size-4 shrink-0" />
+                                                        </IconButton>
+                                                    }
+                                                />
+                                                <CancelOperationModal
+                                                    operation={{
+                                                        id: op.id,
+                                                        entityId: op.entityId,
+                                                        scheduledDate:
+                                                            op.scheduledDate,
+                                                        status: op.status,
+                                                    }}
+                                                    operationLabel={
+                                                        operationData
+                                                            ?.information
+                                                            ?.label ??
+                                                        op.entityId.toString()
+                                                    }
+                                                    trigger={
+                                                        <IconButton
+                                                            variant="plain"
+                                                            title="Otkaži operaciju"
+                                                        >
+                                                            <Close className="size-4 shrink-0" />
+                                                        </IconButton>
+                                                    }
+                                                />
                                             </Row>
                                         </Row>
                                     </div>


### PR DESCRIPTION
## Summary
- allow accepting, rescheduling and canceling raised bed field seeding requests with refunds
- add shared schedule modals for accepting, rescheduling and canceling tasks
- wire raised bed field requests into schedule actions

## Testing
- `pnpm lint`
- `pnpm test` *(fails: www#build)*

------
https://chatgpt.com/codex/tasks/task_e_68c30abc778c832f9142a41c75b3e854