### PR TITLE
Add plant details link to raised bed field modal

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,6 +1,7 @@
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
-import { Book, Hammer, Sprout, Warning } from '@signalco/ui-icons';
+import { Book, ExternalLink, Hammer, Sprout, Warning } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
+import { Link } from '@signalco/ui-primitives/Link';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -14,6 +15,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Image from 'next/image';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
+import { KnownPages } from '../../knownPages';
 import { RaisedBedFieldDiary } from './RaisedBedDiary';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import {
@@ -109,6 +111,11 @@ export function RaisedBedFieldItemPlanted({
               },
           ];
 
+    const plantDetailsUrl = KnownPages.GredicePlantSort(
+        plantSort.information.plant.information?.name ?? 'nepoznato',
+        plantSort.information.name,
+    );
+
     return (
         <Modal
             title={`Biljka "${plantSort.information.name}"`}
@@ -133,16 +140,40 @@ export function RaisedBedFieldItemPlanted({
             }
         >
             <Stack spacing={2}>
-                <Row spacing={2}>
+                <Row
+                    spacing={2}
+                    alignItems="center"
+                    className="flex-wrap gap-y-2"
+                >
                     <Image
                         src={`https://www.gredice.com/${plantSort.image?.cover?.url || plantSort.information.plant.image?.cover?.url}`}
                         alt={plantSort.information.name}
                         width={60}
                         height={60}
                     />
-                    <Typography level="h3">
-                        {plantSort.information.name}
-                    </Typography>
+                    <Row
+                        spacing={1}
+                        alignItems="center"
+                        className="min-w-0 flex-1"
+                    >
+                        <Typography
+                            level="h3"
+                            className="truncate"
+                            title={plantSort.information.name}
+                        >
+                            {plantSort.information.name}
+                        </Typography>
+                        <Link
+                            href={plantDetailsUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label="Detalji o biljci"
+                            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-primary shrink-0"
+                        >
+                            <ExternalLink className="size-4" />
+                            <span className="hidden sm:inline">Detalji</span>
+                        </Link>
+                    </Row>
                 </Row>
                 <Tabs defaultValue="lifecycle" className="flex flex-col gap-2">
                     <TabsList className="border w-fit self-center">

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,5 +1,11 @@
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
-import { Book, ExternalLink, Hammer, Sprout, Warning } from '@signalco/ui-icons';
+import {
+    Book,
+    ExternalLink,
+    Hammer,
+    Sprout,
+    Warning,
+} from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Link } from '@signalco/ui-primitives/Link';
 import { Modal } from '@signalco/ui-primitives/Modal';
@@ -140,22 +146,14 @@ export function RaisedBedFieldItemPlanted({
             }
         >
             <Stack spacing={2}>
-                <Row
-                    spacing={2}
-                    alignItems="center"
-                    className="flex-wrap gap-y-2"
-                >
+                <Row spacing={2} className="flex-wrap gap-y-2">
                     <Image
                         src={`https://www.gredice.com/${plantSort.image?.cover?.url || plantSort.information.plant.image?.cover?.url}`}
                         alt={plantSort.information.name}
                         width={60}
                         height={60}
                     />
-                    <Row
-                        spacing={1}
-                        alignItems="center"
-                        className="min-w-0 flex-1"
-                    >
+                    <Row spacing={2} alignItems="end">
                         <Typography
                             level="h3"
                             className="truncate"
@@ -166,9 +164,8 @@ export function RaisedBedFieldItemPlanted({
                         <Link
                             href={plantDetailsUrl}
                             target="_blank"
-                            rel="noreferrer"
                             aria-label="Detalji o biljci"
-                            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-primary shrink-0"
+                            className="inline-flex mb-1 items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-muted-foreground/60 shrink-0"
                         >
                             <ExternalLink className="size-4" />
                             <span className="hidden sm:inline">Detalji</span>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -112,7 +112,7 @@ export function RaisedBedFieldItemPlanted({
           ];
 
     const plantDetailsUrl = KnownPages.GredicePlantSort(
-        plantSort.information.plant.information?.name ?? 'nepoznato',
+        plantSort.information.plant.information?.name ?? plantSort.information.name,
         plantSort.information.name,
     );
 


### PR DESCRIPTION
## Summary
- add an inline link next to the planted field name to open plant details
- generate the plant sort URL so players can jump to the information page from the modal

## Testing
- pnpm --filter @gredice/game lint *(fails: biome config version mismatch and pre-existing lint errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c849455a9c832f844c9627b711cdb4