### PR TITLE
feat(auth): increase default JWT expiry durations

### DIFF
--- a/apps/app/lib/auth/auth.ts
+++ b/apps/app/lib/auth/auth.ts
@@ -31,7 +31,7 @@ async function getUser(id: string): Promise<User | null> {
 export const { withAuth, createJwt, setCookie, auth, clearCookie } = initRbac(
     initAuth({
         security: {
-            expiry: 60 * 60 * 1000,
+            expiry: 24 * 60 * 60 * 1000,
         },
         jwt: {
             namespace: 'gredice',

--- a/apps/farm/lib/auth/auth.ts
+++ b/apps/farm/lib/auth/auth.ts
@@ -32,7 +32,7 @@ async function getUser(id: string): Promise<User | null> {
 export const { withAuth, createJwt, setCookie, auth, clearCookie } = initRbac(
     initAuth({
         security: {
-            expiry: 60 * 60 * 1000,
+            expiry: 7 * 24 * 60 * 60 * 1000,
         },
         jwt: {
             namespace: 'gredice',


### PR DESCRIPTION
Extend JWT expiry times to reduce how frequently users must 
re-authenticate. Set the app-level token lifetime to 24 hours to allow 
day-long sessions without frequent renewals. Increase the farm-level 
token lifetime to 7 days to support longer-lived sessions for 
farm-related workflows and reduce friction for users who interact less 
frequently.

This change targets security.expiry in both auth configs to adjust session
lengths while retaining existing JWT settings and namespaces.