### PR TITLE
feat: include dev Next types and add seasonal perks copy

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -20,6 +20,12 @@
         ],
         "target": "ESNext"
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        ".next\\dev/types/**/*.ts"
+    ],
     "exclude": ["node_modules"]
 }

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -20,6 +20,12 @@
         ],
         "target": "ESNext"
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        ".next\\dev/types/**/*.ts"
+    ],
     "exclude": ["node_modules"]
 }

--- a/apps/farm/tsconfig.json
+++ b/apps/farm/tsconfig.json
@@ -20,6 +20,12 @@
         ],
         "target": "ESNext"
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        ".next\\dev/types/**/*.ts"
+    ],
     "exclude": ["node_modules"]
 }

--- a/apps/garden/tsconfig.json
+++ b/apps/garden/tsconfig.json
@@ -20,6 +20,12 @@
         ],
         "target": "ESNext"
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        ".next\\dev/types/**/*.ts"
+    ],
     "exclude": ["node_modules"]
 }

--- a/apps/www/app/sjetva/page.tsx
+++ b/apps/www/app/sjetva/page.tsx
@@ -70,10 +70,28 @@ export default function SowingPage() {
                         vremenu sjetve, pa slobodno eksperimentiraj i istražuj
                         nove biljke!
                     </p>
+                    <h2>🌱 Proljetne pogodnosti</h2>
+                    <p>
+                        Tijekom proljeća svaka naručena sjetva donosi besplatno
+                        3 zalijevanja* &quot;
+                        <strong>Površinsko zalijevanje (10&nbsp;L)</strong>
+                        &quot; za podignutu gredicu, pri čemu se zalijevanje
+                        obavlja svaki drugi dan.
+                    </p>
+                    <small>
+                        *{' '}
+                        <i>
+                            Ako posiješ novu biljku dok je prethodni besplatni
+                            period još aktivan, zalijevanje se produžuje. Na
+                            primjer, ako tijekom 6 uzastopnih dana siješ po
+                            jednu biljku, imat ćeš ukupno 12 besplatnih
+                            zalijevanja.
+                        </i>
+                    </small>
                     <h2>☀️ Ljetne pogodnosti</h2>
                     <p>
-                        Tijekom ljeta svaka naručena sjetva donosi besplatno pet
-                        dana usluge* &quot;
+                        Tijekom ljeta svaka naručena sjetva donosi besplatno 5
+                        zalijevanja* &quot;
                         <strong>Površinsko zalijevanje (10&nbsp;L)</strong>
                         &quot; za podignutu gredicu.
                     </p>
@@ -82,9 +100,27 @@ export default function SowingPage() {
                         <i>
                             Ako posiješ novu biljku dok je prethodni besplatni
                             period još aktivan, zalijevanje se produžuje. Na
-                            primjer, ako tijekom pet uzastopnih dana siješ po
-                            jednu biljku, dobit ćeš ukupno deset dana besplatnog
-                            zalijevanja, a ne dvadeset i pet dana.
+                            primjer, ako tijekom 5 uzastopnih dana siješ po
+                            jednu biljku, imat ćeš ukupno 10 dana besplatnog
+                            zalijevanja.
+                        </i>
+                    </small>
+                    <h2>🍂 Jesenske pogodnosti</h2>
+                    <p>
+                        Tijekom jeseni svaka naručena sjetva donosi besplatno 3
+                        zalijevanja* &quot;
+                        <strong>Površinsko zalijevanje (10&nbsp;L)</strong>
+                        &quot; za podignutu gredicu, pri čemu se zalijevanje
+                        obavlja svaki drugi dan.
+                    </p>
+                    <small>
+                        *{' '}
+                        <i>
+                            Ako posiješ novu biljku dok je prethodni besplatni
+                            period još aktivan, zalijevanje se produžuje. Na
+                            primjer, ako tijekom 6 uzastopnih dana siješ po
+                            jednu biljku, imat ćeš ukupno 12 besplatnih
+                            zalijevanja.
                         </i>
                     </small>
                     <h2>💭 Sljedeći koraci</h2>

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -20,6 +20,12 @@
         ],
         "target": "ESNext"
     },
-    "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+    "include": [
+        "next-env.d.ts",
+        ".next/types/**/*.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next\\dev/types/**/*.ts"
+    ],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Update tsconfig include paths across apps (farm, www, garden,
app, api) to add ".next\dev/types/**/*.ts" so Next.js dev-only type
definitions are picked up in development environments on Windows.
This prevents missing type errors when running dev builds locally.

Add seasonal promotions content to www app sjetva page:
- Add Spring, Summer, and Autumn headings with descriptive copy.
- Clarify free watering counts (3 for spring, 5 for summer, 3 for
  autumn) and examples explaining extension when new plantings
  occur during an active free period.
- Fix summer wording to consistently reference "5 zalijevanja" and
  harmonize examples for counts and phrasing.

These changes improve developer DX by including dev type files and
enhance the public site with clearer seasonal offer information.