### PR TITLE
feat(docs): improve suncokreti text and use Markdown component

### DIFF
--- a/apps/www/app/suncokreti/page.tsx
+++ b/apps/www/app/suncokreti/page.tsx
@@ -1,11 +1,13 @@
 import type { SectionData } from '@signalco/cms-core/SectionData';
 import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import type { Metadata } from 'next';
 import Image from 'next/image';
+import { Markdown } from '../../components/shared/Markdown';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { sectionsComponentRegistry } from '../../components/shared/sectionsComponentRegistry';
 
-export const metadata = {
+export const metadata: Metadata = {
     title: 'Suncokreti',
     description: 'Sve što trebaš znati o suncokretima.',
 };
@@ -24,13 +26,18 @@ const sectionsData: SectionData[] = [
             },
             {
                 header: 'Kako skupljam suncokrete?',
-                description:
-                    'Suncokrete dobiješ prilikom registracije, redovnim posjetima svog vrta, te za svaku odrađenu akciju u vrtu. Također, za svaku kupnju od 1€ dobivaš 🌻 10.',
+                description: (
+                    <Markdown>
+                        {
+                            'Suncokrete dobiješ prilikom registracije, redovnim posjetima svog vrta, te za svaku odrađenu akciju u vrtu. Također, za svaku kupnju od 1€ dobivaš 🌻10.\n\nUjedno, posjeti svoj vrt svaki dan i uvijek će te čekati novi 🌻.'
+                        }
+                    </Markdown>
+                ),
             },
             {
                 header: 'Za što se mogu koristiti suncokreti?',
                 description:
-                    'Suncokrete možeš koristiti za ukrašavanje svog vrta te brigu o gredicama i biljkama. Suncokrete možeš koristiti umjesto plaćanja pojedinih akcija. 1€ je jednako 🌻 1000 prilikom korištenja za akcije u svom vrtu.',
+                    'Suncokrete možeš koristiti za ukrašavanje svog vrta te brigu o gredicama i biljkama. Suncokrete možeš koristiti umjesto plaćanja pojedinih akcija. 🌻1000 je jednako 1€ prilikom korištenja za akcije ili kupnju biljaka u svom vrtu.',
             },
         ],
     },
@@ -41,7 +48,7 @@ export default function SunflowersPage() {
         <Stack>
             <PageHeader
                 header="Suncokreti"
-                subHeader={`Sakupljaj suncokrete i koristi ih u svom vrtu za uređenje i dekoraciju ili kupnju novih biljaka 🌱`}
+                subHeader={`Sakupljaj i koristi suncokrete za uređenje i dekoraciju vrta ili kupnju i brigu o svojim biljkama 🌱`}
                 padded
                 visual={
                     <Image

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -65,10 +65,9 @@ function SunflowersCard() {
                         />
                         <Stack spacing={2}>
                             <Typography level="body2">
-                                Suncokreti su vrsta bodova na tvom Gredice
-                                racunu koje dobiva za razne radnje i pomocu
-                                kojih mozes uciniti svoj vrt sto lijepsim i
-                                zdravijim.
+                                Sakupljaj i koristi suncokrete za uređenje i
+                                dekoraciju vrta ili kupnju i brigu o svojim
+                                biljkama 🌱
                             </Typography>
                             <Button
                                 variant="solid"


### PR DESCRIPTION
Update UI copy and content handling for Suncokreti (sunflower) pages and HUD.

- Revise explanatory in SunflowersHud to a, action-oriented
  message instructing users to collect and use suncokreti for garden
  decoration and plant care.
- Tighten and clarify descriptions on the public suncokreti page:
  - Use the shared Markdown component for richer text (line breaks and
    paragraphs) in the "Kako skupljam suncokrete?" section.
  - Rephrase value conversion and usage details to explicitly state
    that 🌻1000 equals 1€ for actions and plant purchases.
  - Align PageHeader subHeader with the HUD copy for consistent wording.
- Add next Metadata typing and import for Markdown; adjust imports
  accordingly.

These changes improve clarity, consistency across HUD and pages, and
enable richer formatting for explanatory content.