### PR TITLE
Stop overriding plant sort when rescheduling raised beds

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -175,10 +175,9 @@ export async function rescheduleRaisedBedFieldAction(formData: FormData) {
     }
 
     await createEvent(
-        knownEvents.raisedBedFields.plantPlaceV1(
+        knownEvents.raisedBedFields.plantScheduleV1(
             `${raisedBedId}|${positionIndex}`,
             {
-                plantSortId: field.plantSortId.toString(),
                 scheduledDate: new Date(scheduledDate).toISOString(),
             },
         ),

--- a/packages/storage/src/repositories/eventsRepo.ts
+++ b/packages/storage/src/repositories/eventsRepo.ts
@@ -44,6 +44,7 @@ export const knownEventTypes = {
         create: 'raisedBedField.create',
         delete: 'raisedBedField.delete',
         plantPlace: 'raisedBedField.plantPlace',
+        plantSchedule: 'raisedBedField.plantSchedule',
         plantUpdate: 'raisedBedField.plantUpdate',
         plantReplaceSort: 'raisedBedField.plantReplaceSort',
     },
@@ -287,6 +288,15 @@ export const knownEvents = {
             },
         ) => ({
             type: knownEventTypes.raisedBedFields.plantPlace,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        plantScheduleV1: (
+            aggregateId: string,
+            data: { scheduledDate: string | null | undefined },
+        ) => ({
+            type: knownEventTypes.raisedBedFields.plantSchedule,
             version: 1,
             aggregateId,
             data,

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -380,6 +380,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
             knownEventTypes.raisedBedFields.create,
             knownEventTypes.raisedBedFields.delete,
             knownEventTypes.raisedBedFields.plantPlace,
+            knownEventTypes.raisedBedFields.plantSchedule,
             knownEventTypes.raisedBedFields.plantUpdate,
             knownEventTypes.raisedBedFields.plantReplaceSort,
         ],
@@ -443,6 +444,25 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
 
                 // Set status to new when plant is placed
                 plantStatus = 'new';
+            }
+            // Handle plant schedule update event
+            else if (
+                event.type === knownEventTypes.raisedBedFields.plantSchedule
+            ) {
+                if (
+                    data?.scheduledDate &&
+                    typeof data.scheduledDate === 'string'
+                ) {
+                    plantScheduledDate = new Date(data.scheduledDate);
+                } else if (
+                    data?.scheduledDate &&
+                    typeof data.scheduledDate === 'object' &&
+                    data?.scheduledDate instanceof Date
+                ) {
+                    plantScheduledDate = data?.scheduledDate;
+                } else if (data?.scheduledDate == null) {
+                    plantScheduledDate = undefined;
+                }
             }
             // Handle plant status update event
             else if (
@@ -654,6 +674,7 @@ export async function getRaisedBedFieldDiaryEntries(
             [
                 knownEventTypes.raisedBedFields.create,
                 knownEventTypes.raisedBedFields.plantPlace,
+                knownEventTypes.raisedBedFields.plantSchedule,
                 knownEventTypes.raisedBedFields.plantUpdate,
                 knownEventTypes.raisedBedFields.plantReplaceSort,
                 knownEventTypes.raisedBedFields.delete,
@@ -689,6 +710,11 @@ export async function getRaisedBedFieldDiaryEntries(
                     name = 'Zatraženo sijanje biljke';
                     description =
                         'Sijanje biljke je zatraženo i čeka na odobrenje.';
+                    break;
+                }
+                case knownEventTypes.raisedBedFields.plantSchedule: {
+                    name = 'Ažuriran termin sijanja';
+                    description = 'Termin sijanja biljke je promijenjen.';
                     break;
                 }
                 case knownEventTypes.raisedBedFields.plantUpdate: {


### PR DESCRIPTION
## Summary
- remove the extra plant sort handling added to the raised bed reschedule action
- drop the hidden plant sort field from the reschedule modal so submissions rely on the stored sort

## Testing
- pnpm lint --filter app

------
https://chatgpt.com/codex/tasks/task_e_68e984ad14f4832f9ca8341a3bf25656