### PR TITLE
Adjust landing game scene zoom for mobile visibility

### DIFF
--- a/apps/www/app/LandingGameScene.tsx
+++ b/apps/www/app/LandingGameScene.tsx
@@ -37,6 +37,7 @@ export function LandingGameScene() {
         <GameScene
             appBaseUrl="https://vrt.gredice.com"
             freezeTime={freezeTime}
+            zoom="far"
             noBackground
             hideHud
             noControls


### PR DESCRIPTION
## Summary
- set the landing page GameScene to use the farther camera zoom so the tree remains visible on mobile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694544e81b74832f8963423bcfee4dbd)