### PR TITLE
feat(storage): simplify garden queries and strengthen handling

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx
@@ -1,7 +1,7 @@
 import {
-    getAccountGardensFiltered,
+    getAccountGardens,
     getAllRaisedBedsFiltered,
-    getRaisedBedsFiltered,
+    getRaisedBeds,
 } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
@@ -43,11 +43,11 @@ export async function RaisedBedsTableCard({
 
     // Fetch filtered data using the repository filtering functions
     const raisedBeds = accountId
-        ? (await getAccountGardensFiltered(accountId, filters)).flatMap(
+        ? (await getAccountGardens(accountId, filters)).flatMap(
               (garden) => garden.raisedBeds,
           )
         : gardenId
-          ? await getRaisedBedsFiltered(gardenId, filters)
+          ? await getRaisedBeds(gardenId, filters)
           : await getAllRaisedBedsFiltered(filters);
 
     return (

--- a/apps/app/app/admin/schedule/ScheduleDay.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDay.tsx
@@ -452,9 +452,15 @@ export function ScheduleDay({
                         const operationData = operationDataById.get(
                             op.entityId,
                         );
+
+                        const isFullRaisedBed =
+                            operationData?.attributes?.application ===
+                            'raisedBedFull';
+                        const text = `${isFullRaisedBed ? '' : `${op.physicalPositionIndex} - `}${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`;
+
                         return {
                             id: `operation-${op.id}`,
-                            text: `${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`,
+                            text,
                             link: operationData?.information?.label
                                 ? KnownPages.GrediceOperation(
                                       operationData?.information?.label,
@@ -702,7 +708,10 @@ export function ScheduleDay({
                                 const operationData = operationDataById.get(
                                     op.entityId,
                                 );
-                                const operationLabel = `${op.physicalPositionIndex} - ${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`;
+                                const isFullRaisedBed =
+                                    operationData?.attributes?.application ===
+                                    'raisedBedFull';
+                                const operationLabel = `${isFullRaisedBed ? '' : `${op.physicalPositionIndex} - `}${operationData?.information?.label ?? op.entityId}${op.sort ? `: ${op.sort.information?.name ?? 'Nepoznato'}` : ''}`;
                                 const operationCompleted = isOperationCompleted(
                                     op.status,
                                 );

--- a/apps/app/lib/@types/EntityStandardized.ts
+++ b/apps/app/lib/@types/EntityStandardized.ts
@@ -12,6 +12,7 @@ export type EntityStandardized = {
     attributes?: {
         seedingDistance?: number; // in cm
         duration?: number | string;
+        application?: string; // garden, raisedBedFull, raisedBed1m, plant
     };
     images?: {
         cover?: { url?: string };


### PR DESCRIPTION
- Rename getAccountGardFiltered -> getAccountGardens and unify API so
  callers provide an optional filter object (filter?.status). Keep title
  at 50 chars and hard-wrap body at 72 columns.
- Remove duplicated getRaisedBeds function and consolidate raised-bed
  fetching to a single getRaisedBeds that accepts optional filters.
- Adjust raised-bed and garden assembly to always attach raisedBeds
  via getRaisedBeds(garden.id, filter) and ensure comments match logic.
- Clean up imports by removing unused drizzle operator gte.
- Improve event-sourcing parsing for raised bed fields:
  - Explicitly handle plantPlace, plantUpdate and plantReplaceSort
    branches and add defensive parsing for plantSortId (number|string)
    and scheduledDate.
  - Set plant status to "new" on plantPlace and log an error for invalid
    plantSortId payloads.
  - Add clarifying comments for each event branch and avoid swallowing
    parse issues silently.

These changes reduce duplicated code, simplify repository APIs, and make
event processing more robust and debuggable.