### PR TITLE
chore(proxy): forward original scheme and dev start

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbopack -p 3005 --hostname api.gredice.test",
+        "dev": "next dev --turbopack -p 3005",
         "build": "next build --turbopack",
         "start": "next start -p 3005",
         "test": "pnpm run /^test:.*/",

--- a/scripts/dev/Caddyfile
+++ b/scripts/dev/Caddyfile
@@ -55,5 +55,7 @@ http://api.gredice.test {
 
 https://api.gredice.test {
     tls internal
-    reverse_proxy http://host.docker.internal:3005
+    reverse_proxy http://host.docker.internal:3005 {
+        header_up X-Forwarded-Proto {http.request.scheme}
+    }
 }


### PR DESCRIPTION
Add-Forwarded-Proto header to the Caddy reverse proxy so upstream
receives the original request scheme. This ensures the app can detect
http vs https correctly behind the proxy (fixes protocol-sensitive
behavior and URL generation).

Also remove explicit hostname from the API dev script to simplify local
dev startup and avoid hostname binding issues when using the proxy and
docker host forwarding.