### PR TITLE
feat(nav): enable client-side rendering for admin nav

### DIFF
--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AuthProtectedSection } from '@signalco/auth-client/components';
 import {
     Add,


### PR DESCRIPTION
Mark the admin navigation component as a client component by
adding the 'use client' directive. This ensures React hooks and
client-only APIs (such as auth client components) work correctly
within the Admin navigation.

This change fixes rendering issues and avoids server-side
execution of client-only logic in the Nav component.