### PR TITLE
Add duration card to operation details

### DIFF
--- a/apps/www/app/radnje/[alias]/OperationAttributesCards.tsx
+++ b/apps/www/app/radnje/[alias]/OperationAttributesCards.tsx
@@ -6,6 +6,7 @@ import {
     Sprout,
     Sun,
     Tally3,
+    Timer,
 } from '@signalco/ui-icons';
 import type { JSX } from 'react';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
@@ -54,6 +55,16 @@ export function OperationAttributesCards({
                 header="Učestalost"
                 subheader="Savjet o učestalosti izvođenja radnje"
                 value={operationFrequencyLabel(attributes?.frequency)}
+            />
+            <AttributeCard
+                icon={<Timer />}
+                header="Trajanje"
+                subheader="Prosječno vrijeme izvođenja radnje u minutama"
+                value={
+                    attributes?.duration != null
+                        ? `${attributes.duration} min`
+                        : '-'
+                }
             />
             <AttributeCard
                 icon={<Sprout />}


### PR DESCRIPTION
## Summary
- add a duration attribute card to operation detail view
- show the average time in minutes required for the operation with a timer icon

## Testing
- pnpm lint --filter www

------
https://chatgpt.com/codex/tasks/task_e_68d5608b4160832f901506d4eabae80d