### PR TITLE
refactor(types): make several optional properties required

### DIFF
--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -412,7 +412,7 @@ export interface components {
                 /** @default Biljka */
                 label: string;
             };
-            calendar?: {
+            calendar: {
                 planting?: {
                     start?: number;
                     end?: number;
@@ -430,7 +430,7 @@ export interface components {
                     end?: number;
                 }[];
             };
-            attributes?: {
+            attributes: {
                 /** @description (u gramima) */
                 yieldMax: number;
                 /** @description (u danima) */
@@ -465,7 +465,7 @@ export interface components {
                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                 yieldType: string;
             };
-            information?: {
+            information: {
                 storage: string;
                 maintenance: string;
                 /** @description Informacije o berbi biljke. */
@@ -539,14 +539,14 @@ export interface components {
                 soilPreparation: string;
                 growth: string;
             };
-            prices?: {
+            prices: {
                 /** @description (EUR cijena za jednu biljku - presadnica ili 30x30cm sijanje) */
                 perPlant: number;
             };
-            image?: {
+            image: {
                 cover: components["schemas"]["image"];
             };
-            store?: {
+            store: {
                 availableInStore: boolean;
             };
             /** Format: date-time */
@@ -564,7 +564,7 @@ export interface components {
                 /** @default Sorta biljke */
                 label: string;
             };
-            information?: {
+            information: {
                 planting?: string;
                 flowering?: string;
                 plant: {
@@ -720,13 +720,13 @@ export interface components {
                 harvest?: string;
                 shortDescription: string;
             };
-            image?: {
+            image: {
                 cover?: components["schemas"]["image"];
             };
-            store?: {
+            store: {
                 availableInStore: boolean;
             };
-            attributes?: {
+            attributes: {
                 /** @description (vrsta reprodukcije sorte dostupne u Gredicama; "seed" ili "bulb") */
                 reproductionType: string;
             };
@@ -745,7 +745,7 @@ export interface components {
                 /** @default Stadij biljke */
                 label: string;
             };
-            information?: {
+            information: {
                 name: string;
                 label: string;
             };
@@ -764,7 +764,7 @@ export interface components {
                 /** @default Sjeme */
                 label: string;
             };
-            information?: {
+            information: {
                 name: string;
                 barcode?: string;
                 brand: {
@@ -1085,10 +1085,10 @@ export interface components {
                 };
                 countryOfOrigin?: string;
             };
-            application?: {
+            application: {
                 applicationArea?: number;
             };
-            attributes?: {
+            attributes: {
                 germinationPercentage?: number;
                 /** @description (cijena pakiranja u EUR) */
                 price: number;
@@ -1110,7 +1110,7 @@ export interface components {
                 /** @default Brend sjemena */
                 label: string;
             };
-            information?: {
+            information: {
                 website?: string;
                 name: string;
             };
@@ -1129,7 +1129,7 @@ export interface components {
                 /** @default Radnje */
                 label: string;
             };
-            attributes?: {
+            attributes: {
                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                 relativeDays?: number;
                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -1149,10 +1149,10 @@ export interface components {
                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                 deliverable: boolean;
             };
-            image?: {
+            image: {
                 cover?: components["schemas"]["image"];
             };
-            information?: {
+            information: {
                 /** @description (prevedeni naziv operacije) */
                 label: string;
                 /** @description (kratki opis operacije) */
@@ -1164,7 +1164,7 @@ export interface components {
                 /** @description (postupak za izvršavanje radnje) */
                 instructions: string;
             };
-            prices?: {
+            prices: {
                 /** @description (EUR cijena za jednu operaciju) */
                 perOperation: number;
                 /** @description (EUR cijena s popustom) */
@@ -1172,7 +1172,7 @@ export interface components {
                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                 discountDescription?: string;
             };
-            conditions?: {
+            conditions: {
                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                 completionAttachImagesRequired: boolean;
                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -1208,12 +1208,12 @@ export interface components {
                 /** @default FAQ */
                 label: string;
             };
-            information?: {
+            information: {
                 header: string;
                 name: string;
                 content: string;
             };
-            attributes?: {
+            attributes: {
                 tags?: string[];
                 category: {
                     id?: number;
@@ -1238,7 +1238,7 @@ export interface components {
                 /** @default FAQ Kategorija */
                 label: string;
             };
-            information?: {
+            information: {
                 name: string;
                 label: string;
             };
@@ -1257,22 +1257,22 @@ export interface components {
                 /** @default Blok */
                 label: string;
             };
-            attributes?: {
+            attributes: {
                 /** @description (jedan od: decoration, raisedBed, raisedBedPart, plant, plantPart) */
                 type: string;
                 height: number;
                 stackable: boolean;
             };
-            information?: {
+            information: {
                 shortDescription: string;
                 fullDescription: string;
                 name: string;
                 label: string;
             };
-            prices?: {
+            prices: {
                 sunflowers: number;
             };
-            functions?: {
+            functions: {
                 /** @description Blokovi koji predstavljaju podignutu gredicu */
                 raisedBed: boolean;
                 /** @description Blokovi koji mogu reciklirati druge blokove */

--- a/packages/client/src/lib/directories-api/v1.d.ts
+++ b/packages/client/src/lib/directories-api/v1.d.ts
@@ -412,7 +412,7 @@ export interface components {
                 /** @default Biljka */
                 label: string;
             };
-            calendar?: {
+            calendar: {
                 planting?: {
                     start?: number;
                     end?: number;
@@ -430,7 +430,7 @@ export interface components {
                     end?: number;
                 }[];
             };
-            attributes?: {
+            attributes: {
                 /** @description (u gramima) */
                 yieldMax: number;
                 /** @description (u danima) */
@@ -465,7 +465,7 @@ export interface components {
                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                 yieldType: string;
             };
-            information?: {
+            information: {
                 storage: string;
                 maintenance: string;
                 /** @description Informacije o berbi biljke. */
@@ -539,14 +539,14 @@ export interface components {
                 soilPreparation: string;
                 growth: string;
             };
-            prices?: {
+            prices: {
                 /** @description (EUR cijena za jednu biljku - presadnica ili 30x30cm sijanje) */
                 perPlant: number;
             };
-            image?: {
+            image: {
                 cover: components["schemas"]["image"];
             };
-            store?: {
+            store: {
                 availableInStore: boolean;
             };
             /** Format: date-time */
@@ -564,7 +564,7 @@ export interface components {
                 /** @default Sorta biljke */
                 label: string;
             };
-            information?: {
+            information: {
                 planting?: string;
                 flowering?: string;
                 plant: {
@@ -720,13 +720,13 @@ export interface components {
                 harvest?: string;
                 shortDescription: string;
             };
-            image?: {
+            image: {
                 cover?: components["schemas"]["image"];
             };
-            store?: {
+            store: {
                 availableInStore: boolean;
             };
-            attributes?: {
+            attributes: {
                 /** @description (vrsta reprodukcije sorte dostupne u Gredicama; "seed" ili "bulb") */
                 reproductionType: string;
             };
@@ -745,7 +745,7 @@ export interface components {
                 /** @default Stadij biljke */
                 label: string;
             };
-            information?: {
+            information: {
                 name: string;
                 label: string;
             };
@@ -764,7 +764,7 @@ export interface components {
                 /** @default Sjeme */
                 label: string;
             };
-            information?: {
+            information: {
                 name: string;
                 barcode?: string;
                 brand: {
@@ -1085,10 +1085,10 @@ export interface components {
                 };
                 countryOfOrigin?: string;
             };
-            application?: {
+            application: {
                 applicationArea?: number;
             };
-            attributes?: {
+            attributes: {
                 germinationPercentage?: number;
                 /** @description (cijena pakiranja u EUR) */
                 price: number;
@@ -1110,7 +1110,7 @@ export interface components {
                 /** @default Brend sjemena */
                 label: string;
             };
-            information?: {
+            information: {
                 website?: string;
                 name: string;
             };
@@ -1129,7 +1129,7 @@ export interface components {
                 /** @default Radnje */
                 label: string;
             };
-            attributes?: {
+            attributes: {
                 /** @description (broj dana kada se radi operacija relativno na životni ciklus biljke) */
                 relativeDays?: number;
                 /** @description (na koji stadij biljke se primjenjuje radnja) */
@@ -1149,10 +1149,10 @@ export interface components {
                 /** @description (ako je radnja za dostavu, korisnik mora ugovoriti dostavu za odrađivanje ove radnje npr. Branje svih plodova) */
                 deliverable: boolean;
             };
-            image?: {
+            image: {
                 cover?: components["schemas"]["image"];
             };
-            information?: {
+            information: {
                 /** @description (prevedeni naziv operacije) */
                 label: string;
                 /** @description (kratki opis operacije) */
@@ -1164,7 +1164,7 @@ export interface components {
                 /** @description (postupak za izvršavanje radnje) */
                 instructions: string;
             };
-            prices?: {
+            prices: {
                 /** @description (EUR cijena za jednu operaciju) */
                 perOperation: number;
                 /** @description (EUR cijena s popustom) */
@@ -1172,7 +1172,7 @@ export interface components {
                 /** @description (opis popusta npr. "Za kupnju 18 biljaka") */
                 discountDescription?: string;
             };
-            conditions?: {
+            conditions: {
                 /** @description (da li je obavezno proložiti slike za završetak radnje) */
                 completionAttachImagesRequired: boolean;
                 /** @description (da li se mogu proložiti slike za završetak radnje) */
@@ -1208,12 +1208,12 @@ export interface components {
                 /** @default FAQ */
                 label: string;
             };
-            information?: {
+            information: {
                 header: string;
                 name: string;
                 content: string;
             };
-            attributes?: {
+            attributes: {
                 tags?: string[];
                 category: {
                     id?: number;
@@ -1238,7 +1238,7 @@ export interface components {
                 /** @default FAQ Kategorija */
                 label: string;
             };
-            information?: {
+            information: {
                 name: string;
                 label: string;
             };
@@ -1257,22 +1257,22 @@ export interface components {
                 /** @default Blok */
                 label: string;
             };
-            attributes?: {
+            attributes: {
                 /** @description (jedan od: decoration, raisedBed, raisedBedPart, plant, plantPart) */
                 type: string;
                 height: number;
                 stackable: boolean;
             };
-            information?: {
+            information: {
                 shortDescription: string;
                 fullDescription: string;
                 name: string;
                 label: string;
             };
-            prices?: {
+            prices: {
                 sunflowers: number;
             };
-            functions?: {
+            functions: {
                 /** @description Blokovi koji predstavljaju podignutu gredicu */
                 raisedBed: boolean;
                 /** @description Blokovi koji mogu reciklirati druge blokove */


### PR DESCRIPTION
Convert numerous optional properties in directories API TypeScript
declarations to be required. Changes touch calendar, attributes,
information, prices, image, store, application and other nested fields
across multiple schemas.

This clarifies data contracts by ensuring fields that are expected to
always exist (e.g. calendar, attributes, information, image, store,
prices) are present at compile time, preventing accidental runtime
undefined access and reducing the need for defensive checks in client
code.