### PR TITLE
fix(email, notifications): update wording for delivery survey copy

### DIFF
--- a/apps/api/app/api/internal/cron/delivery-survey/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-survey/route.ts
@@ -147,7 +147,7 @@ export async function GET(request: NextRequest) {
             await createNotification({
                 accountId: group.accountId,
                 header: `📣 Kako su ti se svidjele dostave u ${formattedMonth}?`,
-                content: `U ${formattedMonth} imali smo ${deliveryCountText} dostava. Podijeli svoje dojmove i ispuni kratku anketu 📋⭐️⭐️⭐️⭐️⭐️`,
+                content: `U ${formattedMonth} imali smo ${deliveryCountText}. Podijeli svoje dojmove i ispuni kratku anketu 📋⭐️⭐️⭐️⭐️⭐️`,
                 linkUrl: SURVEY_URL,
                 timestamp: new Date(),
             });

--- a/apps/api/lib/email/transactional.ts
+++ b/apps/api/lib/email/transactional.ts
@@ -70,7 +70,7 @@ export async function sendDeliverySurvey(
     return await sendEmail({
         from: 'suncokret@obavijesti.gredice.com',
         to,
-        subject: 'Gredice - podijeli dojam o dostavi',
+        subject: 'Gredice - podijeli dojam o dostavama',
         template: DeliverySurveyEmailTemplate(config),
     });
 }

--- a/packages/transactional/emails/Notifications/delivery-survey.tsx
+++ b/packages/transactional/emails/Notifications/delivery-survey.tsx
@@ -31,7 +31,7 @@ export default function DeliverySurveyEmailTemplate({
     appName = 'Gredice',
     appDomain = 'gredice.com',
 }: DeliverySurveyEmailTemplateProps) {
-    const previewText = `${appName} - Podijeli dojam o dostavi`;
+    const previewText = `${appName} - Podijeli dojam o dostavama`;
 
     const periodSummary = deliveryPeriod
         ? `🚚 Tijekom ${deliveryPeriod} ${
@@ -50,7 +50,7 @@ export default function DeliverySurveyEmailTemplate({
                     <Section className="text-center">
                         <GrediceLogotype />
                     </Section>
-                    <Header>Kakva su bile dostave?</Header>
+                    <Header>Kakve su bile dostave?</Header>
                     <Paragraph>Pozdrav!</Paragraph>
                     <Paragraph>
                         Nadamo se da te povrće iz tvog vrta razveselilo.{' '}
@@ -60,7 +60,7 @@ export default function DeliverySurveyEmailTemplate({
                         <Paragraph>{periodSummary}</Paragraph>
                     ) : null}
                     <Paragraph>
-                        ⏱️ Anketa traje manje od minute, a svaki odgovor pomaže našem timu i vrtlarima.
+                        ⏱️ Anketa traje manje od minute, a svaki odgovor pomaže našem timu unaprijediti uslugu dostave.
                     </Paragraph>
                     <Section className="my-[32px] text-center">
                         <PrimaryButton href={surveyUrl}>Ispuni anketu</PrimaryButton>


### PR DESCRIPTION
Update delivery survey copy to use "dostavama" and improve
clarity across email template, notification content, and subject.

- Change preview, email subject, and transactional send to
  "podijeli dojam o dostavama" for consistent plural usage.
- Adjust email header from "Kakva su bile dostave?" to
  "Kakve su bile dostave?" to fix grammar.
- Clarify survey blurb to state responses help "unaprijediti uslugu
  dostave" instead of a shorter ambiguous phrase.
- Remove redundant "dostava" word from notification content to
  avoid repetition ("imali smo X" -> "imali smo X.").

These wording updates improve consistency and clarity for users
receiving the delivery survey.