### PR TITLE
✨ feat(nav): show pending achievements count in admin navAdd pending achievements count to the admin navigation so users can seehow many achievements are awaiting action.

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -1,4 +1,4 @@
-import { getEntityTypesOrganizedByCategories } from '@gredice/storage';
+import { getEntityTypesOrganizedByCategories, getPendingAchievementsCount } from '@gredice/storage';
 import { SignedOut } from '@signalco/auth-client/components';
 import { AuthProtectedSection } from '@signalco/auth-server/components';
 import { type PropsWithChildren, Suspense } from 'react';
@@ -15,8 +15,12 @@ export const dynamic = 'force-dynamic';
 
 export default async function AdminLayout({ children }: PropsWithChildren) {
     const authAdmin = auth.bind(null, ['admin']);
-    const { categorizedTypes, uncategorizedTypes, shadowTypes } =
-        await getEntityTypesOrganizedByCategories();
+    const isAdmin = await auth(['admin']).then(() => true, () => false);
+    const [{ categorizedTypes, uncategorizedTypes, shadowTypes }, pendingAchievementsCount] =
+        await Promise.all([
+            getEntityTypesOrganizedByCategories(),
+            isAdmin ? getPendingAchievementsCount() : Promise.resolve(0),
+        ]);
 
     return (
         <AuthAppProvider>
@@ -24,6 +28,7 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                 categorizedTypes={categorizedTypes}
                 uncategorizedTypes={uncategorizedTypes}
                 shadowTypes={shadowTypes}
+                pendingAchievementsCount={pendingAchievementsCount}
             >
                 <div className="grow bg-secondary">
                     <MobileHeader />

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -128,9 +128,11 @@ function EntityTypeList({
 }
 
 export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
-    const categorizedTypes = useContext(NavContext)?.categorizedTypes || [];
-    const uncategorizedTypes = useContext(NavContext)?.uncategorizedTypes || [];
-    const shadowTypes = useContext(NavContext)?.shadowTypes || [];
+    const navContext = useContext(NavContext);
+    const categorizedTypes = navContext?.categorizedTypes || [];
+    const uncategorizedTypes = navContext?.uncategorizedTypes || [];
+    const shadowTypes = navContext?.shadowTypes || [];
+    const pendingAchievementsCount = navContext?.pendingAchievementsCount ?? 0;
 
     return (
         <Stack spacing={2}>
@@ -204,6 +206,7 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                         label="Postignuća"
                         icon={<Success className="size-5" />}
                         onClick={onItemClick}
+                        badge={pendingAchievementsCount}
                     />
                     <NavItem
                         href={KnownPages.ShoppingCarts}

--- a/apps/app/components/admin/navigation/NavContext.ts
+++ b/apps/app/components/admin/navigation/NavContext.ts
@@ -5,6 +5,8 @@ import { createContext } from 'react';
 
 export type NavContextType = Awaited<
     ReturnType<typeof getEntityTypesOrganizedByCategories>
->;
+> & {
+    pendingAchievementsCount: number;
+};
 
 export const NavContext = createContext<NavContextType | undefined>(undefined);

--- a/apps/app/components/admin/navigation/NavItem.tsx
+++ b/apps/app/components/admin/navigation/NavItem.tsx
@@ -13,6 +13,7 @@ export function NavItem({
     strictMatch,
     onClick,
     isDragging = false,
+    badge,
 }: {
     href: Route;
     label: string;
@@ -20,6 +21,7 @@ export function NavItem({
     strictMatch?: boolean;
     onClick?: () => void;
     isDragging?: boolean;
+    badge?: number;
 }) {
     const pathname = usePathname();
 
@@ -46,6 +48,11 @@ export function NavItem({
                 onSelected={() => {}}
                 label={label}
                 startDecorator={icon}
+                endDecorator={badge != null && badge > 0 ? (
+                    <span className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-medium min-w-5 h-5 px-1.5">
+                        {badge}
+                    </span>
+                ) : undefined}
             />
         </Link>
     );

--- a/apps/app/components/admin/providers/AdminClientProvider.tsx
+++ b/apps/app/components/admin/providers/AdminClientProvider.tsx
@@ -6,16 +6,18 @@ export function AdminClientProvider({
     categorizedTypes,
     uncategorizedTypes,
     shadowTypes,
+    pendingAchievementsCount,
     children,
 }: {
     categorizedTypes: NavContextType['categorizedTypes'];
     uncategorizedTypes: NavContextType['uncategorizedTypes'];
     shadowTypes: NavContextType['shadowTypes'];
+    pendingAchievementsCount: number;
     children: React.ReactNode;
 }) {
     return (
         <NavContext.Provider
-            value={{ categorizedTypes, uncategorizedTypes, shadowTypes }}
+            value={{ categorizedTypes, uncategorizedTypes, shadowTypes, pendingAchievementsCount }}
         >
             {children}
         </NavContext.Provider>

--- a/packages/storage/src/repositories/achievementsRepo.ts
+++ b/packages/storage/src/repositories/achievementsRepo.ts
@@ -44,6 +44,14 @@ export async function getAccountAchievements(accountId: string) {
     });
 }
 
+export async function getPendingAchievementsCount() {
+    const result = await storage()
+        .select({ count: sql<number>`count(*)` })
+        .from(accountAchievements)
+        .where(eq(accountAchievements.status, 'pending'));
+    return result[0]?.count ?? 0;
+}
+
 export async function getAchievements({
     status,
     limit,


### PR DESCRIPTION
- storage: add getPendingAchievementsCount() to fetch count of rows with status = 'pending' from accountAchievements.
- app admin layout: fetch pendingAchievementsCount in parallel with entity type data and pass it into AdminClientProvider.
- NavContext: extend NavContextType to include pendingAchievementsCount.
- AdminClientProvider: include pendingAchievementsCount in provided context value.
- Nav: read pendingAchievementsCount from context and forward it to NavItem as badge.
- NavItem: accept badge prop and render a small rounded badge when the value is greater than zero.

This improves visibility of outstanding achievement items and avoids anextra round-trip by fetching counts alongside existing nav data.