### PR TITLE
Mark game notifications as read on click

### DIFF
--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -75,15 +75,27 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
         });
     }
 
+    function handleNotificationSelected() {
+        if (!readAt) {
+            setNotificationRead.mutate({
+                id,
+                read: true,
+                readWhere: 'game',
+            });
+        }
+
+        if (computedLinkUrl !== '#') {
+            router.push(computedLinkUrl as Route);
+        }
+    }
+
     const isRead = Boolean(readAt);
 
     return (
         <div className="relative">
             <ListItem
                 nodeId={id}
-                onSelected={() => {
-                    router.push(computedLinkUrl as Route);
-                }}
+                onSelected={handleNotificationSelected}
                 className="rounded-none p-4"
                 label={
                     <Row spacing={2}>


### PR DESCRIPTION
### Motivation
- Clicking a notification in the game HUD should mark it as read even when the notification has no link, so user interaction correctly updates read state.

### Description
- Modified `packages/game/src/hud/NotificationList.tsx` to add `handleNotificationSelected`, which marks an unread notification as read via `useSetNotificationRead` and then navigates only when `computedLinkUrl` is not `'#'`, and wired `ListItem`'s `onSelected` to this handler while leaving the manual read/unread toggle button unchanged.

### Testing
- Ran `pnpm --dir packages/game exec biome check src/hud/NotificationList.tsx`, which succeeded for the updated file.
- Ran `pnpm --filter @gredice/game lint`, which surfaced unrelated pre-existing Biome diagnostics and a schema/version mismatch but did not indicate failures caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ddac08874832fafb55681e3e67ac4)