### PR TITLE
feat(ui): add borders and timer icon to cards

### DIFF
--- a/apps/www/app/PlantsShowcase.tsx
+++ b/apps/www/app/PlantsShowcase.tsx
@@ -39,7 +39,7 @@ export async function PlantsShowcase() {
                 ))}
                 <Link
                     href={KnownPages.Plants}
-                    className="flex flex-col justify-center items-center hover:border-muted-foreground/50 hover:bg-white/30 bg-white/70 rounded-lg border border-dashed p-4 transition-all"
+                    className="flex flex-col justify-center items-center hover:border-muted-foreground/50 hover:bg-white/30 bg-white/70 rounded-lg border border-tertiary border-dashed p-4 transition-all"
                 >
                     <Row spacing={1}>
                         <span>Sve biljke</span>

--- a/apps/www/app/biljke/[alias]/PlantSortsList.tsx
+++ b/apps/www/app/biljke/[alias]/PlantSortsList.tsx
@@ -53,6 +53,7 @@ async function PlantSortsListContent({
                                 basePlantName,
                                 sort.information.name,
                             )}
+                            className="border-tertiary border-b-4"
                         >
                             <Row spacing={2}>
                                 <AiWatermark

--- a/apps/www/app/biljke/[alias]/PlantTips.tsx
+++ b/apps/www/app/biljke/[alias]/PlantTips.tsx
@@ -19,7 +19,11 @@ export function PlantTips({
             </Typography>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {plant.information?.tip?.map((tip) => (
-                    <Accordion defaultOpen key={tip.header} className="h-fit">
+                    <Accordion
+                        defaultOpen
+                        key={tip.header}
+                        className="h-fit border-tertiary border-b-4"
+                    >
                         <Typography
                             level="h3"
                             className="text-lg"

--- a/apps/www/app/cesta-pitanja/page.tsx
+++ b/apps/www/app/cesta-pitanja/page.tsx
@@ -58,7 +58,7 @@ export default async function FaqPage() {
                                 .map((item) => (
                                     <Accordion
                                         key={item.information.name}
-                                        className="h-min"
+                                        className="h-min border-tertiary border-b-4"
                                     >
                                         <Typography className="px-3" semiBold>
                                             {item.information.header}

--- a/apps/www/app/dostava/termini/page.tsx
+++ b/apps/www/app/dostava/termini/page.tsx
@@ -1,5 +1,6 @@
 import { client } from '@gredice/client';
 import { LocalDateTime, TimeRange } from '@gredice/ui/LocalDateTime';
+import { Timer } from '@signalco/ui-icons';
 import {
     Card,
     CardContent,
@@ -108,23 +109,32 @@ async function SlotsDisplay({ type }: { type: 'delivery' | 'pickup' }) {
 
     if (Object.keys(groupedSlots).length === 0) {
         return (
-            <Card className="p-6">
-                <Stack spacing={2} className="text-center">
-                    <Typography level="h6">Nema dostupnih termina</Typography>
-                    <Typography level="body2" className="text-muted-foreground">
-                        Trenutno nema dostupnih termina za{' '}
-                        {type === 'delivery' ? 'dostavu' : 'osobno preuzimanje'}{' '}
-                        u sljedećih 14 dana.
-                    </Typography>
-                </Stack>
+            <Card className="p-6 border-tertiary border-b-4">
+                <CardContent noHeader>
+                    <Stack spacing={2} className="text-center">
+                        <Typography level="h6">
+                            Nema dostupnih termina
+                        </Typography>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Trenutno nema dostupnih termina za{' '}
+                            {type === 'delivery'
+                                ? 'dostavu'
+                                : 'osobno preuzimanje'}{' '}
+                            u sljedećih 14 dana.
+                        </Typography>
+                    </Stack>
+                </CardContent>
             </Card>
         );
     }
 
     return (
-        <Stack spacing={1}>
+        <Stack spacing={2}>
             {Object.entries(groupedSlots).map(([date, dateSlots]) => (
-                <Card key={date}>
+                <Card key={date} className="border-tertiary border-b-4">
                     <CardHeader>
                         <CardTitle>
                             <Typography
@@ -154,10 +164,8 @@ async function SlotsDisplay({ type }: { type: 'delivery' | 'pickup' }) {
                                         className="border rounded-lg p-3 bg-background"
                                     >
                                         <Stack spacing={2}>
-                                            <Row
-                                                spacing={2}
-                                                className="items-center"
-                                            >
+                                            <Row spacing={1}>
+                                                <Timer className="size-5 shrink-0 text-tertiary-foreground" />
                                                 <Typography
                                                     level="body2"
                                                     semiBold
@@ -168,9 +176,6 @@ async function SlotsDisplay({ type }: { type: 'delivery' | 'pickup' }) {
                                                         timeOnly
                                                     />
                                                 </Typography>
-                                                <Chip color="success" size="sm">
-                                                    Dostupno
-                                                </Chip>
                                             </Row>
                                             {slot.location &&
                                                 slot.type === 'pickup' && (
@@ -219,7 +224,7 @@ export default async function DeliverySlotsPage() {
                     dva dana mogu biti ograničeni.
                 </Typography>
 
-                <Card className="w-fit p-4 pt-6 pr-6">
+                <Card className="w-fit p-4 pr-12 border-tertiary border-b-4">
                     <CardHeader>
                         <CardTitle>💡 Kako rezervirati termin?</CardTitle>
                     </CardHeader>

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -91,9 +91,9 @@ export default async function RootLayout({
                         >
                             <NavigatingButton
                                 href={KnownPages.GardenApp}
-                                className="bg-green-800 hover:bg-green-700"
+                                className="bg-green-800 hover:bg-green-700 rounded-full"
                             >
-                                Vrt
+                                Moj vrt
                             </NavigatingButton>
                         </PageNav>
                         <main className="mt-16 relative">

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -5,6 +5,7 @@ import type { SectionData } from '@signalco/cms-core/SectionData';
 import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { NavigatingButton } from '@signalco/ui/NavigatingButton';
 import { Check, Navigate } from '@signalco/ui-icons';
+import { Card, CardContent } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
@@ -23,213 +24,11 @@ import { PlantsShowcase } from './PlantsShowcase';
 
 const sectionsData: SectionData[] = [
     {
-        component: 'Heading1',
-        tagline: 'Gredice',
-        header: 'Vrt po tvom',
-        description: 'Dobiješ povrće iz svojih gredica - nit oro, nit kopo!',
-        asset: (
-            <div className="min-h-96 relative rounded-xl overflow-hidden">
-                <GameScene
-                    appBaseUrl="https://vrt.gredice.com"
-                    freezeTime={new Date(2025, 5, 21, 11, 30)}
-                    noBackground
-                    hideHud
-                    noControls
-                    noWeather
-                    noSound
-                    mockGarden
-                />
-            </div>
-        ),
-        ctas: [
-            {
-                label: 'Posjeti svoj vrt',
-                href: KnownPages.GardenApp,
-                icon: <Navigate />,
-            },
-        ],
-    },
-    {
         component: 'Feature1',
         tagline: 'Vrt po tvom',
         header: 'Klikneš, mi sadimo - ti uživaš',
         description:
             'Par klikova i tvoje gredice su spremne! Odaberi povrće, mi ga posadimo, a ti ubrzo uživaš u plodovima svog novog vrta.',
-        asset: (
-            <div className="h-full items-center flex flex-row mb-8 -mt-4">
-                <Stack spacing={4}>
-                    <Row spacing={2}>
-                        <Check className="size-5 shrink-0" />
-                        <Stack>
-                            <Typography level="h6" component="span">
-                                Samo tvoj vrt
-                            </Typography>
-                            <Typography level="body2" secondary>
-                                Tvoja gredica - tvoje povrće
-                            </Typography>
-                        </Stack>
-                    </Row>
-                    <Row spacing={2}>
-                        <Check className="size-5 shrink-0" />
-                        <Stack>
-                            <Typography level="h6" component="span">
-                                Mi radimo umjesto tebe
-                            </Typography>
-                            <Typography level="body1" secondary>
-                                Sve što klikneš, mi odradimo. Tvoj zadatak je
-                                pratiti svoj vrt preko aplikacije i biti
-                                maštovit u biranju sljedeće biljke za svoj vrt.
-                            </Typography>
-                        </Stack>
-                    </Row>
-                    <Row spacing={2}>
-                        <Check className="size-5 shrink-0" />
-                        <Stack>
-                            <Typography level="h6" component="span">
-                                Poželiš plodove - mi dostavljamo
-                            </Typography>
-                            <Typography level="body1" secondary>
-                                Kad poželiš plodove iz svog vrta, mi ih
-                                dostavljamo na tvoj kućni prag. Prva dostava za
-                                svaku biljku je besplatna.
-                            </Typography>
-                            <Typography level="body3">
-                                * Besplatna dostava je dostupna samo za područje
-                                Zagreba
-                            </Typography>
-                        </Stack>
-                    </Row>
-                </Stack>
-            </div>
-        ),
-        features: [
-            {
-                asset: (
-                    <Row spacing={4}>
-                        <Image
-                            alt="Sjeme i presadnice"
-                            className="w-32 sm:w-[200px]"
-                            src={SeedsAndTransplants}
-                            width={200}
-                            height={200}
-                        />
-                        <Stack spacing={2}>
-                            <Stack spacing={2}>
-                                <Typography level="h4" component="h3">
-                                    Zasadi
-                                </Typography>
-                                <Typography
-                                    level="body1"
-                                    className="text-balance"
-                                >
-                                    Odaberi svoju kombinaciju povrća u
-                                    aplikaciji i složi svoju gredicu.
-                                </Typography>
-                                <Typography
-                                    level="body1"
-                                    className="text-balance"
-                                >
-                                    Mi postavljamo gredice kod lokalnog OPG-a i
-                                    brzo sadimo tvoje biljke.
-                                </Typography>
-                            </Stack>
-                            <NavigatingButton
-                                variant="link"
-                                className="w-fit"
-                                href={KnownPages.RaisedBeds}
-                            >
-                                Više o podignutim gredicama
-                            </NavigatingButton>
-                        </Stack>
-                    </Row>
-                ),
-            },
-            {
-                asset: (
-                    <Row spacing={4}>
-                        <Stack spacing={2}>
-                            <Stack spacing={2}>
-                                <Typography level="h4" component="h3">
-                                    Održavaj
-                                </Typography>
-                                <Typography
-                                    level="body1"
-                                    className="text-balance"
-                                >
-                                    Prati stanje svojih gredica, naruči
-                                    zalijevanje, okopavanje ili što god treba
-                                    tvom vrtu.
-                                </Typography>
-                                <Typography
-                                    level="body1"
-                                    className="text-balance"
-                                >
-                                    U aplikaciji ćeš dobivati obavijesti, slike
-                                    svojih gredica i savjete kako bi tvoje
-                                    biljke bile sretne i zdrave.
-                                </Typography>
-                            </Stack>
-                            <NavigatingButton
-                                variant="link"
-                                className="w-fit"
-                                href={KnownPages.Operations}
-                            >
-                                Više o radnjama
-                            </NavigatingButton>
-                        </Stack>
-                        <Image
-                            alt="Održavanje gredice"
-                            className="w-32 sm:w-[200px]"
-                            src={RaisedBedMaintenance}
-                            width={200}
-                            height={200}
-                        />
-                    </Row>
-                ),
-            },
-            {
-                asset: (
-                    <Row spacing={4}>
-                        <Image
-                            alt="Dostava povrća"
-                            className="w-32 sm:w-[200px]"
-                            src={DeliveryTruck}
-                            width={200}
-                            height={200}
-                        />
-                        <Stack spacing={2}>
-                            <Typography level="h4" component="h3">
-                                Uberi i uživaj
-                            </Typography>
-                            <Typography level="body1" className="text-balance">
-                                Kad poželiš, klikni za branje svog povrća.
-                            </Typography>
-                            <Stack>
-                                <Typography
-                                    level="body1"
-                                    className="text-balance"
-                                >
-                                    Mi ćemo ubrati sve plodove tvojih gredica i
-                                    dostaviti ih još svježe iz tvog vrta
-                                    direktno na tvoj kućni prag.
-                                </Typography>
-                                <Typography level="body3">
-                                    * Besplatna dostava je dostupna samo za
-                                    područje Zagreba
-                                </Typography>
-                            </Stack>
-                            <NavigatingButton
-                                variant="link"
-                                className="w-fit"
-                                href={KnownPages.Delivery}
-                            >
-                                Više o dostavi
-                            </NavigatingButton>
-                        </Stack>
-                    </Row>
-                ),
-            },
-        ],
     },
 ];
 
@@ -243,9 +42,9 @@ function PlantsStatisticsCard({
     value: string;
 }) {
     return (
-        <div className="rounded-2xl border shadow-lg bg-white p-6 grid grid-rows-[auto_auto_1fr] h-full">
+        <div className="rounded-2xl border border-tertiary border-b-4 bg-white p-6 grid grid-rows-[auto_auto_1fr] h-full">
             <CountingNumber
-                className="mb-4 text-5xl font-thin"
+                className="mb-4 text-5xl font-mono"
                 number={parseInt(value, 10)}
                 inView
             >
@@ -262,9 +61,9 @@ function PlantsStatisticsCard({
 function PlantsStatisticsLoading() {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div className="rounded-2xl border shadow-lg bg-white p-6 h-[182px] animate-pulse" />
-            <div className="rounded-2xl border shadow-lg bg-white p-6 h-[182px] animate-pulse" />
-            <div className="rounded-2xl border shadow-lg bg-white p-6 h-[182px] animate-pulse" />
+            <div className="rounded-2xl border border-tertiary border-b-4 bg-white p-6 h-[182px] animate-pulse" />
+            <div className="rounded-2xl border border-tertiary border-b-4 bg-white p-6 h-[182px] animate-pulse" />
+            <div className="rounded-2xl border border-tertiary border-b-4 bg-white p-6 h-[182px] animate-pulse" />
         </div>
     );
 }
@@ -299,13 +98,172 @@ async function PlantsStatistics() {
     );
 }
 
+function StepsSection() {
+    return (
+        <Stack spacing={4} className="mb-20">
+            <div className="lg:flex lg:items-center lg:gap-8">
+                <Image
+                    alt="Sjeme i presadnice"
+                    className="w-32 sm:w-[200px]"
+                    src={SeedsAndTransplants}
+                    width={200}
+                    height={200}
+                />
+                <Card className="border-tertiary border-b-4 lg:max-w-[40%]">
+                    <CardContent noHeader>
+                        <Stack spacing={2}>
+                            <Stack spacing={2}>
+                                <Typography level="h4" component="h3">
+                                    Zasadi
+                                </Typography>
+                                <Typography
+                                    level="body1"
+                                    className="text-pretty"
+                                >
+                                    Odaberi svoju kombinaciju povrća u
+                                    aplikaciji i složi svoju gredicu.
+                                </Typography>
+                                <Typography
+                                    level="body1"
+                                    className="text-pretty"
+                                >
+                                    Mi postavljamo gredice kod lokalnog OPG-a i
+                                    brzo sadimo tvoje biljke.
+                                </Typography>
+                            </Stack>
+                            <NavigatingButton
+                                variant="link"
+                                className="w-fit"
+                                href={KnownPages.RaisedBeds}
+                            >
+                                Više o podignutim gredicama
+                            </NavigatingButton>
+                        </Stack>
+                    </CardContent>
+                </Card>
+            </div>
+            <div className="flex flex-col-reverse lg:flex-row lg:justify-end lg:items-center lg:gap-8">
+                <Card className="border-tertiary border-b-4  lg:max-w-[40%]">
+                    <CardContent noHeader>
+                        <Stack spacing={2}>
+                            <Stack spacing={2}>
+                                <Typography level="h4" component="h3">
+                                    Održavaj
+                                </Typography>
+                                <Typography
+                                    level="body1"
+                                    className="text-pretty"
+                                >
+                                    Prati stanje svojih gredica, naruči
+                                    zalijevanje, okopavanje ili što god treba
+                                    tvom vrtu.
+                                </Typography>
+                                <Typography
+                                    level="body1"
+                                    className="text-pretty"
+                                >
+                                    U aplikaciji ćeš dobivati obavijesti, slike
+                                    svojih gredica i savjete kako bi tvoje
+                                    biljke bile sretne i zdrave.
+                                </Typography>
+                            </Stack>
+                            <NavigatingButton
+                                variant="link"
+                                className="w-fit"
+                                href={KnownPages.Operations}
+                            >
+                                Više o radnjama
+                            </NavigatingButton>
+                        </Stack>
+                    </CardContent>
+                </Card>
+                <Image
+                    alt="Održavanje gredice"
+                    className="w-32 sm:w-[200px]"
+                    src={RaisedBedMaintenance}
+                    width={200}
+                    height={200}
+                />
+            </div>
+            <div className="lg:flex lg:items-center lg:gap-8">
+                <Image
+                    alt="Dostava povrća"
+                    className="w-32 sm:w-[200px]"
+                    src={DeliveryTruck}
+                    width={200}
+                    height={200}
+                />
+                <Card className="border-tertiary border-b-4  lg:max-w-[40%]">
+                    <CardContent noHeader>
+                        <Stack spacing={2}>
+                            <Typography level="h4" component="h3">
+                                Uberi i uživaj
+                            </Typography>
+                            <Typography level="body1" className="text-pretty">
+                                Kad poželiš, klikni za branje svog povrća.
+                            </Typography>
+                            <Stack>
+                                <Typography
+                                    level="body1"
+                                    className="text-pretty"
+                                >
+                                    Mi ćemo ubrati sve plodove tvojih gredica i
+                                    dostaviti ih još svježe iz tvog vrta
+                                    direktno na tvoj kućni prag.
+                                </Typography>
+                                <Typography level="body3">
+                                    * Besplatna dostava je dostupna za područje
+                                    Zagreba
+                                </Typography>
+                            </Stack>
+                            <NavigatingButton
+                                variant="link"
+                                className="w-fit"
+                                href={KnownPages.Delivery}
+                            >
+                                Više o dostavi
+                            </NavigatingButton>
+                        </Stack>
+                    </CardContent>
+                </Card>
+            </div>
+        </Stack>
+    );
+}
+
 export default function Home() {
     return (
         <Stack>
+            <Stack spacing={2}>
+                <Card className="mt-10 w-fit border-tertiary border-b-4">
+                    <CardContent noHeader className="p-6 lg:pr-10">
+                        <Stack spacing={2}>
+                            <Typography level="h2">Vrt po tvom 🌱</Typography>
+                            <Typography level="body1">
+                                Dobiješ povrće iz svojih gredica - nit oro, nit
+                                kopo!
+                            </Typography>
+                        </Stack>
+                    </CardContent>
+                </Card>
+                <div className="h-[400px] -mx-4 relative overflow-hidden">
+                    <GameScene
+                        appBaseUrl="https://vrt.gredice.com"
+                        freezeTime={new Date(2025, 5, 21, 11, 30)}
+                        noBackground
+                        hideHud
+                        noControls
+                        noWeather
+                        noSound
+                        mockGarden
+                    />
+                </div>
+            </Stack>
             <SectionsView
                 sectionsData={sectionsData}
                 componentsRegistry={sectionsComponentRegistry}
             />
+            <StepsSection />
             <Stack spacing={4}>
                 <Stack spacing={1}>
                     <Typography level="body1" semiBold tertiary>
@@ -338,7 +296,7 @@ export default function Home() {
                     <WhatsAppCard />
                     <InstagramCard />
                     <FacebookCard />
-                    <div className="bg-white border shadow p-6 rounded-xl lg:col-start-2 lg:row-start-1 lg:row-span-3">
+                    <div className="bg-white border border-tertiary border-b-4 shadow p-6 rounded-xl lg:col-start-2 lg:row-start-1 lg:row-span-3">
                         <NewsletterSignUp />
                     </div>
                 </div>

--- a/apps/www/app/radnje/OperationCard.tsx
+++ b/apps/www/app/radnje/OperationCard.tsx
@@ -12,7 +12,10 @@ export function OperationCard({
     operation: Omit<OperationData, 'entityType' | 'createdAt' | 'updatedAt'>;
 }) {
     return (
-        <Card href={KnownPages.Operation(operation.information.label)}>
+        <Card
+            href={KnownPages.Operation(operation.information.label)}
+            className="border-tertiary border-b-4"
+        >
             <CardContent noHeader>
                 <Row justifyContent="space-between" spacing={1}>
                     <Row spacing={2}>

--- a/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
+++ b/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
@@ -27,7 +27,7 @@ export async function OperationApplicationsList({
     if (operation.attributes.application === 'garden') {
         return (
             <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-                <Card>
+                <Card className="border-tertiary border-b-4">
                     <CardContent noHeader>
                         <Row justifyContent="space-between">
                             <Typography>Dostupno u tvom vrtu</Typography>
@@ -50,7 +50,7 @@ export async function OperationApplicationsList({
     ) {
         return (
             <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-                <Card>
+                <Card className="border-tertiary border-b-4">
                     <CardContent noHeader>
                         <Row spacing={2}>
                             <BlockImage
@@ -82,6 +82,7 @@ export async function OperationApplicationsList({
                         <Card
                             key={plant.id}
                             href={KnownPages.Plant(plant.information.name)}
+                            className="border-tertiary border-b-4"
                         >
                             <CardContent noHeader>
                                 <Row spacing={2}>

--- a/apps/www/components/attributes/DetailCard.tsx
+++ b/apps/www/components/attributes/DetailCard.tsx
@@ -44,7 +44,7 @@ export function AttributeCard({
     }
 
     return (
-        <Card className="flex items-center gap-1 justify-between">
+        <Card className="flex items-center gap-1 justify-between border-tertiary border-b-4">
             <Row spacing={2}>
                 <div className="shrink-0 ml-2">{icon}</div>
                 <Stack spacing={subheader ? 0.5 : 0}>

--- a/apps/www/components/shared/ItemCard.tsx
+++ b/apps/www/components/shared/ItemCard.tsx
@@ -9,7 +9,7 @@ export function ItemCard({
 }: PropsWithChildren<{ label: string | ReactElement; href: Route | URL }>) {
     return (
         <Card
-            className="overflow-hidden shadow-lg hover:shadow-xl transition-all group"
+            className="overflow-hidden hover:shadow-xl transition-all group border-tertiary border-b-4"
             href={href as string}
         >
             <CardOverflow className="p-2 sm:p-4 md:p-6 aspect-square">

--- a/apps/www/components/shared/PageHeader.tsx
+++ b/apps/www/components/shared/PageHeader.tsx
@@ -39,7 +39,7 @@ export function PageHeader({
                 )}
             >
                 {visual && (
-                    <Card className="min-w-48 min-h-48 shadow-lg rounded-none md:rounded-lg -mx-4 md:mx-0 md:size-48">
+                    <Card className="min-w-48 min-h-48 border-tertiary border-b-4 rounded-none md:rounded-lg -mx-4 md:mx-0 md:size-48">
                         <CardOverflow className="p-6 flex justify-center">
                             {visual}
                         </CardOverflow>


### PR DESCRIPTION
- Add tertiary bottom border (border-tertiary border-b-4) to multiple Card components for consistent visual emphasis
- Adjust padding and spacing for balanced layouts across affected cards
- Replace "Dostupno" Chip with a Timer icon next to time entries
- Reduce row spacing for tighter time rows
- Wrap empty-state content in CardContent(noHeader)
- Increase Stack spacing for grouped slots list
- Files updated:
  - dostava/termini/page.tsx: styled empty state and date cards, added Timer icon, removed Chip, tweaked spacing/paddings, adjusted help Card width/padding
  - radnje/OperationCard.tsx: added tertiary border and CardContent noHeader
  - components/attributes/DetailCard.tsx: added tertiary border