### PR TITLE
feat(www): show availability indicators for plant sorts

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -104,6 +104,14 @@ export function PlantPageHeader({
                         )}
                         {plant.isRecommended && <SeedTimeInformationBadge />}
                     </Row>
+                    {sort?.store?.availableInStore === false && (
+                        <Typography
+                            level="body2"
+                            className="text-amber-600 font-semibold"
+                        >
+                            Trenutno nije dostupna za sjetvu
+                        </Typography>
+                    )}
                     {informationSections.some(
                         (section) => section.avaialble,
                     ) && (

--- a/apps/www/app/biljke/[alias]/PlantSortsList.tsx
+++ b/apps/www/app/biljke/[alias]/PlantSortsList.tsx
@@ -40,50 +40,65 @@ async function PlantSortsListContent({
                 Sorte
             </Typography>
             <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-                {sorts.map((sort) => (
-                    <Card
-                        key={sort.id}
-                        href={KnownPages.PlantSort(
-                            basePlantName,
-                            sort.information.name,
-                        )}
-                    >
-                        <Row spacing={2}>
-                            <AiWatermark
-                                className="size-20 aspect-square"
-                                reason="Primjer ploda biljke visoke rezolucije bez nedostataka."
-                                aiPrompt={`Realistic and not perfect image of requested plant on white background. No Text Or Banners. Square image. ${sort.information.plant.information?.name}`}
-                                aiModel="ChatGPT-4o"
-                            >
-                                <PlantImage
-                                    plant={{
-                                        image: {
-                                            cover:
-                                                sort.image?.cover ??
-                                                sort.information.plant.image
-                                                    ?.cover,
-                                        },
-                                        information: {
-                                            name: sort.information.name,
-                                        },
-                                    }}
-                                    width={72}
-                                    height={72}
-                                />
-                            </AiWatermark>
-                            <Stack className="grow">
-                                <Typography level="h5">
-                                    {sort.information.name}
-                                </Typography>
-                                {sort.information.shortDescription && (
-                                    <Typography level="body1">
-                                        {sort.information.shortDescription}
+                {sorts.map((sort) => {
+                    const isAvailable =
+                        sort.store?.availableInStore ??
+                        sort.information.plant.store?.availableInStore ??
+                        false;
+
+                    return (
+                        <Card
+                            key={sort.id}
+                            href={KnownPages.PlantSort(
+                                basePlantName,
+                                sort.information.name,
+                            )}
+                        >
+                            <Row spacing={2}>
+                                <AiWatermark
+                                    className="size-20 aspect-square"
+                                    reason="Primjer ploda biljke visoke rezolucije bez nedostataka."
+                                    aiPrompt={`Realistic and not perfect image of requested plant on white background. No Text Or Banners. Square image. ${sort.information.plant.information?.name}`}
+                                    aiModel="ChatGPT-4o"
+                                >
+                                    <PlantImage
+                                        plant={{
+                                            image: {
+                                                cover:
+                                                    sort.image?.cover ??
+                                                    sort.information.plant.image
+                                                        ?.cover,
+                                            },
+                                            information: {
+                                                name: sort.information.name,
+                                            },
+                                        }}
+                                        width={72}
+                                        height={72}
+                                    />
+                                </AiWatermark>
+                                <Stack className="grow">
+                                    <Typography level="h5">
+                                        {sort.information.name}
                                     </Typography>
-                                )}
-                            </Stack>
-                        </Row>
-                    </Card>
-                ))}
+                                    {sort.information.shortDescription && (
+                                        <Typography level="body1">
+                                            {sort.information.shortDescription}
+                                        </Typography>
+                                    )}
+                                    {!isAvailable && (
+                                        <Typography
+                                            level="body2"
+                                            className="text-amber-600 font-medium"
+                                        >
+                                            Trenutno nije dostupna u trgovini
+                                        </Typography>
+                                    )}
+                                </Stack>
+                            </Row>
+                        </Card>
+                    );
+                })}
             </div>
         </Stack>
     );


### PR DESCRIPTION
## Summary
- show unavailable store status in the plant detail sort list while keeping all sorts visible
- surface a sowing unavailability warning on the plant sort detail header when the sort is not in stock

## Testing
- pnpm lint --filter www

------
https://chatgpt.com/codex/tasks/task_e_68d55f22514c832fb60c1109b56e1c8e