### PR TITLE
feat(ui/game): add greenhouse suggestion + improve OperationImage styling

### DIFF
--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -10,6 +10,7 @@ import { ButtonGreen } from '../shared-ui/ButtonGreen';
 import { useGameState } from '../useGameState';
 import { RaisedBedField } from './raisedBed/RaisedBedField';
 import { RaisedBedFieldSuggestions } from './raisedBed/RaisedBedFieldSuggestions';
+import { RaisedBedGreenhouseSuggestion } from './raisedBed/RaisedBedGreenhouseSuggestion';
 import { RaisedBedInfo } from './raisedBed/RaisedBedInfo';
 import { RaisedBedSensorInfo } from './raisedBed/RaisedBedSensorInfo';
 import { RaisedBedWatering } from './raisedBed/RaisedBedWatering';
@@ -84,6 +85,10 @@ export function RaisedBedFieldHud(_props: {
                 <>
                     <div className="absolute top-[calc(50%+160px)] left-[calc(50%-156.5px)] md:left-[calc(50%+210px)] md:top-[calc(50%+74px)]">
                         <Stack spacing={0.5}>
+                            <RaisedBedGreenhouseSuggestion
+                                gardenId={currentGarden.id}
+                                raisedBedId={raisedBed.id}
+                            />
                             <RaisedBedWatering
                                 gardenId={currentGarden.id}
                                 raisedBedId={raisedBed.id}

--- a/packages/game/src/hud/raisedBed/RaisedBedGreenhouseSuggestion.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedGreenhouseSuggestion.tsx
@@ -1,0 +1,66 @@
+import type { OperationData } from '@gredice/client';
+import { OperationImage } from '@gredice/ui/OperationImage';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useState } from 'react';
+import { useOperations } from '../../hooks/useOperations';
+import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
+import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { OperationsList } from './shared/OperationsList';
+
+function greenhouseOperationsFilter(operation: OperationData) {
+    return (
+        operation.attributes.stage.information?.name === 'growth' &&
+        operation.attributes.application === 'raisedBedFull' &&
+        operation.information.name.toLocaleLowerCase().includes('greenhouse')
+    );
+}
+
+export function RaisedBedGreenhouseSuggestion({
+    gardenId,
+    raisedBedId,
+}: {
+    gardenId: number;
+    raisedBedId: number;
+}) {
+    const [open, setOpen] = useState(false);
+    const { data: operations } = useOperations();
+    const greenhouseOperations = operations?.filter(greenhouseOperationsFilter);
+    const basicGreenhouseOperation = greenhouseOperations?.at(0);
+    if (!basicGreenhouseOperation) {
+        return null;
+    }
+
+    return (
+        <Modal
+            className="border border-tertiary border-b-4"
+            title="Zalijevanje"
+            open={open}
+            modal={false}
+            onOpenChange={setOpen}
+            trigger={
+                <ButtonGreen className="rounded-full p-0 pr-4 gap-0" fullWidth>
+                    <OperationImage
+                        size={32}
+                        operation={basicGreenhouseOperation}
+                        className="size-14 mr-4"
+                    />
+                    <span className="-ml-2">Plastenik</span>
+                </ButtonGreen>
+            }
+        >
+            <Stack spacing={2}>
+                <Typography level="h5">Radnje zalijevanja</Typography>
+                <Typography>
+                    Odaberite radnju zalijevanja za ovu gredicu.
+                </Typography>
+                <OperationsList
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                    filterFunc={greenhouseOperationsFilter}
+                />
+            </Stack>
+        </Modal>
+    );
+}

--- a/packages/ui/src/OperationImage/OperationImage.tsx
+++ b/packages/ui/src/OperationImage/OperationImage.tsx
@@ -1,4 +1,5 @@
 import { Hammer } from '@signalco/ui-icons';
+import { cx } from '@signalco/ui-primitives/cx';
 import Image from 'next/image';
 
 export type OperationImageProps = {
@@ -13,9 +14,14 @@ export type OperationImageProps = {
         };
     };
     size?: number;
+    className?: string;
 };
 
-export function OperationImage({ operation, size }: OperationImageProps) {
+export function OperationImage({
+    operation,
+    size,
+    className,
+}: OperationImageProps) {
     if (!operation.image?.cover?.url) {
         return (
             <div
@@ -23,7 +29,10 @@ export function OperationImage({ operation, size }: OperationImageProps) {
                     width: size ? `${size}px` : '48px',
                     height: size ? `${size}px` : '48px',
                 }}
-                className="aspect-square flex items-center justify-center"
+                className={cx(
+                    'aspect-square flex items-center justify-center',
+                    className,
+                )}
             >
                 <Hammer
                     style={
@@ -48,6 +57,7 @@ export function OperationImage({ operation, size }: OperationImageProps) {
                 height: `${size ?? 24}px`,
             }}
             alt={operation.information?.label ?? 'Slika operacije'}
+            className={className}
         />
     );
 }


### PR DESCRIPTION
Add RaisedBedGreenhouseSuggestion component and integrate it into the
RaisedBedField HUD so greenhouse watering operations are suggested in
the raised bed controls. The suggestion filters operations by stage,
application and name (includes "greenhouse"), opens a non-modal Modal
triggered by a green button, and lists matching operations via the
existing OperationsList.

Improve OperationImage component: add optional className prop and apply
it to both the wrapper using cx and the Image element, and import cx
utility. This enables passing custom layout and spacing classes (used
for the new greenhouse suggestion button). Also preserve existing size
handling and fallback icon behavior.

These changes enable a focused UI affordance for greenhouse watering
and make OperationImage styling extensible.