### PR TITLE
Allow gallery selection for operation completion images

### DIFF
--- a/apps/app/app/admin/schedule/CompleteOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CompleteOperationModal.tsx
@@ -80,7 +80,6 @@ export function CompleteOperationModal({
                             ref={fileInputRef}
                             type="file"
                             accept="image/*"
-                            capture="environment"
                             multiple
                             className="hidden"
                             onChange={handleFileChange}


### PR DESCRIPTION
### Motivation
- Mobile users could only take new photos when completing scheduled operations because the file input used `capture="environment"` which forces the camera on many devices.  
- The intent is to let users choose existing images from their device gallery as well as take new photos when attaching images to operation completions.  

### Description
- Removed the `capture="environment"` attribute from the file input in `apps/app/app/admin/schedule/CompleteOperationModal.tsx` so the OS/file picker can offer gallery selection.  
- The file input still uses `type="file"`, `accept="image/*"`, and `multiple` to allow multiple image selection.  
- No other functional changes were made to the upload handling; `completeOperationWithImages` remains the submit path when images are present.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695505ef4da0832f92bc034aadece380)