### PR TITLE
Replace Leva debug HUD with custom controls

### DIFF
--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -38,7 +38,6 @@
         "@types/three": "0.180.0",
         "@use-gesture/react": "10.3.1",
         "chroma-js": "3.1.2",
-        "leva": "0.10.0",
         "next": "canary",
         "next-themes": "0.4.6",
         "r3f-perf": "7.2.3",

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -388,98 +388,99 @@ export function DebugHud() {
                     dragging={isDraggingPanel}
                     onDragHandlePointerDown={handlePanelPointerDown}
                 >
-                <Stack spacing={2}>
-                    <DebugPanelSection
-                        title="Time of day"
-                        description="Adjust the sun position across the day."
-                    >
-                        <Slider
-                            label={`Time: ${formatTimeLabel(timeOfDay)}`}
-                            min={0}
-                            max={1}
-                            step={0.01}
-                            value={[timeOfDay]}
-                            onValueChange={(value) => {
-                                const [nextValue] = value;
-                                if (typeof nextValue === 'number') {
-                                    setTimeOfDay(clampToRange(nextValue, 0, 1));
-                                }
-                            }}
-                        />
-                        <Typography level="body3" secondary>
-                            Local time freeze is applied immediately.
-                        </Typography>
-                    </DebugPanelSection>
-                    <DebugPanelSection
-                        title="Weather"
-                        description="Override live weather data when necessary."
-                    >
-                        <Checkbox
-                            label="Override live weather"
-                            checked={overrideWeather}
-                            onCheckedChange={handleOverrideChange}
-                        />
-                        <Stack spacing={1} className="pt-1">
+                    <Stack spacing={2}>
+                        <DebugPanelSection
+                            title="Time of day"
+                            description="Adjust the sun position across the day."
+                        >
                             <Slider
-                                label={`Cloudiness: ${formatPercent(cloudy)}`}
+                                label={`Time: ${formatTimeLabel(timeOfDay)}`}
                                 min={0}
                                 max={1}
                                 step={0.01}
-                                value={[cloudy]}
-                                disabled={weatherControlsDisabled}
+                                value={[timeOfDay]}
                                 onValueChange={(value) => {
                                     const [nextValue] = value;
                                     if (typeof nextValue === 'number') {
-                                        setCloudy(clampToRange(nextValue, 0, 1));
+                                        setTimeOfDay(clampToRange(nextValue, 0, 1));
                                     }
                                 }}
                             />
-                            <Slider
-                                label={`Rain: ${formatPercent(rainy)}`}
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={[rainy]}
-                                disabled={weatherControlsDisabled}
-                                onValueChange={(value) => {
-                                    const [nextValue] = value;
-                                    if (typeof nextValue === 'number') {
-                                        setRainy(clampToRange(nextValue, 0, 1));
-                                    }
-                                }}
+                            <Typography level="body3" secondary>
+                                Local time freeze is applied immediately.
+                            </Typography>
+                        </DebugPanelSection>
+                        <DebugPanelSection
+                            title="Weather"
+                            description="Override live weather data when necessary."
+                        >
+                            <Checkbox
+                                label="Override live weather"
+                                checked={overrideWeather}
+                                onCheckedChange={handleOverrideChange}
                             />
-                            <Slider
-                                label={`Snow: ${formatPercent(snowy)}`}
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={[snowy]}
-                                disabled={weatherControlsDisabled}
-                                onValueChange={(value) => {
-                                    const [nextValue] = value;
-                                    if (typeof nextValue === 'number') {
-                                        setSnowy(clampToRange(nextValue, 0, 1));
-                                    }
-                                }}
-                            />
-                            <Slider
-                                label={`Fog: ${formatPercent(foggy)}`}
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={[foggy]}
-                                disabled={weatherControlsDisabled}
-                                onValueChange={(value) => {
-                                    const [nextValue] = value;
-                                    if (typeof nextValue === 'number') {
-                                        setFoggy(clampToRange(nextValue, 0, 1));
-                                    }
-                                }}
-                            />
-                        </Stack>
-                    </DebugPanelSection>
-                </Stack>
-            </DebugPanel>
+                            <Stack spacing={1} className="pt-1">
+                                <Slider
+                                    label={`Cloudiness: ${formatPercent(cloudy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[cloudy]}
+                                    disabled={weatherControlsDisabled}
+                                    onValueChange={(value) => {
+                                        const [nextValue] = value;
+                                        if (typeof nextValue === 'number') {
+                                            setCloudy(clampToRange(nextValue, 0, 1));
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    label={`Rain: ${formatPercent(rainy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[rainy]}
+                                    disabled={weatherControlsDisabled}
+                                    onValueChange={(value) => {
+                                        const [nextValue] = value;
+                                        if (typeof nextValue === 'number') {
+                                            setRainy(clampToRange(nextValue, 0, 1));
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    label={`Snow: ${formatPercent(snowy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[snowy]}
+                                    disabled={weatherControlsDisabled}
+                                    onValueChange={(value) => {
+                                        const [nextValue] = value;
+                                        if (typeof nextValue === 'number') {
+                                            setSnowy(clampToRange(nextValue, 0, 1));
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    label={`Fog: ${formatPercent(foggy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[foggy]}
+                                    disabled={weatherControlsDisabled}
+                                    onValueChange={(value) => {
+                                        const [nextValue] = value;
+                                        if (typeof nextValue === 'number') {
+                                            setFoggy(clampToRange(nextValue, 0, 1));
+                                        }
+                                    }}
+                                />
+                            </Stack>
+                        </DebugPanelSection>
+                    </Stack>
+                </DebugPanel>
+            </div>
         </div>
     );
 }

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -15,8 +15,24 @@ function getTimeOfDayFromDate(date: Date) {
     return totalSeconds / (24 * 60 * 60);
 }
 
+// Avoid thrashing the time-of-day slider when the live clock only moves by a
+// handful of milliseconds between frames.
+const TIME_OF_DAY_SYNC_THRESHOLD = 0.0005;
+
+function clampToRange(value: number, min: number, max: number) {
+    if (value < min) {
+        return min;
+    }
+
+    if (value > max) {
+        return max;
+    }
+
+    return value;
+}
+
 function formatTimeLabel(value: number) {
-    const clamped = Math.max(0, Math.min(1, value));
+    const clamped = clampToRange(value, 0, 1);
     const totalSeconds = Math.round(clamped * 24 * 60 * 60);
     const hours = Math.floor(totalSeconds / (60 * 60));
     const minutes = Math.floor((totalSeconds % (60 * 60)) / 60);
@@ -26,7 +42,7 @@ function formatTimeLabel(value: number) {
 }
 
 function formatPercent(value: number) {
-    return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+    return `${Math.round(clampToRange(value, 0, 1) * 100)}%`;
 }
 
 export function DebugHud() {
@@ -46,12 +62,14 @@ export function DebugHud() {
     useEffect(() => {
         const nextTimeOfDay = getTimeOfDayFromDate(currentTime);
         setTimeOfDay((previous) =>
-            Math.abs(previous - nextTimeOfDay) < 0.0005 ? previous : nextTimeOfDay,
+            Math.abs(previous - nextTimeOfDay) < TIME_OF_DAY_SYNC_THRESHOLD
+                ? previous
+                : nextTimeOfDay,
         );
     }, [currentTime]);
 
     useEffect(() => {
-        const seconds = Math.max(0, Math.min(1, timeOfDay)) * 24 * 60 * 60;
+        const seconds = clampToRange(timeOfDay, 0, 1) * 24 * 60 * 60;
         const date = new Date();
         date.setHours(seconds / 60 / 60);
         date.setMinutes((seconds / 60) % 60);
@@ -113,7 +131,7 @@ export function DebugHud() {
                             onValueChange={(value) => {
                                 const [nextValue] = value;
                                 if (typeof nextValue === 'number') {
-                                    setTimeOfDay(Math.max(0, Math.min(1, nextValue)));
+                                    setTimeOfDay(clampToRange(nextValue, 0, 1));
                                 }
                             }}
                         />
@@ -141,7 +159,7 @@ export function DebugHud() {
                                 onValueChange={(value) => {
                                     const [nextValue] = value;
                                     if (typeof nextValue === 'number') {
-                                        setCloudy(Math.max(0, Math.min(1, nextValue)));
+                                        setCloudy(clampToRange(nextValue, 0, 1));
                                     }
                                 }}
                             />
@@ -155,7 +173,7 @@ export function DebugHud() {
                                 onValueChange={(value) => {
                                     const [nextValue] = value;
                                     if (typeof nextValue === 'number') {
-                                        setRainy(Math.max(0, Math.min(1, nextValue)));
+                                        setRainy(clampToRange(nextValue, 0, 1));
                                     }
                                 }}
                             />
@@ -169,7 +187,7 @@ export function DebugHud() {
                                 onValueChange={(value) => {
                                     const [nextValue] = value;
                                     if (typeof nextValue === 'number') {
-                                        setSnowy(Math.max(0, Math.min(1, nextValue)));
+                                        setSnowy(clampToRange(nextValue, 0, 1));
                                     }
                                 }}
                             />
@@ -183,7 +201,7 @@ export function DebugHud() {
                                 onValueChange={(value) => {
                                     const [nextValue] = value;
                                     if (typeof nextValue === 'number') {
-                                        setFoggy(Math.max(0, Math.min(1, nextValue)));
+                                        setFoggy(clampToRange(nextValue, 0, 1));
                                     }
                                 }}
                             />

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -1,9 +1,33 @@
 'use client';
 
-import { useControls } from 'leva';
-import { useEffect } from 'react';
+import { DebugPanel, DebugPanelSection } from '@gredice/ui/DebugControls';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Slider } from '@signalco/ui-primitives/Slider';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useEffect, useState } from 'react';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import { useGameState } from '../useGameState';
+
+function getTimeOfDayFromDate(date: Date) {
+    const totalSeconds =
+        date.getHours() * 60 * 60 + date.getMinutes() * 60 + date.getSeconds();
+    return totalSeconds / (24 * 60 * 60);
+}
+
+function formatTimeLabel(value: number) {
+    const clamped = Math.max(0, Math.min(1, value));
+    const totalSeconds = Math.round(clamped * 24 * 60 * 60);
+    const hours = Math.floor(totalSeconds / (60 * 60));
+    const minutes = Math.floor((totalSeconds % (60 * 60)) / 60);
+    return `${hours.toString().padStart(2, '0')}:${minutes
+        .toString()
+        .padStart(2, '0')}`;
+}
+
+function formatPercent(value: number) {
+    return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+}
 
 export function DebugHud() {
     const setWeather = useGameState((s) => s.setWeather);
@@ -11,65 +35,162 @@ export function DebugHud() {
     const setFreezeTime = useGameState((s) => s.setFreezeTime);
 
     const { data: weather } = useWeatherNow();
-    const { timeOfDay } = useControls('Environment', {
-        timeOfDay: {
-            value:
-                (currentTime.getHours() * 60 * 60 +
-                    currentTime.getMinutes() * 60 +
-                    currentTime.getSeconds()) /
-                (24 * 60 * 60),
-            min: 0,
-            max: 1,
-        },
-    });
-    const { overrideWeather } = useControls('Environment', {
-        overrideWeather: { value: false },
-    });
-    const { cloudy, rainy, snowy, foggy } = useControls(
-        'Environment',
-        {
-            cloudy: {
-                value: weather?.cloudy ?? 0,
-                min: 0,
-                max: 1,
-                disabled: !overrideWeather,
-            },
-            rainy: {
-                value: weather?.rainy ?? 0,
-                min: 0,
-                max: 1,
-                disabled: !overrideWeather,
-            },
-            snowy: {
-                value: weather?.snowy ?? 0,
-                min: 0,
-                max: 1,
-                disabled: !overrideWeather,
-            },
-            foggy: {
-                value: weather?.foggy ?? 0,
-                min: 0,
-                max: 1,
-                disabled: !overrideWeather,
-            },
-        },
-        [overrideWeather],
-    );
+
+    const [timeOfDay, setTimeOfDay] = useState(() => getTimeOfDayFromDate(currentTime));
+    const [overrideWeather, setOverrideWeather] = useState(false);
+    const [cloudy, setCloudy] = useState(weather?.cloudy ?? 0);
+    const [rainy, setRainy] = useState(weather?.rainy ?? 0);
+    const [snowy, setSnowy] = useState(weather?.snowy ?? 0);
+    const [foggy, setFoggy] = useState(weather?.foggy ?? 0);
 
     useEffect(() => {
-        if (overrideWeather) {
-            setWeather({ cloudy, rainy, snowy, foggy });
-        }
-    }, [cloudy, rainy, snowy, foggy, overrideWeather, setWeather]);
+        const nextTimeOfDay = getTimeOfDayFromDate(currentTime);
+        setTimeOfDay((previous) =>
+            Math.abs(previous - nextTimeOfDay) < 0.0005 ? previous : nextTimeOfDay,
+        );
+    }, [currentTime]);
 
     useEffect(() => {
+        const seconds = Math.max(0, Math.min(1, timeOfDay)) * 24 * 60 * 60;
         const date = new Date();
-        const seconds = timeOfDay * 24 * 60 * 60;
         date.setHours(seconds / 60 / 60);
         date.setMinutes((seconds / 60) % 60);
         date.setSeconds(seconds % 60);
         setFreezeTime(date);
     }, [timeOfDay, setFreezeTime]);
 
-    return null;
+    useEffect(() => {
+        if (overrideWeather) {
+            setWeather({ cloudy, rainy, snowy, foggy });
+            return;
+        }
+
+        if (weather) {
+            setWeather({
+                cloudy: weather.cloudy ?? 0,
+                rainy: weather.rainy ?? 0,
+                snowy: weather.snowy ?? 0,
+                foggy: weather.foggy ?? 0,
+            });
+        }
+    }, [overrideWeather, cloudy, rainy, snowy, foggy, weather, setWeather]);
+
+    useEffect(() => {
+        if (!weather || overrideWeather) {
+            return;
+        }
+
+        setCloudy(weather.cloudy ?? 0);
+        setRainy(weather.rainy ?? 0);
+        setSnowy(weather.snowy ?? 0);
+        setFoggy(weather.foggy ?? 0);
+    }, [weather, overrideWeather]);
+
+    const handleOverrideChange = (checked: boolean | 'indeterminate') => {
+        setOverrideWeather(checked === true);
+    };
+
+    const weatherControlsDisabled = !overrideWeather;
+
+    return (
+        <div className="pointer-events-none fixed top-4 right-4 z-50 flex max-w-full justify-end px-2">
+            <DebugPanel
+                title="Environment"
+                description="Tune lighting and weather parameters for debugging."
+                className="pointer-events-auto"
+            >
+                <Stack spacing={2}>
+                    <DebugPanelSection
+                        title="Time of day"
+                        description="Adjust the sun position across the day."
+                    >
+                        <Slider
+                            label={`Time: ${formatTimeLabel(timeOfDay)}`}
+                            min={0}
+                            max={1}
+                            step={0.01}
+                            value={[timeOfDay]}
+                            onValueChange={(value) => {
+                                const [nextValue] = value;
+                                if (typeof nextValue === 'number') {
+                                    setTimeOfDay(Math.max(0, Math.min(1, nextValue)));
+                                }
+                            }}
+                        />
+                        <Typography level="body3" secondary>
+                            Local time freeze is applied immediately.
+                        </Typography>
+                    </DebugPanelSection>
+                    <DebugPanelSection
+                        title="Weather"
+                        description="Override live weather data when necessary."
+                    >
+                        <Checkbox
+                            label="Override live weather"
+                            checked={overrideWeather}
+                            onCheckedChange={handleOverrideChange}
+                        />
+                        <Stack spacing={1} className="pt-1">
+                            <Slider
+                                label={`Cloudiness: ${formatPercent(cloudy)}`}
+                                min={0}
+                                max={1}
+                                step={0.01}
+                                value={[cloudy]}
+                                disabled={weatherControlsDisabled}
+                                onValueChange={(value) => {
+                                    const [nextValue] = value;
+                                    if (typeof nextValue === 'number') {
+                                        setCloudy(Math.max(0, Math.min(1, nextValue)));
+                                    }
+                                }}
+                            />
+                            <Slider
+                                label={`Rain: ${formatPercent(rainy)}`}
+                                min={0}
+                                max={1}
+                                step={0.01}
+                                value={[rainy]}
+                                disabled={weatherControlsDisabled}
+                                onValueChange={(value) => {
+                                    const [nextValue] = value;
+                                    if (typeof nextValue === 'number') {
+                                        setRainy(Math.max(0, Math.min(1, nextValue)));
+                                    }
+                                }}
+                            />
+                            <Slider
+                                label={`Snow: ${formatPercent(snowy)}`}
+                                min={0}
+                                max={1}
+                                step={0.01}
+                                value={[snowy]}
+                                disabled={weatherControlsDisabled}
+                                onValueChange={(value) => {
+                                    const [nextValue] = value;
+                                    if (typeof nextValue === 'number') {
+                                        setSnowy(Math.max(0, Math.min(1, nextValue)));
+                                    }
+                                }}
+                            />
+                            <Slider
+                                label={`Fog: ${formatPercent(foggy)}`}
+                                min={0}
+                                max={1}
+                                step={0.01}
+                                value={[foggy]}
+                                disabled={weatherControlsDisabled}
+                                onValueChange={(value) => {
+                                    const [nextValue] = value;
+                                    if (typeof nextValue === 'number') {
+                                        setFoggy(Math.max(0, Math.min(1, nextValue)));
+                                    }
+                                }}
+                            />
+                        </Stack>
+                    </DebugPanelSection>
+                </Stack>
+            </DebugPanel>
+        </div>
+    );
 }

--- a/packages/ui/src/DebugControls/DebugPanel.tsx
+++ b/packages/ui/src/DebugControls/DebugPanel.tsx
@@ -1,0 +1,81 @@
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { cx } from '@signalco/ui-primitives/cx';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import type { PropsWithChildren } from 'react';
+
+interface DebugPanelProps extends PropsWithChildren {
+    title: string;
+    description?: string;
+    className?: string;
+}
+
+export function DebugPanel({
+    title,
+    description,
+    className,
+    children,
+}: DebugPanelProps) {
+    return (
+        <Card
+            className={cx(
+                'w-full max-w-sm border border-border/40 bg-background/95 shadow-lg backdrop-blur',
+                className,
+            )}
+        >
+            <CardHeader className="space-y-1">
+                <CardTitle className="text-base font-semibold">
+                    {title}
+                </CardTitle>
+                {description ? (
+                    <Typography level="body3" secondary>
+                        {description}
+                    </Typography>
+                ) : null}
+            </CardHeader>
+            <CardContent noHeader className="space-y-3">
+                {children}
+            </CardContent>
+        </Card>
+    );
+}
+
+interface DebugPanelSectionProps extends PropsWithChildren {
+    title: string;
+    description?: string;
+    className?: string;
+}
+
+export function DebugPanelSection({
+    title,
+    description,
+    className,
+    children,
+}: DebugPanelSectionProps) {
+    return (
+        <Stack
+            spacing={1.5}
+            className={cx(
+                'rounded-lg border border-border/40 bg-background/80 p-3 shadow-sm backdrop-blur-sm',
+                className,
+            )}
+        >
+            <div className="space-y-1">
+                <Typography level="body2" semiBold>
+                    {title}
+                </Typography>
+                {description ? (
+                    <Typography level="body3" secondary>
+                        {description}
+                    </Typography>
+                ) : null}
+            </div>
+            {children}
+        </Stack>
+    );
+}

--- a/packages/ui/src/DebugControls/DebugPanel.tsx
+++ b/packages/ui/src/DebugControls/DebugPanel.tsx
@@ -7,18 +7,22 @@ import {
 import { cx } from '@signalco/ui-primitives/cx';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import type { PropsWithChildren } from 'react';
+import type { PointerEvent, PropsWithChildren } from 'react';
 
 interface DebugPanelProps extends PropsWithChildren {
     title: string;
     description?: string;
     className?: string;
+    dragging?: boolean;
+    onDragHandlePointerDown?: (event: PointerEvent<HTMLDivElement>) => void;
 }
 
 export function DebugPanel({
     title,
     description,
     className,
+    dragging = false,
+    onDragHandlePointerDown,
     children,
 }: DebugPanelProps) {
     return (
@@ -28,7 +32,16 @@ export function DebugPanel({
                 className,
             )}
         >
-            <CardHeader className="space-y-1">
+            <CardHeader
+                className={cx(
+                    'space-y-1',
+                    onDragHandlePointerDown
+                        ? 'cursor-grab select-none touch-none active:cursor-grabbing'
+                        : undefined,
+                    dragging ? 'cursor-grabbing' : undefined,
+                )}
+                onPointerDown={onDragHandlePointerDown}
+            >
                 <CardTitle className="text-base font-semibold">
                     {title}
                 </CardTitle>

--- a/packages/ui/src/DebugControls/index.ts
+++ b/packages/ui/src/DebugControls/index.ts
@@ -1,0 +1,1 @@
+export * from './DebugPanel';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,9 +854,6 @@ importers:
       chroma-js:
         specifier: 3.1.2
         version: 3.1.2
-      leva:
-        specifier: 0.10.0
-        version: 0.10.0(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next:
         specifier: canary
         version: 15.6.0-canary.42(@playwright/test@1.55.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.93.2)
@@ -6784,12 +6781,6 @@ packages:
 
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
-
-  leva@0.10.0:
-    resolution: {integrity: sha512-RiNJWmeqQdKIeHuVXgshmxIHu144a2AMYtLxKf8Nm1j93pisDPexuQDHKNdQlbo37wdyDQibLjY9JKGIiD7gaw==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
 
   leven@4.1.0:
     resolution: {integrity: sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==}
@@ -15866,24 +15857,6 @@ snapshots:
   kleur@4.1.5: {}
 
   leac@0.6.0: {}
-
-  leva@0.10.0(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
-    dependencies:
-      '@radix-ui/react-portal': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-tooltip': 1.0.5(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@stitches/react': 1.2.8(react@19.2.0)
-      '@use-gesture/react': 10.3.1(react@19.2.0)
-      colord: 2.9.3
-      dequal: 2.0.3
-      merge-value: 1.0.0
-      react: 19.2.0
-      react-colorful: 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react-dom: 19.2.0(react@19.2.0)
-      react-dropzone: 12.1.0(react@19.2.0)
-      v8n: 1.5.1
-      zustand: 3.7.2(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
 
   leven@4.1.0: {}
 


### PR DESCRIPTION
## Summary
- rebuild the game DebugHud using custom sliders and checkboxes built on @signalco primitives instead of Leva
- add reusable DebugPanel and DebugPanelSection components to @gredice/ui for composing debugging controls
- remove the Leva dependency from @gredice/game and clean up the lockfile

## Testing
- `pnpm --filter @gredice/ui lint`
- `pnpm --filter @gredice/game lint` *(fails: existing Biome issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e17676e740832fa7b9da20fa197fe0