### PR TITLE
fix(ui): simplify inventory slot border style

### DIFF
--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -36,7 +36,7 @@ function InventoryItemCell({
     if (!item || !sortData) {
         // Empty slot
         return (
-            <div className="aspect-square rounded-lg border-2 border-dashed border-muted/30 bg-card/20" />
+            <div className="aspect-square rounded-lg border-2 border-dashed bg-card/20" />
         );
     }
 


### PR DESCRIPTION
Remove the muted color token from the empty inventory slot border in
InventoryHud.tsx and fall back to the default border color. This
changes the class from border-dashed border-muted/30 to just
border-dashed border, making the dashed placeholder border use the
standard border color for better visibility and visual consistency with
the surrounding UI.