### PR TITLE
Enable players to manage raised bed operations

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -1,5 +1,6 @@
 import { signalcoClient } from '@gredice/signalco';
 import {
+    cancelOperation,
     createEvent,
     createGardenBlock,
     createGardenStack,
@@ -14,9 +15,12 @@ import {
     getRaisedBedDiaryEntries,
     getRaisedBedFieldDiaryEntries,
     getRaisedBedSensors,
-    getRaisedBeds,
     knownEvents,
     knownEventTypes,
+    OperationInvalidStateError,
+    OperationNotFoundError,
+    OperationValidationError,
+    rescheduleOperation,
     spendSunflowers,
     updateGardenBlock,
     updateGardenStack,
@@ -999,6 +1003,158 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const diaryEntries =
                 await getRaisedBedDiaryEntries(raisedBedIdNumber);
             return context.json(diaryEntries);
+        },
+    )
+    .post(
+        '/:gardenId/raised-beds/:raisedBedId/operations/:operationId/reschedule',
+        describeRoute({
+            description: 'Reschedule a raised bed operation',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                raisedBedId: z.string(),
+                operationId: z.string(),
+            }),
+        ),
+        zValidator(
+            'json',
+            z.object({
+                scheduledDate: z.string().datetime(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, raisedBedId, operationId } =
+                context.req.valid('param');
+            const { scheduledDate } = context.req.valid('json');
+
+            const gardenIdNumber = parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const raisedBedIdNumber = parseInt(raisedBedId, 10);
+            if (Number.isNaN(raisedBedIdNumber)) {
+                return context.json({ error: 'Invalid raised bed ID' }, 400);
+            }
+
+            const operationIdNumber = parseInt(operationId, 10);
+            if (Number.isNaN(operationIdNumber)) {
+                return context.json({ error: 'Invalid operation ID' }, 400);
+            }
+
+            const { accountId } = context.get('authContext');
+
+            try {
+                const scheduledAt = new Date(scheduledDate);
+                await rescheduleOperation(operationIdNumber, scheduledAt, {
+                    accountId,
+                    gardenId: gardenIdNumber,
+                    raisedBedId: raisedBedIdNumber,
+                });
+                return context.json({ success: true });
+            } catch (error) {
+                if (error instanceof OperationValidationError) {
+                    return context.json({ error: error.message }, 400);
+                }
+                if (error instanceof OperationInvalidStateError) {
+                    return context.json({ error: error.message }, 400);
+                }
+                if (error instanceof OperationNotFoundError) {
+                    return context.json({ error: 'Operation not found' }, 404);
+                }
+                console.error('Failed to reschedule operation', {
+                    error,
+                    operationId: operationIdNumber,
+                    raisedBedId: raisedBedIdNumber,
+                    gardenId: gardenIdNumber,
+                });
+                return context.json(
+                    { error: 'Failed to reschedule operation' },
+                    500,
+                );
+            }
+        },
+    )
+    .post(
+        '/:gardenId/raised-beds/:raisedBedId/operations/:operationId/cancel',
+        describeRoute({
+            description: 'Cancel a planned raised bed operation',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                raisedBedId: z.string(),
+                operationId: z.string(),
+            }),
+        ),
+        zValidator(
+            'json',
+            z.object({
+                reason: z.string().min(1),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, raisedBedId, operationId } =
+                context.req.valid('param');
+            const { reason } = context.req.valid('json');
+
+            const gardenIdNumber = parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const raisedBedIdNumber = parseInt(raisedBedId, 10);
+            if (Number.isNaN(raisedBedIdNumber)) {
+                return context.json({ error: 'Invalid raised bed ID' }, 400);
+            }
+
+            const operationIdNumber = parseInt(operationId, 10);
+            if (Number.isNaN(operationIdNumber)) {
+                return context.json({ error: 'Invalid operation ID' }, 400);
+            }
+
+            const { accountId, userId } = context.get('authContext');
+
+            try {
+                await cancelOperation(
+                    {
+                        operationId: operationIdNumber,
+                        canceledBy: userId,
+                        reason,
+                    },
+                    {
+                        accountId,
+                        gardenId: gardenIdNumber,
+                        raisedBedId: raisedBedIdNumber,
+                    },
+                );
+                return context.json({ success: true });
+            } catch (error) {
+                if (error instanceof OperationValidationError) {
+                    return context.json({ error: error.message }, 400);
+                }
+                if (error instanceof OperationInvalidStateError) {
+                    return context.json({ error: error.message }, 400);
+                }
+                if (error instanceof OperationNotFoundError) {
+                    return context.json({ error: 'Operation not found' }, 404);
+                }
+                console.error('Failed to cancel operation', {
+                    error,
+                    operationId: operationIdNumber,
+                    raisedBedId: raisedBedIdNumber,
+                    gardenId: gardenIdNumber,
+                });
+                return context.json(
+                    { error: 'Failed to cancel operation' },
+                    500,
+                );
+            }
         },
     )
     .get(

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -3,13 +3,14 @@
 import { randomUUID } from 'node:crypto';
 import {
     acceptOperation,
+    cancelOperation,
     createEvent,
     createNotification,
     createOperation,
-    earnSunflowers,
     getEntityFormatted,
     getOperationById,
     getRaisedBed,
+    rescheduleOperation,
     type InsertOperation,
     knownEvents,
 } from '@gredice/storage';
@@ -126,17 +127,8 @@ export async function rescheduleOperationAction(formData: FormData) {
         throw new Error('Scheduled Date is required');
     }
 
-    const operation = await getOperationById(operationId);
-    if (!operation) {
-        throw new Error(`Operation with ID ${operationId} not found.`);
-    }
-
-    // Create a new scheduled event to reschedule the operation
-    await createEvent(
-        knownEvents.operations.scheduledV1(operationId.toString(), {
-            scheduledDate: new Date(scheduledDate).toISOString(),
-        }),
-    );
+    const scheduledAt = new Date(scheduledDate);
+    const operation = await rescheduleOperation(operationId, scheduledAt);
 
     revalidatePath(KnownPages.Schedule);
     if (operation.accountId)
@@ -277,92 +269,14 @@ export async function cancelOperationAction(formData: FormData) {
         throw new Error('Cancellation reason is required');
     }
 
-    const operation = await getOperationById(operationId);
-    if (!operation) {
-        throw new Error(`Operation with ID ${operationId} not found.`);
-    }
-
-    // Only allow canceling new or planned operations
-    if (
-        operation.status === 'completed' ||
-        operation.status === 'failed' ||
-        operation.status === 'canceled'
-    ) {
-        throw new Error(
-            `Cannot cancel operation with status ${operation.status}`,
-        );
-    }
-
-    // Get operation details for notification and refund calculation
-    const operationData = await getEntityFormatted<EntityStandardized>(
-        operation.entityId,
+    const { operation } = await cancelOperation(
+        {
+            operationId,
+            canceledBy: userId,
+            reason,
+        },
+        undefined,
     );
-
-    // Calculate refund amount (operation price in sunflowers - multiplied by 1000 as per checkout logic)
-    const refundAmount = operationData?.prices?.perOperation
-        ? Math.round(operationData.prices.perOperation * 1000)
-        : 0;
-
-    const header = 'Radnje je otkazana';
-    let content = `Radnja **${operationData?.information?.label}** je otkazana.`;
-    if (operation.raisedBedId) {
-        const raisedBed = await getRaisedBed(operation.raisedBedId);
-        if (!raisedBed) {
-            console.error(
-                `Raised bed with ID ${operation.raisedBedId} not found.`,
-            );
-        } else {
-            const positionIndex = operation.raisedBedFieldId
-                ? raisedBed.fields.find(
-                      (f) => f.id === operation.raisedBedFieldId,
-                  )?.positionIndex
-                : null;
-            if (typeof positionIndex === 'number') {
-                content = `Radnja **${operationData?.information?.label}** na gredici **${raisedBed.name}** za polje **${positionIndex + 1}** je otkazana.`;
-            } else {
-                content = `Radnja **${operationData?.information?.label}** na gredici **${raisedBed.name}** je otkazana.`;
-            }
-        }
-    }
-
-    // Add reason
-    if (reason) {
-        content += `\nRazlog otkazivanja: ${reason}`;
-    }
-
-    // Add refund information
-    if (refundAmount > 0) {
-        content += `\nSredstva su ti vraćana u iznosu od ${refundAmount} 🌻.`;
-    }
-
-    await Promise.all([
-        // Create cancellation event
-        createEvent(
-            knownEvents.operations.canceledV1(operationId.toString(), {
-                canceledBy: userId,
-                reason,
-            }),
-        ),
-        // Refund sunflowers if operation had a cost
-        refundAmount > 0 && operation.accountId
-            ? earnSunflowers(
-                  operation.accountId,
-                  refundAmount,
-                  `refund:operation:${operationId}`,
-              )
-            : Promise.resolve(),
-        // Send notification to user
-        operation.accountId
-            ? createNotification({
-                  accountId: operation.accountId,
-                  gardenId: operation.gardenId,
-                  raisedBedId: operation.raisedBedId,
-                  header,
-                  content,
-                  timestamp: new Date(),
-              })
-            : undefined,
-    ]);
 
     revalidatePath(KnownPages.Schedule);
     if (operation.accountId)

--- a/packages/game/src/hooks/useOperationDiaryMutations.ts
+++ b/packages/game/src/hooks/useOperationDiaryMutations.ts
@@ -1,0 +1,97 @@
+import { client } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
+
+type RescheduleVariables = {
+    gardenId: number;
+    raisedBedId: number;
+    operationId: number;
+    scheduledDate: string;
+};
+
+type CancelVariables = {
+    gardenId: number;
+    raisedBedId: number;
+    operationId: number;
+    reason: string;
+};
+
+export function useRescheduleOperationMutation() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({
+            gardenId,
+            raisedBedId,
+            operationId,
+            scheduledDate,
+        }: RescheduleVariables) => {
+            const response = await client().api.gardens[':gardenId'][
+                'raised-beds'
+            ][':raisedBedId'].operations[':operationId'].reschedule.$post({
+                param: {
+                    gardenId: gardenId.toString(),
+                    raisedBedId: raisedBedId.toString(),
+                    operationId: operationId.toString(),
+                },
+                json: { scheduledDate },
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                const message =
+                    errorData && typeof errorData.error === 'string'
+                        ? errorData.error
+                        : 'Failed to reschedule operation';
+                throw new Error(message);
+            }
+
+            return response.json().catch(() => ({ success: true }));
+        },
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: raisedBedDiaryQueryKeys.byId(variables.raisedBedId),
+            });
+        },
+    });
+}
+
+export function useCancelOperationMutation() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({
+            gardenId,
+            raisedBedId,
+            operationId,
+            reason,
+        }: CancelVariables) => {
+            const response = await client().api.gardens[':gardenId'][
+                'raised-beds'
+            ][':raisedBedId'].operations[':operationId'].cancel.$post({
+                param: {
+                    gardenId: gardenId.toString(),
+                    raisedBedId: raisedBedId.toString(),
+                    operationId: operationId.toString(),
+                },
+                json: { reason },
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                const message =
+                    errorData && typeof errorData.error === 'string'
+                        ? errorData.error
+                        : 'Failed to cancel operation';
+                throw new Error(message);
+            }
+
+            return response.json().catch(() => ({ success: true }));
+        },
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: raisedBedDiaryQueryKeys.byId(variables.raisedBedId),
+            });
+        },
+    });
+}

--- a/packages/game/src/hooks/useRaisedBedFieldDiaryEntries.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldDiaryEntries.ts
@@ -1,5 +1,9 @@
 import { client } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
+import type {
+    OperationStatusCode,
+    RaisedBedDiaryEntry,
+} from './useRaisedBedDiaryEntries';
 
 export const queryKeys = {
     byId: (raisedBedId: number, positionIndex: number) => [
@@ -16,7 +20,7 @@ export function useRaisedBedFieldDiaryEntries(
     raisedBedId: number,
     positionIndex: number,
 ) {
-    return useQuery({
+    return useQuery<RaisedBedDiaryEntry[]>({
         queryKey: queryKeys.byId(raisedBedId, positionIndex),
         queryFn: async () => {
             const entries = await client().api.gardens[':gardenId'][
@@ -42,8 +46,23 @@ export function useRaisedBedFieldDiaryEntries(
                 );
                 return [];
             }
-            return (await entries.json()).map((entry) => ({
+            const data = (await entries.json()) as Array<{
+                id: number;
+                kind?: 'raisedBed' | 'raisedBedField' | 'operation';
+                name: string;
+                description?: string;
+                status: string | null;
+                statusCode?: OperationStatusCode | null;
+                timestamp: string;
+                imageUrls?: string[] | null;
+                scheduledDate?: string | null;
+            }>;
+            return data.map((entry) => ({
                 ...entry,
+                statusCode: entry.statusCode ?? null,
+                scheduledDate: entry.scheduledDate
+                    ? new Date(entry.scheduledDate)
+                    : null,
                 timestamp: new Date(entry.timestamp),
             }));
         },

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -1,14 +1,26 @@
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Alert } from '@signalco/ui/Alert';
+import { Button } from '@signalco/ui-primitives/Button';
 import { Chip } from '@signalco/ui-primitives/Chip';
+import { Input } from '@signalco/ui-primitives/Input';
 import { List } from '@signalco/ui-primitives/List';
 import { ListItem } from '@signalco/ui-primitives/ListItem';
+import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Spinner } from '@signalco/ui-primitives/Spinner';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
+import { type ReactElement, useState } from 'react';
+import {
+    useCancelOperationMutation,
+    useRescheduleOperationMutation,
+} from '../../hooks/useOperationDiaryMutations';
+import {
+    type RaisedBedDiaryEntry,
+    useRaisedBedDiaryEntries,
+} from '../../hooks/useRaisedBedDiaryEntries';
 import { useRaisedBedFieldDiaryEntries } from '../../hooks/useRaisedBedFieldDiaryEntries';
+import { formatLocalDate } from './RaisedBedPlantPicker';
 
 function DiaryEntryImages({
     name,
@@ -36,23 +48,290 @@ function DiaryEntryImages({
     );
 }
 
+function RescheduleOperationModal({
+    gardenId,
+    raisedBedId,
+    operationId,
+    scheduledDate,
+    trigger,
+}: {
+    gardenId: number;
+    raisedBedId: number;
+    operationId: number;
+    scheduledDate: Date | null | undefined;
+    trigger: ReactElement;
+}) {
+    const [open, setOpen] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const rescheduleOperation = useRescheduleOperationMutation();
+
+    const today = new Date();
+    const tomorrow = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() + 1,
+    );
+    const threeMonthsFromTomorrow = new Date(
+        tomorrow.getFullYear(),
+        tomorrow.getMonth() + 3,
+        tomorrow.getDate(),
+    );
+    const defaultDate = scheduledDate ?? tomorrow;
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+        const formData = new FormData(event.currentTarget);
+        const newDate = formData.get('scheduledDate') as string | null;
+        if (!newDate) {
+            setError('Odaberi novi datum za radnju.');
+            return;
+        }
+
+        try {
+            await rescheduleOperation.mutateAsync({
+                gardenId,
+                raisedBedId,
+                operationId,
+                scheduledDate: new Date(newDate).toISOString(),
+            });
+            setOpen(false);
+        } catch (mutationError) {
+            console.error('Failed to reschedule operation:', mutationError);
+            setError(
+                mutationError instanceof Error
+                    ? mutationError.message
+                    : 'Neuspjelo prebacivanje radnje.',
+            );
+        }
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setError(null);
+            rescheduleOperation.reset();
+        }
+    }
+
+    const min = formatLocalDate(tomorrow);
+    const max = formatLocalDate(threeMonthsFromTomorrow);
+    const defaultValue = formatLocalDate(defaultDate);
+
+    return (
+        <Modal
+            trigger={trigger}
+            open={open}
+            onOpenChange={handleOpenChange}
+            title="Promijeni termin radnje"
+            className="border border-tertiary border-b-4"
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="body1">
+                        Odaberi novi datum kada želiš da se radnja izvrši.
+                    </Typography>
+                    {error && (
+                        <Alert color="danger">
+                            <Typography level="body2">{error}</Typography>
+                        </Alert>
+                    )}
+                    <Input
+                        type="date"
+                        name="scheduledDate"
+                        label="Novi datum radnje"
+                        className="w-full bg-card"
+                        defaultValue={defaultValue}
+                        min={min}
+                        max={max}
+                        disabled={rescheduleOperation.isPending}
+                        required
+                    />
+                    <Row spacing={1} justifyContent="end">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={rescheduleOperation.isPending}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={rescheduleOperation.isPending}
+                        >
+                            Spremi
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}
+
+function CancelOperationModal({
+    gardenId,
+    raisedBedId,
+    operationId,
+    trigger,
+}: {
+    gardenId: number;
+    raisedBedId: number;
+    operationId: number;
+    trigger: ReactElement;
+}) {
+    const [open, setOpen] = useState(false);
+    const [reason, setReason] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const cancelOperation = useCancelOperationMutation();
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+
+        if (!reason.trim()) {
+            setError('Navedi razlog otkazivanja.');
+            return;
+        }
+
+        try {
+            await cancelOperation.mutateAsync({
+                gardenId,
+                raisedBedId,
+                operationId,
+                reason: reason.trim(),
+            });
+            setOpen(false);
+            setReason('');
+        } catch (mutationError) {
+            console.error('Failed to cancel operation:', mutationError);
+            setError(
+                mutationError instanceof Error
+                    ? mutationError.message
+                    : 'Neuspjelo otkazivanje radnje.',
+            );
+        }
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setReason('');
+            setError(null);
+            cancelOperation.reset();
+        }
+    }
+
+    return (
+        <Modal
+            trigger={trigger}
+            open={open}
+            onOpenChange={handleOpenChange}
+            title="Otkaži radnju"
+            className="border border-tertiary border-b-4"
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="body1">
+                        Otkazivanje radnje je nepovratno. Navedi razlog kako bi
+                        ekipa znala što se dogodilo.
+                    </Typography>
+                    {error && (
+                        <Alert color="danger">
+                            <Typography level="body2">{error}</Typography>
+                        </Alert>
+                    )}
+                    <Stack spacing={1}>
+                        <Typography level="body3" semiBold>
+                            Razlog otkazivanja
+                        </Typography>
+                        <textarea
+                            name="reason"
+                            value={reason}
+                            onChange={(event) => setReason(event.target.value)}
+                            className="w-full bg-card border border-border rounded-md p-3 min-h-24 resize-vertical text-base text-foreground"
+                            placeholder="Objasni zašto želiš otkazati radnju..."
+                            required
+                        />
+                    </Stack>
+                    <Row spacing={1} justifyContent="end">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            onClick={() => setOpen(false)}
+                            disabled={cancelOperation.isPending}
+                        >
+                            Zatvori
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            color="danger"
+                            loading={cancelOperation.isPending}
+                            disabled={
+                                !reason.trim() || cancelOperation.isPending
+                            }
+                        >
+                            Otkaži radnju
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}
+
+function OperationActions({
+    entry,
+    gardenId,
+    raisedBedId,
+}: {
+    entry: RaisedBedDiaryEntry;
+    gardenId: number;
+    raisedBedId: number;
+}) {
+    if (entry.kind !== 'operation' || entry.statusCode !== 'planned') {
+        return null;
+    }
+
+    return (
+        <Row spacing={1} className="flex-wrap gap-y-1">
+            <RescheduleOperationModal
+                gardenId={gardenId}
+                raisedBedId={raisedBedId}
+                operationId={entry.id}
+                scheduledDate={entry.scheduledDate ?? null}
+                trigger={
+                    <Button variant="outlined" size="sm">
+                        Promijeni termin
+                    </Button>
+                }
+            />
+            <CancelOperationModal
+                gardenId={gardenId}
+                raisedBedId={raisedBedId}
+                operationId={entry.id}
+                trigger={
+                    <Button variant="outlined" color="danger" size="sm">
+                        Otkaži radnju
+                    </Button>
+                }
+            />
+        </Row>
+    );
+}
+
 function DiaryList({
     error,
     isLoading,
     entries,
+    renderActions,
 }: {
     error: Error | null;
     isLoading: boolean;
-    entries:
-        | Array<{
-              id: number;
-              name: string;
-              description: string | undefined;
-              status: string | null;
-              timestamp: Date;
-              imageUrls?: string[] | null;
-          }>
-        | undefined;
+    entries: RaisedBedDiaryEntry[] | undefined;
+    renderActions?: (entry: RaisedBedDiaryEntry) => React.ReactNode;
 }) {
     return (
         <List>
@@ -85,53 +364,60 @@ function DiaryList({
                 <ListItem
                     key={entry.id}
                     label={
-                        <Row
-                            spacing={2}
-                            className="justify-between font-normal"
-                        >
-                            <Row spacing={2} className="items-start flex-1">
-                                <DiaryEntryImages
-                                    name={entry.name}
-                                    imageUrls={entry.imageUrls}
-                                />
+                        <Stack spacing={2}>
+                            <Row
+                                spacing={2}
+                                className="justify-between font-normal"
+                            >
+                                <Row spacing={2} className="items-start flex-1">
+                                    <DiaryEntryImages
+                                        name={entry.name}
+                                        imageUrls={entry.imageUrls}
+                                    />
+                                    <Stack spacing={1}>
+                                        <Typography level="body1" semiBold>
+                                            {entry.name}
+                                        </Typography>
+                                        {entry.description && (
+                                            <Typography level="body2">
+                                                {entry.description}
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                </Row>
                                 <Stack>
-                                    <Typography level="body1" semiBold>
-                                        {entry.name}
-                                    </Typography>
-                                    <Typography level="body2">
-                                        {entry.description}
+                                    {entry.status && (
+                                        <Chip
+                                            color={
+                                                entry.status === 'Novo'
+                                                    ? 'warning'
+                                                    : entry.status ===
+                                                        'Završeno'
+                                                      ? 'success'
+                                                      : entry.status ===
+                                                          'Planirano'
+                                                        ? 'info'
+                                                        : entry.status ===
+                                                                'Neuspješno' ||
+                                                            entry.status ===
+                                                                'Otkazano'
+                                                          ? 'error'
+                                                          : 'neutral'
+                                            }
+                                            className="shrink-0 w-fit self-end"
+                                        >
+                                            {entry.status}
+                                        </Chip>
+                                    )}
+                                    <Typography level="body2" noWrap>
+                                        {entry.timestamp.toLocaleDateString(
+                                            'hr-HR',
+                                        )}
                                     </Typography>
                                 </Stack>
                             </Row>
-                            <Stack>
-                                {entry.status && (
-                                    <Chip
-                                        color={
-                                            entry.status === 'Novo'
-                                                ? 'warning'
-                                                : entry.status === 'Završeno'
-                                                  ? 'success'
-                                                  : entry.status === 'Planirano'
-                                                    ? 'info'
-                                                    : entry.status ===
-                                                            'Neuspješno' ||
-                                                        entry.status ===
-                                                            'Otkazano'
-                                                      ? 'error'
-                                                      : 'neutral'
-                                        }
-                                        className="shrink-0 w-fit self-end"
-                                    >
-                                        {entry.status}
-                                    </Chip>
-                                )}
-                                <Typography level="body2" noWrap>
-                                    {entry.timestamp.toLocaleDateString(
-                                        'hr-HR',
-                                    )}
-                                </Typography>
-                            </Stack>
-                        </Row>
+                            {renderActions?.(entry)}
+                        </Stack>
                     }
                 />
             ))}
@@ -168,5 +454,18 @@ export function RaisedBedDiary({
         isLoading,
         error,
     } = useRaisedBedDiaryEntries(gardenId, raisedBedId);
-    return <DiaryList error={error} isLoading={isLoading} entries={entries} />;
+    return (
+        <DiaryList
+            error={error}
+            isLoading={isLoading}
+            entries={entries}
+            renderActions={(entry) => (
+                <OperationActions
+                    entry={entry}
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                />
+            )}
+        />
+    );
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -25,4 +25,5 @@ export * from './repositories/timeSlotsRepo';
 export * from './repositories/transactionsRepo';
 export * from './repositories/usersRepo';
 export * from './schema';
+export * from './services/operationsService';
 export * from './storage';

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { plantFieldStatusLabel } from '@gredice/js/plants';
-import { and, count, desc, eq, gte } from 'drizzle-orm';
+import { and, count, desc, eq } from 'drizzle-orm';
 import { v4 as uuidV4 } from 'uuid';
 import { getEntitiesFormatted, getOperations, storage } from '..';
 import type { EntityStandardized } from '../@types/EntityStandardized';
@@ -571,12 +571,14 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
             const data = event.data as Record<string, unknown> | undefined;
             return {
                 id: event.id,
+                kind: 'raisedBed' as const,
                 name:
                     event.type === knownEventTypes.raisedBeds.create
                         ? 'Gredica stvorena'
                         : 'Gredica obrisana',
                 description: '',
                 status: null,
+                statusCode: null,
                 timestamp: event.createdAt,
                 imageUrls: Array.isArray(data?.imageUrls)
                     ? data.imageUrls.filter(
@@ -592,6 +594,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
         .filter((op) => !op.raisedBedFieldId) // Filter out operations with raisedBedFieldId
         .map((op) => ({
             id: op.id,
+            kind: 'operation' as const,
             name:
                 operationsData?.find((opData) => opData.id === op.entityId)
                     ?.information?.label ?? 'Nepoznato',
@@ -599,6 +602,8 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
                 (opData) => opData.id === op.entityId,
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
+            statusCode: op.status,
+            scheduledDate: op.scheduledDate ?? null,
             timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
             imageUrls: op.imageUrls,
         }))
@@ -739,9 +744,11 @@ export async function getRaisedBedFieldDiaryEntries(
 
             return {
                 id: event.id,
+                kind: 'raisedBedField' as const,
                 name,
                 description,
                 status: null,
+                statusCode: null,
                 timestamp: event.createdAt,
                 imageUrls: Array.isArray(data?.imageUrls)
                     ? data.imageUrls.filter(
@@ -757,6 +764,7 @@ export async function getRaisedBedFieldDiaryEntries(
     const operationsDiaryEntries = operations
         .map((op) => ({
             id: op.id,
+            kind: 'operation' as const,
             name:
                 operationsData?.find((opData) => opData.id === op.entityId)
                     ?.information?.label ?? 'Nepoznato',
@@ -764,6 +772,8 @@ export async function getRaisedBedFieldDiaryEntries(
                 (opData) => opData.id === op.entityId,
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
+            statusCode: op.status,
+            scheduledDate: op.scheduledDate ?? null,
             timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
             imageUrls: op.imageUrls,
         }))

--- a/packages/storage/src/services/operationsService.ts
+++ b/packages/storage/src/services/operationsService.ts
@@ -1,0 +1,180 @@
+import type { EntityStandardized } from '../@types/EntityStandardized';
+import { earnSunflowers } from '../repositories/accountsRepo';
+import { getEntityFormatted } from '../repositories/entitiesRepo';
+import { createEvent, knownEvents } from '../repositories/eventsRepo';
+import { getRaisedBed } from '../repositories/gardensRepo';
+import { createNotification } from '../repositories/notificationsRepo';
+import { getOperationById } from '../repositories/operationsRepo';
+
+export class OperationNotFoundError extends Error {
+    constructor(message = 'Operation not found') {
+        super(message);
+        this.name = 'OperationNotFoundError';
+    }
+}
+
+export class OperationInvalidStateError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'OperationInvalidStateError';
+    }
+}
+
+export class OperationValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'OperationValidationError';
+    }
+}
+
+type OperationValidationOptions = {
+    accountId?: string;
+    gardenId?: number;
+    raisedBedId?: number;
+};
+
+async function fetchOperation(operationId: number) {
+    try {
+        return await getOperationById(operationId);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('not found')) {
+            throw new OperationNotFoundError();
+        }
+        throw error;
+    }
+}
+
+function assertOperationAccess(
+    operation: Awaited<ReturnType<typeof getOperationById>>,
+    options?: OperationValidationOptions,
+) {
+    if (!options) {
+        return;
+    }
+
+    if (
+        (options.accountId && operation.accountId !== options.accountId) ||
+        (options.gardenId && operation.gardenId !== options.gardenId) ||
+        (options.raisedBedId && operation.raisedBedId !== options.raisedBedId)
+    ) {
+        throw new OperationNotFoundError();
+    }
+}
+
+export async function rescheduleOperation(
+    operationId: number,
+    scheduledDate: Date,
+    options?: OperationValidationOptions,
+) {
+    if (
+        !(scheduledDate instanceof Date) ||
+        Number.isNaN(scheduledDate.getTime())
+    ) {
+        throw new OperationValidationError('Scheduled date is invalid');
+    }
+
+    const operation = await fetchOperation(operationId);
+    assertOperationAccess(operation, options);
+
+    await createEvent(
+        knownEvents.operations.scheduledV1(operationId.toString(), {
+            scheduledDate: scheduledDate.toISOString(),
+        }),
+    );
+
+    return operation;
+}
+
+export async function cancelOperation(
+    {
+        operationId,
+        canceledBy,
+        reason,
+    }: {
+        operationId: number;
+        canceledBy: string;
+        reason: string;
+    },
+    options?: OperationValidationOptions,
+) {
+    if (!reason || reason.trim().length === 0) {
+        throw new OperationValidationError('Cancellation reason is required');
+    }
+
+    const operation = await fetchOperation(operationId);
+    assertOperationAccess(operation, options);
+
+    if (
+        operation.status === 'completed' ||
+        operation.status === 'failed' ||
+        operation.status === 'canceled'
+    ) {
+        throw new OperationInvalidStateError(
+            `Cannot cancel operation with status ${operation.status}`,
+        );
+    }
+
+    const operationData = await getEntityFormatted<EntityStandardized>(
+        operation.entityId,
+    );
+
+    const refundAmount = operationData?.prices?.perOperation
+        ? Math.round(operationData.prices.perOperation * 1000)
+        : 0;
+
+    let content = `Radnja **${operationData?.information?.label}** je otkazana.`;
+    if (operation.raisedBedId) {
+        const raisedBed = await getRaisedBed(operation.raisedBedId);
+        if (raisedBed) {
+            const positionIndex = operation.raisedBedFieldId
+                ? (raisedBed.fields.find(
+                      (field) => field.id === operation.raisedBedFieldId,
+                  )?.positionIndex ?? null)
+                : null;
+            if (typeof positionIndex === 'number') {
+                content = `Radnja **${operationData?.information?.label}** na gredici **${raisedBed.name}** za polje **${positionIndex + 1}** je otkazana.`;
+            } else {
+                content = `Radnja **${operationData?.information?.label}** na gredici **${raisedBed.name}** je otkazana.`;
+            }
+        }
+    }
+
+    if (reason) {
+        content += `\nRazlog otkazivanja: ${reason}`;
+    }
+
+    if (refundAmount > 0) {
+        content += `\nSredstva su ti vraćana u iznosu od ${refundAmount} 🌻.`;
+    }
+
+    await Promise.all([
+        createEvent(
+            knownEvents.operations.canceledV1(operationId.toString(), {
+                canceledBy,
+                reason,
+            }),
+        ),
+        refundAmount > 0 && operation.accountId
+            ? earnSunflowers(
+                  operation.accountId,
+                  refundAmount,
+                  `refund:operation:${operationId}`,
+              )
+            : Promise.resolve(),
+        operation.accountId
+            ? createNotification({
+                  accountId: operation.accountId,
+                  gardenId: operation.gardenId,
+                  raisedBedId: operation.raisedBedId,
+                  header: 'Radnje je otkazana',
+                  content,
+                  timestamp: new Date(),
+              })
+            : undefined,
+    ]);
+
+    return {
+        operation,
+        refundAmount,
+    };
+}


### PR DESCRIPTION
## Summary
- add shared operations service with validation helpers to reschedule or cancel operations and export it for reuse
- expose raised bed operation reschedule and cancellation API endpoints that enforce account access checks and reuse the shared logic
- enrich raised bed diary entries with operation metadata and surface new game UI workflows plus mutations so planned operations can be rescheduled or canceled from the diary

## Testing
- pnpm lint --filter @gredice/storage
- pnpm lint --filter @gredice/api
- pnpm lint --filter @gredice/game *(fails: existing lint issues in package)*

------
https://chatgpt.com/codex/tasks/task_e_68c9dc0db600832fa5201a8e644b2dd2