### PR TITLE
feat(audio): audio hook to React state and callbacks

### DIFF
--- a/packages/game/src/hooks/useAudioState.ts
+++ b/packages/game/src/hooks/useAudioState.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from 'react';
+import { audioConfig } from '../utils/audioConfig';
+
+/**
+ * A more React-like audio state management hook that separates
+ * concerns and provides a cleaner API for audio management.
+ */
+
+export interface AudioState {
+    masterVolume: number;
+    masterIsMuted: boolean;
+    ambientVolume: number;
+    ambientIsMuted: boolean;
+    effectsVolume: number;
+    effectsIsMuted: boolean;
+    isSuspended: boolean;
+}
+
+export interface AudioActions {
+    setMasterVolume: (volume: number) => void;
+    setMasterMuted: (muted: boolean) => void;
+    setAmbientVolume: (volume: number) => void;
+    setAmbientMuted: (muted: boolean) => void;
+    setEffectsVolume: (volume: number) => void;
+    setEffectsMuted: (muted: boolean) => void;
+    resumeAudio: () => Promise<void>;
+    resetToDefaults: () => void;
+}
+
+export interface UseAudioStateReturn extends AudioState, AudioActions {}
+
+/**
+ * Custom hook for managing audio state in a React-friendly way.
+ * Provides a clean separation between state and actions.
+ */
+export function useAudioState(): UseAudioStateReturn {
+    // Initialize state from audio config
+    const [state, setState] = useState<AudioState>(() => {
+        const config = audioConfig().config;
+        return {
+            masterVolume: config.masterVolume,
+            masterIsMuted: config.masterIsMuted,
+            ambientVolume: config.ambientVolume / config.masterVolume,
+            ambientIsMuted: config.ambientIsMuted,
+            effectsVolume: config.effectsVolume / config.masterVolume,
+            effectsIsMuted: config.effectsIsMuted,
+            isSuspended: false, // Will be updated by polling
+        };
+    });
+
+    // Actions
+    const setMasterVolume = useCallback((volume: number) => {
+        setState((prev) => ({ ...prev, masterVolume: volume }));
+    }, []);
+
+    const setMasterMuted = useCallback((muted: boolean) => {
+        setState((prev) => ({ ...prev, masterIsMuted: muted }));
+    }, []);
+
+    const setAmbientVolume = useCallback((volume: number) => {
+        setState((prev) => ({ ...prev, ambientVolume: volume }));
+    }, []);
+
+    const setAmbientMuted = useCallback((muted: boolean) => {
+        setState((prev) => ({ ...prev, ambientIsMuted: muted }));
+    }, []);
+
+    const setEffectsVolume = useCallback((volume: number) => {
+        setState((prev) => ({ ...prev, effectsVolume: volume }));
+    }, []);
+
+    const setEffectsMuted = useCallback((muted: boolean) => {
+        setState((prev) => ({ ...prev, effectsIsMuted: muted }));
+    }, []);
+
+    const resumeAudio = useCallback(async () => {
+        // This will be implemented to work with the mixer system
+        console.log('Resume audio called');
+    }, []);
+
+    const resetToDefaults = useCallback(() => {
+        setState({
+            masterVolume: 0.5,
+            masterIsMuted: false,
+            ambientVolume: 0.5,
+            ambientIsMuted: false,
+            effectsVolume: 0.5,
+            effectsIsMuted: false,
+            isSuspended: false,
+        });
+    }, []);
+
+    // Save to config when state changes
+    useEffect(() => {
+        audioConfig().setConfig({
+            masterVolume: state.masterVolume,
+            masterIsMuted: state.masterIsMuted,
+            ambientVolume: state.ambientVolume * state.masterVolume,
+            ambientIsMuted: state.ambientIsMuted,
+            effectsVolume: state.effectsVolume * state.masterVolume,
+            effectsIsMuted: state.effectsIsMuted,
+        });
+    }, [state]);
+
+    return {
+        ...state,
+        setMasterVolume,
+        setMasterMuted,
+        setAmbientVolume,
+        setAmbientMuted,
+        setEffectsVolume,
+        setEffectsMuted,
+        resumeAudio,
+        resetToDefaults,
+    };
+}

--- a/packages/game/src/hooks/useGameAudio.ts
+++ b/packages/game/src/hooks/useGameAudio.ts
@@ -1,78 +1,276 @@
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGameState } from '../useGameState';
 import { audioConfig } from '../utils/audioConfig';
 
 export function useGameAudio() {
     const { ambient, effects } = useGameState((state) => state.audio);
-    const mixers = [ambient, effects];
-    const masterVolume = useRef(audioConfig().config.masterVolume);
-    const masterIsMuted = useRef(audioConfig().config.masterIsMuted);
+    const mixers = useMemo(() => [ambient, effects], [ambient, effects]);
 
-    function setVolume(value: number) {
-        const oldVolume = masterVolume.current;
-        masterVolume.current = value;
-        mixers.forEach((mixer) => {
-            mixer.setVolume((mixer.getState().volume / oldVolume) * value);
-        });
-    }
+    // Use React state instead of refs for values that need to trigger re-renders
+    const [masterVolume, setMasterVolumeState] = useState(
+        () => audioConfig().config.masterVolume,
+    );
+    const [masterIsMuted, setMasterIsMutedState] = useState(
+        () => audioConfig().config.masterIsMuted,
+    );
 
-    function setMuted(newMuted: boolean) {
-        console.debug('Setting all mixers to muted:', newMuted);
-        masterIsMuted.current = newMuted;
-        mixers.forEach((mixer) => {
-            mixer.setMuted(newMuted);
-        });
-    }
+    // Track ambient and effects state in React state for UI updates
+    const [ambientVolume, setAmbientVolumeState] = useState(() => {
+        const config = audioConfig().config;
+        return config.ambientVolume / config.masterVolume;
+    });
+    const [ambientIsMuted, setAmbientIsMutedState] = useState(
+        () => audioConfig().config.ambientIsMuted,
+    );
+    const [effectsVolume, setEffectsVolumeState] = useState(() => {
+        const config = audioConfig().config;
+        return config.effectsVolume / config.masterVolume;
+    });
+    const [effectsIsMuted, setEffectsIsMutedState] = useState(
+        () => audioConfig().config.effectsIsMuted,
+    );
 
-    function refreshStateAfter<T extends unknown[], R>(
-        func: (...props: T) => Promise<R> | R,
-    ) {
-        return async (...props: T) => {
-            await func(...props);
-            const newState = getState();
-            setState(newState);
-            audioConfig().setConfig({
-                masterVolume: newState.volume,
-                masterIsMuted: newState.isMuted,
-                ambientVolume: newState.ambient.volume,
-                ambientIsMuted: newState.ambient.isMuted,
-                effectsVolume: newState.effects.volume,
-                effectsIsMuted: newState.effects.isMuted,
+    // Track suspension state to trigger re-renders
+    const [isSuspended, setIsSuspendedState] = useState(() =>
+        mixers.some((mixer) => mixer.getState().isSuspended),
+    );
+
+    const setVolume = useCallback(
+        (value: number) => {
+            const oldVolume = masterVolume;
+            setMasterVolumeState(value);
+            mixers.forEach((mixer) => {
+                mixer.setVolume((mixer.getState().volume / oldVolume) * value);
             });
-        };
-    }
+        },
+        [mixers, masterVolume],
+    );
 
-    function getState() {
-        return {
-            isSuspended: mixers.some((mixer) => mixer.getState().isSuspended),
-            isMuted: masterIsMuted.current,
-            setMuted: refreshStateAfter(setMuted),
-            volume: masterVolume.current,
-            setVolume: refreshStateAfter(setVolume),
-            ambient: {
-                isMuted: ambient.getState().isMuted,
-                volume: ambient.getState().volume / masterVolume.current,
-                setMuted: refreshStateAfter(ambient.setMuted),
-                setVolume: refreshStateAfter<[number], void>((value) =>
-                    ambient.setVolume(value * masterVolume.current),
-                ),
-            },
-            effects: {
-                isMuted: effects.getState().isMuted,
-                volume: effects.getState().volume / masterVolume.current,
-                setMuted: refreshStateAfter(effects.setMuted),
-                setVolume: refreshStateAfter<[number], void>((value) =>
-                    effects.setVolume(value * masterVolume.current),
-                ),
-            },
-            resumeIfNeeded: refreshStateAfter(() =>
-                Promise.all(
-                    mixers.map((mixer) => mixer.resumeContextIfNeeded()),
-                ),
-            ),
-        };
-    }
+    const setMuted = useCallback(
+        (newMuted: boolean) => {
+            console.debug('Setting all mixers to muted:', newMuted);
+            setMasterIsMutedState(newMuted);
+            mixers.forEach((mixer) => {
+                mixer.setMuted(newMuted);
+            });
+        },
+        [mixers],
+    );
 
-    const [state, setState] = useState(getState());
+    const updateConfig = useCallback(() => {
+        audioConfig().setConfig({
+            masterVolume: masterVolume,
+            masterIsMuted: masterIsMuted,
+            ambientVolume: ambientVolume * masterVolume,
+            ambientIsMuted: ambientIsMuted,
+            effectsVolume: effectsVolume * masterVolume,
+            effectsIsMuted: effectsIsMuted,
+        });
+    }, [
+        masterVolume,
+        masterIsMuted,
+        ambientVolume,
+        ambientIsMuted,
+        effectsVolume,
+        effectsIsMuted,
+    ]);
+
+    const wrappedSetVolume = useCallback(
+        async (value: number) => {
+            setVolume(value);
+            updateConfig();
+        },
+        [setVolume, updateConfig],
+    );
+
+    const wrappedSetMuted = useCallback(
+        async (newMuted: boolean) => {
+            setMuted(newMuted);
+            updateConfig();
+        },
+        [setMuted, updateConfig],
+    );
+
+    const ambientSetMuted = useCallback(
+        async (muted: boolean) => {
+            ambient.setMuted(muted);
+            setAmbientIsMutedState(muted);
+            updateConfig();
+        },
+        [ambient, updateConfig],
+    );
+
+    const ambientSetVolume = useCallback(
+        async (value: number) => {
+            ambient.setVolume(value * masterVolume);
+            setAmbientVolumeState(value);
+            updateConfig();
+        },
+        [ambient, updateConfig, masterVolume],
+    );
+
+    const effectsSetMuted = useCallback(
+        async (muted: boolean) => {
+            effects.setMuted(muted);
+            setEffectsIsMutedState(muted);
+            updateConfig();
+        },
+        [effects, updateConfig],
+    );
+
+    const effectsSetVolume = useCallback(
+        async (value: number) => {
+            effects.setVolume(value * masterVolume);
+            setEffectsVolumeState(value);
+            updateConfig();
+        },
+        [effects, updateConfig, masterVolume],
+    );
+
+    const resumeIfNeeded = useCallback(async () => {
+        console.debug('Attempting to resume audio context...');
+        await Promise.all(mixers.map((mixer) => mixer.resumeContextIfNeeded()));
+
+        // Check if audio was successfully resumed
+        const currentlySuspended = mixers.some(
+            (mixer) => mixer.getState().isSuspended,
+        );
+        setIsSuspendedState(currentlySuspended);
+
+        if (!currentlySuspended) {
+            // After resuming, restore the mixer states to match our React state
+            console.debug('Audio resumed, restoring mixer states:', {
+                masterVolume,
+                masterIsMuted,
+                ambientVolume,
+                ambientIsMuted,
+                effectsVolume,
+                effectsIsMuted,
+            });
+
+            // Restore master mute state
+            mixers.forEach((mixer) => {
+                mixer.setMuted(masterIsMuted);
+            });
+
+            // Restore individual mixer states
+            ambient.setMuted(ambientIsMuted);
+            effects.setMuted(effectsIsMuted);
+
+            // Restore volumes (ambient and effects volumes are relative to master)
+            ambient.setVolume(ambientVolume * masterVolume);
+            effects.setVolume(effectsVolume * masterVolume);
+        }
+
+        updateConfig();
+    }, [
+        mixers,
+        updateConfig,
+        masterVolume,
+        masterIsMuted,
+        ambientVolume,
+        ambientIsMuted,
+        effectsVolume,
+        effectsIsMuted,
+        ambient,
+        effects,
+    ]);
+
+    // Sync React state with mixer state when audio context changes
+    useEffect(() => {
+        const currentlySuspended = mixers.some(
+            (mixer) => mixer.getState().isSuspended,
+        );
+
+        if (currentlySuspended !== isSuspended) {
+            setIsSuspendedState(currentlySuspended);
+        }
+
+        if (!currentlySuspended) {
+            // When audio becomes available, check if our React state matches mixer state
+            const ambientMixerState = ambient.getState();
+            const effectsMixerState = effects.getState();
+
+            const ambientActualVolume = ambientMixerState.volume / masterVolume;
+            const effectsActualVolume = effectsMixerState.volume / masterVolume;
+
+            // Only update React state if there's a significant difference
+            if (
+                Math.abs(ambientActualVolume - ambientVolume) > 0.01 ||
+                ambientMixerState.isMuted !== ambientIsMuted
+            ) {
+                console.debug('Syncing ambient state from mixer:', {
+                    reactVolume: ambientVolume,
+                    mixerVolume: ambientActualVolume,
+                    reactMuted: ambientIsMuted,
+                    mixerMuted: ambientMixerState.isMuted,
+                });
+                setAmbientVolumeState(ambientActualVolume);
+                setAmbientIsMutedState(ambientMixerState.isMuted);
+            }
+
+            if (
+                Math.abs(effectsActualVolume - effectsVolume) > 0.01 ||
+                effectsMixerState.isMuted !== effectsIsMuted
+            ) {
+                console.debug('Syncing effects state from mixer:', {
+                    reactVolume: effectsVolume,
+                    mixerVolume: effectsActualVolume,
+                    reactMuted: effectsIsMuted,
+                    mixerMuted: effectsMixerState.isMuted,
+                });
+                setEffectsVolumeState(effectsActualVolume);
+                setEffectsIsMutedState(effectsMixerState.isMuted);
+            }
+        }
+    }, [
+        mixers,
+        ambient,
+        effects,
+        masterVolume,
+        ambientVolume,
+        ambientIsMuted,
+        effectsVolume,
+        effectsIsMuted,
+        isSuspended,
+    ]);
+
+    // Poll for suspension state changes (since mixers don't emit events)
+    useEffect(() => {
+        const interval = setInterval(() => {
+            const currentlySuspended = mixers.some(
+                (mixer) => mixer.getState().isSuspended,
+            );
+            if (currentlySuspended !== isSuspended) {
+                console.debug('Suspension state changed:', currentlySuspended);
+                setIsSuspendedState(currentlySuspended);
+            }
+        }, 250); // Poll every 250ms for more responsive UI updates
+
+        return () => clearInterval(interval);
+    }, [mixers, isSuspended]);
+
+    // Create the state object with stable references
+    const state = {
+        isSuspended: isSuspended,
+        isMuted: masterIsMuted,
+        setMuted: wrappedSetMuted,
+        volume: masterVolume,
+        setVolume: wrappedSetVolume,
+        ambient: {
+            isMuted: ambientIsMuted,
+            volume: ambientVolume,
+            setMuted: ambientSetMuted,
+            setVolume: ambientSetVolume,
+        },
+        effects: {
+            isMuted: effectsIsMuted,
+            volume: effectsVolume,
+            setMuted: effectsSetMuted,
+            setVolume: effectsSetVolume,
+        },
+        resumeIfNeeded,
+    };
+
     return state;
 }

--- a/packages/game/src/hud/AudioHud.tsx
+++ b/packages/game/src/hud/AudioHud.tsx
@@ -1,20 +1,43 @@
 import { Mute, Volume2 } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { useCallback } from 'react';
 import { useGameAudio } from '../hooks/useGameAudio';
 
 export function AudioHud() {
     const { isMuted, isSuspended, setMuted, resumeIfNeeded } = useGameAudio();
 
+    const handleAudioToggle = useCallback(async () => {
+        if (isSuspended) {
+            console.debug('Audio is suspended, attempting to resume...');
+            await resumeIfNeeded();
+        } else {
+            console.debug(
+                'Toggling audio mute state from',
+                isMuted,
+                'to',
+                !isMuted,
+            );
+            setMuted(!isMuted);
+        }
+    }, [isSuspended, isMuted, resumeIfNeeded, setMuted]);
+
+    // Show muted icon if either suspended or muted
+    const shouldShowMuted = isMuted || isSuspended;
+
     return (
         <IconButton
-            title="Upali/ugasi zvuk"
-            onClick={() =>
-                isSuspended ? resumeIfNeeded() : setMuted(!isMuted)
+            title={
+                isSuspended
+                    ? 'Kliknite da omogućite zvuk'
+                    : isMuted
+                      ? 'Uključi zvuk'
+                      : 'Ugasi zvuk'
             }
+            onClick={handleAudioToggle}
             variant="plain"
             className="pointer-events-auto hover:bg-muted"
         >
-            {isMuted || isSuspended ? <Mute /> : <Volume2 />}
+            {shouldShowMuted ? <Mute /> : <Volume2 />}
         </IconButton>
     );
 }


### PR DESCRIPTION
Replace refs with React state to ensure UI updates and predictable
renders. Memoize mixers and switch to useCallback/useMemo for stable
handlers. Add derived state for ambient/effects volumes and muted flags,
and track suspension state so components can react to mixer suspension.

Introduce updateConfig and wrapped setters that persist combined master
and channel values to audioConfig after changes. Update setters to
synchronize mixer API calls with local state (ambientSetVolume,
ambientSetMuted, wrappedSetVolume, wrappedSetMuted).

Overall this refactor improves reactivity, keeps config in sync with
state, and simplifies side-effect management when updating volume and
mute settings.