### PR TITLE
feat(next): enable turbopack fs cache and turbopack flagsEnable turbopackFileSystemForDev in all Next.js configs to

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
     reactStrictMode: true,
     experimental: {
         typedEnv: true,
+        turbopackFileSystemCacheForDev: true,
     },
     images: {
         remotePatterns: [

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,8 +8,8 @@
     },
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbopack -p 3005",
-        "build": "next build --turbopack",
+        "dev": "next dev -p 3005",
+        "build": "next build",
         "start": "next start -p 3005",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
     experimental: {
         typedEnv: true,
+        turbopackFileSystemCacheForDev: true,
         serverActions: {
             bodySizeLimit: '10mb',
         },

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -5,8 +5,8 @@
     "type": "module",
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbopack -p 3003",
-        "build": "next build --turbopack",
+        "dev": "next dev -p 3003",
+        "build": "next build",
         "start": "next start -p 3003",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",

--- a/apps/farm/next.config.ts
+++ b/apps/farm/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
     typedRoutes: true,
     reactCompiler: true,
     experimental: {
+        turbopackFileSystemCacheForDev: true,
         typedEnv: true,
     },
     expireTime: 10800, // CDN ISR expiration time: 3 hour in seconds

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -5,8 +5,8 @@
     "type": "module",
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbopack -p 3002",
-        "build": "next build --turbopack",
+        "dev": "next dev -p 3002",
+        "build": "next build",
         "start": "next start -p 3002",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",

--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
     typedRoutes: true,
     reactCompiler: true,
     experimental: {
+        turbopackFileSystemCacheForDev: true,
         typedEnv: true,
     },
     expireTime: 10800, // CDN ISR expiration time: 3 hour in seconds

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -5,8 +5,8 @@
     "type": "module",
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbo -p 3001",
-        "build": "next build --turbopack",
+        "dev": "next dev -p 3001",
+        "build": "next build",
         "start": "next start -p 3001",
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
     typedRoutes: true,
     reactCompiler: true,
     experimental: {
+        turbopackFileSystemCacheForDev: true,
         typedEnv: true,
     },
     expireTime: 10800, // CDN ISR expiration time: 3 hour in seconds

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,8 +5,8 @@
     "type": "module",
     "scripts": {
         "lint": "biome check",
-        "dev": "next dev --turbopack -p 3000",
-        "build": "next build --turbopack",
+        "dev": "next dev -p 3000",
+        "build": "next build",
         "postbuild": "next-sitemap --config next-sitemap.config.cjs",
         "start": "next start -p 3000",
         "test": "pnpm run /^test:.*/",


### PR DESCRIPTION
improve dev performance by caching filesystem data when Turbopack is
available. This adds the experimental flag to studios: app, www, farm,
garden and api Next.js configs.

Also remove explicit --turbopack/--turbo CLI flags from package.json
scripts and stop forcing Turbopack at build/dev time. Scripts now use
the default Next.js commands (next dev / next build) and preserve
custom ports for each app. This avoids forcing a specific bundler and
lets Next.js choose the appropriate compiler (or respect local
configuration), while still benefiting from the filesystem cache when
available.