### PR TITLE
feat(game): show weekday before delivery slot dates

### DIFF
--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -129,16 +129,24 @@ export function DeliveryStep({
     const formatSlotTime = (slot: TimeSlotData) => {
         const start = new Date(slot.startAt);
         const end = new Date(slot.endAt);
-        return `${start.toLocaleDateString('hr-HR')} ${start.toLocaleTimeString(
-            'hr-HR',
-            {
-                hour: '2-digit',
-                minute: '2-digit',
-            },
-        )} - ${end.toLocaleTimeString('hr-HR', {
+
+        const dayOfWeek = start.toLocaleDateString('hr-HR', {
+            weekday: 'long',
+        });
+        const capitalizedDayOfWeek =
+            dayOfWeek.charAt(0).toUpperCase() + dayOfWeek.slice(1);
+
+        const datePart = start.toLocaleDateString('hr-HR');
+        const timePartStart = start.toLocaleTimeString('hr-HR', {
             hour: '2-digit',
             minute: '2-digit',
-        })}`;
+        });
+        const timePartEnd = end.toLocaleTimeString('hr-HR', {
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+
+        return `${capitalizedDayOfWeek}, ${datePart} ${timePartStart} - ${timePartEnd}`;
     };
 
     if (manageAddresses) {


### PR DESCRIPTION
## Summary
- show the weekday before the date when formatting delivery and pickup time slot labels so players can spot the right day faster

## Testing
- pnpm lint --filter @gredice/game *(fails: existing lint errors in packages/game unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a11f4138832faaea35319bb49565