### PR TITLE
Refine do-not-reply disclaimer wording

### DIFF
--- a/packages/transactional/components/shared/GrediceDisclaimer.tsx
+++ b/packages/transactional/components/shared/GrediceDisclaimer.tsx
@@ -16,6 +16,9 @@ export function GrediceDisclaimer({
             <Link href={`mailto:sigurnost@${appDomain}`}>
                 sigurnost@{appDomain}
             </Link>
+            . Ova poruka poslana je automatski. Na ovu adresu nije moguće
+            zaprimati odgovore. Ako imaš pitanja, molimo kontaktiraj nas drugim
+            kanalima.
         </Disclaimer>
     );
 }

--- a/packages/transactional/emails/Newsletter/newsletter.tsx
+++ b/packages/transactional/emails/Newsletter/newsletter.tsx
@@ -40,7 +40,10 @@ export default function MarkdownEmailTemplate({
                     <Divider className="my-[26px]" />
                     <Disclaimer>
                         Ovaj email je poslan pretplatniku na newsletter Gredice.
-                        Ukoliko se želiš odjaviti, kontaktiraj nas na{' '}
+                        Ova poruka poslana je automatski. Na ovu adresu nije
+                        moguće zaprimati odgovore. Ako imaš pitanja, molimo
+                        kontaktiraj nas drugim kanalima. Ukoliko se želiš
+                        odjaviti, kontaktiraj nas na{' '}
                         <Link href="mailto:info@gredice.com">
                             info@gredice.com
                         </Link>


### PR DESCRIPTION
### Motivation
- Use clearer, explicit Croatian copy for automated emails to indicate messages are sent automatically, replies are not received, and users should contact other channels.

### Description
- Updated the shared transactional disclaimer in `packages/transactional/components/shared/GrediceDisclaimer.tsx` and the newsletter footer in `packages/transactional/emails/Newsletter/newsletter.tsx` to the requested phrasing.

### Testing
- Ran `pnpm lint --filter @gredice/transactional`, which completed successfully and auto-fixed two files while reporting one lint warning and a configuration schema info message (no failing checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb1f563f8832fbf67af8a97477d3f)