### PR TITLE
feat(manifest): add additional origin scope extensions

### DIFF
--- a/apps/garden/app/manifest.json
+++ b/apps/garden/app/manifest.json
@@ -37,10 +37,6 @@
     "scope_extensions": [
         {
             "type": "origin",
-            "origin": "https://vrt.gredice.com"
-        },
-        {
-            "type": "origin",
             "origin": "https://www.gredice.com"
         },
         {


### PR DESCRIPTION
Expand scope_extensions in the PWA manifest to specify origin types
and include the www and placanje subdomains using full https origins.
This ensures the service worker and scope handling explicitly match the
secure origins and allows the app to operate correctly across those
hostnames.