### PR TITLE
feat(ui): add instant search option to FilterInput

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -249,23 +249,11 @@ export function PlantPicker({
                     <FilterInput
                         searchParamName={'pretraga'}
                         fieldName={'search'}
+                        instant
                     />
                 )}
                 {currentStep === 0 && (
-                    <>
-                        <PlantsList onChange={handlePlantSelect} />
-                        <Row>
-                            <Button
-                                variant="plain"
-                                onClick={() => {
-                                    setOpen(false);
-                                }}
-                                startDecorator={<Left className="size-5" />}
-                            >
-                                Odustani
-                            </Button>
-                        </Row>
-                    </>
+                    <PlantsList onChange={handlePlantSelect} />
                 )}
                 {currentStep === 1 && selectedPlantId && (
                     <>

--- a/packages/ui/src/FilterInput/FilterInput.tsx
+++ b/packages/ui/src/FilterInput/FilterInput.tsx
@@ -7,14 +7,23 @@ import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
 import type { HTMLAttributes } from 'react';
 
-export type FilterInputProps = HTMLAttributes<HTMLFormElement> & {
+export type FilterInputProps = Omit<
+    HTMLAttributes<HTMLFormElement>,
+    'onChange'
+> & {
     searchParamName: string;
     fieldName: string;
+    /**
+     * If true, search updates immediately on input change.
+     * If false (default), search updates on form submit.
+     */
+    instant?: boolean;
 };
 
 export function FilterInput({
     searchParamName,
     fieldName,
+    instant = false,
     ...rest
 }: FilterInputProps) {
     const [search, setSearch] = useSearchParam(searchParamName);
@@ -25,22 +34,34 @@ export function FilterInput({
         }
     };
 
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (instant) {
+            setSearch(e.target.value);
+        }
+    };
+
     return (
         <form action={handleSubmit} {...rest}>
             <Input
                 name={fieldName}
-                defaultValue={search}
+                value={instant ? search : undefined}
+                defaultValue={instant ? undefined : search}
+                onChange={handleChange}
                 placeholder="Pretraži..."
                 startDecorator={
-                    <IconButton
-                        className="hover:bg-neutral-300 ml-1 rounded-full aspect-square"
-                        title="Pretraga"
-                        type="submit"
-                        size="sm"
-                        variant="plain"
-                    >
-                        <Search className="size-5" />
-                    </IconButton>
+                    instant ? (
+                        <Search className="size-5 shrink-0 ml-3" />
+                    ) : (
+                        <IconButton
+                            className="hover:bg-neutral-300 ml-1 rounded-full aspect-square"
+                            title="Pretraga"
+                            type="submit"
+                            size="sm"
+                            variant="plain"
+                        >
+                            <Search className="size-5" />
+                        </IconButton>
+                    )
                 }
                 // Clear search
                 endDecorator={


### PR DESCRIPTION
Add an optional instant prop to FilterInput that updates the search
query immediately on input change instead of waiting for form submit.
When instant is true, the component uses controlled value binding and
renders a plain Search icon; when false it keeps the submit button
behavior and uses defaultValue.

Enable instant mode in RaisedBedPlantPicker to allow immediate
filtering of the plants list and simplify the step-0 markup by removing
the surrounding cancel button row. This improves UX by making search
more responsive and streamlines the picker UI.