### PR TITLE
chore(formatter): set lineEnding to auto in biome configs

### DIFF
--- a/apps/api/biome.json
+++ b/apps/api/biome.json
@@ -19,6 +19,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/apps/app/biome.json
+++ b/apps/app/biome.json
@@ -18,6 +18,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/apps/farm/biome.json
+++ b/apps/farm/biome.json
@@ -18,6 +18,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/apps/garden/biome.json
+++ b/apps/garden/biome.json
@@ -18,6 +18,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/apps/www/biome.json
+++ b/apps/www/biome.json
@@ -19,6 +19,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/client/biome.json
+++ b/packages/client/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/fiscalization/biome.json
+++ b/packages/fiscalization/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/game/biome.json
+++ b/packages/game/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/js/biome.json
+++ b/packages/js/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/notifications/biome.json
+++ b/packages/notifications/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/observability/biome.json
+++ b/packages/observability/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4,
         "lineWidth": 80

--- a/packages/signalco/biome.json
+++ b/packages/signalco/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/slack/biome.json
+++ b/packages/slack/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/storage/biome.json
+++ b/packages/storage/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/stripe/biome.json
+++ b/packages/stripe/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -11,6 +11,7 @@
     },
     "formatter": {
         "enabled": true,
+        "lineEnding": "auto",
         "indentStyle": "space",
         "indentWidth": 4
     },


### PR DESCRIPTION
Add "lineEnding": "auto" to formatter settings across multiple
biome.json files (apps and packages). This standardizes line ending
handling for projects including notifications, ui, observability,
game, garden, slack, storage, farm, fiscalization, js, client app,
stripe, api, signalco, and www. The change prevents editor/OS line
ending discrepancies and reduces spurious diffs from CRLF vs LF
variations.