### PR TITLE
:seedling: feat(nav): replace Tally3 with RaisedBedIcon for raised bedsReplace uses of the generic Tally3 icon with the new RaisedBedIcon inadmin navigation and the dashboard client. Update imports to pullRaisedBedIcon from @gredice/ui/RaisedBedIcon and remove the Tally3 importwhere applicable. Adjust icon classNames to remove rotation offsets andmatch sizing.

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { getAnalyticsTotals } from '@gredice/storage';
-import { Calendar, Tally3 } from '@signalco/ui-icons';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
+import { Calendar } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -170,7 +171,7 @@ export function AdminDashboardClient({
                     size="sm"
                     className="rounded-full"
                     startDecorator={
-                        <Tally3 className="size-4 shrink-0 -rotate-90 -mt-1" />
+                        <RaisedBedIcon className="size-4 shrink-0" />
                     }
                     href={KnownPages.RaisedBeds}
                 >

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -16,6 +16,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { SelectEntityType } from '@gredice/storage';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { AuthProtectedSection } from '@signalco/auth-client/components';
 import {
     Add,
@@ -296,7 +297,7 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                     <NavItem
                         href={KnownPages.RaisedBeds}
                         label="Gredice"
-                        icon={<Tally3 className="size-5 rotate-90 mt-1" />}
+                        icon={<RaisedBedIcon className="size-5" />}
                         onClick={onItemClick}
                     />
                     <NavItem


### PR DESCRIPTION
- Replace generic Tally3 icon with new RaisedBedIcon in admin navigation and dashboard client- Import RaisedBedIcon from @gredice/ui/RaisedBedIcon and remove Tally3 imports- Adjust icon classNames to remove rotation offsets and match sizing- Ensure consistent styling and semantic iconography for Raised Beds (Gredice) across navigation and dashboard