### PR TITLE
fix(game): correct raised-bed orientation mapping

### DIFF
--- a/packages/game/src/utils/raisedBedOrientation.ts
+++ b/packages/game/src/utils/raisedBedOrientation.ts
@@ -21,13 +21,13 @@ export function getGridPositionFromIndex(
 
     if (orientation === 'horizontal') {
         return {
-            row: baseCol,
-            col: 2 - baseRow,
+            row: baseRow,
+            col: 2 - baseCol,
         };
     }
 
     return {
-        row: 2 - baseRow,
-        col: 2 - baseCol,
+        row: baseCol,
+        col: baseRow,
     };
 }


### PR DESCRIPTION
Fix the coordinate mapping for raised bed rotations to use the
correct base indices. The previous logic swapped row/col inputs
when computing the transformed coordinates, causing incorrect
placement for horizontal and vertical orientations.

- Use baseRow for the output row and 2 - baseCol for the output
  col when orientation is horizontal.
- Use baseCol for the output row and baseRow for the output col
  for the other orientation.

This restores consistent and correct orientation behavior for
raised beds.