### PR TITLE
fix(hud): prefer label over duplicate name field in inventory

### DIFF
--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -95,7 +95,6 @@ function InventoryItemModal({
 }) {
     const displayName =
         sortData?.information?.name ??
-        operationData?.information?.name ??
         operationData?.information?.label ??
         operationData?.information?.name ??
         item.name ??


### PR DESCRIPTION
Adjust InventoryHud displayName resolution to avoid selecting a
duplicate name field from operationData. Remove the fallback that
preferred operationData.information.name before operationData.information.label,
so label is used when available and name is used as a last resort.
This prevents repeated or incorrect item names showing in the HUD
when an operation supplies both label and name fields.