### PR TITLE
✨ feat(raised-bed): show correct positions and unify raisedBedFullUpdate raised bed scheduling and HUD components to properly handlephysical position indexing and the 'raisedBedFull' application.

### DIFF
--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -63,8 +63,6 @@ export function RaisedBedOperationsScheduleSection({
                 ),
         )
         .map((operation) => {
-            const isFirstRaisedBed =
-                operation.raisedBedId === sortedRaisedBeds.at(0)?.id;
             const field = operation.raisedBedFieldId
                 ? sortedRaisedBeds
                       .flatMap((raisedBed) => raisedBed.fields)
@@ -80,13 +78,8 @@ export function RaisedBedOperationsScheduleSection({
                 : null;
 
             const physicalPositionIndex = field
-                ? (isFirstRaisedBed
-                      ? field.positionIndex + 1
-                      : field.positionIndex + 10
-                  ).toString()
-                : isFirstRaisedBed
-                  ? '1-9'
-                  : '10-18';
+                ? (field.positionIndex + 1).toString()
+                : '';
 
             return {
                 ...operation,
@@ -108,7 +101,7 @@ export function RaisedBedOperationsScheduleSection({
         const operationData = operationDataById.get(operation.entityId);
         const isFullRaisedBed =
             operationData?.attributes?.application === 'raisedBedFull';
-        const text = `${isFullRaisedBed ? '' : `${operation.physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${operation.sort ? `: ${operation.sort.information?.name ?? 'Nepoznato'}` : ''}`;
+        const text = `${isFullRaisedBed || !operation.physicalPositionIndex ? '' : `${operation.physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${operation.sort ? `: ${operation.sort.information?.name ?? 'Nepoznato'}` : ''}`;
 
         return {
             id: `operation-${operation.id}`,
@@ -134,7 +127,7 @@ export function RaisedBedOperationsScheduleSection({
             const operationData = operationDataById.get(operation.entityId);
             const isFullRaisedBed =
                 operationData?.attributes?.application === 'raisedBedFull';
-            const label = `${isFullRaisedBed ? '' : `${operation.physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${operation.sort ? `: ${operation.sort.information?.name ?? 'Nepoznato'}` : ''}`;
+            const label = `${isFullRaisedBed || !operation.physicalPositionIndex ? '' : `${operation.physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${operation.sort ? `: ${operation.sort.information?.name ?? 'Nepoznato'}` : ''}`;
 
             return {
                 id: operation.id,
@@ -195,7 +188,7 @@ export function RaisedBedOperationsScheduleSection({
                     const isFullRaisedBed =
                         operationData?.attributes?.application ===
                         'raisedBedFull';
-                    const operationLabel = `${isFullRaisedBed ? '' : `${operation.physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${operation.sort ? `: ${operation.sort.information?.name ?? 'Nepoznato'}` : ''}`;
+                    const operationLabel = `${isFullRaisedBed || !operation.physicalPositionIndex ? '' : `${operation.physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${operation.sort ? `: ${operation.sort.information?.name ?? 'Nepoznato'}` : ''}`;
 
                     const operationInactive =
                         isOperationCancelled(operation.status) ||

--- a/apps/www/app/LayoutContainer.tsx
+++ b/apps/www/app/LayoutContainer.tsx
@@ -11,7 +11,7 @@ export function LayoutContainer({
 }>) {
     const pathname = usePathname();
 
-    if (pathname === '/') {
+    if (pathname === '/' || pathname.startsWith('/blokovi/biljke/generator')) {
         return <>{children}</>;
     }
 

--- a/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
@@ -50,7 +50,7 @@ export function RaisedBedWatering({
                     filterFunc={(operation) =>
                         operation.attributes.stage.information?.name ===
                             'watering' &&
-                        operation.attributes.application === 'raisedBed1m'
+                        operation.attributes.application === 'raisedBedFull'
                     }
                 />
             </Stack>


### PR DESCRIPTION
- Remove special-casing for the first raised bed; compute physicalPositionIndex from the field position when available and otherwise use an empty string so labels don't show misleading ranges.
- Ensure labels omit position when the operation is a full raised bed or when physicalPositionIndex is empty. Apply this logic in list,
 select, and detail renderings to keep UI consistent.
- Change watering HUD filter to use 'raisedBedFull' application (was 'raisedBed1m') so watering operations are displayed for the correct raised bed type.
- Allow LayoutContainer to render root layout for generator routes by treating paths that start with '/blokovi/biljke/generator' like '/'.

This fixes incorrect position labels and inconsistent filtering acrossraised bed UIs, improving clarity and correctness for full-bedoperations.