### PR TITLE
Add status page link to marketing footer

### DIFF
--- a/apps/www/app/Footer.tsx
+++ b/apps/www/app/Footer.tsx
@@ -89,6 +89,10 @@ const sectionsData: SectionData[] = [
                         href: KnownPages.LegalCookies,
                     },
                     {
+                        label: 'Status sustava',
+                        href: 'https://status.gredice.com/',
+                    },
+                    {
                         label: 'Licenca izvornog koda',
                         href: KnownPages.LegalLicense,
                     },


### PR DESCRIPTION
## Summary
- add a link to the status page in the marketing footer "Više" section

## Testing
- pnpm lint --filter www

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2786cbb4832f8b6cb95712b9294b)