### PR TITLE
Add quick access links to admin dashboard

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import type { getAnalyticsTotals } from '@gredice/storage';
+import { Calendar, Fence } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
 import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -87,6 +89,25 @@ export function AdminDashboardClient({
 
     return (
         <Stack spacing={2}>
+            <Stack spacing={1}>
+                <DashboardDivider>Brzi pristup</DashboardDivider>
+                <Row spacing={1}>
+                    <Button
+                        variant="outlined"
+                        startDecorator={<Calendar className="size-5" />}
+                        href={KnownPages.Schedule}
+                    >
+                        Raspored
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        startDecorator={<Fence className="size-5" />}
+                        href={KnownPages.Gardens}
+                    >
+                        Vrtovi
+                    </Button>
+                </Row>
+            </Stack>
             <Stack spacing={1}>
                 <Row justifyContent="space-between">
                     <DashboardDivider>Računi i korisnici</DashboardDivider>


### PR DESCRIPTION
## Summary
- add quick access buttons on the admin dashboard to reach the schedule and gardens quickly

## Testing
- pnpm lint --filter app

------
https://chatgpt.com/codex/tasks/task_e_68ef9db5e9d8832f9d0a37fc2fae6b78