### PR TITLE
feat(advent): refine UI text and layout; remove unused prop

### DIFF
--- a/packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx
+++ b/packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx
@@ -80,7 +80,7 @@ export function AdventAlreadyOpenedScreen({
                     Dan {day}
                 </Typography>
                 <Typography level="body2">
-                    Već si pokupio nagrade za ovaj dan!
+                    Nagrade za ovaj dan su već skupljene!
                 </Typography>
             </Stack>
 

--- a/packages/game/src/modals/advent/AdventAwardScreen.tsx
+++ b/packages/game/src/modals/advent/AdventAwardScreen.tsx
@@ -29,7 +29,6 @@ type AdventAwardScreenProps = {
     award: AdventAward;
     description: AdventAwardDescription;
     onContinue: () => void;
-    hasMoreAwards: boolean;
 };
 
 function AwardImage({ award }: { award: AdventAward }) {
@@ -75,7 +74,6 @@ export function AdventAwardScreen({
     award,
     description,
     onContinue,
-    hasMoreAwards,
 }: AdventAwardScreenProps) {
     return (
         <Stack spacing={4} className="items-center text-center p-8 relative">

--- a/packages/game/src/modals/advent/AdventDayCell.tsx
+++ b/packages/game/src/modals/advent/AdventDayCell.tsx
@@ -144,13 +144,11 @@ export function AdventDayCell({
     const baseClasses = cx(
         'overflow-hidden relative w-full rounded-sm h-full flex items-center justify-center font-bold text-2xl transition-all duration-200',
         'cursor-pointer hover:bg-white/30 hover:scale-105 active:scale-95',
-        colSpan === 1 && 'aspect-square',
-        colSpan === 2 && 'aspect-[2/1]',
     );
 
     const wrapperClasses = cx(
         variantClasses[variant],
-        'p-0.5',
+        'p-0.5 min-h-0 min-w-0',
         colSpan === 2 && 'col-span-2',
     );
 

--- a/packages/game/src/modals/advent/AdventMissedDayScreen.tsx
+++ b/packages/game/src/modals/advent/AdventMissedDayScreen.tsx
@@ -24,7 +24,7 @@ export function AdventMissedDayScreen({
                     Dan {day}
                 </Typography>
                 <Typography level="body2">
-                    Nažalost, nisi pokupio nagradu za ovaj dan.
+                    Nažalost, nagrade za ovaj dan su istekle.
                 </Typography>
                 <Typography level="body2">
                     Ne brini, ima još vremena za pokupiti ostale nagrade! 🎁

--- a/packages/game/src/modals/advent/AdventModal.tsx
+++ b/packages/game/src/modals/advent/AdventModal.tsx
@@ -203,7 +203,6 @@ export function AdventModal() {
                         award={awards[currentAwardIndex]}
                         description={awardDescriptions[currentAwardIndex]}
                         onContinue={handleAwardContinue}
-                        hasMoreAwards={currentAwardIndex < awards.length - 1}
                     />
                 );
             case 'missed':


### PR DESCRIPTION
Update Advent modal and related components to clean up props,
improve layout flexibility, and change copy for clarity.

- Remove the now-unused hasMoreAwards prop from AdventAwardScreen
  and stop passing it from AdventModal. This simplifies the award
  component API and eliminates dead prop plumbing.
- Adjust AdventDayCell styles: remove fixed aspect constraints and
  add min-height/min-width reset to wrapper so grid cells can shrink
  correctly when spanning columns.
- Update localized copy in AdventAlreadyOpenedScreen and
  AdventMissedDayScreen to clearer Croatian phrasing:
  "Nagrade za ovaj dan su već skupljene!" and
  "Nažalost, nagrade za ovaj dan su istekle."
- Minor formatting tidy-up.

These changes improve component simplicity, prevent layout issues
for multi-column cells, and make user messages clearer.