### PR TITLE
feat(gift-box): load block name and improve modal UI

### DIFF
--- a/packages/game/src/modals/GiftBoxModal.tsx
+++ b/packages/game/src/modals/GiftBoxModal.tsx
@@ -15,7 +15,7 @@ export function GiftBoxModal() {
     const handleClose = () => setGiftBoxParam(null);
 
     const blockName = garden?.stacks
-        .flatMap((stack) => stack.blocks)
+        ?.flatMap((stack) => stack.blocks)
         .find((block) => block.id === giftBoxParam)?.name;
 
     return (


### PR DESCRIPTION
Load current garden data and derive the block name for the gift
box instead of using the URL param directly. Use useCurrentGarden to
obtain garden stacks and find the matching block by id. Show a larger
BlockImage (160px) when data is available, display a placeholder
while loading or when no param is set, and show a fallback gift icon
when the block is not found.

Also update modal copy to be more inviting and adjust text order so
the reveal date is placed in the secondary description. This improves
UX by showing the correct block artwork, handling loading states, and
making the messaging clearer.