### PR TITLE
fix(hud): truncate garden name in shopping cart item

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -99,8 +99,8 @@ function ProfileCard() {
             <DropdownMenuSeparator className="my-4" />
             {currentGarden ? (
                 <DropdownMenuItem className="gap-3 bg-muted">
-                    <Check className="size-4" />
-                    <span>{currentGarden.name}</span>
+                    <Check className="size-4 shrink-0" />
+                    <Typography noWrap>{currentGarden.name}</Typography>
                 </DropdownMenuItem>
             ) : (
                 <DropdownMenuLabel className="bg-muted">

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -111,7 +111,11 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                         <Row spacing={1}>
                             <Row spacing={0.5} className="flex-wrap gap-y-0">
                                 {hasGarden && (
-                                    <Typography level="body3" secondary>
+                                    <Typography
+                                        level="body3"
+                                        className="overflow-ellipsis max-w-[200px] overflow-hidden"
+                                        secondary
+                                    >
                                         {garden?.name || 'Nepoznati vrt'}
                                     </Typography>
                                 )}


### PR DESCRIPTION
Limit the displayed garden name in the shopping cart item to prevent
layout overflow. Add an overflow-ellipsis class and max width to the
Typography element so long names are truncated with an ellipsis.
This preserves the layout and maintains readability when garden names
are unexpectedly long or missing.