### PR TITLE
Allow updating raised bed status from detail page

### DIFF
--- a/apps/app/app/(actions)/raisedBedActions.ts
+++ b/apps/app/app/(actions)/raisedBedActions.ts
@@ -30,16 +30,12 @@ export async function setRaisedBedStatus(
 ) {
     await auth(['admin']);
 
-    if (!raisedBedStatuses.includes(status)) {
-        throw new Error(`Invalid raised bed status: ${status}`);
-    }
-
     const raisedBed = await getRaisedBed(raisedBedId);
-
     if (!raisedBed) {
         throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
     }
 
+    // Ignore if unchanged
     if (raisedBed.status === status) {
         return;
     }

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedStatusSelect.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedStatusSelect.tsx
@@ -45,6 +45,7 @@ export function RaisedBedStatusSelect({
 
     return (
         <SelectItems
+            label="Status"
             value={status}
             onValueChange={(newValue) => {
                 if (!isRaisedBedStatus(newValue) || newValue === status) {

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedStatusSelect.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedStatusSelect.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { useMemo } from 'react';
+import { setRaisedBedStatus } from '../../../(actions)/raisedBedActions';
+
+type RaisedBedStatusValue = Parameters<typeof setRaisedBedStatus>[1];
+
+const STATUS_ITEMS: Array<{
+    value: RaisedBedStatusValue;
+    label: string;
+    icon: string;
+}> = [
+    { value: 'new', label: 'Nova', icon: '🆕' },
+    { value: 'approved', label: 'Odobrena', icon: '✅' },
+    { value: 'built', label: 'Izgrađena', icon: '🏗️' },
+    { value: 'active', label: 'Aktivna', icon: '🌿' },
+];
+
+function isRaisedBedStatus(value: string): value is RaisedBedStatusValue {
+    return STATUS_ITEMS.some((item) => item.value === value);
+}
+
+export function RaisedBedStatusSelect({
+    raisedBedId,
+    status,
+}: {
+    raisedBedId: number;
+    status: string;
+}) {
+    const items = useMemo(() => {
+        if (isRaisedBedStatus(status)) {
+            return STATUS_ITEMS;
+        }
+
+        return [
+            {
+                value: status,
+                label: status?.length ? status : 'Nepoznato',
+                icon: 'ℹ️',
+            },
+            ...STATUS_ITEMS,
+        ];
+    }, [status]);
+
+    return (
+        <SelectItems
+            value={status}
+            onValueChange={(newValue) => {
+                if (!isRaisedBedStatus(newValue) || newValue === status) {
+                    return;
+                }
+
+                void setRaisedBedStatus(raisedBedId, newValue);
+            }}
+            items={items}
+        />
+    );
+}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedStatusSelect.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedStatusSelect.tsx
@@ -36,7 +36,7 @@ export function RaisedBedStatusSelect({
         return [
             {
                 value: status,
-                label: status?.length ? status : 'Nepoznato',
+                label: status,
                 icon: 'ℹ️',
             },
             ...STATUS_ITEMS,
@@ -52,7 +52,7 @@ export function RaisedBedStatusSelect({
                     return;
                 }
 
-                void setRaisedBedStatus(raisedBedId, newValue);
+                setRaisedBedStatus(raisedBedId, newValue);
             }}
             items={items}
         />

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -19,6 +19,7 @@ import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
 import { OperationsTableCard } from './OperationsTableCard';
 import { RaisedBedPhysicalIdInput } from './RaisedBedPhysicalIdInput';
+import { RaisedBedStatusSelect } from './RaisedBedStatusSelect';
 
 export const dynamic = 'force-dynamic';
 
@@ -69,6 +70,15 @@ export default async function RaisedBedPage({
                         <RaisedBedPhysicalIdInput
                             raisedBedId={raisedBed.id}
                             physicalId={raisedBed.physicalId}
+                        />
+                        <Field
+                            name="Status"
+                            value={
+                                <RaisedBedStatusSelect
+                                    raisedBedId={raisedBed.id}
+                                    status={raisedBed.status}
+                                />
+                            }
                         />
                         <Field
                             name="Datum kreiranja"

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -71,14 +71,9 @@ export default async function RaisedBedPage({
                             raisedBedId={raisedBed.id}
                             physicalId={raisedBed.physicalId}
                         />
-                        <Field
-                            name="Status"
-                            value={
-                                <RaisedBedStatusSelect
-                                    raisedBedId={raisedBed.id}
-                                    status={raisedBed.status}
-                                />
-                            }
+                        <RaisedBedStatusSelect
+                            raisedBedId={raisedBed.id}
+                            status={raisedBed.status}
                         />
                         <Field
                             name="Datum kreiranja"


### PR DESCRIPTION
## Summary
- add a server action that updates raised bed status and refreshes dependent pages
- expose a status selector on the raised bed detail page so admins can change the value
- ensure the selector handles unknown statuses gracefully while using localized labels

## Testing
- pnpm lint --filter app

------
https://chatgpt.com/codex/tasks/task_e_68cf0afdcd10832f8c22e12286325d40