### PR TITLE
Prioritize recommended plants in landing showcase

### DIFF
--- a/apps/www/app/PlantsShowcase.tsx
+++ b/apps/www/app/PlantsShowcase.tsx
@@ -8,7 +8,13 @@ import { PlantsGalleryItem } from './biljke/PlantsGalleryItem';
 
 export async function PlantsShowcase() {
     const entities = await getPlantsData();
-    const plants = entities?.slice(0, 4);
+    const plants = entities
+        ?.slice()
+        .sort(
+            (first, second) =>
+                Number(second.isRecommended) - Number(first.isRecommended),
+        )
+        .slice(0, 4);
 
     return (
         <div>


### PR DESCRIPTION
## Summary
- sort landing page plant showcase so recommended plants appear first

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d55f78091c832fb42d99c277a91406