### PR TITLE
refactor(advent): rename fields to English and add flag

### DIFF
--- a/apps/api/app/api/[...route]/occasionsRoutes.ts
+++ b/apps/api/app/api/[...route]/occasionsRoutes.ts
@@ -66,15 +66,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     day,
                 });
                 return context.json({
-                    poruka: `Dan ${day} je otvoren!`,
-                    nagrade: result.payload.awards,
-                    opisNagrada: result.opisNagrada,
+                    message: `Dan ${day} je otvoren!`,
+                    awards: result.payload.awards,
+                    awardDescriptions: result.awardDescriptions,
                 });
             } catch (error) {
                 if (error instanceof AdventCalendarDayAlreadyOpenedError) {
                     return context.json(
                         {
-                            poruka: 'Taj dan adventskog kalendara je već otvoren.',
+                            message:
+                                'Taj dan adventskog kalendara je već otvoren.',
                         },
                         409,
                     );
@@ -82,8 +83,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 if (error instanceof AdventCalendarDayNotYetAvailableError) {
                     return context.json(
                         {
-                            poruka: `Dan ${day} još nije dostupan. Dostupan od ${error.availableAt.toISOString()}.`,
-                            dostupnoOd: error.availableAt.toISOString(),
+                            message: `Dan ${day} još nije dostupan. Dostupan od ${error.availableAt.toISOString()}.`,
+                            availableAt: error.availableAt.toISOString(),
                         },
                         400,
                     );
@@ -91,7 +92,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 console.error('Pogreška pri otvaranju adventskog dana:', error);
                 return context.json(
                     {
-                        poruka: 'Došlo je do pogreške pri otvaranju prozorčića.',
+                        message:
+                            'Došlo je do pogreške pri otvaranju prozorčića.',
                     },
                     500,
                 );

--- a/apps/api/lib/occasions/advent2025.ts
+++ b/apps/api/lib/occasions/advent2025.ts
@@ -99,17 +99,17 @@ const DECORATION_BLOCK_IDS = [
 ];
 
 export type AdventDayStatus = {
-    dan: number;
-    otvoren: boolean;
-    otvorenoAt?: string;
-    otvorio?: string;
-    nagrade?: AdventAward[];
-    opisNagrada?: AdventAwardDescription[];
+    day: number;
+    opened: boolean;
+    openedAt?: string;
+    openedBy?: string;
+    awards?: AdventAward[];
+    awardDescriptions?: AdventAwardDescription[];
 };
 
 export type AdventAwardDescription = {
-    naslov: string;
-    opis: string;
+    title: string;
+    description: string;
 };
 
 const ADVENT_DESCRIPTION =
@@ -119,34 +119,36 @@ function describeAward(award: AdventAward): AdventAwardDescription {
     switch (award.kind) {
         case 'sunflowers':
             return {
-                naslov: `${award.amount} suncokreta`,
-                opis: 'Suncokreta na tvom računu.',
+                title: `${award.amount} suncokreta`,
+                description: 'Suncokreta na tvom računu.',
             };
         case 'plant':
             return {
-                naslov: award.title ?? 'Nova biljka',
-                opis: 'Biljka samo za tebe.',
+                title: award.title ?? 'Nova biljka',
+                description: 'Biljka samo za tebe.',
             };
         case 'decoration':
             return {
-                naslov: award.title ?? 'Blagdanska dekoracija',
-                opis: 'Ukras koji će uljepšati tvoj vrt u blagdansko vrijeme.',
+                title: award.title ?? 'Blagdanska dekoracija',
+                description:
+                    'Ukras koji će uljepšati tvoj vrt u blagdansko vrijeme.',
             };
         case 'tree-decoration':
             return {
-                naslov: award.title ?? `Ukras za drvce (dan ${award.day})`,
-                opis: 'Ukras koji će uljepšati tvoje božićno drvce.',
+                title: award.title ?? `Ukras za drvce (dan ${award.day})`,
+                description: 'Ukras koji će uljepšati tvoje božićno drvce.',
             };
         case 'gift':
             if (award.gift === 'christmas-tree') {
                 return {
-                    naslov: 'Božićno drvce',
-                    opis: 'Posebno drvce za tvoj prvi dan adventskog kalendara.',
+                    title: 'Božićno drvce',
+                    description:
+                        'Posebno drvce za tvoj prvi dan adventskog kalendara.',
                 };
             }
             return {
-                naslov: 'Adventski box',
-                opis:
+                title: 'Adventski box',
+                description:
                     award.delivery === 'digital+physical'
                         ? 'Fizički poklon box jer su otvoreni svi dani kalendara.'
                         : 'Nagrade za posljednji dan adventa.',
@@ -285,34 +287,34 @@ export async function getAdventCalendar2025Status(accountId: string) {
         });
     }
 
-    const dani: AdventDayStatus[] = [];
+    const days: AdventDayStatus[] = [];
     for (let day = 1; day <= ADVENT_TOTAL_DAYS; day++) {
         const existing = opened.get(day);
         const awards =
             existing?.awards ??
             (existing?.award ? [existing.award] : undefined);
-        dani.push({
-            dan: day,
-            otvoren: Boolean(existing),
-            otvorenoAt: existing?.createdAt,
-            otvorio: existing?.openedBy,
-            nagrade: awards,
-            opisNagrada: awards?.map(describeAward),
+        days.push({
+            day,
+            opened: Boolean(existing),
+            openedAt: existing?.createdAt,
+            openedBy: existing?.openedBy,
+            awards,
+            awardDescriptions: awards?.map(describeAward),
         });
     }
 
-    const brojOtvorenih = opened.size;
-    const sljedeciDan = dani.find((day) => !day.otvoren)?.dan ?? null;
+    const openedCount = opened.size;
+    const nextDay = days.find((d) => !d.opened)?.day ?? null;
 
     return {
-        kalendarId: ADVENT_CALENDAR_2025_ID,
-        godina: ADVENT_YEAR,
-        brojDana: ADVENT_TOTAL_DAYS,
-        brojOtvorenih,
-        preostalo: ADVENT_TOTAL_DAYS - brojOtvorenih,
-        sljedeciDan,
-        opis: ADVENT_DESCRIPTION,
-        dani,
+        calendarId: ADVENT_CALENDAR_2025_ID,
+        year: ADVENT_YEAR,
+        totalDays: ADVENT_TOTAL_DAYS,
+        openedCount,
+        remaining: ADVENT_TOTAL_DAYS - openedCount,
+        nextDay,
+        description: ADVENT_DESCRIPTION,
+        days,
     };
 }
 
@@ -541,7 +543,7 @@ export async function openAdventCalendar2025Day({
 
     return {
         payload: result.payload,
-        opisNagrada: resolvedAwards.map(describeAward),
+        awardDescriptions: resolvedAwards.map(describeAward),
     };
 }
 

--- a/apps/garden/tailwind.config.ts
+++ b/apps/garden/tailwind.config.ts
@@ -23,9 +23,18 @@ const tailwindConfig: Config = {
                     '40%': { transform: 'translateX(0) scaleX(0.4)' },
                     '100%': { transform: 'translateX(100%) scaleX(0.5)' },
                 },
+                wobble: {
+                    '0%, 100%': { transform: 'rotate(0deg)' },
+                    '15%': { transform: 'rotate(-5deg)' },
+                    '30%': { transform: 'rotate(4deg)' },
+                    '45%': { transform: 'rotate(-4deg)' },
+                    '60%': { transform: 'rotate(3deg)' },
+                    '75%': { transform: 'rotate(-2deg)' },
+                },
             },
             animation: {
                 progress: 'progress 1s infinite linear',
+                wobble: 'wobble 0.5s ease-in-out',
             },
         },
     },

--- a/packages/game/src/entities/PineAdvent.tsx
+++ b/packages/game/src/entities/PineAdvent.tsx
@@ -328,7 +328,7 @@ export function PineAdvent({
     const currentStackHeight = useStackHeight(stack, block);
     const { data: calendar } = useAdventCalendar();
     const openCalendarDays =
-        (variant ?? 0) > 99 ? 24 : (calendar?.brojOtvorenih ?? 0);
+        (variant ?? 0) > 99 ? 24 : (calendar?.openedCount ?? 0);
 
     // Ball decorations count
     const ballDecorationCount = Math.min(

--- a/packages/game/src/hooks/useAdventCalendar.ts
+++ b/packages/game/src/hooks/useAdventCalendar.ts
@@ -4,7 +4,7 @@ import { useCurrentUser } from './useCurrentUser';
 
 export const adventCalendarKeys = ['occasions', 'advent', 'calendar-2025'];
 
-export function useAdventCalendar() {
+export function useAdventCalendar(enabled?: boolean) {
     const { data: currentUser } = useCurrentUser();
     return useQuery({
         queryKey: adventCalendarKeys,
@@ -14,6 +14,6 @@ export function useAdventCalendar() {
             return res.json();
         },
         staleTime: 1000 * 60 * 5,
-        enabled: Boolean(currentUser),
+        enabled: Boolean(currentUser) && enabled !== false,
     });
 }

--- a/packages/game/src/hud/AdventHud.tsx
+++ b/packages/game/src/hud/AdventHud.tsx
@@ -1,34 +1,94 @@
 'use client';
 
 import { useSearchParam } from '@signalco/hooks/useSearchParam';
+import { cx } from '@signalco/ui-primitives/cx';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
-import { Stack } from '@signalco/ui-primitives/Stack';
+import { useCallback, useEffect, useState } from 'react';
+import { useAdventCalendar } from '../hooks/useAdventCalendar';
 import { SantaCapIcon } from '../icons/SantaCap';
 import { HudCard } from './components/HudCard';
+import { HudMessageBubble } from './components/HudMessageBubble';
+
+const ADVENT_MESSAGE_DISMISSED_KEY = 'advent-message-dismissed-day';
+
+function useAdventMessageDismissed(currentDay: number | null) {
+    const [isDismissed, setIsDismissed] = useState(true); // Default to dismissed to prevent flash
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || currentDay === null) return;
+        const dismissedDay = localStorage.getItem(ADVENT_MESSAGE_DISMISSED_KEY);
+        setIsDismissed(dismissedDay === String(currentDay));
+    }, [currentDay]);
+
+    const dismiss = useCallback(() => {
+        if (typeof window === 'undefined' || currentDay === null) return;
+        localStorage.setItem(ADVENT_MESSAGE_DISMISSED_KEY, String(currentDay));
+        setIsDismissed(true);
+    }, [currentDay]);
+
+    return { isDismissed, dismiss };
+}
 
 export function AdventHud() {
     const [, setAdventParam] = useSearchParam('advent');
 
-    // Only show during December
+    // Check if current date is in December
     const now = new Date();
     const isDecember = now.getMonth() === 11;
-    const dayOfMonth = now.getDate();
-    const isAdventPeriod = isDecember && dayOfMonth <= 24;
+    const isAdventPeriod = isDecember;
+    const currentDay = now.getDate();
 
+    // Determine if there's a day to open (today's day exists and is not opened yet)
+    const { data: calendar } = useAdventCalendar(isAdventPeriod);
+    const todayStatus = calendar?.days?.find((d) => d.day === currentDay);
+    const hasDayToOpen = todayStatus && !todayStatus.opened;
+
+    const { isDismissed, dismiss } = useAdventMessageDismissed(
+        hasDayToOpen ? currentDay : null,
+    );
+
+    // Only show advent period
     if (!isAdventPeriod) {
         return null;
     }
 
+    const handleMessageClick = () => {
+        dismiss();
+        setAdventParam('open');
+    };
+
     return (
         <HudCard open position="floating" className="static p-0.5">
-            <IconButton
-                variant="plain"
-                className="rounded-full size-10 border-[1.5px] border-white dark:border-green-950 bg-green-500 dark:bg-green-700 hover:bg-green-600"
-                title="Adventski kalendar"
-                onClick={() => setAdventParam('open')}
-            >
-                <SantaCapIcon className="size-6 shrink-0" />
-            </IconButton>
+            <div className="relative flex items-center gap-2">
+                {/* Message bubble */}
+                {hasDayToOpen && !isDismissed && (
+                    <HudMessageBubble
+                        position="right"
+                        variant="green"
+                        onClick={handleMessageClick}
+                    >
+                        Novi dan je stigao! 🎄
+                    </HudMessageBubble>
+                )}
+                <div className="relative">
+                    {/* Pulsating ring when there's a day to open */}
+                    {hasDayToOpen && (
+                        <div className="absolute -inset-1 rounded-full border-2 border-green-400 animate-ping pointer-events-none" />
+                    )}
+                    <IconButton
+                        variant="plain"
+                        className={cx(
+                            'rounded-full size-10',
+                            hasDayToOpen &&
+                                'border-[1.5px] border-green-400 !bg-green-500 dark:!bg-green-800 hover:!bg-green-400 dark:hover:!bg-green-600',
+                        )}
+                        title="Adventski kalendar"
+                        onClick={() => setAdventParam('open')}
+                    >
+                        <SantaCapIcon className="size-6 shrink-0" />
+                    </IconButton>
+                </div>
+            </div>
         </HudCard>
     );
 }

--- a/packages/game/src/hud/components/HudMessageBubble.tsx
+++ b/packages/game/src/hud/components/HudMessageBubble.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { cx } from '@signalco/ui-primitives/cx';
+import type { ReactNode } from 'react';
+
+export type HudMessageBubblePosition = 'left' | 'right' | 'top' | 'bottom';
+export type HudMessageBubbleVariant = 'default' | 'green';
+
+type HudMessageBubbleProps = {
+    children: ReactNode;
+    position?: HudMessageBubblePosition;
+    variant?: HudMessageBubbleVariant;
+    onClick?: () => void;
+    className?: string;
+};
+
+const positionClasses: Record<HudMessageBubblePosition, string> = {
+    right: 'left-full ml-2',
+    left: 'right-full mr-2',
+    top: 'bottom-full mb-2 left-1/2 -translate-x-1/2',
+    bottom: 'top-full mt-2 left-1/2 -translate-x-1/2',
+};
+
+const tailPositionClasses: Record<HudMessageBubblePosition, string> = {
+    right: 'left-0 top-1/2 -translate-y-1/2 -translate-x-full',
+    left: 'right-0 top-1/2 -translate-y-1/2 translate-x-full',
+    top: 'bottom-0 left-1/2 -translate-x-1/2 translate-y-full',
+    bottom: 'top-0 left-1/2 -translate-x-1/2 -translate-y-full',
+};
+
+const tailFillOffsetClasses: Record<HudMessageBubblePosition, string> = {
+    right: 'left-[1px] top-1/2 -translate-y-1/2 -translate-x-full',
+    left: 'right-[1px] top-1/2 -translate-y-1/2 translate-x-full',
+    top: 'bottom-[1px] left-1/2 -translate-x-1/2 translate-y-full',
+    bottom: 'top-[1px] left-1/2 -translate-x-1/2 -translate-y-full',
+};
+
+const tailBorderClasses: Record<
+    HudMessageBubblePosition,
+    Record<HudMessageBubbleVariant, string>
+> = {
+    right: {
+        default: 'border-r-neutral-200 dark:border-r-neutral-700',
+        green: 'border-r-green-200 dark:border-r-green-700',
+    },
+    left: {
+        default: 'border-l-neutral-200 dark:border-l-neutral-700',
+        green: 'border-l-green-200 dark:border-l-green-700',
+    },
+    top: {
+        default: 'border-t-neutral-200 dark:border-t-neutral-700',
+        green: 'border-t-green-200 dark:border-t-green-700',
+    },
+    bottom: {
+        default: 'border-b-neutral-200 dark:border-b-neutral-700',
+        green: 'border-b-green-200 dark:border-b-green-700',
+    },
+};
+
+const tailFillClasses: Record<
+    HudMessageBubblePosition,
+    Record<HudMessageBubbleVariant, string>
+> = {
+    right: {
+        default: 'border-r-white dark:border-r-neutral-900',
+        green: 'border-r-white dark:border-r-green-900',
+    },
+    left: {
+        default: 'border-l-white dark:border-l-neutral-900',
+        green: 'border-l-white dark:border-l-green-900',
+    },
+    top: {
+        default: 'border-t-white dark:border-t-neutral-900',
+        green: 'border-t-white dark:border-t-green-900',
+    },
+    bottom: {
+        default: 'border-b-white dark:border-b-neutral-900',
+        green: 'border-b-white dark:border-b-green-900',
+    },
+};
+
+const variantClasses: Record<HudMessageBubbleVariant, string> = {
+    default:
+        'bg-white dark:bg-neutral-900 text-neutral-800 dark:text-neutral-100 border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800',
+    green: 'bg-white dark:bg-green-900 text-green-800 dark:text-green-100 border-green-200 dark:border-green-700 hover:bg-green-50 dark:hover:bg-green-800',
+};
+
+export function HudMessageBubble({
+    children,
+    position = 'right',
+    variant = 'default',
+    onClick,
+    className,
+}: HudMessageBubbleProps) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={cx(
+                'absolute flex items-center whitespace-nowrap rounded-lg px-3 py-2 text-sm font-medium shadow-lg border transition-colors',
+                positionClasses[position],
+                variantClasses[variant],
+                className,
+            )}
+        >
+            {/* Speech bubble tail - border layer */}
+            <div className={cx('absolute', tailPositionClasses[position])}>
+                <div
+                    className={cx(
+                        'border-8 border-transparent',
+                        tailBorderClasses[position][variant],
+                    )}
+                />
+            </div>
+            {/* Speech bubble tail - fill layer */}
+            <div className={cx('absolute', tailFillOffsetClasses[position])}>
+                <div
+                    className={cx(
+                        'border-8 border-transparent',
+                        tailFillClasses[position][variant],
+                    )}
+                />
+            </div>
+            {children}
+        </button>
+    );
+}

--- a/packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx
+++ b/packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { BlockImage } from '@gredice/ui/BlockImage';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import Image from 'next/image';
+
+type AdventAward = {
+    kind: 'sunflowers' | 'plant' | 'decoration' | 'tree-decoration' | 'gift';
+    amount?: number;
+    plantSortId?: number;
+    blockId?: string;
+    day?: number;
+    title?: string;
+    gift?: string;
+    delivery?: string;
+};
+
+type AdventAlreadyOpenedScreenProps = {
+    day: number;
+    awards: AdventAward[];
+    onClose: () => void;
+};
+
+function SmallAwardImage({ award }: { award: AdventAward }) {
+    switch (award.kind) {
+        case 'sunflowers':
+            return (
+                <div className="relative flex items-center gap-2">
+                    <Image
+                        src="https://cdn.gredice.com/sunflower-large.svg"
+                        alt="Suncokret"
+                        width={40}
+                        height={40}
+                    />
+                    <span className="font-bold text-yellow-500">
+                        x{award.amount}
+                    </span>
+                </div>
+            );
+        case 'plant':
+            return <div className="text-3xl">🌱</div>;
+        case 'decoration':
+        case 'tree-decoration':
+            if (award.blockId) {
+                return (
+                    <BlockImage
+                        blockName={award.blockId}
+                        width={40}
+                        height={40}
+                        className="rounded-lg"
+                    />
+                );
+            }
+            return <div className="text-3xl">🎄</div>;
+        case 'gift':
+            if (award.gift === 'christmas-tree') {
+                return <div className="text-3xl">🎄</div>;
+            }
+            return <div className="text-3xl">🎁</div>;
+        default:
+            return <div className="text-3xl">🎁</div>;
+    }
+}
+
+export function AdventAlreadyOpenedScreen({
+    day,
+    awards,
+    onClose,
+}: AdventAlreadyOpenedScreenProps) {
+    return (
+        <Stack spacing={4} className="items-center text-center p-8">
+            {/* Checkmark icon */}
+            <div className="text-6xl">✅</div>
+
+            {/* Message */}
+            <Stack spacing={2}>
+                <Typography level="h4" className="font-bold">
+                    Dan {day}
+                </Typography>
+                <Typography level="body2">
+                    Već si pokupio nagrade za ovaj dan!
+                </Typography>
+            </Stack>
+
+            {/* Awards list */}
+            {awards.length > 0 && (
+                <Stack spacing={2} className="w-full">
+                    <Typography
+                        level="body2"
+                        className="text-muted-foreground font-semibold"
+                    >
+                        Nagrade:
+                    </Typography>
+                    <div className="flex flex-wrap justify-center gap-3">
+                        {awards.map((award) => (
+                            <div
+                                key={`${award.kind}-${award.blockId ?? award.amount ?? ''}`}
+                                className="bg-muted rounded-lg p-3 flex items-center justify-center"
+                            >
+                                <SmallAwardImage award={award} />
+                            </div>
+                        ))}
+                    </div>
+                </Stack>
+            )}
+
+            {/* Come back message */}
+            <Typography level="body2">
+                Vrati se već sutra po nove nagrade! 🎁
+            </Typography>
+
+            {/* Close button */}
+            <Button
+                variant="solid"
+                size="lg"
+                className="bg-[#8B0000] hover:bg-[#6B0000] text-white"
+                onClick={onClose}
+            >
+                U redu
+            </Button>
+        </Stack>
+    );
+}

--- a/packages/game/src/modals/advent/AdventAwardScreen.tsx
+++ b/packages/game/src/modals/advent/AdventAwardScreen.tsx
@@ -21,8 +21,8 @@ type AdventAward = {
 };
 
 type AdventAwardDescription = {
-    naslov: string;
-    opis: string;
+    title: string;
+    description: string;
 };
 
 type AdventAwardScreenProps = {
@@ -100,11 +100,11 @@ export function AdventAwardScreen({
             <Stack spacing={1}>
                 {award.kind !== 'sunflowers' && (
                     <Typography level="h4" className="font-bold">
-                        {description.naslov}
+                        {description.title}
                     </Typography>
                 )}
                 <Typography level="body1" className="text-muted-foreground">
-                    {description.opis}
+                    {description.description}
                 </Typography>
             </Stack>
 

--- a/packages/game/src/modals/advent/AdventDayCell.tsx
+++ b/packages/game/src/modals/advent/AdventDayCell.tsx
@@ -2,6 +2,7 @@
 
 import { Check } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
+import { useState } from 'react';
 import { adventDayFont } from './fonts';
 
 type DayCellVariant = 'red' | 'green' | 'brown' | 'striped';
@@ -11,6 +12,7 @@ type AdventDayCellProps = {
     variant: DayCellVariant;
     isOpen: boolean;
     isToday: boolean;
+    isFuture: boolean;
     onClick?: () => void;
     disabled?: boolean;
     colSpan?: number;
@@ -25,7 +27,7 @@ export function getDayVariant(day: number): DayCellVariant {
 function StripedPattern() {
     return (
         <svg
-            className="absolute inset-0 w-full h-full rounded-sm"
+            className="absolute inset-0.5 w-full h-full rounded-sm"
             preserveAspectRatio="none"
             aria-hidden="true"
         >
@@ -37,7 +39,7 @@ function StripedPattern() {
                     height="10"
                     patternTransform="rotate(45)"
                 >
-                    <rect x="0" y="0" width="5" height="10" fill="#F5DEB3" />
+                    <rect x="0" y="0" width="5" height="10" fill="#F5DEB300" />
                     <rect x="5" y="0" width="5" height="10" fill="#DAA520" />
                 </pattern>
             </defs>
@@ -49,7 +51,7 @@ function StripedPattern() {
 function DotsPattern() {
     return (
         <svg
-            className="absolute inset-0 w-full h-full rounded-sm"
+            className="absolute inset-0.5 w-full h-full rounded-sm"
             preserveAspectRatio="none"
             aria-hidden="true"
         >
@@ -72,7 +74,7 @@ function DotsPattern() {
 function WavePattern() {
     return (
         <svg
-            className="absolute inset-0 w-full h-full rounded-sm"
+            className="absolute inset-0.5 w-full h-full rounded-sm"
             preserveAspectRatio="none"
             aria-hidden="true"
         >
@@ -101,10 +103,22 @@ export function AdventDayCell({
     variant,
     isOpen,
     isToday,
+    isFuture,
     onClick,
     disabled,
     colSpan = 1,
 }: AdventDayCellProps) {
+    const [isWobbling, setIsWobbling] = useState(false);
+
+    const handleClick = () => {
+        if (isFuture && !isOpen) {
+            // Trigger wobble animation for future days
+            setIsWobbling(true);
+            setTimeout(() => setIsWobbling(false), 500);
+            return;
+        }
+        onClick?.();
+    };
     const variantClasses: Record<DayCellVariant, string> = {
         red: 'bg-[#8B0000]',
         green: 'bg-[#1B5E20]',
@@ -122,13 +136,14 @@ export function AdventDayCell({
 
     const variantOpenBgClasses: Record<DayCellVariant, string> = {
         red: 'bg-[#6B0000]',
-        green: 'bg-[#3E2723]',
+        green: 'bg-[#0D3D10]',
         brown: 'bg-[#3E2723]',
-        striped: 'bg-[#5D3A1A]',
+        striped: 'bg-[#DAA520]',
     };
 
     const baseClasses = cx(
-        'relative w-full rounded-sm h-full flex items-center justify-center font-bold text-2xl transition-all duration-200',
+        'overflow-hidden relative w-full rounded-sm h-full flex items-center justify-center font-bold text-2xl transition-all duration-200',
+        'cursor-pointer hover:bg-white/30 hover:scale-105 active:scale-95',
         colSpan === 1 && 'aspect-square',
         colSpan === 2 && 'aspect-[2/1]',
     );
@@ -139,29 +154,16 @@ export function AdventDayCell({
         colSpan === 2 && 'col-span-2',
     );
 
-    // When opened, use border color as background but keep the variant styling
-    const openBgClass = 'bg-[#5D3A1A]';
-
-    const interactiveClasses =
-        !disabled && !isOpen
-            ? 'cursor-pointer hover:scale-105 hover:shadow-lg active:scale-95'
-            : '';
-
-    const todayRingClasses =
-        isToday && !isOpen ? 'ring-4 ring-yellow-400 z-20' : '';
-
     return (
         <div className={wrapperClasses}>
             <button
                 type="button"
-                onClick={onClick}
-                disabled={disabled || isOpen}
+                onClick={handleClick}
+                disabled={disabled}
                 className={cx(
                     baseClasses,
-                    isOpen ? openBgClass : variantClasses[variant],
-                    interactiveClasses,
-                    todayRingClasses,
-                    'overflow-hidden',
+                    !isOpen && variantClasses[variant],
+                    isWobbling && 'animate-wobble',
                 )}
             >
                 {/* Pattern backgrounds with inset - show for closed cells only */}
@@ -184,7 +186,7 @@ export function AdventDayCell({
                 {isOpen && (
                     <div
                         className={cx(
-                            'inset-0 absolute',
+                            'inset-0.5 rounded-sm absolute',
                             variantOpenBgClasses[variant],
                         )}
                     ></div>
@@ -212,7 +214,7 @@ export function AdventDayCell({
                 {/* Border for cell separation */}
                 <div
                     className={cx(
-                        'absolute rounded-sm inset-0 border border-dashed pointer-events-none',
+                        'absolute rounded-sm inset-0.5 border border-dashed pointer-events-none',
                         variantBorderClasses[variant],
                     )}
                 />

--- a/packages/game/src/modals/advent/AdventMissedDayScreen.tsx
+++ b/packages/game/src/modals/advent/AdventMissedDayScreen.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+
+type AdventMissedDayScreenProps = {
+    day: number;
+    onClose: () => void;
+};
+
+export function AdventMissedDayScreen({
+    day,
+    onClose,
+}: AdventMissedDayScreenProps) {
+    return (
+        <Stack spacing={4} className="items-center text-center p-8">
+            {/* Sad emoji */}
+            <div className="text-6xl">😢</div>
+
+            {/* Message */}
+            <Stack spacing={2}>
+                <Typography level="h4" className="font-bold">
+                    Dan {day}
+                </Typography>
+                <Typography level="body2">
+                    Nažalost, nisi pokupio nagradu za ovaj dan.
+                </Typography>
+                <Typography level="body2">
+                    Ne brini, ima još vremena za pokupiti ostale nagrade! 🎁
+                </Typography>
+            </Stack>
+
+            {/* Close button */}
+            <Button
+                variant="solid"
+                size="lg"
+                className="bg-[#8B0000] hover:bg-[#6B0000] text-white"
+                onClick={onClose}
+            >
+                U redu
+            </Button>
+        </Stack>
+    );
+}

--- a/packages/game/tailwind.config.ts
+++ b/packages/game/tailwind.config.ts
@@ -9,16 +9,27 @@ const tailwindConfig: Config = {
         './node_modules/@signalco/ui/**/*.{js,ts,jsx,tsx,mdx}',
     ],
     presets: [config],
-    extend: {
-        keyframes: {
-            progress: {
-                '0%': { transform: 'translateX(0) scaleX(0)' },
-                '40%': { transform: 'translateX(0) scaleX(0.4)' },
-                '100%': { transform: 'translateX(100%) scaleX(0.5)' },
+    theme: {
+        extend: {
+            keyframes: {
+                progress: {
+                    '0%': { transform: 'translateX(0) scaleX(0)' },
+                    '40%': { transform: 'translateX(0) scaleX(0.4)' },
+                    '100%': { transform: 'translateX(100%) scaleX(0.5)' },
+                },
+                wobble: {
+                    '0%, 100%': { transform: 'rotate(0deg)' },
+                    '15%': { transform: 'rotate(-5deg)' },
+                    '30%': { transform: 'rotate(4deg)' },
+                    '45%': { transform: 'rotate(-4deg)' },
+                    '60%': { transform: 'rotate(3deg)' },
+                    '75%': { transform: 'rotate(-2deg)' },
+                },
             },
-        },
-        animation: {
-            progress: 'progress 1s infinite linear',
+            animation: {
+                progress: 'progress 1s infinite linear',
+                wobble: 'wobble 0.5s ease-in-out',
+            },
         },
     },
     plugins: [tailwindcssTypography],


### PR DESCRIPTION
Rename advent calendar types and response fields from Bosnian
to English for consistency across the API:
- AdventDayStatus: dan->day, otvoren->opened, otvorenoAt->openedAt,
  otvorio->openedBy, nagrade->awards, opisNagrada->awardDescriptions.
- AdventAwardDescription: naslov->title, opis->description.
- Response fields: kalendarId->calendarId, godina->year,
  brojDana->totalDays, brojOtvorenih->openedCount, preostalo->remaining,
  dani->days, opis->description.
- Local variables: dani->days, brojOtvorenih->openedCount,
  sljedeciDan->nextDay.

Adjust describeAward outputs to use title/description and wrap long
strings. Update payload mapping to awardDescriptions.

Also make useAdventCalendar accept an optional enabled flag to allow
conditional queries.

This standardizes naming, improves readability and makes the API more
consistent for frontend consumers.