### PR TITLE
Add Nuqs adapter to www provider

### DIFF
--- a/apps/www/components/providers/ClientAppProvider.tsx
+++ b/apps/www/components/providers/ClientAppProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { NuqsAdapter } from '@gredice/ui/nuqs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { PropsWithChildren } from 'react';
 import { WinterModeProvider } from './WinterModeProvider';
@@ -8,8 +9,10 @@ export const queryClient = new QueryClient();
 
 export function ClientAppProvider({ children }: PropsWithChildren) {
     return (
-        <QueryClientProvider client={queryClient}>
-            <WinterModeProvider>{children}</WinterModeProvider>
-        </QueryClientProvider>
+        <NuqsAdapter>
+            <QueryClientProvider client={queryClient}>
+                <WinterModeProvider>{children}</WinterModeProvider>
+            </QueryClientProvider>
+        </NuqsAdapter>
     );
 }


### PR DESCRIPTION
## Summary
- wrap the www ClientAppProvider with the Nuqs adapter so nuqs-based components function correctly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937edc9a0cc832fbc63c18d6d754029)