### PR TITLE
feat(farm): add farmer login experience

### DIFF
--- a/apps/app/app/admin/users/SelectUserRole.tsx
+++ b/apps/app/app/admin/users/SelectUserRole.tsx
@@ -2,7 +2,7 @@
 
 import type { getUsers } from '@gredice/storage';
 import { ModalConfirm } from '@signalco/ui/ModalConfirm';
-import { Security, User } from '@signalco/ui-icons';
+import { Fence, Security, User } from '@signalco/ui-icons';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
@@ -14,6 +14,29 @@ export function SelectUserRole({
     user: Awaited<ReturnType<typeof getUsers>>[0];
 }) {
     const [confirmOpen, setConfirmOpen] = useState<string | null>(null);
+
+    const roleItems = [
+        {
+            value: 'admin',
+            label: 'Administrator',
+            icon: <Security className="size-5" />,
+        },
+        {
+            value: 'user',
+            label: 'Korisnik',
+            icon: <User className="size-5" />,
+        },
+        {
+            value: 'farmer',
+            label: 'Poljoprivrednik',
+            icon: <Fence className="size-5" />,
+        },
+    ] as const;
+
+    const roleLabels = roleItems.reduce<Record<string, string>>((acc, item) => {
+        acc[item.value] = item.label;
+        return acc;
+    }, {});
 
     const handleUserRoleChange = async (userId: string, newRole: string) => {
         await updateUserRole(userId, newRole);
@@ -33,18 +56,7 @@ export function SelectUserRole({
                 variant="plain"
                 value={user.role}
                 onValueChange={(newRole) => setConfirmOpen(newRole)}
-                items={[
-                    {
-                        value: 'admin',
-                        label: 'Administrator',
-                        icon: <Security className="size-5" />,
-                    },
-                    {
-                        value: 'user',
-                        label: 'Korisnik',
-                        icon: <User className="size-5" />,
-                    },
-                ]}
+                items={roleItems}
             />
             <ModalConfirm
                 header="Promena uloge korisnika"
@@ -57,7 +69,9 @@ export function SelectUserRole({
                     Da li ste sigurni da želite promjeniti ulogu korisnika{' '}
                     <strong>{user.userName}</strong> u{' '}
                     <strong>
-                        {confirmOpen === 'admin' ? 'Administrator' : 'Korisnik'}
+                        {confirmOpen
+                            ? (roleLabels[confirmOpen] ?? confirmOpen)
+                            : ''}
                     </strong>
                     ?
                 </Typography>

--- a/apps/farm/app/api/login/route.ts
+++ b/apps/farm/app/api/login/route.ts
@@ -1,0 +1,24 @@
+import { setCookie } from '../../../lib/auth/auth';
+
+export async function POST(request: Request) {
+    const body = await request.json();
+    const { email, password } = body;
+    if (!email || !password) {
+        return new Response('User name and password are required', {
+            status: 400,
+        });
+    }
+
+    const response = await fetch('https://api.gredice.com/api/auth/login', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password }),
+    });
+    const data = await response.json();
+
+    await setCookie(data.token);
+
+    return Response.json(data);
+}

--- a/apps/farm/app/api/logout/route.ts
+++ b/apps/farm/app/api/logout/route.ts
@@ -1,0 +1,7 @@
+import { clearCookie } from '../../../lib/auth/auth';
+
+export async function POST() {
+    await clearCookie();
+
+    return new Response(null, { status: 200 });
+}

--- a/apps/farm/app/api/users/current/route.ts
+++ b/apps/farm/app/api/users/current/route.ts
@@ -1,0 +1,23 @@
+import { getUser } from '@gredice/storage';
+
+import { withAuth } from '../../../../lib/auth/auth';
+
+export async function GET() {
+    return await withAuth(['farmer', 'admin'], async ({ userId }) => {
+        const dbUser = await getUser(userId);
+        if (!dbUser) {
+            return new Response(JSON.stringify({ error: 'User not found' }), {
+                status: 404,
+            });
+        }
+
+        return Response.json({
+            id: dbUser.id,
+            userName: dbUser.userName,
+            displayName: dbUser.displayName ?? dbUser.userName,
+            avatarUrl: dbUser.avatarUrl,
+            role: dbUser.role,
+            createdAt: dbUser.createdAt,
+        });
+    });
+}

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -4,6 +4,7 @@ import { AxiomWebVitals } from 'next-axiom';
 import './globals.css';
 import Head from 'next/head';
 import type { ReactNode } from 'react';
+import { AuthAppProvider } from '../components/providers/AuthAppProvider';
 import { ClientAppProvider } from '../components/providers/ClientAppProvider';
 
 export const metadata: Metadata = {
@@ -28,8 +29,10 @@ export default function RootLayout({
                 <meta name="theme-color" content="#2e6f40" />
                 <title>Farma | Gredice</title>
             </Head>
-            <body className="antialiased min-h-screen flex">
-                <ClientAppProvider>{children}</ClientAppProvider>
+            <body className="antialiased min-h-screen flex bg-muted">
+                <ClientAppProvider>
+                    <AuthAppProvider>{children}</AuthAppProvider>
+                </ClientAppProvider>
                 <Analytics />
                 <AxiomWebVitals />
             </body>

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -1,5 +1,206 @@
-import { redirect } from 'next/navigation';
+import { getFarms, getUser } from '@gredice/storage';
+import {
+    AuthProtectedSection,
+    SignedOut,
+} from '@signalco/auth-server/components';
+import { Calendar, Droplets, Fence, Sprout } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { Suspense } from 'react';
+import LoginDialog from '../components/auth/LoginDialog';
+import { LogoutButton } from '../components/auth/LogoutButton';
+import { auth } from '../lib/auth/auth';
+
+function formatDate(date?: Date | string | null) {
+    if (!date) {
+        return '—';
+    }
+
+    const parsed = typeof date === 'string' ? new Date(date) : date;
+    if (Number.isNaN(parsed.getTime())) {
+        return '—';
+    }
+
+    return parsed.toLocaleDateString('hr-HR', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+    });
+}
+
+function formatCoordinate(value?: number | null) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return '—';
+    }
+
+    return `${value.toFixed(4)}°`;
+}
+
+async function FarmerDashboard() {
+    const { userId } = await auth(['farmer', 'admin']);
+    const dbUser = await getUser(userId);
+    const farms = await getFarms();
+
+    if (!dbUser) {
+        return (
+            <div className="max-w-5xl mx-auto w-full px-4 py-10">
+                <Typography level="h3" semiBold>
+                    Korisnik nije pronađen.
+                </Typography>
+            </div>
+        );
+    }
+
+    const displayName = dbUser.displayName ?? dbUser.userName;
+    const joinDate = formatDate(dbUser.createdAt);
+
+    return (
+        <div className="max-w-5xl mx-auto w-full px-4 py-10 space-y-6">
+            <div className="rounded-2xl border border-primary/20 bg-primary/5 shadow-sm p-6 space-y-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="space-y-2">
+                        <Typography level="h1" className="text-3xl" semiBold>
+                            {`Dobrodošli, ${displayName}!`}
+                        </Typography>
+                        <Typography className="text-muted-foreground">
+                            Upravljaj farmom, planiraj nadolazeće aktivnosti i
+                            prati napredak u realnom vremenu.
+                        </Typography>
+                    </div>
+                    <LogoutButton />
+                </div>
+                <div className="flex flex-wrap gap-2">
+                    <Chip
+                        color="success"
+                        startDecorator={<Fence className="size-4" />}
+                    >
+                        Poljoprivrednik
+                    </Chip>
+                    <Chip color="neutral">Član od {joinDate}</Chip>
+                    <Chip color="neutral">
+                        Povezanih računa: {dbUser.accounts.length}
+                    </Chip>
+                </div>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+                <Card className="h-full">
+                    <CardHeader>
+                        <Stack spacing={1}>
+                            <CardTitle>Moje farme</CardTitle>
+                            <Typography className="text-sm text-muted-foreground">
+                                Pregled aktivnih farmi u Gredice sustavu.
+                            </Typography>
+                        </Stack>
+                    </CardHeader>
+                    <CardOverflow>
+                        {farms.length ? (
+                            <Table>
+                                <Table.Header>
+                                    <Table.Row>
+                                        <Table.Head>Naziv</Table.Head>
+                                        <Table.Head>Lokacija</Table.Head>
+                                        <Table.Head>Aktivna od</Table.Head>
+                                    </Table.Row>
+                                </Table.Header>
+                                <Table.Body>
+                                    {farms.map((farm) => (
+                                        <Table.Row key={farm.id}>
+                                            <Table.Cell>{farm.name}</Table.Cell>
+                                            <Table.Cell>
+                                                {formatCoordinate(
+                                                    farm.latitude,
+                                                )}
+                                                ,{' '}
+                                                {formatCoordinate(
+                                                    farm.longitude,
+                                                )}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {formatDate(farm.createdAt)}
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    ))}
+                                </Table.Body>
+                            </Table>
+                        ) : (
+                            <div className="p-6 text-sm text-muted-foreground">
+                                Još nema dodanih farmi. Kontaktiraj
+                                administratora kako bi dodali tvoju prvu
+                                lokaciju.
+                            </div>
+                        )}
+                    </CardOverflow>
+                </Card>
+                <Card className="h-full">
+                    <CardHeader>
+                        <Stack spacing={1}>
+                            <CardTitle>Brze radnje</CardTitle>
+                            <Typography className="text-sm text-muted-foreground">
+                                Alati za svakodnevno upravljanje farmom stižu
+                                uskoro.
+                            </Typography>
+                        </Stack>
+                    </CardHeader>
+                    <CardOverflow>
+                        <Stack spacing={2} className="p-4">
+                            <Button
+                                variant="soft"
+                                className="justify-start"
+                                disabled
+                                startDecorator={<Sprout className="size-4" />}
+                            >
+                                Planiraj novu sadnju
+                            </Button>
+                            <Button
+                                variant="soft"
+                                className="justify-start"
+                                disabled
+                                startDecorator={<Droplets className="size-4" />}
+                            >
+                                Postavi raspored navodnjavanja
+                            </Button>
+                            <Button
+                                variant="soft"
+                                className="justify-start"
+                                disabled
+                                startDecorator={<Calendar className="size-4" />}
+                            >
+                                Pregled dnevnih zadataka
+                            </Button>
+                            <Typography className="text-xs text-muted-foreground pt-2">
+                                Više mogućnosti za upravljanje farmom bit će
+                                dostupno uskoro.
+                            </Typography>
+                        </Stack>
+                    </CardOverflow>
+                </Card>
+            </div>
+        </div>
+    );
+}
 
 export default function Home() {
-    redirect('https://www.gredice.com');
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-muted">
+            <AuthProtectedSection auth={authFarmer}>
+                <Suspense>
+                    <FarmerDashboard />
+                </Suspense>
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
 }

--- a/apps/farm/biome.json
+++ b/apps/farm/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { authCurrentUserQueryKeys } from '@signalco/auth-client';
+import { Alert } from '@signalco/ui/Alert';
+import { Warning } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useRouter } from 'next/navigation';
+import { useActionState } from 'react';
+import { queryClient } from '../providers/ClientAppProvider';
+
+export function LoginDialog() {
+    const router = useRouter();
+    const [error, submitAction, isPending] = useActionState<
+        string | null,
+        FormData
+    >(async (_previousState, formData) => {
+        const email = formData.get('email');
+        const password = formData.get('password');
+
+        if (typeof email !== 'string' || typeof password !== 'string') {
+            return 'Unesi korisničko ime i zaporku.';
+        }
+
+        try {
+            const response = await fetch('/api/login', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ email, password }),
+            });
+
+            if (!response.ok) {
+                console.error('Login failed with status', response.status);
+                return 'Prijava nije uspjela. Provjeri podatke i pokušaj ponovno.';
+            }
+
+            const { token } = (await response.json()) as { token?: string };
+            if (token) {
+                localStorage.setItem('gredice-token', token);
+            }
+
+            const currentUserResponse = await fetch('/api/users/current');
+            if (!currentUserResponse.ok) {
+                localStorage.removeItem('gredice-token');
+                return 'Tvoj korisnički račun nema pristup Gredice farmi.';
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: authCurrentUserQueryKeys,
+            });
+            router.refresh();
+            return null;
+        } catch (cause) {
+            console.error('Login request failed', cause);
+            return 'Dogodila se neočekivana greška. Pokušaj ponovno kasnije.';
+        }
+    }, null);
+
+    return (
+        <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-primary/10 via-transparent to-success/10 p-4">
+            <Modal
+                open
+                dismissible={false}
+                hideClose
+                title="Prijava u Gredice farmu"
+                className="md:max-w-md"
+            >
+                <Stack spacing={4}>
+                    <Stack spacing={1}>
+                        <Typography level="h3" className="text-2xl" semiBold>
+                            Dobrodošli natrag
+                        </Typography>
+                        <Typography className="text-muted-foreground">
+                            Prijavi se s Gredice računom kako bi upravljao
+                            farmom.
+                        </Typography>
+                    </Stack>
+                    <form action={submitAction} className="space-y-4">
+                        <Stack spacing={3}>
+                            <Stack spacing={1}>
+                                <Input
+                                    name="email"
+                                    label="Email"
+                                    placeholder="ime@primjer.com"
+                                    type="email"
+                                    autoComplete="email"
+                                    required
+                                />
+                                <Input
+                                    name="password"
+                                    label="Zaporka"
+                                    type="password"
+                                    autoComplete="current-password"
+                                    required
+                                />
+                            </Stack>
+                            <Button
+                                type="submit"
+                                loading={isPending}
+                                variant="solid"
+                                fullWidth
+                            >
+                                Prijavi se
+                            </Button>
+                            {error && (
+                                <Alert
+                                    color="danger"
+                                    startDecorator={
+                                        <Warning className="size-5" />
+                                    }
+                                >
+                                    {error}
+                                </Alert>
+                            )}
+                        </Stack>
+                    </form>
+                </Stack>
+            </Modal>
+        </div>
+    );
+}
+
+export default LoginDialog;

--- a/apps/farm/components/auth/LogoutButton.tsx
+++ b/apps/farm/components/auth/LogoutButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { authCurrentUserQueryKeys } from '@signalco/auth-client';
+import { LogOut } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { queryClient } from '../providers/ClientAppProvider';
+
+export function LogoutButton() {
+    const router = useRouter();
+    const [loading, setLoading] = useState(false);
+
+    const handleLogout = async () => {
+        setLoading(true);
+        try {
+            const response = await fetch('/api/logout', { method: 'POST' });
+            if (!response.ok) {
+                console.error('Logout failed with status', response.status);
+                return;
+            }
+
+            localStorage.removeItem('gredice-token');
+            await queryClient.invalidateQueries({
+                queryKey: authCurrentUserQueryKeys,
+            });
+            router.refresh();
+        } catch (cause) {
+            console.error('Logout request failed', cause);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <Button
+            variant="outlined"
+            startDecorator={<LogOut className="size-4" />}
+            loading={loading}
+            onClick={handleLogout}
+        >
+            Odjavi se
+        </Button>
+    );
+}

--- a/apps/farm/components/providers/AuthAppProvider.tsx
+++ b/apps/farm/components/providers/AuthAppProvider.tsx
@@ -6,6 +6,10 @@ import type { PropsWithChildren } from 'react';
 export type User = {
     id: string;
     userName: string;
+    displayName?: string;
+    avatarUrl?: string | null;
+    role: string;
+    createdAt?: string;
 };
 
 async function currentUserFactory() {

--- a/apps/farm/components/providers/ClientAppProvider.tsx
+++ b/apps/farm/components/providers/ClientAppProvider.tsx
@@ -3,7 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { PropsWithChildren } from 'react';
 
-const queryClient = new QueryClient();
+export const queryClient = new QueryClient();
 
 export function ClientAppProvider({ children }: PropsWithChildren) {
     return (

--- a/apps/farm/lib/auth/auth.ts
+++ b/apps/farm/lib/auth/auth.ts
@@ -1,0 +1,48 @@
+import 'server-only';
+
+import { getUser as storageGetUser } from '@gredice/storage';
+import { initAuth, initRbac } from '@signalco/auth-server';
+
+function jwtSecretFactory() {
+    const signSecret = process.env.GREDICE_JWT_SIGN_SECRET as string;
+    return Buffer.from(signSecret, 'base64');
+}
+
+type User = {
+    id: string;
+    userName: string;
+    accountIds: string[];
+    role: string;
+};
+
+async function getUser(id: string): Promise<User | null> {
+    const user = await storageGetUser(id);
+    if (!user) {
+        return null;
+    }
+
+    return {
+        id: user.id,
+        userName: user.userName,
+        accountIds: user.accounts.map((accountUsers) => accountUsers.accountId),
+        role: user.role,
+    };
+}
+
+export const { withAuth, createJwt, setCookie, auth, clearCookie } = initRbac(
+    initAuth({
+        security: {
+            expiry: 60 * 60 * 1000,
+        },
+        jwt: {
+            namespace: 'gredice',
+            issuer: 'api',
+            audience: 'web',
+            jwtSecretFactory,
+        },
+        cookie: {
+            name: 'gredice_session',
+        },
+        getUser,
+    }),
+);


### PR DESCRIPTION
## Summary
- implement dedicated auth provider, login dialog, and logout handling for the farm app
- build a farmer landing dashboard with farm overview cards and quick actions
- add farmer option to the admin user role selector and align tooling configuration

## Testing
- pnpm --filter farm lint
- pnpm --filter app lint

------
https://chatgpt.com/codex/tasks/task_e_68c84987980c832fac60a2e54f17ac0d