### PR TITLE
chore(package): require Node.js >= 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
     "engines": {
-        "node": ">=22"
+        "node": ">=24"
     },
     "pnpm": {
         "onlyBuiltDependencies": [


### PR DESCRIPTION
Raise the Node.js engine requirement from 22 to 24 in package.json.
This ensures compatibility with newer language features and runtime APIs
used by the codebase and aligns with the project's supported Node
versions for development and CI.