### PR TITLE
✨ feat: defer camera enumeration until user opens modalCheck camera support without activating hardware and delay expensiveenumeration/permission requests until the camera modal is opened.

### DIFF
--- a/apps/app/components/shared/attributes/typed/BarcodeScanButton.tsx
+++ b/apps/app/components/shared/attributes/typed/BarcodeScanButton.tsx
@@ -112,40 +112,14 @@ export function BarcodeScanButton({
         }
     }, []);
 
-    // Check if camera is supported
+    // Check if camera is supported (without activating camera)
     useEffect(() => {
-        const checkSupport = async () => {
-            const hasCamera = !!navigator.mediaDevices?.getUserMedia;
-            setIsSupported(hasCamera);
-
-            if (hasCamera) {
-                try {
-                    // Request permission to enumerate devices
-                    await navigator.mediaDevices.getUserMedia({ video: true });
-                    const cameras = await enumerateCameras();
-                    setAvailableCameras(cameras);
-
-                    // Load saved camera preference
-                    const savedIndex = loadSavedCameraIndex(cameras.length);
-                    setSelectedCameraIndex(savedIndex);
-
-                    if (cameras.length > 0) {
-                        const preferredCamera =
-                            cameras[savedIndex] || cameras[0];
-                        setActiveCameraLabel(
-                            getCameraLabel(preferredCamera, savedIndex),
-                        );
-                    }
-                } catch (err) {
-                    console.error('Failed to get camera list:', err);
-                }
-            } else {
-                setError('Camera not supported on this device');
-            }
-        };
-
-        checkSupport();
-    }, [enumerateCameras, getCameraLabel, loadSavedCameraIndex]);
+        const hasCamera = !!navigator.mediaDevices?.getUserMedia;
+        setIsSupported(hasCamera);
+        if (!hasCamera) {
+            setError('Camera not supported on this device');
+        }
+    }, []);
 
     // Save camera preference to localStorage
     const saveCameraIndex = (index: number) => {
@@ -296,9 +270,28 @@ export function BarcodeScanButton({
     }
 
     // Open camera modal
-    function openCamera() {
+    async function openCamera() {
         setIsCameraOpen(true);
         setLastScannedCode(''); // Reset last scanned code
+
+        // Enumerate cameras on first open
+        if (availableCameras.length === 0) {
+            try {
+                await navigator.mediaDevices.getUserMedia({ video: true });
+                const cameras = await enumerateCameras();
+                setAvailableCameras(cameras);
+
+                const savedIndex = loadSavedCameraIndex(cameras.length);
+                setSelectedCameraIndex(savedIndex);
+
+                if (cameras.length > 0) {
+                    const preferredCamera = cameras[savedIndex] || cameras[0];
+                    setActiveCameraLabel(getCameraLabel(preferredCamera, savedIndex));
+                }
+            } catch (err) {
+                console.error('Failed to get camera list:', err);
+            }
+        }
 
         // Start camera when modal opens
         setTimeout(() => {


### PR DESCRIPTION
- Simplify initial effect to only detect navigator.mediaDevices existence and set an error when no camera support is available. Do not call getUserMedia or enumerate devices during component mount.
- Move camera permission request and device enumeration into openCamera,
 which runs the first time the user opens the camera modal. Populate availableCameras, selectedCameraIndex and activeCameraLabel there.
- Keep saving/loading of camera preference and existing camera-start logic intact; reset lastScannedCode when opening modal.

This reduces intrusive permission prompts and avoids unnecessaryhardware activation on mount, improving privacy and perceived appperformance.