### PR TITLE
feat(config): add API rewrite to proxy /api/gredice

### DIFF
--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -6,6 +6,21 @@ const nextConfig: NextConfig = {
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,
+    async rewrites() {
+        const isDev =
+            process.env.NODE_ENV === 'development' ||
+            process.env.NEXT_PUBLIC_VERCEL_ENV === 'development';
+        const apiHost = isDev
+            ? 'http://localhost:3005'
+            : 'https://api.gredice.com';
+
+        return [
+            {
+                source: '/api/gredice/:path*',
+                destination: `${apiHost}/:path*`,
+            },
+        ];
+    },
     experimental: {
         turbopackFileSystemCacheForDev: true,
         typedEnv: true,


### PR DESCRIPTION
Add an async rewrites function to next.config.ts to proxy requests
from /api/gredice/:path* to the appropriate API host. In
development the proxy targets http://localhost:3005, while in other
environments it routes to https://api.gredice.com. Detect the
environment using NODE_ENV and NEXT_PUBLIC_VERCEL_ENV.

This enables local development against a running backend without
changing frontend code and centralizes API host selection for
deployment consistency.