### PR TITLE
Add schedule day summary and duration breakdown

### DIFF
--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -224,11 +224,16 @@ export function ScheduleDay({
                         </Typography>
                         <Typography level="body3">zadataka</Typography>
                     </Row>
-                    <Typography level="body2">
-                        Vrijeme (odobreno/ukupno):{' '}
-                        {formatMinutes(approvedDuration)} /{' '}
-                        {formatMinutes(totalDuration)}
-                    </Typography>
+                    <Row spacing={0.5}>
+                        <Typography level="body3">Vrijeme:</Typography>
+                        <Typography level="body1" semiBold>
+                            {formatMinutes(approvedDuration)}
+                        </Typography>
+                        <Typography level="body3">/</Typography>
+                        <Typography level="body3" semiBold>
+                            {formatMinutes(totalDuration)}
+                        </Typography>
+                    </Row>
                 </Row>
             </Stack>
             {!hasTasks && (


### PR DESCRIPTION
## Summary
- add a daily summary row on the admin schedule highlighting approved vs total tasks and time
- compute task durations from operation metadata and planting defaults, rounding up and showing minutes
- show raised bed level approved/total minute counts next to the physical label while keeping copy output unchanged

## Testing
- pnpm lint --filter app

------
https://chatgpt.com/codex/tasks/task_e_68d26962acd0832f83c0af53e779f9f7