### PR TITLE
Show completed schedule tasks and copy summary

### DIFF
--- a/apps/app/app/admin/schedule/CopySummaryButton.tsx
+++ b/apps/app/app/admin/schedule/CopySummaryButton.tsx
@@ -39,7 +39,7 @@ export function CopySummaryButton({
             <Button
                 title="Kopiraj sažetak u međuspremnik"
                 onClick={handleCopy}
-                variant="plain"
+                variant="link"
                 startDecorator={<Duplicate className="size-4 shrink-0" />}
                 disabled={disabled}
             >

--- a/apps/app/app/admin/schedule/CopySummaryButton.tsx
+++ b/apps/app/app/admin/schedule/CopySummaryButton.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Duplicate } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Row } from '@signalco/ui-primitives/Row';
+import type { MouseEvent } from 'react';
+import { useState } from 'react';
+
+type CopySummaryButtonProps = {
+    summaryText: string;
+    disabled?: boolean;
+};
+
+export function CopySummaryButton({
+    summaryText,
+    disabled,
+}: CopySummaryButtonProps) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (disabled) {
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(summaryText);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (error) {
+            console.error('Failed to copy summary to clipboard:', error);
+        }
+    };
+
+    return (
+        <Row spacing={1}>
+            <Button
+                title="Kopiraj sažetak u međuspremnik"
+                onClick={handleCopy}
+                variant="plain"
+                startDecorator={<Duplicate className="size-4 shrink-0" />}
+                disabled={disabled}
+            >
+                Kopiraj sažetak
+            </Button>
+            {copied && (
+                <span className="text-sm text-green-500">Kopirano!</span>
+            )}
+        </Row>
+    );
+}
+
+export default CopySummaryButton;

--- a/apps/app/app/admin/schedule/ScheduleClient.tsx
+++ b/apps/app/app/admin/schedule/ScheduleClient.tsx
@@ -83,42 +83,15 @@ export function ScheduleClient({
                 {dates.map((date, dateIndex) => {
                     return (
                         <Fragment key={date.toISOString()}>
-                            <div className="flex flex-col md:flex-row gap-x-4 gap-y-2">
-                                <Row spacing={1}>
-                                    <Calendar className="size-5 shrink-0 ml-2 mb-1" />
-                                    <Stack>
-                                        <Typography level="body2">
-                                            <LocalDateTime time={false}>
-                                                {date}
-                                            </LocalDateTime>
-                                        </Typography>
-                                        <Typography
-                                            level="body1"
-                                            uppercase
-                                            semiBold={dateIndex !== 0}
-                                            bold={dateIndex === 0}
-                                        >
-                                            {dateIndex === 0
-                                                ? 'Danas'
-                                                : new Intl.DateTimeFormat(
-                                                      'hr-HR',
-                                                      { weekday: 'long' },
-                                                  )
-                                                      .format(date)
-                                                      .substring(0, 3)}
-                                        </Typography>
-                                    </Stack>
-                                </Row>
-                                <ScheduleDay
-                                    isToday={dateIndex === 0}
-                                    date={date}
-                                    allRaisedBeds={allRaisedBeds}
-                                    operations={operations}
-                                    plantSorts={plantSorts}
-                                    operationsData={operationsData}
-                                    userId={userId}
-                                />
-                            </div>
+                            <ScheduleDay
+                                isToday={dateIndex === 0}
+                                date={date}
+                                allRaisedBeds={allRaisedBeds}
+                                operations={operations}
+                                plantSorts={plantSorts}
+                                operationsData={operationsData}
+                                userId={userId}
+                            />
                             <Divider />
                         </Fragment>
                     );

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -8,21 +8,49 @@ import { auth } from '../../../lib/auth/auth';
 import { ScheduleClient } from './ScheduleClient';
 
 export const dynamic = 'force-dynamic';
+const operationsBackDays = 90;
 
 export default async function AdminSchedulePage() {
     const { userId } = await auth(['admin']);
-    const [allRaisedBeds, operations, plantSorts, operationsData] =
-        await Promise.all([
-            getAllRaisedBeds(),
-            getAllOperations(),
-            getEntitiesFormatted<EntityStandardized>('plantSort'),
-            getEntitiesFormatted<EntityStandardized>('operation'),
-        ]);
+    const [
+        allRaisedBeds,
+        newOrScheduledOperations,
+        completedOperationsFuture,
+        plantSorts,
+        operationsData,
+    ] = await Promise.all([
+        getAllRaisedBeds(),
+        getAllOperations({
+            // 90 days back
+            from: new Date(
+                new Date().setDate(new Date().getDate() - operationsBackDays),
+            ),
+            status: ['new', 'planned'],
+        }),
+        getAllOperations({
+            completedFrom: new Date(new Date().setHours(0, 0, 0, 0)),
+            status: 'completed',
+        }),
+        getEntitiesFormatted<EntityStandardized>('plantSort'),
+        getEntitiesFormatted<EntityStandardized>('operation'),
+    ]);
+
+    // Make sure operations are sorted by timestamp desc
+    // and that we don't have duplicates
+    const operations = [
+        ...newOrScheduledOperations,
+        ...completedOperationsFuture,
+    ].sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+    // Remove duplicates
+    const uniqueOperations = Array.from(
+        new Map(operations.map((op) => [op.id, op])).values(),
+    );
 
     return (
         <ScheduleClient
             allRaisedBeds={allRaisedBeds}
-            operations={operations}
+            operations={uniqueOperations}
             plantSorts={plantSorts}
             operationsData={operationsData}
             userId={userId}


### PR DESCRIPTION
## Summary
- surface completed schedule items alongside active work with updated status handling and UI cues
- display completed/approved/total metrics for days and raised beds while keeping clipboard copies limited to approved tasks
- add a daily summary clipboard action for quickly sharing approved workload details

## Testing
- pnpm lint --filter app

------
https://chatgpt.com/codex/tasks/task_e_68d56a306394832f9da7679a2658a917