### PR TITLE
✨ feat(raised-bed): mark occupied fields and improve merge logicIntroduce utilities and use them to treat raised bed fields as"occupied" instead of relying on the old `active` flag in multiplecomponents. This clarifies semantics and prevents incorrect plantingsuggestions and rendering of empty slots.

### DIFF
--- a/apps/api/lib/garden/gardenStacksSyncService.node.spec.ts
+++ b/apps/api/lib/garden/gardenStacksSyncService.node.spec.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getRaisedBedMergeCandidates } from './gardenStacksSyncService';
+
+describe('getRaisedBedMergeCandidates', () => {
+    it('does not miss a valid pair when an orphan raised-bed block is checked first', () => {
+        const mergeCandidates = getRaisedBedMergeCandidates({
+            placements: [
+                {
+                    blockId: 'active-a',
+                    index: 1,
+                    x: 0,
+                    y: 0,
+                },
+                {
+                    blockId: 'orphan-bed',
+                    index: 1,
+                    x: 0,
+                    y: -1,
+                },
+                {
+                    blockId: 'active-b',
+                    index: 1,
+                    x: 1,
+                    y: 0,
+                },
+            ],
+            raisedBeds: [
+                {
+                    id: 10,
+                    blockId: 'active-a',
+                    status: 'new',
+                },
+                {
+                    id: 11,
+                    blockId: 'active-b',
+                    status: 'new',
+                },
+            ],
+        });
+
+        assert.deepStrictEqual(mergeCandidates, [
+            {
+                targetRaisedBedId: 10,
+                sourceRaisedBedId: 11,
+            },
+        ]);
+    });
+});

--- a/apps/api/lib/garden/gardenStacksSyncService.ts
+++ b/apps/api/lib/garden/gardenStacksSyncService.ts
@@ -77,7 +77,7 @@ function getMissingRaisedBedBlockIds(
     return raisedBedsToCreate;
 }
 
-function getRaisedBedMergeCandidates(params: {
+export function getRaisedBedMergeCandidates(params: {
     placements: RaisedBedPlacement[];
     raisedBeds: { id: number; blockId: string | null; status: string }[];
 }) {
@@ -95,9 +95,11 @@ function getRaisedBedMergeCandidates(params: {
     );
 
     const merges = new Map<number, number>();
+    const mergedRaisedBedIds = new Set<number>();
+    const processedPairs = new Set<string>();
 
     for (const placement of placements) {
-        const adjacentPlacement = placements.find(
+        const adjacentPlacements = placements.filter(
             (candidate) =>
                 candidate.blockId !== placement.blockId &&
                 candidate.index === placement.index &&
@@ -106,47 +108,64 @@ function getRaisedBedMergeCandidates(params: {
                     (candidate.y === placement.y &&
                         Math.abs(candidate.x - placement.x) === 1)),
         );
-        if (!adjacentPlacement) {
+        if (adjacentPlacements.length === 0) {
             continue;
         }
 
-        const leftBlockId =
-            placement.blockId.localeCompare(adjacentPlacement.blockId) <= 0
-                ? placement.blockId
-                : adjacentPlacement.blockId;
-        const rightBlockId =
-            leftBlockId === placement.blockId
-                ? adjacentPlacement.blockId
-                : placement.blockId;
+        for (const adjacentPlacement of adjacentPlacements) {
+            const leftBlockId =
+                placement.blockId.localeCompare(adjacentPlacement.blockId) <= 0
+                    ? placement.blockId
+                    : adjacentPlacement.blockId;
+            const rightBlockId =
+                leftBlockId === placement.blockId
+                    ? adjacentPlacement.blockId
+                    : placement.blockId;
+            const pairKey = `${leftBlockId}|${rightBlockId}`;
+            if (processedPairs.has(pairKey)) {
+                continue;
+            }
+            processedPairs.add(pairKey);
 
-        const leftRaisedBed = raisedBedByBlockId.get(leftBlockId);
-        const rightRaisedBed = raisedBedByBlockId.get(rightBlockId);
-        if (!leftRaisedBed || !rightRaisedBed) {
-            continue;
-        }
+            const leftRaisedBed = raisedBedByBlockId.get(leftBlockId);
+            const rightRaisedBed = raisedBedByBlockId.get(rightBlockId);
+            if (!leftRaisedBed || !rightRaisedBed) {
+                continue;
+            }
 
-        if (leftRaisedBed.id === rightRaisedBed.id) {
-            continue;
-        }
+            if (leftRaisedBed.id === rightRaisedBed.id) {
+                continue;
+            }
 
-        if (leftRaisedBed.status !== 'new' || rightRaisedBed.status !== 'new') {
-            continue;
-        }
+            if (
+                leftRaisedBed.status !== 'new' ||
+                rightRaisedBed.status !== 'new'
+            ) {
+                continue;
+            }
 
-        const leftPlacement = placementByBlockId.get(leftBlockId);
-        const rightPlacement = placementByBlockId.get(rightBlockId);
-        if (!leftPlacement || !rightPlacement) {
-            continue;
-        }
+            if (
+                mergedRaisedBedIds.has(leftRaisedBed.id) ||
+                mergedRaisedBedIds.has(rightRaisedBed.id)
+            ) {
+                continue;
+            }
 
-        if (leftPlacement.index !== rightPlacement.index) {
-            continue;
-        }
+            const leftPlacement = placementByBlockId.get(leftBlockId);
+            const rightPlacement = placementByBlockId.get(rightBlockId);
+            if (!leftPlacement || !rightPlacement) {
+                continue;
+            }
 
-        const targetRaisedBedId = leftRaisedBed.id;
-        const sourceRaisedBedId = rightRaisedBed.id;
-        if (!merges.has(targetRaisedBedId)) {
+            if (leftPlacement.index !== rightPlacement.index) {
+                continue;
+            }
+
+            const targetRaisedBedId = leftRaisedBed.id;
+            const sourceRaisedBedId = rightRaisedBed.id;
             merges.set(targetRaisedBedId, sourceRaisedBedId);
+            mergedRaisedBedIds.add(targetRaisedBedId);
+            mergedRaisedBedIds.add(sourceRaisedBedId);
         }
     }
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
         "test": "pnpm run /^test:.*/",
         "test:run": "playwright test",
         "test:node": "node --import tsx --test --conditions=react-server ./lib/**/*.node.spec.ts",
+        "merge:raised-beds:all": "node --conditions=react-server --env-file=.env --import tsx ./scripts/mergeAllRaisedBeds.ts",
         "regenerate": "pnpm run /^regenerate:.*/",
         "regenerate:directories-api": "pnpm dlx openapi-typescript https://api.gredice.com/api/docs/directories -o ./lib/@types/directories-api/v1.d.ts"
     },

--- a/apps/api/scripts/mergeAllRaisedBeds.ts
+++ b/apps/api/scripts/mergeAllRaisedBeds.ts
@@ -1,0 +1,350 @@
+import { mergeRaisedBeds } from '@gredice/storage';
+import { Client } from 'pg';
+import { synchronizeGardenStacksAndRaisedBeds } from '../lib/garden/gardenStacksSyncService';
+
+type Args = {
+    execute: boolean;
+    gardenIds: number[];
+};
+
+type GardenMergeStats = {
+    gardenId: number;
+    maxDegree: number;
+    pairCount: number;
+    participatingBeds: number;
+};
+
+type MergeSnapshot = {
+    ambiguous: GardenMergeStats[];
+    safe: GardenMergeStats[];
+};
+
+type SafeMergePair = {
+    gardenId: number;
+    sourceRaisedBedId: number;
+    targetRaisedBedId: number;
+};
+
+function parseArgs(): Args {
+    const args = process.argv.slice(2);
+    const execute = args.includes('--execute');
+    const gardenIdsArg = args.find((arg) => arg.startsWith('--garden-ids='));
+
+    return {
+        execute,
+        gardenIds: gardenIdsArg
+            ? gardenIdsArg
+                  .slice('--garden-ids='.length)
+                  .split(',')
+                  .map((value) => Number.parseInt(value.trim(), 10))
+                  .filter((value) => Number.isInteger(value))
+            : [],
+    };
+}
+
+function sumPairCount(gardens: GardenMergeStats[]) {
+    return gardens.reduce((total, garden) => total + garden.pairCount, 0);
+}
+
+async function getMergeSnapshot(
+    client: Client,
+    gardenIds: number[],
+): Promise<MergeSnapshot> {
+    const params: unknown[] = [];
+    const gardenFilter =
+        gardenIds.length > 0
+            ? `and rb.garden_id = any($${params.push(gardenIds)}::int[])`
+            : '';
+
+    const result = await client.query<{
+        garden_id: number;
+        max_degree: number;
+        pair_count: string;
+        participating_beds: string;
+    }>(
+        `
+            with active_raised_beds as (
+                select id, garden_id, block_id
+                from raised_beds rb
+                where rb.is_deleted = false
+                  and rb.status = 'new'
+                  and rb.block_id is not null
+                  ${gardenFilter}
+            ),
+            block_positions as (
+                select
+                    rb.id,
+                    rb.garden_id,
+                    rb.block_id,
+                    gs.position_x,
+                    gs.position_y,
+                    array_position(gs.blocks, rb.block_id) as idx
+                from active_raised_beds rb
+                join garden_stacks gs
+                  on gs.garden_id = rb.garden_id
+                 and gs.is_deleted = false
+                 and rb.block_id = any(gs.blocks)
+            ),
+            edges as (
+                select distinct
+                    least(a.id, b.id) as left_id,
+                    greatest(a.id, b.id) as right_id,
+                    a.garden_id
+                from block_positions a
+                join block_positions b
+                  on a.garden_id = b.garden_id
+                 and a.id < b.id
+                 and a.idx = b.idx
+                 and (
+                    (
+                        a.position_x = b.position_x
+                        and abs(a.position_y - b.position_y) = 1
+                    ) or (
+                        a.position_y = b.position_y
+                        and abs(a.position_x - b.position_x) = 1
+                    )
+                 )
+            ),
+            degrees as (
+                select garden_id, raised_bed_id, count(*)::int as degree
+                from (
+                    select garden_id, left_id as raised_bed_id
+                    from edges
+                    union all
+                    select garden_id, right_id as raised_bed_id
+                    from edges
+                ) edge_members
+                group by garden_id, raised_bed_id
+            ),
+            garden_stats as (
+                select
+                    d.garden_id,
+                    max(d.degree)::int as max_degree,
+                    count(*)::int as participating_beds,
+                    pc.pair_count
+                from degrees d
+                join (
+                    select garden_id, count(*)::int as pair_count
+                    from edges
+                    group by garden_id
+                ) pc on pc.garden_id = d.garden_id
+                group by d.garden_id, pc.pair_count
+            )
+            select
+                garden_id,
+                max_degree,
+                pair_count::text,
+                participating_beds::text
+            from garden_stats
+            order by garden_id
+        `,
+        params,
+    );
+
+    const rows = result.rows.map((row) => ({
+        gardenId: row.garden_id,
+        maxDegree: row.max_degree,
+        pairCount: Number.parseInt(row.pair_count, 10),
+        participatingBeds: Number.parseInt(row.participating_beds, 10),
+    })) satisfies GardenMergeStats[];
+
+    return {
+        safe: rows.filter((row) => row.maxDegree === 1),
+        ambiguous: rows.filter((row) => row.maxDegree > 1),
+    };
+}
+
+async function getSafeMergePairs(
+    client: Client,
+    gardenIds: number[],
+): Promise<SafeMergePair[]> {
+    const params: unknown[] = [];
+    const gardenFilter =
+        gardenIds.length > 0
+            ? `and rb.garden_id = any($${params.push(gardenIds)}::int[])`
+            : '';
+
+    const result = await client.query<{
+        garden_id: number;
+        source_raised_bed_id: number;
+        target_raised_bed_id: number;
+    }>(
+        `
+            with active_raised_beds as (
+                select id, garden_id, block_id
+                from raised_beds rb
+                where rb.is_deleted = false
+                  and rb.status = 'new'
+                  and rb.block_id is not null
+                  ${gardenFilter}
+            ),
+            block_positions as (
+                select
+                    rb.id,
+                    rb.garden_id,
+                    rb.block_id,
+                    gs.position_x,
+                    gs.position_y,
+                    array_position(gs.blocks, rb.block_id) as idx
+                from active_raised_beds rb
+                join garden_stacks gs
+                  on gs.garden_id = rb.garden_id
+                 and gs.is_deleted = false
+                 and rb.block_id = any(gs.blocks)
+            ),
+            edges as (
+                select distinct
+                    a.garden_id,
+                    a.id as left_raised_bed_id,
+                    b.id as right_raised_bed_id,
+                    a.block_id as left_block_id,
+                    b.block_id as right_block_id
+                from block_positions a
+                join block_positions b
+                  on a.garden_id = b.garden_id
+                 and a.id < b.id
+                 and a.idx = b.idx
+                 and (
+                    (
+                        a.position_x = b.position_x
+                        and abs(a.position_y - b.position_y) = 1
+                    ) or (
+                        a.position_y = b.position_y
+                        and abs(a.position_x - b.position_x) = 1
+                    )
+                 )
+            ),
+            degrees as (
+                select garden_id, raised_bed_id, count(*)::int as degree
+                from (
+                    select garden_id, left_raised_bed_id as raised_bed_id
+                    from edges
+                    union all
+                    select garden_id, right_raised_bed_id as raised_bed_id
+                    from edges
+                ) edge_members
+                group by garden_id, raised_bed_id
+            ),
+            safe_gardens as (
+                select garden_id
+                from degrees
+                group by garden_id
+                having max(degree) = 1
+            )
+            select
+                e.garden_id,
+                case
+                    when e.left_block_id <= e.right_block_id
+                        then e.left_raised_bed_id
+                    else e.right_raised_bed_id
+                end as target_raised_bed_id,
+                case
+                    when e.left_block_id <= e.right_block_id
+                        then e.right_raised_bed_id
+                    else e.left_raised_bed_id
+                end as source_raised_bed_id
+            from edges e
+            join safe_gardens sg on sg.garden_id = e.garden_id
+            order by e.garden_id, target_raised_bed_id, source_raised_bed_id
+        `,
+        params,
+    );
+
+    return result.rows.map((row) => ({
+        gardenId: row.garden_id,
+        sourceRaisedBedId: row.source_raised_bed_id,
+        targetRaisedBedId: row.target_raised_bed_id,
+    }));
+}
+
+function printSummary(label: string, snapshot: MergeSnapshot) {
+    console.log(
+        JSON.stringify(
+            {
+                label,
+                ambiguousGardenCount: snapshot.ambiguous.length,
+                ambiguousGardens: snapshot.ambiguous,
+                safeGardenCount: snapshot.safe.length,
+                safeGardenIds: snapshot.safe.map((garden) => garden.gardenId),
+                safePairCount: sumPairCount(snapshot.safe),
+                totalPairCount:
+                    sumPairCount(snapshot.safe) +
+                    sumPairCount(snapshot.ambiguous),
+            },
+            null,
+            2,
+        ),
+    );
+}
+
+const { execute, gardenIds } = parseArgs();
+
+if (!process.env.POSTGRES_URL) {
+    throw new Error('POSTGRES_URL environment variable is not set.');
+}
+
+const client = new Client({
+    connectionString: process.env.POSTGRES_URL,
+});
+
+await client.connect();
+
+try {
+    const before = await getMergeSnapshot(client, gardenIds);
+    printSummary('before', before);
+
+    if (!execute) {
+        console.log(
+            'Dry run only. Re-run with --execute to merge the safe raised-bed pairs.',
+        );
+        if (before.ambiguous.length > 0) {
+            console.log(
+                'Ambiguous gardens were not selected for automatic merge.',
+            );
+        }
+        process.exit(0);
+    }
+
+    const failures: Array<{ error: string; gardenId: number }> = [];
+    const synchronizedGardenIds = new Set<number>();
+    const safeMergePairs = await getSafeMergePairs(client, gardenIds);
+
+    for (const [index, mergePair] of safeMergePairs.entries()) {
+        try {
+            await mergeRaisedBeds(
+                mergePair.targetRaisedBedId,
+                mergePair.sourceRaisedBedId,
+            );
+            console.log(
+                `Merged pair ${mergePair.targetRaisedBedId} <- ${mergePair.sourceRaisedBedId} in garden ${mergePair.gardenId} (${index + 1}/${safeMergePairs.length})`,
+            );
+            synchronizedGardenIds.add(mergePair.gardenId);
+        } catch (error) {
+            failures.push({
+                gardenId: mergePair.gardenId,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    for (const gardenId of synchronizedGardenIds) {
+        try {
+            await synchronizeGardenStacksAndRaisedBeds(gardenId);
+        } catch (error) {
+            failures.push({
+                gardenId,
+                error: `Post-merge sync failed: ${error instanceof Error ? error.message : String(error)}`,
+            });
+        }
+    }
+
+    const after = await getMergeSnapshot(client, gardenIds);
+    printSummary('after', after);
+
+    if (failures.length > 0) {
+        console.log(JSON.stringify({ failures }, null, 2));
+        process.exitCode = 1;
+    }
+} finally {
+    await client.end();
+}

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -4,6 +4,7 @@ import {
     findRaisedBedByBlockId,
     getRaisedBedBlockIds,
 } from '../../utils/raisedBedBlocks';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import { RaisedBedPlantField } from './RaisedBedPlantField';
 
 export function RiasedBedFields({ blockId }: { blockId: string }) {
@@ -35,7 +36,7 @@ export function RiasedBedFields({ blockId }: { blockId: string }) {
     const displayedFields = [
         ...(raisedBed?.fields?.filter(
             (field) =>
-                field.active &&
+                isRaisedBedFieldOccupied(field) &&
                 field.positionIndex >= blockOffset &&
                 field.positionIndex < blockOffset + 9,
         ) || []),

--- a/packages/game/src/hooks/useRaisedBedFieldRemove.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldRemove.ts
@@ -2,6 +2,10 @@ import { client } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { useGameState } from '../useGameState';
+import {
+    findRaisedBedOccupiedField,
+    isRaisedBedFieldOccupied,
+} from '../utils/raisedBedFields';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
 const mutationKey = ['gardens', 'current', 'raisedBedFieldRemove'];
@@ -33,9 +37,9 @@ export function useRaisedBedFieldRemove() {
                 throw new Error('Raised bed not found');
             }
 
-            const field = raisedBed.fields.find(
-                (field) =>
-                    field.positionIndex === positionIndex && field.active,
+            const field = findRaisedBedOccupiedField(
+                raisedBed.fields,
+                positionIndex,
             );
             if (!field) {
                 throw new Error('Field not found');
@@ -80,7 +84,7 @@ export function useRaisedBedFieldRemove() {
                         fields: raisedBed.fields.map((field) => {
                             if (
                                 field.positionIndex === positionIndex &&
-                                field.active
+                                isRaisedBedFieldOccupied(field)
                             ) {
                                 return {
                                     ...field,

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -13,6 +13,7 @@ import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { useSwapShoppingCartPositions } from '../../hooks/useSwapShoppingCartPositions';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import { getPositionIndexFromGrid } from '../../utils/raisedBedOrientation';
 import { RaisedBedFieldInvalidShape } from './RaisedBedFieldInvalidShape';
 import { RaisedBedFieldItem } from './RaisedBedFieldItem';
@@ -102,7 +103,7 @@ export function RaisedBedField({
     // Determine which positions have planted fields (not draggable)
     const plantedPositions = new Set(
         raisedBed.fields
-            .filter((field) => field.active)
+            .filter((field) => isRaisedBedFieldOccupied(field))
             .map((field) => field.positionIndex),
     );
 

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
@@ -1,4 +1,5 @@
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { findRaisedBedOccupiedField } from '../../utils/raisedBedFields';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import { RaisedBedFieldItemEmpty } from './RaisedBedFieldItemEmpty';
 import { RaisedBedFieldItemPlanted } from './RaisedBedFieldItemPlanted';
@@ -20,9 +21,7 @@ export function RaisedBedFieldItem({
         return null;
     }
 
-    const field = raisedBed.fields.find(
-        (field) => field.positionIndex === positionIndex && field.active,
-    );
+    const field = findRaisedBedOccupiedField(raisedBed.fields, positionIndex);
     const hasField = Boolean(field);
 
     if (isGardenLoading) {

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -24,6 +24,7 @@ import { useState } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
 import { KnownPages } from '../../knownPages';
+import { findRaisedBedOccupiedField } from '../../utils/raisedBedFields';
 import { RaisedBedFieldDiary } from './RaisedBedDiary';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import {
@@ -43,9 +44,7 @@ export function RaisedBedFieldItemPlanted({
 }) {
     const { data: garden, isLoading: isGardenLoading } = useCurrentGarden();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
-    const field = raisedBed?.fields.find(
-        (field) => field.positionIndex === positionIndex && field.active,
-    );
+    const field = findRaisedBedOccupiedField(raisedBed?.fields, positionIndex);
     const plantSortId = field?.plantSortId;
     const { data: plantSort, isLoading: isPlantSortLoading } =
         usePlantSort(plantSortId);

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -10,6 +10,7 @@ import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
 import { useRaisedBedFieldRemove } from '../../hooks/useRaisedBedFieldRemove';
 import { ShovelIcon } from '../../icons/Shovel';
+import { findRaisedBedOccupiedField } from '../../utils/raisedBedFields';
 import type { PlantFieldStatus } from './featuredOperations';
 import { PlantStageSection } from './PlantStageSection';
 import { RecommendationsCard } from './RecommendationsCard';
@@ -32,9 +33,7 @@ export function useRaisedBedFieldLifecycleData(
     };
     const { data: garden } = useCurrentGarden();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
-    const field = raisedBed?.fields.find(
-        (field) => field.positionIndex === positionIndex && field.active,
-    );
+    const field = findRaisedBedOccupiedField(raisedBed?.fields, positionIndex);
     const plantSortId = field?.plantSortId;
     const { data: plantSort } = usePlantSort(plantSortId);
     if (!raisedBed || !field || !plantSort) {
@@ -168,10 +167,7 @@ export function RaisedBedFieldLifecycleTab({
     const removeFieldMutation = useRaisedBedFieldRemove();
 
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
-    const field = raisedBed?.fields.find(
-        (currentField) =>
-            currentField.positionIndex === positionIndex && currentField.active,
-    );
+    const field = findRaisedBedOccupiedField(raisedBed?.fields, positionIndex);
     const { data: plantSort } = usePlantSort(field?.plantSortId);
 
     if (!garden || !plantSort || !field) {

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -6,6 +6,10 @@ import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
 import { useGameState } from '../../useGameState';
+import {
+    countRaisedBedOccupiedFields,
+    findRaisedBedOccupiedField,
+} from '../../utils/raisedBedFields';
 import { RaisedBedCard } from './RaisedBedCard';
 
 type QuickSeedType = 'spring' | 'summer' | 'fall' | 'winter' | 'salad';
@@ -215,9 +219,7 @@ export function RaisedBedFieldSuggestions({
     const cartPlantItems = cartItems?.filter(
         (item) => item.entityTypeName === 'plantSort' && item.status === 'new',
     );
-    const plantedFieldsCount = raisedBed.fields.filter(
-        (field) => field.active,
-    ).length;
+    const plantedFieldsCount = countRaisedBedOccupiedFields(raisedBed.fields);
     if (plantedFieldsCount + (cartPlantItems?.length ?? 0) >= 18) {
         console.debug('Skipping planting suggestions: raised bed is full', {
             plantedFieldsCount,
@@ -250,13 +252,7 @@ export function RaisedBedFieldSuggestions({
                 const sort = allSorts.find((item) => item.id === sortId);
                 if (!sort?.store?.availableInStore) return;
 
-                if (
-                    raisedBed.fields.find(
-                        (field) =>
-                            field.positionIndex === index && field.active,
-                    )
-                )
-                    return;
+                if (findRaisedBedOccupiedField(raisedBed.fields, index)) return;
                 if (
                     shoppingCart.items.find(
                         (item) =>

--- a/packages/game/src/hud/raisedBed/RaisedBedInfoTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfoTab.tsx
@@ -2,6 +2,10 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useAllSorts } from '../../hooks/usePlantSorts';
+import {
+    countRaisedBedOccupiedFields,
+    isRaisedBedFieldOccupied,
+} from '../../utils/raisedBedFields';
 
 export function RaisedBedInfoTab({
     gardenId,
@@ -23,7 +27,7 @@ export function RaisedBedInfoTab({
     // Get all raised bed fields and calculate average, min and max yield based on plant sorts
     const yieldStats = raisedBed?.fields.reduce(
         (acc, field) => {
-            if (!field.active) return acc;
+            if (!isRaisedBedFieldOccupied(field)) return acc;
             const sortData = sorts?.find(
                 (sort) => sort.id === field.plantSortId,
             );
@@ -57,7 +61,7 @@ export function RaisedBedInfoTab({
             <Stack>
                 <Typography level="body2">Broj popunjenih polja</Typography>
                 <Typography level="body1">
-                    {raisedBed.fields.filter((field) => field.active).length}
+                    {countRaisedBedOccupiedFields(raisedBed.fields)}
                 </Typography>
             </Stack>
             <Stack>

--- a/packages/game/src/utils/raisedBedFields.ts
+++ b/packages/game/src/utils/raisedBedFields.ts
@@ -1,0 +1,30 @@
+type RaisedBedFieldLike = {
+    active?: boolean | null;
+    plantSortId?: number | null;
+    positionIndex: number;
+};
+
+export function isRaisedBedFieldOccupied(
+    field: Omit<RaisedBedFieldLike, 'positionIndex'> | null | undefined,
+) {
+    return Boolean(field?.active && typeof field.plantSortId === 'number');
+}
+
+export function findRaisedBedOccupiedField<T extends RaisedBedFieldLike>(
+    fields: T[] | null | undefined,
+    positionIndex: number,
+) {
+    return fields?.find(
+        (field) =>
+            field.positionIndex === positionIndex &&
+            isRaisedBedFieldOccupied(field),
+    );
+}
+
+export function countRaisedBedOccupiedFields<T extends RaisedBedFieldLike>(
+    fields: T[] | null | undefined,
+) {
+    return (
+        fields?.filter((field) => isRaisedBedFieldOccupied(field)).length ?? 0
+    );
+}


### PR DESCRIPTION
- Add and use isRaisedBedFieldOccupied, countRaisedBedOccupiedFields,
 and findRaisedBedOccupiedField to check/aggregate occupancy in RaisedBedFields and RaisedBedFieldSuggestions.
- Replace ad-hoc field.active checks with the new helpers to ensure consistent occupancy logic across UI and suggestion flow. This avoids suggesting plants for already-occupied positions and fixes display of fields per block offsets.
- Add a new npm script merge:raised-beds:all to apps/api package.json to run the raised bed merge script more easily.
- Export getRaisedBedMergeCandidates and refactor its loop to gather adjacent placements, introduce mergedRaisedBedIds and processedPairs to prepare for safer merge candidate computation and avoid duplicate work when evaluating neighboring placements.

These changes standardize occupancy handling and make merge candidateprocessing more robust, reducing bugs in planting suggestions and bedmerging logic.