### PR TITLE
feat(holiday): add snowman and giftbox assets & entity

### DIFF
--- a/apps/garden/app/debug/entities/page.tsx
+++ b/apps/garden/app/debug/entities/page.tsx
@@ -1,6 +1,5 @@
-'use client';
-
-import { EntityGridViewer, entityNameMap } from '@gredice/game';
+import { entityNameMap } from '@gredice/game';
+import { EntityGridViewerDynamic } from './EntityGridViewerDynamic';
 
 const entityNames = Object.keys(entityNameMap);
 
@@ -16,10 +15,7 @@ export default function DebugEntitiesPage() {
                 </p>
             </div>
             <div className="flex-1">
-                <EntityGridViewer
-                    entityNames={entityNames}
-                    className="w-full h-full"
-                />
+                <EntityGridViewerDynamic />
             </div>
         </div>
     );


### PR DESCRIPTION
Add Snowman model GiftBox sub-meshes to the game assets and scenes,
and register a Snowman entity for runtime use.

- Add repeating 'Snowman' chance entries to the Advent event config to raise spawn probability during the Advent 2025 occasion.
- Add Snowman and GiftBox meshes (Bow, Strip, Box) to GameAssets type definitions so they are available in the scene graph.
- Insert Snowman and GiftBox mesh instances into the appropriate model JSX so they render with correct position, rotation and scale.
- Ensure GiftBox components are placed where they belong in the scene and remove duplicate/incorrect placements.
- Implement a Snowman entity component that uses the shared GLTF nodes, applies stack-based vertical positioning, and provides a simple animated rotation wrapper.
- Export/register Snowman in the EntityFactory so the entity can be instantiated by the game.