### PR TITLE
✨ chore(api+storage): pass block names to validity/orientationand add repair script- apps/api: provide blockNameById where raised-bed validity and orientation are calculated/updated. Fetch blocks alongside garden (Promise.all) to avoid extra requests and pass block name map into calculateRaisedBedsValidity and updateRaisedBedsOrientation.

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -141,6 +141,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const blocksById = new Map(
                 blocks.map((block) => [block.id, block]),
             );
+            const blockNameById = new Map(
+                blocks.map((block) => [block.id, block.name] as const),
+            );
 
             // Stacks: group by x then by y
             const stacks = garden.stacks.reduce(
@@ -192,6 +195,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     const validityMap = calculateRaisedBedsValidity(
                         garden.raisedBeds,
                         garden.stacks,
+                        blockNameById,
                     );
                     return garden.raisedBeds.map((raisedBed) => ({
                         id: raisedBed.id,
@@ -1108,7 +1112,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             // Check garden exists and is owned by user
             const { accountId } = context.get('authContext');
-            const garden = await getGarden(gardenIdNumber);
+            const [garden, blocks] = await Promise.all([
+                getGarden(gardenIdNumber),
+                getGardenBlocks(gardenIdNumber),
+            ]);
             if (!garden || garden.accountId !== accountId) {
                 return context.json(
                     {
@@ -1118,9 +1125,13 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
 
+            const blockNameById = new Map(
+                blocks.map((block) => [block.id, block.name] as const),
+            );
             const validityMap = calculateRaisedBedsValidity(
                 garden.raisedBeds,
                 garden.stacks,
+                blockNameById,
             );
             return context.json(
                 garden.raisedBeds.map((raisedBed) => ({
@@ -1159,7 +1170,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }
 
             const { accountId } = context.get('authContext');
-            const garden = await getGarden(gardenIdNumber);
+            const [garden, blocks] = await Promise.all([
+                getGarden(gardenIdNumber),
+                getGardenBlocks(gardenIdNumber),
+            ]);
             if (!garden || garden.accountId !== accountId) {
                 return context.json({ error: 'Raised bed not found' }, 404);
             }
@@ -1169,9 +1183,13 @@ const app = new Hono<{ Variables: AuthVariables }>()
             if (!raisedBed) {
                 return context.json({ error: 'Raised bed not found' }, 404);
             }
+            const blockNameById = new Map(
+                blocks.map((block) => [block.id, block.name] as const),
+            );
             const validityMap = calculateRaisedBedsValidity(
                 garden.raisedBeds,
                 garden.stacks,
+                blockNameById,
             );
 
             return context.json({

--- a/apps/api/lib/garden/gardenStacksSyncService.ts
+++ b/apps/api/lib/garden/gardenStacksSyncService.ts
@@ -264,5 +264,8 @@ export async function synchronizeGardenStacksAndRaisedBeds(gardenId: number) {
         return;
     }
 
-    await updateRaisedBedsOrientation(gardenForOrientationUpdate);
+    await updateRaisedBedsOrientation(
+        gardenForOrientationUpdate,
+        blockNameById,
+    );
 }

--- a/apps/api/lib/garden/raisedBedsService.node.spec.ts
+++ b/apps/api/lib/garden/raisedBedsService.node.spec.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    calculateRaisedBedsOrientation,
+    calculateRaisedBedsValidity,
+} from './raisedBedsService';
+
+describe('calculateRaisedBedsValidity', () => {
+    it('ignores adjacent non-raised-bed blocks when validating a merged bed', () => {
+        const blockNameById = new Map([
+            ['grass-a', 'Block_Grass'],
+            ['grass-b', 'Block_Grass'],
+            ['grass-c', 'Block_Grass'],
+            ['bed-a', 'Raised_Bed'],
+            ['bed-b', 'Raised_Bed'],
+            ['shade-a', 'Shade'],
+        ]);
+        const raisedBeds = [{ id: 1, blockId: 'bed-a' }];
+        const stacks = [
+            { positionX: 0, positionY: 0, blocks: ['grass-a', 'bed-a'] },
+            { positionX: 0, positionY: 1, blocks: ['grass-b', 'bed-b'] },
+            { positionX: 1, positionY: 0, blocks: ['grass-c', 'shade-a'] },
+        ];
+
+        const validity = calculateRaisedBedsValidity(
+            raisedBeds,
+            stacks,
+            blockNameById,
+        );
+
+        assert.strictEqual(validity.get(1), true);
+    });
+});
+
+describe('calculateRaisedBedsOrientation', () => {
+    it('derives orientation only from adjacent raised-bed blocks', () => {
+        const blockNameById = new Map([
+            ['grass-a', 'Block_Grass'],
+            ['grass-b', 'Block_Grass'],
+            ['grass-c', 'Block_Grass'],
+            ['bed-a', 'Raised_Bed'],
+            ['bed-b', 'Raised_Bed'],
+            ['shade-a', 'Shade'],
+        ]);
+        const raisedBeds = [{ id: 1, blockId: 'bed-a' }];
+        const stacks = [
+            { positionX: 0, positionY: 0, blocks: ['grass-a', 'bed-a'] },
+            { positionX: 0, positionY: 1, blocks: ['grass-b', 'bed-b'] },
+            { positionX: 1, positionY: 0, blocks: ['grass-c', 'shade-a'] },
+        ];
+
+        const orientations = calculateRaisedBedsOrientation(
+            raisedBeds,
+            stacks,
+            blockNameById,
+        );
+
+        assert.strictEqual(orientations.get(1), 'horizontal');
+    });
+});

--- a/apps/api/lib/garden/raisedBedsService.ts
+++ b/apps/api/lib/garden/raisedBedsService.ts
@@ -8,6 +8,7 @@ import {
 type BlockPosition = { x: number; y: number; index: number };
 
 type RaisedBedInput = Pick<SelectRaisedBed, 'id' | 'blockId'>;
+type BlockNameById = ReadonlyMap<string, string>;
 
 type AdjacentBlockAtSameIndex = {
     blockId: string;
@@ -49,6 +50,26 @@ function getAdjacentBlockIdsAtSameIndex(
 ): string[] {
     return getAdjacentBlocksAtSameIndex(stacks, position).map(
         (candidate) => candidate.blockId,
+    );
+}
+
+function getAdjacentRaisedBedBlockIdsAtSameIndex(
+    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
+    position: BlockPosition,
+    blockNameById: BlockNameById,
+): string[] {
+    return getAdjacentBlockIdsAtSameIndex(stacks, position).filter(
+        (blockId) => blockNameById.get(blockId) === 'Raised_Bed',
+    );
+}
+
+function getAdjacentRaisedBedBlocksAtSameIndex(
+    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
+    position: BlockPosition,
+    blockNameById: BlockNameById,
+): AdjacentBlockAtSameIndex[] {
+    return getAdjacentBlocksAtSameIndex(stacks, position).filter(
+        (candidate) => blockNameById.get(candidate.blockId) === 'Raised_Bed',
     );
 }
 
@@ -159,6 +180,7 @@ function buildBlockPositionMap(
 export function calculateRaisedBedsValidity(
     raisedBeds: Pick<SelectRaisedBed, 'id' | 'blockId'>[],
     stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
+    blockNameById: BlockNameById,
 ): Map<number, boolean> {
     const blockPositions = buildBlockPositionMap(stacks);
     const adjacency = buildRaisedBedAdjacencyByRecord(
@@ -188,19 +210,20 @@ export function calculateRaisedBedsValidity(
             continue;
         }
 
-        const adjacentBlockIds = getAdjacentBlockIdsAtSameIndex(
-            stacks,
-            position,
-        );
-        const adjacentRaisedBedRecordBlockIds = adjacentBlockIds.filter(
-            (blockId) => raisedBedBlockIds.has(blockId),
-        );
-        const adjacentOrphanBlockIds = adjacentBlockIds.filter(
+        const adjacentRaisedBedBlockIds =
+            getAdjacentRaisedBedBlockIdsAtSameIndex(
+                stacks,
+                position,
+                blockNameById,
+            );
+        const adjacentRaisedBedRecordBlockIds =
+            adjacentRaisedBedBlockIds.filter((blockId) =>
+                raisedBedBlockIds.has(blockId),
+            );
+        const adjacentOrphanBlockIds = adjacentRaisedBedBlockIds.filter(
             (blockId) => !raisedBedBlockIds.has(blockId),
         );
-        const totalAdjacentCount =
-            adjacentRaisedBedRecordBlockIds.length +
-            adjacentOrphanBlockIds.length;
+        const totalAdjacentCount = adjacentRaisedBedBlockIds.length;
         if (totalAdjacentCount !== 1) {
             validity.set(bed.id, false);
             continue;
@@ -221,6 +244,7 @@ export function calculateRaisedBedsValidity(
 export function calculateRaisedBedsOrientation(
     raisedBeds: Pick<SelectRaisedBed, 'id' | 'blockId'>[],
     stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
+    blockNameById: BlockNameById,
 ): Map<number, RaisedBedOrientation> {
     const blockPositions = buildBlockPositionMap(stacks);
     const orientations = new Map<number, RaisedBedOrientation>();
@@ -230,9 +254,10 @@ export function calculateRaisedBedsOrientation(
         if (bed.blockId) {
             const position = blockPositions.get(bed.blockId);
             if (position) {
-                const adjacentBlocks = getAdjacentBlocksAtSameIndex(
+                const adjacentBlocks = getAdjacentRaisedBedBlocksAtSameIndex(
                     stacks,
                     position,
+                    blockNameById,
                 );
                 const hasHorizontalNeighbor = adjacentBlocks.some(
                     (neighbor) =>
@@ -260,14 +285,18 @@ export function calculateRaisedBedsOrientation(
     return orientations;
 }
 
-export async function updateRaisedBedsOrientation(garden: {
-    id: number;
-    raisedBeds: Pick<SelectRaisedBed, 'id' | 'blockId' | 'orientation'>[];
-    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[];
-}) {
+export async function updateRaisedBedsOrientation(
+    garden: {
+        id: number;
+        raisedBeds: Pick<SelectRaisedBed, 'id' | 'blockId' | 'orientation'>[];
+        stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[];
+    },
+    blockNameById: BlockNameById,
+) {
     const orientations = calculateRaisedBedsOrientation(
         garden.raisedBeds,
         garden.stacks,
+        blockNameById,
     );
 
     const updates = garden.raisedBeds

--- a/packages/storage/scripts/fixMergedRaisedBedPositions.ts
+++ b/packages/storage/scripts/fixMergedRaisedBedPositions.ts
@@ -1,0 +1,470 @@
+import { Client } from 'pg';
+
+const RAISED_BED_FIELDS_PER_BLOCK = 9;
+const MERGE_WINDOW_MS = 1500;
+const MERGE_POST_WINDOW_MS = 250;
+const FIELD_EVENT_TYPES = [
+    'raisedBedField.create',
+    'raisedBedField.delete',
+    'raisedBedField.plantPlace',
+    'raisedBedField.plantSchedule',
+    'raisedBedField.plantUpdate',
+    'raisedBedField.plantReplaceSort',
+] as const;
+
+type MergeSource = {
+    id: number;
+    updatedAt: Date;
+};
+
+type MovedFieldRow = {
+    id: number;
+    raisedBedId: number;
+    positionIndex: number;
+    updatedAt: Date;
+};
+
+type MovedCartItemRow = {
+    id: number;
+    raisedBedId: number;
+    positionIndex: number;
+    entityTypeName: string;
+    entityId: string;
+    isDeleted: boolean;
+};
+
+type RepairPlan = {
+    sourceBedId: number;
+    targetBedId: number;
+    mergedAt: string;
+    fieldCount: number;
+    cartItemCount: number;
+    cartItemShift: number;
+    currentFieldStart: number | null;
+    expectedFieldStart: number;
+    fieldDelta: number;
+    fieldPositions: number[];
+    cartItemPositions: number[];
+    warnings: string[];
+};
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const execute = args.includes('--execute');
+    const sourceBedIdsArg = args.find((arg) =>
+        arg.startsWith('--source-bed-ids='),
+    );
+    const sourceBedIds = sourceBedIdsArg
+        ? sourceBedIdsArg
+              .slice('--source-bed-ids='.length)
+              .split(',')
+              .map((value) => Number.parseInt(value.trim(), 10))
+              .filter((value) => Number.isInteger(value))
+        : [];
+
+    return {
+        execute,
+        sourceBedIds,
+    };
+}
+
+function uniqueSorted(values: number[]) {
+    return Array.from(new Set(values)).sort((left, right) => left - right);
+}
+
+function expectedBlockStart(currentStart: number) {
+    if (currentStart <= 0) {
+        return 0;
+    }
+
+    return (
+        (Math.floor((currentStart - 1) / RAISED_BED_FIELDS_PER_BLOCK) + 1) *
+        RAISED_BED_FIELDS_PER_BLOCK
+    );
+}
+
+async function getMergeSources(
+    client: Client,
+    sourceBedIds: number[],
+): Promise<MergeSource[]> {
+    if (sourceBedIds.length > 0) {
+        const result = await client.query<{
+            id: number;
+            updated_at: Date;
+        }>(
+            `
+                select id, updated_at
+                from raised_beds
+                where id = any($1::int[])
+                  and is_deleted = true
+                  and garden_id is null
+                  and account_id is null
+                  and block_id is null
+                order by updated_at asc, id asc
+            `,
+            [sourceBedIds],
+        );
+
+        return result.rows.map((row) => ({
+            id: row.id,
+            updatedAt: new Date(row.updated_at),
+        }));
+    }
+
+    const result = await client.query<{
+        id: number;
+        updated_at: Date;
+    }>(`
+        select id, updated_at
+        from raised_beds
+        where is_deleted = true
+          and garden_id is null
+          and account_id is null
+          and block_id is null
+        order by updated_at asc, id asc
+    `);
+
+    return result.rows.map((row) => ({
+        id: row.id,
+        updatedAt: new Date(row.updated_at),
+    }));
+}
+
+async function getMovedFields(
+    client: Client,
+    source: MergeSource,
+): Promise<MovedFieldRow[]> {
+    const windowStart = new Date(source.updatedAt.getTime() - MERGE_WINDOW_MS);
+    const windowEnd = new Date(
+        source.updatedAt.getTime() + MERGE_POST_WINDOW_MS,
+    );
+
+    const result = await client.query<{
+        id: number;
+        raised_bed_id: number;
+        position_index: number;
+        updated_at: Date;
+    }>(
+        `
+            select id, raised_bed_id, position_index, updated_at
+            from raised_bed_fields
+            where updated_at >= $1
+              and updated_at <= $2
+              and raised_bed_id <> $3
+              and position_index is not null
+            order by raised_bed_id asc, position_index asc, id asc
+        `,
+        [windowStart, windowEnd, source.id],
+    );
+
+    return result.rows.map((row) => ({
+        id: row.id,
+        raisedBedId: row.raised_bed_id,
+        positionIndex: row.position_index,
+        updatedAt: new Date(row.updated_at),
+    }));
+}
+
+async function getMovedCartItems(
+    client: Client,
+    source: MergeSource,
+): Promise<MovedCartItemRow[]> {
+    const windowStart = new Date(source.updatedAt.getTime() - MERGE_WINDOW_MS);
+    const windowEnd = new Date(
+        source.updatedAt.getTime() + MERGE_POST_WINDOW_MS,
+    );
+
+    const result = await client.query<{
+        id: number;
+        raised_bed_id: number;
+        position_index: number;
+        entity_type_name: string;
+        entity_id: string;
+        is_deleted: boolean;
+    }>(
+        `
+            select
+                id,
+                raised_bed_id,
+                position_index,
+                entity_type_name,
+                entity_id,
+                is_deleted
+            from shopping_cart_items
+            where updated_at >= $1
+              and updated_at <= $2
+              and raised_bed_id <> $3
+              and position_index is not null
+            order by raised_bed_id asc, position_index asc, id asc
+        `,
+        [windowStart, windowEnd, source.id],
+    );
+
+    return result.rows.map((row) => ({
+        id: row.id,
+        raisedBedId: row.raised_bed_id,
+        positionIndex: row.position_index,
+        entityTypeName: row.entity_type_name,
+        entityId: row.entity_id,
+        isDeleted: row.is_deleted,
+    }));
+}
+
+function chooseTargetBedId(
+    movedFields: MovedFieldRow[],
+    movedCartItems: MovedCartItemRow[],
+) {
+    const counts = new Map<number, number>();
+
+    for (const row of movedFields) {
+        counts.set(row.raisedBedId, (counts.get(row.raisedBedId) ?? 0) + 1000);
+    }
+
+    for (const row of movedCartItems) {
+        counts.set(row.raisedBedId, (counts.get(row.raisedBedId) ?? 0) + 1);
+    }
+
+    if (counts.size === 0) {
+        return null;
+    }
+
+    return (
+        Array.from(counts.entries()).sort((left, right) => {
+            if (right[1] !== left[1]) {
+                return right[1] - left[1];
+            }
+
+            return left[0] - right[0];
+        })[0]?.[0] ?? null
+    );
+}
+
+async function buildRepairPlan(
+    client: Client,
+    source: MergeSource,
+): Promise<RepairPlan | null> {
+    const movedFields = await getMovedFields(client, source);
+    const movedCartItems = await getMovedCartItems(client, source);
+    const targetBedId = chooseTargetBedId(movedFields, movedCartItems);
+
+    if (!targetBedId) {
+        return null;
+    }
+
+    const targetFields = movedFields.filter(
+        (field) => field.raisedBedId === targetBedId,
+    );
+    const targetCartItems = movedCartItems.filter(
+        (item) => item.raisedBedId === targetBedId,
+    );
+    const warnings: string[] = [];
+
+    const distinctFieldTargets = uniqueSorted(
+        movedFields.map((field) => field.raisedBedId),
+    );
+    const distinctCartTargets = uniqueSorted(
+        movedCartItems.map((item) => item.raisedBedId),
+    );
+
+    if (distinctFieldTargets.length > 1) {
+        warnings.push(
+            `Multiple target beds detected from fields: ${distinctFieldTargets.join(', ')}`,
+        );
+    }
+
+    if (distinctCartTargets.length > 1) {
+        warnings.push(
+            `Multiple target beds detected from cart items: ${distinctCartTargets.join(', ')}`,
+        );
+    }
+
+    if (targetFields.length === 0) {
+        warnings.push(
+            'No moved field rows detected; cart-only repair skipped.',
+        );
+
+        return {
+            sourceBedId: source.id,
+            targetBedId,
+            mergedAt: source.updatedAt.toISOString(),
+            fieldCount: 0,
+            cartItemCount: targetCartItems.length,
+            cartItemShift: 0,
+            currentFieldStart: null,
+            expectedFieldStart: 0,
+            fieldDelta: 0,
+            fieldPositions: [],
+            cartItemPositions: uniqueSorted(
+                targetCartItems.map((item) => item.positionIndex),
+            ),
+            warnings,
+        };
+    }
+
+    const currentFieldStart = Math.min(
+        ...targetFields.map((field) => field.positionIndex),
+    );
+    const expectedFieldStart = expectedBlockStart(currentFieldStart);
+    const fieldDelta = expectedFieldStart - currentFieldStart;
+    const cartItemPositions = uniqueSorted(
+        targetCartItems.map((item) => item.positionIndex),
+    );
+    const cartItemShift =
+        expectedFieldStart > 0 &&
+        cartItemPositions.some((position) => position < expectedFieldStart)
+            ? expectedFieldStart
+            : 0;
+
+    return {
+        sourceBedId: source.id,
+        targetBedId,
+        mergedAt: source.updatedAt.toISOString(),
+        fieldCount: targetFields.length,
+        cartItemCount: targetCartItems.length,
+        cartItemShift,
+        currentFieldStart,
+        expectedFieldStart,
+        fieldDelta,
+        fieldPositions: uniqueSorted(
+            targetFields.map((field) => field.positionIndex),
+        ),
+        cartItemPositions,
+        warnings,
+    };
+}
+
+async function applyRepairPlan(
+    client: Client,
+    source: MergeSource,
+    plan: RepairPlan,
+) {
+    if (plan.fieldCount > 0 && plan.fieldDelta !== 0) {
+        const movedFields = (await getMovedFields(client, source)).filter(
+            (field) => field.raisedBedId === plan.targetBedId,
+        );
+        const fieldIds = movedFields.map((field) => field.id);
+
+        if (fieldIds.length > 0) {
+            await client.query(
+                `
+                    update raised_bed_fields
+                    set position_index = position_index + $1
+                    where id = any($2::int[])
+                `,
+                [plan.fieldDelta, fieldIds],
+            );
+        }
+
+        const eventPositions =
+            plan.fieldDelta > 0
+                ? [...plan.fieldPositions].sort((left, right) => right - left)
+                : [...plan.fieldPositions].sort((left, right) => left - right);
+
+        for (const fromPosition of eventPositions) {
+            const toPosition = fromPosition + plan.fieldDelta;
+            await client.query(
+                `
+                    update events
+                    set aggregate_id = $1
+                    where aggregate_id = $2
+                      and type = any($3::text[])
+                `,
+                [
+                    `${plan.targetBedId.toString()}|${toPosition.toString()}`,
+                    `${plan.targetBedId.toString()}|${fromPosition.toString()}`,
+                    FIELD_EVENT_TYPES,
+                ],
+            );
+        }
+    }
+
+    if (plan.cartItemCount > 0 && plan.cartItemShift !== 0) {
+        const movedCartItems = (await getMovedCartItems(client, source)).filter(
+            (item) => item.raisedBedId === plan.targetBedId,
+        );
+        const cartItemIds = movedCartItems.map((item) => item.id);
+
+        if (cartItemIds.length > 0) {
+            await client.query(
+                `
+                    update shopping_cart_items
+                    set position_index = position_index + $1
+                    where id = any($2::int[])
+                `,
+                [plan.cartItemShift, cartItemIds],
+            );
+        }
+    }
+}
+
+function printPlans(plans: RepairPlan[]) {
+    const summary = plans.map((plan) => ({
+        sourceBedId: plan.sourceBedId,
+        targetBedId: plan.targetBedId,
+        mergedAt: plan.mergedAt,
+        fieldCount: plan.fieldCount,
+        cartItemCount: plan.cartItemCount,
+        cartItemShift: plan.cartItemShift,
+        currentFieldStart: plan.currentFieldStart,
+        expectedFieldStart: plan.expectedFieldStart,
+        fieldDelta: plan.fieldDelta,
+        fieldPositions: plan.fieldPositions.join(','),
+        cartItemPositions: plan.cartItemPositions.join(','),
+        warnings: plan.warnings.join(' | '),
+    }));
+
+    console.log(JSON.stringify(summary, null, 2));
+}
+
+const { execute, sourceBedIds } = parseArgs();
+
+if (!process.env.POSTGRES_URL) {
+    throw new Error('POSTGRES_URL environment variable is not set.');
+}
+
+const client = new Client({ connectionString: process.env.POSTGRES_URL });
+
+await client.connect();
+
+try {
+    if (execute) {
+        await client.query('begin');
+    }
+
+    const mergeSources = await getMergeSources(client, sourceBedIds);
+    const plans: RepairPlan[] = [];
+
+    for (const source of mergeSources) {
+        const plan = await buildRepairPlan(client, source);
+        if (!plan) {
+            continue;
+        }
+
+        plans.push(plan);
+
+        if (
+            execute &&
+            plan.warnings.length === 0 &&
+            (plan.fieldDelta !== 0 || plan.cartItemShift !== 0)
+        ) {
+            await applyRepairPlan(client, source, plan);
+        }
+    }
+
+    printPlans(plans);
+
+    if (execute) {
+        await client.query('commit');
+        console.log(
+            `Applied ${plans.filter((plan) => plan.warnings.length === 0).length} repair plans.`,
+        );
+    }
+} catch (error) {
+    if (execute) {
+        await client.query('rollback');
+    }
+
+    throw error;
+} finally {
+    await client.end();
+}

--- a/packages/storage/scripts/fixRaisedBedMergeArtifacts.ts
+++ b/packages/storage/scripts/fixRaisedBedMergeArtifacts.ts
@@ -1,0 +1,357 @@
+import { Client } from 'pg';
+
+const FIELD_EVENT_TYPES = [
+    'raisedBedField.create',
+    'raisedBedField.delete',
+    'raisedBedField.plantPlace',
+    'raisedBedField.plantSchedule',
+    'raisedBedField.plantUpdate',
+    'raisedBedField.plantReplaceSort',
+] as const;
+
+const DEFAULT_PHYSICAL_IDS = [
+    '1',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '13',
+    '14',
+    '15',
+];
+const PHYSICAL_ONE_BED_ID = 5;
+const PHYSICAL_ONE_REPAIR_POSITIONS = [9, 10, 11, 12, 13, 14, 15];
+
+type Args = {
+    execute: boolean;
+    physicalIds: string[];
+};
+
+type OrphanField = {
+    physicalId: string;
+    raisedBedId: number;
+    fieldId: number;
+    positionIndex: number;
+    createdAt: string;
+};
+
+type PhysicalOneField = {
+    fieldId: number;
+    currentPositionIndex: number;
+    plantSortId: string;
+};
+
+type PhysicalOneCartItem = {
+    cartItemId: number;
+    targetPositionIndex: number;
+    plantSortId: string;
+};
+
+type PositionRepairMapping = {
+    fieldId: number;
+    fromPositionIndex: number;
+    toPositionIndex: number;
+    plantSortId: string;
+};
+
+function parseArgs(): Args {
+    const args = process.argv.slice(2);
+    const execute = args.includes('--execute');
+    const physicalIdsArg = args.find((arg) =>
+        arg.startsWith('--physical-ids='),
+    );
+
+    return {
+        execute,
+        physicalIds: physicalIdsArg
+            ? physicalIdsArg
+                  .slice('--physical-ids='.length)
+                  .split(',')
+                  .map((value) => value.trim())
+                  .filter(Boolean)
+            : DEFAULT_PHYSICAL_IDS,
+    };
+}
+
+async function getOrphanFields(
+    client: Client,
+    physicalIds: string[],
+): Promise<OrphanField[]> {
+    const result = await client.query<{
+        physical_id: string;
+        raised_bed_id: number;
+        field_id: number;
+        position_index: number;
+        created_at: Date;
+    }>(
+        `
+            with event_counts as (
+                select
+                    split_part(aggregate_id, '|', 1)::int as raised_bed_id,
+                    split_part(aggregate_id, '|', 2)::int as position_index,
+                    count(*) filter (
+                        where type in (
+                            'raisedBedField.create',
+                            'raisedBedField.delete',
+                            'raisedBedField.plantPlace',
+                            'raisedBedField.plantSchedule',
+                            'raisedBedField.plantUpdate',
+                            'raisedBedField.plantReplaceSort'
+                        )
+                    ) as event_count
+                from events
+                where aggregate_id like '%|%'
+                group by 1, 2
+            )
+            select
+                rb.physical_id,
+                f.raised_bed_id,
+                f.id as field_id,
+                f.position_index,
+                f.created_at
+            from raised_bed_fields f
+            join raised_beds rb on rb.id = f.raised_bed_id
+            left join event_counts ec
+                on ec.raised_bed_id = f.raised_bed_id
+               and ec.position_index = f.position_index
+            where rb.is_deleted = false
+              and f.is_deleted = false
+              and rb.physical_id = any($1::text[])
+              and coalesce(ec.event_count, 0) = 0
+            order by rb.physical_id::int, f.position_index, f.id
+        `,
+        [physicalIds],
+    );
+
+    return result.rows.map((row) => ({
+        physicalId: row.physical_id,
+        raisedBedId: row.raised_bed_id,
+        fieldId: row.field_id,
+        positionIndex: row.position_index,
+        createdAt: row.created_at.toISOString(),
+    }));
+}
+
+async function getPhysicalOneRepairMappings(
+    client: Client,
+): Promise<PositionRepairMapping[]> {
+    const fieldsResult = await client.query<{
+        field_id: number;
+        current_position_index: number;
+        plant_sort_id: string;
+    }>(
+        `
+            select
+                f.id as field_id,
+                f.position_index as current_position_index,
+                e.data->>'plantSortId' as plant_sort_id
+            from raised_bed_fields f
+            join events e
+              on e.aggregate_id =
+                 f.raised_bed_id::text || '|' || f.position_index::text
+             and e.type = 'raisedBedField.plantPlace'
+            where f.raised_bed_id = $1
+              and f.is_deleted = false
+              and f.position_index = any($2::int[])
+            order by f.position_index asc, e.created_at asc, e.id asc
+        `,
+        [PHYSICAL_ONE_BED_ID, PHYSICAL_ONE_REPAIR_POSITIONS],
+    );
+
+    const fields = fieldsResult.rows.map((row) => ({
+        fieldId: row.field_id,
+        currentPositionIndex: row.current_position_index,
+        plantSortId: row.plant_sort_id,
+    })) satisfies PhysicalOneField[];
+
+    if (fields.length !== 7) {
+        throw new Error(
+            `Unexpected physical 1 repair shape: ${fields.length} fields.`,
+        );
+    }
+
+    const cartItemsResult = await client.query<{
+        cart_item_id: number;
+        target_position_index: number;
+        plant_sort_id: string;
+    }>(
+        `
+            select
+                id as cart_item_id,
+                position_index as target_position_index,
+                entity_id as plant_sort_id
+            from shopping_cart_items
+            where raised_bed_id = $1
+              and entity_type_name = 'plantSort'
+              and status = 'paid'
+              and is_deleted = false
+              and entity_id = any($2::text[])
+            order by position_index asc, created_at asc, id asc
+        `,
+        [PHYSICAL_ONE_BED_ID, fields.map((field) => field.plantSortId)],
+    );
+
+    const cartItems = cartItemsResult.rows.map((row) => ({
+        cartItemId: row.cart_item_id,
+        targetPositionIndex: row.target_position_index,
+        plantSortId: row.plant_sort_id,
+    })) satisfies PhysicalOneCartItem[];
+
+    if (cartItems.length !== 7) {
+        throw new Error(
+            `Unexpected physical 1 paid cart shape: ${cartItems.length} cart items.`,
+        );
+    }
+
+    const cartBySortId = new Map<string, PhysicalOneCartItem>();
+    for (const item of cartItems) {
+        if (cartBySortId.has(item.plantSortId)) {
+            throw new Error(
+                `Physical 1 repair is ambiguous for plant sort ${item.plantSortId}.`,
+            );
+        }
+        cartBySortId.set(item.plantSortId, item);
+    }
+
+    return fields.map((field) => {
+        const cartItem = cartBySortId.get(field.plantSortId);
+        if (!cartItem) {
+            throw new Error(
+                `No paid cart item found for physical 1 plant sort ${field.plantSortId}.`,
+            );
+        }
+
+        return {
+            fieldId: field.fieldId,
+            fromPositionIndex: field.currentPositionIndex,
+            toPositionIndex: cartItem.targetPositionIndex,
+            plantSortId: field.plantSortId,
+        };
+    });
+}
+
+async function deleteOrphanFields(client: Client, orphanFields: OrphanField[]) {
+    const fieldIds = orphanFields.map((field) => field.fieldId);
+    if (fieldIds.length === 0) {
+        return;
+    }
+
+    await client.query(
+        `
+            update raised_bed_fields
+            set is_deleted = true
+            where id = any($1::int[])
+        `,
+        [fieldIds],
+    );
+}
+
+async function repairPhysicalOne(
+    client: Client,
+    mappings: PositionRepairMapping[],
+) {
+    if (mappings.length === 0) {
+        return;
+    }
+
+    const cases = mappings
+        .map(
+            (_mapping, index) =>
+                `when $${index * 2 + 1}::int then $${index * 2 + 2}::int`,
+        )
+        .join(' ');
+    const caseParams = mappings.flatMap((mapping) => [
+        mapping.fieldId,
+        mapping.toPositionIndex,
+    ]);
+    const fieldIds = mappings.map((mapping) => mapping.fieldId);
+
+    await client.query(
+        `
+            update raised_bed_fields
+            set position_index = case id ${cases} end
+            where id = any($${caseParams.length + 1}::int[])
+        `,
+        [...caseParams, fieldIds],
+    );
+
+    const sortedMappings = [...mappings].sort(
+        (left, right) => right.fromPositionIndex - left.fromPositionIndex,
+    );
+
+    for (const mapping of sortedMappings) {
+        await client.query(
+            `
+                update events
+                set aggregate_id = $1
+                where aggregate_id = $2
+                  and type = any($3::text[])
+            `,
+            [
+                `${PHYSICAL_ONE_BED_ID}|${mapping.toPositionIndex}`,
+                `${PHYSICAL_ONE_BED_ID}|${mapping.fromPositionIndex}`,
+                FIELD_EVENT_TYPES,
+            ],
+        );
+    }
+}
+
+function printSummary(
+    orphanFields: OrphanField[],
+    physicalOneMappings: PositionRepairMapping[],
+) {
+    console.log(
+        JSON.stringify(
+            {
+                orphanFields,
+                physicalOneMappings,
+            },
+            null,
+            2,
+        ),
+    );
+}
+
+const { execute, physicalIds } = parseArgs();
+
+if (!process.env.POSTGRES_URL) {
+    throw new Error('POSTGRES_URL environment variable is not set.');
+}
+
+const client = new Client({ connectionString: process.env.POSTGRES_URL });
+
+await client.connect();
+
+try {
+    if (execute) {
+        await client.query('begin');
+    }
+
+    const [orphanFields, physicalOneMappings] = await Promise.all([
+        getOrphanFields(client, physicalIds),
+        physicalIds.includes('1')
+            ? getPhysicalOneRepairMappings(client)
+            : Promise.resolve([]),
+    ]);
+
+    printSummary(orphanFields, physicalOneMappings);
+
+    if (execute) {
+        await deleteOrphanFields(client, orphanFields);
+        await repairPhysicalOne(client, physicalOneMappings);
+        await client.query('commit');
+        console.log(
+            `Deleted ${orphanFields.length} orphan fields and repaired ${physicalOneMappings.length} physical 1 positions.`,
+        );
+    }
+} catch (error) {
+    if (execute) {
+        await client.query('rollback');
+    }
+
+    throw error;
+} finally {
+    await client.end();
+}

--- a/packages/storage/scripts/normalizeMergedRaisedBedFields.ts
+++ b/packages/storage/scripts/normalizeMergedRaisedBedFields.ts
@@ -1,0 +1,748 @@
+import { Client } from 'pg';
+
+const RAISED_BED_FIELDS_PER_BLOCK = 9;
+const MERGE_WINDOW_MS = 1500;
+const MERGE_POST_WINDOW_MS = 250;
+const FIELD_EVENT_TYPES = [
+    'raisedBedField.create',
+    'raisedBedField.delete',
+    'raisedBedField.plantPlace',
+    'raisedBedField.plantSchedule',
+    'raisedBedField.plantUpdate',
+    'raisedBedField.plantReplaceSort',
+] as const;
+
+type Args = {
+    execute: boolean;
+    targetBedIds: number[];
+};
+
+type MergeSource = {
+    id: number;
+    updatedAt: Date;
+};
+
+type MovedFieldRow = {
+    id: number;
+    raisedBedId: number;
+    positionIndex: number;
+};
+
+type MovedCartItemRow = {
+    raisedBedId: number;
+};
+
+type MergedTarget = {
+    targetBedId: number;
+    physicalId: string;
+};
+
+type FieldRow = {
+    id: number;
+    positionIndex: number;
+    createdAt: Date;
+};
+
+type FieldMove = {
+    fieldId: number;
+    fromPositionIndex: number;
+    toPositionIndex: number;
+};
+
+type DuplicateMapping = {
+    canonicalFieldId: number;
+    duplicateFieldIds: number[];
+};
+
+type BlockPlan = {
+    label: 'target' | 'source';
+    beforePositions: number[];
+    moves: FieldMove[];
+    insertPositions: number[];
+    duplicateMappings: DuplicateMapping[];
+    warnings: string[];
+};
+
+type BedPlan = {
+    targetBedId: number;
+    physicalId: string;
+    beforePositions: number[];
+    afterPositions: number[];
+    targetBlock: BlockPlan;
+    sourceBlock: BlockPlan;
+    warnings: string[];
+};
+
+function parseArgs(): Args {
+    const args = process.argv.slice(2);
+    const execute = args.includes('--execute');
+    const targetBedIdsArg = args.find((arg) =>
+        arg.startsWith('--target-bed-ids='),
+    );
+
+    return {
+        execute,
+        targetBedIds: targetBedIdsArg
+            ? targetBedIdsArg
+                  .slice('--target-bed-ids='.length)
+                  .split(',')
+                  .map((value) => Number.parseInt(value.trim(), 10))
+                  .filter((value) => Number.isInteger(value))
+            : [],
+    };
+}
+
+function expectedPositions(offset: number) {
+    return Array.from(
+        { length: RAISED_BED_FIELDS_PER_BLOCK },
+        (_, index) => offset + index,
+    );
+}
+
+function chooseTargetBedId(
+    movedFields: MovedFieldRow[],
+    movedCartItems: MovedCartItemRow[],
+) {
+    const counts = new Map<number, number>();
+
+    for (const row of movedFields) {
+        counts.set(row.raisedBedId, (counts.get(row.raisedBedId) ?? 0) + 1000);
+    }
+
+    for (const row of movedCartItems) {
+        counts.set(row.raisedBedId, (counts.get(row.raisedBedId) ?? 0) + 1);
+    }
+
+    if (counts.size === 0) {
+        return null;
+    }
+
+    return (
+        Array.from(counts.entries()).sort((left, right) => {
+            if (right[1] !== left[1]) {
+                return right[1] - left[1];
+            }
+
+            return left[0] - right[0];
+        })[0]?.[0] ?? null
+    );
+}
+
+async function getMergeSources(client: Client): Promise<MergeSource[]> {
+    const result = await client.query<{
+        id: number;
+        updated_at: Date;
+    }>(`
+        select id, updated_at
+        from raised_beds
+        where is_deleted = true
+          and garden_id is null
+          and account_id is null
+          and block_id is null
+        order by updated_at asc, id asc
+    `);
+
+    return result.rows.map((row) => ({
+        id: row.id,
+        updatedAt: new Date(row.updated_at),
+    }));
+}
+
+async function getMovedFields(
+    client: Client,
+    source: MergeSource,
+): Promise<MovedFieldRow[]> {
+    const windowStart = new Date(source.updatedAt.getTime() - MERGE_WINDOW_MS);
+    const windowEnd = new Date(
+        source.updatedAt.getTime() + MERGE_POST_WINDOW_MS,
+    );
+
+    const result = await client.query<{
+        id: number;
+        raised_bed_id: number;
+        position_index: number;
+    }>(
+        `
+            select id, raised_bed_id, position_index
+            from raised_bed_fields
+            where updated_at >= $1
+              and updated_at <= $2
+              and raised_bed_id <> $3
+              and position_index is not null
+            order by raised_bed_id asc, position_index asc, id asc
+        `,
+        [windowStart, windowEnd, source.id],
+    );
+
+    return result.rows.map((row) => ({
+        id: row.id,
+        raisedBedId: row.raised_bed_id,
+        positionIndex: row.position_index,
+    }));
+}
+
+async function getMovedCartItems(
+    client: Client,
+    source: MergeSource,
+): Promise<MovedCartItemRow[]> {
+    const windowStart = new Date(source.updatedAt.getTime() - MERGE_WINDOW_MS);
+    const windowEnd = new Date(
+        source.updatedAt.getTime() + MERGE_POST_WINDOW_MS,
+    );
+
+    const result = await client.query<{
+        raised_bed_id: number;
+    }>(
+        `
+            select raised_bed_id
+            from shopping_cart_items
+            where updated_at >= $1
+              and updated_at <= $2
+              and raised_bed_id <> $3
+              and position_index is not null
+            order by raised_bed_id asc, id asc
+        `,
+        [windowStart, windowEnd, source.id],
+    );
+
+    return result.rows.map((row) => ({
+        raisedBedId: row.raised_bed_id,
+    }));
+}
+
+async function getMergedTargets(
+    client: Client,
+    explicitTargetBedIds: number[],
+): Promise<MergedTarget[]> {
+    if (explicitTargetBedIds.length > 0) {
+        const result = await client.query<{
+            id: number;
+            physical_id: string;
+        }>(
+            `
+                select id, physical_id
+                from raised_beds
+                where id = any($1::int[])
+                  and is_deleted = false
+                  and physical_id is not null
+                order by physical_id::int, id
+            `,
+            [explicitTargetBedIds],
+        );
+
+        return result.rows.map((row) => ({
+            targetBedId: row.id,
+            physicalId: row.physical_id,
+        }));
+    }
+
+    const mergeSources = await getMergeSources(client);
+    const targets = new Map<number, MergedTarget>();
+
+    for (const source of mergeSources) {
+        const movedFields = await getMovedFields(client, source);
+        const movedCartItems = await getMovedCartItems(client, source);
+        const targetBedId = chooseTargetBedId(movedFields, movedCartItems);
+        if (!targetBedId || targets.has(targetBedId)) {
+            continue;
+        }
+
+        const targetResult = await client.query<{
+            id: number;
+            physical_id: string;
+        }>(
+            `
+                select id, physical_id
+                from raised_beds
+                where id = $1
+                  and is_deleted = false
+                  and physical_id is not null
+            `,
+            [targetBedId],
+        );
+        const target = targetResult.rows[0];
+        if (!target) {
+            continue;
+        }
+
+        targets.set(targetBedId, {
+            targetBedId: target.id,
+            physicalId: target.physical_id,
+        });
+    }
+
+    return [...targets.values()].sort((left, right) => {
+        const physicalComparison =
+            Number(left.physicalId) - Number(right.physicalId);
+        if (physicalComparison !== 0) {
+            return physicalComparison;
+        }
+
+        return left.targetBedId - right.targetBedId;
+    });
+}
+
+async function getBedFields(client: Client, targetBedId: number) {
+    const result = await client.query<{
+        id: number;
+        position_index: number;
+        created_at: Date;
+    }>(
+        `
+            select id, position_index, created_at
+            from raised_bed_fields
+            where raised_bed_id = $1
+              and is_deleted = false
+            order by position_index asc, created_at asc, id asc
+        `,
+        [targetBedId],
+    );
+
+    return result.rows.map((row) => ({
+        id: row.id,
+        positionIndex: row.position_index,
+        createdAt: new Date(row.created_at),
+    })) satisfies FieldRow[];
+}
+
+async function getOperationCounts(client: Client, fieldIds: number[]) {
+    if (fieldIds.length === 0) {
+        return new Map<number, number>();
+    }
+
+    const result = await client.query<{
+        raised_bed_field_id: number;
+        count: string;
+    }>(
+        `
+            select raised_bed_field_id, count(*)::text as count
+            from operations
+            where is_deleted = false
+              and raised_bed_field_id = any($1::int[])
+            group by raised_bed_field_id
+        `,
+        [fieldIds],
+    );
+
+    return new Map(
+        result.rows.map((row) => [
+            row.raised_bed_field_id,
+            Number.parseInt(row.count, 10),
+        ]),
+    );
+}
+
+function sortRowsByPriority(
+    rows: FieldRow[],
+    operationCounts: Map<number, number>,
+) {
+    return [...rows].sort((left, right) => {
+        const leftOperationCount = operationCounts.get(left.id) ?? 0;
+        const rightOperationCount = operationCounts.get(right.id) ?? 0;
+        if (rightOperationCount !== leftOperationCount) {
+            return rightOperationCount - leftOperationCount;
+        }
+
+        const createdAtDelta =
+            left.createdAt.getTime() - right.createdAt.getTime();
+        if (createdAtDelta !== 0) {
+            return createdAtDelta;
+        }
+
+        return left.id - right.id;
+    });
+}
+
+function buildBlockPlan(
+    label: 'target' | 'source',
+    rows: FieldRow[],
+    operationCounts: Map<number, number>,
+    startPosition: number,
+) {
+    const plannedPositions = expectedPositions(startPosition);
+    const rowsByPosition = new Map<number, FieldRow[]>();
+    const outsideRows: FieldRow[] = [];
+
+    for (const row of rows) {
+        if (plannedPositions.includes(row.positionIndex)) {
+            const rowsAtPosition = rowsByPosition.get(row.positionIndex);
+            if (rowsAtPosition) {
+                rowsAtPosition.push(row);
+            } else {
+                rowsByPosition.set(row.positionIndex, [row]);
+            }
+            continue;
+        }
+
+        outsideRows.push(row);
+    }
+
+    const duplicateMappings: DuplicateMapping[] = [];
+    const missingPositions: number[] = [];
+
+    for (const position of plannedPositions) {
+        const rowsAtPosition = rowsByPosition.get(position);
+        if (!rowsAtPosition || rowsAtPosition.length === 0) {
+            missingPositions.push(position);
+            continue;
+        }
+
+        const prioritizedRows = sortRowsByPriority(
+            rowsAtPosition,
+            operationCounts,
+        );
+        const canonicalRow = prioritizedRows.shift();
+        if (!canonicalRow || prioritizedRows.length === 0) {
+            continue;
+        }
+
+        duplicateMappings.push({
+            canonicalFieldId: canonicalRow.id,
+            duplicateFieldIds: prioritizedRows.map((row) => row.id),
+        });
+    }
+
+    const moves: FieldMove[] = [];
+    const sortedOutsideRows = outsideRows.sort((left, right) => {
+        if (left.positionIndex !== right.positionIndex) {
+            return left.positionIndex - right.positionIndex;
+        }
+
+        return sortRowsByPriority([left, right], operationCounts)[0]?.id ===
+            left.id
+            ? -1
+            : 1;
+    });
+
+    for (let index = 0; index < missingPositions.length; index += 1) {
+        const row = sortedOutsideRows[index];
+        if (!row) {
+            break;
+        }
+
+        moves.push({
+            fieldId: row.id,
+            fromPositionIndex: row.positionIndex,
+            toPositionIndex: missingPositions[index] ?? row.positionIndex,
+        });
+    }
+
+    const remainingOutsideRows = sortedOutsideRows.slice(
+        missingPositions.length,
+    );
+    const warnings =
+        remainingOutsideRows.length > 0
+            ? [
+                  `${label} block still has ${remainingOutsideRows.length} rows outside ${startPosition}-${startPosition + RAISED_BED_FIELDS_PER_BLOCK - 1}`,
+              ]
+            : [];
+
+    return {
+        label,
+        beforePositions: rows
+            .map((row) => row.positionIndex)
+            .sort((a, b) => a - b),
+        moves,
+        insertPositions: missingPositions.slice(moves.length),
+        duplicateMappings,
+        warnings,
+    } satisfies BlockPlan;
+}
+
+async function applyDuplicateMappings(
+    client: Client,
+    duplicateMappings: DuplicateMapping[],
+) {
+    for (const duplicateMapping of duplicateMappings) {
+        if (duplicateMapping.duplicateFieldIds.length === 0) {
+            continue;
+        }
+
+        await client.query(
+            `
+                update operations
+                set raised_bed_field_id = $1
+                where raised_bed_field_id = any($2::int[])
+            `,
+            [
+                duplicateMapping.canonicalFieldId,
+                duplicateMapping.duplicateFieldIds,
+            ],
+        );
+
+        await client.query(
+            `
+                update raised_bed_fields
+                set is_deleted = true,
+                    updated_at = now()
+                where id = any($1::int[])
+            `,
+            [duplicateMapping.duplicateFieldIds],
+        );
+    }
+}
+
+async function applyMoves(
+    client: Client,
+    targetBedId: number,
+    moves: FieldMove[],
+) {
+    for (const move of moves) {
+        if (move.fromPositionIndex === move.toPositionIndex) {
+            continue;
+        }
+
+        await client.query(
+            `
+                update raised_bed_fields
+                set position_index = $1,
+                    updated_at = now()
+                where id = $2
+            `,
+            [move.toPositionIndex, move.fieldId],
+        );
+
+        await client.query(
+            `
+                update events
+                set aggregate_id = $1
+                where aggregate_id = $2
+                  and type = any($3::text[])
+            `,
+            [
+                `${targetBedId}|${move.toPositionIndex}`,
+                `${targetBedId}|${move.fromPositionIndex}`,
+                FIELD_EVENT_TYPES,
+            ],
+        );
+    }
+}
+
+async function applyInsertions(
+    client: Client,
+    targetBedId: number,
+    positions: number[],
+) {
+    if (positions.length === 0) {
+        return;
+    }
+
+    await client.query(
+        `
+            insert into raised_bed_fields (
+                raised_bed_id,
+                position_index,
+                created_at,
+                updated_at
+            )
+            select $1, position_index, now(), now()
+            from unnest($2::int[]) as position_index
+        `,
+        [targetBedId, positions],
+    );
+}
+
+async function repairOperationsOnDeletedFields(
+    client: Client,
+    targetBedId: number,
+) {
+    const activeFieldsResult = await client.query<{
+        id: number;
+        position_index: number;
+    }>(
+        `
+            select id, position_index
+            from raised_bed_fields
+            where raised_bed_id = $1
+              and is_deleted = false
+        `,
+        [targetBedId],
+    );
+
+    const activeFieldIdByPosition = new Map(
+        activeFieldsResult.rows.map((row) => [row.position_index, row.id]),
+    );
+
+    const deletedFieldOperationsResult = await client.query<{
+        operation_id: number;
+        position_index: number;
+    }>(
+        `
+            select
+                o.id as operation_id,
+                rbf.position_index
+            from operations o
+            join raised_bed_fields rbf on rbf.id = o.raised_bed_field_id
+            where o.is_deleted = false
+              and o.raised_bed_id = $1
+              and rbf.is_deleted = true
+        `,
+        [targetBedId],
+    );
+
+    let reassignedCount = 0;
+    let clearedCount = 0;
+
+    for (const row of deletedFieldOperationsResult.rows) {
+        const nextRaisedBedFieldId =
+            activeFieldIdByPosition.get(row.position_index) ?? null;
+
+        await client.query(
+            `
+                update operations
+                set raised_bed_field_id = $1
+                where id = $2
+            `,
+            [nextRaisedBedFieldId, row.operation_id],
+        );
+
+        if (nextRaisedBedFieldId) {
+            reassignedCount += 1;
+        } else {
+            clearedCount += 1;
+        }
+    }
+
+    return {
+        reassignedCount,
+        clearedCount,
+    };
+}
+
+async function buildBedPlan(
+    client: Client,
+    mergedTarget: MergedTarget,
+): Promise<BedPlan> {
+    const fields = await getBedFields(client, mergedTarget.targetBedId);
+    const operationCounts = await getOperationCounts(
+        client,
+        fields.map((field) => field.id),
+    );
+    const targetRows = fields.filter((field) => field.positionIndex < 9);
+    const sourceRows = fields.filter((field) => field.positionIndex >= 9);
+    const targetBlock = buildBlockPlan(
+        'target',
+        targetRows,
+        operationCounts,
+        0,
+    );
+    const sourceBlock = buildBlockPlan(
+        'source',
+        sourceRows,
+        operationCounts,
+        9,
+    );
+
+    return {
+        targetBedId: mergedTarget.targetBedId,
+        physicalId: mergedTarget.physicalId,
+        beforePositions: fields
+            .map((field) => field.positionIndex)
+            .sort((a, b) => a - b),
+        afterPositions: expectedPositions(0).concat(expectedPositions(9)),
+        targetBlock,
+        sourceBlock,
+        warnings: [...targetBlock.warnings, ...sourceBlock.warnings],
+    };
+}
+
+async function applyBedPlan(client: Client, plan: BedPlan) {
+    await applyDuplicateMappings(client, plan.targetBlock.duplicateMappings);
+    await applyDuplicateMappings(client, plan.sourceBlock.duplicateMappings);
+    await applyMoves(client, plan.targetBedId, plan.targetBlock.moves);
+    await applyMoves(client, plan.targetBedId, plan.sourceBlock.moves);
+    await applyInsertions(
+        client,
+        plan.targetBedId,
+        plan.targetBlock.insertPositions,
+    );
+    await applyInsertions(
+        client,
+        plan.targetBedId,
+        plan.sourceBlock.insertPositions,
+    );
+}
+
+function printPlans(plans: BedPlan[]) {
+    console.log(
+        JSON.stringify(
+            plans.map((plan) => ({
+                targetBedId: plan.targetBedId,
+                physicalId: plan.physicalId,
+                beforePositions: plan.beforePositions,
+                afterPositions: plan.afterPositions,
+                targetMoves: plan.targetBlock.moves,
+                sourceMoves: plan.sourceBlock.moves,
+                targetInsertPositions: plan.targetBlock.insertPositions,
+                sourceInsertPositions: plan.sourceBlock.insertPositions,
+                targetDuplicateDeletes:
+                    plan.targetBlock.duplicateMappings.flatMap(
+                        (mapping) => mapping.duplicateFieldIds,
+                    ),
+                sourceDuplicateDeletes:
+                    plan.sourceBlock.duplicateMappings.flatMap(
+                        (mapping) => mapping.duplicateFieldIds,
+                    ),
+                warnings: plan.warnings,
+            })),
+            null,
+            2,
+        ),
+    );
+}
+
+const { execute, targetBedIds } = parseArgs();
+
+if (!process.env.POSTGRES_URL) {
+    throw new Error('POSTGRES_URL environment variable is not set.');
+}
+
+const client = new Client({ connectionString: process.env.POSTGRES_URL });
+
+await client.connect();
+
+try {
+    const mergedTargets = await getMergedTargets(client, targetBedIds);
+    const plans: BedPlan[] = [];
+    for (const mergedTarget of mergedTargets) {
+        plans.push(await buildBedPlan(client, mergedTarget));
+    }
+
+    printPlans(plans);
+
+    const warnings = plans.flatMap((plan) =>
+        plan.warnings.map((warning) => `${plan.targetBedId}: ${warning}`),
+    );
+
+    if (warnings.length > 0) {
+        throw new Error(`Unsafe normalization plan:\n${warnings.join('\n')}`);
+    }
+
+    if (execute) {
+        await client.query('begin');
+        let repairedOperationCount = 0;
+        let clearedOperationCount = 0;
+        for (const plan of plans) {
+            await applyBedPlan(client, plan);
+            const operationRepair = await repairOperationsOnDeletedFields(
+                client,
+                plan.targetBedId,
+            );
+            repairedOperationCount += operationRepair.reassignedCount;
+            clearedOperationCount += operationRepair.clearedCount;
+        }
+        await client.query('commit');
+        console.log(`Normalized ${plans.length} merged raised beds.`);
+        console.log(
+            `Repaired ${repairedOperationCount} operation field links and cleared ${clearedOperationCount} ambiguous links.`,
+        );
+    }
+} catch (error) {
+    if (execute) {
+        await client.query('rollback');
+    }
+
+    throw error;
+} finally {
+    await client.end();
+}

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -27,6 +27,7 @@ import {
     type InsertRaisedBedSensor,
     raisedBedFields,
     raisedBedSensors,
+    type SelectRaisedBedField,
     type UpdateRaisedBedSensor,
 } from '../schema/gardenSchema';
 import {
@@ -36,6 +37,189 @@ import {
     knownEventTypes,
 } from './eventsRepo';
 import { getFarms } from './farmsRepo';
+
+const RAISED_BED_FIELDS_PER_BLOCK = 9;
+
+type CanonicalRaisedBedField = {
+    id: number;
+    positionIndex: number;
+};
+
+function fieldRowPriority(
+    field: SelectRaisedBedField,
+    operationCountsByFieldId: Map<number, number>,
+) {
+    return {
+        operationCount: operationCountsByFieldId.get(field.id) ?? 0,
+        createdAt: field.createdAt.getTime(),
+        id: field.id,
+    };
+}
+
+async function normalizeRaisedBedFieldsForMerge(
+    tx: ReturnType<typeof storage>,
+    raisedBedId: number,
+    activeFields: SelectRaisedBedField[],
+) {
+    const invalidFields = activeFields.filter(
+        (field) =>
+            field.positionIndex < 0 ||
+            field.positionIndex >= RAISED_BED_FIELDS_PER_BLOCK,
+    );
+    if (invalidFields.length > 0) {
+        throw new Error(
+            `Raised bed ${raisedBedId} has invalid source positions for merge: ${invalidFields.map((field) => field.positionIndex).join(', ')}`,
+        );
+    }
+
+    const activeFieldIds = activeFields.map((field) => field.id);
+    const operationCountsByFieldId =
+        activeFieldIds.length === 0
+            ? new Map<number, number>()
+            : new Map(
+                  (
+                      await tx
+                          .select({
+                              raisedBedFieldId: operations.raisedBedFieldId,
+                              count: count(),
+                          })
+                          .from(operations)
+                          .where(
+                              and(
+                                  inArray(
+                                      operations.raisedBedFieldId,
+                                      activeFieldIds,
+                                  ),
+                                  eq(operations.isDeleted, false),
+                              ),
+                          )
+                          .groupBy(operations.raisedBedFieldId)
+                  ).flatMap((row) =>
+                      typeof row.raisedBedFieldId === 'number'
+                          ? [[row.raisedBedFieldId, row.count]]
+                          : [],
+                  ),
+              );
+
+    const fieldsByPosition = new Map<number, SelectRaisedBedField[]>();
+    for (const field of activeFields) {
+        const fieldsAtPosition = fieldsByPosition.get(field.positionIndex);
+        if (fieldsAtPosition) {
+            fieldsAtPosition.push(field);
+        } else {
+            fieldsByPosition.set(field.positionIndex, [field]);
+        }
+    }
+
+    const duplicateFieldMappings: Array<{
+        canonicalFieldId: number;
+        duplicateFieldIds: number[];
+    }> = [];
+    const canonicalFields = new Map<number, CanonicalRaisedBedField>();
+
+    for (
+        let positionIndex = 0;
+        positionIndex < RAISED_BED_FIELDS_PER_BLOCK;
+        positionIndex += 1
+    ) {
+        const fieldsAtPosition = [
+            ...(fieldsByPosition.get(positionIndex) ?? []),
+        ].sort((left, right) => {
+            const leftPriority = fieldRowPriority(
+                left,
+                operationCountsByFieldId,
+            );
+            const rightPriority = fieldRowPriority(
+                right,
+                operationCountsByFieldId,
+            );
+
+            if (rightPriority.operationCount !== leftPriority.operationCount) {
+                return (
+                    rightPriority.operationCount - leftPriority.operationCount
+                );
+            }
+
+            if (leftPriority.createdAt !== rightPriority.createdAt) {
+                return leftPriority.createdAt - rightPriority.createdAt;
+            }
+
+            return leftPriority.id - rightPriority.id;
+        });
+
+        const canonicalField = fieldsAtPosition.shift();
+        if (canonicalField) {
+            canonicalFields.set(positionIndex, {
+                id: canonicalField.id,
+                positionIndex,
+            });
+
+            if (fieldsAtPosition.length > 0) {
+                duplicateFieldMappings.push({
+                    canonicalFieldId: canonicalField.id,
+                    duplicateFieldIds: fieldsAtPosition.map(
+                        (field) => field.id,
+                    ),
+                });
+            }
+
+            continue;
+        }
+
+        const insertedField = await tx
+            .insert(raisedBedFields)
+            .values({
+                raisedBedId,
+                positionIndex,
+            })
+            .returning({
+                id: raisedBedFields.id,
+            });
+        const insertedFieldId = insertedField[0]?.id;
+        if (!insertedFieldId) {
+            throw new Error(
+                `Failed to create placeholder field ${positionIndex} for raised bed ${raisedBedId}`,
+            );
+        }
+
+        canonicalFields.set(positionIndex, {
+            id: insertedFieldId,
+            positionIndex,
+        });
+    }
+
+    for (const duplicateFieldMapping of duplicateFieldMappings) {
+        if (duplicateFieldMapping.duplicateFieldIds.length === 0) {
+            continue;
+        }
+
+        await tx
+            .update(operations)
+            .set({
+                raisedBedFieldId: duplicateFieldMapping.canonicalFieldId,
+            })
+            .where(
+                inArray(
+                    operations.raisedBedFieldId,
+                    duplicateFieldMapping.duplicateFieldIds,
+                ),
+            );
+
+        await tx
+            .update(raisedBedFields)
+            .set({ isDeleted: true })
+            .where(
+                inArray(
+                    raisedBedFields.id,
+                    duplicateFieldMapping.duplicateFieldIds,
+                ),
+            );
+    }
+
+    return [...canonicalFields.values()].sort(
+        (left, right) => left.positionIndex - right.positionIndex,
+    );
+}
 
 export async function createGarden(garden: InsertGarden) {
     const createdGarden = (
@@ -491,6 +675,18 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
             const data = event.data as Record<string, unknown> | undefined;
             // Handle plant placement event
             if (event.type === knownEventTypes.raisedBedFields.plantPlace) {
+                // A field can be replanted after it was removed, so a new placement
+                // must restart the lifecycle instead of inheriting the previous one.
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
+                plantSowDate = undefined;
+                plantGrowthDate = undefined;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
+
                 // Parse plant sort ID if provided
                 if (typeof data?.plantSortId === 'number') {
                     plantSortId = data.plantSortId;
@@ -565,9 +761,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 } else if (plantStatus === 'removed') {
                     plantRemovedDate = event.createdAt;
                     active = false;
-
-                    // Don't process any newer events for this field
-                    break;
+                    stoppedDate = event.createdAt;
                 }
             }
             // Handle plant sort replace event
@@ -696,20 +890,18 @@ export async function mergeRaisedBeds(
     const db = storage();
 
     await db.transaction(async (tx) => {
-        const [targetRaisedBed, sourceRaisedBed] = await Promise.all([
-            tx.query.raisedBeds.findFirst({
-                where: and(
-                    eq(raisedBeds.id, targetRaisedBedId),
-                    eq(raisedBeds.isDeleted, false),
-                ),
-            }),
-            tx.query.raisedBeds.findFirst({
-                where: and(
-                    eq(raisedBeds.id, sourceRaisedBedId),
-                    eq(raisedBeds.isDeleted, false),
-                ),
-            }),
-        ]);
+        const targetRaisedBed = await tx.query.raisedBeds.findFirst({
+            where: and(
+                eq(raisedBeds.id, targetRaisedBedId),
+                eq(raisedBeds.isDeleted, false),
+            ),
+        });
+        const sourceRaisedBed = await tx.query.raisedBeds.findFirst({
+            where: and(
+                eq(raisedBeds.id, sourceRaisedBedId),
+                eq(raisedBeds.isDeleted, false),
+            ),
+        });
 
         if (!targetRaisedBed) {
             throw new Error(`Target raised bed ${targetRaisedBedId} not found`);
@@ -722,34 +914,36 @@ export async function mergeRaisedBeds(
             throw new Error('Raised beds must belong to the same garden');
         }
 
-        const [targetFields, sourceFields] = await Promise.all([
-            tx.query.raisedBedFields.findMany({
-                where: and(
-                    eq(raisedBedFields.raisedBedId, targetRaisedBedId),
-                    eq(raisedBedFields.isDeleted, false),
-                ),
-            }),
-            tx.query.raisedBedFields.findMany({
-                where: and(
-                    eq(raisedBedFields.raisedBedId, sourceRaisedBedId),
-                    eq(raisedBedFields.isDeleted, false),
-                ),
-            }),
-        ]);
+        const targetFields = await tx.query.raisedBedFields.findMany({
+            where: and(
+                eq(raisedBedFields.raisedBedId, targetRaisedBedId),
+                eq(raisedBedFields.isDeleted, false),
+            ),
+        });
+        const sourceFields = await tx.query.raisedBedFields.findMany({
+            where: and(
+                eq(raisedBedFields.raisedBedId, sourceRaisedBedId),
+                eq(raisedBedFields.isDeleted, false),
+            ),
+        });
 
-        const nextPositionIndex =
-            targetFields.reduce(
-                (max, field) => Math.max(max, field.positionIndex),
-                -1,
-            ) + 1;
+        await normalizeRaisedBedFieldsForMerge(
+            tx,
+            targetRaisedBedId,
+            targetFields,
+        );
+        const normalizedSourceFields = await normalizeRaisedBedFieldsForMerge(
+            tx,
+            sourceRaisedBedId,
+            sourceFields,
+        );
 
-        const sourceFieldMappings = sourceFields
-            .sort((a, b) => a.positionIndex - b.positionIndex)
-            .map((field, index) => ({
-                fieldId: field.id,
-                previousPositionIndex: field.positionIndex,
-                nextPositionIndex: nextPositionIndex + index,
-            }));
+        const sourceFieldMappings = normalizedSourceFields.map((field) => ({
+            fieldId: field.id,
+            previousPositionIndex: field.positionIndex,
+            nextPositionIndex:
+                field.positionIndex + RAISED_BED_FIELDS_PER_BLOCK,
+        }));
 
         for (const mapping of sourceFieldMappings) {
             await tx
@@ -761,38 +955,42 @@ export async function mergeRaisedBeds(
                 .where(eq(raisedBedFields.id, mapping.fieldId));
         }
 
-        await Promise.all([
-            tx
-                .update(operations)
-                .set({ raisedBedId: targetRaisedBedId })
-                .where(eq(operations.raisedBedId, sourceRaisedBedId)),
-            tx
-                .update(notifications)
-                .set({ raisedBedId: targetRaisedBedId })
-                .where(eq(notifications.raisedBedId, sourceRaisedBedId)),
-            tx
-                .update(shoppingCartItems)
-                .set({ raisedBedId: targetRaisedBedId })
-                .where(eq(shoppingCartItems.raisedBedId, sourceRaisedBedId)),
-            tx
-                .update(raisedBedSensors)
-                .set({ raisedBedId: targetRaisedBedId })
-                .where(eq(raisedBedSensors.raisedBedId, sourceRaisedBedId)),
-            tx
-                .update(events)
-                .set({ aggregateId: targetRaisedBedId.toString() })
-                .where(
-                    and(
-                        eq(events.aggregateId, sourceRaisedBedId.toString()),
-                        inArray(events.type, [
-                            knownEventTypes.raisedBeds.create,
-                            knownEventTypes.raisedBeds.place,
-                            knownEventTypes.raisedBeds.delete,
-                            knownEventTypes.raisedBeds.abandon,
-                        ]),
-                    ),
+        await tx
+            .update(operations)
+            .set({ raisedBedId: targetRaisedBedId })
+            .where(eq(operations.raisedBedId, sourceRaisedBedId));
+        await tx
+            .update(notifications)
+            .set({ raisedBedId: targetRaisedBedId })
+            .where(eq(notifications.raisedBedId, sourceRaisedBedId));
+        await tx
+            .update(shoppingCartItems)
+            .set({ isDeleted: true })
+            .where(
+                and(
+                    eq(shoppingCartItems.raisedBedId, sourceRaisedBedId),
+                    eq(shoppingCartItems.isDeleted, false),
+                    eq(shoppingCartItems.status, 'new'),
                 ),
-        ]);
+            );
+        await tx
+            .update(raisedBedSensors)
+            .set({ raisedBedId: targetRaisedBedId })
+            .where(eq(raisedBedSensors.raisedBedId, sourceRaisedBedId));
+        await tx
+            .update(events)
+            .set({ aggregateId: targetRaisedBedId.toString() })
+            .where(
+                and(
+                    eq(events.aggregateId, sourceRaisedBedId.toString()),
+                    inArray(events.type, [
+                        knownEventTypes.raisedBeds.create,
+                        knownEventTypes.raisedBeds.place,
+                        knownEventTypes.raisedBeds.delete,
+                        knownEventTypes.raisedBeds.abandon,
+                    ]),
+                ),
+            );
 
         for (const mapping of sourceFieldMappings) {
             await tx

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -8,11 +8,13 @@ import {
     deleteRaisedBedField,
     getAllOperations,
     getNotifications,
+    getOrCreateShoppingCart,
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     knownEvents,
     mergeRaisedBeds,
     storage,
+    upsertOrRemoveCartItem,
     upsertRaisedBedField,
 } from '@gredice/storage';
 import {
@@ -56,7 +58,7 @@ test('getRaisedBed returns raised bed with event-sourced fields', async () => {
     assert.strictEqual(raisedBed.fields.length, 1);
 });
 
-test('mergeRaisedBeds merges fields and linked records without data loss', async () => {
+test('mergeRaisedBeds remaps source fields to the next block boundary without data loss', async () => {
     createTestDb();
     const accountId = await createAccount();
     const farmId = await ensureFarmId();
@@ -78,7 +80,7 @@ test('mergeRaisedBeds merges fields and linked records without data loss', async
     await Promise.all([
         upsertRaisedBedField({
             raisedBedId: targetRaisedBedId,
-            positionIndex: 0,
+            positionIndex: 8,
         }),
         upsertRaisedBedField({
             raisedBedId: sourceRaisedBedId,
@@ -88,11 +90,33 @@ test('mergeRaisedBeds merges fields and linked records without data loss', async
 
     const sourceRaisedBed = await getRaisedBed(sourceRaisedBedId);
     assert.ok(sourceRaisedBed);
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart);
 
     const sourceField = sourceRaisedBed.fields[0];
     assert.ok(sourceField);
 
-    await Promise.all([
+    const [targetCartItemId, sourceCartItemId] = await Promise.all([
+        upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            '1',
+            'plantSort',
+            1,
+            gardenId,
+            targetRaisedBedId,
+            8,
+        ),
+        upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            '2',
+            'plantSort',
+            1,
+            gardenId,
+            sourceRaisedBedId,
+            0,
+        ),
         createOperation({
             accountId,
             entityId: 1,
@@ -119,6 +143,8 @@ test('mergeRaisedBeds merges fields and linked records without data loss', async
             ),
         ),
     ]);
+    assert.ok(targetCartItemId);
+    assert.ok(sourceCartItemId);
 
     await mergeRaisedBeds(targetRaisedBedId, sourceRaisedBedId);
 
@@ -128,6 +154,8 @@ test('mergeRaisedBeds merges fields and linked records without data loss', async
         operations,
         notifications,
         movedFieldEvent,
+        targetCartItemAfterMerge,
+        sourceCartItemAfterMerge,
     ] = await Promise.all([
         getRaisedBed(targetRaisedBedId),
         getRaisedBed(sourceRaisedBedId),
@@ -137,20 +165,34 @@ test('mergeRaisedBeds merges fields and linked records without data loss', async
             where: (events, { and, eq }) =>
                 and(
                     eq(events.type, 'raisedBedField.plantPlace'),
-                    eq(events.aggregateId, `${targetRaisedBedId.toString()}|1`),
+                    eq(events.aggregateId, `${targetRaisedBedId.toString()}|9`),
                 ),
+        }),
+        storage().query.shoppingCartItems.findFirst({
+            where: (shoppingCartItems, { eq }) =>
+                eq(shoppingCartItems.id, targetCartItemId),
+        }),
+        storage().query.shoppingCartItems.findFirst({
+            where: (shoppingCartItems, { eq }) =>
+                eq(shoppingCartItems.id, sourceCartItemId),
         }),
     ]);
 
     assert.strictEqual(sourceAfterMerge, null);
     assert.ok(targetRaisedBed);
-    assert.strictEqual(targetRaisedBed.fields.length, 2);
+    assert.strictEqual(targetRaisedBed.fields.length, 18);
+    assert.deepStrictEqual(
+        targetRaisedBed.fields
+            .map((field) => field.positionIndex)
+            .sort((a, b) => a - b),
+        Array.from({ length: 18 }, (_, index) => index),
+    );
 
     const movedField = targetRaisedBed.fields.find(
         (field) => field.id === sourceField.id,
     );
     assert.ok(movedField);
-    assert.strictEqual(movedField?.positionIndex, 1);
+    assert.strictEqual(movedField?.positionIndex, 9);
 
     const mergedOperation = operations.find(
         (operation) => operation.raisedBedFieldId === sourceField.id,
@@ -165,4 +207,182 @@ test('mergeRaisedBeds merges fields and linked records without data loss', async
     assert.strictEqual(mergedNotification?.raisedBedId, targetRaisedBedId);
 
     assert.ok(movedFieldEvent);
+    assert.ok(targetCartItemAfterMerge);
+    assert.strictEqual(targetCartItemAfterMerge?.isDeleted, false);
+    assert.strictEqual(
+        targetCartItemAfterMerge?.raisedBedId,
+        targetRaisedBedId,
+    );
+    assert.ok(sourceCartItemAfterMerge);
+    assert.strictEqual(sourceCartItemAfterMerge?.isDeleted, true);
+    assert.strictEqual(
+        sourceCartItemAfterMerge?.raisedBedId,
+        sourceRaisedBedId,
+    );
+});
+
+test('mergeRaisedBeds preserves sparse source positions inside the appended block', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockAId = await createTestBlock(gardenId, 'block-a');
+    const blockBId = await createTestBlock(gardenId, 'block-b');
+
+    const targetRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockAId,
+    );
+    const sourceRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockBId,
+    );
+
+    await Promise.all([
+        upsertRaisedBedField({
+            raisedBedId: targetRaisedBedId,
+            positionIndex: 8,
+        }),
+        upsertRaisedBedField({
+            raisedBedId: sourceRaisedBedId,
+            positionIndex: 2,
+        }),
+        upsertRaisedBedField({
+            raisedBedId: sourceRaisedBedId,
+            positionIndex: 8,
+        }),
+        createEvent(
+            knownEvents.raisedBedFields.plantPlaceV1(
+                `${sourceRaisedBedId.toString()}|2`,
+                {
+                    plantSortId: '101',
+                    scheduledDate: new Date().toISOString(),
+                },
+            ),
+        ),
+        createEvent(
+            knownEvents.raisedBedFields.plantPlaceV1(
+                `${sourceRaisedBedId.toString()}|8`,
+                {
+                    plantSortId: '102',
+                    scheduledDate: new Date().toISOString(),
+                },
+            ),
+        ),
+    ]);
+
+    await mergeRaisedBeds(targetRaisedBedId, sourceRaisedBedId);
+
+    const [targetRaisedBed, movedFirstEvent, movedLastEvent] =
+        await Promise.all([
+            getRaisedBed(targetRaisedBedId),
+            storage().query.events.findFirst({
+                where: (events, { and, eq }) =>
+                    and(
+                        eq(events.type, 'raisedBedField.plantPlace'),
+                        eq(
+                            events.aggregateId,
+                            `${targetRaisedBedId.toString()}|11`,
+                        ),
+                    ),
+            }),
+            storage().query.events.findFirst({
+                where: (events, { and, eq }) =>
+                    and(
+                        eq(events.type, 'raisedBedField.plantPlace'),
+                        eq(
+                            events.aggregateId,
+                            `${targetRaisedBedId.toString()}|17`,
+                        ),
+                    ),
+            }),
+        ]);
+
+    assert.ok(targetRaisedBed);
+    assert.strictEqual(targetRaisedBed.fields.length, 18);
+    assert.deepStrictEqual(
+        targetRaisedBed.fields
+            .map((field) => field.positionIndex)
+            .sort((a, b) => a - b),
+        Array.from({ length: 18 }, (_, index) => index),
+    );
+
+    const plantedPositions = targetRaisedBed.fields
+        .filter((field) => field.plantSortId)
+        .map((field) => field.positionIndex)
+        .sort((a, b) => a - b);
+
+    assert.deepStrictEqual(plantedPositions, [11, 17]);
+    assert.ok(movedFirstEvent);
+    assert.ok(movedLastEvent);
+});
+
+test('getRaisedBed returns the latest plant cycle after a field is removed and replanted', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-a');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '101',
+                scheduledDate: new Date(
+                    '2026-01-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'removed',
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '202',
+                scheduledDate: new Date(
+                    '2026-02-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'sprouted',
+            },
+        ),
+    );
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    assert.ok(raisedBed);
+
+    const field = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.ok(field);
+    assert.strictEqual(field?.active, true);
+    assert.strictEqual(field?.plantStatus, 'sprouted');
+    assert.strictEqual(field?.plantSortId, 202);
+    assert.strictEqual(
+        field?.plantScheduledDate?.toISOString(),
+        '2026-02-01T00:00:00.000Z',
+    );
 });


### PR DESCRIPTION
This ensures validity checks and orientation updates can reference block names (used in messages/heuristics) and prevents undefined lookups.
- apps/api: compute blockNameById in multiple route handlers so raised bed endpoints return validity info that includes block names.
- packages/storage: add a new maintenance script scripts/fixMergedRaisedBedPositions.ts to detect and repair raised bed field/cart-item position merges. The script identifies merged source beds, plans position shifts, and can perform fixes when run with --execute. This helps recover data after rapid merged events and provides operational tooling for storage consistency.

Why:
- Validity and orientation logic require block names to produce accurate validations and to correctly compute orientation-related updates.
- Fetching blocks with the garden reduces latency and avoids extra DB calls.
- The new repair script addresses a class of data corruption caused by rapid merge-like events, enabling safe, repeatable repairs.