### PR TITLE
feat(hud): improve planted item layout and typography

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -173,16 +173,21 @@ export function RaisedBedFieldItemPlanted({
             }
         >
             <Stack spacing={2}>
-                <Row spacing={2} className="flex-wrap gap-y-2">
+                <Row spacing={2}>
                     <PlantOrSortImage
                         plantSort={plantSort}
                         width={60}
                         height={60}
                     />
-                    <Row spacing={2} alignItems="end">
+                    <Row
+                        spacing={2}
+                        alignItems="center"
+                        justifyContent="space-between"
+                        className="w-full"
+                    >
                         <Typography
-                            level="h3"
-                            className="truncate"
+                            level="h4"
+                            className="truncate line-clamp-2"
                             title={plantSort.information.name}
                         >
                             {plantSort.information.name}


### PR DESCRIPTION
Refactor RaisedBedFieldItemPlanted layout to better align image and
text within the row. Replace row wrapping with a single full-width row
and add centered alignment and space-between justification so the image
and text distribute consistently across the available width.

Adjust typography level from h3 to h4 and enable a two-line clamp on the
plant name to prevent overflow while preserving title attribute for full
name visibility. These changes improve visual balance and prevent label
overflow on narrow containers.