### PR TITLE
Filter schedule clipboard tasks to approved items

### DIFF
--- a/apps/app/app/admin/schedule/CopyTasksButton.tsx
+++ b/apps/app/app/admin/schedule/CopyTasksButton.tsx
@@ -9,6 +9,7 @@ type TaskItem = {
     id: string;
     text: string;
     link?: string;
+    approved?: boolean;
 };
 
 type CopyTasksButtonProps = {
@@ -18,13 +19,18 @@ type CopyTasksButtonProps = {
 
 export function CopyTasksButton({ physicalId, tasks }: CopyTasksButtonProps) {
     const [copied, setCopied] = useState(false);
+    const approvedTasks = tasks.filter((task) => task.approved ?? true);
 
     const handleCopy = async (e: React.MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
 
+        if (approvedTasks.length === 0) {
+            return;
+        }
+
         // Create formatted text with links
-        const taskText = tasks
+        const taskText = approvedTasks
             .map((task) => {
                 // TODO: Not working for WhatsApp
                 // if (task.link) {
@@ -51,7 +57,7 @@ export function CopyTasksButton({ physicalId, tasks }: CopyTasksButtonProps) {
                 title="Kopiraj zadatke u međuspremnik"
                 onClick={handleCopy}
                 variant="plain"
-                disabled={tasks.length === 0}
+                disabled={approvedTasks.length === 0}
                 startDecorator={<Duplicate className="size-4 shrink-0" />}
             >
                 Kopiraj zadatke

--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -227,6 +227,7 @@ export function ScheduleDay({
                         return {
                             id: `field-${field.id}`,
                             text: `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : '?'}`,
+                            approved: field.plantStatus === 'planned',
                         };
                     }),
                     ...dayOperations.map((op) => {
@@ -241,6 +242,7 @@ export function ScheduleDay({
                                       operationData?.information?.label,
                                   )
                                 : KnownPages.GrediceOperations,
+                            approved: op.isAccepted,
                         };
                     }),
                 ];


### PR DESCRIPTION
## Summary
- only include accepted operations and planned plantings when preparing schedule clipboard text
- disable the copy button when a schedule group has no approved tasks to prevent empty clipboard output

## Testing
- pnpm lint --filter app

------
https://chatgpt.com/codex/tasks/task_e_68cfc7589864832fa2920231c9b0fe6a