### PR TITLE
feat(garden): allow dev to bind to all interfaces

### DIFF
--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbo -p 3001",
+        "dev": "next dev --turbo -p 3001 --hostname 0.0.0.0",
         "build": "next build --turbopack",
         "start": "next start",
         "test": "pnpm run /^test:.*/",


### PR DESCRIPTION
Add --hostname 0.0.0.0 to the development script so the Next.js dev server listens on all network interfaces. This enables access to the app from other devices and containers (e.g., remote debugging, VM or Docker workflows) without changing host networking. The change keeps existing flags (--turbo and port 3001) intact.