### PR TITLE
feat(hud,actions,urls): add raised bed closeup links for notifications

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { randomUUID } from 'node:crypto';
+import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
 import { notifyOperationUpdate } from '@gredice/notifications';
 import {
     acceptOperation,
@@ -196,6 +197,7 @@ export async function completeOperation(
     // TODO: Add operation icon
     const header = `${operationData?.information?.label}`;
     let content = `Danas je određeno **${operationData?.information?.label}**.`;
+    let linkUrl: string | undefined;
     if (operation.raisedBedId) {
         const raisedBed = await getRaisedBed(operation.raisedBedId);
         if (!raisedBed) {
@@ -203,6 +205,11 @@ export async function completeOperation(
                 `Raised bed with ID ${operation.raisedBedId} not found.`,
             );
         } else {
+            // Generate the linkUrl for raised bed closeup
+            if (raisedBed.name) {
+                linkUrl = getRaisedBedCloseupUrl(raisedBed.name);
+            }
+
             const positionIndex = operation.raisedBedFieldId
                 ? raisedBed.fields.find(
                       (f) => f.id === operation.raisedBedFieldId,
@@ -233,6 +240,7 @@ export async function completeOperation(
                   header,
                   content,
                   imageUrl: imageUrls?.[0],
+                  linkUrl,
                   timestamp: new Date(),
               })
             : undefined,

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
 import {
     createEvent,
     createNotification,
@@ -116,6 +117,9 @@ export async function raisedBedFieldUpdatePlant({
                     raisedBedId: raisedBed.id,
                     header,
                     content,
+                    linkUrl: raisedBed.name
+                        ? getRaisedBedCloseupUrl(raisedBed.name)
+                        : undefined,
                     timestamp: new Date(),
                 });
             }

--- a/packages/js/src/urls/gardenUrls.ts
+++ b/packages/js/src/urls/gardenUrls.ts
@@ -1,0 +1,43 @@
+/**
+ * Utility functions for generating URLs to the garden game
+ */
+
+/**
+ * Gets the base URL for the garden game based on the environment
+ * - Production: https://vrt.gredice.com
+ * - Development: https://vrt.gredice.test
+ */
+function getGardenBaseUrl(): string {
+    // Check if we're in a browser environment
+    if (typeof globalThis !== 'undefined' && 'location' in globalThis) {
+        // Use .test domain if current hostname includes .test
+        const hostname = (
+            globalThis as unknown as { location: { hostname: string } }
+        ).location.hostname;
+        if (hostname.includes('.test')) {
+            return 'https://vrt.gredice.test';
+        }
+    }
+
+    // Check environment variable (for server-side rendering or Node.js)
+    if (
+        typeof process !== 'undefined' &&
+        process.env?.NODE_ENV === 'development'
+    ) {
+        return 'https://vrt.gredice.test';
+    }
+
+    // Default to production
+    return 'https://vrt.gredice.com';
+}
+
+/**
+ * Generates a URL to view a raised bed in closeup mode in the garden game
+ * @param raisedBedName - The name of the raised bed
+ * @returns The full URL with the gredica query parameter
+ * @example
+ * getRaisedBedCloseupUrl('Moja gredica') // => 'https://vrt.gredice.com?gredica=Moja%20gredica'
+ */
+export function getRaisedBedCloseupUrl(raisedBedName: string): string {
+    return `${getGardenBaseUrl()}?gredica=${encodeURIComponent(raisedBedName)}`;
+}

--- a/packages/js/src/urls/index.ts
+++ b/packages/js/src/urls/index.ts
@@ -1,0 +1,1 @@
+export * from './gardenUrls';


### PR DESCRIPTION
Add generation and propagation of raised bed closeup URLs so
notifications link to the correct garden closeup view.

- hud: NotificationList
  - Add useRouter, useMemo and useCurrentGarden to compute a linkUrl
    for legacy notifications that only contain raisedBedId.
  - Compute a fallback URL via getRaisedBedCloseupUrl(raisedBed.name)
    when linkUrl is missing and route to that URL when a notification
    list item is selected.
  - Add nodeId and onSelected handling, and include raisedBedId in
    notification shape.
  - Include a TODO and expiration date note for removing the backward
    compatibility code once all notifications migrate.

- actions: operationActions
  - Import getRaisedBedCloseupUrl and set linkUrl when creating
    notifications for operations that reference a raised bed.
  - Ensure linkUrl is passed into notifyOperationUpdate payload.

- urls: gardenUrls
  - Add a garden URL utility module to centralize base URL and
    generation of garden-related routes (partial file added).

These changes ensure notifications link directly to raised bed closeups,
provide backward compatibility for older notifications stored with only
raisedBedId, and centralize URL generation for consistency.