### PR TITLE
Fix Croatian typos in www content

### DIFF
--- a/apps/garden/biome.json
+++ b/apps/garden/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/www/app/Footer.tsx
+++ b/apps/www/app/Footer.tsx
@@ -89,7 +89,7 @@ const sectionsData: SectionData[] = [
                         href: KnownPages.LegalCookies,
                     },
                     {
-                        label: 'Licenca izvnornog koda',
+                        label: 'Licenca izvornog koda',
                         href: KnownPages.LegalLicense,
                     },
                 ],

--- a/apps/www/app/dostava/termini/page.tsx
+++ b/apps/www/app/dostava/termini/page.tsx
@@ -206,7 +206,7 @@ export default async function DeliverySlotsPage() {
                 <Typography level="body1">
                     Ovdje možeš vidjeti sve dostupne termine za dostavu ili
                     osobno preuzimanje u sljedećih 14 dana. Termin možeš
-                    rezervirati u <strong>aplikaciju</strong> tijekom narudžbe
+                    rezervirati u <strong>aplikaciji</strong> tijekom narudžbe
                     branja.
                 </Typography>
 

--- a/apps/www/app/legalno/politika-kolacica/page.tsx
+++ b/apps/www/app/legalno/politika-kolacica/page.tsx
@@ -26,7 +26,7 @@ export default function PolitikaKolacicaPage() {
                         Kolačići su male tekstualne datoteke koje se pohranjuju
                         na vašem uređaju prilikom posjeta našoj web stranici.
                         Oni omogućuju web stranici da prepozna vaš uređaj i
-                        prikupiti informacije o vašem posjetu.
+                        prikupi informacije o vašem posjetu.
                     </p>
                     <h2>Kolačići koje koristimo</h2>
                     <p>
@@ -51,7 +51,7 @@ export default function PolitikaKolacicaPage() {
                             stranice.
                         </li>
                     </ul>
-                    <h2>Kako se možete upravljati kolačićima</h2>
+                    <h2>Kako možete upravljati kolačićima</h2>
                     <p>
                         Većina web preglednika automatski prihvaća kolačiće, ali
                         vi možete odabrati hoćete li ih prihvatiti ili ne. Ako
@@ -74,16 +74,16 @@ export default function PolitikaKolacicaPage() {
                     <h2>Kontakt informacije</h2>
                     <p>
                         Ako imate bilo kakva pitanja ili trebate više
-                        informacija o našoj Politici Kolačića, slobodno nas
+                        informacija o našoj politici kolačića, slobodno nas
                         kontaktirajte putem adrese e-pošte na{' '}
                         <a href="mailto:kontakt@gredice.com">
                             kontakt@gredice.com
                         </a>
                         .
                     </p>
-                    <h2>Promjene u Politici Kolačića</h2>
+                    <h2>Promjene u politici kolačića</h2>
                     <p>
-                        Zadržavamo pravo izmjene ove Politike Kolačića u bilo
+                        Zadržavamo pravo izmjene ove politike kolačića u bilo
                         kojem trenutku. Sve izmjene bit će objavljene na ovoj
                         stranici, uz datum ažuriranja.
                     </p>

--- a/apps/www/app/podignuta-gredica/page.tsx
+++ b/apps/www/app/podignuta-gredica/page.tsx
@@ -149,11 +149,11 @@ export default function RaisedBedPage() {
                                 na tvoju adresu.
                             </p>
                             <p>
-                                Trenutno surađujemo s jednim OPG-om, a
-                                planiramo proširiti suradnju s drugim OPG-ima
-                                kako bismo ti omogućili veći izbor i
-                                fleksibilnost u odabiru lokacije i vrsta biljaka
-                                koje želiš saditi.
+                                Trenutno surađujemo s jednim OPG-om, a planiramo
+                                proširiti suradnju s drugim OPG-ima kako bismo
+                                ti omogućili veći izbor i fleksibilnost u
+                                odabiru lokacije i vrsta biljaka koje želiš
+                                saditi.
                             </p>
                             <p>OPG koji će brinuti o tvojoj gredici:</p>
                             <ul>
@@ -162,7 +162,8 @@ export default function RaisedBedPage() {
                                 </li>
                             </ul>
                             <em>
-                                Uskoro više informacija o OPG-u na stranici OPG-a
+                                Uskoro više informacija o OPG-u na stranici
+                                OPG-a
                             </em>
                         </div>
                         <Image
@@ -302,8 +303,8 @@ export default function RaisedBedPage() {
                         radnjama na njima.
                     </p>
                     <p>
-                        Sve informacije o pojedinim biljkama koje su
-                        dostupne možeš pronaći na stranicama{' '}
+                        Sve informacije o pojedinim biljkama koje su dostupne
+                        možeš pronaći na stranicama{' '}
                         <a href={KnownPages.Plants}>biljaka</a> i u{' '}
                         <a href={KnownPages.GardenApp}>aplikaciji Gredice</a>.
                     </p>

--- a/apps/www/app/podignuta-gredica/page.tsx
+++ b/apps/www/app/podignuta-gredica/page.tsx
@@ -91,7 +91,7 @@ export default function RaisedBedPage() {
                             />
                         </div>
                     </div>
-                    <div className="grid overflo grid-rows-[auto_1fr] grid-cols-1 sm:grid-rows-1 sm:grid-cols-[1fr_1fr] gap-8 relative">
+                    <div className="grid overflow-hidden grid-rows-[auto_1fr] grid-cols-1 sm:grid-rows-1 sm:grid-cols-[1fr_1fr] gap-8 relative">
                         <div>
                             <h3>Dimenzije i veličina</h3>
                             <p>
@@ -141,15 +141,15 @@ export default function RaisedBedPage() {
                             <h3>Lokacija</h3>
                             <p>
                                 Tvoja podignuta gredica će biti postavljena na
-                                lokaciji jednog od OPGa s kojim surađujemo. OPG
-                                izvršavati radnje na gredici, uključujući
+                                lokaciji jednog od OPG-a s kojim surađujemo. OPG
+                                će izvršavati radnje na gredici, uključujući
                                 sadnju, održavanje i berbu, mi ćemo ti omogućiti
                                 da sve to pratiš putem aplikacije Gredice i
-                                dostaviti svo povrće i plodove tvoje gredice na
-                                tvoju adresu.
+                                dostavit ćemo svo povrće i plodove tvoje gredice
+                                na tvoju adresu.
                             </p>
                             <p>
-                                Trenutno surađujemo sa jednim OPG-om, a
+                                Trenutno surađujemo s jednim OPG-om, a
                                 planiramo proširiti suradnju s drugim OPG-ima
                                 kako bismo ti omogućili veći izbor i
                                 fleksibilnost u odabiru lokacije i vrsta biljaka
@@ -162,7 +162,7 @@ export default function RaisedBedPage() {
                                 </li>
                             </ul>
                             <em>
-                                Uskoro više informacija o OPG-u na stranici OPGa
+                                Uskoro više informacija o OPG-u na stranici OPG-a
                             </em>
                         </div>
                         <Image
@@ -302,7 +302,7 @@ export default function RaisedBedPage() {
                         radnjama na njima.
                     </p>
                     <p>
-                        Sve informacije i pojedinim biljkama i biljakama koje su
+                        Sve informacije o pojedinim biljkama koje su
                         dostupne možeš pronaći na stranicama{' '}
                         <a href={KnownPages.Plants}>biljaka</a> i u{' '}
                         <a href={KnownPages.GardenApp}>aplikaciji Gredice</a>.

--- a/apps/www/app/suncokreti/page.tsx
+++ b/apps/www/app/suncokreti/page.tsx
@@ -22,7 +22,7 @@ const sectionsData: SectionData[] = [
             {
                 header: 'Što su suncokreti?',
                 description:
-                    'Suncokreti su vrsta bodova na tvom Gredice računu koje dobivaš za razne radnje i pomoću kojih možeš učiniti svoj vrt što ljepšim i zdravijim.',
+                    'Sakupljaj i koristi suncokrete za uređenje i dekoraciju vrta ili kupnju i brigu o svojim biljkama 🌱',
             },
             {
                 header: 'Kako skupljam suncokrete?',

--- a/apps/www/app/suncokreti/page.tsx
+++ b/apps/www/app/suncokreti/page.tsx
@@ -22,14 +22,14 @@ const sectionsData: SectionData[] = [
             {
                 header: 'Što su suncokreti?',
                 description:
-                    'Suncokreti su vrsta bodova na tvom Gredice racunu koje dobiva za razne radnje i pomocu kojih mozes uciniti svoj vrt sto lijepsim i zdravijim.',
+                    'Suncokreti su vrsta bodova na tvom Gredice računu koje dobivaš za razne radnje i pomoću kojih možeš učiniti svoj vrt što ljepšim i zdravijim.',
             },
             {
                 header: 'Kako skupljam suncokrete?',
                 description: (
                     <Markdown>
                         {
-                            'Suncokrete dobiješ prilikom registracije, redovnim posjetima svog vrta, te za svaku odrađenu akciju u vrtu. Također, za svaku kupnju od 1€ dobivaš 🌻10.\n\nUjedno, posjeti svoj vrt svaki dan i uvijek će te čekati novi 🌻.'
+                            'Suncokrete dobiješ prilikom registracije, redovitim posjetima svog vrta te za svaku odrađenu radnju u vrtu. Također, za svaku kupnju od 1 € dobivaš 🌻10.\n\nUjedno, posjeti svoj vrt svaki dan i uvijek će te čekati novi 🌻.'
                         }
                     </Markdown>
                 ),
@@ -37,7 +37,7 @@ const sectionsData: SectionData[] = [
             {
                 header: 'Za što se mogu koristiti suncokreti?',
                 description:
-                    'Suncokrete možeš koristiti za ukrašavanje svog vrta te brigu o gredicama i biljkama. Suncokrete možeš koristiti umjesto plaćanja pojedinih akcija. 🌻1000 je jednako 1€ prilikom korištenja za akcije ili kupnju biljaka u svom vrtu.',
+                    'Suncokrete možeš koristiti za ukrašavanje svog vrta te brigu o gredicama i biljkama. Suncokrete možeš koristiti umjesto plaćanja pojedinih akcija. 🌻1000 je jednako 1 € prilikom korištenja za akcije ili kupnju biljaka u svom vrtu.',
             },
         ],
     },

--- a/apps/www/biome.json
+++ b/apps/www/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/client/biome.json
+++ b/packages/client/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/game/biome.json
+++ b/packages/game/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/js/biome.json
+++ b/packages/js/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/signalco/biome.json
+++ b/packages/signalco/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/storage/biome.json
+++ b/packages/storage/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/stripe/biome.json
+++ b/packages/stripe/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
## Summary
- fix various Croatian typos across the www app content, including the cookie policy, delivery slots page, raised bed guide, and sunflowers overview
- correct the footer license link label

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daaa6e7ac0832fa9f32dabfa4dbfec