### PR TITLE
feat(instrumentation): remove Sentry feedbackIntegration from clients

### DIFF
--- a/apps/api/instrumentation-client.ts
+++ b/apps/api/instrumentation-client.ts
@@ -9,11 +9,7 @@ Sentry.init({
 
     // Add optional integrations for additional features
     integrations: [
-        Sentry.replayIntegration(),
-        Sentry.feedbackIntegration({
-            // Additional SDK configuration goes in here, for example:
-            colorScheme: 'system',
-        }),
+        Sentry.replayIntegration()
     ],
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/apps/app/instrumentation-client.ts
+++ b/apps/app/instrumentation-client.ts
@@ -9,11 +9,7 @@ Sentry.init({
 
     // Add optional integrations for additional features
     integrations: [
-        Sentry.replayIntegration(),
-        Sentry.feedbackIntegration({
-            // Additional SDK configuration goes in here, for example:
-            colorScheme: 'system',
-        }),
+        Sentry.replayIntegration()
     ],
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/apps/farm/instrumentation-client.ts
+++ b/apps/farm/instrumentation-client.ts
@@ -9,11 +9,7 @@ Sentry.init({
 
     // Add optional integrations for additional features
     integrations: [
-        Sentry.replayIntegration(),
-        Sentry.feedbackIntegration({
-            // Additional SDK configuration goes in here, for example:
-            colorScheme: 'system',
-        }),
+        Sentry.replayIntegration()
     ],
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/apps/garden/instrumentation-client.ts
+++ b/apps/garden/instrumentation-client.ts
@@ -9,11 +9,7 @@ Sentry.init({
 
     // Add optional integrations for additional features
     integrations: [
-        Sentry.replayIntegration(),
-        Sentry.feedbackIntegration({
-            // Additional SDK configuration goes in here, for example:
-            colorScheme: 'system',
-        }),
+        Sentry.replayIntegration()
     ],
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/apps/www/instrumentation-client.ts
+++ b/apps/www/instrumentation-client.ts
@@ -9,11 +9,7 @@ Sentry.init({
 
     // Add optional integrations for additional features
     integrations: [
-        Sentry.replayIntegration(),
-        Sentry.feedbackIntegration({
-            // Additional SDK configuration goes in here, for example:
-            colorScheme: 'system',
-        }),
+        Sentry.replayIntegration()
     ],
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.


### PR DESCRIPTION
Remove feedbackIntegration from Sentry integrations in multiple client
instrumentation files (www, farm, app, garden, api). Each file now only
registers replayIntegration.

This simplifies SDK setup by disabling the optional feedback UI and
its colorScheme config, reducing bundle surface and avoiding unused
integration code where user feedback is not required.