### PR TITLE
Reset invalid raised-bed closeup when switching gardens

### DIFF
--- a/packages/game/src/useRaisedBedCloseup.tsx
+++ b/packages/game/src/useRaisedBedCloseup.tsx
@@ -16,7 +16,7 @@ export function useSetRaisedBedCloseupParam() {
 
 export function useRaisedBedCloseup() {
     const { data: garden } = useCurrentGarden();
-    const [raisedBedParam] = useRaisedBedCloseupParam();
+    const [raisedBedParam, setRaisedBedParam] = useRaisedBedCloseupParam();
     const setView = useGameState((state) => state.setView);
     const closeupBlock = useGameState((state) => state.closeupBlock);
     const view = useGameState((state) => state.view);
@@ -49,6 +49,10 @@ export function useRaisedBedCloseup() {
                 decodedRaisedBedName.toLowerCase(),
         );
         if (!raisedBed) {
+            if (view === 'closeup') {
+                setView({ view: 'normal' });
+            }
+            setRaisedBedParam(null);
             return;
         }
 
@@ -57,6 +61,10 @@ export function useRaisedBedCloseup() {
             (candidate) => String(candidate.id) === String(raisedBed.blockId),
         );
         if (!block) {
+            if (view === 'closeup') {
+                setView({ view: 'normal' });
+            }
+            setRaisedBedParam(null);
             return;
         }
 
@@ -67,5 +75,13 @@ export function useRaisedBedCloseup() {
 
         console.debug('Navigating to raised bed closeup for', raisedBed, block);
         setView({ view: 'closeup', block });
-    }, [blocks, closeupBlock?.id, garden, raisedBedParam, setView, view]);
+    }, [
+        blocks,
+        closeupBlock?.id,
+        garden,
+        raisedBedParam,
+        setRaisedBedParam,
+        setView,
+        view,
+    ]);
 }


### PR DESCRIPTION
### Motivation

- When switching gardens a stale `gredica` (raised-bed closeup) query param could leave the scene stuck in `closeup` even though the raised bed is not present in the newly selected garden. 
- The intent is to ensure the UI resets to a sane state and remove stale URL params when the closeup target cannot be resolved.

### Description

- Updated `packages/game/src/useRaisedBedCloseup.tsx` to read the `gredica` setter from `useRaisedBedCloseupParam` so the effect can clear the query param. 
- When the raised bed lookup fails the effect now resets the game `view` to `normal` and clears the `gredica` param with `setRaisedBedParam(null)`. 
- The same reset-and-clear behavior is applied when the raised-bed block cannot be resolved. 
- Added `setRaisedBedParam` to the effect dependency array to keep hook dependencies correct.

### Testing

- Ran `pnpm --filter @gredice/game exec biome check src/useRaisedBedCloseup.tsx` and the check completed with no fixes required (the environment printed a Node engine warning but the linter passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976aff469c832f96cf9b49a012b5aa)