### PR TITLE
Tighten vertical spacing in operations list items

### DIFF
--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -64,7 +64,7 @@ export function OperationsListItem({
     const operationButton = (
         <Button
             variant="plain"
-            className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
+            className="justify-start text-start p-0 h-auto py-1 gap-3 px-4 rounded-none font-normal"
             onClick={() => handleOperationPicked(operation)}
         >
             <AnimateFlyToItem {...animateFlyToShoppingCart.props}>


### PR DESCRIPTION
### Motivation
- Reduce excessive vertical space in operations rows so data fields display more compactly and visually align with other list items.

### Description
- Lowered the vertical padding on the raised-bed operations list item button in `packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx` by changing the Tailwind class from `py-2` to `py-1` to make each operation row more compact.

### Testing
- Ran `pnpm --filter @gredice/game lint` which completed successfully (reported unrelated Biome warnings in other files); an automated Playwright screenshot attempt failed because no local web server was available (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cab2cda60832fba1ab19ffaf7476a)