### PR TITLE
✨ feat: ensure table covers all indicesExtend the computed table length so it any field with apositionIndex than the previously hard-coded maximum (8).

### DIFF
--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -71,8 +71,7 @@ export async function RaisedBedFieldsTable({
         return <NoDataPlaceholder />;
     }
 
-    // Currently fixed to 9 positions (0-8)
-    const highestPositionIndex = 8;
+    const highestPositionIndex = Math.max(8, ...fields.map((f) => f.positionIndex));
     const orderedPositions = Array.from(
         { length: highestPositionIndex + 1 },
         (_, index) => index,


### PR DESCRIPTION
Replace the fixed highestPositionIndex with Math.max(, ...fields.map(ff.positionIndex)) so the rendered array to accommodateall actual field indicesThis fixes missing columns/positions when a field's positionIndexexceeds8 and prevents truncated or empty cells in the UI.