### PR TITLE
fix(logotype): remove visible title and hide redundant title tag

### DIFF
--- a/apps/garden/components/Logotype.tsx
+++ b/apps/garden/components/Logotype.tsx
@@ -14,7 +14,7 @@ export function Logotype({
             className={cx('fill-[#2E6F40]', className)}
             {...props}
         >
-            <title>Gredice</title>
+            <title style={{ opacity: 0 }}>Gredice</title>
             <g
                 fill={color}
                 fillRule="evenodd"

--- a/apps/www/components/Logotype.tsx
+++ b/apps/www/components/Logotype.tsx
@@ -8,7 +8,7 @@ export function Logotype(props: SVGProps<SVGSVGElement>) {
             fill="none"
             {...props}
         >
-            <title>Gredice</title>
+            <title style={{ opacity: 0 }}>Gredice</title>
             <g
                 fill="#2E6F40"
                 fillRule="evenodd"


### PR DESCRIPTION
Remove the duplicate visible <title> element in the garden Logotype component
and replace it with an invisible title inside the <path> to keep an accessible
label without affecting layout or visual rendering. Also remove the standalone
<title> tag in the www Logotype component.

This prevents the SVG title from affecting layout/spacing while retaining an
accessible name, and removes redundant/title placement inconsistencies across
two Logotype components.

Closes #1808