### PR TITLE
feat: add operations duration chart

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -24,6 +24,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
         <AdminDashboardClient
             initialAnalyticsData={data.analytics}
             initialEntitiesData={data.entities}
+            initialOperationsDurationData={data.operationsDuration}
             onPeriodChange={handlePeriodChange}
             initialPeriod={selectedPeriod}
         />

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -8,6 +8,10 @@ import { useEffect, useState, useTransition } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
 import { FactCard } from '../cards/FactCard';
 import { DashboardDivider } from './DashboardDivider';
+import {
+    OperationsDurationCard,
+    type OperationsDurationData,
+} from './OperationsDurationCard';
 
 type EntityData = {
     entityTypeName: string;
@@ -20,11 +24,13 @@ export function AdminDashboardClient({
     initialEntitiesData,
     onPeriodChange,
     initialPeriod = '7',
+    initialOperationsDurationData,
 }: {
     initialAnalyticsData: Awaited<ReturnType<typeof getAnalyticsTotals>>;
     initialEntitiesData: EntityData[];
     onPeriodChange: (period: string) => void;
     initialPeriod?: string;
+    initialOperationsDurationData: OperationsDurationData;
 }) {
     const [selectedPeriod, setSelectedPeriod] = useState(initialPeriod);
     const [isPending, startTransition] = useTransition();
@@ -137,6 +143,10 @@ export function AdminDashboardClient({
                         beforeValue={deliveryRequestsBeforeCount}
                     />
                 </div>
+            </Stack>
+            <Stack spacing={1}>
+                <DashboardDivider>Radnje</DashboardDivider>
+                <OperationsDurationCard data={initialOperationsDurationData} />
             </Stack>
             <Stack spacing={1}>
                 <DashboardDivider>Zapisi</DashboardDivider>

--- a/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
+++ b/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@signalco/ui-primitives/Tooltip';
+import { Typography } from '@signalco/ui-primitives/Typography';
+
+export type OperationsDurationPoint = {
+    date: string;
+    durationMinutes: number;
+};
+
+export type OperationsDurationData = {
+    totalMinutes: number;
+    daily: OperationsDurationPoint[];
+};
+
+const dateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: '2-digit',
+    month: '2-digit',
+});
+
+function formatTotalDuration(totalMinutes: number) {
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = Math.round(totalMinutes % 60);
+
+    if (hours <= 0) {
+        return `${minutes} min`;
+    }
+
+    return `${hours} h ${minutes.toString().padStart(2, '0')} min`;
+}
+
+function formatTooltipDuration(minutes: number) {
+    if (!minutes) {
+        return '0 min';
+    }
+
+    if (minutes < 60) {
+        return `${Math.round(minutes)} min`;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    const rest = Math.round(minutes % 60);
+    return rest > 0 ? `${hours} h ${rest} min` : `${hours} h`;
+}
+
+function formatDateLabel(date: string) {
+    const parsed = new Date(date);
+    return dateFormatter.format(parsed);
+}
+
+export function OperationsDurationCard({
+    data,
+}: {
+    data: OperationsDurationData;
+}) {
+    const maxMinutes = Math.max(
+        0,
+        ...data.daily.map((day) => day.durationMinutes),
+    );
+    const hasData = maxMinutes > 0;
+
+    return (
+        <Card>
+            <CardOverflow>
+                <Stack spacing={2} className="p-4">
+                    <Stack spacing={0.5}>
+                        <Typography level="body3">
+                            Ukupno trajanje radnji
+                        </Typography>
+                        <Typography level="h4" semiBold>
+                            {formatTotalDuration(data.totalMinutes)}
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Prikazane su samo završene radnje
+                        </Typography>
+                    </Stack>
+                    {data.daily.length === 0 || !hasData ? (
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Nema podataka za odabrani period.
+                        </Typography>
+                    ) : (
+                        <div className="flex items-end gap-2 h-48">
+                            {data.daily.map((day) => {
+                                const normalizedHeight = maxMinutes
+                                    ? (day.durationMinutes / maxMinutes) * 100
+                                    : 0;
+                                const heightPercent =
+                                    day.durationMinutes > 0
+                                        ? Math.max(4, normalizedHeight)
+                                        : 0;
+
+                                return (
+                                    <div
+                                        key={day.date}
+                                        className="flex-1 flex flex-col items-center gap-1 h-full"
+                                    >
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <div className="flex-1 flex items-end w-full">
+                                                    <div
+                                                        className="w-full rounded-t bg-primary/30"
+                                                        style={{
+                                                            height: `${heightPercent}%`,
+                                                        }}
+                                                    />
+                                                </div>
+                                            </TooltipTrigger>
+                                            <TooltipContent>
+                                                <Stack spacing={0.5}>
+                                                    <Typography level="body2">
+                                                        {formatDateLabel(
+                                                            day.date,
+                                                        )}
+                                                    </Typography>
+                                                    <Typography level="body3">
+                                                        {formatTooltipDuration(
+                                                            day.durationMinutes,
+                                                        )}
+                                                    </Typography>
+                                                </Stack>
+                                            </TooltipContent>
+                                        </Tooltip>
+                                        <Stack
+                                            spacing={0}
+                                            className="items-center"
+                                        >
+                                            <Typography
+                                                level="body3"
+                                                className="text-xs"
+                                            >
+                                                {formatDateLabel(day.date)}
+                                            </Typography>
+                                            <Typography
+                                                level="body3"
+                                                className="text-xs text-muted-foreground"
+                                            >
+                                                {formatTooltipDuration(
+                                                    day.durationMinutes,
+                                                )}
+                                            </Typography>
+                                        </Stack>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </Stack>
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -7,7 +7,7 @@ import {
     getEntitiesRaw,
     getEntityTypes,
 } from '@gredice/storage';
-import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
+import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 
 type OperationsDurationPoint = {
     date: string;

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -88,7 +88,10 @@ export async function getAnalyticsData(days: number) {
         await Promise.all([
             getAnalyticsTotals(safeDays),
             getEntityTypes(),
-            getAllOperations({ from: startDate, to: endDate }),
+            getAllOperations({
+                completedFrom: startDate,
+                completedTo: endDate,
+            }),
             getEntitiesFormatted<EntityStandardized>('operation'),
         ]);
 
@@ -118,14 +121,9 @@ export async function getAnalyticsData(days: number) {
     }
 
     for (const operation of operationsList) {
+        // Operations are already filtered by completion date and status,
+        // but double-check for safety
         if (operation.status !== 'completed' || !operation.completedAt) {
-            continue;
-        }
-
-        if (
-            operation.completedAt < startDate ||
-            operation.completedAt > endDate
-        ) {
             continue;
         }
 

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -1,16 +1,96 @@
 'use server';
 
 import {
+    getAllOperations,
     getAnalyticsTotals,
+    getEntitiesFormatted,
     getEntitiesRaw,
     getEntityTypes,
 } from '@gredice/storage';
+import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
+
+type OperationsDurationPoint = {
+    date: string;
+    durationMinutes: number;
+};
+
+type OperationsDurationData = {
+    totalMinutes: number;
+    daily: OperationsDurationPoint[];
+};
+
+function toDateKey(date: Date) {
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function parseDuration(value: unknown) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.max(0, value);
+    }
+    if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value);
+        if (Number.isFinite(parsed)) {
+            return Math.max(0, parsed);
+        }
+    }
+    return 0;
+}
+
+function createDurationBuckets(startDate: Date, days: number) {
+    const dateKeys: string[] = [];
+    const dailyTotals = new Map<string, number>();
+    for (let i = 0; i < days; i += 1) {
+        const current = new Date(startDate);
+        current.setDate(startDate.getDate() + i);
+        const key = toDateKey(current);
+        dateKeys.push(key);
+        dailyTotals.set(key, 0);
+    }
+
+    return {
+        dateKeys,
+        dailyTotals,
+    };
+}
+
+function formatOperationsDurationData(
+    dateKeys: string[],
+    dailyTotals: Map<string, number>,
+): OperationsDurationData {
+    const daily = dateKeys.map((date) => ({
+        date,
+        durationMinutes: dailyTotals.get(date) ?? 0,
+    }));
+    const totalMinutes = daily.reduce(
+        (total, day) => total + day.durationMinutes,
+        0,
+    );
+
+    return {
+        totalMinutes,
+        daily,
+    };
+}
 
 export async function getAnalyticsData(days: number) {
-    const [analyticsResult, entityTypes] = await Promise.all([
-        getAnalyticsTotals(days),
-        getEntityTypes(),
-    ]);
+    const safeDays = Number.isFinite(days) && days > 0 ? days : 1;
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setHours(0, 0, 0, 0);
+    startDate.setDate(startDate.getDate() - (safeDays - 1));
+    const endDate = new Date(today);
+    endDate.setHours(23, 59, 59, 999);
+
+    const [analyticsResult, entityTypes, operationsList, operationsData] =
+        await Promise.all([
+            getAnalyticsTotals(safeDays),
+            getEntityTypes(),
+            getAllOperations({ from: startDate, to: endDate }),
+            getEntitiesFormatted<EntityStandardized>('operation'),
+        ]);
 
     const entitiesCounts = await Promise.all(
         entityTypes.map(async (entityType) => {
@@ -23,8 +103,53 @@ export async function getAnalyticsData(days: number) {
         }),
     );
 
+    const { dateKeys, dailyTotals } = createDurationBuckets(
+        startDate,
+        safeDays,
+    );
+
+    const operationDurations = new Map<number, number>();
+    for (const operation of operationsData ?? []) {
+        const duration = parseDuration(
+            (operation.attributes as { duration?: unknown } | undefined)
+                ?.duration,
+        );
+        operationDurations.set(operation.id, duration);
+    }
+
+    for (const operation of operationsList) {
+        if (operation.status !== 'completed' || !operation.completedAt) {
+            continue;
+        }
+
+        if (
+            operation.completedAt < startDate ||
+            operation.completedAt > endDate
+        ) {
+            continue;
+        }
+
+        const key = toDateKey(operation.completedAt);
+        if (!dailyTotals.has(key)) {
+            continue;
+        }
+
+        const durationMinutes = operationDurations.get(operation.entityId) ?? 0;
+        if (!durationMinutes) {
+            continue;
+        }
+
+        dailyTotals.set(key, (dailyTotals.get(key) ?? 0) + durationMinutes);
+    }
+
+    const operationsDuration = formatOperationsDurationData(
+        dateKeys,
+        dailyTotals,
+    );
+
     return {
         analytics: analyticsResult,
         entities: entitiesCounts,
+        operationsDuration,
     };
 }

--- a/apps/app/lib/@types/EntityStandardized.ts
+++ b/apps/app/lib/@types/EntityStandardized.ts
@@ -11,6 +11,7 @@ export type EntityStandardized = {
     };
     attributes?: {
         seedingDistance?: number; // in cm
+        duration?: number | string;
     };
     images?: {
         cover?: { url?: string };

--- a/packages/storage/src/@types/EntityStandardized.ts
+++ b/packages/storage/src/@types/EntityStandardized.ts
@@ -11,6 +11,7 @@ export type EntityStandardized = {
     };
     attributes?: {
         seedingDistance?: number; // in cm
+        duration?: number | string;
     };
     images?: {
         cover?: { url?: string };

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -42,9 +42,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
             if (event.type === knownEventTypes.operations.complete) {
                 status = 'completed';
                 completedBy = data?.completedBy;
-                completedAt = data?.completedAt
-                    ? new Date(data.completedAt)
-                    : undefined;
+                completedAt = event.createdAt;
                 if (Array.isArray(data?.images)) {
                     imageUrls = data.images.filter(
                         (url: unknown) => typeof url === 'string',
@@ -63,9 +61,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
                 status = 'canceled';
                 canceledBy = data?.canceledBy;
                 cancelReason = data?.reason;
-                canceledAt = event.createdAt
-                    ? new Date(event.createdAt)
-                    : undefined;
+                canceledAt = event.createdAt;
             } else if (event.type === knownEventTypes.operations.schedule) {
                 status = 'planned';
                 scheduledDate = data?.scheduledDate


### PR DESCRIPTION
## Summary
- calculate completed operation durations for the selected period on the admin dashboard
- add an operations duration card with a per-day bar chart and total duration display
- expose the operation duration attribute in shared entity typings

## Testing
- pnpm --filter app lint

------
https://chatgpt.com/codex/tasks/task_e_68d513bda8e0832f8d16a40a9ad1a2db