### PR TITLE
feat(garden): assign unique block ids and improve block move logs

### DIFF
--- a/packages/client/src/hono.ts
+++ b/packages/client/src/hono.ts
@@ -3,13 +3,14 @@ import { hc, type InferResponseType } from 'hono/client';
 import { getAppUrl, getAuthHeaders } from './shared';
 
 function clientAuth() {
-    if (typeof localStorage === 'undefined') {
+    const authorization = getAuthHeaders();
+    if (!authorization) {
         return {};
     }
 
     return {
         headers: {
-            authorization: getAuthHeaders() ?? '',
+            authorization,
         },
     };
 }

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -52,6 +52,15 @@ const noRenderInViewDefault = [
     'Pine',
     'Block_Sand',
     'Block_Sand_Angle',
+    'Pine',
+    'Shovel_Small',
+    'Mulch_Hey',
+    'Mulch_Coconut',
+    'Mulch_Wood',
+    'Tulip',
+    'BaleHey',
+    'Stick',
+    'Seed',
 ];
 
 export function GameScene({

--- a/packages/game/src/hooks/useBlockMove.ts
+++ b/packages/game/src/hooks/useBlockMove.ts
@@ -46,6 +46,12 @@ export function useBlockMove() {
                 return;
             }
 
+            console.debug(
+                'Optimistically moving block',
+                sourcePosition,
+                destinationPosition,
+                blockIndex,
+            );
             const sourceStack = garden.stacks.find(
                 (stack) =>
                     stack.position.x === sourcePosition.x &&
@@ -70,12 +76,25 @@ export function useBlockMove() {
                 });
             }
 
+            // Ignore if source and destination are the same
+            if (
+                sourcePosition.x === destinationPosition.x &&
+                sourcePosition.z === destinationPosition.z
+            ) {
+                return;
+            }
+
             const updatedStacks = garden.stacks.map((stack) => {
                 // Update source stack
                 if (
                     stack.position.x === sourcePosition.x &&
                     stack.position.z === sourcePosition.z
                 ) {
+                    console.debug(
+                        'Removing block from source stack',
+                        stack,
+                        sourceStack.blocks[blockIndex],
+                    );
                     return {
                         ...stack,
                         blocks: stack.blocks.filter(
@@ -89,6 +108,11 @@ export function useBlockMove() {
                     stack.position.x === destinationPosition.x &&
                     stack.position.z === destinationPosition.z
                 ) {
+                    console.debug(
+                        'Adding block to destination stack',
+                        stack,
+                        sourceStack.blocks[blockIndex],
+                    );
                     return {
                         ...stack,
                         blocks: [
@@ -97,6 +121,8 @@ export function useBlockMove() {
                         ],
                     };
                 }
+
+                // No changes for other stacks
                 return stack;
             });
 

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -31,7 +31,7 @@ function mockGarden() {
                 position: new Vector3(-1, 0, 2),
                 blocks: [
                     {
-                        id: '1',
+                        id: '2',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -41,7 +41,7 @@ function mockGarden() {
                 position: new Vector3(1, 0, 2),
                 blocks: [
                     {
-                        id: '1',
+                        id: '4',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -51,7 +51,7 @@ function mockGarden() {
                 position: new Vector3(0, 0, 2),
                 blocks: [
                     {
-                        id: '1',
+                        id: '5',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -61,7 +61,7 @@ function mockGarden() {
                 position: new Vector3(1, 0, 0),
                 blocks: [
                     {
-                        id: '1',
+                        id: '6',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -71,12 +71,12 @@ function mockGarden() {
                 position: new Vector3(0, 0, 1),
                 blocks: [
                     {
-                        id: '1',
+                        id: '7',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
                     {
-                        id: '4',
+                        id: '8',
                         name: 'Raised_Bed',
                         rotation: 0,
                     },
@@ -86,7 +86,7 @@ function mockGarden() {
                 position: new Vector3(1, 0, 1),
                 blocks: [
                     {
-                        id: '1',
+                        id: '9',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -96,7 +96,7 @@ function mockGarden() {
                 position: new Vector3(-1, 0, 1),
                 blocks: [
                     {
-                        id: '1',
+                        id: '10',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -106,12 +106,12 @@ function mockGarden() {
                 position: new Vector3(1, 0, -1),
                 blocks: [
                     {
-                        id: '1',
+                        id: '11',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
                     {
-                        id: '4',
+                        id: '12',
                         name: 'Bush',
                         rotation: 0,
                     },
@@ -121,7 +121,7 @@ function mockGarden() {
                 position: new Vector3(-1, 0, 0),
                 blocks: [
                     {
-                        id: '2',
+                        id: '13',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -131,7 +131,7 @@ function mockGarden() {
                 position: new Vector3(0, 0, -1),
                 blocks: [
                     {
-                        id: '3',
+                        id: '14',
                         name: 'Block_Grass',
                         rotation: 0,
                     },
@@ -141,7 +141,7 @@ function mockGarden() {
                 position: new Vector3(-1, 0, -1),
                 blocks: [
                     {
-                        id: '4',
+                        id: '15',
                         name: 'Block_Grass',
                         rotation: 0,
                     },


### PR DESCRIPTION
Update hardcoded block ids in the garden fixture to use unique ids
instead of repeated '1', ensuring each block has a distinct identifier
(Block_Grass, Raised_Bed, Bush, etc.). This prevents id collisions and
makes block references unambiguous for future operations and tests.

Add optimistic-move debug logging and guards in useBlockMove:
- Log the optimistic move with source/destination positions and index.
- Log the removed block and source stack when taking from a stack.
- Early-return if source and destination positions are identical.
These changes aid debugging of block moves and avoid unnecessary state
updates when a block is moved to the same position.