### PR TITLE
feat(game): add haptic feedback for block pick/place and closeup selection

### DIFF
--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -28,6 +28,7 @@ import {
     getStackHeight,
     useStackHeight,
 } from '../utils/getStackHeight';
+import { triggerPickHaptic, triggerPlaceHaptic } from '../utils/haptics';
 
 const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
 
@@ -219,6 +220,7 @@ export function PickableGroup({
                     internalPosition: [relative.x, -1.5, relative.z],
                     scale: 0.1,
                 });
+                triggerPlaceHaptic();
                 await recycleBlock.mutateAsync({
                     position: stack.position,
                     blockIndex: stack.blocks.indexOf(block),
@@ -233,6 +235,7 @@ export function PickableGroup({
                     ],
                 });
                 dropSound.play();
+                triggerPlaceHaptic();
                 spawn(
                     resolveBlockParticleType(block.name),
                     stack.position
@@ -253,6 +256,7 @@ export function PickableGroup({
         } else {
             if (!didDrag.current) {
                 pickupSound.play();
+                triggerPickHaptic();
                 if (newIsBlocked !== isBlocked) {
                     setIsBlocked(newIsBlocked);
                 }

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -5,6 +5,7 @@ import { createStore, useStore } from 'zustand';
 import { audioMixer } from './audio/audioMixer';
 import type { Block } from './types/Block';
 import { audioConfig } from './utils/audioConfig';
+import { triggerSelectionHaptic } from './utils/haptics';
 
 const sunriseValue = 0.2;
 const sunsetValue = 0.8;
@@ -194,8 +195,13 @@ export function createGameState({
         view: 'normal',
         closeupBlock: null,
         setView: ({ view, block }) => {
+            const currentView = get().view;
             if (get().mode === 'edit') {
                 get().setMode('normal');
+            }
+
+            if (currentView !== view) {
+                triggerSelectionHaptic();
             }
 
             if (view === 'closeup') {

--- a/packages/game/src/utils/haptics.ts
+++ b/packages/game/src/utils/haptics.ts
@@ -1,0 +1,27 @@
+function canVibrate() {
+    return (
+        typeof window !== 'undefined' &&
+        typeof navigator !== 'undefined' &&
+        typeof navigator.vibrate === 'function'
+    );
+}
+
+function vibrate(pattern: number | number[]) {
+    if (!canVibrate()) {
+        return;
+    }
+
+    navigator.vibrate(pattern);
+}
+
+export function triggerPickHaptic() {
+    vibrate(20);
+}
+
+export function triggerPlaceHaptic() {
+    vibrate([12, 20, 28]);
+}
+
+export function triggerSelectionHaptic() {
+    vibrate(16);
+}


### PR DESCRIPTION
### Motivation
- Improve tactile feedback for the Garden game by adding vibration on block pick, place/recycle, and when switching to/from the raised-bed closeup view.

### Description
- Added a small safe haptics utility at `packages/game/src/utils/haptics.ts` that guards `navigator.vibrate` usage and exposes `triggerPickHaptic`, `triggerPlaceHaptic`, and `triggerSelectionHaptic`.
- Integrated pick/place haptics into the drag flow in `packages/game/src/controls/PickableGroup.tsx` so picking up, placing, and recycling blocks call the appropriate haptic triggers alongside existing audio/particle effects.
- Triggered selection haptics during camera/view transitions by calling the selection trigger from `setView` in `packages/game/src/useGameState.ts` to cover entering and exiting `closeup`.

### Testing
- Ran `pnpm lint --filter @gredice/game`, which completed successfully for the package; the run reported existing workspace Biome config/info messages and unrelated fixable lint suggestions but no blocking failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a801876b90832fbcefd8a30665696b)