### PR TITLE
Deduplicate raised bed sensors per physical bed

### DIFF
--- a/apps/app/app/admin/sensors/SensorServiceForm.tsx
+++ b/apps/app/app/admin/sensors/SensorServiceForm.tsx
@@ -2,15 +2,15 @@
 
 import type { SelectRaisedBedSensor } from '@gredice/storage';
 import { Input } from '@signalco/ui-primitives/Input';
+import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
-import { Stack } from '@signalco/ui-primitives/Stack';
 import { useState } from 'react';
 import { updateSensor } from '../../(actions)/sensorActions';
 
 const statusOptions = [
-    { value: 'new', label: 'Novi' },
-    { value: 'installed', label: 'Instaliran' },
-    { value: 'active', label: 'Aktivan' },
+    { value: 'new', label: '🆕 Novi' },
+    { value: 'installed', label: '🛠️ Instaliran' },
+    { value: 'active', label: '✅ Aktivan' },
 ];
 
 export function SensorServiceForm({
@@ -39,7 +39,8 @@ export function SensorServiceForm({
     };
 
     return (
-        <Stack spacing={1}>
+        <Row spacing={1}>
+            <Input label="ID" value={sensor.id} readOnly />
             <Input
                 label="Signalco ID"
                 value={signalcoId}
@@ -47,10 +48,11 @@ export function SensorServiceForm({
                 onBlur={handleBlur}
             />
             <SelectItems
+                label="Status"
                 value={status}
                 onValueChange={handleStatusChange}
                 items={statusOptions}
             />
-        </Stack>
+        </Row>
     );
 }

--- a/apps/app/app/admin/sensors/page.tsx
+++ b/apps/app/app/admin/sensors/page.tsx
@@ -144,87 +144,63 @@ async function RaisedBedSensorsCard({
 
     return (
         <Card>
-            <CardContent>
-                <Stack spacing={3}>
-                    <Stack spacing={0.5}>
-                        <RaisedBedLabel physicalId={raisedBed.physicalId} />
-                        <Typography level="body3">#{raisedBed.id}</Typography>
-                    </Stack>
+            <CardContent noHeader>
+                <Stack spacing={1}>
+                    <RaisedBedLabel physicalId={raisedBed.physicalId} />
                     {hydratedSensors.length === 0 ? (
                         <Typography>Nema senzora za ovu gredicu.</Typography>
                     ) : (
                         hydratedSensors.map(
                             ({ sensor, moisture, temperature }) => (
-                                <Stack
-                                    key={sensor.id}
-                                    spacing={2}
-                                    className="rounded-lg border border-slate-200 p-3"
-                                >
-                                    <Stack>
-                                        <Row justifyContent="space-between">
-                                            <Typography
-                                                level="h2"
-                                                className="text-lg"
-                                            >
-                                                Senzor #{sensor.id}
-                                            </Typography>
-                                            <Chip>
-                                                {statusLabels[sensor.status] ??
-                                                    sensor.status}
-                                            </Chip>
-                                        </Row>
-                                        <Typography level="body3">
-                                            {sensor.sensorSignalcoId ??
-                                                'Nema Signalco ID'}
-                                        </Typography>
-                                    </Stack>
-                                    <Stack spacing={2}>
+                                <Stack key={sensor.id} spacing={1}>
+                                    <SensorServiceForm sensor={sensor} />
+                                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
                                         <Stack>
-                                            <Typography level="body2">
-                                                Vlažnost tla
-                                            </Typography>
-                                            <Typography semiBold>
-                                                {moisture.value ?? 'N/A'}%
-                                            </Typography>
+                                            <Row spacing={2}>
+                                                <Typography semiBold>
+                                                    💧 {moisture.value ?? 'N/A'}
+                                                    %
+                                                </Typography>
+                                                <Typography level="body3">
+                                                    <LocalDateTime>
+                                                        {moisture.updatedAt
+                                                            ? new Date(
+                                                                  moisture.updatedAt,
+                                                              )
+                                                            : null}
+                                                    </LocalDateTime>
+                                                </Typography>
+                                            </Row>
                                             <SensorMiniChart
                                                 data={moisture.history}
                                                 color="#0ea5e9"
                                                 unit="%"
                                             />
-                                            <Typography level="body3">
-                                                <LocalDateTime>
-                                                    {moisture.updatedAt
-                                                        ? new Date(
-                                                              moisture.updatedAt,
-                                                          )
-                                                        : null}
-                                                </LocalDateTime>
-                                            </Typography>
                                         </Stack>
                                         <Stack>
-                                            <Typography level="body2">
-                                                Temperatura tla
-                                            </Typography>
-                                            <Typography semiBold>
-                                                {temperature.value ?? 'N/A'}°C
-                                            </Typography>
+                                            <Row spacing={2}>
+                                                <Typography semiBold>
+                                                    🔥{' '}
+                                                    {temperature.value ?? 'N/A'}
+                                                    °C
+                                                </Typography>
+                                                <Typography level="body3">
+                                                    <LocalDateTime>
+                                                        {temperature.updatedAt
+                                                            ? new Date(
+                                                                  temperature.updatedAt,
+                                                              )
+                                                            : null}
+                                                    </LocalDateTime>
+                                                </Typography>
+                                            </Row>
                                             <SensorMiniChart
                                                 data={temperature.history}
                                                 color="#f97316"
                                                 unit="°C"
                                             />
-                                            <Typography level="body3">
-                                                <LocalDateTime>
-                                                    {temperature.updatedAt
-                                                        ? new Date(
-                                                              temperature.updatedAt,
-                                                          )
-                                                        : null}
-                                                </LocalDateTime>
-                                            </Typography>
                                         </Stack>
-                                    </Stack>
-                                    <SensorServiceForm sensor={sensor} />
+                                    </div>
                                 </Stack>
                             ),
                         )
@@ -245,13 +221,13 @@ export default async function SensorsPage() {
         }
     }
 
-    const uniqueRaisedBeds = Array.from(uniqueRaisedBedsMap.values()).sort(
-        (a, b) => {
+    const uniqueRaisedBeds = Array.from(uniqueRaisedBedsMap.values())
+        .sort((a, b) => {
             const keyA = a.physicalId ?? a.id.toString();
             const keyB = b.physicalId ?? b.id.toString();
             return keyA.localeCompare(keyB, 'hr-HR', { numeric: true });
-        },
-    );
+        })
+        .filter((bed) => bed.status === 'active');
 
     const raisedBedSensors = await Promise.all(
         uniqueRaisedBeds.map(async (raisedBed) => ({
@@ -281,7 +257,7 @@ export default async function SensorsPage() {
                 <Chip color="primary">{totalSensors}</Chip>
                 <CreateSensorModal raisedBeds={createFormRaisedBeds} />
             </Row>
-            <Stack spacing={2}>
+            <div className="grid gap-2 grid-cols-1 lg:grid-cols-2">
                 {raisedBedSensors.length === 0 ? (
                     <Typography>Nema senzora.</Typography>
                 ) : (
@@ -293,7 +269,9 @@ export default async function SensorsPage() {
                             }
                             fallback={
                                 <Card className="w-full">
-                                    <CardContent>Učitavanje...</CardContent>
+                                    <CardContent noHeader>
+                                        Učitavanje...
+                                    </CardContent>
                                 </Card>
                             }
                         >
@@ -304,7 +282,7 @@ export default async function SensorsPage() {
                         </Suspense>
                     ))
                 )}
-            </Stack>
+            </div>
         </Stack>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -621,21 +621,26 @@ export function RaisedBedSensorInfo({
 
     const sensorGroups: SensorGroup[] = Array.isArray(sensors)
         ? (() => {
-              const groups = sensors.reduce((acc, sensor: SensorReading) => {
-                  const existing = acc.get(sensor.id) ?? {
-                      id: sensor.id,
-                      status: sensor.status,
-                  };
-                  if (sensor.type === 'soil_moisture') {
-                      existing.soilMoisture = sensor;
-                  } else if (sensor.type === 'soil_temperature') {
-                      existing.soilTemperature = sensor;
-                  }
-                  existing.status = sensor.status;
-                  acc.set(sensor.id, existing);
-                  return acc;
-              }, new Map<number, SensorGroup>());
-              return Array.from(groups.values()).sort((a, b) => a.id - b.id);
+              const groups = (sensors as SensorReading[]).reduce(
+                  (acc: Map<number, SensorGroup>, sensor: SensorReading) => {
+                      const existing = acc.get(sensor.id) ?? {
+                          id: sensor.id,
+                          status: sensor.status,
+                      };
+                      if (sensor.type === 'soil_moisture') {
+                          existing.soilMoisture = sensor;
+                      } else if (sensor.type === 'soil_temperature') {
+                          existing.soilTemperature = sensor;
+                      }
+                      existing.status = sensor.status;
+                      acc.set(sensor.id, existing);
+                      return acc;
+                  },
+                  new Map<number, SensorGroup>(),
+              );
+              return Array.from(groups.values()).sort(
+                  (a: SensorGroup, b: SensorGroup) => a.id - b.id,
+              );
           })()
         : [];
 

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -858,6 +858,7 @@ export async function getRaisedBedSensors(raisedBedId: number) {
         columns: {
             id: true,
             physicalId: true,
+            gardenId: true,
         },
         where: and(
             eq(raisedBeds.id, raisedBedId),
@@ -872,12 +873,18 @@ export async function getRaisedBedSensors(raisedBedId: number) {
     let raisedBedIds: number[] = [raisedBed.id];
 
     if (raisedBed.physicalId) {
+        const whereConditions = [
+            eq(raisedBeds.physicalId, raisedBed.physicalId),
+            eq(raisedBeds.isDeleted, false),
+        ];
+
+        if (raisedBed.gardenId) {
+            whereConditions.push(eq(raisedBeds.gardenId, raisedBed.gardenId));
+        }
+
         const relatedBeds = await storage().query.raisedBeds.findMany({
             columns: { id: true },
-            where: and(
-                eq(raisedBeds.physicalId, raisedBed.physicalId),
-                eq(raisedBeds.isDeleted, false),
-            ),
+            where: and(...whereConditions),
         });
 
         raisedBedIds = Array.from(


### PR DESCRIPTION
## Summary
- aggregate raised bed sensors by physical id and deduplicate repeated Signalco devices
- show admin sensors per raised bed with hydrated telemetry for each connected device
- update the game HUD to stack sensor controls when multiple devices are linked to one bed

## Testing
- pnpm lint --filter app
- pnpm lint --filter @gredice/game

------
https://chatgpt.com/codex/tasks/task_e_6902090b85ac832f884e657dabb4abfe