### PR TITLE
feat(ui): add TableFilter component with URL-backed filters

### DIFF
--- a/apps/app/app/admin/accounts/AccountsFilters.tsx
+++ b/apps/app/app/admin/accounts/AccountsFilters.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { User } from '@signalco/ui-icons';
+import {
+    type FilterOption,
+    TableFilter,
+    TIME_FILTER_OPTIONS,
+} from '../../../components/shared/filters';
+
+// Account type filter options (this can be expanded based on your account types)
+const ACCOUNT_TYPE_FILTER_OPTIONS: FilterOption = {
+    key: 'type',
+    label: 'Tip računa',
+    icon: <User className="size-4" />,
+    options: [
+        { value: '', label: 'Svi tipovi' },
+        { value: 'personal', label: 'Osobni' },
+        { value: 'business', label: 'Poslovni' },
+        { value: 'premium', label: 'Premium' },
+    ],
+};
+
+export function AccountsFilters() {
+    const filters = [TIME_FILTER_OPTIONS, ACCOUNT_TYPE_FILTER_OPTIONS];
+
+    return (
+        <TableFilter
+            filters={filters}
+            defaultValues={{
+                from: 'last-30-days',
+                type: '',
+            }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/accounts/AccountsFilters.tsx
+++ b/apps/app/app/admin/accounts/AccountsFilters.tsx
@@ -1,34 +1,18 @@
 'use client';
 
-import { User } from '@signalco/ui-icons';
 import {
-    type FilterOption,
     TableFilter,
     TIME_FILTER_OPTIONS,
 } from '../../../components/shared/filters';
 
-// Account type filter options (this can be expanded based on your account types)
-const ACCOUNT_TYPE_FILTER_OPTIONS: FilterOption = {
-    key: 'type',
-    label: 'Tip računa',
-    icon: <User className="size-4" />,
-    options: [
-        { value: '', label: 'Svi tipovi' },
-        { value: 'personal', label: 'Osobni' },
-        { value: 'business', label: 'Poslovni' },
-        { value: 'premium', label: 'Premium' },
-    ],
-};
-
 export function AccountsFilters() {
-    const filters = [TIME_FILTER_OPTIONS, ACCOUNT_TYPE_FILTER_OPTIONS];
+    const filters = [TIME_FILTER_OPTIONS];
 
     return (
         <TableFilter
             filters={filters}
             defaultValues={{
                 from: 'last-30-days',
-                type: '',
             }}
             className="flex"
         />

--- a/apps/app/app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx
@@ -1,7 +1,7 @@
 import {
-    getAccountGardens,
-    getAllRaisedBeds,
-    getRaisedBeds,
+    getAccountGardensFiltered,
+    getAllRaisedBedsFiltered,
+    getRaisedBedsFiltered,
 } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
@@ -19,17 +19,33 @@ import { KnownPages } from '../../../../src/KnownPages';
 export async function RaisedBedsTableCard({
     accountId,
     gardenId,
+    searchParams,
 }: {
     accountId?: string;
     gardenId?: number;
+    searchParams?: { [key: string]: string | string[] | undefined };
 }) {
+    // Get filter parameters
+    const statusFilter =
+        typeof searchParams?.status === 'string'
+            ? searchParams.status
+            : accountId || gardenId
+              ? ''
+              : 'active';
+
+    // Prepare filter parameters
+    const filters = {
+        status: statusFilter || undefined,
+    };
+
+    // Fetch filtered data using the repository filtering functions
     const raisedBeds = accountId
-        ? (await getAccountGardens(accountId)).flatMap(
+        ? (await getAccountGardensFiltered(accountId, filters)).flatMap(
               (garden) => garden.raisedBeds,
           )
         : gardenId
-          ? await getRaisedBeds(gardenId)
-          : await getAllRaisedBeds();
+          ? await getRaisedBedsFiltered(gardenId, filters)
+          : await getAllRaisedBedsFiltered(filters);
 
     return (
         <Card>

--- a/apps/app/app/admin/accounts/page.tsx
+++ b/apps/app/app/admin/accounts/page.tsx
@@ -1,52 +1,20 @@
-import { getAccounts } from '@gredice/storage';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
-import { Chip } from '@signalco/ui-primitives/Chip';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import Link from 'next/link';
-import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../lib/auth/auth';
 import { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
-import { KnownPages } from '../../../src/KnownPages';
 import { AccountsFilters } from './AccountsFilters';
-
-export const dynamic = 'force-dynamic';
+import { AccountsTable } from './AccountsTable';
 
 export default async function AccountsPage({
     searchParams,
-}: {
-    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-}) {
+}: PageProps<'/admin/accounts'>) {
     await auth(['admin']);
     const params = await searchParams;
-
-    // Get filter parameters
-    const typeFilter = typeof params.type === 'string' ? params.type : '';
     const fromFilter =
         typeof params.from === 'string' ? params.from : 'last-30-days';
     const fromDate = getDateFromTimeFilter(fromFilter);
-
-    // Get all accounts
-    const allAccounts = await getAccounts();
-
-    // Apply filters
-    let filteredAccounts = allAccounts;
-
-    // Apply type filter (this would need to be expanded based on your account schema)
-    if (typeFilter) {
-        // For now, this is a placeholder - you'd need to check your account schema
-        // filteredAccounts = filteredAccounts.filter(account => account.type === typeFilter);
-    }
-
-    // Apply date filter
-    if (fromDate) {
-        filteredAccounts = filteredAccounts.filter((account) => {
-            return account.createdAt && account.createdAt >= fromDate;
-        });
-    }
 
     return (
         <Stack spacing={2}>
@@ -54,65 +22,13 @@ export default async function AccountsPage({
                 <Typography level="h1" className="text-2xl" semiBold>
                     {'Računi'}
                 </Typography>
-                <Chip color="primary">{filteredAccounts.length}</Chip>
             </Row>
 
             <AccountsFilters />
 
             <Card>
                 <CardOverflow>
-                    <Table>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.Head>ID</Table.Head>
-                                <Table.Head>Korisnicko ime</Table.Head>
-                                <Table.Head>Datum kreiranja</Table.Head>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {filteredAccounts.length === 0 && (
-                                <Table.Row>
-                                    <Table.Cell colSpan={3}>
-                                        <NoDataPlaceholder>
-                                            Nema računa
-                                        </NoDataPlaceholder>
-                                    </Table.Cell>
-                                </Table.Row>
-                            )}
-                            {filteredAccounts.map((account) => {
-                                const user = account.accountUsers.at(0)?.user;
-                                return (
-                                    <Table.Row key={account.id}>
-                                        <Table.Cell>
-                                            <Link
-                                                href={KnownPages.Account(
-                                                    account.id,
-                                                )}
-                                            >
-                                                {account.id}
-                                            </Link>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Link
-                                                href={KnownPages.User(
-                                                    user?.id ?? '',
-                                                )}
-                                            >
-                                                {user?.displayName ||
-                                                    user?.userName ||
-                                                    'N/A'}
-                                            </Link>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <LocalDateTime time={false}>
-                                                {account.createdAt}
-                                            </LocalDateTime>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                );
-                            })}
-                        </Table.Body>
-                    </Table>
+                    <AccountsTable from={fromDate} />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/admin/accounts/page.tsx
+++ b/apps/app/app/admin/accounts/page.tsx
@@ -9,13 +9,44 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../lib/auth/auth';
+import { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
 import { KnownPages } from '../../../src/KnownPages';
+import { AccountsFilters } from './AccountsFilters';
 
 export const dynamic = 'force-dynamic';
 
-export default async function AccountsPage() {
+export default async function AccountsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
     await auth(['admin']);
-    const accounts = await getAccounts();
+    const params = await searchParams;
+
+    // Get filter parameters
+    const typeFilter = typeof params.type === 'string' ? params.type : '';
+    const fromFilter =
+        typeof params.from === 'string' ? params.from : 'last-30-days';
+    const fromDate = getDateFromTimeFilter(fromFilter);
+
+    // Get all accounts
+    const allAccounts = await getAccounts();
+
+    // Apply filters
+    let filteredAccounts = allAccounts;
+
+    // Apply type filter (this would need to be expanded based on your account schema)
+    if (typeFilter) {
+        // For now, this is a placeholder - you'd need to check your account schema
+        // filteredAccounts = filteredAccounts.filter(account => account.type === typeFilter);
+    }
+
+    // Apply date filter
+    if (fromDate) {
+        filteredAccounts = filteredAccounts.filter((account) => {
+            return account.createdAt && account.createdAt >= fromDate;
+        });
+    }
 
     return (
         <Stack spacing={2}>
@@ -23,8 +54,11 @@ export default async function AccountsPage() {
                 <Typography level="h1" className="text-2xl" semiBold>
                     {'Računi'}
                 </Typography>
-                <Chip color="primary">{accounts.length}</Chip>
+                <Chip color="primary">{filteredAccounts.length}</Chip>
             </Row>
+
+            <AccountsFilters />
+
             <Card>
                 <CardOverflow>
                     <Table>
@@ -36,7 +70,7 @@ export default async function AccountsPage() {
                             </Table.Row>
                         </Table.Header>
                         <Table.Body>
-                            {accounts.length === 0 && (
+                            {filteredAccounts.length === 0 && (
                                 <Table.Row>
                                     <Table.Cell colSpan={3}>
                                         <NoDataPlaceholder>
@@ -45,7 +79,7 @@ export default async function AccountsPage() {
                                     </Table.Cell>
                                 </Table.Row>
                             )}
-                            {accounts.map((account) => {
+                            {filteredAccounts.map((account) => {
                                 const user = account.accountUsers.at(0)?.user;
                                 return (
                                     <Table.Row key={account.id}>

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsFilters.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsFilters.tsx
@@ -1,99 +1,56 @@
 'use client';
 
-import { Close } from '@signalco/ui-icons';
-import { IconButton } from '@signalco/ui-primitives/IconButton';
-import { Input } from '@signalco/ui-primitives/Input';
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { Check, Truck } from '@signalco/ui-icons';
+import {
+    type FilterOption,
+    TableFilter,
+    TIME_FILTER_OPTIONS,
+} from '../../../../components/shared/filters';
+
+// Status filter options for delivery requests
+const STATUS_FILTER_OPTIONS: FilterOption = {
+    key: 'status',
+    label: 'Status zahtjeva',
+    icon: <Check className="size-4" />,
+    options: [
+        { value: '', label: 'Svi statusi' },
+        { value: 'pending', label: 'Na čekanju' },
+        { value: 'confirmed', label: 'Potvrđen' },
+        { value: 'preparing', label: 'U pripremi' },
+        { value: 'ready', label: 'Spreman' },
+        { value: 'fulfilled', label: 'Ispunjen' },
+        { value: 'cancelled', label: 'Otkazan' },
+    ],
+};
+
+// Delivery mode filter options
+const MODE_FILTER_OPTIONS: FilterOption = {
+    key: 'mode',
+    label: 'Način dostave',
+    icon: <Truck className="size-4" />,
+    options: [
+        { value: '', label: 'Svi načini' },
+        { value: 'delivery', label: 'Dostava' },
+        { value: 'pickup', label: 'Preuzimanje' },
+    ],
+};
 
 export function DeliveryRequestsFilters() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-
-    const [filters, setFilters] = useState({
-        status: searchParams.get('status') || 'all',
-        mode: searchParams.get('mode') || 'all',
-        fromDate: searchParams.get('fromDate') || '',
-        toDate: searchParams.get('toDate') || '',
-    });
-
-    const handleFilterChange = (key: string, value: string) => {
-        const newFilters = { ...filters, [key]: value };
-        setFilters(newFilters);
-
-        // Apply filters immediately
-        const params = new URLSearchParams();
-        Object.entries(newFilters).forEach(([key, value]) => {
-            if (value && value !== 'all') params.set(key, value);
-        });
-
-        router.push(`/admin/delivery/requests?${params.toString()}`);
-    };
-
-    const clearFilters = () => {
-        const clearedFilters = {
-            status: 'all',
-            mode: 'all',
-            fromDate: '',
-            toDate: '',
-        };
-        setFilters(clearedFilters);
-        router.push('/admin/delivery/requests');
-    };
+    const filters = [
+        TIME_FILTER_OPTIONS,
+        STATUS_FILTER_OPTIONS,
+        MODE_FILTER_OPTIONS,
+    ];
 
     return (
-        <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-end">
-            <SelectItems
-                variant="outlined"
-                placeholder="Filtriraj po statusu"
-                value={filters.status}
-                onValueChange={(value) => handleFilterChange('status', value)}
-                items={[
-                    { value: 'all', label: 'Svi statusi' },
-                    { value: 'pending', label: 'Na čekanju' },
-                    { value: 'confirmed', label: 'Potvrđen' },
-                    { value: 'preparing', label: 'U pripremi' },
-                    { value: 'ready', label: 'Spreman' },
-                    { value: 'fulfilled', label: 'Ispunjen' },
-                    { value: 'cancelled', label: 'Otkazan' },
-                ]}
-            />
-
-            <SelectItems
-                variant="outlined"
-                placeholder="Filtriraj po načinu"
-                value={filters.mode}
-                onValueChange={(value) => handleFilterChange('mode', value)}
-                items={[
-                    { value: 'all', label: 'Svi načini' },
-                    { value: 'delivery', label: 'Dostava' },
-                    { value: 'pickup', label: 'Preuzimanje' },
-                ]}
-            />
-
-            <Input
-                type="date"
-                label="Od datuma"
-                value={filters.fromDate}
-                onChange={(e) => handleFilterChange('fromDate', e.target.value)}
-            />
-
-            <Input
-                type="date"
-                label="Do datuma"
-                value={filters.toDate}
-                onChange={(e) => handleFilterChange('toDate', e.target.value)}
-            />
-
-            <IconButton
-                variant="outlined"
-                onClick={clearFilters}
-                title="Očisti filtere"
-                aria-label="Očisti filtere"
-            >
-                <Close />
-            </IconButton>
-        </div>
+        <TableFilter
+            filters={filters}
+            defaultValues={{
+                from: 'last-30-days',
+                status: '',
+                mode: '',
+            }}
+            className="flex"
+        />
     );
 }

--- a/apps/app/app/admin/delivery/requests/page.tsx
+++ b/apps/app/app/admin/delivery/requests/page.tsx
@@ -7,8 +7,14 @@ import { DeliveryRequestsTable } from './DeliveryRequestsTable';
 
 export const dynamic = 'force-dynamic';
 
-export default async function AdminDeliveryRequestsPage() {
+export default async function AdminDeliveryRequestsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
     await auth(['admin']);
+
+    const params = await searchParams;
 
     return (
         <Stack spacing={2}>
@@ -18,7 +24,7 @@ export default async function AdminDeliveryRequestsPage() {
             <DeliveryRequestsFilters />
             <Card>
                 <CardOverflow>
-                    <DeliveryRequestsTable />
+                    <DeliveryRequestsTable searchParams={params} />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/admin/delivery/slots/TimeSlotsFilters.tsx
+++ b/apps/app/app/admin/delivery/slots/TimeSlotsFilters.tsx
@@ -1,34 +1,30 @@
 'use client';
 
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { Check } from '@signalco/ui-icons';
+import {
+    type FilterOption,
+    TableFilter,
+} from '../../../../components/shared/filters';
+
+// Status filter options for delivery slots
+const STATUS_FILTER_OPTIONS: FilterOption = {
+    key: 'status',
+    label: 'Status slotova',
+    icon: <Check className="size-4" />,
+    options: [
+        { value: 'active', label: 'Aktivni' },
+        { value: 'all', label: 'Svi slotovi' },
+    ],
+};
 
 export function TimeSlotsFilters() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const status = searchParams.get('status') || 'active';
-
-    const handleChange = (value: string) => {
-        const params = new URLSearchParams(searchParams.toString());
-        if (value === 'active') {
-            params.delete('status');
-        } else {
-            params.set('status', value);
-        }
-        const query = params.toString();
-        router.push(`/admin/delivery/slots${query ? `?${query}` : ''}`);
-    };
+    const filters = [STATUS_FILTER_OPTIONS];
 
     return (
-        <SelectItems
-            variant="outlined"
-            placeholder="Filtriraj po statusu"
-            value={status}
-            onValueChange={handleChange}
-            items={[
-                { value: 'active', label: 'Aktivni' },
-                { value: 'all', label: 'Svi' },
-            ]}
+        <TableFilter
+            filters={filters}
+            defaultValues={{ status: 'active' }}
+            className="flex"
         />
     );
 }

--- a/apps/app/app/admin/delivery/slots/page.tsx
+++ b/apps/app/app/admin/delivery/slots/page.tsx
@@ -16,12 +16,15 @@ export const dynamic = 'force-dynamic';
 export default async function AdminTimeSlotsPage({
     searchParams,
 }: {
-    searchParams: { [key: string]: string | string[] | undefined };
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
     await auth(['admin']);
 
     const pickupLocations = await getPickupLocations();
-    const statusParam = searchParams.status === 'all' ? 'all' : 'active';
+    const params = await searchParams;
+    const statusParam =
+        typeof params.status === 'string' ? params.status : 'active';
+    const status = statusParam === 'all' ? 'all' : 'active';
 
     return (
         <Stack spacing={4}>
@@ -59,7 +62,7 @@ export default async function AdminTimeSlotsPage({
 
             <Card>
                 <CardOverflow>
-                    <TimeSlotsTable status={statusParam} />
+                    <TimeSlotsTable status={status} />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/admin/gardens/GardensFilters.tsx
+++ b/apps/app/app/admin/gardens/GardensFilters.tsx
@@ -13,7 +13,6 @@ export function GardensFilters() {
             filters={filters}
             defaultValues={{
                 from: 'last-30-days',
-                status: '',
             }}
             className="flex"
         />

--- a/apps/app/app/admin/gardens/GardensFilters.tsx
+++ b/apps/app/app/admin/gardens/GardensFilters.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import {
+    TableFilter,
+    TIME_FILTER_OPTIONS,
+} from '../../../components/shared/filters';
+
+export function GardensFilters() {
+    const filters = [TIME_FILTER_OPTIONS];
+
+    return (
+        <TableFilter
+            filters={filters}
+            defaultValues={{
+                from: 'last-30-days',
+                status: '',
+            }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/operations/OperationsFilters.tsx
+++ b/apps/app/app/admin/operations/OperationsFilters.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import {
+    TableFilter,
+    TIME_FILTER_OPTIONS,
+} from '../../../components/shared/filters';
+
+export function OperationsFilters() {
+    const filters = [TIME_FILTER_OPTIONS];
+
+    return (
+        <TableFilter
+            filters={filters}
+            defaultValues={{ from: 'last-14-days' }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -5,20 +5,31 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { OperationsTable } from '../../../components/operations/OperationsTable';
 import { auth } from '../../../lib/auth/auth';
+import { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
 import { BulkOperationCreateModal } from './BulkOperationCreateModal';
+import { OperationsFilters } from './OperationsFilters';
 
 export const dynamic = 'force-dynamic';
 
-export default async function OperationsPage() {
+export default async function OperationsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
     await auth(['admin']);
     const [gardens, raisedBeds] = await Promise.all([
         getGardens(),
         getAllRaisedBeds(),
     ]);
 
+    const params = await searchParams;
+    const fromFilter =
+        typeof params.from === 'string' ? params.from : 'last-14-days';
+    const fromDate = getDateFromTimeFilter(fromFilter);
+
     return (
         <Stack spacing={2}>
-            <Row justify="space-between" align="center">
+            <Row justifyContent="space-between">
                 <Typography level="h1" className="text-2xl" semiBold>
                     Radnje
                 </Typography>
@@ -27,9 +38,10 @@ export default async function OperationsPage() {
                     raisedBeds={raisedBeds}
                 />
             </Row>
+            <OperationsFilters />
             <Card>
                 <CardOverflow>
-                    <OperationsTable />
+                    <OperationsTable fromDate={fromDate} />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/admin/raised-beds/RaisedBedsFilters.tsx
+++ b/apps/app/app/admin/raised-beds/RaisedBedsFilters.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Check } from '@signalco/ui-icons';
+import {
+    type FilterOption,
+    TableFilter,
+} from '../../../components/shared/filters';
+
+// Raised bed status filter options
+const BED_STATUS_FILTER_OPTIONS: FilterOption = {
+    key: 'status',
+    label: 'Status gredice',
+    icon: <Check className="size-4" />,
+    options: [
+        { value: '', label: 'Svi statusi' },
+        { value: 'new', label: 'Nova' },
+        { value: 'active', label: 'Aktivna' },
+    ],
+};
+
+export function RaisedBedsFilters() {
+    const filters = [BED_STATUS_FILTER_OPTIONS];
+
+    return (
+        <TableFilter
+            filters={filters}
+            defaultValues={{
+                status: 'active',
+            }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/raised-beds/page.tsx
+++ b/apps/app/app/admin/raised-beds/page.tsx
@@ -2,17 +2,27 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { auth } from '../../../lib/auth/auth';
 import { RaisedBedsTableCard } from '../accounts/[accountId]/RaisedBedsTableCard';
+import { RaisedBedsFilters } from './RaisedBedsFilters';
 
 export const dynamic = 'force-dynamic';
 
-export default async function RaisedBedsPage() {
+export default async function RaisedBedsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
     await auth(['admin']);
+    const params = await searchParams;
+
     return (
         <Stack spacing={2}>
             <Typography level="h1" className="text-2xl" semiBold>
                 Gredice
             </Typography>
-            <RaisedBedsTableCard />
+
+            <RaisedBedsFilters />
+
+            <RaisedBedsTableCard searchParams={params} />
         </Stack>
     );
 }

--- a/apps/app/app/admin/users/UsersFilters.tsx
+++ b/apps/app/app/admin/users/UsersFilters.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { User } from '@signalco/ui-icons';
+import {
+    type FilterOption,
+    TableFilter,
+    TIME_FILTER_OPTIONS,
+} from '../../../components/shared/filters';
+
+// User role filter options
+const USER_ROLE_FILTER_OPTIONS: FilterOption = {
+    key: 'role',
+    label: 'Uloga korisnika',
+    icon: <User className="size-4" />,
+    options: [
+        { value: '', label: 'Sve uloge' },
+        { value: 'admin', label: 'Administrator' },
+        { value: 'user', label: 'Korisnik' },
+    ],
+};
+
+export function UsersFilters() {
+    const filters = [TIME_FILTER_OPTIONS, USER_ROLE_FILTER_OPTIONS];
+
+    return (
+        <TableFilter
+            filters={filters}
+            defaultValues={{
+                from: 'last-30-days',
+                role: '',
+            }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/components/operations/OperationsTable.tsx
+++ b/apps/app/components/operations/OperationsTable.tsx
@@ -23,16 +23,18 @@ export async function OperationsTable({
     gardenId,
     raisedBedId,
     raisedBedFieldId,
+    fromDate,
 }: {
     accountId?: string;
     gardenId?: number;
     raisedBedId?: number;
     raisedBedFieldId?: number;
-}) {
+    fromDate?: Date;
+} = {}) {
     const [operationsData, operations, accounts, gardens, raisedBeds] =
         await Promise.all([
             getEntitiesFormatted<EntityStandardized>('operation'),
-            getAllOperations(),
+            getAllOperations(fromDate ? { from: fromDate } : undefined),
             getAccounts(),
             getGardens(),
             getAllRaisedBeds(),

--- a/apps/app/components/shared/filters/README.md
+++ b/apps/app/components/shared/filters/README.md
@@ -1,0 +1,235 @@
+# TableFilter Component
+
+A reusable Notion-style filter component for tables that works with URL search parameters.
+
+## Features
+
+- 🎯 **Notion-style UI** - Clean dropdown interface with nested options
+- 🔄 **URL-based** - Filters persist in URL, allowing bookmarking and sharing
+- ⚡ **Extensible** - Easy to add new filter types
+- 🎨 **Active filter chips** - Visual indicators of applied filters
+- 🧹 **Clear all** - One-click filter reset
+
+## Basic Usage
+
+```tsx
+import { TableFilter, FilterOption } from '../shared/filters';
+
+// Define your filter options
+const filters: FilterOption[] = [
+    {
+        key: 'status',
+        label: 'Status',
+        icon: <Status className="size-4" />,
+        options: [
+            { value: '', label: 'All statuses' },
+            { value: 'active', label: 'Active' },
+            { value: 'completed', label: 'Completed' },
+            { value: 'cancelled', label: 'Cancelled' },
+        ],
+    },
+];
+
+function MyPage() {
+    return <TableFilter filters={filters} />;
+}
+```
+
+## Predefined Filters
+
+### Time Filter
+
+Use the predefined `TIME_FILTER_OPTIONS` for common time-based filtering:
+
+```tsx
+import { TableFilter, TIME_FILTER_OPTIONS } from '../shared/filters';
+
+const filters = [TIME_FILTER_OPTIONS]; // "from" parameter
+```
+
+Available time options:
+
+- Today
+- Yesterday  
+- Last 7 days
+- Last 30 days
+- Last 90 days
+- This month
+- Last month
+- This year
+- Last year
+
+### Converting Time Filters
+
+Use `getDateFromTimeFilter()` to convert filter values to Date objects:
+
+```tsx
+import { getDateFromTimeFilter } from '../lib/utils/timeFilters';
+// or
+import { getDateFromTimeFilter } from '../shared/filters';
+
+// In your server component
+export default async function MyPage({ searchParams }) {
+    const fromFilter = searchParams.from;
+    const fromDate = getDateFromTimeFilter(fromFilter);
+    
+    // Pass to your data fetching function
+    const data = await getData({ from: fromDate });
+}
+```
+
+## Server Components with Search Params
+
+For server components that need to respond to filter changes:
+
+```tsx
+// page.tsx (Server Component)
+export default async function MyPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+    const params = await searchParams;
+    const status = typeof params.status === 'string' ? params.status : '';
+    
+    return (
+        <div>
+            <MyFilters /> {/* Client component with TableFilter */}
+            <MyTable status={status} /> {/* Server component */}
+        </div>
+    );
+}
+
+// MyFilters.tsx (Client Component)
+'use client';
+export function MyFilters() {
+    return <TableFilter filters={myFilters} />;
+}
+```
+
+## Custom Filter Types
+
+Create custom filter configurations:
+
+```tsx
+const PRIORITY_FILTER: FilterOption = {
+    key: 'priority',
+    label: 'Priority',
+    icon: <Flag className="size-4" />,
+    options: [
+        { value: '', label: 'All priorities' },
+        { value: 'high', label: 'High', icon: <FlagRed className="size-4" /> },
+        { value: 'medium', label: 'Medium', icon: <FlagYellow className="size-4" /> },
+        { value: 'low', label: 'Low', icon: <FlagGreen className="size-4" /> },
+    ],
+};
+```
+
+## Multiple Filters
+
+Combine multiple filter types:
+
+```tsx
+const filters = [
+    TIME_FILTER_OPTIONS,
+    STATUS_FILTER,
+    PRIORITY_FILTER,
+];
+
+<TableFilter filters={filters} />
+```
+
+## Styling
+
+The component uses Tailwind classes and can be customized:
+
+```tsx
+<TableFilter 
+    filters={filters} 
+    className="my-4 border-b pb-4" 
+/>
+```
+
+## Examples
+
+### Operations Table (Current Implementation)
+
+```tsx
+// page.tsx
+export default async function OperationsPage({ searchParams }) {
+    const params = await searchParams;
+    const fromDate = getDateFromTimeFilter(params.from);
+    
+    return (
+        <div>
+            <OperationsFilters />
+            <OperationsTable fromDate={fromDate} />
+        </div>
+    );
+}
+
+// OperationsFilters.tsx
+'use client';
+export function OperationsFilters() {
+    return <TableFilter filters={[TIME_FILTER_OPTIONS]} />;
+}
+```
+
+### Users Table with Multiple Filters
+
+```tsx
+const USER_FILTERS: FilterOption[] = [
+    {
+        key: 'role',
+        label: 'Role',
+        options: [
+            { value: '', label: 'All roles' },
+            { value: 'admin', label: 'Admin' },
+            { value: 'user', label: 'User' },
+        ],
+    },
+    {
+        key: 'status',
+        label: 'Status', 
+        options: [
+            { value: '', label: 'All statuses' },
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+        ],
+    },
+];
+
+export function UsersFilters() {
+    return <TableFilter filters={USER_FILTERS} />;
+}
+```
+
+## API Reference
+
+### TableFilter Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `filters` | `FilterOption[]` | Array of filter configurations |
+| `onFiltersChange?` | `(filters: Record<string, string>) => void` | Callback when filters change |
+| `className?` | `string` | Additional CSS classes |
+
+### FilterOption Interface
+
+```tsx
+interface FilterOption {
+    key: string;                    // URL parameter name
+    label: string;                  // Display label
+    icon?: React.ReactNode;         // Optional icon
+    options: Array<{
+        value: string;              // Filter value
+        label: string;              // Display label
+        icon?: React.ReactNode;     // Optional icon
+    }>;
+}
+```
+
+### Helper Functions
+
+- `getDateFromTimeFilter(value: string): Date | undefined` - Convert time filter to Date
+- `TIME_FILTER_OPTIONS: FilterOption` - Predefined time filter configuration

--- a/apps/app/components/shared/filters/TableFilter.tsx
+++ b/apps/app/components/shared/filters/TableFilter.tsx
@@ -12,8 +12,9 @@ import {
     DropdownMenuTrigger,
 } from '@signalco/ui-primitives/Menu';
 import { Row } from '@signalco/ui-primitives/Row';
+import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export interface FilterOption {
     key: string;
@@ -92,7 +93,7 @@ export function TableFilter({
             }
 
             const query = params.toString();
-            router.push(`${pathname}${query ? `?${query}` : ''}` as '/');
+            router.push(`${pathname}${query ? `?${query}` : ''}` as Route);
 
             // Notify parent component with new filters
             const newFilters: Record<string, string> = {};
@@ -114,7 +115,7 @@ export function TableFilter({
 
     // Clear all filters
     const clearAllFilters = useCallback(() => {
-        router.push(pathname as '/');
+        router.push(pathname as Route);
         onFiltersChange?.({});
     }, [router, onFiltersChange, pathname]);
 

--- a/apps/app/components/shared/filters/TableFilter.tsx
+++ b/apps/app/components/shared/filters/TableFilter.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { Calendar, Close, Filter } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@signalco/ui-primitives/Menu';
+import { Row } from '@signalco/ui-primitives/Row';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
+
+export interface FilterOption {
+    key: string;
+    label: string;
+    icon?: React.ReactNode;
+    options: Array<{
+        value: string;
+        label: string;
+        icon?: React.ReactNode;
+    }>;
+}
+
+export interface TableFilterProps {
+    filters: FilterOption[];
+    defaultValues?: Record<string, string>;
+    onFiltersChange?: (filters: Record<string, string>) => void;
+    className?: string;
+}
+
+// Predefined time filter options for easy reuse
+export const TIME_FILTER_OPTIONS: FilterOption = {
+    key: 'from',
+    label: 'Vremenski period',
+    icon: <Calendar className="size-4" />,
+    options: [
+        { value: '', label: 'Sve vrijeme' },
+        { value: 'today', label: 'Danas' },
+        { value: 'yesterday', label: 'Jučer' },
+        { value: 'last-7-days', label: 'Zadnjih 7 dana' },
+        { value: 'last-14-days', label: 'Zadnjih 14 dana' },
+        { value: 'last-30-days', label: 'Zadnjih 30 dana' },
+        { value: 'last-90-days', label: 'Zadnjih 90 dana' },
+        { value: 'this-month', label: 'Ovaj mjesec' },
+        { value: 'last-month', label: 'Prošli mjesec' },
+        { value: 'this-year', label: 'Ova godina' },
+        { value: 'last-year', label: 'Prošla godina' },
+    ],
+};
+
+export function TableFilter({
+    filters,
+    defaultValues = {},
+    onFiltersChange,
+    className,
+}: TableFilterProps) {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const pathname = usePathname();
+
+    // Get current filter values from URL or defaults
+    const currentFilters = useMemo(() => {
+        const filtersObj: Record<string, string> = {};
+        filters.forEach((filter) => {
+            const urlValue = searchParams.get(filter.key);
+            const value = urlValue || defaultValues[filter.key] || '';
+            if (value) {
+                filtersObj[filter.key] = value;
+            }
+        });
+        return filtersObj;
+    }, [searchParams, filters, defaultValues]);
+
+    // Get active filter count for display
+    const activeFilterCount =
+        Object.values(currentFilters).filter(Boolean).length;
+
+    // Update URL and notify parent component
+    const updateFilters = useCallback(
+        (key: string, value: string) => {
+            // Update URL
+            const params = new URLSearchParams(searchParams.toString());
+            if (value && value !== 'all' && value !== '') {
+                params.set(key, value);
+            } else {
+                params.delete(key);
+            }
+
+            const query = params.toString();
+            router.push(`${pathname}${query ? `?${query}` : ''}` as '/');
+
+            // Notify parent component with new filters
+            const newFilters: Record<string, string> = {};
+            filters.forEach((filter) => {
+                const filterValue =
+                    key === filter.key ? value : searchParams.get(filter.key);
+                if (
+                    filterValue &&
+                    filterValue !== 'all' &&
+                    filterValue !== ''
+                ) {
+                    newFilters[filter.key] = filterValue;
+                }
+            });
+            onFiltersChange?.(newFilters);
+        },
+        [searchParams, router, pathname, onFiltersChange, filters],
+    );
+
+    // Clear all filters
+    const clearAllFilters = useCallback(() => {
+        router.push(pathname as '/');
+        onFiltersChange?.({});
+    }, [router, onFiltersChange, pathname]);
+
+    // Get label for filter option
+    const getOptionLabel = (filter: FilterOption, value: string) => {
+        const option = filter.options.find((opt) => opt.value === value);
+        return option?.label || value;
+    };
+
+    return (
+        <div className={className}>
+            <Row spacing={2} className="items-center flex-wrap">
+                {/* Notion-style Filters Button */}
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant="outlined"
+                            size="sm"
+                            startDecorator={
+                                <Filter className="size-4 shrink-0" />
+                            }
+                            className="relative rounded-full"
+                        >
+                            {activeFilterCount > 0 && (
+                                <Chip
+                                    size="sm"
+                                    color="info"
+                                    className="ml-2 px-1.5 py-0.5 text-xs min-w-fit"
+                                >
+                                    {activeFilterCount}
+                                </Chip>
+                            )}
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-64">
+                        <DropdownMenuLabel>Filtriraj po</DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+
+                        {/* Filter Categories - Flat Structure */}
+                        {filters.map((filter) => (
+                            <div key={filter.key}>
+                                <DropdownMenuLabel className="text-xs text-muted-foreground px-3 py-1 flex items-center gap-2">
+                                    {filter.icon}
+                                    {filter.label}
+                                </DropdownMenuLabel>
+                                {filter.options.map((option) => (
+                                    <DropdownMenuItem
+                                        key={`${filter.key}-${option.value}`}
+                                        onClick={() =>
+                                            updateFilters(
+                                                filter.key,
+                                                option.value,
+                                            )
+                                        }
+                                        className="justify-between cursor-pointer pl-6"
+                                    >
+                                        <Row
+                                            spacing={2}
+                                            className="items-center"
+                                        >
+                                            {option.icon}
+                                            <span>{option.label}</span>
+                                        </Row>
+                                        {currentFilters[filter.key] ===
+                                            option.value && (
+                                            <div className="w-2 h-2 bg-primary rounded-full" />
+                                        )}
+                                    </DropdownMenuItem>
+                                ))}
+                                {/* Separator between filter groups, except for last */}
+                                {filters.indexOf(filter) <
+                                    filters.length - 1 && (
+                                    <DropdownMenuSeparator />
+                                )}
+                            </div>
+                        ))}
+
+                        {/* Clear All Option */}
+                        {activeFilterCount > 0 && (
+                            <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                    onClick={clearAllFilters}
+                                    className="text-destructive cursor-pointer"
+                                >
+                                    <Close className="size-4 mr-2" />
+                                    Očisti sve filtere
+                                </DropdownMenuItem>
+                            </>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+
+                {/* Active Filter Chips */}
+                {Object.entries(currentFilters).map(([key, value]) => {
+                    const filter = filters.find((f) => f.key === key);
+                    if (!filter) return null;
+
+                    return (
+                        <Chip
+                            key={key}
+                            color="neutral"
+                            size="sm"
+                            onClick={() => updateFilters(key, '')}
+                        >
+                            <Row spacing={1} className="items-center">
+                                {filter.icon}
+                                <span>
+                                    {filter.label}:{' '}
+                                    {getOptionLabel(filter, value)}
+                                </span>
+                                <Close className="size-3" />
+                            </Row>
+                        </Chip>
+                    );
+                })}
+            </Row>
+        </div>
+    );
+}

--- a/apps/app/components/shared/filters/index.ts
+++ b/apps/app/components/shared/filters/index.ts
@@ -1,0 +1,2 @@
+export { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
+export * from './TableFilter';

--- a/apps/app/lib/utils/timeFilters.ts
+++ b/apps/app/lib/utils/timeFilters.ts
@@ -1,0 +1,34 @@
+/**
+ * Utility functions for handling time filters
+ * Can be used in both server and client components
+ */
+
+export function getDateFromTimeFilter(filterValue: string): Date | undefined {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    switch (filterValue) {
+        case 'today':
+            return today;
+        case 'yesterday':
+            return new Date(today.getTime() - 24 * 60 * 60 * 1000);
+        case 'last-7-days':
+            return new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+        case 'last-14-days':
+            return new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000);
+        case 'last-30-days':
+            return new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
+        case 'last-90-days':
+            return new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
+        case 'this-month':
+            return new Date(now.getFullYear(), now.getMonth(), 1);
+        case 'last-month':
+            return new Date(now.getFullYear(), now.getMonth() - 1, 1);
+        case 'this-year':
+            return new Date(now.getFullYear(), 0, 1);
+        case 'last-year':
+            return new Date(now.getFullYear() - 1, 0, 1);
+        default:
+            return undefined;
+    }
+}


### PR DESCRIPTION
Introduce a new TableFilter React component to provide reusable,
Notion-style filter UI for tables. Add FilterOption types and a
predefined TIME_FILTER_OPTIONS set for common date ranges.

Key changes:
- Implement TableFilter.tsx component with dropdown menu, chips,
  and button-based filter controls.
- Sync filter state with URL search params via next/navigation hooks
  (useSearchParams, usePathname, useRouter) so selections persist in
  the URL and support deep linking.
- Expose onFiltersChange callback and defaultValues prop to allow
  parent components to react to filter updates.
- Add helper utilities: currentFilters derivation, active filter
  count, updateFilters and clearAllFilters handlers, and option label
  resolution.

Why:
- Provide a consistent, accessible filter UI across the app.
- Keep filter state in the URL for shareable links and back/forward
  navigation.
- Make it easy to reuse predefined time ranges and integrate filters
  with parent components.