### PR TITLE
Fix shopping cart details route parameter handling

### DIFF
--- a/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
+++ b/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
@@ -20,11 +20,15 @@ export const dynamic = 'force-dynamic';
 export default async function ShoppingCartDetailsPage({
     params,
 }: {
-    params: { cartId: number };
+    params: { cartId: string };
 }) {
     const { cartId } = params;
+    const cartIdNumber = Number(cartId);
+    if (Number.isNaN(cartIdNumber)) {
+        notFound();
+    }
     await auth(['admin']);
-    const cart = await getShoppingCart(cartId);
+    const cart = await getShoppingCart(cartIdNumber);
     if (!cart) {
         notFound();
     }
@@ -116,7 +120,7 @@ export default async function ShoppingCartDetailsPage({
                 <Breadcrumbs
                     items={[
                         { label: 'Košarice', href: KnownPages.ShoppingCarts },
-                        { label: `Košarica ${cartId}` },
+                        { label: `Košarica ${cartIdNumber}` },
                     ]}
                 />
                 <Typography level="h1" className="text-2xl" semiBold>


### PR DESCRIPTION
## Summary
- parse shopping cart route parameter as a number before loading data
- show the numeric cart identifier in breadcrumbs after validation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e17ef510d4832fb3134d6393cbac0e