### PR TITLE
Render schedule while delivery requests load in suspense

### DIFF
--- a/apps/app/app/admin/schedule/ScheduleClient.tsx
+++ b/apps/app/app/admin/schedule/ScheduleClient.tsx
@@ -8,7 +8,7 @@ import type { EntityStandardized } from '../../../lib/@types/EntityStandardized'
 import { ScheduleDay } from './ScheduleDay';
 import type { DeliveryRequest, Operation, RaisedBed } from './types';
 
-interface ScheduleClientProps {
+export interface ScheduleClientProps {
     allRaisedBeds: RaisedBed[];
     operations: Operation[];
     plantSorts: EntityStandardized[] | null | undefined;

--- a/apps/app/app/admin/schedule/ScheduleWithDeliveryRequests.tsx
+++ b/apps/app/app/admin/schedule/ScheduleWithDeliveryRequests.tsx
@@ -1,0 +1,16 @@
+import { ScheduleClient, type ScheduleClientProps } from './ScheduleClient';
+import type { DeliveryRequest } from './types';
+
+interface ScheduleWithDeliveryRequestsProps
+    extends Omit<ScheduleClientProps, 'deliveryRequests'> {
+    deliveryRequestsPromise: Promise<DeliveryRequest[]>;
+}
+
+export async function ScheduleWithDeliveryRequests({
+    deliveryRequestsPromise,
+    ...props
+}: ScheduleWithDeliveryRequestsProps) {
+    const deliveryRequests = await deliveryRequestsPromise;
+
+    return <ScheduleClient {...props} deliveryRequests={deliveryRequests} />;
+}


### PR DESCRIPTION
## Summary
- load admin schedule data without waiting for delivery requests
- wrap delivery request fetch in a suspense boundary with a fallback
- add helper component to resolve delivery requests before rendering the schedule

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949478f7038832f9316a61bb8c1bfd3)