### PR TITLE
fix(ui): replace Image with img and simplify LoginModal layout

### DIFF
--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -123,16 +123,8 @@ export default function LoginModal() {
             dismissible={false}
         >
             <Tabs defaultValue="login" className="w-full">
-                <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 w-full">
-                    <Image
-                        src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/GrediceLogomark-v1LQ0bdzsonOf0SXkAUHj0h4G36mGB.svg"
-                        alt="Gredice Logo"
-                        width={32}
-                        height={32}
-                        priority
-                        className="dark:mix-blend-plus-lighter"
-                    />
-                    <TabsList className="grid w-full grid-cols-2">
+                <div className="flex justify-center w-full">
+                    <TabsList className="grid grid-cols-2">
                         <TabsTrigger value="login">Prijava</TabsTrigger>
                         <TabsTrigger value="register">Registracija</TabsTrigger>
                     </TabsList>

--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -305,11 +305,10 @@ export function ImageViewer({
                                     transformOrigin: 'center center',
                                 }}
                             >
-                                <Image
+                                {/** biome-ignore lint/performance/noImgElement: <explanation> */}
+                                <img
                                     src={src}
                                     alt={alt}
-                                    fill
-                                    sizes="100vw"
                                     className="object-contain select-none"
                                     draggable={false}
                                 />


### PR DESCRIPTION
Replace Next/Image usage inside ImageViewer with a <img> and add a
biome-ignore lint comment to avoid the performance lint. This Next
Image-specific (fill, sizes) and keeps the image as an object-contain,
non-draggable element. The change is done to avoid framework-specific image
components in this context and simplify rendering where responsive
optimization is not required.

Simplify the LoginModal header layout by removing the hard-coded Image logo
and grid spacer. Replace the three-column grid with a centered flex container
and keep only the TabsList with two triggers. This reduces visual clutter
and simplifies structure when the logo is not needed.