### PR TITLE
Admin dashboard: custom analytics range and weekday registration widget

### DIFF
--- a/apps/app/app/prijava/UrlAuthForward.tsx
+++ b/apps/app/app/prijava/UrlAuthForward.tsx
@@ -3,8 +3,8 @@
 import { authCurrentUserQueryKeys } from '@signalco/auth-client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
-import { invalidatePage } from '../(actions)/sharedActions';
 import { queryClient } from '../../components/providers/ClientAppProvider';
+import { invalidatePage } from '../(actions)/sharedActions';
 
 export function UrlAuthForward() {
     const router = useRouter();

--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -12,7 +12,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
     const selectedPeriod = params?.period || '7';
 
     const data = await getAnalyticsData(
-        Number(selectedPeriod),
+        selectedPeriod === 'custom' ? undefined : Number(selectedPeriod),
         params?.from,
         params?.to,
     );

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -7,6 +7,7 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
@@ -109,8 +110,14 @@ export function AdminDashboardClient({
         });
     };
 
+    const isCustomRangeInvalid =
+        selectedPeriod === 'custom' &&
+        !!customFrom &&
+        !!customTo &&
+        customFrom > customTo;
+
     const handleCustomRangeApply = () => {
-        if (!customFrom || !customTo) {
+        if (!customFrom || !customTo || isCustomRangeInvalid) {
             return;
         }
 
@@ -185,35 +192,50 @@ export function AdminDashboardClient({
                     />
                 </Row>
                 {selectedPeriod === 'custom' ? (
-                    <Row spacing={1} className="items-end">
-                        <Input
-                            type="date"
-                            value={customFrom}
-                            onChange={(event) =>
-                                setCustomFrom(event.target.value)
-                            }
-                            label="Od"
-                            className="max-w-48"
-                            disabled={isPending}
-                        />
-                        <Input
-                            type="date"
-                            value={customTo}
-                            onChange={(event) =>
-                                setCustomTo(event.target.value)
-                            }
-                            label="Do"
-                            className="max-w-48"
-                            disabled={isPending}
-                        />
-                        <Button
-                            size="sm"
-                            onClick={handleCustomRangeApply}
-                            disabled={!customFrom || !customTo || isPending}
-                        >
-                            Primijeni
-                        </Button>
-                    </Row>
+                    <Stack spacing={0.5}>
+                        <Row spacing={1} className="items-end">
+                            <Input
+                                type="date"
+                                value={customFrom}
+                                onChange={(event) =>
+                                    setCustomFrom(event.target.value)
+                                }
+                                label="Od"
+                                className="max-w-48"
+                                disabled={isPending}
+                            />
+                            <Input
+                                type="date"
+                                value={customTo}
+                                onChange={(event) =>
+                                    setCustomTo(event.target.value)
+                                }
+                                label="Do"
+                                className="max-w-48"
+                                disabled={isPending}
+                            />
+                            <Button
+                                size="sm"
+                                onClick={handleCustomRangeApply}
+                                disabled={
+                                    !customFrom ||
+                                    !customTo ||
+                                    isCustomRangeInvalid ||
+                                    isPending
+                                }
+                            >
+                                Primijeni
+                            </Button>
+                        </Row>
+                        {isCustomRangeInvalid ? (
+                            <Typography
+                                level="body3"
+                                className="text-destructive"
+                            >
+                                Datum početka mora biti prije datuma kraja.
+                            </Typography>
+                        ) : null}
+                    </Stack>
                 ) : null}
                 <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2">
                     <FactCard

--- a/apps/app/components/admin/dashboard/UsersRegistrationWeekdayCard.tsx
+++ b/apps/app/components/admin/dashboard/UsersRegistrationWeekdayCard.tsx
@@ -59,7 +59,11 @@ export function UsersRegistrationWeekdayCard({
                                             {item.count}
                                         </Typography>
                                     </Row>
-                                    <div className="h-2 w-full rounded-full bg-primary/10">
+                                    <div
+                                        className="h-2 w-full rounded-full bg-primary/10"
+                                        role="img"
+                                        aria-label={`${item.label}: ${item.count}`}
+                                    >
                                         <div
                                             className="h-2 rounded-full bg-primary/60"
                                             style={{

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -128,6 +128,14 @@ function parseDateInput(value?: string) {
         return null;
     }
 
+    if (
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day
+    ) {
+        return null;
+    }
+
     return date;
 }
 
@@ -165,7 +173,7 @@ function getRangeDays(startDate: Date, endDate: Date) {
 }
 
 export async function getAnalyticsData(
-    days: number,
+    days: number | undefined,
     from?: string,
     to?: string,
 ) {

--- a/packages/storage/src/repositories/analyticsRepo.ts
+++ b/packages/storage/src/repositories/analyticsRepo.ts
@@ -1,4 +1,4 @@
-import { and, count, gte, isNotNull, lt, lte } from 'drizzle-orm';
+import { and, count, gte, isNotNull, lt, lte, sql } from 'drizzle-orm';
 import {
     accounts,
     deliveryRequests,
@@ -179,16 +179,19 @@ export async function getAnalyticsTotals(days: number = 7) {
 }
 
 export async function getUserRegistrationsByWeekday(from: Date, to: Date) {
-    const registrations = await storage()
-        .select({ createdAt: users.createdAt })
+    // EXTRACT(DOW) returns 0 for Sunday through 6 for Saturday, matching JS Date.getDay() indexing
+    const rows = await storage()
+        .select({
+            dayOfWeek: sql<number>`EXTRACT(DOW FROM ${users.createdAt})::integer`,
+            registrations: count(),
+        })
         .from(users)
-        .where(and(gte(users.createdAt, from), lte(users.createdAt, to)));
+        .where(and(gte(users.createdAt, from), lte(users.createdAt, to)))
+        .groupBy(sql`EXTRACT(DOW FROM ${users.createdAt})`);
 
     const weekdayCounts = [0, 0, 0, 0, 0, 0, 0];
-
-    for (const registration of registrations) {
-        const dayIndex = registration.createdAt.getDay();
-        weekdayCounts[dayIndex] += 1;
+    for (const row of rows) {
+        weekdayCounts[row.dayOfWeek] = row.registrations;
     }
 
     return weekdayCounts;

--- a/packages/storage/tests/analyticsRepo.node.spec.ts
+++ b/packages/storage/tests/analyticsRepo.node.spec.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     createAccount as createAccountDirect,
     getAnalyticsTotals,
+    getUserRegistrationsByWeekday,
+    storage,
+    users,
 } from '@gredice/storage';
 import { createTestGarden, ensureFarmId } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
@@ -38,4 +42,48 @@ test('getAnalyticsTotals increases after creating entities', async () => {
     assert.ok(totals.accounts >= 1);
     assert.ok(totals.farms >= 1);
     assert.ok(totals.gardens >= 1);
+});
+
+test('getUserRegistrationsByWeekday returns array of 7 zeros for empty range', async () => {
+    createTestDb();
+    const from = new Date('2000-01-01');
+    const to = new Date('2000-01-01');
+    const counts = await getUserRegistrationsByWeekday(from, to);
+    assert.strictEqual(counts.length, 7);
+    assert.ok(counts.every((c) => c === 0));
+});
+
+test('getUserRegistrationsByWeekday counts registrations per weekday', async () => {
+    createTestDb();
+    const db = storage();
+
+    // Insert users on known dates: 2024-01-01 is Monday (index 1) and 2024-01-07 is Sunday (index 0)
+    const mondayId = randomUUID();
+    const sundayId = randomUUID();
+    await db.insert(users).values([
+        {
+            id: mondayId,
+            userName: `weekday-monday-${mondayId}@test.com`,
+            displayName: 'Monday User',
+            role: 'user',
+            createdAt: new Date('2024-01-01T12:00:00Z'),
+            updatedAt: new Date('2024-01-01T12:00:00Z'),
+        },
+        {
+            id: sundayId,
+            userName: `weekday-sunday-${sundayId}@test.com`,
+            displayName: 'Sunday User',
+            role: 'user',
+            createdAt: new Date('2024-01-07T12:00:00Z'),
+            updatedAt: new Date('2024-01-07T12:00:00Z'),
+        },
+    ]);
+
+    const from = new Date('2024-01-01T00:00:00Z');
+    const to = new Date('2024-01-07T23:59:59Z');
+    const counts = await getUserRegistrationsByWeekday(from, to);
+
+    assert.strictEqual(counts.length, 7);
+    assert.ok(counts[0] >= 1, 'Expected at least 1 registration on Sunday');
+    assert.ok(counts[1] >= 1, 'Expected at least 1 registration on Monday');
 });


### PR DESCRIPTION
### Motivation
- Give admins the ability to select an explicit date range for analytics (besides preset periods) so they can inspect arbitrary intervals. 
- Provide quick insight into which weekday most users register by adding a compact weekday registrations widget.

### Description
- Server: extended `getAnalyticsData` to accept `from`/`to` parameters, compute a safe date range, use that range for operations/sowing aggregation, and return `weekdayRegistrations` (implemented in `apps/app/components/admin/dashboard/actions.ts`).
- Storage: added `getUserRegistrationsByWeekday(from, to)` in `packages/storage/src/repositories/analyticsRepo.ts` which queries `users.createdAt` and returns counts per weekday.
- Client/server wiring: `AdminDashboard` now accepts `from`/`to` search params and passes them to `getAnalyticsData`, and `AdminDashboardClient` receives `initialWeekdayRegistrations`, `initialFrom`, and `initialTo` initial state (files under `apps/app/components/admin/dashboard/`).
- UI: added a `Custom` period option, date inputs (`Od`/`Do`) and `Primijeni` apply action that pushes `period=custom&from=...&to=...` into the URL, and added a new `UsersRegistrationWeekdayCard` component that visualizes weekday registration counts and highlights the top day.

### Testing
- Ran `pnpm --filter app lint` and the run completed (biome fixed a few files and reported info). 
- Ran `pnpm --filter @gredice/storage lint` and the run completed (biome fixed a file and reported info). 
- Ran `pnpm --filter app build` and Next.js compiled the app successfully and generated routes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699986dba540832f9ab807d4a2fbc3b4)