### PR TITLE
fix(hud): make sunflower suggestion non-interactive when hidden

### DIFF
--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -113,7 +113,9 @@ export function ShoppingCart() {
                 <div
                     className={cx(
                         'opacity-0 h-0 transition-all duration-150',
-                        showSunflowersSuggestion && 'opacity-100 h-auto mb-4',
+                        showSunflowersSuggestion
+                            ? 'opacity-100 h-auto mb-4'
+                            : 'pointer-events-none',
                     )}
                 >
                     <Alert color="primary">


### PR DESCRIPTION
Adjust ShoppingCartHud so the sunflowers suggestion keeps pointer
events when it is visible. Previously the conditional only
applied visibility and height classes, causing the hidden element to
still accept interactions. Now the class list toggles between visible
styles and 'pointer-events-none' when hidden to prevent unintended
clicks or focus. This improves accessibility and prevents accidental
interactions with hidden UI.