### PR TITLE
feat(transactional): Email contact info updated

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -17,7 +17,7 @@
         "regenerate:feature-flags": "hypertune"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "3.985.0",
+        "@aws-sdk/client-s3": "3.986.0",
         "@azure/communication-email": "1.1.0",
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "10.0.0",

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -17,7 +17,7 @@
         "regenerate:feature-flags": "hypertune"
     },
     "dependencies": {
-        "@sentry/cli": "3.1.0",
+        "@sentry/cli": "3.2.0",
         "hypertune": "2.10.1",
         "next": "16.1.6",
         "pg": "8.18.0",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -21,7 +21,6 @@
     },
     "dependencies": {
         "@flags-sdk/hypertune": "0.3.2",
-        "@vercel/kv": "3.0.0",
         "@vercel/toolbar": "0.2.2",
         "flags": "4.0.2",
         "hypertune": "2.10.1",
@@ -58,7 +57,7 @@
         "@vercel/analytics": "1.6.1",
         "babel-plugin-react-compiler": "19.1.0-rc.3",
         "dotenv": "17.2.4",
-        "motion": "12.33.0",
+        "motion": "12.34.0",
         "next-sitemap": "4.2.3",
         "postcss": "8.5.6",
         "react-confetti-boom": "2.0.1",

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -13,7 +13,7 @@
         "regenerate-cdn:sounds": "node --env-file=.env --experimental-strip-types ./scripts/regenerate-sounds.ts"
     },
     "devDependencies": {
-        "@aws-sdk/client-s3": "3.985.0",
+        "@aws-sdk/client-s3": "3.986.0",
         "@biomejs/biome": "2.3.14",
         "@ffmpeg-installer/ffmpeg": "1.1.0",
         "@types/node": "24.10.10"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@gredice/directory-types": "workspace:*",
-        "openapi-fetch": "0.15.0"
+        "openapi-fetch": "0.16.0"
     },
     "devDependencies": {
         "@biomejs/biome": "2.3.14",

--- a/packages/directory-types/package.json
+++ b/packages/directory-types/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "2.3.14",
-        "openapi-typescript": "7.10.1",
+        "openapi-typescript": "7.12.0",
         "typescript": "5.9.3"
     }
 }

--- a/packages/signalco/package.json
+++ b/packages/signalco/package.json
@@ -16,12 +16,12 @@
         "regenerate:directories-api": "pnpm dlx openapi-typescript https://api.signalco.io/api/swagger.yaml -o ./src/lib/signalco-api/v1.d.ts"
     },
     "dependencies": {
-        "openapi-fetch": "0.15.0"
+        "openapi-fetch": "0.16.0"
     },
     "devDependencies": {
         "@biomejs/biome": "2.3.14",
         "@types/node": "24.10.10",
-        "openapi-typescript": "7.10.1",
+        "openapi-typescript": "7.12.0",
         "server-only": "0.0.1",
         "typescript": "5.9.3"
     }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
         "@signalco/js": "0.1.0",
         "@upstash/redis": "1.36.2",
         "dotenv": "17.2.4",
-        "drizzle-kit": "0.31.8",
+        "drizzle-kit": "0.31.9",
         "drizzle-orm": "0.45.1",
         "openapi-types": "12.1.3",
         "pg": "8.18.0",

--- a/packages/transactional/components/shared/GrediceContactChannels.tsx
+++ b/packages/transactional/components/shared/GrediceContactChannels.tsx
@@ -1,0 +1,22 @@
+import { Link } from '../Link';
+import { Paragraph } from '../Paragraph';
+
+export function GrediceContactChannels() {
+    return (
+        <Paragraph>
+            Ako imaš pitanja ili trebaš pomoć, javi nam se putem jednog od
+            kanala:
+            <br />
+            {'📧 '}
+            <Link href="mailto:info@gredice.com">info@gredice.com</Link>
+            <br />
+            {'💬 '}
+            <Link href="https://gredice.link/wa">WhatsApp</Link>
+            <br />
+            {'📷 '}
+            <Link href="https://gredice.link/ig">Instagram</Link>
+            {' | '}
+            <Link href="https://gredice.link/fb">Facebook</Link>
+        </Paragraph>
+    );
+}

--- a/packages/transactional/emails/Account/welcome.tsx
+++ b/packages/transactional/emails/Account/welcome.tsx
@@ -10,6 +10,7 @@ import { Divider } from '../../components/Divider';
 import { GrediceLogotype } from '../../components/GrediceLogotype';
 import { Paragraph } from '../../components/Paragraph';
 import { PrimaryButton } from '../../components/PrimaryButton';
+import { GrediceContactChannels } from '../../components/shared/GrediceContactChannels';
 import { GrediceDisclaimer } from '../../components/shared/GrediceDisclaimer';
 
 export interface WelcomeEmailTemplateProps {
@@ -62,19 +63,12 @@ export default function WelcomeEmailTemplate({
                             Posjeti svoj vrt
                         </PrimaryButton>
                     </Section>
-                    <Paragraph>
-                        Ako imaš pitanja ili trebaš pomoć, slobodno nam se javi
-                        - ovdje smo za tebe!
-                    </Paragraph>
+                    <GrediceContactChannels />
                     <Paragraph>Sretno vrtlarenje! 🌻</Paragraph>
                     <Paragraph>
                         Zeleni pozdrav,
                         <br />
                         Gredice tim
-                    </Paragraph>
-                    <Paragraph>
-                        P.S. Pratite nas i na društvenim mrežama za savjete,
-                        trikove i priče iz vrtova. 🌍
                     </Paragraph>
                     <Divider className="my-[26px]" />
                     <GrediceDisclaimer email={email} appDomain={appDomain} />

--- a/packages/transactional/emails/Newsletter/newsletter.tsx
+++ b/packages/transactional/emails/Newsletter/newsletter.tsx
@@ -40,13 +40,13 @@ export default function MarkdownEmailTemplate({
                     <Divider className="my-[26px]" />
                     <Disclaimer>
                         Ovaj email je poslan pretplatniku na newsletter Gredice.
-                        Ukoliko ne želiš primati ovakve emailove, ukoliko se
-                        želiš odjaviti možeš to učiniti tako da nas kontaktiraš
-                        na{' '}
+                        Ukoliko se želiš odjaviti, kontaktiraj nas na{' '}
                         <Link href="mailto:info@gredice.com">
                             info@gredice.com
                         </Link>
-                        .
+                        , <Link href="https://gredice.link/wa">WhatsApp</Link>
+                        {' ili '}
+                        <Link href="https://gredice.link/ig">Instagram</Link>.
                     </Disclaimer>
                 </ContentCard>
             </Tailwind>

--- a/packages/transactional/emails/Notifications/delivery-cancelled.tsx
+++ b/packages/transactional/emails/Notifications/delivery-cancelled.tsx
@@ -11,6 +11,7 @@ import { GrediceLogotype } from '../../components/GrediceLogotype';
 import { Header } from '../../components/Header';
 import { Paragraph } from '../../components/Paragraph';
 import { PrimaryButton } from '../../components/PrimaryButton';
+import { GrediceContactChannels } from '../../components/shared/GrediceContactChannels';
 import { GrediceDisclaimer } from '../../components/shared/GrediceDisclaimer';
 
 export interface DeliveryCancelledEmailTemplateProps {
@@ -67,10 +68,7 @@ export default function DeliveryCancelledEmailTemplate({
                             Upravljaj dostavama
                         </PrimaryButton>
                     </Section>
-                    <Paragraph>
-                        Ako trebaš pomoć ili želiš dodatne informacije, javi nam
-                        se iz aplikacije i rado ćemo pomoći.
-                    </Paragraph>
+                    <GrediceContactChannels />
                     <Paragraph>{appName} tim</Paragraph>
                     <Divider className="my-[26px]" />
                     <GrediceDisclaimer email={email} appDomain={appDomain} />

--- a/packages/transactional/emails/Notifications/delivery-ready.tsx
+++ b/packages/transactional/emails/Notifications/delivery-ready.tsx
@@ -11,6 +11,7 @@ import { GrediceLogotype } from '../../components/GrediceLogotype';
 import { Header } from '../../components/Header';
 import { Paragraph } from '../../components/Paragraph';
 import { PrimaryButton } from '../../components/PrimaryButton';
+import { GrediceContactChannels } from '../../components/shared/GrediceContactChannels';
 import { GrediceDisclaimer } from '../../components/shared/GrediceDisclaimer';
 
 export interface DeliveryReadyEmailTemplateProps {
@@ -58,10 +59,7 @@ export default function DeliveryReadyEmailTemplate({
                             <strong>📍 Adresa:</strong> {addressLine}
                         </Paragraph>
                     ) : null}
-                    <Paragraph>
-                        Ako ti nešto iskrsne ili trebaš dodatne upute, javi nam
-                        se da na vrijeme prilagodimo dostavu.
-                    </Paragraph>
+                    <GrediceContactChannels />
                     <Section className="my-[32px] text-center">
                         <PrimaryButton href={manageUrl}>
                             Prikaži detalje

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -9,6 +9,7 @@
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
+        "postinstall": "node ../../scripts/fix-preview-server-esbuild.mjs",
         "dev": "email dev -p 4001"
     },
     "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,7 @@
         "@signalco/ui": "0.2.10",
         "@signalco/ui-icons": "0.2.2",
         "@signalco/ui-primitives": "0.6.5",
-        "motion": "12.33.0",
+        "motion": "12.34.0",
         "next": "16.1.6",
         "nuqs": "2.8.8",
         "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
   apps/app:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.985.0
-        version: 3.985.0
+        specifier: 3.986.0
+        version: 3.986.0
       '@azure/communication-email':
         specifier: 1.1.0
         version: 1.1.0
@@ -348,8 +348,8 @@ importers:
   apps/farm:
     dependencies:
       '@sentry/cli':
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 3.2.0
+        version: 3.2.0
       hypertune:
         specifier: 2.10.1
         version: 2.10.1
@@ -568,9 +568,6 @@ importers:
       '@flags-sdk/hypertune':
         specifier: 0.3.2
         version: 0.3.2(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
-      '@vercel/kv':
-        specifier: 3.0.0
-        version: 3.0.0
       '@vercel/toolbar':
         specifier: 0.2.2
         version: 0.2.2(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react@19.2.4)(vue-router@4.6.2(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@6.4.1(@types/node@24.10.10)(jiti@2.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -675,8 +672,8 @@ importers:
         specifier: 17.2.4
         version: 17.2.4
       motion:
-        specifier: 12.33.0
-        version: 12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 12.34.0
+        version: 12.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-sitemap:
         specifier: 4.2.3
         version: 4.2.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))
@@ -705,8 +702,8 @@ importers:
   packages/cdn:
     devDependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.985.0
-        version: 3.985.0
+        specifier: 3.986.0
+        version: 3.986.0
       '@biomejs/biome':
         specifier: 2.3.14
         version: 2.3.14
@@ -723,8 +720,8 @@ importers:
         specifier: workspace:*
         version: link:../directory-types
       openapi-fetch:
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.16.0
+        version: 0.16.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.14
@@ -751,8 +748,8 @@ importers:
         specifier: 2.3.14
         version: 2.3.14
       openapi-typescript:
-        specifier: 7.10.1
-        version: 7.10.1(typescript@5.9.3)
+        specifier: 7.12.0
+        version: 7.12.0(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1026,8 +1023,8 @@ importers:
   packages/signalco:
     dependencies:
       openapi-fetch:
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.16.0
+        version: 0.16.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.14
@@ -1036,8 +1033,8 @@ importers:
         specifier: 24.10.10
         version: 24.10.10
       openapi-typescript:
-        specifier: 7.10.1
-        version: 7.10.1(typescript@5.9.3)
+        specifier: 7.12.0
+        version: 7.12.0(typescript@5.9.3)
       server-only:
         specifier: 0.0.1
         version: 0.0.1
@@ -1081,8 +1078,8 @@ importers:
         specifier: 17.2.4
         version: 17.2.4
       drizzle-kit:
-        specifier: 0.31.8
-        version: 0.31.8
+        specifier: 0.31.9
+        version: 0.31.9
       drizzle-orm:
         specifier: 0.45.1
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(@upstash/redis@1.36.2)(pg@8.18.0)
@@ -1197,8 +1194,8 @@ importers:
         specifier: 0.6.5
         version: 0.6.5(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       motion:
-        specifier: 12.33.0
-        version: 12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 12.34.0
+        version: 12.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.1.6
         version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
@@ -1300,8 +1297,8 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-s3@3.985.0':
-    resolution: {integrity: sha512-S9TqjzzZEEIKBnC7yFpvqM7CG9ALpY5qhQ5BnDBJtdG20NoGpjKLGUUfD2wmZItuhbrcM4Z8c6m6Fg0XYIOVvw==}
+  '@aws-sdk/client-s3@3.986.0':
+    resolution: {integrity: sha512-IcDJ8shVVvbxgMe8+dLWcv6uhSwmX65PHTVGX81BhWAElPnp3CL8w/5uzOPRo4n4/bqIk9eskGVEIicw2o+SrA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.985.0':
@@ -1396,8 +1393,8 @@ packages:
     resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.985.0':
-    resolution: {integrity: sha512-W6hTSOPiSbh4IdTYVxN7xHjpCh0qvfQU1GKGBzGQm0ZEIOaMmWqiDEvFfyGYKmfBvumT8vHKxQRTX0av9omtIg==}
+  '@aws-sdk/signature-v4-multi-region@3.986.0':
+    resolution: {integrity: sha512-Upw+rw7wCH93E6QWxqpAqJLrUmJYVUAWrk4tCOBnkeuwzGERZvJFL5UQ6TAJFj9T18Ih+vNFaACh8J5aP4oTBw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.985.0':
@@ -1414,6 +1411,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.985.0':
     resolution: {integrity: sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.986.0':
+    resolution: {integrity: sha512-Mqi79L38qi1gCG3adlVdbNrSxvcm1IPDLiJPA3OBypY5ewxUyWbaA3DD4goG+EwET6LSFgZJcRSIh6KBNpP5pA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.4':
@@ -3929,14 +3930,14 @@ packages:
       react-native:
         optional: true
 
-  '@redocly/ajv@8.17.1':
-    resolution: {integrity: sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==}
+  '@redocly/ajv@8.17.3':
+    resolution: {integrity: sha512-NQsbJbB/GV7JVO88ebFkMndrnuGp/dTm5/2NISeg+JGcLzTfGBJZ01+V5zD8nKBOpi/dLLNFT+Ql6IcUk8ehng==}
 
   '@redocly/config@0.22.2':
     resolution: {integrity: sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==}
 
-  '@redocly/openapi-core@1.34.5':
-    resolution: {integrity: sha512-0EbE8LRbkogtcCXU7liAyC00n9uNG9hJ+eMyHFdUsy9lB/WGqnEBgwjA9q2cyzAVcdTkQqTBBU1XePNnN3OijA==}
+  '@redocly/openapi-core@1.34.6':
+    resolution: {integrity: sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
   '@reduxjs/toolkit@2.11.2':
@@ -4291,8 +4292,8 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
-  '@sentry/cli-darwin@3.1.0':
-    resolution: {integrity: sha512-xT1WlCHenGGO29Lq/wKaIthdqZzNzZhlPs7dXrzlBx9DyA2Jnl0g7WEau0oWi8GyJGVRXCJMiCydR//Tb5qVwA==}
+  '@sentry/cli-darwin@3.2.0':
+    resolution: {integrity: sha512-2If2h0P/X9K0UrwlpZYKnxBmIFfa957lAHGe5VmN64v8nEHk8dxcrX+NS9nX9H75eccLGzGMcYk0Zt0KQgQJ3g==}
     engines: {node: '>=18'}
     os: [darwin]
 
@@ -4302,8 +4303,8 @@ packages:
     cpu: [arm64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm64@3.1.0':
-    resolution: {integrity: sha512-Jm/iHLKiHxrZYlAq2tT07amiegEVCOAQT9Unilr6djjcZzS2tcI9ThSRQvjP9tFpFRKop+NyNGE3XHXf69r00g==}
+  '@sentry/cli-linux-arm64@3.2.0':
+    resolution: {integrity: sha512-YFpYIfYpXYzpSrIspmPOOPjXbxWp/Ve+F2hSIQb1tSKmcxFgaUm6WfuniYF8EIaLNa8YOLECf0xo78yGXBa+ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux, freebsd, android]
@@ -4314,8 +4315,8 @@ packages:
     cpu: [arm]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm@3.1.0':
-    resolution: {integrity: sha512-kbP3/8/Ct/Jbm569KDXbFIyMyPypIegObvIT7LdSsfdYSZdBd396GV7vUpSGKiLUVVN0xjn8OqQ48AVGfjmuMg==}
+  '@sentry/cli-linux-arm@3.2.0':
+    resolution: {integrity: sha512-NVcGcS9mceivVhi8W6iEnlcK96OlPMzOdM6xkIm+7+J0uXHgUyMyc+rT6p2QG3j8jI5I7qAl7fTHWluSX2lx3g==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux, freebsd, android]
@@ -4326,8 +4327,8 @@ packages:
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-i686@3.1.0':
-    resolution: {integrity: sha512-f/PK/EGK5vFOy7LC4Riwb+BEE20Nk7RbEFEMjvRq26DpETCrZYUGlbpIKvJFKOaUmr79aAkFCA/EjJiYfcQP2Q==}
+  '@sentry/cli-linux-i686@3.2.0':
+    resolution: {integrity: sha512-6SOxlF37NqRRKxEuvWryBM7MAgTisq0G6ZQzhI2iuWbcrmlLUDUW2Yssz3gAR01eYJ4jfpqvojSzPRDwqB0K+Q==}
     engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
@@ -4338,8 +4339,8 @@ packages:
     cpu: [x64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-x64@3.1.0':
-    resolution: {integrity: sha512-T+v8x1ujhixZrOrH0sVhsW6uLwK4n0WS+B+5xV46WqUKe32cbYotursp2y53ROjgat8SQDGeP/VnC0Qa3Y2fEA==}
+  '@sentry/cli-linux-x64@3.2.0':
+    resolution: {integrity: sha512-7LRd0A74ma/1ejlTRPOoBiFiJr4LWkoE6CnA2XwAoYd0r62WUjGHtg6gIC+yElOCwtxXP7I9fOiV2BJIAq2DHw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux, freebsd, android]
@@ -4350,8 +4351,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@sentry/cli-win32-arm64@3.1.0':
-    resolution: {integrity: sha512-2DIPq6aW2DC34EDC9J0xwD+9BpFnKdFGdIcQUZMS+5pXlU6V7o8wpZxZAM8TdYNmsPkkQGKp7Dhl/arWpvNgrw==}
+  '@sentry/cli-win32-arm64@3.2.0':
+    resolution: {integrity: sha512-uKRi/++gnGepsaGi4goIcC13YGNEHgOUcROkz4L3H8vAR7QxWv2SHy7SCN+2S6c+Q2mOd0DfY35cMW5MzTpb7g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -4362,8 +4363,8 @@ packages:
     cpu: [x86, ia32]
     os: [win32]
 
-  '@sentry/cli-win32-i686@3.1.0':
-    resolution: {integrity: sha512-2NuywEiiZn6xJ1yAV2xjv/nuHiy6kZU5XR3RSAIrPdEZD1nBoMsH/gB2FufQw58Ziz/7otFcX+vtGpJjbIT5mQ==}
+  '@sentry/cli-win32-i686@3.2.0':
+    resolution: {integrity: sha512-/84NEPeFQne2bQWfDZ+3EzioxFR8ojSwExCgVsyTfqa/4PzmaerAGUAxiD+VcJLJTyJEHAjWXTmSZGbYjIgdyQ==}
     engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [win32]
@@ -4374,8 +4375,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sentry/cli-win32-x64@3.1.0':
-    resolution: {integrity: sha512-Ip405Yqdrr+l9TImsZOJz6c9Nb4zvXcmtOIBKLHc9cowpfXfmlqsHbDp7Xh4+k4L0uLr9i+8ilgQ6ypcuF4UCg==}
+  '@sentry/cli-win32-x64@3.2.0':
+    resolution: {integrity: sha512-N9qGGT91awsh4IMyXrRHH+qIWmv9MJk9tPPAWPvLMWgdlTHT/40WYwvA4tYj80uZXU0TN8ppBWbd3ebDyOjwxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -4385,8 +4386,8 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@sentry/cli@3.1.0':
-    resolution: {integrity: sha512-ngnx6E8XjXpg1uzma45INfKCS8yurb/fl3cZdXTCa2wmek8b4N6WIlmOlTKFTBrV54OauF6mloJxAlpuzoQR6g==}
+  '@sentry/cli@3.2.0':
+    resolution: {integrity: sha512-YLv/xgttSc8sRhK2xBoxmLS+yQlCW154ey2cXFsFe+yY73lXvQ9nZ7BkHmSc+YUl8y5CKHL+8edQLYV8O8PQMA==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -5163,11 +5164,6 @@ packages:
       next:
         optional: true
 
-  '@vercel/kv@3.0.0':
-    resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
-    engines: {node: '>=14.6'}
-    deprecated: 'Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis'
-
   '@vercel/microfrontends@2.0.1':
     resolution: {integrity: sha512-lVo3h0qVibxFkl8/oO+F50B6CtdHZgNmjPZMqME4iCH+EmQ7MDoFDQqN2Pjwn3Pnj/5SvCZPzmI0HQJlpQmP/g==}
     hasBin: true
@@ -5563,8 +5559,8 @@ packages:
     resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
 
-  bowser@2.14.0:
-    resolution: {integrity: sha512-P8J1R788N3SUX80KWjr6CKO8RMlbZR4tVqN6A0sMamSK5PCIlfW5LrBGzMB8hKYAdzhX28M8MDgbNJMsBN74sA==}
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -6023,8 +6019,8 @@ packages:
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
-  drizzle-kit@0.31.8:
-    resolution: {integrity: sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==}
+  drizzle-kit@0.31.9:
+    resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
   drizzle-orm@0.45.1:
@@ -6453,8 +6449,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.33.0:
-    resolution: {integrity: sha512-ca8d+rRPcDP5iIF+MoT3WNc0KHJMjIyFAbtVLvM9eA7joGSpeqDfiNH/kCs1t4CHi04njYvWyj0jS4QlEK/rJQ==}
+  framer-motion@12.34.0:
+    resolution: {integrity: sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -7401,14 +7397,14 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  motion-dom@12.33.0:
-    resolution: {integrity: sha512-XRPebVypsl0UM+7v0Hr8o9UAj0S2djsQWRdHBd5iVouVpMrQqAI0C/rDAT3QaYnXnHuC5hMcwDHCboNeyYjPoQ==}
+  motion-dom@12.34.0:
+    resolution: {integrity: sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q==}
 
   motion-utils@12.29.2:
     resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
 
-  motion@12.33.0:
-    resolution: {integrity: sha512-TcND7PijsrTeIA9SRVUB8TOJQ+6mJnJ5K4a9oAJZvyI0Zy47Gq5oofU+VkTxbLcvDoKXnHspQcII2mnk3TbFsQ==}
+  motion@12.34.0:
+    resolution: {integrity: sha512-01Sfa/zgsD/di8zA/uFW5Eb7/SPXoGyUfy+uMRMW5Spa8j0z/UbfQewAYvPMYFCXRlyD6e5aLHh76TxeeJD+RA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -7582,8 +7578,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openapi-fetch@0.15.0:
-    resolution: {integrity: sha512-OjQUdi61WO4HYhr9+byCPMj0+bgste/LtSBEcV6FzDdONTs7x0fWn8/ndoYwzqCsKWIxEZwo4FN/TG1c1rI8IQ==}
+  openapi-fetch@0.16.0:
+    resolution: {integrity: sha512-EVLlvcUOugBYMXhuITAm2Ihv9EmQ7b9gJYn7hg2wvcf/GxbanhQ9olDz9I3DcS0Jr4Jv/53I2oVuIYQsFHa9mA==}
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
@@ -7591,8 +7587,8 @@ packages:
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
-  openapi-typescript@7.10.1:
-    resolution: {integrity: sha512-rBcU8bjKGGZQT4K2ekSTY2Q5veOQbVG/lTKZ49DeCyT9z62hM2Vj/LLHjDHC9W7LJG8YMHcdXpRZDqC1ojB/lw==}
+  openapi-typescript@7.12.0:
+    resolution: {integrity: sha512-dtk3h5rbILWfDEUCNgMeBHSpvVsslM0ik1psDxxlrIAJk34SDqZIbhF+qKZy6MytW7Fp+wxynq9y5S3wgJcn0g==}
     hasBin: true
     peerDependencies:
       typescript: ^5.x
@@ -9197,7 +9193,7 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.985.0':
+  '@aws-sdk/client-s3@3.986.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
@@ -9215,9 +9211,9 @@ snapshots:
       '@aws-sdk/middleware-ssec': 3.972.3
       '@aws-sdk/middleware-user-agent': 3.972.7
       '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/signature-v4-multi-region': 3.985.0
+      '@aws-sdk/signature-v4-multi-region': 3.986.0
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-endpoints': 3.986.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.5
       '@smithy/config-resolver': 4.4.6
@@ -9570,7 +9566,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.985.0':
+  '@aws-sdk/signature-v4-multi-region@3.986.0':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.7
       '@aws-sdk/types': 3.973.1
@@ -9608,6 +9604,14 @@ snapshots:
       '@smithy/util-endpoints': 3.2.8
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.986.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
   '@aws-sdk/util-locate-window@3.965.4':
     dependencies:
       tslib: 2.8.1
@@ -9616,7 +9620,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@smithy/types': 4.12.0
-      bowser: 2.14.0
+      bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.972.5':
@@ -12252,7 +12256,7 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@redocly/ajv@8.17.1':
+  '@redocly/ajv@8.17.3':
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -12261,9 +12265,9 @@ snapshots:
 
   '@redocly/config@0.22.2': {}
 
-  '@redocly/openapi-core@1.34.5(supports-color@10.2.2)':
+  '@redocly/openapi-core@1.34.6(supports-color@10.2.2)':
     dependencies:
-      '@redocly/ajv': 8.17.1
+      '@redocly/ajv': 8.17.3
       '@redocly/config': 0.22.2
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
@@ -12852,49 +12856,49 @@ snapshots:
   '@sentry/cli-darwin@2.58.4':
     optional: true
 
-  '@sentry/cli-darwin@3.1.0':
+  '@sentry/cli-darwin@3.2.0':
     optional: true
 
   '@sentry/cli-linux-arm64@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-arm64@3.1.0':
+  '@sentry/cli-linux-arm64@3.2.0':
     optional: true
 
   '@sentry/cli-linux-arm@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-arm@3.1.0':
+  '@sentry/cli-linux-arm@3.2.0':
     optional: true
 
   '@sentry/cli-linux-i686@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-i686@3.1.0':
+  '@sentry/cli-linux-i686@3.2.0':
     optional: true
 
   '@sentry/cli-linux-x64@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-x64@3.1.0':
+  '@sentry/cli-linux-x64@3.2.0':
     optional: true
 
   '@sentry/cli-win32-arm64@2.58.4':
     optional: true
 
-  '@sentry/cli-win32-arm64@3.1.0':
+  '@sentry/cli-win32-arm64@3.2.0':
     optional: true
 
   '@sentry/cli-win32-i686@2.58.4':
     optional: true
 
-  '@sentry/cli-win32-i686@3.1.0':
+  '@sentry/cli-win32-i686@3.2.0':
     optional: true
 
   '@sentry/cli-win32-x64@2.58.4':
     optional: true
 
-  '@sentry/cli-win32-x64@3.1.0':
+  '@sentry/cli-win32-x64@3.2.0':
     optional: true
 
   '@sentry/cli@2.58.4':
@@ -12917,21 +12921,21 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/cli@3.1.0':
+  '@sentry/cli@3.2.0':
     dependencies:
       progress: 2.0.3
       proxy-from-env: 1.1.0
       undici: 6.23.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 3.1.0
-      '@sentry/cli-linux-arm': 3.1.0
-      '@sentry/cli-linux-arm64': 3.1.0
-      '@sentry/cli-linux-i686': 3.1.0
-      '@sentry/cli-linux-x64': 3.1.0
-      '@sentry/cli-win32-arm64': 3.1.0
-      '@sentry/cli-win32-i686': 3.1.0
-      '@sentry/cli-win32-x64': 3.1.0
+      '@sentry/cli-darwin': 3.2.0
+      '@sentry/cli-linux-arm': 3.2.0
+      '@sentry/cli-linux-arm64': 3.2.0
+      '@sentry/cli-linux-i686': 3.2.0
+      '@sentry/cli-linux-x64': 3.2.0
+      '@sentry/cli-win32-arm64': 3.2.0
+      '@sentry/cli-win32-i686': 3.2.0
+      '@sentry/cli-win32-x64': 3.2.0
 
   '@sentry/core@10.38.0': {}
 
@@ -13877,10 +13881,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
 
-  '@vercel/kv@3.0.0':
-    dependencies:
-      '@upstash/redis': 1.36.2
-
   '@vercel/microfrontends@2.0.1(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react@19.2.4)(vue-router@4.6.2(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3)))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@6.4.1(@types/node@24.10.10)(jiti@2.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@next/env': 15.5.4
@@ -14338,7 +14338,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bowser@2.14.0: {}
+  bowser@2.14.1: {}
 
   brace-expansion@2.0.2:
     dependencies:
@@ -14751,7 +14751,7 @@ snapshots:
 
   draco3d@1.5.7: {}
 
-  drizzle-kit@0.31.8:
+  drizzle-kit@0.31.9:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
@@ -15211,9 +15211,9 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  framer-motion@12.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      motion-dom: 12.33.0
+      motion-dom: 12.34.0
       motion-utils: 12.29.2
       tslib: 2.8.1
     optionalDependencies:
@@ -16487,15 +16487,15 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  motion-dom@12.33.0:
+  motion-dom@12.34.0:
     dependencies:
       motion-utils: 12.29.2
 
   motion-utils@12.29.2: {}
 
-  motion@12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  motion@12.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      framer-motion: 12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      framer-motion: 12.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.4
@@ -16660,7 +16660,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openapi-fetch@0.15.0:
+  openapi-fetch@0.16.0:
     dependencies:
       openapi-typescript-helpers: 0.0.15
 
@@ -16668,9 +16668,9 @@ snapshots:
 
   openapi-typescript-helpers@0.0.15: {}
 
-  openapi-typescript@7.10.1(typescript@5.9.3):
+  openapi-typescript@7.12.0(typescript@5.9.3):
     dependencies:
-      '@redocly/openapi-core': 1.34.5(supports-color@10.2.2)
+      '@redocly/openapi-core': 1.34.6(supports-color@10.2.2)
       ansi-colors: 4.1.3
       change-case: 5.4.4
       parse-json: 8.3.0

--- a/scripts/fix-preview-server-esbuild.mjs
+++ b/scripts/fix-preview-server-esbuild.mjs
@@ -1,0 +1,93 @@
+/**
+ * Workaround for react-email preview server esbuild version mismatch.
+ *
+ * @react-email/preview-server ships a pre-built .next directory that bundles
+ * esbuild 0.25.10 JS, but the native @esbuild/* binary it resolves at runtime
+ * may be a different version (e.g. 0.25.12 from the react-email CLI dependency).
+ *
+ * This script creates a symlink so the bundled esbuild JS finds the matching
+ * native binary in .next/node_modules/@esbuild/<platform>.
+ */
+
+import { existsSync, mkdirSync, symlinkSync, readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+try {
+    // Find the preview-server .next/node_modules dir
+    const previewServerDir = dirname(
+        require.resolve('@react-email/preview-server/package.json'),
+    );
+    const nextNm = join(previewServerDir, '.next', 'node_modules');
+
+    if (!existsSync(nextNm)) {
+        process.exit(0);
+    }
+
+    // Find the bundled esbuild and extract its version
+    const bundledEsbuildDirs = readdirSync(nextNm).filter((d) =>
+        d.startsWith('esbuild-'),
+    );
+    if (bundledEsbuildDirs.length === 0) {
+        process.exit(0);
+    }
+
+    const bundledEsbuildDir = join(nextNm, bundledEsbuildDirs[0]);
+    const bundledPkg = JSON.parse(
+        readFileSync(join(bundledEsbuildDir, 'package.json'), 'utf8'),
+    );
+    const bundledVersion = bundledPkg.version;
+
+    // Determine current platform package name
+    const platformKey = `${process.platform} ${process.arch} ${
+        process.arch === 'ia32' || process.arch === 'x64' || process.arch === 'arm64'
+            ? 'LE'
+            : 'BE'
+    }`;
+    const platformMap = {
+        'darwin arm64 LE': '@esbuild/darwin-arm64',
+        'darwin x64 LE': '@esbuild/darwin-x64',
+        'linux arm64 LE': '@esbuild/linux-arm64',
+        'linux x64 LE': '@esbuild/linux-x64',
+        'win32 x64 LE': '@esbuild/win32-x64',
+        'win32 arm64 LE': '@esbuild/win32-arm64',
+    };
+
+    const pkg = platformMap[platformKey];
+    if (!pkg) {
+        process.exit(0);
+    }
+
+    const targetLink = join(nextNm, ...pkg.split('/'));
+    if (existsSync(targetLink)) {
+        process.exit(0);
+    }
+
+    // Find the matching native binary in pnpm store
+    const pnpmDir = join(
+        process.cwd(),
+        'node_modules',
+        '.pnpm',
+        `${pkg.replace('/', '+')}@${bundledVersion}`,
+        'node_modules',
+        ...pkg.split('/'),
+    );
+
+    if (!existsSync(pnpmDir)) {
+        console.warn(
+            `[fix-esbuild] Could not find ${pkg}@${bundledVersion} at ${pnpmDir}`,
+        );
+        process.exit(0);
+    }
+
+    mkdirSync(dirname(targetLink), { recursive: true });
+    // Use 'junction' on Windows (no elevated privileges needed), symlink elsewhere
+    symlinkSync(pnpmDir, targetLink, process.platform === 'win32' ? 'junction' : 'dir');
+    console.log(
+        `[fix-esbuild] Linked ${pkg}@${bundledVersion} into preview-server .next`,
+    );
+} catch {
+    // Non-fatal — only affects local dev
+}


### PR DESCRIPTION
- Update @sentry/cli from 3.1.0 to 3.2.0 for apps/farm to pick up bug
  fixes and improvements.
- Bump @aws-sdk/client-s3 from 3.985.0 to 3.986.0 in apps/app and
  packages/cdn to stay current with AWS SDK patches.
- Upgrade openapi-typescript to 7.12.0 in packages/directory-types to
  adopt recent type generation fixes.
- Bump motion to 12.34.0 in packages/ui to get latest performance and
  bug fixes.
- Update drizzle-kit to 0.31.9 in packages/storage for recent fixes.
- Promote a postinstall script in packages/transactional to run a local
  esbuild fix script for preview server compatibility.
- Add GrediceContactChannels component to transactional welcome email,
  remove redundant paragraphs and social call-to-action; keep layout and
  disclaimer intact.
- Update pnpm lockfile entries to reflect the above version changes and
  remove an unused @vercel/kv entry.