### PR TITLE
Show Advent top users on Admin Dashboard

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -18,6 +18,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
             initialAnalyticsData={data.analytics}
             initialEntitiesData={data.entities}
             initialOperationsDurationData={data.operationsDuration}
+            initialTopAdventUsers={data.topAdventUsers}
             initialPeriod={selectedPeriod}
         />
     );

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { getAnalyticsTotals } from '@gredice/storage';
+import type { AdventCalendarTopUser, getAnalyticsTotals } from '@gredice/storage';
 import { Calendar, Tally3 } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -15,6 +15,7 @@ import {
     OperationsDurationCard,
     type OperationsDurationData,
 } from './OperationsDurationCard';
+import { TopAdventUsersCard } from './TopAdventUsersCard';
 
 type EntityData = {
     entityTypeName: string;
@@ -27,11 +28,13 @@ export function AdminDashboardClient({
     initialEntitiesData,
     initialPeriod = '7',
     initialOperationsDurationData,
+    initialTopAdventUsers,
 }: {
     initialAnalyticsData: Awaited<ReturnType<typeof getAnalyticsTotals>>;
     initialEntitiesData: EntityData[];
     initialPeriod?: string;
     initialOperationsDurationData: OperationsDurationData;
+    initialTopAdventUsers: AdventCalendarTopUser[];
 }) {
     const [selectedPeriod, setSelectedPeriod] = useState(initialPeriod);
     const [isPending, startTransition] = useTransition();
@@ -193,6 +196,10 @@ export function AdminDashboardClient({
             <Stack spacing={1}>
                 <DashboardDivider>Radnje</DashboardDivider>
                 <OperationsDurationCard data={initialOperationsDurationData} />
+            </Stack>
+            <Stack spacing={1}>
+                <DashboardDivider>Natječaji</DashboardDivider>
+                <TopAdventUsersCard users={initialTopAdventUsers} />
             </Stack>
             <Stack spacing={1}>
                 <DashboardDivider>Zapisi</DashboardDivider>

--- a/apps/app/components/admin/dashboard/TopAdventUsersCard.tsx
+++ b/apps/app/components/admin/dashboard/TopAdventUsersCard.tsx
@@ -1,0 +1,57 @@
+import type { AdventCalendarTopUser } from '@gredice/storage';
+import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
+
+type TopAdventUsersCardProps = {
+    users: AdventCalendarTopUser[];
+};
+
+export function TopAdventUsersCard({ users }: TopAdventUsersCardProps) {
+    return (
+        <Card>
+            <CardOverflow>
+                <Stack spacing={1} className="p-4">
+                    <Typography level="h2" className="text-lg" semiBold>
+                        Advent - top korisnici
+                    </Typography>
+                    <Table>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Head>Korisnik</Table.Head>
+                                <Table.Head className="text-right">
+                                    Otvoreni dani
+                                </Table.Head>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {users.length === 0 && (
+                                <Table.Row>
+                                    <Table.Cell colSpan={2}>
+                                        <NoDataPlaceholder>
+                                            Nema otvorenih dana
+                                        </NoDataPlaceholder>
+                                    </Table.Cell>
+                                </Table.Row>
+                            )}
+                            {users.map((user) => (
+                                <Table.Row key={user.userId}>
+                                    <Table.Cell>
+                                        {user.displayName ||
+                                            user.userName ||
+                                            user.userId}
+                                    </Table.Cell>
+                                    <Table.Cell className="text-right">
+                                        {user.openedDays}
+                                    </Table.Cell>
+                                </Table.Row>
+                            ))}
+                        </Table.Body>
+                    </Table>
+                </Stack>
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -3,6 +3,7 @@
 import {
     getAllOperations,
     getAnalyticsTotals,
+    getAdventCalendarTopUsers,
     getEntitiesFormatted,
     getEntitiesRaw,
     getEntityTypes,
@@ -188,9 +189,12 @@ export async function getAnalyticsData(days: number) {
         sowingTotals,
     );
 
+    const topAdventUsers = await getAdventCalendarTopUsers(today.getFullYear());
+
     return {
         analytics: analyticsResult,
         entities: entitiesCounts,
         operationsDuration,
+        topAdventUsers,
     };
 }

--- a/apps/app/components/admin/dashboard/index.ts
+++ b/apps/app/components/admin/dashboard/index.ts
@@ -1,2 +1,3 @@
 export { AdminDashboard } from './AdminDashboard';
 export { AdminDashboardClient } from './AdminDashboardClient';
+export { TopAdventUsersCard } from './TopAdventUsersCard';


### PR DESCRIPTION
### Motivation
- Provide visibility into the Advent contest by listing users who opened the most advent days.
- Surface contest metrics alongside existing admin analytics so admins can monitor engagement.

### Description
- Added `AdventCalendarTopUser` type and `getAdventCalendarTopUsers` query in `packages/storage/src/repositories/occasionsRepo.ts` that aggregates advent open counts per user by reading `events.data` and joining the `users` table.
- Exported the new repository API through `packages/storage` and wired `getAdventCalendarTopUsers` into the admin fetcher `getAnalyticsData` in `apps/app/components/admin/dashboard/actions.ts` to include `topAdventUsers` in the response.
- Introduced a new UI component `TopAdventUsersCard` and integrated it into the dashboard by adding `initialTopAdventUsers` props to `AdminDashboard`/`AdminDashboardClient` and rendering the card under a new "Natječaji" section.
- Updated dashboard barrel exports to include `TopAdventUsersCard`.

### Testing
- No automated tests were executed as part of this change.
- TypeScript and runtime integration should be covered by existing workspace tests and CI when run.
- Manual verification was not performed in this environment (component added and server query wired end-to-end in code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958481c7960832f93b0662817c78be9)