### PR TITLE
chore(clean): add universal clean scripts and rimraf

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,7 @@
         "./routes": "./export/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "next dev -p 3005",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
+        "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "next dev -p 3003",

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
+        "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "next dev -p 3002",

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
+        "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "next dev -p 3001",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
+        "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "next dev -p 3000",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "scripts": {
         "build": "turbo build",
+        "clean": "turbo clean",
         "dev": "node ./scripts/dev-with-proxy.mjs",
         "env:pull": "node ./scripts/pull-envs.mjs",
         "lint": "turbo lint",
@@ -15,6 +16,7 @@
         "generate:game-assets": "node ./scripts/generate-game-assets.mjs"
     },
     "devDependencies": {
+        "rimraf": "6.0.1",
         "turbo": "2.6.3",
         "typescript": "5.9.3"
     },

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -6,6 +6,7 @@
     "type": "module",
     "license": "MIT",
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "regenerate-cdn": "pnpm run /^regenerate-cdn:.*/",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/directory-types/package.json
+++ b/packages/directory-types/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "regenerate": "pnpm run /^regenerate:.*/",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -6,6 +6,7 @@
         "./*": "./src/*/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/fiscalization/package.json
+++ b/packages/fiscalization/package.json
@@ -6,6 +6,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -11,6 +11,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -7,6 +7,7 @@
         "./*": "./src/*/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/signalco/package.json
+++ b/packages/signalco/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "regenerate": "pnpm run /^regenerate:.*/",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "db-generate": "drizzle-kit generate",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -10,6 +10,7 @@
         "./server": "./src/lib/server/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -6,6 +6,7 @@
         ".react-email"
     ],
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "email dev -p 4001"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
         "./*": "./src/*/index.ts"
     },
     "scripts": {
+        "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
       turbo:
         specifier: 2.6.3
         version: 2.6.3
@@ -7835,6 +7838,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   rollup@4.53.3:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
@@ -16692,6 +16700,11 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rimraf@6.0.1:
+    dependencies:
+      glob: 11.1.0
+      package-json-from-dist: 1.0.1
 
   rollup@4.53.3:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,9 @@
                 "!.next/cache/**"
             ]
         },
+        "clean": {
+            "cache": false
+        },
         "lint": {},
         "lint:migrate": {
             "cache": false


### PR DESCRIPTION
Add a reusable "clean" script to multiple package and app package.json
files to remove build artifacts (.turbo, dist, build, out, coverage,
tsconfig.tsbuildinfo) and framework-specific output (.next, .vercel,
storybook-static) to standardize workspace cleanup.

Add rimraf@6.0.1 to pnpm-lock.yaml so the new clean script has a
deterministic dev dependency and lockfile resolution entries. This
ensures consistent removal behavior across environments and makes CI
and local cleanup reliable.