### PR TITLE
Add plant collage background to plants showcase link

### DIFF
--- a/apps/www/app/PlantsShowcase.tsx
+++ b/apps/www/app/PlantsShowcase.tsx
@@ -46,7 +46,10 @@ export async function PlantsShowcase() {
                     href={KnownPages.Plants}
                     className="relative flex flex-col justify-center items-center overflow-hidden hover:border-muted-foreground/50 hover:bg-card/30 bg-card/70 rounded-lg border border-tertiary border-dashed p-4 transition-all"
                 >
-                    <div className="absolute inset-0 grid grid-cols-4 gap-2 p-2 opacity-50">
+                    <div
+                        className="absolute inset-0 grid grid-cols-4 gap-2 p-2 opacity-50"
+                        aria-hidden="true"
+                    >
                         {extraPlants?.map((plant) => (
                             <div
                                 key={plant.id}
@@ -54,6 +57,7 @@ export async function PlantsShowcase() {
                             >
                                 <PlantOrSortImage
                                     plant={plant}
+                                    alt=""
                                     fill
                                     className="object-contain"
                                     sizes="60px"


### PR DESCRIPTION
### Motivation
- Make the "Sve biljke" call-to-action more visually informative by showing a collage of additional plant images so users know there are many other plants available.

### Description
- Import and reuse the existing `PlantOrSortImage` component to render plant thumbnails for visual consistency.
- Compute an `extraPlants` list (up to 8) that excludes the four showcased items and render them as a small grid behind the CTA tile in `apps/www/app/PlantsShowcase.tsx`.
- Add positioning, opacity, and a translucent overlay so the collage appears as a subtle background and the CTA label remains readable.

### Testing
- Started the local dev server with `pnpm --filter www dev` and ran a Playwright script to capture a screenshot of the landing page, producing a visual artifact at `artifacts/plants-showcase.png` which shows the updated CTA background.  
- The app attempted to fetch remote data during the run and encountered network errors (`ENETUNREACH`) which produced `GET / 500` in the dev server logs, so server-side data resolution failed but the visual layout for the CTA was rendered in the captured screenshot.  
- No unit or UI automated tests were added or run beyond the local dev + screenshot verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698882d86d88832f84f48e99539e6312)