### PR TITLE
chore(biome): bump schema to 2.3.6 across packages

### DIFF
--- a/apps/api/biome.json
+++ b/apps/api/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/app/biome.json
+++ b/apps/app/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/farm/biome.json
+++ b/apps/farm/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/garden/biome.json
+++ b/apps/garden/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/www/biome.json
+++ b/apps/www/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/client/biome.json
+++ b/packages/client/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/fiscalization/biome.json
+++ b/packages/fiscalization/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/game/biome.json
+++ b/packages/game/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/game/src/snow/createSnowOverlayGeometry.ts
+++ b/packages/game/src/snow/createSnowOverlayGeometry.ts
@@ -1,5 +1,5 @@
 import {
-    BufferAttribute,
+    type BufferAttribute,
     BufferGeometry,
     Float32BufferAttribute,
     Uint16BufferAttribute,
@@ -23,7 +23,10 @@ const scratchMid = new Vector3();
 const scratchCenter = new Vector3();
 const scratchDir = new Vector3();
 
-function getAttributeClone<T extends BufferAttribute>(geometry: BufferGeometry, name: string) {
+function getAttributeClone<T extends BufferAttribute>(
+    geometry: BufferGeometry,
+    name: string,
+) {
     const attr = geometry.getAttribute(name) as T | undefined;
     if (!attr) {
         throw new Error(`Geometry is missing required attribute "${name}"`);
@@ -31,7 +34,9 @@ function getAttributeClone<T extends BufferAttribute>(geometry: BufferGeometry, 
     return attr;
 }
 
-export function createSnowOverlayGeometry(source: BufferGeometry): BufferGeometry {
+export function createSnowOverlayGeometry(
+    source: BufferGeometry,
+): BufferGeometry {
     const cached = cache.get(source);
     if (cached) {
         return cached;
@@ -44,18 +49,30 @@ export function createSnowOverlayGeometry(source: BufferGeometry): BufferGeometr
     workingGeometry.computeBoundingBox();
     const boundingBox = workingGeometry.boundingBox;
     if (!boundingBox) {
-        throw new Error('Unable to resolve geometry bounding box for snow overlay.');
+        throw new Error(
+            'Unable to resolve geometry bounding box for snow overlay.',
+        );
     }
 
-    const positionAttr = getAttributeClone<BufferAttribute>(workingGeometry, 'position');
-    const normalAttr = getAttributeClone<BufferAttribute>(workingGeometry, 'normal');
-    const uvAttr = workingGeometry.getAttribute('uv') as BufferAttribute | undefined;
+    const positionAttr = getAttributeClone<BufferAttribute>(
+        workingGeometry,
+        'position',
+    );
+    const normalAttr = getAttributeClone<BufferAttribute>(
+        workingGeometry,
+        'normal',
+    );
+    const uvAttr = workingGeometry.getAttribute('uv') as
+        | BufferAttribute
+        | undefined;
 
     const vertexCount = positionAttr.count;
     const positions: number[] = Array.from(positionAttr.array);
     const normals: number[] = Array.from(normalAttr.array);
     const snowLayers: number[] = new Array(vertexCount).fill(1);
-    const uvs: number[] | undefined = uvAttr ? Array.from(uvAttr.array) : undefined;
+    const uvs: number[] | undefined = uvAttr
+        ? Array.from(uvAttr.array)
+        : undefined;
 
     const indexAttr = workingGeometry.getIndex();
     const indices: number[] = indexAttr
@@ -132,13 +149,18 @@ export function createSnowOverlayGeometry(source: BufferGeometry): BufferGeometr
     const result = new BufferGeometry();
     result.setAttribute('position', new Float32BufferAttribute(positions, 3));
     result.setAttribute('normal', new Float32BufferAttribute(normals, 3));
-    result.setAttribute('aSnowLayer', new Float32BufferAttribute(snowLayers, 1));
+    result.setAttribute(
+        'aSnowLayer',
+        new Float32BufferAttribute(snowLayers, 1),
+    );
     if (uvs) {
         result.setAttribute('uv', new Float32BufferAttribute(uvs, 2));
     }
 
     const IndexAttributeCtor =
-        positions.length / 3 > 65535 ? Uint32BufferAttribute : Uint16BufferAttribute;
+        positions.length / 3 > 65535
+            ? Uint32BufferAttribute
+            : Uint16BufferAttribute;
     result.setIndex(new IndexAttributeCtor(indices, 1));
     result.computeBoundingBox();
     result.computeBoundingSphere();

--- a/packages/js/biome.json
+++ b/packages/js/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/notifications/biome.json
+++ b/packages/notifications/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/observability/biome.json
+++ b/packages/observability/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/signalco/biome.json
+++ b/packages/signalco/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/slack/biome.json
+++ b/packages/slack/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/storage/biome.json
+++ b/packages/storage/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/stripe/biome.json
+++ b/packages/stripe/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
Update biome.json schema references from older 2.3.x versions to
https://biomejs.dev/schemas/2.3.6/schema.json for multiple packages and
apps so tooling uses the latest schema.
refactor(game): apply TypeScript/formatting improvements in snow
overlay geometry
- add explicit type-only import for BufferAttribute
- reformat function signatures and long lines for readability
- wrap error and multi-line expressions to satisfy lint/formatter
- make uv attribute typing and conditional array conversion clearer
These changes improve type clarity and adhere to project style/linting
rules, preventing type/import issues and improving maintainability.