### PR TITLE
Add archive-all control for closed delivery slots

### DIFF
--- a/apps/app/app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx
+++ b/apps/app/app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { useTransition } from 'react';
+import { archiveClosedTimeSlotsAction } from './actions';
+
+interface ArchiveClosedSlotsButtonProps {
+    slotIds: number[];
+}
+
+export function ArchiveClosedSlotsButton({
+    slotIds,
+}: ArchiveClosedSlotsButtonProps) {
+    const [isPending, startTransition] = useTransition();
+
+    const handleArchiveAll = () => {
+        startTransition(async () => {
+            const result = await archiveClosedTimeSlotsAction(slotIds);
+            if (!result.success) {
+                alert(result.message);
+            }
+        });
+    };
+
+    return (
+        <Button
+            variant="outlined"
+            color="neutral"
+            onClick={handleArchiveAll}
+            disabled={isPending || slotIds.length === 0}
+            loading={isPending}
+        >
+            Arhiviraj sve zatvorene ({slotIds.length})
+        </Button>
+    );
+}

--- a/apps/app/app/admin/delivery/slots/actions.ts
+++ b/apps/app/app/admin/delivery/slots/actions.ts
@@ -6,6 +6,7 @@ import {
     bulkGenerateTimeSlots,
     closeTimeSlot,
     createTimeSlot,
+    getTimeSlot,
     TimeSlotStatuses,
     updateTimeSlot,
 } from '@gredice/storage';
@@ -223,6 +224,63 @@ export async function archiveTimeSlotAction(slotId: number) {
                 error instanceof Error
                     ? error.message
                     : 'Greška pri arhiviranju slota',
+        };
+    }
+}
+
+export async function archiveClosedTimeSlotsAction(slotIds: number[]) {
+    try {
+        await auth(['admin']);
+
+        if (slotIds.length === 0) {
+            return {
+                success: false,
+                message: 'Nema zatvorenih slotova za arhiviranje',
+            };
+        }
+
+        const now = new Date();
+        const eligibleSlotIds: number[] = [];
+
+        await Promise.all(
+            slotIds.map(async (slotId) => {
+                const slot = await getTimeSlot(slotId);
+                if (
+                    slot &&
+                    slot.status === TimeSlotStatuses.CLOSED &&
+                    new Date(slot.endAt) < now
+                ) {
+                    eligibleSlotIds.push(slotId);
+                }
+            }),
+        );
+
+        if (eligibleSlotIds.length === 0) {
+            return {
+                success: false,
+                message: 'Nema zatvorenih slotova koji se mogu arhivirati',
+            };
+        }
+
+        await Promise.all(
+            eligibleSlotIds.map(async (slotId) => {
+                await archiveTimeSlot(slotId);
+            }),
+        );
+
+        revalidatePath('/admin/delivery/slots');
+        return {
+            success: true,
+            message: `Arhivirano ${eligibleSlotIds.length} zatvorenih slotova`,
+        };
+    } catch (error) {
+        console.error('Failed to archive closed slots:', error);
+        return {
+            success: false,
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'Greška pri arhiviranju zatvorenih slotova',
         };
     }
 }

--- a/apps/app/app/admin/delivery/slots/page.tsx
+++ b/apps/app/app/admin/delivery/slots/page.tsx
@@ -1,4 +1,4 @@
-import { getPickupLocations } from '@gredice/storage';
+import { getAllTimeSlots, getPickupLocations } from '@gredice/storage';
 import { Add, Calendar } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
@@ -6,6 +6,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { auth } from '../../../../lib/auth/auth';
+import { ArchiveClosedSlotsButton } from './ArchiveClosedSlotsButton';
 import { BulkGenerateModal } from './BulkGenerateModal';
 import { CreateTimeSlotModal } from './CreateTimeSlotModal';
 import { TimeSlotsFilters } from './TimeSlotsFilters';
@@ -20,8 +21,18 @@ export default async function AdminTimeSlotsPage({
 }) {
     await auth(['admin']);
 
-    const pickupLocations = await getPickupLocations();
+    const [pickupLocations, timeSlots] = await Promise.all([
+        getPickupLocations(),
+        getAllTimeSlots(),
+    ]);
     const params = await searchParams;
+
+    const now = new Date();
+    const archivableClosedSlotIds = timeSlots
+        .filter(
+            (slot) => slot.status === 'closed' && new Date(slot.endAt) < now,
+        )
+        .map((slot) => slot.id);
     const statusParam =
         typeof params.status === 'string' ? params.status : 'active';
     const status = statusParam === 'all' ? 'all' : 'active';
@@ -56,6 +67,10 @@ export default async function AdminTimeSlotsPage({
                         locations={pickupLocations}
                     />
                 </Row>
+            </Row>
+
+            <Row justifyContent="flex-end">
+                <ArchiveClosedSlotsButton slotIds={archivableClosedSlotIds} />
             </Row>
 
             <TimeSlotsFilters />


### PR DESCRIPTION
### Motivation

- Provide an admin convenience to archive all eligible closed delivery slots in one action to reduce manual work.
- Ensure bulk operation only archives slots that are still `closed` and whose `endAt` is in the past to avoid accidental archival.
- Surface a client-side loading state and disable the control when no eligible slots exist for clear UX feedback.

### Description

- Added a new client component `ArchiveClosedSlotsButton` that accepts `slotIds`, shows a loading state via `useTransition`, and disables when `slotIds.length === 0` (file: `app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx`).
- Implemented a server action `archiveClosedTimeSlotsAction(slotIds: number[])` that runs `auth(['admin'])`, revalidates eligibility by calling `getTimeSlot` for each id (only archives those with status `TimeSlotStatuses.CLOSED` and `endAt` < now), archives eligible slots via `archiveTimeSlot`, and calls `revalidatePath('/admin/delivery/slots')` (file: `app/admin/delivery/slots/actions.ts`).
- Updated the admin delivery slots page to fetch `getAllTimeSlots()` server-side, compute `archivableClosedSlotIds` (closed + past end time), and render the new `ArchiveClosedSlotsButton` above the filters (file: `app/admin/delivery/slots/page.tsx`).

### Testing

- Ran `pnpm --filter app lint` which completed successfully (fixed minor formatting issues).
- Ran `pnpm --filter app exec biome check --write app/admin/delivery/slots/actions.ts app/admin/delivery/slots/page.tsx app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx` which reported no remaining issues.
- Attempted to run the dev server and capture a page screenshot with Playwright, but the admin route requires authentication and a `POSTGRES_URL` environment variable in this environment, so end-to-end rendering validation was not possible in CI here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ecc6e814832f8fcd0b66445a98a7)