### PR TITLE
fix(www): keep ClientAppProvider inside body in root layout

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -76,8 +76,8 @@ export default async function RootLayout({
                 <meta name="apple-mobile-web-app-title" content="Gredice" />
                 <meta name="theme-color" content="#2e6f40" />
             </Head>
-            <ClientAppProvider>
-                <body className="antialiased">
+            <body className="antialiased">
+                <ClientAppProvider>
                     <Stack>
                         <div className="z-20">
                             <PageNav
@@ -110,8 +110,8 @@ export default async function RootLayout({
                     </Stack>
                     <Analytics />
                     {shouldInjectToolbar && <VercelToolbar />}
-                </body>
-            </ClientAppProvider>
+                </ClientAppProvider>
+            </body>
         </html>
     );
 }


### PR DESCRIPTION
### Motivation
- Prevent provider-injected `<script>` tags from being rendered as direct children of `<html>`, which caused Next.js 16/Turbopack runtime and hydration errors. 

### Description
- Move `ClientAppProvider` inside `<body>` in `apps/www/app/layout.tsx` so provider output is nested correctly. 
- Adjust closing tag order so that `Analytics` and optional `VercelToolbar` remain inside the body and provider. 
- Confirmed other app root layouts (`apps/app`, `apps/garden`, `apps/farm`) already follow the correct pattern, so no additional app changes were required. 

### Testing
- Ran `pnpm --filter www exec biome check app/layout.tsx`, which passed. 
- Ran `pnpm lint --filter www`, which passed (auto-fixed one file).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca8eaee54832fba2b2dcf18547f06)