### PR TITLE
refactor(pickable): remove unused UI and data lookups

### DIFF
--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { animated, useSpring } from '@react-spring/three';
-import { Billboard, Html, Shadow, useTexture } from '@react-three/drei';
+import { Billboard, Shadow, useTexture } from '@react-three/drei';
 import { useThree } from '@react-three/fiber';
 import { type Handler, useDrag } from '@use-gesture/react';
 import {
@@ -28,7 +28,6 @@ import {
     getStackHeight,
     useStackHeight,
 } from '../utils/getStackHeight';
-import { MoveIndicator } from './components/MoveIndicator';
 
 const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
 
@@ -72,9 +71,6 @@ export function PickableGroup({
     const { spawn } = useParticles();
     const { data: garden } = useCurrentGarden();
     const { data: blocksData } = useBlockData();
-    const currentBlockData = blocksData?.find(
-        (data) => data.information.name === block.name,
-    );
     const getStack = ({ x, z }: { x: number; z: number }) => {
         return garden?.stacks.find(
             (stack) => stack.position.x === x && stack.position.z === z,
@@ -351,7 +347,7 @@ export function PickableGroup({
                     </animated.group>
                 </Suspense>
             )}
-            <group
+            {/* <group
                 position={[
                     stack.position.x,
                     currentBlockData?.attributes.height ?? 0,
@@ -361,7 +357,7 @@ export function PickableGroup({
                 <Html center>
                     <MoveIndicator />
                 </Html>
-            </group>
+            </group> */}
         </animated.group>
     );
 }


### PR DESCRIPTION
Remove an unused MoveIndicator import and the corresponding Html
wrapper markup, and eliminate an unused lookup for current block
data from blocksData. Also remove Html, Billboard and Shadow from
drei imports that were not used, keeping only the needed helpers.

These changes clean up dead code, reduce bundle/compile noise, and
avoid unnecessary computations and component rendering for pickable
groups that are not currently displayed.