### PR TITLE
fix(api+types): add null-safety and make many DTO fields optional

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -752,7 +752,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             // Retrieve block information (cost)
             const block = blockData.find(
-                (block) => block.information.name === blockName,
+                (block) => block.information?.name === blockName,
             );
             if (!block) {
                 return context.json(
@@ -760,7 +760,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     400,
                 );
             }
-            const cost = block.prices.sunflowers ?? 0;
+            const cost = block.prices?.sunflowers ?? 0;
             if (cost <= 0) {
                 return context.json(
                     { error: 'Requested block not for sale' },
@@ -770,12 +770,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             // Spend sunflowers and create block in parallel
             const [, blockId] = await Promise.all([
-                spendSunflowers(
-                    accountId,
-                    cost,
-                    `block:${block.information.name}`,
-                ),
-                createGardenBlock(gardenIdNumber, block.information.name),
+                spendSunflowers(accountId, cost, `block:${blockName}`),
+                createGardenBlock(gardenIdNumber, blockName),
             ]);
 
             return context.json({ id: blockId });

--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -412,7 +412,7 @@ export interface components {
                 /** @default Biljka */
                 label: string;
             };
-            calendar: {
+            calendar?: {
                 planting?: {
                     start?: number;
                     end?: number;
@@ -430,7 +430,7 @@ export interface components {
                     end?: number;
                 }[];
             };
-            attributes: {
+            attributes?: {
                 /** @description (u gramima) */
                 yieldMax: number;
                 /** @description (u danima) */
@@ -465,7 +465,7 @@ export interface components {
                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                 yieldType: string;
             };
-            information: {
+            information?: {
                 storage: string;
                 maintenance: string;
                 /** @description Informacije o berbi biljke. */
@@ -479,8 +479,8 @@ export interface components {
                 latinName: string;
                 description: string;
                 operations: {
-                    id?: number;
-                    attributes?: {
+                    id: number;
+                    attributes: {
                         /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                         relativeDays?: number;
                         /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -500,10 +500,10 @@ export interface components {
                         /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                         deliverable: boolean;
                     };
-                    image?: {
+                    image: {
                         cover?: components["schemas"]["image"];
                     };
-                    information?: {
+                    information: {
                         /** @description (prevedeni naziv operacije) */
                         label: string;
                         /** @description (kratki opis operacije) */
@@ -515,7 +515,7 @@ export interface components {
                         /** @description (postupak za izvršavanje radnje) */
                         instructions: string;
                     };
-                    prices?: {
+                    prices: {
                         /** @description (EUR cijena za jednu operaciju) */
                         perOperation: number;
                         /** @description (EUR cijena s popustom) */
@@ -523,7 +523,7 @@ export interface components {
                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                         discountDescription?: string;
                     };
-                    conditions?: {
+                    conditions: {
                         /** @description (da li je obavezno proložiti slike za završetak radnje) */
                         completionAttachImagesRequired: boolean;
                         /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -533,19 +533,20 @@ export interface components {
                 flowering?: string;
                 tip?: {
                     header?: string;
+                    /** @description Markdown formatted text */
                     content?: string;
                 }[];
                 soilPreparation: string;
                 growth: string;
             };
-            prices: {
+            prices?: {
                 /** @description (EUR cijena za jednu biljku - presadnica ili 30x30cm sijanje) */
                 perPlant: number;
             };
-            image: {
+            image?: {
                 cover: components["schemas"]["image"];
             };
-            store: {
+            store?: {
                 availableInStore: boolean;
             };
             /** Format: date-time */
@@ -563,7 +564,7 @@ export interface components {
                 /** @default Sorta biljke */
                 label: string;
             };
-            information: {
+            information?: {
                 planting?: string;
                 flowering?: string;
                 plant: {
@@ -635,8 +636,8 @@ export interface components {
                         latinName: string;
                         description: string;
                         operations: {
-                            id?: number;
-                            attributes?: {
+                            id: number;
+                            attributes: {
                                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                                 relativeDays?: number;
                                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -656,10 +657,10 @@ export interface components {
                                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                                 deliverable: boolean;
                             };
-                            image?: {
+                            image: {
                                 cover?: components["schemas"]["image"];
                             };
-                            information?: {
+                            information: {
                                 /** @description (prevedeni naziv operacije) */
                                 label: string;
                                 /** @description (kratki opis operacije) */
@@ -671,7 +672,7 @@ export interface components {
                                 /** @description (postupak za izvršavanje radnje) */
                                 instructions: string;
                             };
-                            prices?: {
+                            prices: {
                                 /** @description (EUR cijena za jednu operaciju) */
                                 perOperation: number;
                                 /** @description (EUR cijena s popustom) */
@@ -679,7 +680,7 @@ export interface components {
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
                             };
-                            conditions?: {
+                            conditions: {
                                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                                 completionAttachImagesRequired: boolean;
                                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -689,6 +690,7 @@ export interface components {
                         flowering?: string;
                         tip?: {
                             header?: string;
+                            /** @description Markdown formatted text */
                             content?: string;
                         }[];
                         soilPreparation: string;
@@ -718,13 +720,13 @@ export interface components {
                 harvest?: string;
                 shortDescription: string;
             };
-            image: {
+            image?: {
                 cover?: components["schemas"]["image"];
             };
-            store: {
+            store?: {
                 availableInStore: boolean;
             };
-            attributes: {
+            attributes?: {
                 /** @description (vrsta reprodukcije sorte dostupne u Gredicama; "seed" ili "bulb") */
                 reproductionType: string;
             };
@@ -743,7 +745,7 @@ export interface components {
                 /** @default Stadij biljke */
                 label: string;
             };
-            information: {
+            information?: {
                 name: string;
                 label: string;
             };
@@ -762,7 +764,7 @@ export interface components {
                 /** @default Sjeme */
                 label: string;
             };
-            information: {
+            information?: {
                 name: string;
                 barcode?: string;
                 brand: {
@@ -841,8 +843,8 @@ export interface components {
                         latinName: string;
                         description: string;
                         operations: {
-                            id?: number;
-                            attributes?: {
+                            id: number;
+                            attributes: {
                                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                                 relativeDays?: number;
                                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -862,10 +864,10 @@ export interface components {
                                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                                 deliverable: boolean;
                             };
-                            image?: {
+                            image: {
                                 cover?: components["schemas"]["image"];
                             };
-                            information?: {
+                            information: {
                                 /** @description (prevedeni naziv operacije) */
                                 label: string;
                                 /** @description (kratki opis operacije) */
@@ -877,7 +879,7 @@ export interface components {
                                 /** @description (postupak za izvršavanje radnje) */
                                 instructions: string;
                             };
-                            prices?: {
+                            prices: {
                                 /** @description (EUR cijena za jednu operaciju) */
                                 perOperation: number;
                                 /** @description (EUR cijena s popustom) */
@@ -885,7 +887,7 @@ export interface components {
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
                             };
-                            conditions?: {
+                            conditions: {
                                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                                 completionAttachImagesRequired: boolean;
                                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -895,6 +897,7 @@ export interface components {
                         flowering?: string;
                         tip?: {
                             header?: string;
+                            /** @description Markdown formatted text */
                             content?: string;
                         }[];
                         soilPreparation: string;
@@ -985,8 +988,8 @@ export interface components {
                                 latinName: string;
                                 description: string;
                                 operations: {
-                                    id?: number;
-                                    attributes?: {
+                                    id: number;
+                                    attributes: {
                                         /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                                         relativeDays?: number;
                                         /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -1006,10 +1009,10 @@ export interface components {
                                         /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                                         deliverable: boolean;
                                     };
-                                    image?: {
+                                    image: {
                                         cover?: components["schemas"]["image"];
                                     };
-                                    information?: {
+                                    information: {
                                         /** @description (prevedeni naziv operacije) */
                                         label: string;
                                         /** @description (kratki opis operacije) */
@@ -1021,7 +1024,7 @@ export interface components {
                                         /** @description (postupak za izvršavanje radnje) */
                                         instructions: string;
                                     };
-                                    prices?: {
+                                    prices: {
                                         /** @description (EUR cijena za jednu operaciju) */
                                         perOperation: number;
                                         /** @description (EUR cijena s popustom) */
@@ -1029,7 +1032,7 @@ export interface components {
                                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                         discountDescription?: string;
                                     };
-                                    conditions?: {
+                                    conditions: {
                                         /** @description (da li je obavezno proložiti slike za završetak radnje) */
                                         completionAttachImagesRequired: boolean;
                                         /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -1039,6 +1042,7 @@ export interface components {
                                 flowering?: string;
                                 tip?: {
                                     header?: string;
+                                    /** @description Markdown formatted text */
                                     content?: string;
                                 }[];
                                 soilPreparation: string;
@@ -1081,10 +1085,10 @@ export interface components {
                 };
                 countryOfOrigin?: string;
             };
-            application: {
+            application?: {
                 applicationArea?: number;
             };
-            attributes: {
+            attributes?: {
                 germinationPercentage?: number;
                 /** @description (cijena pakiranja u EUR) */
                 price: number;
@@ -1106,7 +1110,7 @@ export interface components {
                 /** @default Brend sjemena */
                 label: string;
             };
-            information: {
+            information?: {
                 website?: string;
                 name: string;
             };
@@ -1125,7 +1129,7 @@ export interface components {
                 /** @default Radnje */
                 label: string;
             };
-            attributes: {
+            attributes?: {
                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                 relativeDays?: number;
                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -1145,10 +1149,10 @@ export interface components {
                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                 deliverable: boolean;
             };
-            image: {
+            image?: {
                 cover?: components["schemas"]["image"];
             };
-            information: {
+            information?: {
                 /** @description (prevedeni naziv operacije) */
                 label: string;
                 /** @description (kratki opis operacije) */
@@ -1160,7 +1164,7 @@ export interface components {
                 /** @description (postupak za izvršavanje radnje) */
                 instructions: string;
             };
-            prices: {
+            prices?: {
                 /** @description (EUR cijena za jednu operaciju) */
                 perOperation: number;
                 /** @description (EUR cijena s popustom) */
@@ -1168,7 +1172,7 @@ export interface components {
                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                 discountDescription?: string;
             };
-            conditions: {
+            conditions?: {
                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                 completionAttachImagesRequired: boolean;
                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -1204,12 +1208,12 @@ export interface components {
                 /** @default FAQ */
                 label: string;
             };
-            information: {
+            information?: {
                 header: string;
                 name: string;
                 content: string;
             };
-            attributes: {
+            attributes?: {
                 tags?: string[];
                 category: {
                     id?: number;
@@ -1234,7 +1238,7 @@ export interface components {
                 /** @default FAQ Kategorija */
                 label: string;
             };
-            information: {
+            information?: {
                 name: string;
                 label: string;
             };
@@ -1253,22 +1257,22 @@ export interface components {
                 /** @default Blok */
                 label: string;
             };
-            attributes: {
+            attributes?: {
                 /** @description (jedan od: decoration, raisedBed, raisedBedPart, plant, plantPart) */
                 type: string;
                 height: number;
                 stackable: boolean;
             };
-            information: {
+            information?: {
                 shortDescription: string;
                 fullDescription: string;
                 name: string;
                 label: string;
             };
-            prices: {
+            prices?: {
                 sunflowers: number;
             };
-            functions: {
+            functions?: {
                 /** @description Blokovi koji predstavljaju podignutu gredicu */
                 raisedBed: boolean;
                 /** @description Blokovi koji mogu reciklirati druge blokove */

--- a/apps/api/lib/garden/gardenBlocksService.ts
+++ b/apps/api/lib/garden/gardenBlocksService.ts
@@ -45,7 +45,7 @@ export async function deleteGardenBlock(
 
     // Retrieve block data
     const blockData = blocksData.find(
-        (bd) => bd.information.name === block.name,
+        (bd) => bd.information?.name === block.name,
     );
     if (!blockData) {
         console.warn('Block data not found', { blockId });
@@ -72,7 +72,7 @@ export async function deleteGardenBlock(
     }
 
     // Retrieve block price
-    const price = blockData.prices.sunflowers ?? 0;
+    const price = blockData.prices?.sunflowers ?? 0;
     if (price <= 0) {
         console.warn(
             "Block not for sale so we can't refund. Will continue with removal.",
@@ -95,11 +95,7 @@ export async function deleteGardenBlock(
     // Prepare block refund operation
     const refundBlockPromise =
         price > 0
-            ? earnSunflowers(
-                  garden.accountId,
-                  price,
-                  `recycle:${blockData.information.name}`,
-              )
+            ? earnSunflowers(garden.accountId, price, `recycle:${block.name}`)
             : Promise.resolve();
 
     await Promise.all([

--- a/apps/garden/components/GardenDisplay2D.tsx
+++ b/apps/garden/components/GardenDisplay2D.tsx
@@ -122,16 +122,16 @@ export function GardenDisplay2D({
                             underStackHeight +=
                                 blockData?.find(
                                     (b) =>
-                                        b.information.name ===
+                                        b.information?.name ===
                                         currentBlock.name,
-                                )?.attributes.height ?? 0;
+                                )?.attributes?.height ?? 0;
                         }
 
                         // Large blocks do snaphots with zoomed view so we need to compensite with 1.5x size and -0.25x offset
                         const isLargeBlock =
                             (blockData?.find(
-                                (b) => b.information.name === block.name,
-                            )?.attributes.height ?? 0) > 1.5;
+                                (b) => b.information?.name === block.name,
+                            )?.attributes?.height ?? 0) > 1.5;
                         const realizedBlockSize = isLargeBlock
                             ? blockSize * 1.5
                             : blockSize;

--- a/packages/client/src/lib/directories-api/v1.d.ts
+++ b/packages/client/src/lib/directories-api/v1.d.ts
@@ -412,7 +412,7 @@ export interface components {
                 /** @default Biljka */
                 label: string;
             };
-            calendar: {
+            calendar?: {
                 planting?: {
                     start?: number;
                     end?: number;
@@ -430,7 +430,7 @@ export interface components {
                     end?: number;
                 }[];
             };
-            attributes: {
+            attributes?: {
                 /** @description (u gramima) */
                 yieldMax: number;
                 /** @description (u danima) */
@@ -465,7 +465,7 @@ export interface components {
                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                 yieldType: string;
             };
-            information: {
+            information?: {
                 storage: string;
                 maintenance: string;
                 /** @description Informacije o berbi biljke. */
@@ -479,8 +479,8 @@ export interface components {
                 latinName: string;
                 description: string;
                 operations: {
-                    id?: number;
-                    attributes?: {
+                    id: number;
+                    attributes: {
                         /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                         relativeDays?: number;
                         /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -500,10 +500,10 @@ export interface components {
                         /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                         deliverable: boolean;
                     };
-                    image?: {
+                    image: {
                         cover?: components["schemas"]["image"];
                     };
-                    information?: {
+                    information: {
                         /** @description (prevedeni naziv operacije) */
                         label: string;
                         /** @description (kratki opis operacije) */
@@ -515,7 +515,7 @@ export interface components {
                         /** @description (postupak za izvršavanje radnje) */
                         instructions: string;
                     };
-                    prices?: {
+                    prices: {
                         /** @description (EUR cijena za jednu operaciju) */
                         perOperation: number;
                         /** @description (EUR cijena s popustom) */
@@ -523,7 +523,7 @@ export interface components {
                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                         discountDescription?: string;
                     };
-                    conditions?: {
+                    conditions: {
                         /** @description (da li je obavezno proložiti slike za završetak radnje) */
                         completionAttachImagesRequired: boolean;
                         /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -533,19 +533,20 @@ export interface components {
                 flowering?: string;
                 tip?: {
                     header?: string;
+                    /** @description Markdown formatted text */
                     content?: string;
                 }[];
                 soilPreparation: string;
                 growth: string;
             };
-            prices: {
+            prices?: {
                 /** @description (EUR cijena za jednu biljku - presadnica ili 30x30cm sijanje) */
                 perPlant: number;
             };
-            image: {
+            image?: {
                 cover: components["schemas"]["image"];
             };
-            store: {
+            store?: {
                 availableInStore: boolean;
             };
             /** Format: date-time */
@@ -563,7 +564,7 @@ export interface components {
                 /** @default Sorta biljke */
                 label: string;
             };
-            information: {
+            information?: {
                 planting?: string;
                 flowering?: string;
                 plant: {
@@ -635,8 +636,8 @@ export interface components {
                         latinName: string;
                         description: string;
                         operations: {
-                            id?: number;
-                            attributes?: {
+                            id: number;
+                            attributes: {
                                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                                 relativeDays?: number;
                                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -656,10 +657,10 @@ export interface components {
                                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                                 deliverable: boolean;
                             };
-                            image?: {
+                            image: {
                                 cover?: components["schemas"]["image"];
                             };
-                            information?: {
+                            information: {
                                 /** @description (prevedeni naziv operacije) */
                                 label: string;
                                 /** @description (kratki opis operacije) */
@@ -671,7 +672,7 @@ export interface components {
                                 /** @description (postupak za izvršavanje radnje) */
                                 instructions: string;
                             };
-                            prices?: {
+                            prices: {
                                 /** @description (EUR cijena za jednu operaciju) */
                                 perOperation: number;
                                 /** @description (EUR cijena s popustom) */
@@ -679,7 +680,7 @@ export interface components {
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
                             };
-                            conditions?: {
+                            conditions: {
                                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                                 completionAttachImagesRequired: boolean;
                                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -689,6 +690,7 @@ export interface components {
                         flowering?: string;
                         tip?: {
                             header?: string;
+                            /** @description Markdown formatted text */
                             content?: string;
                         }[];
                         soilPreparation: string;
@@ -718,13 +720,13 @@ export interface components {
                 harvest?: string;
                 shortDescription: string;
             };
-            image: {
+            image?: {
                 cover?: components["schemas"]["image"];
             };
-            store: {
+            store?: {
                 availableInStore: boolean;
             };
-            attributes: {
+            attributes?: {
                 /** @description (vrsta reprodukcije sorte dostupne u Gredicama; "seed" ili "bulb") */
                 reproductionType: string;
             };
@@ -743,7 +745,7 @@ export interface components {
                 /** @default Stadij biljke */
                 label: string;
             };
-            information: {
+            information?: {
                 name: string;
                 label: string;
             };
@@ -762,7 +764,7 @@ export interface components {
                 /** @default Sjeme */
                 label: string;
             };
-            information: {
+            information?: {
                 name: string;
                 barcode?: string;
                 brand: {
@@ -841,8 +843,8 @@ export interface components {
                         latinName: string;
                         description: string;
                         operations: {
-                            id?: number;
-                            attributes?: {
+                            id: number;
+                            attributes: {
                                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                                 relativeDays?: number;
                                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -862,10 +864,10 @@ export interface components {
                                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                                 deliverable: boolean;
                             };
-                            image?: {
+                            image: {
                                 cover?: components["schemas"]["image"];
                             };
-                            information?: {
+                            information: {
                                 /** @description (prevedeni naziv operacije) */
                                 label: string;
                                 /** @description (kratki opis operacije) */
@@ -877,7 +879,7 @@ export interface components {
                                 /** @description (postupak za izvršavanje radnje) */
                                 instructions: string;
                             };
-                            prices?: {
+                            prices: {
                                 /** @description (EUR cijena za jednu operaciju) */
                                 perOperation: number;
                                 /** @description (EUR cijena s popustom) */
@@ -885,7 +887,7 @@ export interface components {
                                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                 discountDescription?: string;
                             };
-                            conditions?: {
+                            conditions: {
                                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                                 completionAttachImagesRequired: boolean;
                                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -895,6 +897,7 @@ export interface components {
                         flowering?: string;
                         tip?: {
                             header?: string;
+                            /** @description Markdown formatted text */
                             content?: string;
                         }[];
                         soilPreparation: string;
@@ -985,8 +988,8 @@ export interface components {
                                 latinName: string;
                                 description: string;
                                 operations: {
-                                    id?: number;
-                                    attributes?: {
+                                    id: number;
+                                    attributes: {
                                         /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                                         relativeDays?: number;
                                         /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -1006,10 +1009,10 @@ export interface components {
                                         /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                                         deliverable: boolean;
                                     };
-                                    image?: {
+                                    image: {
                                         cover?: components["schemas"]["image"];
                                     };
-                                    information?: {
+                                    information: {
                                         /** @description (prevedeni naziv operacije) */
                                         label: string;
                                         /** @description (kratki opis operacije) */
@@ -1021,7 +1024,7 @@ export interface components {
                                         /** @description (postupak za izvršavanje radnje) */
                                         instructions: string;
                                     };
-                                    prices?: {
+                                    prices: {
                                         /** @description (EUR cijena za jednu operaciju) */
                                         perOperation: number;
                                         /** @description (EUR cijena s popustom) */
@@ -1029,7 +1032,7 @@ export interface components {
                                         /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                                         discountDescription?: string;
                                     };
-                                    conditions?: {
+                                    conditions: {
                                         /** @description (da li je obavezno proložiti slike za završetak radnje) */
                                         completionAttachImagesRequired: boolean;
                                         /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -1039,6 +1042,7 @@ export interface components {
                                 flowering?: string;
                                 tip?: {
                                     header?: string;
+                                    /** @description Markdown formatted text */
                                     content?: string;
                                 }[];
                                 soilPreparation: string;
@@ -1081,10 +1085,10 @@ export interface components {
                 };
                 countryOfOrigin?: string;
             };
-            application: {
+            application?: {
                 applicationArea?: number;
             };
-            attributes: {
+            attributes?: {
                 germinationPercentage?: number;
                 /** @description (cijena pakiranja u EUR) */
                 price: number;
@@ -1106,7 +1110,7 @@ export interface components {
                 /** @default Brend sjemena */
                 label: string;
             };
-            information: {
+            information?: {
                 website?: string;
                 name: string;
             };
@@ -1125,7 +1129,7 @@ export interface components {
                 /** @default Radnje */
                 label: string;
             };
-            attributes: {
+            attributes?: {
                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                 relativeDays?: number;
                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -1145,10 +1149,10 @@ export interface components {
                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                 deliverable: boolean;
             };
-            image: {
+            image?: {
                 cover?: components["schemas"]["image"];
             };
-            information: {
+            information?: {
                 /** @description (prevedeni naziv operacije) */
                 label: string;
                 /** @description (kratki opis operacije) */
@@ -1160,7 +1164,7 @@ export interface components {
                 /** @description (postupak za izvršavanje radnje) */
                 instructions: string;
             };
-            prices: {
+            prices?: {
                 /** @description (EUR cijena za jednu operaciju) */
                 perOperation: number;
                 /** @description (EUR cijena s popustom) */
@@ -1168,7 +1172,7 @@ export interface components {
                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                 discountDescription?: string;
             };
-            conditions: {
+            conditions?: {
                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                 completionAttachImagesRequired: boolean;
                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -1204,12 +1208,12 @@ export interface components {
                 /** @default FAQ */
                 label: string;
             };
-            information: {
+            information?: {
                 header: string;
                 name: string;
                 content: string;
             };
-            attributes: {
+            attributes?: {
                 tags?: string[];
                 category: {
                     id?: number;
@@ -1234,7 +1238,7 @@ export interface components {
                 /** @default FAQ Kategorija */
                 label: string;
             };
-            information: {
+            information?: {
                 name: string;
                 label: string;
             };
@@ -1253,22 +1257,22 @@ export interface components {
                 /** @default Blok */
                 label: string;
             };
-            attributes: {
+            attributes?: {
                 /** @description (jedan od: decoration, raisedBed, raisedBedPart, plant, plantPart) */
                 type: string;
                 height: number;
                 stackable: boolean;
             };
-            information: {
+            information?: {
                 shortDescription: string;
                 fullDescription: string;
                 name: string;
                 label: string;
             };
-            prices: {
+            prices?: {
                 sunflowers: number;
             };
-            functions: {
+            functions?: {
                 /** @description Blokovi koji predstavljaju podignutu gredicu */
                 raisedBed: boolean;
                 /** @description Blokovi koji mogu reciklirati druge blokove */

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -20,7 +20,7 @@ export function RaisedBedPlantField({
     const multiplierY = 0.27;
 
     const { plantsPerRow, totalPlants } = calculatePlantsPerField(
-        sortData?.information.plant.attributes?.seedingDistance,
+        sortData?.information?.plant.attributes?.seedingDistance,
     );
     const seedsCount = totalPlants;
 


### PR DESCRIPTION
- gardenBlocksService: guard against missing properties by
  using optional chaining. Lookup now checks bd.information?.name and
  uses block.name in the refund memo. Also handle missing price with
  blockData.prices?.sunflowers. These changes avoid runtime exceptions
  when block data fields are absent and ensure refund logging uses the
  correct value.
- client types (directories-api v1): mark many properties optional and
  tighten some types to reflect actual API shapes. Several top-level
  objects (calendar, attributes, information, prices, image, store)
  become optional where data can be omitted. Normalize nested fields
  (operation id/attributes/image/information/prices/conditions) to the
  real required/optional mix and add a Markdown doc comment for tip
  content. These adjustments reduce type errors and improve resilience
  when the server returns partial objects.