### PR TITLE
Improve admin operations chart responsiveness

### DIFF
--- a/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
+++ b/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
@@ -74,6 +74,24 @@ export function OperationsDurationCard({
         1,
         Math.ceil(data.daily.length / maxVisibleLabels),
     );
+    const points = data.daily.map((day, index) => {
+        const normalizedHeight = maxMinutes
+            ? (day.totalMinutes / maxMinutes) * 100
+            : 0;
+        const heightPercent =
+            day.totalMinutes > 0 ? Math.max(4, normalizedHeight) : 0;
+        const barHasSegments =
+            day.operationsMinutes > 0 || day.sowingMinutes > 0;
+        const shouldShowLabel =
+            index % labelStep === 0 || index === data.daily.length - 1;
+
+        return {
+            barHasSegments,
+            day,
+            heightPercent,
+            shouldShowLabel,
+        };
+    });
 
     return (
         <Card>
@@ -119,30 +137,17 @@ export function OperationsDurationCard({
                             Nema podataka za odabrani period.
                         </Typography>
                     ) : (
-                        <div className="flex h-48 w-full items-end gap-2">
-                            {data.daily.map((day, index) => {
-                                const normalizedHeight = maxMinutes
-                                    ? (day.totalMinutes / maxMinutes) * 100
-                                    : 0;
-                                const heightPercent =
-                                    day.totalMinutes > 0
-                                        ? Math.max(4, normalizedHeight)
-                                        : 0;
-                                const barHasSegments =
-                                    day.operationsMinutes > 0 ||
-                                    day.sowingMinutes > 0;
-                                const shouldShowLabel =
-                                    index % labelStep === 0 ||
-                                    index === data.daily.length - 1;
-
-                                return (
-                                    <div
-                                        key={day.date}
-                                        className="flex h-full min-w-0 flex-1 flex-col items-center gap-1"
-                                    >
-                                        <Tooltip>
+                        <>
+                            <div className="flex h-48 w-full items-end gap-[3px] sm:gap-2">
+                                {points.map(
+                                    ({
+                                        barHasSegments,
+                                        day,
+                                        heightPercent,
+                                    }) => (
+                                        <Tooltip key={day.date}>
                                             <TooltipTrigger asChild>
-                                                <div className="flex w-full flex-1 items-end">
+                                                <div className="flex h-full min-w-[6px] flex-1 basis-0 items-end">
                                                     <div
                                                         className="flex w-full min-w-0 flex-col justify-end overflow-hidden rounded-t bg-primary/10"
                                                         style={{
@@ -212,6 +217,15 @@ export function OperationsDurationCard({
                                                 </Stack>
                                             </TooltipContent>
                                         </Tooltip>
+                                    ),
+                                )}
+                            </div>
+                            <div className="mt-2 flex w-full gap-[3px] sm:gap-2">
+                                {points.map(({ day, shouldShowLabel }) => (
+                                    <div
+                                        key={`${day.date}-label`}
+                                        className="min-w-[6px] flex-1 basis-0 text-center"
+                                    >
                                         {shouldShowLabel ? (
                                             <Stack
                                                 spacing={0}
@@ -219,43 +233,39 @@ export function OperationsDurationCard({
                                             >
                                                 <Typography
                                                     level="body3"
-                                                    className="text-xs leading-tight"
+                                                    className="text-xs font-medium leading-tight"
                                                 >
                                                     {formatDateLabel(day.date)}
                                                 </Typography>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-xs leading-tight text-muted-foreground"
+                                                <Stack
+                                                    spacing={0}
+                                                    className="hidden min-w-0 items-center text-[10px] leading-tight text-muted-foreground md:flex"
                                                 >
-                                                    Ukupno{' '}
-                                                    {formatTooltipDuration(
-                                                        day.totalMinutes,
-                                                    )}
-                                                </Typography>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-[10px] leading-tight text-muted-foreground"
-                                                >
-                                                    Radnje{' '}
-                                                    {formatTooltipDuration(
-                                                        day.operationsMinutes,
-                                                    )}
-                                                </Typography>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-[10px] leading-tight text-muted-foreground"
-                                                >
-                                                    Sijanje{' '}
-                                                    {formatTooltipDuration(
-                                                        day.sowingMinutes,
-                                                    )}
-                                                </Typography>
+                                                    <Typography level="body3">
+                                                        Ukupno{' '}
+                                                        {formatTooltipDuration(
+                                                            day.totalMinutes,
+                                                        )}
+                                                    </Typography>
+                                                    <Typography level="body3">
+                                                        Radnje{' '}
+                                                        {formatTooltipDuration(
+                                                            day.operationsMinutes,
+                                                        )}
+                                                    </Typography>
+                                                    <Typography level="body3">
+                                                        Sijanje{' '}
+                                                        {formatTooltipDuration(
+                                                            day.sowingMinutes,
+                                                        )}
+                                                    </Typography>
+                                                </Stack>
                                             </Stack>
                                         ) : null}
                                     </div>
-                                );
-                            })}
-                        </div>
+                                ))}
+                            </div>
+                        </>
                     )}
                 </Stack>
             </CardOverflow>

--- a/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
+++ b/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
@@ -69,6 +69,11 @@ export function OperationsDurationCard({
         ...data.daily.map((day) => day.totalMinutes),
     );
     const hasData = maxMinutes > 0;
+    const maxVisibleLabels = 10;
+    const labelStep = Math.max(
+        1,
+        Math.ceil(data.daily.length / maxVisibleLabels),
+    );
 
     return (
         <Card>
@@ -114,8 +119,8 @@ export function OperationsDurationCard({
                             Nema podataka za odabrani period.
                         </Typography>
                     ) : (
-                        <div className="flex items-end gap-2 h-48">
-                            {data.daily.map((day) => {
+                        <div className="flex h-48 w-full items-end gap-2">
+                            {data.daily.map((day, index) => {
                                 const normalizedHeight = maxMinutes
                                     ? (day.totalMinutes / maxMinutes) * 100
                                     : 0;
@@ -126,17 +131,20 @@ export function OperationsDurationCard({
                                 const barHasSegments =
                                     day.operationsMinutes > 0 ||
                                     day.sowingMinutes > 0;
+                                const shouldShowLabel =
+                                    index % labelStep === 0 ||
+                                    index === data.daily.length - 1;
 
                                 return (
                                     <div
                                         key={day.date}
-                                        className="flex-1 flex flex-col items-center gap-1 h-full"
+                                        className="flex h-full min-w-0 flex-1 flex-col items-center gap-1"
                                     >
                                         <Tooltip>
                                             <TooltipTrigger asChild>
-                                                <div className="flex-1 flex items-end w-full">
+                                                <div className="flex w-full flex-1 items-end">
                                                     <div
-                                                        className="w-full rounded-t overflow-hidden flex flex-col justify-end bg-primary/10"
+                                                        className="flex w-full min-w-0 flex-col justify-end overflow-hidden rounded-t bg-primary/10"
                                                         style={{
                                                             height: `${heightPercent}%`,
                                                         }}
@@ -204,44 +212,46 @@ export function OperationsDurationCard({
                                                 </Stack>
                                             </TooltipContent>
                                         </Tooltip>
-                                        <Stack
-                                            spacing={0}
-                                            className="items-center"
-                                        >
-                                            <Typography
-                                                level="body3"
-                                                className="text-xs"
+                                        {shouldShowLabel ? (
+                                            <Stack
+                                                spacing={0}
+                                                className="min-w-0 items-center text-center"
                                             >
-                                                {formatDateLabel(day.date)}
-                                            </Typography>
-                                            <Typography
-                                                level="body3"
-                                                className="text-xs text-muted-foreground"
-                                            >
-                                                Ukupno{' '}
-                                                {formatTooltipDuration(
-                                                    day.totalMinutes,
-                                                )}
-                                            </Typography>
-                                            <Typography
-                                                level="body3"
-                                                className="text-[10px] text-muted-foreground"
-                                            >
-                                                Radnje{' '}
-                                                {formatTooltipDuration(
-                                                    day.operationsMinutes,
-                                                )}
-                                            </Typography>
-                                            <Typography
-                                                level="body3"
-                                                className="text-[10px] text-muted-foreground"
-                                            >
-                                                Sijanje{' '}
-                                                {formatTooltipDuration(
-                                                    day.sowingMinutes,
-                                                )}
-                                            </Typography>
-                                        </Stack>
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-xs leading-tight"
+                                                >
+                                                    {formatDateLabel(day.date)}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-xs leading-tight text-muted-foreground"
+                                                >
+                                                    Ukupno{' '}
+                                                    {formatTooltipDuration(
+                                                        day.totalMinutes,
+                                                    )}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-[10px] leading-tight text-muted-foreground"
+                                                >
+                                                    Radnje{' '}
+                                                    {formatTooltipDuration(
+                                                        day.operationsMinutes,
+                                                    )}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-[10px] leading-tight text-muted-foreground"
+                                                >
+                                                    Sijanje{' '}
+                                                    {formatTooltipDuration(
+                                                        day.sowingMinutes,
+                                                    )}
+                                                </Typography>
+                                            </Stack>
+                                        ) : null}
                                     </div>
                                 );
                             })}


### PR DESCRIPTION
## Summary
- allow the operations duration chart to shrink within its container by using flexible widths
- hide excess x-axis labels when there are many data points to avoid overflow on smaller screens

## Testing
- pnpm --filter app lint

------
https://chatgpt.com/codex/tasks/task_e_68e18128b938832f82831cb990e9f8a0