### PR TITLE
feat(deps): add pg and image quality for Next.js config

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -17,6 +17,7 @@ const nextConfig: NextConfig = {
                 protocol: 'https',
             },
         ],
+        qualities: [80, 100],
     },
     productionBrowserSourceMaps: true,
 };

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "hypertune": "2.10.0",
         "next": "15.5.3",
+        "pg": "8.16.3",
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "server-only": "0.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       next:
         specifier: 15.5.3
         version: 15.5.3(@playwright/test@1.55.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.92.1)
+      pg:
+        specifier: 8.16.3
+        version: 8.16.3
       react:
         specifier: 19.1.1
         version: 19.1.1


### PR DESCRIPTION
Add the PostgreSQL client (pg v8.16.3) to the farm app dependencies
and pnpm lockfile so the application can connect to Postgres databases
from the Next.js server/runtime.

Adjust Next.js image config in apps/api/next.config.ts to include
qualities [80, 100], enabling specified image output quality settings
for optimized image handling and consistent production assets.