### PR TITLE
docs: add conventions section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ This repository is the **Gredice** monorepo. It hosts several Next.js applicatio
 - **Testing**: Use `pnpm test` to execute the configured Turborepo test tasks. Many apps expose Playwright-powered suites (`pnpm test:run --filter www`, etc.). Scope tests to the area you modified whenever possible.
 - **Builds**: Validate production builds with `pnpm build`, or filter down to specific packages/apps as needed.
 
+## Conventions and standards
+
+- Don't create new components or utilities without checking for existing ones in `@gredice/ui` or other shared packages.
+- If component is not present in `@gredice/ui`, consider contributing it there if it has potential for reuse and general applicability.
+
 ## Database & storage tooling
 
 - Schema changes live under `packages/storage`. Use `pnpm db-generate` after modifying the schema to create migrations.


### PR DESCRIPTION
Introduce a "Conventions and standards" section to AGENTS.md that
documents guidance about reusing shared components and contributing
new ones to the @gredice/ui package. The change clarifies that:
- Developers should check existing shared packages (like @gredice/ui)
  before adding new components or utilities.
- If a component is reusable, consider contributing it to @gredice/ui.

This reduces duplication, encourages consistency across packages,
and promotes sharing reusable UI and utilities within the monorepo.