### PR TITLE
feat(ui): filter-pick by available sorts and wait for sorts

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -130,8 +130,10 @@ export function RaisedBedFieldSuggestions({
             Array.from({ length: 9 }).map(async (_, index) => {
                 if (!raisedBed || !shoppingCart) return;
 
-                // If not in store, ignore
                 const sortId = layout[index];
+                if (!sortId) return;
+
+                // If not in store, ignore
                 const sort = allSorts.find((item) => item.id === sortId);
                 if (!sort?.store?.availableInStore) return;
 
@@ -152,11 +154,11 @@ export function RaisedBedFieldSuggestions({
                     )
                 )
                     return;
-                const plantSortId = layout[index];
-                if (plantSortId == null) return;
+
+                if (sortId == null) return;
                 return setCartItem.mutateAsync({
                     entityTypeName: 'plantSort',
-                    entityId: plantSortId.toString(),
+                    entityId: sortId.toString(),
                     amount: 1,
                     gardenId,
                     raisedBedId,


### PR DESCRIPTION
Add useAllSorts hook to RaisedBedFieldSuggestions and ensure quick-
pick actions only add seeds that are available in the store. Guard
quick-pick early return on missing sorts data and skip layout slots
where the referenced sort is not found or not availableInStore.

Also include isLoadingSorts in button loading state so the quick-
pick buttons show loading while sort data is being fetched. This
prevents adding unavailable sorts and avoids race conditions when
sort metadata is not yet loaded.