### PR TITLE
refactor(storage): derive operation completedAt from event createdAt

### DIFF
--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -15,9 +15,10 @@ export type OperationStatus =
     | 'failed'
     | 'canceled';
 
+// TODO: Use event payloads to determine these fields
+//       (combine all possible data fields from event type payloads)
 interface OperationEventData {
     completedBy?: string;
-    completedAt?: string;
     images?: string[];
     imageUrl?: string;
     error?: string;
@@ -37,9 +38,6 @@ function parseOperationEventData(value: unknown): OperationEventData {
 
     if (typeof record.completedBy === 'string') {
         data.completedBy = record.completedBy;
-    }
-    if (typeof record.completedAt === 'string') {
-        data.completedAt = record.completedAt;
     }
     if (Array.isArray(record.images)) {
         data.images = record.images.filter(
@@ -107,9 +105,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
             if (event.type === knownEventTypes.operations.complete) {
                 status = 'completed';
                 completedBy = asString(data?.completedBy) ?? completedBy;
-                completedAt = data.completedAt
-                    ? new Date(data.completedAt)
-                    : completedAt;
+                completedAt = event.createdAt;
                 if (Array.isArray(data?.images)) {
                     imageUrls = (data.images as unknown[]).filter(
                         (url): url is string => typeof url === 'string',


### PR DESCRIPTION
Update OperationEventData and operation record handling to rely on
event.createdAt for operation completion timestamps instead of reading
a completedAt string from event payloads.

- Remove completedAt from OperationEventData and skip parsing it from
  database records.
- Set completedAt to event.createdAt when handling
  operations.complete events.
- Add a TODO noting that event payloads should be consolidated to
  determine available data fields uniformly.

This simplifies timestamp handling (uses trusted event metadata),
reduces parsing duplication, and prepares for future unified payload
schema handling.