### PR TITLE
feat(hud): avoid suggestions when raised bed is full

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -110,8 +110,16 @@ export function RaisedBedFieldSuggestions({
     const cartPlantItems = cartItems?.filter(
         (item) => item.entityTypeName === 'plantSort' && item.status === 'new',
     );
-    if (raisedBed.fields.length + (cartPlantItems?.length ?? 0) >= 9)
+    const plantedFieldsCount = raisedBed.fields.filter(
+        (field) => field.active,
+    ).length;
+    if (plantedFieldsCount + (cartPlantItems?.length ?? 0) >= 9) {
+        console.debug('Skipping planting suggestions: raised bed is full', {
+            plantedFieldsCount,
+            cartPlantItemsCount: cartPlantItems?.length ?? 0,
+        });
         return null;
+    }
 
     const season = getSeasonForDate(currentTime);
 


### PR DESCRIPTION
Skip planting suggestions when the raised bed already has nine or
more active planted fields including plants pending in the cart.
Replace a simple length check on raisedBed.fields with a count of
only active fields, and add a debug log that reports the number of
planted fields and cart plant items when suggestions are skipped.

This prevents showing redundant planting prompts and clarifies the
reason via logging for easier debugging.