### PR TITLE
fix(images): use absolute-or-fallback URLs for plant images

### DIFF
--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -1,3 +1,4 @@
+import { isAbsoluteUrl } from '@signalco/js';
 import { ModalConfirm } from '@signalco/ui/ModalConfirm';
 import { Delete, Euro, Navigate, Timer } from '@signalco/ui-icons';
 import { Chip } from '@signalco/ui-primitives/Chip';
@@ -53,6 +54,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     // Hide delete button for paid items
     const isProcessed = item.status === 'paid';
 
+    const imageOrFallback =
+        item.shopData.image ?? '/assets/plants/placeholder.png';
+    const shopImageUrl = isAbsoluteUrl(imageOrFallback)
+        ? imageOrFallback
+        : `https://www.gredice.com${imageOrFallback}`;
+
     return (
         <Row spacing={2} alignItems="start">
             <Image
@@ -60,10 +67,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                 width={56}
                 height={56}
                 alt={item.shopData.name ?? 'Nepoznato'}
-                src={
-                    'https://www.gredice.com' +
-                    (item.shopData.image ?? '/assets/plants/placeholder.png')
-                }
+                src={shopImageUrl}
             />
             <Stack className="grow">
                 <div className="grid grid-cols-[1fr_auto] items-center gap-2">

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -1,3 +1,4 @@
+import { isAbsoluteUrl } from '@signalco/js';
 import { ShoppingCart } from '@signalco/ui-icons';
 import { DotIndicator } from '@signalco/ui-primitives/DotIndicator';
 import Image from 'next/image';
@@ -61,6 +62,12 @@ export function RaisedBedFieldItemEmpty({
         );
     }
 
+    const shopImageOrFallback =
+        cartPlantItem?.shopData.image ?? '/assets/plants/placeholder.png';
+    const plantImageUrl = isAbsoluteUrl(shopImageOrFallback)
+        ? shopImageOrFallback
+        : `https://www.gredice.com/${shopImageOrFallback}`;
+
     return (
         <PlantPicker
             trigger={
@@ -74,7 +81,7 @@ export function RaisedBedFieldItemEmpty({
                     {!isLoading && cartPlantItem && (
                         <>
                             <Image
-                                src={`https://www.gredice.com/${cartPlantItem.shopData.image}`}
+                                src={plantImageUrl}
                                 alt={cartPlantItem.shopData.name ?? 'Nepoznato'}
                                 width={60}
                                 height={60}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,4 +1,5 @@
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
+import { isAbsoluteUrl } from '@signalco/js';
 import {
     Book,
     ExternalLink,
@@ -131,6 +132,14 @@ export function RaisedBedFieldItemPlanted({
         plantSort.information.name,
     );
 
+    const coverUrl =
+        (plantSort.image?.cover?.url ||
+            plantSort.information.plant.image?.cover?.url) ??
+        '/assets/plants/placeholder.png';
+    const plantImageUrl = isAbsoluteUrl(coverUrl)
+        ? coverUrl
+        : `https://www.gredice.com/${coverUrl}`;
+
     return (
         <Modal
             title={`Biljka "${plantSort.information.name}"`}
@@ -144,7 +153,7 @@ export function RaisedBedFieldItemPlanted({
                         segments={segments}
                     >
                         <Image
-                            src={`https://www.gredice.com/${plantSort.image?.cover?.url || plantSort.information.plant.image?.cover?.url}`}
+                            src={plantImageUrl}
                             alt={plantSort.information.name}
                             className="absolute top-1/2 start-1/2 transform -translate-y-1/2 -translate-x-1/2"
                             width={60}
@@ -157,7 +166,7 @@ export function RaisedBedFieldItemPlanted({
             <Stack spacing={2}>
                 <Row spacing={2} className="flex-wrap gap-y-2">
                     <Image
-                        src={`https://www.gredice.com/${plantSort.image?.cover?.url || plantSort.information.plant.image?.cover?.url}`}
+                        src={plantImageUrl}
                         alt={plantSort.information.name}
                         width={60}
                         height={60}


### PR DESCRIPTION
Detect and handle absolute image URLs and provide a local fallback
placeholder for plant images across multiple HUD components.
hardcoded concatenation with a utility check (isAbsoluteUrl) and
compute a single image URL (absolute or prefixed with the CDN base or
fallback). Affected files:
- RaisedBedFieldItemEmpty.tsx
- ShoppingCartItem.tsx
- RaisedBedFieldItemPlanted.tsx

This prevents broken image paths when shop data already contains full
URLs and ensures a consistent placeholder is shown when image data is
missing.