### PR TITLE
feat(env): add script and docs to pull envs for all apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Gredice is a Turborepo monorepo that powers the entire Gredice platform. It incl
    pnpm install
    ```
 
-3. Pull environment variables for each application (see below).
+3. Pull environment variables for all applications:
+
+   ```bash
+   pnpm env:pull
+   ```
 
 4. Start the development server from the project root:
 
@@ -90,13 +94,13 @@ After the certificate is trusted, browsers will stop warning about the `*.gredic
 
 ### Environment variables
 
-Use the Vercel CLI to pull the environment variables for each application by running the following command inside the `apps/<app-name>` directory:
+Use the Vercel CLI to pull environment variables for every app at once:
 
 ```bash
-vercel env pull .env.development.local
+pnpm env:pull
 ```
 
-`<app-name>` can be any of `www`, `garden`, `farm`, or `app`.
+This runs `vercel env pull .env` in `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, and `apps/api`.
 
 If you are running the command for the first time on the development machine, make sure you are logged in to the Vercel CLI and that the project is linked:
 
@@ -105,7 +109,7 @@ vercel login
 vercel link
 ```
 
-After logging in and linking, you can proceed with pulling the environment variables for the applications you need.
+After logging in and linking, rerun `pnpm env:pull` to update all local environment files.
 
 ### API reference
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "scripts": {
         "build": "turbo build",
         "dev": "node ./scripts/dev-with-proxy.mjs",
+        "env:pull": "node ./scripts/pull-envs.mjs",
         "lint": "turbo lint",
         "lint:migrate": "turbo lint:migrate",
         "db-generate": "turbo db-generate",

--- a/scripts/pull-envs.mjs
+++ b/scripts/pull-envs.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+// Pulls Vercel environment variables for every app in one go.
+
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const vercelCommand = process.platform === 'win32' ? 'vercel.cmd' : 'vercel';
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const appNames = ['www', 'garden', 'farm', 'app', 'api'];
+
+function run(command, args, options) {
+    return new Promise((resolvePromise, rejectPromise) => {
+        const child = spawn(command, args, {
+            ...options,
+            stdio: 'inherit',
+        });
+
+        child.on('error', (error) => {
+            rejectPromise(error);
+        });
+
+        child.on('close', (code) => {
+            resolvePromise(code ?? 1);
+        });
+    });
+}
+
+async function main() {
+    for (const appName of appNames) {
+        const cwd = resolve(repoRoot, 'apps', appName);
+        console.log(`\nPulling environment variables for ${appName}...`);
+
+        const code = await run(vercelCommand, ['env', 'pull', '.env'], {
+            cwd,
+            env: process.env,
+        });
+
+        if (code !== 0) {
+            console.error(`Vercel env pull failed for ${appName}.`);
+            process.exit(code ?? 1);
+        }
+    }
+
+    console.log('\nFinished pulling environment variables for all apps.');
+}
+
+main().catch((error) => {
+    if (error?.code === 'ENOENT') {
+        console.error(
+            'Vercel CLI was not found. Install it first (e.g. `pnpm dlx vercel@latest` or `npm i -g vercel`).',
+        );
+    } else if (error?.message) {
+        console.error(error.message);
+    } else if (error) {
+        console.error(error);
+    }
+
+    process.exit(1);
+});


### PR DESCRIPTION
Add scripts/pull-envs.mjs to run `vercel env pull .env` for all apps
(www, garden, farm, app, api) from the monorepo root. Expose it as
pnpm script env:pull in package.json.

Update README to document the new pnpm env:pull command and explain
that it runs the Vercel CLI in each apps/<name> directory to produce
local .env files. Clarify login/link instructions and advise rerunning
pnpm env:pull after linking.

This centralizes environment fetching, simplifies developer setup,
and avoids repeating the pull command per app.