### PR TITLE
feat(advent): enforce availability times for calendar days

### DIFF
--- a/apps/api/app/api/[...route]/occasionsRoutes.ts
+++ b/apps/api/app/api/[...route]/occasionsRoutes.ts
@@ -9,6 +9,7 @@ import {
     ADVENT_CALENDAR_2025_ID,
     ADVENT_TOTAL_DAYS,
     AdventCalendarDayAlreadyOpenedError,
+    AdventCalendarDayNotYetAvailableError,
     getAdventCalendar2025Status,
     getAdventOccasionOverview,
     openAdventCalendar2025Day,
@@ -76,6 +77,15 @@ const app = new Hono<{ Variables: AuthVariables }>()
                             poruka: 'Taj dan adventskog kalendara je već otvoren.',
                         },
                         409,
+                    );
+                }
+                if (error instanceof AdventCalendarDayNotYetAvailableError) {
+                    return context.json(
+                        {
+                            poruka: `Dan ${day} još nije dostupan. Dostupan od ${error.availableAt.toISOString()}.`,
+                            dostupnoOd: error.availableAt.toISOString(),
+                        },
+                        400,
                     );
                 }
                 console.error('Pogreška pri otvaranju adventskog dana:', error);


### PR DESCRIPTION
Add a new AdventCalendarDayNotYetAvailableError and enforce day
availability checks before opening a calendar day. Calculate the
moment a given advent day becomes openable using a UTC+14 based
rule (first timezone to hit midnight) and provide helper functions
getAdDayAvailableAt andAdventDay.

Return a 400 response with a localized message and dostupnoOd
timestamp when a client attempts to open a day that is not yet
available. Preserve existing 409 handling for already-opened days.

This prevents users from opening future days early and makes the
availability logic explicit and testable.