### PR TITLE
feat(ui): update dashboard quick-access buttons and icons

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { getAnalyticsTotals } from '@gredice/storage';
-import { Calendar, Fence, Tally3 } from '@signalco/ui-icons';
+import { Calendar, Tally3 } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';


### PR DESCRIPTION
Refactor the Admin dashboard quick-access area to use compact,
rounded pill buttons and updated icons for consistency and clarity.

- Replace the two-button stacked layout with a single Row of small,
  rounded-full buttons to save vertical space and improve visual flow.
- Update Calendar button: apply size="sm", rounded-full class and a
  smaller Calendar icon with shrink-0 to prevent icon scaling.
- Replace Fence button with a Tally3 icon rotated and nudged to match
  visual orientation, change target page from Gardens to RaisedBeds,
  and update label from "Vrtovi" to "Gredice".
- Import the new Tally3 icon from @signalco/ui-icons.

These changes improve compactness and alignment of quick actions and
correct the target/navigation for raised beds.