### PR TITLE
refactor(types unify page prop handling and rename params

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/edit/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/edit/page.tsx
@@ -10,12 +10,11 @@ export const dynamic = 'force-dynamic';
 
 export default async function EditEntityTypePage({
     params,
-}: {
-    params: { entityType: string };
-}) {
+}: PageProps<'/admin/directories/[entityType]/edit'>) {
     await auth(['admin']);
+    const { entityType: entityTypeName } = await params;
 
-    const entityType = await getEntityTypeByNameWithCategory(params.entityType);
+    const entityType = await getEntityTypeByNameWithCategory(entityTypeName);
     if (!entityType) {
         notFound();
     }

--- a/apps/app/app/admin/invoices/[invoiceId]/edit/page.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/edit/page.tsx
@@ -9,12 +9,10 @@ export const dynamic = 'force-dynamic';
 
 export default async function EditInvoicePage({
     params,
-}: {
-    params: { invoiceId: string };
-}) {
+}: PageProps<'/admin/invoices/[invoiceId]/edit'>) {
     await auth(['admin']);
-
-    const invoiceId = parseInt(params.invoiceId, 10);
+    const { invoiceId: invoiceIdParam } = await params;
+    const invoiceId = parseInt(invoiceIdParam, 10);
     if (Number.isNaN(invoiceId)) {
         notFound();
     }


### PR DESCRIPTION
Update admin page handlers to use PageProps generic for typed
params and extract param values from the awaited params object.
- Change function signatures to PageProps<'/admin/.../edit'> for the
  directories and invoices edit pages.
- Destructure params with explicit local names (entityTypeName,
  invoiceIdParam) before using them.
- Pass the extracted values to existing helpers (getEntityTypeByNameWithCategory)
  and parse invoiceId after extraction.
- Remove inline anonymous params type blocks.

This clarifies typing, avoids repeated inline type declarations,
and prevents accidental misuse of the raw params object.