### PR TITLE
Hide return prompt on final advent day

### DIFF
--- a/packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx
+++ b/packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx
@@ -83,6 +83,8 @@ export function AdventAlreadyOpenedScreen({
     awards,
     onClose,
 }: AdventAlreadyOpenedScreenProps) {
+    const isLastDay = day === 24;
+
     return (
         <Stack spacing={4} className="items-center text-center p-8">
             {/* Checkmark icon */}
@@ -121,9 +123,11 @@ export function AdventAlreadyOpenedScreen({
             )}
 
             {/* Come back message */}
-            <Typography level="body2">
-                Vrati se već sutra po nove nagrade! 🎁
-            </Typography>
+            {!isLastDay && (
+                <Typography level="body2">
+                    Vrati se već sutra po nove nagrade! 🎁
+                </Typography>
+            )}
 
             {/* Close button */}
             <Button


### PR DESCRIPTION
### Motivation
- The advent UI always showed the "Vrati se već sutra po nove nagrade! 🎁" prompt after viewing an already-opened day, which is misleading on the final day of the advent calendar.
- Hide the return prompt on day 24 to avoid suggesting there are future rewards when the advent has ended.

### Description
- Added a local `isLastDay` flag (`day === 24`) to `packages/game/src/modals/advent/AdventAlreadyOpenedScreen.tsx` to determine the final advent day.
- Conditionally render the return message only when `isLastDay` is false by wrapping the `Typography` element in `!isLastDay`.
- No other UI elements or layout changes were modified.

### Testing
- No automated tests were executed as part of this change.
- No build or typecheck was run in CI for this PR.
- Manual inspection of the modified component was performed to verify the conditional rendering logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d059c7b50832faad68ad90a628a47)