### PR TITLE
Await async cookie helpers in app logout route

### DIFF
--- a/apps/app/app/api/logout/route.ts
+++ b/apps/app/app/api/logout/route.ts
@@ -6,12 +6,12 @@ import {
 } from '../../../lib/auth/refreshCookies';
 
 export async function POST() {
-    const refreshToken = getRefreshTokenCookie();
+    const refreshToken = await getRefreshTokenCookie();
     if (refreshToken) {
         await revokeRefreshToken(refreshToken);
     }
     await clearCookie();
-    clearRefreshCookie();
+    await clearRefreshCookie();
 
     return new Response(null, { status: 200 });
 }


### PR DESCRIPTION
### Motivation
- The logout API used async cookie helpers without awaiting them, which could let refresh-token revocation or refresh-cookie clearing be skipped and cause users to remain effectively logged in.

### Description
- Await `getRefreshTokenCookie()` and `clearRefreshCookie()` in `apps/app/app/api/logout/route.ts` so the refresh token is revoked (when present) and both session and refresh cookies are cleared before returning a `200` response.

### Testing
- Ran `pnpm --filter app exec biome check app/api/logout/route.ts`, which completed successfully (environment printed a non-blocking engine warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fdb59c4bc832fbbffdb161ebe61fa)