### PR TITLE
feat(slots): parse local dates and bulk-generate slots

### DIFF
--- a/apps/app/app/admin/delivery/slots/BulkGenerateForm.tsx
+++ b/apps/app/app/admin/delivery/slots/BulkGenerateForm.tsx
@@ -86,7 +86,7 @@ export function BulkGenerateForm({ locations }: BulkGenerateFormProps) {
             return;
         }
 
-        formAction(formData);
+        return formAction(formData);
     };
 
     return (

--- a/apps/app/app/admin/delivery/slots/BulkGenerateForm.tsx
+++ b/apps/app/app/admin/delivery/slots/BulkGenerateForm.tsx
@@ -4,7 +4,7 @@ import { Button } from '@signalco/ui-primitives/Button';
 import { Input } from '@signalco/ui-primitives/Input';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { useActionState, useState } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import { bulkGenerateSlotsAction } from './actions';
 
@@ -41,8 +41,56 @@ export function BulkGenerateForm({ locations }: BulkGenerateFormProps) {
     const defaultStartDate = tomorrow.toISOString().split('T')[0];
     const defaultEndDate = nextWeek.toISOString().split('T')[0];
 
+    // Reset form on successful submission
+    useEffect(() => {
+        if (state?.success) {
+            const timer = setTimeout(() => {
+                setSelectedLocation('');
+                setSelectedType('');
+            }, 2000); // Reset after showing success message
+            return () => clearTimeout(timer);
+        }
+    }, [state?.success]);
+
+    const handleSubmit = (formData: FormData) => {
+        // Validate required fields
+        if (!selectedLocation) {
+            alert('Molimo odaberite lokaciju');
+            return;
+        }
+        if (!selectedType) {
+            alert('Molimo odaberite tip slota');
+            return;
+        }
+
+        // Check if at least one day is selected
+        const daysOfWeek = formData.getAll('daysOfWeek');
+        if (daysOfWeek.length === 0) {
+            alert('Molimo odaberite barem jedan dan u tjednu');
+            return;
+        }
+
+        // Validate time range
+        const startTime = formData.get('startTime') as string;
+        const endTime = formData.get('endTime') as string;
+        const startDate = formData.get('startDate') as string;
+        const endDate = formData.get('endDate') as string;
+
+        if (startTime >= endTime) {
+            alert('Vrijeme završetka mora biti nakon vremena početka');
+            return;
+        }
+
+        if (new Date(endDate) < new Date(startDate)) {
+            alert('Datum završetka mora biti nakon datuma početka');
+            return;
+        }
+
+        formAction(formData);
+    };
+
     return (
-        <form action={formAction}>
+        <form action={handleSubmit}>
             <Stack spacing={3}>
                 <SelectItems
                     variant="outlined"
@@ -53,6 +101,7 @@ export function BulkGenerateForm({ locations }: BulkGenerateFormProps) {
                         value: location.id.toString(),
                         label: location.name,
                     }))}
+                    required
                 />
                 <input
                     type="hidden"
@@ -69,6 +118,7 @@ export function BulkGenerateForm({ locations }: BulkGenerateFormProps) {
                         { value: 'delivery', label: 'Dostava' },
                         { value: 'pickup', label: 'Preuzimanje' },
                     ]}
+                    required
                 />
                 <input type="hidden" name="type" value={selectedType} />
 
@@ -103,25 +153,6 @@ export function BulkGenerateForm({ locations }: BulkGenerateFormProps) {
                     label="Vrijeme završetka"
                     defaultValue="18:00"
                     step="3600"
-                    required
-                />
-
-                <Input
-                    type="number"
-                    name="slotDurationMinutes"
-                    label="Trajanje slota (minute)"
-                    defaultValue="60"
-                    min="30"
-                    step="30"
-                    required
-                />
-
-                <Input
-                    type="number"
-                    name="maxCapacity"
-                    label="Maksimalni kapacitet po slotu"
-                    defaultValue="5"
-                    min="1"
                     required
                 />
 

--- a/apps/app/app/admin/delivery/slots/actions.ts
+++ b/apps/app/app/admin/delivery/slots/actions.ts
@@ -89,19 +89,19 @@ export async function bulkGenerateSlotsAction(
             .getAll('daysOfWeek')
             .map((day) => parseInt(day as string, 10));
 
-        // Validate required fields
+        // Validate required fields and date validity
         if (
             !locationId ||
             !type ||
-            !startDate ||
-            !endDate ||
+            isNaN(startDate.getTime()) ||
+            isNaN(endDate.getTime()) ||
             !startTime ||
             !endTime ||
             daysOfWeek.length === 0
         ) {
             return {
                 success: false,
-                message: 'Molimo popunite sva obavezna polja',
+                message: 'Molimo popunite sva obavezna polja ili unesite ispravne datume',
             };
         }
 

--- a/apps/app/app/admin/delivery/slots/actions.ts
+++ b/apps/app/app/admin/delivery/slots/actions.ts
@@ -21,11 +21,21 @@ export async function createTimeSlotAction(
 
         const locationId = parseInt(formData.get('locationId') as string, 10);
         const type = formData.get('type') as 'delivery' | 'pickup';
-        const startDate = formData.get('startDate') as string;
+        const startDateString = formData.get('startDate') as string;
         const startTime = formData.get('startTime') as string;
 
-        // Combine date and time
-        const startAt = new Date(`${startDate}T${startTime}:00.000Z`);
+        // Parse date in local timezone to avoid UTC offset issues
+        const [year, month, day] = startDateString.split('-').map(Number);
+        const [hours, minutes] = startTime.split(':').map(Number);
+        const startAt = new Date(
+            year,
+            month - 1,
+            day,
+            hours,
+            minutes || 0,
+            0,
+            0,
+        ); // Month is 0-indexed
         const endAt = new Date(startAt.getTime() + 2 * 60 * 60 * 1000); // +2 hours
 
         await createTimeSlot({
@@ -59,27 +69,114 @@ export async function bulkGenerateSlotsAction(
 
         const locationId = parseInt(formData.get('locationId') as string, 10);
         const type = formData.get('type') as 'delivery' | 'pickup';
-        const startDate = new Date(formData.get('startDate') as string);
-        const daysAhead = parseInt(formData.get('daysAhead') as string, 10);
-        const windows = (formData.get('windows') as string)
-            .split(',')
-            .map((w) => w.trim())
-            .filter(Boolean);
+        const startDateString = formData.get('startDate') as string;
+        const endDateString = formData.get('endDate') as string;
 
-        const params: BulkSlotCreationParams = {
-            startDate,
-            daysAhead,
-            windows,
-            type,
-            locationId,
-        };
+        // Parse dates in local timezone to avoid UTC offset issues
+        const [startYear, startMonth, startDay] = startDateString
+            .split('-')
+            .map(Number);
+        const [endYear, endMonth, endDay] = endDateString
+            .split('-')
+            .map(Number);
+        const startDate = new Date(startYear, startMonth - 1, startDay); // Month is 0-indexed
+        const endDate = new Date(endYear, endMonth - 1, endDay);
 
-        const result = await bulkGenerateTimeSlots(params);
+        const startTime = formData.get('startTime') as string;
+        const endTime = formData.get('endTime') as string;
+        const slotDurationMinutes = 120; // Fixed 2-hour duration
+        const daysOfWeek = formData
+            .getAll('daysOfWeek')
+            .map((day) => parseInt(day as string, 10));
+
+        // Validate required fields
+        if (
+            !locationId ||
+            !type ||
+            !startDate ||
+            !endDate ||
+            !startTime ||
+            !endTime ||
+            daysOfWeek.length === 0
+        ) {
+            return {
+                success: false,
+                message: 'Molimo popunite sva obavezna polja',
+            };
+        }
+
+        // Validate date range
+        if (endDate < startDate) {
+            return {
+                success: false,
+                message: 'Datum završetka mora biti nakon datuma početka',
+            };
+        }
+
+        // Generate time windows based on start time, end time, and slot duration
+        const windows: string[] = [];
+        const [startHours, startMinutes] = startTime.split(':').map(Number);
+        const [endHours, endMinutes] = endTime.split(':').map(Number);
+
+        const startTotalMinutes = startHours * 60 + startMinutes;
+        const endTotalMinutes = endHours * 60 + endMinutes;
+
+        for (
+            let minutes = startTotalMinutes;
+            minutes < endTotalMinutes;
+            minutes += slotDurationMinutes
+        ) {
+            const hours = Math.floor(minutes / 60);
+            const mins = minutes % 60;
+            windows.push(
+                `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}`,
+            );
+        }
+
+        if (windows.length === 0) {
+            return {
+                success: false,
+                message:
+                    'Nema dostupnih slotova za generiranje s odabranim parametrima',
+            };
+        }
+
+        // Calculate total days between start and end date
+        const timeDiff = endDate.getTime() - startDate.getTime();
+        const totalDays = Math.ceil(timeDiff / (1000 * 3600 * 24)) + 1; // +1 to include the end date
+
+        // Filter dates by selected days of week and generate slots
+        let created = 0;
+        let skippedExisting = 0;
+
+        for (let dayOffset = 0; dayOffset < totalDays; dayOffset++) {
+            const currentDate = new Date(startDate);
+            currentDate.setDate(currentDate.getDate() + dayOffset);
+
+            // Check if this day of week is selected (0 = Sunday, 1 = Monday, etc.)
+            const dayOfWeek = currentDate.getDay();
+            if (!daysOfWeek.includes(dayOfWeek)) {
+                continue;
+            }
+
+            // Generate slots for this day using the existing bulk function
+            const params: BulkSlotCreationParams = {
+                startDate: currentDate,
+                daysAhead: 1, // Just this one day
+                windows,
+                type,
+                locationId,
+            };
+
+            const result = await bulkGenerateTimeSlots(params);
+            created += result.created;
+            skippedExisting += result.skippedExisting;
+        }
 
         revalidatePath('/admin/delivery/slots');
         return {
             success: true,
-            message: `Kreirano ${result.created} slotova, preskočeno ${result.skippedExisting} postojećih slotova`,
+            message: `Kreirano ${created} slotova, preskočeno ${skippedExisting} postojećih slotova`,
         };
     } catch (error) {
         console.error('Failed to bulk generate slots:', error);

--- a/apps/app/app/admin/delivery/slots/actions.ts
+++ b/apps/app/app/admin/delivery/slots/actions.ts
@@ -93,15 +93,16 @@ export async function bulkGenerateSlotsAction(
         if (
             !locationId ||
             !type ||
-            isNaN(startDate.getTime()) ||
-            isNaN(endDate.getTime()) ||
+            Number.isNaN(startDate.getTime()) ||
+            Number.isNaN(endDate.getTime()) ||
             !startTime ||
             !endTime ||
             daysOfWeek.length === 0
         ) {
             return {
                 success: false,
-                message: 'Molimo popunite sva obavezna polja ili unesite ispravne datume',
+                message:
+                    'Molimo popunite sva obavezna polja ili unesite ispravne datume',
             };
         }
 
@@ -123,7 +124,7 @@ export async function bulkGenerateSlotsAction(
 
         for (
             let minutes = startTotalMinutes;
-            minutes < endTotalMinutes;
+            minutes + slotDurationMinutes <= endTotalMinutes;
             minutes += slotDurationMinutes
         ) {
             const hours = Math.floor(minutes / 60);


### PR DESCRIPTION
Update time slot creation to parse dates/times in the local timezone
instead of constructing UTC ISO strings. Replace simple string-based
combination with explicit year/month/day/hour/minute parsing so created
Date objects reflect local time and avoid UTC offset issues.

Extend bulk slot action to accept start and end dates/times and to
generate windows programmatically. Add:
- parsing of startDate/endDate and startTime/endTime from the form
- validation for required fields and date range with user-facing
  messages
- generation of 2-hour slot windows between start and end times
- filtering by selected days of week and iteration over date range to
  build slots (with counters for created/skipped)

These changes fix timezone bugs, add input validation, and enable
server-side generation of multiple slots across a date range. Hardest
problems solved: incorrect UTC offsets and lack of bulk window gen.