### PR TITLE
Add gift box to winter landing scene

### DIFF
--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -65,6 +65,15 @@ function mockGarden(isWinterMode: boolean) {
                         name: 'Block_Grass',
                         rotation: 0,
                     },
+                    ...(isWinterMode
+                        ? [
+                              {
+                                  id: '16',
+                                  name: 'GiftBox_RedWhite',
+                                  rotation: 0,
+                              },
+                          ]
+                        : []),
                 ],
             },
             {


### PR DESCRIPTION
## Summary
- add a red gift box next to the winter landing page tree in the mock garden

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453edb5ba0832f8a5355daf45cdb22)