### PR TITLE
feat(www): expose plant lifecycle and yield details

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantAttributeCards.tsx
+++ b/apps/www/app/biljke/[alias]/PlantAttributeCards.tsx
@@ -4,11 +4,17 @@ import {
     Droplet,
     Leaf,
     Ruler,
+    ShoppingCart,
     Sprout,
+    Store,
     Sun,
+    SunMoon,
     Tally3,
     Thermometer,
+    Timer,
 } from '@signalco/ui-icons';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
 
 export function PlantAttributeCards({
@@ -16,6 +22,110 @@ export function PlantAttributeCards({
 }: {
     attributes: PlantData['attributes'] | undefined;
 }) {
+    const formatDayRange = (
+        min?: number | null,
+        max?: number | null,
+    ): string => {
+        if (min == null && max == null) {
+            return '-';
+        }
+        if (min != null && max != null) {
+            if (min === max) {
+                return `${min} ${min === 1 ? 'dan' : 'dana'}`;
+            }
+            return `${min}-${max} dana`;
+        }
+        const value = min ?? max;
+        return value == null ? '-' : `${value} ${value === 1 ? 'dan' : 'dana'}`;
+    };
+
+    const formatWeightRange = (
+        min?: number | null,
+        max?: number | null,
+    ): string | undefined => {
+        if (min == null && max == null) {
+            return undefined;
+        }
+        if (min != null && max != null) {
+            if (min === max) {
+                return `${min} g`;
+            }
+            return `${min}-${max} g`;
+        }
+        const value = min ?? max;
+        return value == null ? undefined : `${value} g`;
+    };
+
+    const getPlantsLabel = (count: number) => {
+        if (count === 1) {
+            return 'biljku';
+        }
+        if (count > 4) {
+            return 'biljaka';
+        }
+        return 'biljke';
+    };
+
+    const getYieldDetails = () => {
+        if (!attributes) {
+            return null;
+        }
+
+        const seedingDistance = attributes.seedingDistance ?? 30;
+        const plantsPerRow = Math.max(1, Math.floor(30 / seedingDistance));
+        const totalPlants = Math.max(
+            1,
+            Math.floor(plantsPerRow * plantsPerRow),
+        );
+
+        const yieldMin = attributes.yieldMin ?? null;
+        const yieldMax = attributes.yieldMax ?? null;
+        if (yieldMin == null && yieldMax == null) {
+            return null;
+        }
+
+        const yieldType = attributes.yieldType ?? 'perField';
+        const yieldMultiplier = yieldType === 'perPlant' ? totalPlants : 1;
+
+        const minValue = yieldMin ?? yieldMax;
+        const maxValue = yieldMax ?? yieldMin;
+
+        const expectedBase =
+            minValue != null && maxValue != null
+                ? (maxValue - minValue) / 2 + minValue
+                : (minValue ?? maxValue);
+
+        const expectedPerField =
+            expectedBase == null ? null : expectedBase * yieldMultiplier;
+
+        const perFieldMin =
+            minValue == null ? null : minValue * yieldMultiplier;
+        const perFieldMax =
+            maxValue == null ? null : maxValue * yieldMultiplier;
+
+        const perFieldRange = formatWeightRange(perFieldMin, perFieldMax);
+        const perPlantRange =
+            yieldType === 'perPlant'
+                ? formatWeightRange(yieldMin, yieldMax)
+                : undefined;
+
+        return {
+            expectedPerFieldKg:
+                expectedPerField == null
+                    ? undefined
+                    : (expectedPerField / 1000).toFixed(1),
+            perFieldRange: perFieldRange
+                ? `${perFieldRange} po polju`
+                : undefined,
+            perPlantRange: perPlantRange
+                ? `${perPlantRange} po biljci`
+                : undefined,
+            plantsDescription: `Preračunato za ${totalPlants} ${getPlantsLabel(totalPlants)}`,
+        };
+    };
+
+    const yieldDetails = getYieldDetails();
+
     return (
         <div className="grid grid-cols-2 gap-2">
             <AttributeCard
@@ -24,47 +134,107 @@ export function PlantAttributeCards({
                 value={
                     attributes?.light == null || Number.isNaN(attributes?.light)
                         ? '-'
-                        : attributes?.light > 0.3
-                          ? 'Polu-sjena'
-                          : attributes?.light > 0.7
-                            ? 'Sunce'
+                        : attributes.light >= 0.7
+                          ? 'Sunce'
+                          : attributes.light >= 0.3
+                            ? 'Polu-sjena'
                             : 'Hlad'
                 }
             />
             <AttributeCard
                 icon={<Droplet />}
                 header="Voda"
-                value={attributes?.water}
+                value={attributes?.water ?? '-'}
             />
             <AttributeCard
                 icon={<Tally3 className="size-6 rotate-90 mt-2" />}
                 header="Zemlja"
-                value={attributes?.soil}
+                value={attributes?.soil ?? '-'}
             />
             <AttributeCard
                 icon={<Leaf />}
                 header="Nutrijenti"
-                value={attributes?.nutrients}
+                value={attributes?.nutrients ?? '-'}
             />
             <AttributeCard
                 icon={<Ruler />}
                 header="Razmak sijanja/sadnje"
-                value={`${attributes?.seedingDistance || '-'} cm`}
+                value={`${
+                    attributes?.seedingDistance != null
+                        ? attributes.seedingDistance
+                        : '-'
+                } cm`}
             />
             <AttributeCard
                 icon={<ArrowDownToLine />}
                 header="Dubina sijanja"
-                value={`${attributes?.seedingDepth || '-'} cm`}
+                value={`${
+                    attributes?.seedingDepth != null
+                        ? attributes.seedingDepth
+                        : '-'
+                } cm`}
             />
             <AttributeCard
                 icon={<Sprout />}
                 header="Klijanje"
-                value={`${attributes?.germinationType || '-'}`}
+                value={attributes?.germinationType ?? '-'}
             />
             <AttributeCard
                 icon={<Thermometer />}
                 header="Temperatura klijanja"
-                value={`${attributes?.gernimationTemperature || '-'}°C`}
+                value={`${attributes?.gernimationTemperature ?? '-'}°C`}
+            />
+            <AttributeCard
+                icon={<Timer />}
+                header="Vrijeme klijanja"
+                value={formatDayRange(
+                    attributes?.germinationWindowMin,
+                    attributes?.germinationWindowMax,
+                )}
+            />
+            <AttributeCard
+                icon={<SunMoon />}
+                header="Vrijeme rasta"
+                value={formatDayRange(
+                    attributes?.growthWindowMin,
+                    attributes?.growthWindowMax,
+                )}
+            />
+            <AttributeCard
+                icon={<Store />}
+                header="Vrijeme berbe"
+                value={formatDayRange(
+                    attributes?.harvestWindowMin,
+                    attributes?.harvestWindowMax,
+                )}
+            />
+            <AttributeCard
+                icon={<ShoppingCart />}
+                header="Očekivani prinos"
+                value={
+                    yieldDetails ? (
+                        <Stack spacing={0.5}>
+                            <Typography semiBold>
+                                {yieldDetails.expectedPerFieldKg
+                                    ? `~${yieldDetails.expectedPerFieldKg} kg po polju`
+                                    : '-'}
+                            </Typography>
+                            {yieldDetails.perFieldRange && (
+                                <Typography level="body3">
+                                    {yieldDetails.perFieldRange}
+                                </Typography>
+                            )}
+                            {yieldDetails.perPlantRange && (
+                                <Typography level="body3">
+                                    {yieldDetails.perPlantRange}
+                                </Typography>
+                            )}
+                            <Typography level="body3">
+                                {yieldDetails.plantsDescription}
+                            </Typography>
+                        </Stack>
+                    ) : undefined
+                }
             />
         </div>
     );

--- a/apps/www/components/attributes/DetailCard.tsx
+++ b/apps/www/components/attributes/DetailCard.tsx
@@ -13,7 +13,7 @@ export type AttributeCardProps = {
     icon: ReactNode;
     header: string;
     subheader?: string;
-    value: string | null | undefined;
+    value?: ReactNode;
     description?: string;
     navigateLabel?: string;
     navigateHref?: string;
@@ -28,6 +28,21 @@ export function AttributeCard({
     navigateLabel,
     navigateHref,
 }: AttributeCardProps) {
+    let valueContent: ReactNode;
+    if (value == null) {
+        valueContent = <Typography semiBold>-</Typography>;
+    } else if (typeof value === 'string') {
+        valueContent = value.trim().length ? (
+            <Typography semiBold>{value}</Typography>
+        ) : (
+            <Typography semiBold>-</Typography>
+        );
+    } else if (typeof value === 'number') {
+        valueContent = <Typography semiBold>{value}</Typography>;
+    } else {
+        valueContent = value;
+    }
+
     return (
         <Card className="flex items-center gap-1 justify-between">
             <Row spacing={2}>
@@ -41,7 +56,7 @@ export function AttributeCard({
                             <Typography level="body3">{subheader}</Typography>
                         )}
                     </Stack>
-                    <Typography semiBold>{value ?? '-'}</Typography>
+                    {valueContent}
                 </Stack>
             </Row>
             {description && (


### PR DESCRIPTION
## Summary
- expose germination, growth, and harvest windows on the plant details attribute grid
- show calculated yield information alongside existing plant attributes
- allow attribute cards to render complex value content instead of plain strings

## Testing
- pnpm lint --filter www

------
https://chatgpt.com/codex/tasks/task_e_68d560657da4832fb75ba6f51221acc9