### PR TITLE
feat(ui): allow ImageViewer preview to render as div

### DIFF
--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -102,6 +102,7 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
                                     alt={header}
                                     previewWidth={80}
                                     previewHeight={80}
+                                    previewAs="div"
                                 />
                             )
                         )}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -30,6 +30,7 @@ function DiaryEntryImages({
                     alt={name}
                     previewWidth={80}
                     previewHeight={80}
+                    previewAs="div"
                 />
             ))}
         </Row>

--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -14,6 +14,11 @@ interface ImageViewerProps {
     alt: string;
     previewWidth?: number;
     previewHeight?: number;
+    /**
+     * By default the preview is rendered as a native <button>.
+     * Use "div" when ImageViewer is placed inside another <button> to avoid invalid HTML.
+     */
+    previewAs?: 'button' | 'div';
 }
 
 export function ImageViewer({
@@ -21,6 +26,7 @@ export function ImageViewer({
     alt,
     previewWidth = 300,
     previewHeight = 200,
+    previewAs = 'button',
 }: ImageViewerProps) {
     const [isExpanded, setIsExpanded] = useState(false);
     const [zoomLevel, setZoomLevel] = useState(1);
@@ -190,17 +196,33 @@ export function ImageViewer({
         }
     };
 
+    const PreviewComponent = previewAs;
+
     return (
         <>
             {/* Preview Image */}
-            <button
-                type="button"
+            <PreviewComponent
+                {...(previewAs === 'button'
+                    ? { type: 'button' as const }
+                    : {
+                          role: 'button' as const,
+                          tabIndex: 0,
+                          'aria-label': 'Otvori u punoj veličini',
+                      })}
                 title="Otvori u punoj veličini"
                 className="group relative hover:cursor-zoom-in flex items-center justify-center overflow-hidden rounded-lg shadow-md bg-muted hover:shadow-lg transition-shadow duration-200"
                 style={{ width: previewWidth, height: previewHeight }}
-                onClick={(event) => {
+                onClick={(event: React.MouseEvent) => {
                     event.stopPropagation();
                     setIsExpanded(true);
+                }}
+                onKeyDown={(event: React.KeyboardEvent) => {
+                    if (previewAs === 'button') return;
+                    event.stopPropagation();
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        setIsExpanded(true);
+                    }
                 }}
             >
                 <Image
@@ -212,7 +234,7 @@ export function ImageViewer({
                 />
                 <div className="absolute inset-0 bg-white/40 opacity-0 group-hover:opacity-50 transition-opacity"></div>
                 <Search className="stroke-white group-hover:scale-110 size-4 shrink-0 absolute bottom-1 right-1" />
-            </button>
+            </PreviewComponent>
 
             {/* Modal for expanded view */}
             <Modal


### PR DESCRIPTION
Update ImageViewer to support rendering the preview as either a native
button or a div to avoid invalid nested button markup when the viewer
is used inside another interactive element.

- Add new prop `previewAs?: 'button' | 'div'` with default 'button'.
- Use the prop in RaisedBedDiary and NotificationList to render
  previews as divs (previewAs="div") where those viewers may be nested
  inside other buttons.
- Render the preview using a variable component (`PreviewComponent`)
  and adjust props: when rendering as div, add role="button", tabIndex=0,
  aria-label and keyboard handling so the preview remains accessible.
- Stop event propagation and open the modal on click; handle Enter and
  Space key activation for non-button previews.

This fixes invalid HTML caused by nesting a button inside another
button and preserves keyboard accessibility for div-based previews.