### PR TITLE
✨ feat: simplify grid classes in RaisedBedFieldsTableConsolidate the Tailwind grid utility classes used on the raisedbeds fields container. Replace the multi-breakpoint class set("grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4") with a single,

### DIFF
--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -86,7 +86,7 @@ export async function RaisedBedFieldsTable({
 
     return (
         <Stack spacing={3}>
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4">
+            <div className="grid gap-3 grid-cols-3">
                 {orderedPositions.map((positionIndex) => {
                     const field = fields.find(
                         (item) =>


### PR DESCRIPTION
clear "grid gap-3 grid-cols-3" configuration.

This change reduces complexity and ensures a consistent three-columnlayout across viewports, making the component styling easier toreason about and maintain. It also removes redundant breakpointsthat were not needed for the current layout requirements.