### PR TITLE
feat(advent): invalidate garden cache when opening day

### DIFF
--- a/packages/game/src/hooks/useOpenAdventDay.ts
+++ b/packages/game/src/hooks/useOpenAdventDay.ts
@@ -2,6 +2,7 @@ import { client } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { adventCalendarKeys } from './useAdventCalendar';
 import { currentAccountKeys } from './useCurrentAccount';
+import { currentGardenKeys } from './useCurrentGarden';
 
 export function useOpenAdventDay() {
     const queryClient = useQueryClient();
@@ -17,6 +18,7 @@ export function useOpenAdventDay() {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: adventCalendarKeys });
             queryClient.invalidateQueries({ queryKey: currentAccountKeys });
+            queryClient.invalidateQueries({ queryKey: currentGardenKeys });
         },
     });
 }


### PR DESCRIPTION
Import currentGardenKeys and invalidate the garden cache after a
successful open-advent-day mutation. This ensures the current garden
state is refreshed alongside the advent calendar and account data,
preventing stale garden-related UI after opening a day.