### PR TITLE
Adjust delivery survey cadence to monthly

### DIFF
--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -1,3 +1,4 @@
+import { formatDeliveryCount } from '@gredice/js/i18n';
 import {
     createNotification,
     type DeliverySurveyCandidate,
@@ -23,18 +24,6 @@ function formatMonth(date: Date) {
         month: 'long',
         year: 'numeric',
     }).format(date);
-}
-
-function formatDeliveryCount(count: number) {
-    if (count === 1) {
-        return '1 dostava';
-    }
-
-    if (count >= 2 && count <= 4) {
-        return `${count} dostave`;
-    }
-
-    return `${count} dostava`;
 }
 
 interface DeliverySurveyGroup {

--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -158,8 +158,8 @@ export async function GET(request: NextRequest) {
         try {
             await createNotification({
                 accountId: group.accountId,
-                header: `📣 Kako ti se svidjele dostave u ${formattedMonth}?`,
-                content: `U ${formattedMonth} smo imali ${deliveryCountText}. Podijeli svoje dojmove i ispuni kratku anketu 📋⭐️⭐️⭐️⭐️⭐️`,
+                header: `📣 Kako su ti se svidjele dostave u ${formattedMonth}?`,
+                content: `U ${formattedMonth} imali smo ${deliveryCountText} dostava. Podijeli svoje dojmove i ispuni kratku anketu 📋⭐️⭐️⭐️⭐️⭐️`,
                 linkUrl: SURVEY_URL,
                 timestamp: new Date(),
             });

--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -99,7 +99,6 @@ export async function GET(request: NextRequest) {
             for (const candidate of candidatesInGroup) {
                 await markDeliverySurveySent(candidate.requestId, []);
             }
-            sentMonthGroups.add(monthGroupKey);
             continue;
         }
 

--- a/packages/js/src/i18n/croatian.ts
+++ b/packages/js/src/i18n/croatian.ts
@@ -1,0 +1,53 @@
+/**
+ * Croatian pluralization utilities
+ */
+
+/**
+ * Formats delivery count in Croatian with proper pluralization
+ * @param count - Number of deliveries
+ * @param includeVerb - Whether to include the verb form (bila je/bile su/bilo je)
+ * @returns Formatted string in Croatian
+ */
+export function formatDeliveryCount(
+    count: number,
+    includeVerb = false,
+): string {
+    const noun = getDeliveryNoun(count);
+
+    if (!includeVerb) {
+        return `${count} ${noun}`;
+    }
+
+    const verb = getDeliveryVerb(count);
+    return `${verb} ${count} ${noun}`;
+}
+
+/**
+ * Gets the correct Croatian noun form for "dostava" based on count
+ */
+function getDeliveryNoun(count: number): string {
+    if (count === 1) {
+        return 'dostava';
+    }
+
+    if (count >= 2 && count <= 4) {
+        return 'dostave';
+    }
+
+    return 'dostava';
+}
+
+/**
+ * Gets the correct Croatian verb form for deliveries based on count
+ */
+function getDeliveryVerb(count: number): string {
+    if (count === 1) {
+        return 'bila je';
+    }
+
+    if (count >= 2 && count <= 4) {
+        return 'bile su';
+    }
+
+    return 'bilo je';
+}

--- a/packages/js/src/i18n/index.ts
+++ b/packages/js/src/i18n/index.ts
@@ -1,0 +1,1 @@
+export * from './croatian';

--- a/packages/transactional/emails/Notifications/delivery-survey.tsx
+++ b/packages/transactional/emails/Notifications/delivery-survey.tsx
@@ -34,21 +34,21 @@ export default function DeliverySurveyEmailTemplate({
 
     const formatDeliveryCount = (count: number) => {
         if (count === 1) {
-            return '1 dostavu';
+            return 'bila je 1 dostava';
         }
 
         if (count >= 2 && count <= 4) {
-            return `${count} dostave`;
+            return `bile su ${count} dostave`;
         }
 
-        return `${count} dostava`;
+        return `bilo je ${count} dostava`;
     };
 
     const periodSummary = deliveryPeriod
-        ? `🚚 Tijekom ${deliveryPeriod} dostavili smo ti ${
+        ? `🚚 Tijekom ${deliveryPeriod} ${
               typeof deliveryCount === 'number'
                   ? formatDeliveryCount(deliveryCount)
-                  : 'nekoliko dostava'
+                  : 'bilo je nekoliko dostava'
           }.`
         : null;
 
@@ -61,14 +61,14 @@ export default function DeliverySurveyEmailTemplate({
                     <Section className="text-center">
                         <GrediceLogotype />
                     </Section>
-                    <Header>Kakva je bila dostava?</Header>
+                    <Header>Kakva su bile dostave?</Header>
                     <Paragraph>Pozdrav!</Paragraph>
                     <Paragraph>
-                        Nadamo se da te je povrće iz tvog vrta razveselilo.{' '}
-                        Voljeli bismo čuti tvoje dojmove o dostavi kako bismo idući put bili još bolji.
+                        Nadamo se da te povrće iz tvog vrta razveselilo.{' '}
+                        Voljeli bismo čuti tvoje dojmove o dostavama kako bismo idući put bili još bolji.
                     </Paragraph>
                     {periodSummary ? (
-                        <Paragraph>{periodSummary} </Paragraph>
+                        <Paragraph>{periodSummary}</Paragraph>
                     ) : null}
                     <Paragraph>
                         ⏱️ Anketa traje manje od minute, a svaki odgovor pomaže našem timu i vrtlarima.

--- a/packages/transactional/emails/Notifications/delivery-survey.tsx
+++ b/packages/transactional/emails/Notifications/delivery-survey.tsx
@@ -5,6 +5,7 @@ import {
     Section,
     Tailwind,
 } from '@react-email/components';
+import { formatDeliveryCount } from '@gredice/js/i18n';
 import { ContentCard } from '../../components/ContentCard';
 import { Divider } from '../../components/Divider';
 import { GrediceDisclaimer } from '../../components/shared/GrediceDisclaimer';
@@ -32,22 +33,10 @@ export default function DeliverySurveyEmailTemplate({
 }: DeliverySurveyEmailTemplateProps) {
     const previewText = `${appName} - Podijeli dojam o dostavi`;
 
-    const formatDeliveryCount = (count: number) => {
-        if (count === 1) {
-            return 'bila je 1 dostava';
-        }
-
-        if (count >= 2 && count <= 4) {
-            return `bile su ${count} dostave`;
-        }
-
-        return `bilo je ${count} dostava`;
-    };
-
     const periodSummary = deliveryPeriod
         ? `🚚 Tijekom ${deliveryPeriod} ${
               typeof deliveryCount === 'number'
-                  ? formatDeliveryCount(deliveryCount)
+                  ? formatDeliveryCount(deliveryCount, true)
                   : 'bilo je nekoliko dostava'
           }.`
         : null;

--- a/packages/transactional/emails/Notifications/delivery-survey.tsx
+++ b/packages/transactional/emails/Notifications/delivery-survey.tsx
@@ -16,7 +16,8 @@ import { PrimaryButton } from '../../components/PrimaryButton';
 export interface DeliverySurveyEmailTemplateProps {
     email: string;
     surveyUrl: string;
-    deliveryDate?: string;
+    deliveryPeriod?: string;
+    deliveryCount?: number;
     appName?: string;
     appDomain?: string;
 }
@@ -24,11 +25,32 @@ export interface DeliverySurveyEmailTemplateProps {
 export default function DeliverySurveyEmailTemplate({
     email = 'login@example.com',
     surveyUrl = 'https://form.typeform.com/to/X727vyBk',
-    deliveryDate,
+    deliveryPeriod,
+    deliveryCount,
     appName = 'Gredice',
     appDomain = 'gredice.com',
 }: DeliverySurveyEmailTemplateProps) {
     const previewText = `${appName} - Podijeli dojam o dostavi`;
+
+    const formatDeliveryCount = (count: number) => {
+        if (count === 1) {
+            return '1 dostavu';
+        }
+
+        if (count >= 2 && count <= 4) {
+            return `${count} dostave`;
+        }
+
+        return `${count} dostava`;
+    };
+
+    const periodSummary = deliveryPeriod
+        ? `🚚 Tijekom ${deliveryPeriod} dostavili smo ti ${
+              typeof deliveryCount === 'number'
+                  ? formatDeliveryCount(deliveryCount)
+                  : 'nekoliko dostava'
+          }.`
+        : null;
 
     return (
         <Html>
@@ -42,13 +64,11 @@ export default function DeliverySurveyEmailTemplate({
                     <Header>Kakva je bila dostava?</Header>
                     <Paragraph>Pozdrav!</Paragraph>
                     <Paragraph>
-                        Nadamo se da te povrće iz tvog vrta razveselilo.{' '}
+                        Nadamo se da te je povrće iz tvog vrta razveselilo.{' '}
                         Voljeli bismo čuti tvoje dojmove o dostavi kako bismo idući put bili još bolji.
                     </Paragraph>
-                    {deliveryDate ? (
-                        <Paragraph>
-                            🚚 Dostava je bila {deliveryDate}.{' '}
-                        </Paragraph>
+                    {periodSummary ? (
+                        <Paragraph>{periodSummary} </Paragraph>
                     ) : null}
                     <Paragraph>
                         ⏱️ Anketa traje manje od minute, a svaki odgovor pomaže našem timu i vrtlarima.

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -15,6 +15,7 @@
         "typescript": "5.9.3"
     },
     "dependencies": {
+        "@gredice/js": "workspace:*",
         "@react-email/components": "0.5.5",
         "react": "19.2.0",
         "react-email": "4.2.12"

--- a/packages/transactional/tsconfig.json
+++ b/packages/transactional/tsconfig.json
@@ -11,9 +11,9 @@
             "DOM",
             "DOM.Iterable"
         ],
-        "module": "NodeNext",
+        "module": "esnext",
         "moduleDetection": "force",
-        "moduleResolution": "NodeNext",
+        "moduleResolution": "bundler",
         "noUncheckedIndexedAccess": true,
         "resolveJsonModule": true,
         "skipLibCheck": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,7 @@ importers:
         version: 2.10.0
       next:
         specifier: canary
-        version: 15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2)
+        version: 15.6.0-canary.41(@babel/core@7.28.0)(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -268,106 +268,6 @@ importers:
         version: 1.55.1
       '@signalco/auth-client':
         specifier: 0.3.0
-        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18))(@tanstack/react-query@5.90.2(react@19.2.0))(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@signalco/auth-server':
-        specifier: 0.5.3
-        version: 0.5.3(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@signalco/hooks':
-        specifier: 0.2.1
-        version: 0.2.1(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@signalco/js':
-        specifier: 0.1.0
-        version: 0.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@signalco/ui':
-        specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18)
-      '@signalco/ui-icons':
-        specifier: 0.2.2
-        version: 0.2.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@signalco/ui-primitives':
-        specifier: 0.6.5
-        version: 0.6.5(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18)
-      '@signalco/ui-themes-minimal-app':
-        specifier: 0.1.3
-        version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18)
-      '@tailwindcss/typography':
-        specifier: 0.5.19
-        version: 0.5.19(tailwindcss@3.4.18)
-      '@tanstack/react-query':
-        specifier: 5.90.2
-        version: 5.90.2(react@19.2.0)
-      '@types/node':
-        specifier: 22.18.8
-        version: 22.18.8
-      '@types/react':
-        specifier: 19.2.0
-        version: 19.2.0
-      '@types/react-dom':
-        specifier: 19.2.0
-        version: 19.2.0(@types/react@19.2.0)
-      '@vercel/analytics':
-        specifier: 1.5.0
-        version: 1.5.0(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react@19.2.0)(vue-router@4.5.1(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
-      '@zxing/library':
-        specifier: 0.21.3
-        version: 0.21.3
-      babel-plugin-react-compiler:
-        specifier: 19.1.0-rc.3
-        version: 19.1.0-rc.3
-      next-axiom:
-        specifier: 1.9.2
-        version: 1.9.2(@aws-sdk/credential-provider-web-identity@3.901.0)(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react@19.2.0)
-      postcss:
-        specifier: 8.5.6
-        version: 8.5.6
-      tailwindcss:
-        specifier: 3.4.18
-        version: 3.4.18
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
-
-  apps/farm:
-    dependencies:
-      hypertune:
-        specifier: 2.10.0
-        version: 2.10.0
-      next:
-        specifier: canary
-        version: 15.6.0-canary.41(@babel/core@7.28.0)(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2)
-      pg:
-        specifier: 8.16.3
-        version: 8.16.3
-      react:
-        specifier: 19.2.0
-        version: 19.2.0
-      react-dom:
-        specifier: 19.2.0
-        version: 19.2.0(react@19.2.0)
-      server-only:
-        specifier: 0.0.1
-        version: 0.0.1
-    devDependencies:
-      '@biomejs/biome':
-        specifier: 2.2.5
-        version: 2.2.5
-      '@gredice/storage':
-        specifier: workspace:*
-        version: link:../../packages/storage
-      '@gredice/ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
-      '@mdxeditor/editor':
-        specifier: 3.46.1
-        version: 3.46.1(@codemirror/language@6.11.3)(@lezer/highlight@1.2.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(yjs@13.6.20)
-      '@playwright/experimental-ct-react':
-        specifier: 1.55.1
-        version: 1.55.1(@types/node@22.18.8)(jiti@2.4.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(vite@6.3.5(@types/node@22.18.8)(jiti@2.4.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.0))(yaml@2.8.0)
-      '@playwright/test':
-        specifier: 1.55.1
-        version: 1.55.1
-      '@signalco/auth-client':
-        specifier: 0.3.0
         version: 0.3.0(@signalco/ui-primitives@0.6.5(next@15.6.0-canary.41(@babel/core@7.28.0)(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18))(@tanstack/react-query@5.90.2(react@19.2.0))(next@15.6.0-canary.41(@babel/core@7.28.0)(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@signalco/auth-server':
         specifier: 0.5.3
@@ -408,12 +308,112 @@ importers:
       '@vercel/analytics':
         specifier: 1.5.0
         version: 1.5.0(next@15.6.0-canary.41(@babel/core@7.28.0)(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react@19.2.0)(vue-router@4.5.1(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+      '@zxing/library':
+        specifier: 0.21.3
+        version: 0.21.3
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3
       next-axiom:
         specifier: 1.9.2
         version: 1.9.2(@aws-sdk/credential-provider-web-identity@3.901.0)(next@15.6.0-canary.41(@babel/core@7.28.0)(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react@19.2.0)
+      postcss:
+        specifier: 8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: 3.4.18
+        version: 3.4.18
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  apps/farm:
+    dependencies:
+      hypertune:
+        specifier: 2.10.0
+        version: 2.10.0
+      next:
+        specifier: canary
+        version: 15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2)
+      pg:
+        specifier: 8.16.3
+        version: 8.16.3
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.2.5
+        version: 2.2.5
+      '@gredice/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      '@gredice/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@mdxeditor/editor':
+        specifier: 3.46.1
+        version: 3.46.1(@codemirror/language@6.11.3)(@lezer/highlight@1.2.1)(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(yjs@13.6.20)
+      '@playwright/experimental-ct-react':
+        specifier: 1.55.1
+        version: 1.55.1(@types/node@22.18.8)(jiti@2.4.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(vite@6.3.5(@types/node@22.18.8)(jiti@2.4.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.0))(yaml@2.8.0)
+      '@playwright/test':
+        specifier: 1.55.1
+        version: 1.55.1
+      '@signalco/auth-client':
+        specifier: 0.3.0
+        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18))(@tanstack/react-query@5.90.2(react@19.2.0))(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@signalco/auth-server':
+        specifier: 0.5.3
+        version: 0.5.3(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@signalco/hooks':
+        specifier: 0.2.1
+        version: 0.2.1(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@signalco/js':
+        specifier: 0.1.0
+        version: 0.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@signalco/ui':
+        specifier: 0.2.10
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18)
+      '@signalco/ui-icons':
+        specifier: 0.2.2
+        version: 0.2.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@signalco/ui-primitives':
+        specifier: 0.6.5
+        version: 0.6.5(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18)
+      '@signalco/ui-themes-minimal-app':
+        specifier: 0.1.3
+        version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.18))(tailwindcss@3.4.18)
+      '@tailwindcss/typography':
+        specifier: 0.5.19
+        version: 0.5.19(tailwindcss@3.4.18)
+      '@tanstack/react-query':
+        specifier: 5.90.2
+        version: 5.90.2(react@19.2.0)
+      '@types/node':
+        specifier: 22.18.8
+        version: 22.18.8
+      '@types/react':
+        specifier: 19.2.0
+        version: 19.2.0
+      '@types/react-dom':
+        specifier: 19.2.0
+        version: 19.2.0(@types/react@19.2.0)
+      '@vercel/analytics':
+        specifier: 1.5.0
+        version: 1.5.0(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react@19.2.0)(vue-router@4.5.1(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+      babel-plugin-react-compiler:
+        specifier: 19.1.0-rc.3
+        version: 19.1.0-rc.3
+      next-axiom:
+        specifier: 1.9.2
+        version: 1.9.2(@aws-sdk/credential-provider-web-identity@3.901.0)(next@15.6.0-canary.41(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2))(react@19.2.0)
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -1028,6 +1028,9 @@ importers:
 
   packages/transactional:
     dependencies:
+      '@gredice/js':
+        specifier: workspace:*
+        version: link:../js
       '@react-email/components':
         specifier: 0.5.5
         version: 0.5.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## Summary
- group delivery survey cron processing by account and month so each user only receives one survey per month
- extend delivery survey candidate query to track month-level send state and skip additional sends after the first
- refresh the delivery survey email copy to describe the monthly summary, fix missing words, and pluralise delivery counts correctly

## Testing
- pnpm lint --filter @gredice/api
- pnpm lint --filter @gredice/storage *(fails: existing lint issues in @gredice/storage unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdf27a3e0832fa95d467eb99d10fa