### PR TITLE
Avoid duplicate delivery survey communications per date

### DIFF
--- a/apps/api/app/api/internal/cron/auto-close-slots/route.ts
+++ b/apps/api/app/api/internal/cron/auto-close-slots/route.ts
@@ -14,7 +14,9 @@ export async function GET(request: NextRequest) {
     try {
         await autoCloseUpcomingSlots();
 
-        console.log('Auto-closed upcoming time slots within the 48-hour window');
+        console.log(
+            'Auto-closed upcoming time slots within the 48-hour window',
+        );
 
         return Response.json({
             success: true,

--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -25,7 +25,11 @@ function formatDate(date: Date) {
 }
 
 function getDateKey(date: Date) {
-    return date.toISOString().split('T')[0];
+    // Use local date components to avoid timezone issues
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
 }
 
 interface DeliverySurveyGroup {

--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: NextRequest) {
                 accountId: candidate.accountId,
                 fulfilledAt: candidate.fulfilledAt,
                 candidates: new Map<string, DeliverySurveyCandidate>(),
-            } satisfies DeliverySurveyGroup;
+            };
             groups.set(groupKey, group);
             orderedGroups.push(group);
         }

--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -1,5 +1,6 @@
 import {
     createNotification,
+    type DeliverySurveyCandidate,
     getDeliverySurveyCandidates,
     markDeliverySurveySent,
 } from '@gredice/storage';
@@ -23,6 +24,16 @@ function formatDate(date: Date) {
     }).format(date);
 }
 
+function getDateKey(date: Date) {
+    return date.toISOString().split('T')[0];
+}
+
+interface DeliverySurveyGroup {
+    accountId: string;
+    fulfilledAt: Date;
+    candidates: Map<string, DeliverySurveyCandidate>;
+}
+
 export async function GET(request: NextRequest) {
     const authHeader = request.headers.get('authorization');
     if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
@@ -37,27 +48,69 @@ export async function GET(request: NextRequest) {
     let emailsSent = 0;
     let notificationsCreated = 0;
 
+    const groups = new Map<string, DeliverySurveyGroup>();
+    const orderedGroups: DeliverySurveyGroup[] = [];
+
     for (const candidate of candidates) {
-        const formattedDate = formatDate(candidate.fulfilledAt);
+        const dateKey = getDateKey(candidate.fulfilledAt);
+        const groupKey = `${candidate.accountId}:${dateKey}`;
+
+        let group = groups.get(groupKey);
+        if (!group) {
+            group = {
+                accountId: candidate.accountId,
+                fulfilledAt: candidate.fulfilledAt,
+                candidates: new Map<string, DeliverySurveyCandidate>(),
+            } satisfies DeliverySurveyGroup;
+            groups.set(groupKey, group);
+            orderedGroups.push(group);
+        }
+
+        const existingCandidate = group.candidates.get(candidate.requestId);
+        if (!existingCandidate) {
+            group.candidates.set(candidate.requestId, candidate);
+        } else if (candidate.fulfilledAt < existingCandidate.fulfilledAt) {
+            group.candidates.set(candidate.requestId, candidate);
+        }
+
+        if (candidate.fulfilledAt < group.fulfilledAt) {
+            group.fulfilledAt = candidate.fulfilledAt;
+        }
+    }
+
+    for (const group of orderedGroups) {
+        const candidatesInGroup = Array.from(group.candidates.values());
+        if (candidatesInGroup.length === 0) {
+            continue;
+        }
+
+        const formattedDate = formatDate(group.fulfilledAt);
+        const requestIds = candidatesInGroup.map((item) => item.requestId);
+
+        const uniqueEmails = new Map<string, string>();
+
+        for (const candidate of candidatesInGroup) {
+            for (const user of candidate.userEmails) {
+                const trimmedEmail = user.email.trim();
+                const normalizedEmail = trimmedEmail.toLowerCase();
+
+                if (
+                    normalizedEmail.length === 0 ||
+                    uniqueEmails.has(normalizedEmail)
+                ) {
+                    continue;
+                }
+
+                uniqueEmails.set(normalizedEmail, trimmedEmail);
+            }
+        }
 
         const sentEmails: string[] = [];
-        const seenEmails = new Set<string>();
 
-        for (const user of candidate.userEmails) {
-            const normalizedEmail = user.email.trim().toLowerCase();
-            if (normalizedEmail.length === 0) {
-                continue;
-            }
-
-            if (seenEmails.has(normalizedEmail)) {
-                continue;
-            }
-
-            seenEmails.add(normalizedEmail);
-
+        for (const [normalizedEmail, email] of uniqueEmails) {
             try {
-                await sendDeliverySurvey(user.email, {
-                    email: user.email,
+                await sendDeliverySurvey(email, {
+                    email,
                     surveyUrl: SURVEY_URL,
                     deliveryDate: formattedDate,
                 });
@@ -65,8 +118,8 @@ export async function GET(request: NextRequest) {
                 emailsSent += 1;
             } catch (error) {
                 console.error('Failed to send delivery survey email', {
-                    requestId: candidate.requestId,
-                    email: user.email,
+                    requestIds,
+                    email,
                     error,
                 });
             }
@@ -76,7 +129,7 @@ export async function GET(request: NextRequest) {
 
         try {
             await createNotification({
-                accountId: candidate.accountId,
+                accountId: group.accountId,
                 header: '📣 Kako ti se svidjela dostava?',
                 content: `Tvoja dostava je stigla ${formattedDate}. Podijeli svoje dojmove i ispuni kratku anketu 📋⭐️⭐️⭐️⭐️⭐️`,
                 linkUrl: SURVEY_URL,
@@ -86,13 +139,19 @@ export async function GET(request: NextRequest) {
             notificationsCreated += 1;
         } catch (error) {
             console.error('Failed to create delivery survey notification', {
-                requestId: candidate.requestId,
+                requestIds,
                 error,
             });
         }
 
         if (notificationSuccess || sentEmails.length > 0) {
-            await markDeliverySurveySent(candidate.requestId, sentEmails);
+            const sentEmailsList = [...sentEmails];
+            for (const candidate of candidatesInGroup) {
+                await markDeliverySurveySent(
+                    candidate.requestId,
+                    sentEmailsList,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- send delivery survey emails and notifications once per account per fulfillment date by grouping candidates
- mark every request in a grouped delivery as survey sent after the shared communication completes
- format the auto-close cron route to satisfy Biome’s linting rules

## Testing
- pnpm lint --filter @gredice/api

------
https://chatgpt.com/codex/tasks/task_e_68d3b7736740832f8e3d35b9512b015a