### PR TITLE
refactor(advent): remove isToday prop and adjust layout

### DIFF
--- a/packages/game/src/modals/advent/AdventCalendarScreen.tsx
+++ b/packages/game/src/modals/advent/AdventCalendarScreen.tsx
@@ -59,12 +59,11 @@ export function AdventCalendarScreen({
             </div>
 
             {/* Calendar grid */}
-            <div className="bg-[#C1977C] p-3 border-4 border-[#E6CAB5] aspect-[0.625] relative">
-                <div className="grid grid-cols-5 gap-0 grid-rows-[repeat(5,1fr)] h-full">
+            <div className="bg-[#C1977C] p-3 border-4 border-[#E6CAB5] relative">
+                <div className="grid grid-cols-5 gap-0 grid-rows-[repeat(5,1fr)] h-full aspect-[0.625] w-full">
                     {calendarLayout.map((dayNum) => {
                         const dayData = dayMap.get(dayNum);
                         const isOpen = dayData?.opened ?? false;
-                        const isToday = dayNum === currentDay;
                         const isFuture = dayNum > currentDay;
                         const isPast = dayNum < currentDay;
                         const canOpen = dayNum <= currentDay && !isOpen;
@@ -89,7 +88,6 @@ export function AdventCalendarScreen({
                                 day={dayNum}
                                 variant={getDayVariant(dayNum)}
                                 isOpen={isOpen}
-                                isToday={isToday}
                                 isFuture={isFuture}
                                 disabled={isLoading}
                                 onClick={handleDayClick}

--- a/packages/game/src/modals/advent/AdventDayCell.tsx
+++ b/packages/game/src/modals/advent/AdventDayCell.tsx
@@ -11,7 +11,6 @@ type AdventDayCellProps = {
     day: number;
     variant: DayCellVariant;
     isOpen: boolean;
-    isToday: boolean;
     isFuture: boolean;
     onClick?: () => void;
     disabled?: boolean;
@@ -102,7 +101,6 @@ export function AdventDayCell({
     day,
     variant,
     isOpen,
-    isToday,
     isFuture,
     onClick,
     disabled,


### PR DESCRIPTION
Remove the unused isToday prop from AdventCalendarScreen and
AdventDayCell. Relocate the aspect ratio and width classes from
the outer calendar container to the inner grid to prevent layout
shrinkage and ensure the grid fills the container consistently.
Also drop passing isToday to day cells since it is unused in thecomponent props.

These changes simplify the component API and fix a layout issue
where the calendar grid could render with an incorrect aspect
ratio or size.