### PR TITLE
feat(admin): add Occasions section and surface Advent top users

### DIFF
--- a/apps/app/app/admin/occasions/OccasionsClient.tsx
+++ b/apps/app/app/admin/occasions/OccasionsClient.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { AdventCalendarTopUser } from '@gredice/storage';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { TopAdventUsersCard } from '../../../components/admin/dashboard/TopAdventUsersCard';
+
+type OccasionsClientProps = {
+    topAdventUsers2025: AdventCalendarTopUser[];
+};
+
+export function OccasionsClient({ topAdventUsers2025 }: OccasionsClientProps) {
+    return (
+        <Stack spacing={4}>
+            <Typography level="h1" semiBold>
+                Prigode
+            </Typography>
+            <Stack spacing={2}>
+                <TopAdventUsersCard year={2025} users={topAdventUsers2025} />
+            </Stack>
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/occasions/actions.ts
+++ b/apps/app/app/admin/occasions/actions.ts
@@ -1,0 +1,9 @@
+'use server';
+
+import { getAdventCalendarTopUsers } from '@gredice/storage';
+import { auth } from '../../../lib/auth/auth';
+
+export async function getAdventTopUsers(year: number) {
+    await auth(['admin']);
+    return await getAdventCalendarTopUsers(year);
+}

--- a/apps/app/app/admin/occasions/page.tsx
+++ b/apps/app/app/admin/occasions/page.tsx
@@ -1,0 +1,10 @@
+import { auth } from '../../../lib/auth/auth';
+import { getAdventTopUsers } from './actions';
+import { OccasionsClient } from './OccasionsClient';
+
+export default async function OccasionsPage() {
+    await auth(['admin']);
+    const topAdventUsers2025 = await getAdventTopUsers(2025);
+
+    return <OccasionsClient topAdventUsers2025={topAdventUsers2025} />;
+}

--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -18,7 +18,6 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
             initialAnalyticsData={data.analytics}
             initialEntitiesData={data.entities}
             initialOperationsDurationData={data.operationsDuration}
-            initialTopAdventUsers={data.topAdventUsers}
             initialPeriod={selectedPeriod}
         />
     );

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AdventCalendarTopUser, getAnalyticsTotals } from '@gredice/storage';
+import type { getAnalyticsTotals } from '@gredice/storage';
 import { Calendar, Tally3 } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -15,7 +15,6 @@ import {
     OperationsDurationCard,
     type OperationsDurationData,
 } from './OperationsDurationCard';
-import { TopAdventUsersCard } from './TopAdventUsersCard';
 
 type EntityData = {
     entityTypeName: string;
@@ -28,13 +27,11 @@ export function AdminDashboardClient({
     initialEntitiesData,
     initialPeriod = '7',
     initialOperationsDurationData,
-    initialTopAdventUsers,
 }: {
     initialAnalyticsData: Awaited<ReturnType<typeof getAnalyticsTotals>>;
     initialEntitiesData: EntityData[];
     initialPeriod?: string;
     initialOperationsDurationData: OperationsDurationData;
-    initialTopAdventUsers: AdventCalendarTopUser[];
 }) {
     const [selectedPeriod, setSelectedPeriod] = useState(initialPeriod);
     const [isPending, startTransition] = useTransition();
@@ -196,10 +193,6 @@ export function AdminDashboardClient({
             <Stack spacing={1}>
                 <DashboardDivider>Radnje</DashboardDivider>
                 <OperationsDurationCard data={initialOperationsDurationData} />
-            </Stack>
-            <Stack spacing={1}>
-                <DashboardDivider>Natječaji</DashboardDivider>
-                <TopAdventUsersCard users={initialTopAdventUsers} />
             </Stack>
             <Stack spacing={1}>
                 <DashboardDivider>Zapisi</DashboardDivider>

--- a/apps/app/components/admin/dashboard/TopAdventUsersCard.tsx
+++ b/apps/app/components/admin/dashboard/TopAdventUsersCard.tsx
@@ -7,15 +7,16 @@ import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
 
 type TopAdventUsersCardProps = {
     users: AdventCalendarTopUser[];
+    year: number;
 };
 
-export function TopAdventUsersCard({ users }: TopAdventUsersCardProps) {
+export function TopAdventUsersCard({ users, year }: TopAdventUsersCardProps) {
     return (
         <Card>
             <CardOverflow>
                 <Stack spacing={1} className="p-4">
                     <Typography level="h2" className="text-lg" semiBold>
-                        Advent - top korisnici
+                        Advent {year} - top korisnici
                     </Typography>
                     <Table>
                         <Table.Header>

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -3,7 +3,6 @@
 import {
     getAllOperations,
     getAnalyticsTotals,
-    getAdventCalendarTopUsers,
     getEntitiesFormatted,
     getEntitiesRaw,
     getEntityTypes,
@@ -189,12 +188,9 @@ export async function getAnalyticsData(days: number) {
         sowingTotals,
     );
 
-    const topAdventUsers = await getAdventCalendarTopUsers(today.getFullYear());
-
     return {
         analytics: analyticsResult,
         entities: entitiesCounts,
         operationsDuration,
-        topAdventUsers,
     };
 }

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -311,6 +311,12 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                 <ListHeader header="Upravljanje" />
                 <List>
                     <NavItem
+                        href={KnownPages.Occasions}
+                        label="Prigode"
+                        icon={<Calendar className="size-5" />}
+                        onClick={onItemClick}
+                    />
+                    <NavItem
                         href={KnownPages.Schedule}
                         label="Raspored"
                         icon={<Calendar className="size-5" />}

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -64,6 +64,7 @@ export const KnownPages = {
         `/admin/operations/${operationId}` as Route,
     Sensors: '/admin/sensors',
     Cache: '/admin/cache',
+    Occasions: '/admin/occasions',
 
     // Delivery management
     DeliverySlots: '/admin/delivery/slots',


### PR DESCRIPTION
Add a new Occasions admin page and client components to display Advent
calendar top users for a given year. Introduce route KnownPages.Occasions
and wire it into the admin navigation.

Move Advent top users data handling from the main dashboard server flow:
- Remove fetching and initialTopAdventUsers prop from AdminDashboard
  server actions and client component.
- Remove TopAdventUsersCard from the dashboard view.

Add OccasionsClient and server action getAdventTopUsers:
- New server action enforces admin auth and fetches top users for a
  specified year.
- OccasionsClient renders a page header and the TopAdventUsersCard for
  year 2025 (prop year added to the card).

Update TopAdventUsersCard:
- Accept a year prop and show it in the card title.

These changes separate the Advent top users UI into a dedicated admin
Occasions area, simplifying the dashboard and making the feature more
focused and easier to extend.