### PR TITLE
fix(app): await params and use PageProps type for cart page

### DIFF
--- a/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
+++ b/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
@@ -19,10 +19,8 @@ export const dynamic = 'force-dynamic';
 
 export default async function ShoppingCartDetailsPage({
     params,
-}: {
-    params: { cartId: string };
-}) {
-    const { cartId } = params;
+}: PageProps<'/admin/shopping-carts/[cartId]'>) {
+    const { cartId } = await params;
     const cartIdNumber = Number(cartId);
     if (Number.isNaN(cartIdNumber)) {
         notFound();


### PR DESCRIPTION
Update ShoppingCartDetailsPage to accept PageProps for the
/admin/shopping-carts/[cartId] route and await params to extract the
cartId Convert cartId to a number and handle NaN via notFound() as
before.

This change fixes typing for the route component and ensures params
are resolved (awaited) correctly in the async server component.