### PR TITLE
Add plant sort selector to raised bed fields table

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -54,9 +54,8 @@ export async function raisedBedFieldUpdatePlant({
     );
     if (plantSortId && existingField?.plantSortId !== plantSortId) {
         await createEvent(
-            knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            knownEvents.raisedBedFields.plantReplaceSortV1(aggregateId, {
                 plantSortId: plantSortId.toString(),
-                scheduledDate: null,
             }),
         );
     }

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -37,7 +37,7 @@ export async function raisedBedFieldUpdatePlant({
 }: {
     raisedBedId: number;
     positionIndex: number;
-    status: string;
+    status?: string;
     plantSortId?: number;
 }) {
     await auth(['admin']);
@@ -61,14 +61,16 @@ export async function raisedBedFieldUpdatePlant({
         );
     }
 
-    await createEvent(
-        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
-            status: status,
-        }),
-    );
+    if (status) {
+        await createEvent(
+            knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+                status: status,
+            }),
+        );
+    }
 
     const sortIdToUse = plantSortId ?? existingField?.plantSortId;
-    if (sortIdToUse) {
+    if (sortIdToUse && status) {
         const sortData =
             await getEntityFormatted<EntityStandardized>(sortIdToUse);
         if (sortData) {
@@ -123,7 +125,7 @@ export async function raisedBedFieldUpdatePlant({
                 `No plant sort data found for raised bed ${raisedBedId} at position ${positionIndex}.`,
             );
         }
-    } else {
+    } else if (status && !sortIdToUse) {
         console.warn(
             `No plant sort found for raised bed ${raisedBedId} at position ${positionIndex}.`,
         );

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
 import { raisedBedFieldUpdatePlant } from '../../../(actions)/raisedBedFieldsActions';
-import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 
 type RaisedBedFieldPlantSortSelectorProps = {
     raisedBedId: number;
@@ -19,13 +19,15 @@ export function RaisedBedFieldPlantSortSelector({
     plantSortId,
     plantSorts,
 }: RaisedBedFieldPlantSortSelectorProps) {
-    const items = plantSorts.map((sort) => ({
-        value: sort.id.toString(),
-        label:
-            sort.information?.label ??
-            sort.information?.name ??
-            `Biljka ${sort.id}`,
-    }));
+    const items = plantSorts
+        .map((sort) => ({
+            value: sort.id.toString(),
+            label:
+                sort.information?.label ??
+                sort.information?.name ??
+                `Biljka ${sort.id}`,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label));
 
     if (
         plantSortId &&
@@ -50,7 +52,7 @@ export function RaisedBedFieldPlantSortSelector({
             return;
         }
 
-        void raisedBedFieldUpdatePlant({
+        raisedBedFieldUpdatePlant({
             raisedBedId,
             positionIndex,
             status: status ?? undefined,

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { raisedBedFieldUpdatePlant } from '../../../(actions)/raisedBedFieldsActions';
+import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
+
+type RaisedBedFieldPlantSortSelectorProps = {
+    raisedBedId: number;
+    positionIndex: number;
+    status: string | null;
+    plantSortId?: number | null;
+    plantSorts: EntityStandardized[];
+};
+
+export function RaisedBedFieldPlantSortSelector({
+    raisedBedId,
+    positionIndex,
+    status,
+    plantSortId,
+    plantSorts,
+}: RaisedBedFieldPlantSortSelectorProps) {
+    const items = plantSorts.map((sort) => ({
+        value: sort.id.toString(),
+        label:
+            sort.information?.label ??
+            sort.information?.name ??
+            `Biljka ${sort.id}`,
+    }));
+
+    if (
+        plantSortId &&
+        !items.some((item) => item.value === plantSortId.toString())
+    ) {
+        items.push({
+            value: plantSortId.toString(),
+            label: `Biljka ${plantSortId}`,
+        });
+    }
+
+    const placeholder =
+        items.length === 0 ? 'Nema dostupnih biljaka' : 'Odaberi biljku';
+
+    const handleChange = (newValue: string) => {
+        if (!newValue) {
+            return;
+        }
+
+        const nextPlantSortId = Number.parseInt(newValue, 10);
+        if (Number.isNaN(nextPlantSortId) || nextPlantSortId === plantSortId) {
+            return;
+        }
+
+        void raisedBedFieldUpdatePlant({
+            raisedBedId,
+            positionIndex,
+            status: status ?? undefined,
+            plantSortId: nextPlantSortId,
+        });
+    };
+
+    return (
+        <SelectItems
+            placeholder={placeholder}
+            value={plantSortId ? plantSortId.toString() : ''}
+            onValueChange={handleChange}
+            items={items}
+            disabled={items.length === 0}
+        />
+    );
+}

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -4,6 +4,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { RaisedBedFieldPlantSortSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector';
 import { RaisedBedFieldPlantStatusSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector';
 import type { EntityStandardized } from '../../lib/@types/EntityStandardized';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
@@ -41,16 +42,19 @@ export async function RaisedBedFieldsTable({
                 {fields
                     ?.sort((fa, fb) => fa.positionIndex - fb.positionIndex)
                     .map((field) => {
-                        const sortData = sortsData?.find(
-                            (sort) => sort.id === field.plantSortId,
-                        );
                         return (
                             <Table.Row key={field.id}>
                                 <Table.Cell>
                                     {field.positionIndex + 1}
                                 </Table.Cell>
                                 <Table.Cell>
-                                    {sortData?.information?.name}
+                                    <RaisedBedFieldPlantSortSelector
+                                        raisedBedId={raisedBedId}
+                                        positionIndex={field.positionIndex}
+                                        status={field.plantStatus ?? null}
+                                        plantSortId={field.plantSortId}
+                                        plantSorts={sortsData ?? []}
+                                    />
                                 </Table.Cell>
                                 <Table.Cell>
                                     {field.plantStatus ? (

--- a/packages/storage/src/repositories/eventsRepo.ts
+++ b/packages/storage/src/repositories/eventsRepo.ts
@@ -45,6 +45,7 @@ export const knownEventTypes = {
         delete: 'raisedBedField.delete',
         plantPlace: 'raisedBedField.plantPlace',
         plantUpdate: 'raisedBedField.plantUpdate',
+        plantReplaceSort: 'raisedBedField.plantReplaceSort',
     },
     operations: {
         schedule: 'operation.schedule',
@@ -291,6 +292,15 @@ export const knownEvents = {
         }),
         plantUpdateV1: (aggregateId: string, data: { status: string }) => ({
             type: knownEventTypes.raisedBedFields.plantUpdate,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        plantReplaceSortV1: (
+            aggregateId: string,
+            data: { plantSortId: string },
+        ) => ({
+            type: knownEventTypes.raisedBedFields.plantReplaceSort,
             version: 1,
             aggregateId,
             data,

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -419,6 +419,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
             knownEventTypes.raisedBedFields.delete,
             knownEventTypes.raisedBedFields.plantPlace,
             knownEventTypes.raisedBedFields.plantUpdate,
+            knownEventTypes.raisedBedFields.plantReplaceSort,
         ],
         fieldAggregateIds,
         0,
@@ -503,6 +504,12 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
 
                     // Don't process any newer events for this field
                     break;
+                }
+            } else if (
+                event.type === knownEventTypes.raisedBedFields.plantReplaceSort
+            ) {
+                if (data?.plantSortId && typeof data.plantSortId === 'string') {
+                    plantSortId = parseInt(data.plantSortId, 10);
                 }
             }
             // else if (event.type === knownEventTypes.raisedBedFields.operationOrder) {
@@ -679,6 +686,7 @@ export async function getRaisedBedFieldDiaryEntries(
                 knownEventTypes.raisedBedFields.create,
                 knownEventTypes.raisedBedFields.plantPlace,
                 knownEventTypes.raisedBedFields.plantUpdate,
+                knownEventTypes.raisedBedFields.plantReplaceSort,
                 knownEventTypes.raisedBedFields.delete,
             ],
             [`${raisedBedId.toString()}|${positionIndex.toString()}`],
@@ -725,6 +733,11 @@ export async function getRaisedBedFieldDiaryEntries(
                     const statusLabels = plantFieldStatusLabel(newStatus);
                     name = statusLabels.label;
                     description = statusLabels.description;
+                    break;
+                }
+                case knownEventTypes.raisedBedFields.plantReplaceSort: {
+                    name = 'Zamjena sorte biljke';
+                    description = 'Za biljku je zamjenjena navedena sorta.';
                     break;
                 }
                 case knownEventTypes.raisedBedFields.delete: {


### PR DESCRIPTION
## Summary
- add a client-side selector to each raised bed field row so admins can change the plant sort in place
- allow the raised bed field update action to skip status updates and notifications when no status change is requested

## Testing
- pnpm --filter app lint

------
https://chatgpt.com/codex/tasks/task_e_68cefa458518832f9e626fe7b9db2d4c