### PR TITLE
Adjust landing page game zoom for mobile

### DIFF
--- a/apps/www/app/LandingGameScene.tsx
+++ b/apps/www/app/LandingGameScene.tsx
@@ -1,10 +1,22 @@
 'use client';
 
 import { GameScene } from '@gredice/game';
+import { useEffect, useState } from 'react';
 import { useWinterMode } from '../components/providers/WinterModeProvider';
 
 export function LandingGameScene() {
     const { isWinter } = useWinterMode();
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia('(max-width: 768px)');
+        const handleChange = (event: MediaQueryListEvent) =>
+            setIsMobile(event.matches);
+
+        setIsMobile(mediaQuery.matches);
+        mediaQuery.addEventListener('change', handleChange);
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
 
     // Summer weather - warm and sunny
     const summerWeather = {
@@ -37,7 +49,7 @@ export function LandingGameScene() {
         <GameScene
             appBaseUrl="https://vrt.gredice.com"
             freezeTime={freezeTime}
-            zoom="far"
+            zoom={isMobile ? 'far' : 'normal'}
             noBackground
             hideHud
             noControls


### PR DESCRIPTION
## Summary
- detect mobile viewport on the landing page game scene
- apply far zoom only for mobile while keeping normal zoom on desktop

## Testing
- pnpm lint --filter www

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694551a82078832fb18d8b0f3358e3fb)