### PR TITLE
Handle HTML entities in route params with `decodeRouteParam` and apply to plant pages

### DIFF
--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -1,3 +1,4 @@
+import { decodeRouteParam } from '@gredice/js/uri';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -26,7 +27,7 @@ export async function generateMetadata(
     props: PageProps<'/biljke/[alias]'>,
 ): Promise<Metadata> {
     const { alias: aliasUnescaped } = await props.params;
-    const alias = aliasUnescaped ? decodeURIComponent(aliasUnescaped) : null;
+    const alias = aliasUnescaped ? decodeRouteParam(aliasUnescaped) : null;
     const plant = (await getPlantsData())?.find(
         (plant) =>
             plant.information.name.toLowerCase() === alias?.toLowerCase(),
@@ -54,7 +55,7 @@ export async function generateStaticParams() {
 
 export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
     const { alias: aliasUnescaped } = await props.params;
-    const alias = aliasUnescaped ? decodeURIComponent(aliasUnescaped) : null;
+    const alias = aliasUnescaped ? decodeRouteParam(aliasUnescaped) : null;
     if (!alias) {
         notFound();
     }

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -1,3 +1,4 @@
+import { decodeRouteParam } from '@gredice/js/uri';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -18,14 +19,15 @@ import { SowingAttributeCards } from '../../SowingAttributeCards';
 import { WateringAttributeCards } from '../../WateringAttributeCards';
 
 export const revalidate = 3600; // 1 hour
+
 export async function generateMetadata(
     props: PageProps<'/biljke/[alias]/sorte/[sortAlias]'>,
 ): Promise<Metadata> {
     const { alias: aliasUnescaped, sortAlias: sortAliasUnescaped } =
         await props.params;
-    const alias = aliasUnescaped ? decodeURIComponent(aliasUnescaped) : null;
+    const alias = aliasUnescaped ? decodeRouteParam(aliasUnescaped) : null;
     const sortAlias = sortAliasUnescaped
-        ? decodeURIComponent(sortAliasUnescaped)
+        ? decodeRouteParam(sortAliasUnescaped)
         : null;
     const sort = (await getPlantSortsData())?.find(
         (sort) =>
@@ -63,9 +65,9 @@ export default async function PlantSortPage(
 ) {
     const { alias: aliasUnescaped, sortAlias: sortAliasUnescaped } =
         await props.params;
-    const alias = aliasUnescaped ? decodeURIComponent(aliasUnescaped) : null;
+    const alias = aliasUnescaped ? decodeRouteParam(aliasUnescaped) : null;
     const sort = sortAliasUnescaped
-        ? decodeURIComponent(sortAliasUnescaped)
+        ? decodeRouteParam(sortAliasUnescaped)
         : null;
     if (!alias || !sort) {
         console.warn(

--- a/packages/js/src/uri/index.ts
+++ b/packages/js/src/uri/index.ts
@@ -6,3 +6,29 @@ export function decodeUriComponentSafe(value: string) {
         return value;
     }
 }
+
+/**
+ * Decodes URL percent-encoding and common HTML entities found in route params.
+ */
+export function decodeRouteParam(value: string) {
+    const decodedParam = decodeUriComponentSafe(value);
+
+    return decodedParam.replaceAll(
+        /&(?:amp|apos|quot);|&#(?:39|x27);/gi,
+        (entity) => {
+            const normalizedEntity = entity.toLowerCase();
+            switch (normalizedEntity) {
+                case '&amp;':
+                    return '&';
+                case '&apos;':
+                case '&#39;':
+                case '&#x27;':
+                    return "'";
+                case '&quot;':
+                    return '"';
+                default:
+                    return entity;
+            }
+        },
+    );
+}


### PR DESCRIPTION
### Motivation
- Route parameters containing HTML entities (e.g. `&amp;`, `&apos;`, `&#39;`) were not being normalized which could break matching for plant and sort pages. 
- Provide a safe, centralized decoder to consistently handle percent-encoding and common HTML entities in route params.

### Description
- Added `decodeRouteParam` to `packages/js/src/uri/index.ts` that wraps `decodeUriComponentSafe` and replaces common HTML entities with their characters. 
- Replaced direct `decodeURIComponent` calls with `decodeRouteParam` in `apps/www/app/biljke/[alias]/page.tsx` for plant pages. 
- Replaced direct `decodeURIComponent` calls with `decodeRouteParam` in `apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx` for plant sort pages and added the necessary imports.

### Testing
- Ran the codebase type check and build (`yarn build`) to ensure the new helper compiles and pages resolve, and the build succeeded. 
- Ran unit tests (`yarn test`) to verify no regressions in route handling, and all tests passed. 
- Ran linter (`yarn lint`) to confirm formatting and imports are correct, and the linter passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6345b18a8832f9f18a55bec541031)