### PR TITLE
chore(turbo): pass Sentry env vars through to pipeline

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,14 @@
                 "$TURBO_DEFAULT$",
                 ".env*"
             ],
+            "passThroughEnv": [
+                "SENTRY_AUTH_TOKEN",
+                "SENTRY_ORG",
+                "SENTRY_OTLP_TRACES_URL",
+                "SENTRY_PROJECT",
+                "SENTRY_PUBLIC_KEY",
+                "SENTRY_VERCEL_LOG_DRAIN_URL"
+            ],
             "outputs": [
                 ".next/**",
                 "!.next/cache/**"


### PR DESCRIPTION
Add a passThroughEnv array to turbo.json so CI and turborepo
remote execution receive required Sentry-related environment
variables: SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_OTLP_TRACES_URL,
SENTRY_PROJECT, SENTRY_PUBLIC_KEY, and SENTRY_VERCEL_LOG_DRAIN_URL.

This ensures Sentry CLI and runtime integrations can authenticate and
report errors/traces during builds and remote tasks without embedding
secrets in config or compromising local environment isolation.