### PR TITLE
feat(layout): add focus border and increase text expand height

### DIFF
--- a/apps/www/app/biljke/[alias]/InformationSection.tsx
+++ b/apps/www/app/biljke/[alias]/InformationSection.tsx
@@ -69,7 +69,7 @@ export async function InformationSection({
 
     return (
         <div className="relative grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 group">
-            <div className="absolute -inset-4 border border-transparent rounded-2xl group-hover:border-border pointer-events-none"></div>
+            <div className="absolute -inset-4 border border-transparent rounded-2xl group-hover:border-border pointer-events-none group-focus-within:border-border"></div>
             <Typography
                 id={slug(header)}
                 level="h2"


### PR DESCRIPTION
Add a relative wrapper and an absolutely positioned rounded
border element that becomes visible on group hover. This creates a
subtle focus/hover outline around the information section to improve
visual affordance and accessibility.

Increase ExpandableText maxHeight from 150 to 240 in two places so
longer content shows more by default before collapsing. This reduces
unexpected truncation for longer descriptions while keeping expandable
behavior for very long content.