### PR TITLE
fix(www): avoid nuqs adapter error on /biljke search filter

### DIFF
--- a/apps/www/components/shared/PageFilterInput.tsx
+++ b/apps/www/components/shared/PageFilterInput.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { useSearchParam } from '@signalco/hooks/useSearchParam';
 import { Close, Search } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
-import { useQueryState } from 'nuqs';
 import type { HTMLAttributes } from 'react';
 
 export type PageFilterInputProps = HTMLAttributes<HTMLFormElement> & {
@@ -17,8 +17,8 @@ export function PageFilterInput({
     fieldName,
     ...rest
 }: PageFilterInputProps) {
-    const [search, setSearch] = useQueryState(searchParamName);
-    const updateSearch = (value: string) => setSearch(value || null);
+    const [search, setSearch] = useSearchParam(searchParamName);
+    const updateSearch = (value: string) => setSearch(value);
 
     return (
         <form onSubmit={(event) => event.preventDefault()} {...rest}>


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by `nuqs` requiring a framework adapter when the biljke page search input is rendered by removing the direct dependency on `nuqs` hooks.

### Description
- Replaced `useQueryState` from `nuqs` with the local `useSearchParam` hook in `apps/www/components/shared/PageFilterInput.tsx` and updated the `updateSearch` logic to use `string` values.
- Preserved existing UX and behavior for typing and clearing the `pretraga` query parameter so the filter continues to update and reset as before.

### Testing
- Ran `pnpm --filter www exec biome check components/shared/PageFilterInput.tsx` which completed successfully. 
- Ran `pnpm --filter www build` which completed successfully; the build output included expected external fetch/network warnings during static generation in this environment but the production build finished.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a171c86d30832fbe9b998dc0c0c3d2)