### PR TITLE
fix(raised-bed): ignore inactive fields when searching

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -50,7 +50,7 @@ export async function raisedBedFieldUpdatePlant({
     // If a plant sort id is provided and differs from current field, place the plant
     const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
     const existingField = raisedBed.fields.find(
-        (field) => field.positionIndex === positionIndex,
+        (field) => field.positionIndex === positionIndex && field.active,
     );
     if (plantSortId && existingField?.plantSortId !== plantSortId) {
         await createEvent(
@@ -168,7 +168,7 @@ export async function rescheduleRaisedBedFieldAction(formData: FormData) {
         throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
     }
     const field = raisedBed.fields.find(
-        (f) => f.positionIndex === positionIndex,
+        (f) => f.positionIndex === positionIndex && f.active,
     );
     if (!field || !field.plantSortId) {
         throw new Error('Field or plant sort not found.');
@@ -218,7 +218,7 @@ export async function cancelRaisedBedFieldAction(formData: FormData) {
         throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
     }
     const field = raisedBed.fields.find(
-        (f) => f.positionIndex === positionIndex,
+        (f) => f.positionIndex === positionIndex && f.active,
     );
     if (!field) {
         throw new Error(


### PR DESCRIPTION
Ensure field lookups only consider active fields to avoid
interacting with deactivated entries. Update three search sites
to add an "active" check on positionIndex matches so actions
like placing plants, retrieving plant sort, and other field
operations skip inactive records. This prevents incorrect
matches and potential errors when inactive fields share the
same positionIndex as active ones.