### PR TITLE
feat(app): support dragging and ordering entities

### DIFF
--- a/apps/app/app/(actions)/definitionActions.ts
+++ b/apps/app/app/(actions)/definitionActions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { lexinsert } from '@gredice/js';
 import {
     type InsertAttributeDefinition,
     type InsertAttributeDefinitionCategory,
@@ -125,4 +126,32 @@ export async function upsertAttributeDefinitionCategory(
             ),
         );
     }
+}
+
+export async function reorderAttributeDefinitionCategory(
+    entityTypeName: string,
+    categoryId: number,
+    prevOrder?: string | null,
+    nextOrder?: string | null,
+) {
+    await auth(['admin']);
+    const order = lexinsert(prevOrder ?? undefined, nextOrder ?? undefined);
+    await storageUpdateAttributeDefinitionCategory({ id: categoryId, order });
+    revalidatePath(
+        KnownPages.DirectoryEntityTypeAttributeDefinitions(entityTypeName),
+    );
+}
+
+export async function reorderAttributeDefinition(
+    entityTypeName: string,
+    definitionId: number,
+    prevOrder?: string | null,
+    nextOrder?: string | null,
+) {
+    await auth(['admin']);
+    const order = lexinsert(prevOrder ?? undefined, nextOrder ?? undefined);
+    await storageUpdateAttributeDefinition({ id: definitionId, order });
+    revalidatePath(
+        KnownPages.DirectoryEntityTypeAttributeDefinitions(entityTypeName),
+    );
 }

--- a/apps/app/app/(actions)/definitionActions.ts
+++ b/apps/app/app/(actions)/definitionActions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { lexinsert } from '@gredice/js';
+import { lexinsert } from '@gredice/js/lexorder';
 import {
     type InsertAttributeDefinition,
     type InsertAttributeDefinitionCategory,
@@ -154,4 +154,40 @@ export async function reorderAttributeDefinition(
     revalidatePath(
         KnownPages.DirectoryEntityTypeAttributeDefinitions(entityTypeName),
     );
+}
+
+export async function createAttributeDefinitionFromForm(
+    entityTypeName: string,
+    categoryName: string,
+    formData: FormData,
+) {
+    await auth(['admin']);
+
+    const name = formData.get('name') as string;
+    const label = formData.get('label') as string;
+    const dataType = formData.get('dataType') as string;
+
+    await upsertAttributeDefinition({
+        name,
+        label,
+        dataType,
+        entityTypeName,
+        category: categoryName,
+    });
+}
+
+export async function createAttributeDefinitionCategoryFromForm(
+    entityTypeName: string,
+    formData: FormData,
+) {
+    await auth(['admin']);
+
+    const name = formData.get('name') as string;
+    const label = formData.get('label') as string;
+
+    await storageCreateAttributeDefinitionCategory({
+        name,
+        label,
+        entityTypeName,
+    });
 }

--- a/apps/app/app/(actions)/entityActions.ts
+++ b/apps/app/app/(actions)/entityActions.ts
@@ -2,6 +2,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { lexinsert } from '@gredice/js';
 import {
     deleteAttributeValue,
     deleteEntity,
@@ -221,4 +222,15 @@ export async function handleEntityDelete(
     await deleteEntity(entityId);
     revalidatePath(KnownPages.Directories);
     redirect(KnownPages.DirectoryEntityType(entityTypeName));
+}
+
+export async function reorderEntityType(
+    entityTypeId: number,
+    prevOrder?: string | null,
+    nextOrder?: string | null,
+) {
+    await auth(['admin']);
+    const order = lexinsert(prevOrder ?? undefined, nextOrder ?? undefined);
+    await upsertEntityType({ id: entityTypeId, order });
+    revalidatePath(KnownPages.Directories);
 }

--- a/apps/app/app/(actions)/entityActions.ts
+++ b/apps/app/app/(actions)/entityActions.ts
@@ -2,7 +2,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { lexinsert } from '@gredice/js';
+import { lexinsert } from '@gredice/js/lexorder';
 import {
     deleteAttributeValue,
     deleteEntity,

--- a/apps/app/app/admin/accounts/AccountsTable.tsx
+++ b/apps/app/app/admin/accounts/AccountsTable.tsx
@@ -1,0 +1,66 @@
+import { getAccounts } from '@gredice/storage';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Table } from '@signalco/ui-primitives/Table';
+import Link from 'next/link';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
+import { KnownPages } from '../../../src/KnownPages';
+
+export async function AccountsTable({ from }: { from?: Date | null }) {
+    // Get all accounts
+    const allAccounts = await getAccounts();
+
+    // Apply filters
+    let filteredAccounts = allAccounts;
+
+    // Apply date filter
+    if (from) {
+        filteredAccounts = filteredAccounts.filter((account) => {
+            return account.createdAt && account.createdAt >= from;
+        });
+    }
+
+    return (
+        <Table>
+            <Table.Header>
+                <Table.Row>
+                    <Table.Head>ID</Table.Head>
+                    <Table.Head>Korisnicko ime</Table.Head>
+                    <Table.Head>Datum kreiranja</Table.Head>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {filteredAccounts.length === 0 && (
+                    <Table.Row>
+                        <Table.Cell colSpan={3}>
+                            <NoDataPlaceholder>Nema računa</NoDataPlaceholder>
+                        </Table.Cell>
+                    </Table.Row>
+                )}
+                {filteredAccounts.map((account) => {
+                    const user = account.accountUsers.at(0)?.user;
+                    return (
+                        <Table.Row key={account.id}>
+                            <Table.Cell>
+                                <Link href={KnownPages.Account(account.id)}>
+                                    {account.id}
+                                </Link>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <Link href={KnownPages.User(user?.id ?? '')}>
+                                    {user?.displayName ||
+                                        user?.userName ||
+                                        'N/A'}
+                                </Link>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <LocalDateTime time={false}>
+                                    {account.createdAt}
+                                </LocalDateTime>
+                            </Table.Cell>
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </Table>
+    );
+}

--- a/apps/app/components/admin/buttons/CreateAttributeDefinitionButton.tsx
+++ b/apps/app/components/admin/buttons/CreateAttributeDefinitionButton.tsx
@@ -5,8 +5,7 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { upsertAttributeDefinition } from '../../../app/(actions)/definitionActions';
-import { auth } from '../../../lib/auth/auth';
+import { createAttributeDefinitionFromForm } from '../../../app/(actions)/definitionActions';
 
 export function CreateAttributeDefinitionButton({
     entityTypeName,
@@ -15,22 +14,11 @@ export function CreateAttributeDefinitionButton({
     entityTypeName: string;
     categoryName: string;
 }) {
-    async function submitForm(formData: FormData) {
-        'use server';
-        await auth(['admin']);
-
-        const name = formData.get('name') as string;
-        const label = formData.get('label') as string;
-        const dataType = formData.get('dataType') as string;
-
-        await upsertAttributeDefinition({
-            name,
-            label,
-            dataType,
-            entityTypeName,
-            category: categoryName,
-        });
-    }
+    const submitForm = createAttributeDefinitionFromForm.bind(
+        null,
+        entityTypeName,
+        categoryName,
+    );
 
     return (
         <Modal

--- a/apps/app/components/admin/buttons/CreateAttributeDefinitionCategoryButton.tsx
+++ b/apps/app/components/admin/buttons/CreateAttributeDefinitionCategoryButton.tsx
@@ -1,4 +1,3 @@
-import { createAttributeDefinitionCategory } from '@gredice/storage';
 import { Add } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
@@ -6,26 +5,17 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { auth } from '../../../lib/auth/auth';
+import { createAttributeDefinitionCategoryFromForm } from '../../../app/(actions)/definitionActions';
 
 export function CreateAttributeDefinitionCategoryButton({
     entityTypeName,
 }: {
     entityTypeName: string;
 }) {
-    async function submitForm(formData: FormData) {
-        'use server';
-        await auth(['admin']);
-
-        const name = formData.get('name') as string;
-        const label = formData.get('label') as string;
-
-        await createAttributeDefinitionCategory({
-            name,
-            label,
-            entityTypeName,
-        });
-    }
+    const submitForm = createAttributeDefinitionCategoryFromForm.bind(
+        null,
+        entityTypeName,
+    );
 
     return (
         <Modal

--- a/apps/app/components/admin/directories/AttributeDefinitionsList.tsx
+++ b/apps/app/components/admin/directories/AttributeDefinitionsList.tsx
@@ -1,198 +1,25 @@
 import {
-    type ExtendedAttributeDefinition,
     getAttributeDefinitionCategories,
     getAttributeDefinitions,
-    type SelectAttributeDefinitionCategory,
 } from '@gredice/storage';
-import { SplitView } from '@signalco/ui/SplitView';
-import {
-    Binary,
-    BookA,
-    Bookmark,
-    File,
-    FontType,
-    Hash,
-    Tally3,
-    ToggleRight,
-} from '@signalco/ui-icons';
-import { Card } from '@signalco/ui-primitives/Card';
-import { Row } from '@signalco/ui-primitives/Row';
-import { Stack } from '@signalco/ui-primitives/Stack';
-import { Typography } from '@signalco/ui-primitives/Typography';
-import Link from 'next/link';
-import type { HTMLAttributes } from 'react';
-import { KnownPages } from '../../../src/KnownPages';
-import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
-import { CreateAttributeDefinitionButton } from '../buttons/CreateAttributeDefinitionButton';
-import { CreateAttributeDefinitionCategoryButton } from '../buttons/CreateAttributeDefinitionCategoryButton';
-
-function AttributeDataTypeIcon({
-    dataType,
-    ...rest
-}: { dataType: string } & HTMLAttributes<SVGElement>) {
-    if (dataType.startsWith('ref:')) {
-        return <File {...rest} />;
-    }
-    switch (dataType) {
-        case 'text':
-            return <FontType {...rest} />;
-        case 'number':
-            return <Hash {...rest} />;
-        case 'boolean':
-            return <ToggleRight {...rest} />;
-        case 'barcode':
-            return <Tally3 {...rest} />;
-        case 'markdown':
-            return (
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="24"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    {...rest}
-                >
-                    <title>Markdown</title>
-                    <path d="M2 16V8l4 4 4-4v8" />
-                    <path d="M18 8v8" />
-                    <path d="m22 12-4 4-4-4" />
-                </svg>
-            );
-        // case 'json': return <Text />;
-        default:
-            return <Binary {...rest} />;
-    }
-}
-
-function AttributeDefinitionCard({
-    attributeDefinition,
-}: {
-    attributeDefinition: ExtendedAttributeDefinition;
-}) {
-    return (
-        <Link
-            href={KnownPages.DirectoryEntityTypeAttributeDefinition(
-                attributeDefinition.entityTypeName,
-                attributeDefinition.id,
-            )}
-        >
-            <Card>
-                <Row spacing={1}>
-                    <AttributeDataTypeIcon
-                        dataType={attributeDefinition.dataType}
-                        className="size-5 text-muted-foreground"
-                    />
-                    <Stack>
-                        <Typography level="body1">
-                            {attributeDefinition.label}
-                            {attributeDefinition.required && (
-                                <span className="text-red-600/60 ml-1">*</span>
-                            )}
-                        </Typography>
-                        <Typography level="body3" className="line-clamp-2">
-                            {attributeDefinition.description}
-                        </Typography>
-                    </Stack>
-                </Row>
-            </Card>
-        </Link>
-    );
-}
-
-function AttributeDefinitionCategoryCard({
-    attributeDefinitionCategory,
-}: {
-    attributeDefinitionCategory: SelectAttributeDefinitionCategory;
-}) {
-    return (
-        <Link
-            href={KnownPages.DirectoryEntityTypeAttributeDefinitionCategory(
-                attributeDefinitionCategory.entityTypeName,
-                attributeDefinitionCategory.id,
-            )}
-        >
-            <Card>
-                <Row spacing={1} justifyContent="space-between">
-                    <Stack>
-                        <Typography level="body2">
-                            {attributeDefinitionCategory.label}
-                        </Typography>
-                    </Stack>
-                </Row>
-            </Card>
-        </Link>
-    );
-}
+import { AttributeDefinitionsListClient } from './AttributeDefinitionsListClient';
 
 export async function AttributeDefinitionsList({
     entityTypeName,
 }: {
     entityTypeName: string;
 }) {
-    const attributeDefinitions = await getAttributeDefinitions(entityTypeName);
-    const attributeDefinitionCategories =
-        await getAttributeDefinitionCategories(entityTypeName);
+    const [attributeDefinitions, attributeDefinitionCategories] =
+        await Promise.all([
+            getAttributeDefinitions(entityTypeName),
+            getAttributeDefinitionCategories(entityTypeName),
+        ]);
 
     return (
-        <SplitView minSize={220}>
-            <Stack spacing={2} className="mr-4">
-                <Row spacing={1} justifyContent="space-between">
-                    <Row spacing={1}>
-                        <Bookmark className="size-5 text-tertiary-foreground" />
-                        <Typography level="body2" className="">
-                            Kategorije
-                        </Typography>
-                    </Row>
-                    <CreateAttributeDefinitionCategoryButton
-                        entityTypeName={entityTypeName}
-                    />
-                </Row>
-                <Stack spacing={1}>
-                    {attributeDefinitionCategories.length <= 0 && (
-                        <NoDataPlaceholder />
-                    )}
-                    {attributeDefinitionCategories.map((c) => (
-                        <AttributeDefinitionCategoryCard
-                            key={c.id}
-                            attributeDefinitionCategory={c}
-                        />
-                    ))}
-                </Stack>
-            </Stack>
-            <Stack spacing={2} className="ml-4">
-                {attributeDefinitions.length <= 0 && <NoDataPlaceholder />}
-                {attributeDefinitionCategories.map((category) => (
-                    <Stack spacing={1} key={category.id}>
-                        <Row spacing={1} justifyContent="space-between">
-                            <Row spacing={1}>
-                                <BookA className="size-5 text-tertiary-foreground" />
-                                <Typography level="body2" className="">
-                                    {category.label}
-                                </Typography>
-                            </Row>
-                            <CreateAttributeDefinitionButton
-                                entityTypeName={entityTypeName}
-                                categoryName={category.name}
-                            />
-                        </Row>
-                        {attributeDefinitions
-                            .filter(
-                                (attribute) =>
-                                    attribute.category === category.name,
-                            )
-                            .map((attribute) => (
-                                <AttributeDefinitionCard
-                                    key={attribute.id}
-                                    attributeDefinition={attribute}
-                                />
-                            ))}
-                    </Stack>
-                ))}
-            </Stack>
-        </SplitView>
+        <AttributeDefinitionsListClient
+            entityTypeName={entityTypeName}
+            attributeDefinitions={attributeDefinitions}
+            attributeDefinitionCategories={attributeDefinitionCategories}
+        />
     );
 }

--- a/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
+++ b/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
@@ -35,7 +35,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
-import type { CSSProperties, HTMLAttributes } from 'react';
+import type { CSSProperties, HTMLAttributes, MouseEvent } from 'react';
 import { useState } from 'react';
 import {
     reorderAttributeDefinition,
@@ -89,15 +89,25 @@ function AttributeDataTypeIcon({
 
 function AttributeDefinitionCard({
     attributeDefinition,
+    isDragging = false,
 }: {
     attributeDefinition: ExtendedAttributeDefinition;
+    isDragging?: boolean;
 }) {
+    const handleClick = (e: MouseEvent) => {
+        if (isDragging) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    };
+
     return (
         <Link
             href={KnownPages.DirectoryEntityTypeAttributeDefinition(
                 attributeDefinition.entityTypeName,
                 attributeDefinition.id,
             )}
+            onClick={handleClick}
         >
             <Card>
                 <Row spacing={1}>
@@ -124,15 +134,25 @@ function AttributeDefinitionCard({
 
 function AttributeDefinitionCategoryCard({
     attributeDefinitionCategory,
+    isDragging = false,
 }: {
     attributeDefinitionCategory: SelectAttributeDefinitionCategory;
+    isDragging?: boolean;
 }) {
+    const handleClick = (e: MouseEvent) => {
+        if (isDragging) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    };
+
     return (
         <Link
             href={KnownPages.DirectoryEntityTypeAttributeDefinitionCategory(
                 attributeDefinitionCategory.entityTypeName,
                 attributeDefinitionCategory.id,
             )}
+            onClick={handleClick}
         >
             <Card>
                 <Row spacing={1} justifyContent="space-between">
@@ -152,8 +172,14 @@ function SortableCategory({
 }: {
     category: SelectAttributeDefinitionCategory;
 }) {
-    const { attributes, listeners, setNodeRef, transform, transition } =
-        useSortable({ id: category.id.toString() });
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: category.id.toString() });
     const style: CSSProperties = {
         transform: CSS.Transform.toString(transform),
         transition,
@@ -162,6 +188,7 @@ function SortableCategory({
         <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
             <AttributeDefinitionCategoryCard
                 attributeDefinitionCategory={category}
+                isDragging={isDragging}
             />
         </div>
     );
@@ -172,15 +199,24 @@ function SortableAttributeDefinition({
 }: {
     attribute: ExtendedAttributeDefinition;
 }) {
-    const { attributes, listeners, setNodeRef, transform, transition } =
-        useSortable({ id: attribute.id.toString() });
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: attribute.id.toString() });
     const style: CSSProperties = {
         transform: CSS.Transform.toString(transform),
         transition,
     };
     return (
         <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-            <AttributeDefinitionCard attributeDefinition={attribute} />
+            <AttributeDefinitionCard
+                attributeDefinition={attribute}
+                isDragging={isDragging}
+            />
         </div>
     );
 }

--- a/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
+++ b/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import {
+    closestCenter,
+    DndContext,
+    type DragEndEvent,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type {
+    ExtendedAttributeDefinition,
+    SelectAttributeDefinitionCategory,
+} from '@gredice/storage';
+import { SplitView } from '@signalco/ui/SplitView';
+import {
+    Binary,
+    BookA,
+    Bookmark,
+    File,
+    FontType,
+    Hash,
+    Tally3,
+    ToggleRight,
+} from '@signalco/ui-icons';
+import { Card } from '@signalco/ui-primitives/Card';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
+import type { CSSProperties, HTMLAttributes } from 'react';
+import { useState } from 'react';
+import {
+    reorderAttributeDefinition,
+    reorderAttributeDefinitionCategory,
+} from '../../../app/(actions)/definitionActions';
+import { KnownPages } from '../../../src/KnownPages';
+import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
+import { CreateAttributeDefinitionButton } from '../buttons/CreateAttributeDefinitionButton';
+import { CreateAttributeDefinitionCategoryButton } from '../buttons/CreateAttributeDefinitionCategoryButton';
+
+function AttributeDataTypeIcon({
+    dataType,
+    ...rest
+}: { dataType: string } & HTMLAttributes<SVGElement>) {
+    if (dataType.startsWith('ref:')) {
+        return <File {...rest} />;
+    }
+    switch (dataType) {
+        case 'text':
+            return <FontType {...rest} />;
+        case 'number':
+            return <Hash {...rest} />;
+        case 'boolean':
+            return <ToggleRight {...rest} />;
+        case 'barcode':
+            return <Tally3 {...rest} />;
+        case 'markdown':
+            return (
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    {...rest}
+                >
+                    <title>Markdown</title>
+                    <path d="M2 16V8l4 4 4-4v8" />
+                    <path d="M18 8v8" />
+                    <path d="m22 12-4 4-4-4" />
+                </svg>
+            );
+        default:
+            return <Binary {...rest} />;
+    }
+}
+
+function AttributeDefinitionCard({
+    attributeDefinition,
+}: {
+    attributeDefinition: ExtendedAttributeDefinition;
+}) {
+    return (
+        <Link
+            href={KnownPages.DirectoryEntityTypeAttributeDefinition(
+                attributeDefinition.entityTypeName,
+                attributeDefinition.id,
+            )}
+        >
+            <Card>
+                <Row spacing={1}>
+                    <AttributeDataTypeIcon
+                        dataType={attributeDefinition.dataType}
+                        className="size-5 text-muted-foreground"
+                    />
+                    <Stack>
+                        <Typography level="body1">
+                            {attributeDefinition.label}
+                            {attributeDefinition.required && (
+                                <span className="text-red-600/60 ml-1">*</span>
+                            )}
+                        </Typography>
+                        <Typography level="body3" className="line-clamp-2">
+                            {attributeDefinition.description}
+                        </Typography>
+                    </Stack>
+                </Row>
+            </Card>
+        </Link>
+    );
+}
+
+function AttributeDefinitionCategoryCard({
+    attributeDefinitionCategory,
+}: {
+    attributeDefinitionCategory: SelectAttributeDefinitionCategory;
+}) {
+    return (
+        <Link
+            href={KnownPages.DirectoryEntityTypeAttributeDefinitionCategory(
+                attributeDefinitionCategory.entityTypeName,
+                attributeDefinitionCategory.id,
+            )}
+        >
+            <Card>
+                <Row spacing={1} justifyContent="space-between">
+                    <Stack>
+                        <Typography level="body2">
+                            {attributeDefinitionCategory.label}
+                        </Typography>
+                    </Stack>
+                </Row>
+            </Card>
+        </Link>
+    );
+}
+
+function SortableCategory({
+    category,
+}: {
+    category: SelectAttributeDefinitionCategory;
+}) {
+    const { attributes, listeners, setNodeRef, transform, transition } =
+        useSortable({ id: category.id.toString() });
+    const style: CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+    return (
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+            <AttributeDefinitionCategoryCard
+                attributeDefinitionCategory={category}
+            />
+        </div>
+    );
+}
+
+function SortableAttributeDefinition({
+    attribute,
+}: {
+    attribute: ExtendedAttributeDefinition;
+}) {
+    const { attributes, listeners, setNodeRef, transform, transition } =
+        useSortable({ id: attribute.id.toString() });
+    const style: CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+    return (
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+            <AttributeDefinitionCard attributeDefinition={attribute} />
+        </div>
+    );
+}
+
+function CategorySection({
+    category,
+    initialDefinitions,
+    entityTypeName,
+}: {
+    category: SelectAttributeDefinitionCategory;
+    initialDefinitions: ExtendedAttributeDefinition[];
+    entityTypeName: string;
+}) {
+    const [items, setItems] = useState(initialDefinitions);
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    async function handleDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        const oldIndex = items.findIndex((i) => i.id.toString() === active.id);
+        const newIndex = items.findIndex((i) => i.id.toString() === over.id);
+        const newItems = arrayMove(items, oldIndex, newIndex);
+        setItems(newItems);
+        const prev = newItems[newIndex - 1]?.order ?? null;
+        const next = newItems[newIndex + 1]?.order ?? null;
+        await reorderAttributeDefinition(
+            entityTypeName,
+            Number(active.id),
+            prev,
+            next,
+        );
+    }
+
+    return (
+        <Stack spacing={1} key={category.id}>
+            <Row spacing={1} justifyContent="space-between">
+                <Row spacing={1}>
+                    <BookA className="size-5 text-tertiary-foreground" />
+                    <Typography level="body2" className="">
+                        {category.label}
+                    </Typography>
+                </Row>
+                <CreateAttributeDefinitionButton
+                    entityTypeName={entityTypeName}
+                    categoryName={category.name}
+                />
+            </Row>
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+            >
+                <SortableContext
+                    items={items.map((i) => i.id.toString())}
+                    strategy={verticalListSortingStrategy}
+                >
+                    {items.map((attribute) => (
+                        <SortableAttributeDefinition
+                            key={attribute.id}
+                            attribute={attribute}
+                        />
+                    ))}
+                </SortableContext>
+            </DndContext>
+        </Stack>
+    );
+}
+
+export function AttributeDefinitionsListClient({
+    entityTypeName,
+    attributeDefinitionCategories,
+    attributeDefinitions,
+}: {
+    entityTypeName: string;
+    attributeDefinitionCategories: SelectAttributeDefinitionCategory[];
+    attributeDefinitions: ExtendedAttributeDefinition[];
+}) {
+    const [categories, setCategories] = useState(attributeDefinitionCategories);
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    async function handleCategoryDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        const oldIndex = categories.findIndex(
+            (c) => c.id.toString() === active.id,
+        );
+        const newIndex = categories.findIndex(
+            (c) => c.id.toString() === over.id,
+        );
+        const newItems = arrayMove(categories, oldIndex, newIndex);
+        setCategories(newItems);
+        const prev = newItems[newIndex - 1]?.order ?? null;
+        const next = newItems[newIndex + 1]?.order ?? null;
+        await reorderAttributeDefinitionCategory(
+            entityTypeName,
+            Number(active.id),
+            prev,
+            next,
+        );
+    }
+
+    return (
+        <SplitView minSize={220}>
+            <Stack spacing={2} className="mr-4">
+                <Row spacing={1} justifyContent="space-between">
+                    <Row spacing={1}>
+                        <Bookmark className="size-5 text-tertiary-foreground" />
+                        <Typography level="body2" className="">
+                            Kategorije
+                        </Typography>
+                    </Row>
+                    <CreateAttributeDefinitionCategoryButton
+                        entityTypeName={entityTypeName}
+                    />
+                </Row>
+                <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleCategoryDragEnd}
+                >
+                    <SortableContext
+                        items={categories.map((c) => c.id.toString())}
+                        strategy={verticalListSortingStrategy}
+                    >
+                        <Stack spacing={1}>
+                            {categories.length <= 0 && <NoDataPlaceholder />}
+                            {categories.map((c) => (
+                                <SortableCategory key={c.id} category={c} />
+                            ))}
+                        </Stack>
+                    </SortableContext>
+                </DndContext>
+            </Stack>
+            <Stack spacing={2} className="ml-4">
+                {categories.length <= 0 && <NoDataPlaceholder />}
+                {categories.map((category) => (
+                    <CategorySection
+                        key={category.id}
+                        category={category}
+                        initialDefinitions={attributeDefinitions.filter(
+                            (a) => a.category === category.name,
+                        )}
+                        entityTypeName={entityTypeName}
+                    />
+                ))}
+            </Stack>
+        </SplitView>
+    );
+}

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -55,8 +55,14 @@ function SortableNavItem({
     entityType: SelectEntityType;
     onClick?: () => void;
 }) {
-    const { attributes, listeners, setNodeRef, transform, transition } =
-        useSortable({ id: entityType.id.toString() });
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: entityType.id.toString() });
     const style: CSSProperties = {
         transform: CSS.Transform.toString(transform),
         transition,
@@ -68,6 +74,7 @@ function SortableNavItem({
                 label={entityType.label}
                 icon={<File className="size-5" />}
                 onClick={onClick}
+                isDragging={isDragging}
             />
         </div>
     );

--- a/apps/app/components/admin/navigation/NavItem.tsx
+++ b/apps/app/components/admin/navigation/NavItem.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { ListItem } from '@signalco/ui-primitives/ListItem';
+import type { Route } from 'next';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import type { ReactElement } from 'react';
+import type { MouseEvent, ReactElement } from 'react';
 
 export function NavItem({
     href,
@@ -11,16 +12,30 @@ export function NavItem({
     icon,
     strictMatch,
     onClick,
+    isDragging = false,
 }: {
-    href: string;
+    href: Route;
     label: string;
     icon: ReactElement;
     strictMatch?: boolean;
     onClick?: () => void;
+    isDragging?: boolean;
 }) {
     const pathname = usePathname();
+
+    const handleClick = (e: MouseEvent) => {
+        if (isDragging) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
+        if (onClick) {
+            onClick();
+        }
+    };
+
     return (
-        <Link href={href}>
+        <Link href={href} onClick={handleClick}>
             <ListItem
                 nodeId={href}
                 selected={
@@ -28,7 +43,7 @@ export function NavItem({
                         ? pathname === href
                         : pathname === href || pathname.startsWith(`${href}/`)
                 }
-                onSelected={onClick ? () => onClick() : () => {}}
+                onSelected={() => {}}
                 label={label}
                 startDecorator={icon}
             />

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -30,7 +30,8 @@
         "react-email": "4.2.11",
         "server-only": "0.0.1",
         "@dnd-kit/core": "6.1.0",
-        "@dnd-kit/sortable": "8.0.0"
+        "@dnd-kit/sortable": "8.0.0",
+        "@dnd-kit/utilities": "3.2.2"
     },
     "devDependencies": {
         "@biomejs/biome": "2.2.4",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -28,7 +28,9 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-email": "4.2.11",
-        "server-only": "0.0.1"
+        "server-only": "0.0.1",
+        "@dnd-kit/core": "6.1.0",
+        "@dnd-kit/sortable": "8.0.0"
     },
     "devDependencies": {
         "@biomejs/biome": "2.2.4",

--- a/packages/js/src/lexorder/index.ts
+++ b/packages/js/src/lexorder/index.ts
@@ -1,0 +1,1 @@
+export * from './lexorder';

--- a/packages/js/src/lexorder/lexorder.ts
+++ b/packages/js/src/lexorder/lexorder.ts
@@ -1,0 +1,81 @@
+// Inspired by:
+// - https://stackoverflow.com/a/49956113/563228
+// - https://stackoverflow.com/questions/38923376/return-a-new-string-that-sorts-between-two-given-strings/38927158#38927158
+
+export type LexorderOptions = {
+    start?: string;
+    mid?: string;
+    end?: string;
+};
+
+function trimLast(curr: string) {
+    return curr.substring(0, curr.length - 1);
+}
+
+function incrementLast(
+    curr: string | null | undefined,
+    mid: string,
+    end: string,
+) {
+    if (!curr) return mid;
+
+    let nextIdentifier = String.fromCharCode(
+        curr.charCodeAt(curr.length - 1) + 1,
+    );
+
+    // Edge case: We are at the end, insert next level mid
+    if (nextIdentifier === end) nextIdentifier = end + mid;
+
+    return trimLast(curr) + nextIdentifier;
+}
+
+function decrementLast(
+    curr: string | null | undefined,
+    mid: string,
+    start: string,
+) {
+    if (!curr) return mid;
+
+    let nextIdentifier = String.fromCharCode(
+        curr.charCodeAt(curr.length - 1) - 1,
+    );
+
+    // Edge case: We are at the start, insert next level mid
+    if (nextIdentifier === start) nextIdentifier = start + mid;
+
+    return trimLast(curr) + nextIdentifier;
+}
+
+/**
+ * Given two lex identifiers, returns a lex identifier that is between them.
+ * Can be used to (change) item order in a list without having to re-order all items.
+ */
+export function lexinsert(
+    prev?: string | null | undefined,
+    next?: string | null | undefined,
+    options?: LexorderOptions,
+) {
+    const { start = 'a', mid = 'i', end = 'z' } = options ?? {};
+
+    if (!prev && !next) return mid;
+
+    if (!next && prev && prev[prev.length - 1] === end) return prev + mid;
+
+    if (!prev && next && next[next.length - 1] === start) return next + mid;
+
+    if (
+        prev &&
+        next &&
+        prev.length === next.length &&
+        prev.substring(0, prev.length - 1) ===
+            next.substring(0, next.length - 1) &&
+        Math.abs(
+            next.charCodeAt(next.length - 1) - prev.charCodeAt(prev.length - 1),
+        ) <= 1
+    )
+        return prev + mid;
+
+    if ((next?.length ?? 0) > (prev?.length ?? 0))
+        return decrementLast(next, mid, start);
+    return incrementLast(prev, mid, end);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,15 @@ importers:
       '@azure/communication-email':
         specifier: 1.0.0
         version: 1.0.0
+      '@dnd-kit/core':
+        specifier: 6.1.0
+        version: 6.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/sortable':
+        specifier: 8.0.0
+        version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@19.1.1)
       '@gredice/transactional':
         specifier: workspace:*
         version: link:../../packages/transactional
@@ -177,7 +186,7 @@ importers:
         version: 2.10.0
       next:
         specifier: 15.5.3
-        version: 15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1)
+        version: 15.5.3(@babel/core@7.28.0)(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -238,100 +247,6 @@ importers:
         version: 1.55.0
       '@signalco/auth-client':
         specifier: 0.3.0
-        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17))(@tanstack/react-query@5.87.4(react@19.1.1))(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@signalco/auth-server':
-        specifier: 0.5.3
-        version: 0.5.3(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@signalco/hooks':
-        specifier: 0.2.1
-        version: 0.2.1(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@signalco/js':
-        specifier: 0.1.0
-        version: 0.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@signalco/ui':
-        specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
-      '@signalco/ui-icons':
-        specifier: 0.2.2
-        version: 0.2.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@signalco/ui-primitives':
-        specifier: 0.6.5
-        version: 0.6.5(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
-      '@signalco/ui-themes-minimal-app':
-        specifier: 0.1.3
-        version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
-      '@tailwindcss/typography':
-        specifier: 0.5.16
-        version: 0.5.16(tailwindcss@3.4.17)
-      '@tanstack/react-query':
-        specifier: 5.87.4
-        version: 5.87.4(react@19.1.1)
-      '@types/node':
-        specifier: 22.18.1
-        version: 22.18.1
-      '@types/react':
-        specifier: 19.1.12
-        version: 19.1.12
-      '@types/react-dom':
-        specifier: 19.1.9
-        version: 19.1.9(@types/react@19.1.12)
-      '@vercel/analytics':
-        specifier: 1.5.0
-        version: 1.5.0(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react@19.1.1)(vue-router@4.5.1(vue@3.5.21(typescript@5.9.2)))(vue@3.5.21(typescript@5.9.2))
-      '@zxing/library':
-        specifier: 0.21.3
-        version: 0.21.3
-      babel-plugin-react-compiler:
-        specifier: 19.1.0-rc.3
-        version: 19.1.0-rc.3
-      next-axiom:
-        specifier: 1.9.2
-        version: 1.9.2(@aws-sdk/credential-provider-web-identity@3.888.0)(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react@19.1.1)
-      postcss:
-        specifier: 8.5.6
-        version: 8.5.6
-      tailwindcss:
-        specifier: 3.4.17
-        version: 3.4.17
-      typescript:
-        specifier: 5.9.2
-        version: 5.9.2
-
-  apps/farm:
-    dependencies:
-      hypertune:
-        specifier: 2.10.0
-        version: 2.10.0
-      next:
-        specifier: 15.5.3
-        version: 15.5.3(@babel/core@7.28.0)(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1)
-      react:
-        specifier: 19.1.1
-        version: 19.1.1
-      react-dom:
-        specifier: 19.1.1
-        version: 19.1.1(react@19.1.1)
-      server-only:
-        specifier: 0.0.1
-        version: 0.0.1
-    devDependencies:
-      '@biomejs/biome':
-        specifier: 2.2.4
-        version: 2.2.4
-      '@gredice/storage':
-        specifier: workspace:*
-        version: link:../../packages/storage
-      '@mdxeditor/editor':
-        specifier: 3.45.0
-        version: 3.45.0(@codemirror/language@6.11.3)(@lezer/highlight@1.2.1)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(yjs@13.6.20)
-      '@playwright/experimental-ct-react':
-        specifier: 1.55.0
-        version: 1.55.0(@types/node@22.18.1)(jiti@2.4.2)(sass@1.92.1)(terser@5.37.0)(tsx@4.20.5)(vite@6.3.5(@types/node@22.18.1)(jiti@2.4.2)(sass@1.92.1)(terser@5.37.0)(tsx@4.20.5)(yaml@2.8.0))(yaml@2.8.0)
-      '@playwright/test':
-        specifier: 1.55.0
-        version: 1.55.0
-      '@signalco/auth-client':
-        specifier: 0.3.0
         version: 0.3.0(@signalco/ui-primitives@0.6.5(next@15.5.3(@babel/core@7.28.0)(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17))(@tanstack/react-query@5.87.4(react@19.1.1))(next@15.5.3(@babel/core@7.28.0)(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@signalco/auth-server':
         specifier: 0.5.3
@@ -372,12 +287,106 @@ importers:
       '@vercel/analytics':
         specifier: 1.5.0
         version: 1.5.0(next@15.5.3(@babel/core@7.28.0)(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react@19.1.1)(vue-router@4.5.1(vue@3.5.21(typescript@5.9.2)))(vue@3.5.21(typescript@5.9.2))
+      '@zxing/library':
+        specifier: 0.21.3
+        version: 0.21.3
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3
       next-axiom:
         specifier: 1.9.2
         version: 1.9.2(@aws-sdk/credential-provider-web-identity@3.888.0)(next@15.5.3(@babel/core@7.28.0)(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react@19.1.1)
+      postcss:
+        specifier: 8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: 3.4.17
+        version: 3.4.17
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
+  apps/farm:
+    dependencies:
+      hypertune:
+        specifier: 2.10.0
+        version: 2.10.0
+      next:
+        specifier: 15.5.3
+        version: 15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1)
+      react:
+        specifier: 19.1.1
+        version: 19.1.1
+      react-dom:
+        specifier: 19.1.1
+        version: 19.1.1(react@19.1.1)
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.2.4
+        version: 2.2.4
+      '@gredice/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      '@mdxeditor/editor':
+        specifier: 3.45.0
+        version: 3.45.0(@codemirror/language@6.11.3)(@lezer/highlight@1.2.1)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(yjs@13.6.20)
+      '@playwright/experimental-ct-react':
+        specifier: 1.55.0
+        version: 1.55.0(@types/node@22.18.1)(jiti@2.4.2)(sass@1.92.1)(terser@5.37.0)(tsx@4.20.5)(vite@6.3.5(@types/node@22.18.1)(jiti@2.4.2)(sass@1.92.1)(terser@5.37.0)(tsx@4.20.5)(yaml@2.8.0))(yaml@2.8.0)
+      '@playwright/test':
+        specifier: 1.55.0
+        version: 1.55.0
+      '@signalco/auth-client':
+        specifier: 0.3.0
+        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17))(@tanstack/react-query@5.87.4(react@19.1.1))(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@signalco/auth-server':
+        specifier: 0.5.3
+        version: 0.5.3(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@signalco/hooks':
+        specifier: 0.2.1
+        version: 0.2.1(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@signalco/js':
+        specifier: 0.1.0
+        version: 0.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@signalco/ui':
+        specifier: 0.2.10
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
+      '@signalco/ui-icons':
+        specifier: 0.2.2
+        version: 0.2.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@signalco/ui-primitives':
+        specifier: 0.6.5
+        version: 0.6.5(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
+      '@signalco/ui-themes-minimal-app':
+        specifier: 0.1.3
+        version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.17))(tailwindcss@3.4.17)
+      '@tailwindcss/typography':
+        specifier: 0.5.16
+        version: 0.5.16(tailwindcss@3.4.17)
+      '@tanstack/react-query':
+        specifier: 5.87.4
+        version: 5.87.4(react@19.1.1)
+      '@types/node':
+        specifier: 22.18.1
+        version: 22.18.1
+      '@types/react':
+        specifier: 19.1.12
+        version: 19.1.12
+      '@types/react-dom':
+        specifier: 19.1.9
+        version: 19.1.9(@types/react@19.1.12)
+      '@vercel/analytics':
+        specifier: 1.5.0
+        version: 1.5.0(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react@19.1.1)(vue-router@4.5.1(vue@3.5.21(typescript@5.9.2)))(vue@3.5.21(typescript@5.9.2))
+      babel-plugin-react-compiler:
+        specifier: 19.1.0-rc.3
+        version: 19.1.0-rc.3
+      next-axiom:
+        specifier: 1.9.2
+        version: 1.9.2(@aws-sdk/credential-provider-web-identity@3.888.0)(next@15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1))(react@19.1.1)
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -1532,6 +1541,28 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.1.0':
+    resolution: {integrity: sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@8.0.0':
+    resolution: {integrity: sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.1.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -8748,6 +8779,31 @@ snapshots:
   '@date-fns/tz@1.4.1': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/core': 6.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 


### PR DESCRIPTION
## Summary
- add drag-and-drop reordering for attribute categories, attribute definitions and navigation entity types
- update order on the server using `lexinsert`

## Testing
- `pnpm install --filter app` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm --filter app lint`


------
https://chatgpt.com/codex/tasks/task_e_68c41a4a8c50832fb8b409719fa6b824