### PR TITLE
Move plant sorts below tips on plant details page

### DIFF
--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -115,10 +115,10 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                             )}
                         />
                     ))}
-                <PlantSortsList basePlantName={plant.information.name} />
                 {(plant.information.tip?.length ?? 0) > 0 && (
                     <PlantTips plant={plant} />
                 )}
+                <PlantSortsList basePlantName={plant.information.name} />
                 {recipes.length > 0 && (
                     <Stack spacing={2}>
                         <Typography level="h2">


### PR DESCRIPTION
### Motivation
- Place the plant sorts block below the plant tips on the plant details page to match the requested UI order.

### Description
- Reordered JSX in `apps/www/app/biljke/[alias]/page.tsx` so `PlantTips` renders before `PlantSortsList basePlantName={plant.information.name}` and committed the change.

### Testing
- Ran `pnpm --filter www exec biome check app/biljke/[alias]/page.tsx` which succeeded, and attempted to run the dev server and a Playwright check but the `/biljke` page returned HTTP 500 due to an upstream fetch/network error (`ENETUNREACH`), preventing visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cab739388832f86fbdb87bfd22c2c)