### PR TITLE
style: use theme background for image viewer controls

### DIFF
--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -234,7 +234,7 @@ export function ImageViewer({
                         <IconButton
                             title="Smanji"
                             variant="outlined"
-                            className="rounded-xl bg-black/60 backdrop-blur"
+                            className="rounded-xl bg-background/80 backdrop-blur"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 handleZoomOut(e);
@@ -246,7 +246,7 @@ export function ImageViewer({
                         <IconButton
                             title="Uvećaj"
                             variant="outlined"
-                            className="rounded-xl bg-black/60 backdrop-blur"
+                            className="rounded-xl bg-background/80 backdrop-blur"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 handleZoomIn(e);
@@ -258,7 +258,7 @@ export function ImageViewer({
                         <IconButton
                             title="Preuzmi"
                             variant="outlined"
-                            className="rounded-xl bg-black/60 backdrop-blur"
+                            className="rounded-xl bg-background/80 backdrop-blur"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 handleDownload(e);


### PR DESCRIPTION
Change ImageViewer control button backgrounds from a hardcoded
semi-transparent black to use the theme/background token
(bg-background/80). Update three IconButton instances (zoom out,
zoom in, download) to ensure consistent theming and proper contrast
when the app theme changes.

This avoids a fixed color that could clash with light/dark themes
and keeps the backdrop-blur effect intact.