### PR TITLE
Adjust advent decoration rewards odds

### DIFF
--- a/apps/api/lib/occasions/advent2025.ts
+++ b/apps/api/lib/occasions/advent2025.ts
@@ -100,11 +100,8 @@ const DECORATION_BLOCK_IDS = [
     'GiftBox_PurpleSilver',
     'GiftBox_GoldRed',
     'GiftBox_WhiteGreen',
-    'Block_Snow_Falling', // Increase chance of snowy blocks by
-    'Block_Snow_Falling', // including multiple times
-    'Block_Snow_Falling', // (3 to counteract 6 GiftBox chance)
-    'Snowman', // Also increase chance of snowman by
-    'Snowman', // including multiple times
+    'Block_Snow_Falling',
+    'Snowman',
 ];
 
 export type AdventDayStatus = {


### PR DESCRIPTION
## Summary
- remove duplicate non-gift decorations from the advent reward pool so gift boxes are more likely to be selected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f7a3b55c832fab9e116a78d7f2a3)