### PR TITLE
Add inventory support to admin shopping carts

### DIFF
--- a/apps/api/app/api/[...route]/inventoryRoutes.ts
+++ b/apps/api/app/api/[...route]/inventoryRoutes.ts
@@ -1,0 +1,54 @@
+import { getEntitiesFormatted, getInventory } from '@gredice/storage';
+import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
+import {
+    type AuthVariables,
+    authValidator,
+} from '../../../lib/hono/authValidator';
+
+const app = new Hono<{ Variables: AuthVariables }>().get(
+    '/',
+    describeRoute({ description: 'Popis inventara za račun' }),
+    authValidator(['user', 'admin']),
+    async (context) => {
+        const { accountId } = context.get('authContext');
+        const inventory = await getInventory(accountId);
+
+        const entityTypeNames = Array.from(
+            new Set(inventory.map((item) => item.entityTypeName)),
+        );
+        const entitiesData = await Promise.all(
+            entityTypeNames.map(getEntitiesFormatted),
+        );
+        const entitiesByType = entityTypeNames.reduce(
+            (acc, type, index) => {
+                acc[type] = entitiesData[index] ?? [];
+                return acc;
+            },
+            {} as Record<string, unknown[]>,
+        );
+
+        return context.json({
+            items: inventory.map((item) => {
+                const entity = (entitiesByType[item.entityTypeName] ?? []).find(
+                    (entity) =>
+                        (entity as { id?: string | number }).id?.toString() ===
+                        item.entityId,
+                ) as {
+                    information?: { label?: string; name?: string };
+                    image?: any;
+                };
+
+                return {
+                    ...item,
+                    name:
+                        entity?.information?.label ?? entity?.information?.name,
+                    image: (entity as { image?: { cover?: { url?: string } } })
+                        ?.image?.cover?.url,
+                };
+            }),
+        });
+    },
+);
+
+export default app;

--- a/apps/api/app/api/[...route]/route.ts
+++ b/apps/api/app/api/[...route]/route.ts
@@ -11,6 +11,7 @@ import deliveryRoutes from './deliveryRoutes';
 import directoriesRoutes from './directoriesRoutes';
 import feedbackRoutes from './feedbackRoutes';
 import gardensRoutes from './gardensRoutes';
+import inventoryRoutes from './inventoryRoutes';
 import notificationsRoutes from './notificationsRoutes';
 import occasionsRoutes from './occasionsRoutes';
 import shoppingCartRoutes from './shoppingCartRoutes';
@@ -61,6 +62,7 @@ const app = new Hono()
     .route('/gardens', gardensRoutes)
     .route('/feedback', feedbackRoutes)
     .route('/occasions', occasionsRoutes)
+    .route('/inventory', inventoryRoutes)
     .route('/shopping-cart', shoppingCartRoutes)
     .route('/checkout', checkoutRoutes)
     .route('/delivery', deliveryRoutes)
@@ -81,6 +83,7 @@ app.get('/docs/auth', docs(authRoutes, 'Auth API', 'auth'))
         '/docs/shopping-cart',
         docs(shoppingCartRoutes, 'Shopping Cart API', 'shopping-cart'),
     )
+    .get('/docs/inventory', docs(inventoryRoutes, 'Inventory API', 'inventory'))
     .get('/docs/checkout', docs(checkoutRoutes, 'Checkout API', 'checkout'))
     .get('/docs/delivery', docs(deliveryRoutes, 'Delivery API', 'delivery'))
     .get(

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -36,7 +36,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }
 
             // Calculate total amount of items in the cart (exclude paid items)
-            const cartInfo = await getCartInfo(cart.items);
+            const cartInfo = await getCartInfo(cart.items, accountId);
             const total = cartInfo.items
                 .filter(
                     (item) => item.status !== 'paid' && item.currency === 'eur',

--- a/apps/api/lib/occasions/advent2025.ts
+++ b/apps/api/lib/occasions/advent2025.ts
@@ -8,6 +8,7 @@ import {
     createGardenBlock,
     createGardenStack,
     earnSunflowers,
+    addInventoryItem,
     getAccountGardens,
     getAdventCalendarOpenEvents,
     getEntitiesFormatted,
@@ -476,6 +477,19 @@ export async function openAdventCalendar2025Day({
                         accountId,
                         award.amount,
                         `advent-${ADVENT_YEAR}-dan-${day}`,
+                        tx,
+                    );
+                }
+
+                if (award.kind === 'plant') {
+                    await addInventoryItem(
+                        accountId,
+                        {
+                            entityTypeName: 'plantSort',
+                            entityId: award.plantSortId.toString(),
+                            amount: 1,
+                            source: `advent-${ADVENT_YEAR}-dan-${day}`,
+                        },
                         tx,
                     );
                 }

--- a/apps/app/app/admin/accounts/[accountId]/AccountInventoryCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountInventoryCard.tsx
@@ -1,0 +1,130 @@
+import {
+    getEntitiesFormatted,
+    getInventory,
+    getLastInventoryUpdate,
+} from '@gredice/storage';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Divider } from '@signalco/ui-primitives/Divider';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Field } from '../../../../components/shared/fields/Field';
+import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
+import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
+
+export async function AccountInventoryCard({
+    accountId,
+}: {
+    accountId: string;
+}) {
+    const inventory = await getInventory(accountId);
+    const lastUpdated = await getLastInventoryUpdate(accountId);
+
+    const entityTypes = [
+        ...new Set(inventory.map((item) => item.entityTypeName)),
+    ];
+    const entitiesResults = await Promise.all(
+        entityTypes.map(async (entityTypeName) => ({
+            entityTypeName,
+            entities: await getEntitiesFormatted(entityTypeName),
+        })),
+    );
+
+    const entitiesLookup: Record<string, EntityStandardized[]> = {};
+    entitiesResults.forEach(({ entityTypeName, entities }) => {
+        entitiesLookup[entityTypeName] = entities as EntityStandardized[];
+    });
+
+    const itemsWithNames = inventory
+        .map((item) => {
+            const entities = entitiesLookup[item.entityTypeName] || [];
+            const entity = entities.find(
+                (e) => e.id?.toString() === item.entityId,
+            );
+            const label =
+                entity?.information?.label ||
+                entity?.information?.name ||
+                `${item.entityTypeName} ${item.entityId}`;
+
+            return {
+                ...item,
+                label,
+            };
+        })
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+    const totalCount = inventory.reduce((sum, item) => sum + item.amount, 0);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Inventar</CardTitle>
+            </CardHeader>
+            <CardContent className="pb-4">
+                <div className="grid grid-cols-2 gap-2">
+                    <Stack spacing={2}>
+                        <Field name="Ukupno predmeta" value={totalCount} />
+                        <Field
+                            name="Zadnja izmjena"
+                            value={
+                                lastUpdated ? (
+                                    <LocalDateTime time={false}>
+                                        {lastUpdated}
+                                    </LocalDateTime>
+                                ) : (
+                                    'Nije dostupno'
+                                )
+                            }
+                        />
+                    </Stack>
+                </div>
+            </CardContent>
+            <CardOverflow>
+                <Divider />
+                <div className="max-h-80 overflow-auto">
+                    <Table>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Head>Entitet</Table.Head>
+                                <Table.Head>Tip</Table.Head>
+                                <Table.Head>Količina</Table.Head>
+                                <Table.Head>Ažurirano</Table.Head>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {itemsWithNames.length === 0 && (
+                                <Table.Row>
+                                    <Table.Cell colSpan={4}>
+                                        <NoDataPlaceholder>
+                                            Nema predmeta u inventaru
+                                        </NoDataPlaceholder>
+                                    </Table.Cell>
+                                </Table.Row>
+                            )}
+                            {itemsWithNames.map((item) => (
+                                <Table.Row
+                                    key={`${item.entityTypeName}-${item.entityId}`}
+                                >
+                                    <Table.Cell>{item.label}</Table.Cell>
+                                    <Table.Cell>{item.entityTypeName}</Table.Cell>
+                                    <Table.Cell>{item.amount}</Table.Cell>
+                                    <Table.Cell>
+                                        <LocalDateTime time={false}>
+                                            {item.updatedAt}
+                                        </LocalDateTime>
+                                    </Table.Cell>
+                                </Table.Row>
+                            ))}
+                        </Table.Body>
+                    </Table>
+                </div>
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -15,6 +15,7 @@ import { getAccountTimeZone } from '../../../(actions)/accountTimeZoneActions';
 import { AccountAchievementsCard } from './AccountAchievementsCard';
 import { AccountEventsCard } from './AccountEventsCard';
 import { AccountGardensCard } from './AccountGardensCard';
+import { AccountInventoryCard } from './AccountInventoryCard';
 import { AccountShoppingCartsCard } from './AccountShoppingCartsCard';
 import { AccountSunflowersCard } from './AccountSunflowersCard';
 import { AccountTimeZonePicker } from './AccountTimeZonePicker';
@@ -85,6 +86,7 @@ export default async function AccountPage({
                 <RaisedBedsTableCard accountId={accountId} />
                 <AccountEventsCard accountId={accountId} />
                 <NotificationsTableCard accountId={accountId} scroll />
+                <AccountInventoryCard accountId={accountId} />
                 <AccountShoppingCartsCard accountId={accountId} />
             </div>
         </Stack>

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -9,6 +9,7 @@ import { DayNightCycleHud } from './hud/DayNightCycleHud';
 import { DebugHud } from './hud/DebugHud';
 import { GameModeHud } from './hud/GameModeHud';
 import { ItemsHud } from './hud/ItemsHud';
+import { InventoryHud } from './hud/InventoryHud';
 import { PaymentSuccessfulMessage } from './hud/PaymentSuccessfulMessage';
 import { RaisedBedFieldHud } from './hud/RaisedBedFieldHud';
 import { ShoppingCartHud } from './hud/ShoppingCartHud';
@@ -28,6 +29,7 @@ export function GameHud({ flags }: { flags: GameSceneProps['flags'] }) {
                 <AccountHud />
                 {!isCloseup && <GameModeHud />}
                 {!isCloseup && <AdventHud />}
+                {!isCloseup && <InventoryHud />}
                 <ShoppingCartHud />
             </div>
             <div className="absolute top-2 right-2 flex items-end flex-col-reverse md:flex-row gap-1 md:gap-2">

--- a/packages/game/src/hooks/useInventory.ts
+++ b/packages/game/src/hooks/useInventory.ts
@@ -1,0 +1,21 @@
+import { client } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+import { useCurrentUser } from './useCurrentUser';
+
+export const inventoryQueryKey = ['inventory'];
+
+export function useInventory() {
+    const { data: user } = useCurrentUser();
+    return useQuery({
+        queryKey: inventoryQueryKey,
+        queryFn: async () => {
+            const response = await client().api.inventory.$get();
+            if (response.status === 401) {
+                return null;
+            }
+            return response.json();
+        },
+        enabled: Boolean(user),
+        staleTime: 1000 * 60 * 5,
+    });
+}

--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -1,0 +1,92 @@
+import { PlantOrSortImage } from '@gredice/ui/plants';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useMemo, useState } from 'react';
+import { useInventory } from '../hooks/useInventory';
+import { BackpackIcon } from '../icons/Backpack';
+import { HudCard } from './components/HudCard';
+
+export function InventoryHud() {
+    const { data: inventory } = useInventory();
+    const [open, setOpen] = useState(false);
+
+    const totalItems = useMemo(
+        () =>
+            inventory?.items?.reduce(
+                (sum: number, item: { amount: number }) => sum + item.amount,
+                0,
+            ) ?? 0,
+        [inventory?.items],
+    );
+
+    return (
+        <HudCard open position="floating" className="static p-0.5">
+            <Modal
+                open={open}
+                onOpenChange={setOpen}
+                title="Ruksak"
+                trigger={
+                    <IconButton
+                        variant="plain"
+                        className="rounded-full size-10"
+                        title="Inventar"
+                    >
+                        <div className="relative flex items-center justify-center">
+                            <BackpackIcon className="size-6" />
+                            {totalItems > 0 && (
+                                <span className="absolute -top-1 -right-1 text-[10px] font-semibold bg-emerald-500 text-white rounded-full px-1">
+                                    {totalItems}
+                                </span>
+                            )}
+                        </div>
+                    </IconButton>
+                }
+            >
+                <Stack spacing={2}>
+                    <Typography level="body2" secondary>
+                        Pregled biljaka i radnji spremljenih u ruksak.
+                    </Typography>
+                    <Stack spacing={1} className="max-h-80 overflow-y-auto pr-1">
+                        {inventory?.items?.length ? (
+                            inventory.items.map((item: any) => (
+                                <Row
+                                    key={`${item.entityTypeName}-${item.entityId}`}
+                                    spacing={1.5}
+                                    alignItems="center"
+                                    className="border rounded-lg p-2"
+                                >
+                                    <PlantOrSortImage
+                                        width={40}
+                                        height={40}
+                                        className="rounded-md border"
+                                        coverUrl={item.image}
+                                        alt={item.name || item.entityId}
+                                        baseUrl="https://www.gredice.com"
+                                    />
+                                    <Stack className="grow">
+                                        <Typography level="body2" semiBold>
+                                            {item.name ?? 'Nepoznati predmet'}
+                                        </Typography>
+                                        <Typography level="body3" secondary>
+                                            {item.entityTypeName}
+                                        </Typography>
+                                    </Stack>
+                                    <Typography level="body2" semiBold>
+                                        ×{item.amount}
+                                    </Typography>
+                                </Row>
+                            ))
+                        ) : (
+                            <Typography level="body2" secondary>
+                                Još nema spremljenih predmeta.
+                            </Typography>
+                        )}
+                    </Stack>
+                </Stack>
+            </Modal>
+        </HudCard>
+    );
+}

--- a/packages/game/src/icons/Backpack.tsx
+++ b/packages/game/src/icons/Backpack.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react';
+
+export function BackpackIcon(props: SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            {...props}
+        >
+            <path d="M9 6.5v-1a3 3 0 0 1 6 0v1" />
+            <rect x={5} y={6.5} width={14} height={13} rx={3} />
+            <path d="M9 11h6M9 15h2" />
+        </svg>
+    );
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -21,6 +21,7 @@ export * from './repositories/farmsRepo';
 export * from './repositories/feedbacksRepo';
 export * from './repositories/fiscalizationRepo';
 export * from './repositories/gardensRepo';
+export * from './repositories/inventoryRepo';
 export * from './repositories/invoicesRepo';
 export * from './repositories/notificationSettingsRepo';
 export * from './repositories/notificationsRepo';

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -37,6 +37,7 @@ export type {
     // Garden
     GardenCreatePayload,
     GardenRenamePayload,
+    InventoryChangePayload,
     // Invoice
     InvoiceCreatePayload,
     InvoicePaidPayload,

--- a/packages/storage/src/repositories/events/knownEventTypes.ts
+++ b/packages/storage/src/repositories/events/knownEventTypes.ts
@@ -66,4 +66,8 @@ export const knownEventTypes = {
     occasions: {
         adventCalendarOpen: 'occasion.advent.calendar.open',
     },
+    inventory: {
+        add: 'inventory.add',
+        consume: 'inventory.consume',
+    },
 } as const;

--- a/packages/storage/src/repositories/events/knownEvents.ts
+++ b/packages/storage/src/repositories/events/knownEvents.ts
@@ -21,6 +21,7 @@ import type {
     OperationCompletePayload,
     OperationFailPayload,
     OperationSchedulePayload,
+    InventoryChangePayload,
     RaisedBedAbandonPayload,
     RaisedBedCreatePayload,
     RaisedBedFieldCreatePayload,
@@ -377,6 +378,23 @@ export const knownEvents = {
             data: AdventCalendarOpenPayload,
         ) => ({
             type: knownEventTypes.occasions.adventCalendarOpen,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+    },
+    inventory: {
+        addedV1: (aggregateId: string, data: InventoryChangePayload) => ({
+            type: knownEventTypes.inventory.add,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        consumedV1: (
+            aggregateId: string,
+            data: InventoryChangePayload,
+        ) => ({
+            type: knownEventTypes.inventory.consume,
             version: 1,
             aggregateId,
             data,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -49,6 +49,16 @@ export type AdventCalendarOpenPayload = {
 };
 
 // ============================================================================
+// Inventory event payload types
+// ============================================================================
+export type InventoryChangePayload = {
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+    source?: string | null;
+};
+
+// ============================================================================
 // Garden event payload types
 // ============================================================================
 export type GardenCreatePayload = {

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -1,0 +1,122 @@
+import { and, eq, gte } from 'drizzle-orm';
+import { events } from '../schema';
+import { storage } from '../storage';
+import { createEvent, getEvents, knownEvents, knownEventTypes } from './events';
+
+type StorageClient = ReturnType<typeof storage>;
+type TransactionClient = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+type DatabaseClient = TransactionClient | StorageClient;
+
+type InventoryItemEventPayload = {
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+    source?: string | null;
+};
+
+const INVENTORY_PREFIX = 'inventory:';
+
+function getInventoryAggregateId(accountId: string) {
+    return `${INVENTORY_PREFIX}${accountId}`;
+}
+
+export type InventoryItem = {
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+    updatedAt: Date;
+};
+
+export async function addInventoryItem(
+    accountId: string,
+    payload: InventoryItemEventPayload,
+    db: DatabaseClient = storage(),
+) {
+    await createEvent(
+        knownEvents.inventory.addedV1(
+            getInventoryAggregateId(accountId),
+            payload,
+        ),
+        db,
+    );
+}
+
+export async function consumeInventoryItem(
+    accountId: string,
+    payload: InventoryItemEventPayload,
+    db: DatabaseClient = storage(),
+) {
+    const inventory = await getInventory(accountId);
+    const currentAmount =
+        inventory.find(
+            (item) =>
+                item.entityTypeName === payload.entityTypeName &&
+                item.entityId === payload.entityId,
+        )?.amount ?? 0;
+
+    if (currentAmount < payload.amount) {
+        throw new Error('Nedovoljno predmeta u inventaru');
+    }
+
+    await createEvent(
+        knownEvents.inventory.consumedV1(
+            getInventoryAggregateId(accountId),
+            payload,
+        ),
+        db,
+    );
+}
+
+export async function getInventory(accountId: string) {
+    const aggregateId = getInventoryAggregateId(accountId);
+    const inventoryEvents = await getEvents(
+        [knownEventTypes.inventory.add, knownEventTypes.inventory.consume],
+        [aggregateId],
+        0,
+        5000,
+    );
+
+    const totals = new Map<string, InventoryItem>();
+
+    for (const event of inventoryEvents) {
+        const data = event.data as InventoryItemEventPayload | null;
+        if (!data) continue;
+
+        const key = `${data.entityTypeName}-${data.entityId}`;
+        const existing = totals.get(key) ?? {
+            entityTypeName: data.entityTypeName,
+            entityId: data.entityId,
+            amount: 0,
+            updatedAt: event.createdAt,
+        };
+
+        const delta =
+            event.type === knownEventTypes.inventory.consume
+                ? -data.amount
+                : data.amount;
+
+        totals.set(key, {
+            ...existing,
+            amount: existing.amount + delta,
+            updatedAt: event.createdAt,
+        });
+    }
+
+    return Array.from(totals.values()).filter((item) => item.amount > 0);
+}
+
+export async function getLastInventoryUpdate(accountId: string) {
+    const aggregateId = getInventoryAggregateId(accountId);
+    const [latestEvent] = await storage().query.events.findMany({
+        where: and(
+            eq(events.aggregateId, aggregateId),
+            gte(events.createdAt, new Date('2024-01-01')),
+        ),
+        orderBy: (events, { desc }) => [desc(events.createdAt)],
+        limit: 1,
+    });
+
+    return latestEvent?.createdAt ?? null;
+}


### PR DESCRIPTION
## Summary
- handle shopping cart items that use inventory currency, showing availability and preventing currency formatting issues
- add an account inventory card to the admin account detail page to view backpack contents and last update

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f86b7b60832fa67af4c2a2b21747)