### PR TITLE
Refactor admin events tables to reuse shared component

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/AccountEventsCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountEventsCard.tsx
@@ -1,0 +1,124 @@
+import { getAccount, getEvents, knownEventTypes } from '@gredice/storage';
+import {
+    Card,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import type { ReactNode } from 'react';
+import { EventsTable } from '../../../../components/shared/events/EventsTable';
+
+interface AccountEventsCardProps {
+    accountId: string;
+}
+
+const ACCOUNT_EVENT_TYPE_LABELS: Record<string, string> = {
+    [knownEventTypes.accounts.create]: 'Račun stvoren',
+    [knownEventTypes.accounts.assignUser]: 'Korisnik dodan',
+    [knownEventTypes.accounts.earnSunflowers]: 'Dodani suncokreti',
+    [knownEventTypes.accounts.spendSunflowers]: 'Potrošeni suncokreti',
+};
+
+const ACCOUNT_EVENT_TYPES = Object.values(knownEventTypes.accounts);
+
+type AccountEvent = Awaited<ReturnType<typeof getEvents>>[number];
+
+type AccountUserLabels = Map<string, string>;
+
+function renderEventDetails(
+    event: AccountEvent,
+    userLabels: AccountUserLabels,
+): ReactNode {
+    const data =
+        event.data && typeof event.data === 'object'
+            ? (event.data as Record<string, unknown>)
+            : null;
+
+    if (event.type === knownEventTypes.accounts.assignUser) {
+        const userId =
+            typeof data?.userId === 'string' ? data.userId : undefined;
+        if (!userId) {
+            return null;
+        }
+
+        const userLabel = userLabels.get(userId) ?? userId;
+        return <span key="user">Korisnik: {userLabel}</span>;
+    }
+
+    if (
+        event.type === knownEventTypes.accounts.earnSunflowers ||
+        event.type === knownEventTypes.accounts.spendSunflowers
+    ) {
+        const amountValue = data?.amount;
+        const amount =
+            typeof amountValue === 'number'
+                ? amountValue
+                : typeof amountValue === 'string'
+                  ? Number.parseFloat(amountValue)
+                  : undefined;
+        const reason =
+            typeof data?.reason === 'string' ? data.reason : undefined;
+
+        const details: ReactNode[] = [];
+        if (typeof amount === 'number' && !Number.isNaN(amount)) {
+            details.push(<span key="amount">Iznos: {amount}</span>);
+        }
+        if (reason) {
+            details.push(<span key="reason">Razlog: {reason}</span>);
+        }
+
+        if (details.length > 0) {
+            return (
+                <Stack spacing={0.5} className="text-sm">
+                    {details}
+                </Stack>
+            );
+        }
+
+        return null;
+    }
+
+    return null;
+}
+
+export async function AccountEventsCard({ accountId }: AccountEventsCardProps) {
+    const [events, account] = await Promise.all([
+        getEvents(ACCOUNT_EVENT_TYPES, [accountId], 0, 10000),
+        getAccount(accountId),
+    ]);
+
+    const userLabels: AccountUserLabels = new Map();
+    for (const accountUser of account?.accountUsers ?? []) {
+        if (!accountUser.user) {
+            continue;
+        }
+        const { id, userName, email } = accountUser.user;
+        userLabels.set(id, userName ?? email ?? id);
+    }
+
+    const sortedEvents = [...events].sort(
+        (first, second) =>
+            second.createdAt.getTime() - first.createdAt.getTime(),
+    );
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Događaji</CardTitle>
+            </CardHeader>
+            <CardOverflow className="overflow-auto">
+                <EventsTable
+                    events={sortedEvents}
+                    renderType={(event) =>
+                        ACCOUNT_EVENT_TYPE_LABELS[event.type] ?? event.type
+                    }
+                    renderDetails={(event) =>
+                        renderEventDetails(event, userLabels)
+                    }
+                    labels={{ details: 'Detalji' }}
+                />
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -12,6 +12,7 @@ import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
 import { sendDeleteAccountEmail } from '../../../(actions)/accountsActions';
 import { AccountAchievementsCard } from './AccountAchievementsCard';
+import { AccountEventsCard } from './AccountEventsCard';
 import { AccountGardensCard } from './AccountGardensCard';
 import { AccountShoppingCartsCard } from './AccountShoppingCartsCard';
 import { AccountSunflowersCard } from './AccountSunflowersCard';
@@ -75,6 +76,7 @@ export default async function AccountPage({
                 <AccountAchievementsCard accountId={accountId} />
                 <AccountTransactionsCard accountId={accountId} />
                 <RaisedBedsTableCard accountId={accountId} />
+                <AccountEventsCard accountId={accountId} />
                 <NotificationsTableCard accountId={accountId} scroll />
                 <AccountShoppingCartsCard accountId={accountId} />
             </div>

--- a/apps/app/biome.json
+++ b/apps/app/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/apps/app/components/raised-beds/RaisedBedEventsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedEventsTable.tsx
@@ -6,9 +6,8 @@ import {
 } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Table } from '@signalco/ui-primitives/Table';
-import { Typography } from '@signalco/ui-primitives/Typography';
 import type { ReactNode } from 'react';
+import { EventsTable } from '../shared/events/EventsTable';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
 import { RaisedBedEventDeleteButton } from './RaisedBedEventDeleteButton';
 
@@ -170,61 +169,20 @@ export async function RaisedBedEventsTable({
     );
 
     return (
-        <Table>
-            <Table.Header>
-                <Table.Row>
-                    <Table.Head>ID</Table.Head>
-                    <Table.Head>Tip</Table.Head>
-                    <Table.Head>Lokacija</Table.Head>
-                    <Table.Head>Detalji</Table.Head>
-                    <Table.Head>Vrijeme</Table.Head>
-                    <Table.Head className="w-32 text-right">Akcije</Table.Head>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {sortedEvents.length === 0 && (
-                    <Table.Row>
-                        <Table.Cell colSpan={6}>
-                            <NoDataPlaceholder />
-                        </Table.Cell>
-                    </Table.Row>
-                )}
-                {sortedEvents.map((event) => {
-                    const location = getEventLocationLabel(
-                        event.aggregateId,
-                        raisedBedId,
-                    );
-                    const typeLabel =
-                        EVENT_TYPE_LABELS[event.type] ?? event.type;
-                    const details = renderEventDetails(event);
-
-                    return (
-                        <Table.Row key={event.id}>
-                            <Table.Cell>{event.id}</Table.Cell>
-                            <Table.Cell>{typeLabel}</Table.Cell>
-                            <Table.Cell>{location}</Table.Cell>
-                            <Table.Cell>
-                                {details ? (
-                                    details
-                                ) : (
-                                    <Typography level="body3" color="neutral">
-                                        -
-                                    </Typography>
-                                )}
-                            </Table.Cell>
-                            <Table.Cell>
-                                <LocalDateTime>{event.createdAt}</LocalDateTime>
-                            </Table.Cell>
-                            <Table.Cell className="text-right">
-                                <RaisedBedEventDeleteButton
-                                    eventId={event.id}
-                                    raisedBedId={raisedBedId}
-                                />
-                            </Table.Cell>
-                        </Table.Row>
-                    );
-                })}
-            </Table.Body>
-        </Table>
+        <EventsTable
+            events={sortedEvents}
+            renderType={(event) => EVENT_TYPE_LABELS[event.type] ?? event.type}
+            renderDetails={(event) => renderEventDetails(event)}
+            renderLocation={(event) =>
+                getEventLocationLabel(event.aggregateId, raisedBedId)
+            }
+            renderActions={(event) => (
+                <RaisedBedEventDeleteButton
+                    eventId={event.id}
+                    raisedBedId={raisedBedId}
+                />
+            )}
+            actionsColumnClassName="w-32 text-right"
+        />
     );
 }

--- a/apps/app/components/shared/events/EventsTable.tsx
+++ b/apps/app/components/shared/events/EventsTable.tsx
@@ -1,0 +1,114 @@
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import type { ReactNode } from 'react';
+import { NoDataPlaceholder } from '../placeholders/NoDataPlaceholder';
+
+export interface EventsTableProps<
+    TEvent extends { id: string | number; createdAt: Date },
+> {
+    events: TEvent[];
+    renderType: (event: TEvent) => ReactNode;
+    renderDetails?: (event: TEvent) => ReactNode | null;
+    renderLocation?: (event: TEvent) => ReactNode;
+    renderActions?: (event: TEvent) => ReactNode;
+    actionsColumnClassName?: string;
+    labels?: {
+        id?: ReactNode;
+        type?: ReactNode;
+        location?: ReactNode;
+        details?: ReactNode;
+        time?: ReactNode;
+        actions?: ReactNode;
+    };
+}
+
+export function EventsTable<
+    TEvent extends { id: string | number; createdAt: Date },
+>({
+    events,
+    renderType,
+    renderDetails,
+    renderLocation,
+    renderActions,
+    actionsColumnClassName,
+    labels = {},
+}: EventsTableProps<TEvent>) {
+    const hasLocation = Boolean(renderLocation);
+    const hasActions = Boolean(renderActions);
+
+    const {
+        id: idLabel = 'ID',
+        type: typeLabel = 'Tip',
+        location: locationLabel = 'Lokacija',
+        details: detailsLabel = 'Detalji',
+        time: timeLabel = 'Vrijeme',
+        actions: actionsLabel = 'Akcije',
+    } = labels;
+
+    const columnCount = 4 + Number(hasLocation) + Number(hasActions);
+
+    return (
+        <Table>
+            <Table.Header>
+                <Table.Row>
+                    <Table.Head>{idLabel}</Table.Head>
+                    <Table.Head>{typeLabel}</Table.Head>
+                    {hasLocation && <Table.Head>{locationLabel}</Table.Head>}
+                    <Table.Head>{detailsLabel}</Table.Head>
+                    <Table.Head>{timeLabel}</Table.Head>
+                    {hasActions && (
+                        <Table.Head className={actionsColumnClassName}>
+                            {actionsLabel}
+                        </Table.Head>
+                    )}
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {events.length === 0 && (
+                    <Table.Row>
+                        <Table.Cell colSpan={columnCount}>
+                            <NoDataPlaceholder />
+                        </Table.Cell>
+                    </Table.Row>
+                )}
+                {events.map((event) => {
+                    const details = renderDetails ? renderDetails(event) : null;
+
+                    return (
+                        <Table.Row key={event.id}>
+                            <Table.Cell>{event.id}</Table.Cell>
+                            <Table.Cell>{renderType(event)}</Table.Cell>
+                            {hasLocation && (
+                                <Table.Cell>
+                                    {renderLocation
+                                        ? renderLocation(event)
+                                        : null}
+                                </Table.Cell>
+                            )}
+                            <Table.Cell>
+                                {details ? (
+                                    details
+                                ) : (
+                                    <Typography level="body3" color="neutral">
+                                        -
+                                    </Typography>
+                                )}
+                            </Table.Cell>
+                            <Table.Cell>
+                                <LocalDateTime>{event.createdAt}</LocalDateTime>
+                            </Table.Cell>
+                            {hasActions && (
+                                <Table.Cell className={actionsColumnClassName}>
+                                    {renderActions
+                                        ? renderActions(event)
+                                        : null}
+                                </Table.Cell>
+                            )}
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </Table>
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared events table component for rendering event history
- switch the account events card to use the shared table while keeping event detail rendering
- refactor the raised bed events table to consume the shared table and retain delete actions

## Testing
- pnpm lint --filter app -- --write

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccf9e4b48832fae20a3a2633f2261)