### PR TITLE
fix: enable for spawned process pull-envs scriptAllow spawned child processes scripts/pulls.mjs to inside a

### DIFF
--- a/scripts/pull-envs.mjs
+++ b/scripts/pull-envs.mjs
@@ -16,6 +16,7 @@ function run(command, args, options) {
         const child = spawn(command, args, {
             ...options,
             stdio: 'inherit',
+            shell: true,
         });
 
         child.on('error', (error) => {


### PR DESCRIPTION
by setting shell:. This fixes issues where commands with
shell-specific syntax, environment variable expansion, or command
chaining fail to execute when spawn is invoked without a shell. The
change ensures command strings behave consistently across platforms and
resolves runtime errors seen on complex command invocations.