### PR TITLE
chore(dev): set service hostnames for local dev

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
         "lint": "biome check",
         "dev": "next dev --turbopack -p 3005 --hostname api.gredice.local",
         "build": "next build --turbopack",
-        "start": "next start -p 3005 --hostname api.gredice.local",
+        "start": "next start -p 3005",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",
         "regenerate": "pnpm run /^regenerate:.*/",

--- a/apps/api/playwright.config.ts
+++ b/apps/api/playwright.config.ts
@@ -14,7 +14,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter: 'html',
     use: {
-        baseURL: 'http://api.gredice.local:3005',
+        baseURL: 'http://127.0.0.1:3005',
         trace: 'on-first-retry',
     },
     projects: [
@@ -25,7 +25,7 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: 'http://api.gredice.local:3005',
+        url: 'http://127.0.0.1:3005',
         reuseExistingServer: !process.env.CI,
     },
 };

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -7,7 +7,7 @@
         "lint": "biome check",
         "dev": "next dev --turbopack -p 3003 --hostname app.gredice.local",
         "build": "next build --turbopack",
-        "start": "next start -p 3003 --hostname app.gredice.local",
+        "start": "next start -p 3003",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",
         "test-ui": "playwright test --ui",

--- a/apps/app/playwright.config.ts
+++ b/apps/app/playwright.config.ts
@@ -14,7 +14,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter: 'html',
     use: {
-        baseURL: 'http://app.gredice.local:3003',
+        baseURL: 'http://127.0.0.1:3003',
         trace: 'on-first-retry',
         ctPort: 3100,
     },
@@ -26,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: 'http://app.gredice.local:3003',
+        url: 'http://127.0.0.1:3003',
         reuseExistingServer: !process.env.CI,
     },
 };

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -7,7 +7,7 @@
         "lint": "biome check",
         "dev": "next dev --turbopack -p 3002 --hostname farma.gredice.local",
         "build": "next build --turbopack",
-        "start": "next start -p 3002 --hostname farma.gredice.local",
+        "start": "next start -p 3002",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",
         "test-ui": "playwright test --ui",

--- a/apps/farm/playwright.config.ts
+++ b/apps/farm/playwright.config.ts
@@ -14,7 +14,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter: 'html',
     use: {
-        baseURL: 'http://farma.gredice.local:3002',
+        baseURL: 'http://127.0.0.1:3002',
         trace: 'on-first-retry',
         ctPort: 3100,
     },
@@ -26,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: 'http://farma.gredice.local:3002',
+        url: 'http://127.0.0.1:3002',
         reuseExistingServer: !process.env.CI,
     },
 };

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -7,7 +7,7 @@
         "lint": "biome check",
         "dev": "next dev --turbo -p 3001 --hostname vrt.gredice.local",
         "build": "next build --turbopack",
-        "start": "next start -p 3001 --hostname vrt.gredice.local",
+        "start": "next start -p 3001",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",
         "test-ui": "playwright test --ui",

--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -14,7 +14,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter: 'html',
     use: {
-        baseURL: 'http://vrt.gredice.local:3001',
+        baseURL: 'http://127.0.0.1:3001',
         trace: 'on-first-retry',
         ctPort: 3100,
     },
@@ -26,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: 'http://vrt.gredice.local:3001',
+        url: 'http://127.0.0.1:3001',
         reuseExistingServer: !process.env.CI,
     },
 };

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -8,7 +8,7 @@
         "dev": "next dev --turbopack -p 3000 --hostname www.gredice.local",
         "build": "next build --turbopack",
         "postbuild": "next-sitemap --config next-sitemap.config.cjs",
-        "start": "next start -p 3000 --hostname www.gredice.local",
+        "start": "next start -p 3000",
         "test": "pnpm run /^test:.*/",
         "test:run": "node --experimental-strip-types ./tests/populate-test-cases.ts && playwright test",
         "test-ui": "playwright test --ui",

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -14,7 +14,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter: 'html',
     use: {
-        baseURL: 'http://www.gredice.local:3000',
+        baseURL: 'http://127.0.0.1:3000',
         trace: 'on-first-retry',
         ctPort: 3100,
     },
@@ -26,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: 'http://www.gredice.local:3000',
+        url: 'http://127.0.0.1:3000',
         reuseExistingServer: !process.env.CI,
     },
 };


### PR DESCRIPTION
Update dev scripts across apps to bind Next.js development servers
to explicit local hostnames instead of 0.0.0.0. This assigns readable,
service-specific hostnames for easier local routing and testing:
- apps/www -> www.gredice.local (port 3000)
- apps/garden -> vrt.gredice.local (port 3001)
- apps/farm -> farma.gredice.local (port 3002)
- apps/app  -> app.gredice.local (port 3003)
- apps/api  -> api.gredice.local (port 3005)

This improves clarity when using host-based dev proxies / system DNS
entries and reduces accidental exposure to all network interfaces.