### PR TITLE
chore(biome): upgrade schema to 2.2.5

### DIFF
--- a/apps/api/biome.json
+++ b/apps/api/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/app/biome.json
+++ b/apps/app/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/farm/biome.json
+++ b/apps/farm/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/garden/biome.json
+++ b/apps/garden/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/www/biome.json
+++ b/apps/www/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/client/biome.json
+++ b/packages/client/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/game/biome.json
+++ b/packages/game/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/js/biome.json
+++ b/packages/js/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/signalco/biome.json
+++ b/packages/signalco/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/storage/biome.json
+++ b/packages/storage/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/stripe/biome.json
+++ b/packages/stripe/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
Update biome.json files across apps and packages to reference the
biome schema v2.2.5 instead of v2.2.4. This ensures configuration
files align with the latest Biome schema and benefit from fixes or
new validations introduced in 2.2.5. No other content is changed.