### PR TITLE
✨ feat: load and display plant cycles in raised bed fields raised bed field plant cycles expose to UI sofield cards display the most recent and active plant cycle info.

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -9,6 +9,7 @@ import {
     getEntityFormatted,
     getRaisedBed,
     knownEvents,
+    moveRaisedBedFieldPlantHistory,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import type { EntityStandardized } from '../../lib/@types/EntityStandardized';
@@ -135,6 +136,81 @@ export async function raisedBedFieldUpdatePlant({
     }
 
     revalidatePath(KnownPages.RaisedBed(raisedBedId));
+}
+
+export async function moveRaisedBedFieldPlantAction({
+    raisedBedId,
+    sourcePositionIndex,
+    targetPositionIndex,
+    sourcePlantPlaceEventId,
+}: {
+    raisedBedId: number;
+    sourcePositionIndex: number;
+    targetPositionIndex: number;
+    sourcePlantPlaceEventId: number;
+}) {
+    await auth(['admin']);
+
+    if (sourcePositionIndex === targetPositionIndex) {
+        return {
+            success: false,
+            message: 'Izvorišno i ciljno polje moraju biti različiti.',
+        };
+    }
+
+    if (sourcePositionIndex < 0 || targetPositionIndex < 0) {
+        return {
+            success: false,
+            message: 'Pozicije polja moraju biti nula ili veće.',
+        };
+    }
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (!raisedBed) {
+        return {
+            success: false,
+            message: `Gredica s ID-em ${raisedBedId} nije pronađena.`,
+        };
+    }
+
+    const highestPositionIndex = Math.max(
+        8,
+        ...raisedBed.fields.map((field) => field.positionIndex),
+    );
+    if (targetPositionIndex > highestPositionIndex) {
+        return {
+            success: false,
+            message: 'Ciljno polje nije dostupno u ovoj gredici.',
+        };
+    }
+
+    try {
+        await moveRaisedBedFieldPlantHistory({
+            raisedBedId,
+            sourcePositionIndex,
+            targetPositionIndex,
+            sourcePlantPlaceEventId,
+        });
+    } catch (error) {
+        return {
+            success: false,
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'Premještanje biljke nije uspjelo.',
+        };
+    }
+
+    revalidatePath(KnownPages.Schedule);
+    if (raisedBed.accountId)
+        revalidatePath(KnownPages.Account(raisedBed.accountId));
+    if (raisedBed.gardenId)
+        revalidatePath(KnownPages.Garden(raisedBed.gardenId));
+    revalidatePath(KnownPages.RaisedBed(raisedBedId));
+
+    return {
+        success: true,
+    };
 }
 
 export async function acceptRaisedBedFieldAction(

--- a/apps/app/components/raised-beds/MoveRaisedBedFieldPlantModal.tsx
+++ b/apps/app/components/raised-beds/MoveRaisedBedFieldPlantModal.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useEffect, useState, useTransition } from 'react';
+import { moveRaisedBedFieldPlantAction } from '../../app/(actions)/raisedBedFieldsActions';
+
+type MoveRaisedBedFieldPlantOption = {
+    value: string;
+    label: string;
+};
+
+type MoveRaisedBedFieldPlantModalProps = {
+    raisedBedId: number;
+    sourcePositionIndex: number;
+    sourcePlantPlaceEventId: number;
+    sourcePlantLabel: string;
+    targetOptions: MoveRaisedBedFieldPlantOption[];
+};
+
+export function MoveRaisedBedFieldPlantModal({
+    raisedBedId,
+    sourcePositionIndex,
+    sourcePlantPlaceEventId,
+    sourcePlantLabel,
+    targetOptions,
+}: MoveRaisedBedFieldPlantModalProps) {
+    const [open, setOpen] = useState(false);
+    const [selectedTarget, setSelectedTarget] = useState(
+        targetOptions[0]?.value ?? '',
+    );
+    const [isPending, startTransition] = useTransition();
+
+    useEffect(() => {
+        if (targetOptions.some((option) => option.value === selectedTarget)) {
+            return;
+        }
+
+        setSelectedTarget(targetOptions[0]?.value ?? '');
+    }, [selectedTarget, targetOptions]);
+
+    const handleMove = () => {
+        if (!selectedTarget) {
+            return;
+        }
+
+        startTransition(async () => {
+            const targetPositionIndex = Number.parseInt(selectedTarget, 10);
+            const result = await moveRaisedBedFieldPlantAction({
+                raisedBedId,
+                sourcePositionIndex,
+                targetPositionIndex,
+                sourcePlantPlaceEventId,
+            });
+
+            if (!result.success) {
+                alert(result.message);
+                return;
+            }
+
+            setOpen(false);
+        });
+    };
+
+    return (
+        <Modal
+            title={`Premjesti biljku: ${sourcePlantLabel}`}
+            trigger={
+                <Button
+                    variant="outlined"
+                    size="sm"
+                    disabled={targetOptions.length === 0}
+                >
+                    Premjesti
+                </Button>
+            }
+            open={open}
+            onOpenChange={setOpen}
+        >
+            <Stack spacing={2}>
+                <Typography level="body2">
+                    Premještanje čuva postojeće datume događaja i prenosi samo
+                    odabranu povijest biljke. Ako na ciljnom polju postoji
+                    preklapanje u tom vremenskom rasponu, povijesti će
+                    zamijeniti pozicije.
+                </Typography>
+
+                <SelectItems
+                    label="Ciljno polje"
+                    placeholder="Odaberi polje"
+                    items={targetOptions}
+                    value={selectedTarget}
+                    onValueChange={setSelectedTarget}
+                    disabled={isPending || targetOptions.length === 0}
+                />
+
+                <Row spacing={1}>
+                    <Button
+                        variant="plain"
+                        onClick={() => setOpen(false)}
+                        disabled={isPending}
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        variant="solid"
+                        onClick={handleMove}
+                        disabled={!selectedTarget || isPending}
+                        loading={isPending}
+                    >
+                        Premjesti
+                    </Button>
+                </Row>
+            </Stack>
+        </Modal>
+    );
+}

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -1,5 +1,9 @@
 import type { PlantSortData } from '@gredice/client';
-import { getEntitiesFormatted, getRaisedBed } from '@gredice/storage';
+import {
+    getEntitiesFormatted,
+    getRaisedBed,
+    getRaisedBedFieldPlantCycles,
+} from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -8,6 +12,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { RaisedBedFieldPlantSortSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector';
 import { RaisedBedFieldPlantStatusSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
+import { MoveRaisedBedFieldPlantModal } from './MoveRaisedBedFieldPlantModal';
 import {
     RaisedBedRemovedFieldsModal,
     type RemovedFieldDetails,
@@ -16,6 +21,9 @@ import {
 type RaisedBedField = NonNullable<
     Awaited<ReturnType<typeof getRaisedBed>>
 >['fields'][number];
+type RaisedBedFieldPlantCycle = Awaited<
+    ReturnType<typeof getRaisedBedFieldPlantCycles>
+>[number];
 
 const fieldStatusMetadata: Record<string, { label: string; icon: string }> = {
     new: { label: 'Novo', icon: '🆕' },
@@ -63,12 +71,27 @@ interface RaisedBedFieldsTableProps {
 export async function RaisedBedFieldsTable({
     raisedBedId,
 }: RaisedBedFieldsTableProps) {
-    const sortsData = await getEntitiesFormatted<PlantSortData>('plantSort');
-    const raisedBed = await getRaisedBed(raisedBedId);
+    const [sortsData, raisedBed, plantCycles] = await Promise.all([
+        getEntitiesFormatted<PlantSortData>('plantSort'),
+        getRaisedBed(raisedBedId),
+        getRaisedBedFieldPlantCycles(raisedBedId),
+    ]);
     const fields = raisedBed?.fields ?? [];
 
     if (!raisedBed || fields.length === 0) {
         return <NoDataPlaceholder />;
+    }
+
+    const plantCyclesByPosition = new Map<number, RaisedBedFieldPlantCycle[]>();
+    for (const plantCycle of plantCycles) {
+        const positionPlantCycles = plantCyclesByPosition.get(
+            plantCycle.positionIndex,
+        );
+        if (positionPlantCycles) {
+            positionPlantCycles.push(plantCycle);
+        } else {
+            plantCyclesByPosition.set(plantCycle.positionIndex, [plantCycle]);
+        }
     }
 
     const highestPositionIndex = Math.max(
@@ -88,15 +111,100 @@ export async function RaisedBedFieldsTable({
         <Stack spacing={3}>
             <div className="grid gap-3 grid-cols-3">
                 {orderedPositions.map((positionIndex) => {
+                    const positionPlantCycles = [
+                        ...(plantCyclesByPosition.get(positionIndex) ?? []),
+                    ].sort(
+                        (left, right) =>
+                            new Date(right.startedAt).getTime() -
+                            new Date(left.startedAt).getTime(),
+                    );
+                    const activePlantCycle = positionPlantCycles.find(
+                        (plantCycle) => plantCycle.active,
+                    );
                     const field = fields.find(
                         (item) =>
-                            item.positionIndex === positionIndex && item.active,
+                            item.positionIndex === positionIndex &&
+                            item.active &&
+                            typeof item.plantSortId === 'number',
                     );
-                    const removedFieldsAtPosition = fields
+                    const moveTargetOptions = [...orderedPositions]
+                        .sort((a, b) => a - b)
                         .filter(
-                            (f) =>
-                                !f.active && f.positionIndex === positionIndex,
+                            (targetPositionIndex) =>
+                                targetPositionIndex !== positionIndex,
                         )
+                        .map((targetPositionIndex) => {
+                            const targetField = fields.find(
+                                (item) =>
+                                    item.positionIndex ===
+                                        targetPositionIndex &&
+                                    item.active &&
+                                    typeof item.plantSortId === 'number',
+                            );
+                            const targetSort = targetField?.plantSortId
+                                ? sortsData?.find(
+                                      (item) =>
+                                          item.id === targetField.plantSortId,
+                                  )
+                                : undefined;
+
+                            return {
+                                value: targetPositionIndex.toString(),
+                                label: `Polje ${targetPositionIndex + 1} · ${
+                                    targetField
+                                        ? getSortLabel(
+                                              targetSort,
+                                              targetField.plantSortId,
+                                          )
+                                        : 'Prazno'
+                                }`,
+                            };
+                        });
+                    const removedFieldsAtPosition = positionPlantCycles
+                        .filter((plantCycle) => !plantCycle.active)
+                        .map((plantCycle) => {
+                            const sort = sortsData?.find(
+                                (item) => item.id === plantCycle.plantSortId,
+                            );
+                            const statusMeta = getStatusMeta(
+                                plantCycle.plantStatus,
+                            );
+                            return {
+                                id: plantCycle.plantPlaceEventId,
+                                positionIndex: plantCycle.positionIndex,
+                                plantPlaceEventId: plantCycle.plantPlaceEventId,
+                                plantLabel: getSortLabel(
+                                    sort,
+                                    plantCycle.plantSortId,
+                                ),
+                                plantStatusLabel: statusMeta?.label ?? null,
+                                plantStatusIcon: statusMeta?.icon ?? null,
+                                sortData: sort,
+                                createdAt: normalizeDate(plantCycle.startedAt),
+                                plantScheduledDate: normalizeDate(
+                                    plantCycle.plantScheduledDate,
+                                ),
+                                plantSowDate: normalizeDate(
+                                    plantCycle.plantSowDate,
+                                ),
+                                plantGrowthDate: normalizeDate(
+                                    plantCycle.plantGrowthDate,
+                                ),
+                                plantReadyDate: normalizeDate(
+                                    plantCycle.plantReadyDate,
+                                ),
+                                plantHarvestedDate: normalizeDate(
+                                    plantCycle.plantHarvestedDate,
+                                ),
+                                plantDeadDate: normalizeDate(
+                                    plantCycle.plantDeadDate,
+                                ),
+                                plantRemovedDate: normalizeDate(
+                                    plantCycle.plantRemovedDate ??
+                                        plantCycle.endedAt,
+                                ),
+                            } satisfies RemovedFieldDetails;
+                        })
                         .sort((a, b) => {
                             const dateA = a.plantRemovedDate ?? a.createdAt;
                             const dateB = b.plantRemovedDate ?? b.createdAt;
@@ -105,46 +213,18 @@ export async function RaisedBedFieldsTable({
                                 new Date(dateB).getTime() -
                                 new Date(dateA).getTime()
                             );
-                        })
-                        .map((f) => {
-                            const sort = sortsData?.find(
-                                (item) => item.id === f.plantSortId,
-                            );
-                            const statusMeta = getStatusMeta(f.plantStatus);
-                            return {
-                                id: f.id,
-                                positionIndex: f.positionIndex,
-                                plantLabel: getSortLabel(sort, f.plantSortId),
-                                plantStatusLabel: statusMeta?.label ?? null,
-                                plantStatusIcon: statusMeta?.icon ?? null,
-                                sortData: sort,
-                                createdAt: normalizeDate(f.createdAt),
-                                plantScheduledDate: normalizeDate(
-                                    f.plantScheduledDate,
-                                ),
-                                plantSowDate: normalizeDate(f.plantSowDate),
-                                plantGrowthDate: normalizeDate(
-                                    f.plantGrowthDate,
-                                ),
-                                plantReadyDate: normalizeDate(f.plantReadyDate),
-                                plantHarvestedDate: normalizeDate(
-                                    f.plantHarvestedDate,
-                                ),
-                                plantDeadDate: normalizeDate(f.plantDeadDate),
-                                plantRemovedDate: normalizeDate(
-                                    f.plantRemovedDate,
-                                ),
-                            } satisfies RemovedFieldDetails;
                         });
 
                     return (
                         <RaisedBedFieldTile
                             key={positionIndex}
                             field={field}
+                            activePlantCycle={activePlantCycle}
                             positionIndex={positionIndex}
                             plantSorts={sortsData ?? []}
                             raisedBedId={raisedBedId}
                             removedFields={removedFieldsAtPosition}
+                            moveTargetOptions={moveTargetOptions}
                         />
                     );
                 })}
@@ -155,24 +235,31 @@ export async function RaisedBedFieldsTable({
 
 type RaisedBedFieldTileProps = {
     field?: RaisedBedField;
+    activePlantCycle?: RaisedBedFieldPlantCycle;
     positionIndex: number;
     plantSorts: PlantSortData[];
     raisedBedId: number;
     removedFields: RemovedFieldDetails[];
+    moveTargetOptions: Array<{
+        value: string;
+        label: string;
+    }>;
 };
 
 function RaisedBedFieldTile({
     field,
+    activePlantCycle,
     positionIndex,
     plantSorts,
     raisedBedId,
     removedFields,
+    moveTargetOptions,
 }: RaisedBedFieldTileProps) {
     const sort = field?.plantSortId
         ? plantSorts.find((item) => item.id === field.plantSortId)
         : undefined;
-    const plantLabel = field?.active
-        ? getSortLabel(sort, field?.plantSortId)
+    const plantLabel = field
+        ? getSortLabel(sort, field.plantSortId)
         : 'Prazno polje';
     const dateItems: {
         label: string;
@@ -213,7 +300,11 @@ function RaisedBedFieldTile({
                 )}
                 {removedFields.length > 0 && (
                     <div className="absolute bottom-2 left-2">
-                        <RaisedBedRemovedFieldsModal fields={removedFields} />
+                        <RaisedBedRemovedFieldsModal
+                            raisedBedId={raisedBedId}
+                            fields={removedFields}
+                            targetOptions={moveTargetOptions}
+                        />
                     </div>
                 )}
                 <div className="absolute bottom-2 right-2 rounded-full bg-background/90 px-2 py-1 text-xs font-semibold shadow">
@@ -228,6 +319,17 @@ function RaisedBedFieldTile({
                                 raisedBedId={raisedBedId}
                                 positionIndex={positionIndex}
                                 status={field.plantStatus}
+                            />
+                        )}
+                        {activePlantCycle && (
+                            <MoveRaisedBedFieldPlantModal
+                                raisedBedId={raisedBedId}
+                                sourcePositionIndex={positionIndex}
+                                sourcePlantPlaceEventId={
+                                    activePlantCycle.plantPlaceEventId
+                                }
+                                sourcePlantLabel={plantLabel}
+                                targetOptions={moveTargetOptions}
                             />
                         )}
                         <Stack>

--- a/apps/app/components/raised-beds/RaisedBedRemovedFieldsModal.tsx
+++ b/apps/app/components/raised-beds/RaisedBedRemovedFieldsModal.tsx
@@ -9,10 +9,12 @@ import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { MoveRaisedBedFieldPlantModal } from './MoveRaisedBedFieldPlantModal';
 
 export type RemovedFieldDetails = {
     id: number;
     positionIndex: number;
+    plantPlaceEventId: number;
     plantLabel: string;
     plantStatusLabel: string | null;
     plantStatusIcon: string | null;
@@ -29,7 +31,12 @@ export type RemovedFieldDetails = {
 };
 
 type RaisedBedRemovedFieldsModalProps = {
+    raisedBedId: number;
     fields: RemovedFieldDetails[];
+    targetOptions: Array<{
+        value: string;
+        label: string;
+    }>;
 };
 
 const dateEntries: {
@@ -47,7 +54,9 @@ const dateEntries: {
 ];
 
 export function RaisedBedRemovedFieldsModal({
+    raisedBedId,
     fields,
+    targetOptions,
 }: RaisedBedRemovedFieldsModalProps) {
     if (!fields.length) {
         return null;
@@ -117,6 +126,15 @@ export function RaisedBedRemovedFieldsModal({
                                         </Typography>
                                     )}
                                 </Stack>
+                                <MoveRaisedBedFieldPlantModal
+                                    raisedBedId={raisedBedId}
+                                    sourcePositionIndex={field.positionIndex}
+                                    sourcePlantPlaceEventId={
+                                        field.plantPlaceEventId
+                                    }
+                                    sourcePlantLabel={field.plantLabel}
+                                    targetOptions={targetOptions}
+                                />
                             </Row>
                             <Stack spacing={1.5}>
                                 {dateEntries.map(({ key, label }) => {

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { plantFieldStatusLabel } from '@gredice/js/plants';
-import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray } from 'drizzle-orm';
 import { v4 as uuidV4 } from 'uuid';
 import { getEntitiesFormatted, getOperations, storage } from '..';
 import type { EntityStandardized } from '../@types/EntityStandardized';
@@ -39,10 +39,39 @@ import {
 import { getFarms } from './farmsRepo';
 
 const RAISED_BED_FIELDS_PER_BLOCK = 9;
+const PLANT_CYCLE_EVENT_TYPES = [
+    knownEventTypes.raisedBedFields.plantPlace,
+    knownEventTypes.raisedBedFields.plantSchedule,
+    knownEventTypes.raisedBedFields.plantUpdate,
+    knownEventTypes.raisedBedFields.plantReplaceSort,
+] as const;
 
 type CanonicalRaisedBedField = {
     id: number;
     positionIndex: number;
+};
+
+type RaisedBedFieldPlantCycleEvent = typeof events.$inferSelect;
+
+export type RaisedBedFieldPlantCycle = {
+    aggregateId: string;
+    positionIndex: number;
+    plantPlaceEventId: number;
+    eventIds: number[];
+    startedAt: Date;
+    endedAt: Date;
+    active: boolean;
+    plantStatus?: string;
+    plantSortId?: number;
+    plantScheduledDate?: Date;
+    plantSowDate?: Date;
+    plantGrowthDate?: Date;
+    plantReadyDate?: Date;
+    plantDeadDate?: Date;
+    plantHarvestedDate?: Date;
+    plantRemovedDate?: Date;
+    stoppedDate?: Date;
+    toBeRemoved: boolean;
 };
 
 function fieldRowPriority(
@@ -219,6 +248,313 @@ async function normalizeRaisedBedFieldsForMerge(
     return [...canonicalFields.values()].sort(
         (left, right) => left.positionIndex - right.positionIndex,
     );
+}
+
+async function getRaisedBedFieldRowsAtPosition(
+    tx: ReturnType<typeof storage>,
+    raisedBedId: number,
+    positionIndex: number,
+) {
+    return tx.query.raisedBedFields.findMany({
+        where: and(
+            eq(raisedBedFields.raisedBedId, raisedBedId),
+            eq(raisedBedFields.positionIndex, positionIndex),
+        ),
+        orderBy: [asc(raisedBedFields.createdAt), asc(raisedBedFields.id)],
+    });
+}
+
+async function collapseDuplicateRaisedBedFieldRows(
+    tx: ReturnType<typeof storage>,
+    fieldRows: SelectRaisedBedField[],
+) {
+    const canonicalField = fieldRows[0];
+    if (!canonicalField) {
+        return null;
+    }
+
+    const duplicateFieldIds = fieldRows
+        .slice(1)
+        .map((existingField) => existingField.id);
+    if (duplicateFieldIds.length > 0) {
+        await tx
+            .update(operations)
+            .set({
+                raisedBedFieldId: canonicalField.id,
+            })
+            .where(inArray(operations.raisedBedFieldId, duplicateFieldIds));
+
+        await tx
+            .update(raisedBedFields)
+            .set({
+                isDeleted: true,
+                updatedAt: new Date(),
+            })
+            .where(inArray(raisedBedFields.id, duplicateFieldIds));
+    }
+
+    return canonicalField;
+}
+
+async function syncRaisedBedFieldRow(
+    tx: ReturnType<typeof storage>,
+    field: Omit<
+        InsertRaisedBedField,
+        'id' | 'createdAt' | 'updatedAt' | 'isDeleted'
+    >,
+) {
+    const existingFieldRows = await getRaisedBedFieldRowsAtPosition(
+        tx,
+        field.raisedBedId,
+        field.positionIndex,
+    );
+    const canonicalField = await collapseDuplicateRaisedBedFieldRows(
+        tx,
+        existingFieldRows,
+    );
+
+    if (!canonicalField) {
+        await tx.insert(raisedBedFields).values(field);
+        return;
+    }
+
+    await tx
+        .update(raisedBedFields)
+        .set({
+            ...field,
+            isDeleted: false,
+            updatedAt: new Date(),
+        })
+        .where(eq(raisedBedFields.id, canonicalField.id));
+}
+
+function parsePlantSortId(value: unknown) {
+    if (typeof value === 'number') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        const parsedPlantSortId = parseInt(value, 10);
+        return Number.isNaN(parsedPlantSortId) ? undefined : parsedPlantSortId;
+    }
+
+    return undefined;
+}
+
+function splitPlantCycleEvents(
+    plantEvents: RaisedBedFieldPlantCycleEvent[],
+): RaisedBedFieldPlantCycleEvent[][] {
+    const plantCycles: RaisedBedFieldPlantCycleEvent[][] = [];
+    let currentPlantCycle: RaisedBedFieldPlantCycleEvent[] = [];
+
+    for (const plantEvent of plantEvents) {
+        if (plantEvent.type === knownEventTypes.raisedBedFields.plantPlace) {
+            if (currentPlantCycle.length > 0) {
+                plantCycles.push(currentPlantCycle);
+            }
+
+            currentPlantCycle = [plantEvent];
+            continue;
+        }
+
+        if (currentPlantCycle.length > 0) {
+            currentPlantCycle.push(plantEvent);
+        }
+    }
+
+    if (currentPlantCycle.length > 0) {
+        plantCycles.push(currentPlantCycle);
+    }
+
+    return plantCycles;
+}
+
+function summarizePlantCycle(
+    aggregateId: string,
+    positionIndex: number,
+    plantCycleEvents: RaisedBedFieldPlantCycleEvent[],
+): RaisedBedFieldPlantCycle | null {
+    const plantPlaceEvent = plantCycleEvents[0];
+    if (
+        !plantPlaceEvent ||
+        plantPlaceEvent.type !== knownEventTypes.raisedBedFields.plantPlace
+    ) {
+        return null;
+    }
+
+    let plantStatus: string | undefined;
+    let plantSortId: number | undefined;
+    let plantScheduledDate: Date | undefined;
+    let plantSowDate: Date | undefined;
+    let plantGrowthDate: Date | undefined;
+    let plantReadyDate: Date | undefined;
+    let plantDeadDate: Date | undefined;
+    let plantHarvestedDate: Date | undefined;
+    let plantRemovedDate: Date | undefined;
+    let active = false;
+    let toBeRemoved = false;
+    let stoppedDate: Date | undefined;
+
+    for (const plantCycleEvent of plantCycleEvents) {
+        const data = plantCycleEvent.data as
+            | Record<string, unknown>
+            | undefined;
+
+        if (
+            plantCycleEvent.type === knownEventTypes.raisedBedFields.plantPlace
+        ) {
+            active = true;
+            toBeRemoved = false;
+            stoppedDate = undefined;
+            plantStatus = 'new';
+            plantSortId = parsePlantSortId(data?.plantSortId);
+
+            if (data?.scheduledDate && typeof data.scheduledDate === 'string') {
+                plantScheduledDate = new Date(data.scheduledDate);
+            } else if (
+                data?.scheduledDate &&
+                typeof data.scheduledDate === 'object' &&
+                data.scheduledDate instanceof Date
+            ) {
+                plantScheduledDate = data.scheduledDate;
+            } else {
+                plantScheduledDate = undefined;
+            }
+
+            plantSowDate = undefined;
+            plantGrowthDate = undefined;
+            plantReadyDate = undefined;
+            plantDeadDate = undefined;
+            plantHarvestedDate = undefined;
+            plantRemovedDate = undefined;
+            continue;
+        }
+
+        if (
+            plantCycleEvent.type ===
+            knownEventTypes.raisedBedFields.plantSchedule
+        ) {
+            if (data?.scheduledDate && typeof data.scheduledDate === 'string') {
+                plantScheduledDate = new Date(data.scheduledDate);
+            } else if (
+                data?.scheduledDate &&
+                typeof data.scheduledDate === 'object' &&
+                data.scheduledDate instanceof Date
+            ) {
+                plantScheduledDate = data.scheduledDate;
+            } else if (data?.scheduledDate == null) {
+                plantScheduledDate = undefined;
+            }
+            continue;
+        }
+
+        if (
+            plantCycleEvent.type ===
+            knownEventTypes.raisedBedFields.plantReplaceSort
+        ) {
+            const nextPlantSortId = parsePlantSortId(data?.plantSortId);
+            if (typeof nextPlantSortId === 'number') {
+                plantSortId = nextPlantSortId;
+            }
+            continue;
+        }
+
+        if (
+            plantCycleEvent.type === knownEventTypes.raisedBedFields.plantUpdate
+        ) {
+            plantStatus =
+                typeof data?.status === 'string' ? data.status : plantStatus;
+
+            if (plantStatus === 'sowed') {
+                plantSowDate = plantCycleEvent.createdAt;
+            } else if (plantStatus === 'sprouted') {
+                plantGrowthDate = plantCycleEvent.createdAt;
+            } else if (plantStatus === 'notSprouted') {
+                plantDeadDate = plantCycleEvent.createdAt;
+                stoppedDate = plantCycleEvent.createdAt;
+                toBeRemoved = true;
+            } else if (plantStatus === 'died') {
+                plantDeadDate = plantCycleEvent.createdAt;
+                stoppedDate = plantCycleEvent.createdAt;
+            } else if (plantStatus === 'ready') {
+                plantReadyDate = plantCycleEvent.createdAt;
+            } else if (plantStatus === 'harvested') {
+                plantHarvestedDate = plantCycleEvent.createdAt;
+                stoppedDate = plantCycleEvent.createdAt;
+            } else if (plantStatus === 'removed') {
+                plantRemovedDate = plantCycleEvent.createdAt;
+                active = false;
+                stoppedDate = plantCycleEvent.createdAt;
+            }
+        }
+    }
+
+    const lastPlantCycleEvent = plantCycleEvents[plantCycleEvents.length - 1];
+    const endedAt = lastPlantCycleEvent?.createdAt ?? plantPlaceEvent.createdAt;
+
+    return {
+        aggregateId,
+        positionIndex,
+        plantPlaceEventId: plantPlaceEvent.id,
+        eventIds: plantCycleEvents.map((plantCycleEvent) => plantCycleEvent.id),
+        startedAt: plantPlaceEvent.createdAt,
+        endedAt,
+        active,
+        plantStatus,
+        plantSortId,
+        plantScheduledDate,
+        plantSowDate,
+        plantGrowthDate,
+        plantReadyDate,
+        plantDeadDate,
+        plantHarvestedDate,
+        plantRemovedDate,
+        stoppedDate,
+        toBeRemoved,
+    };
+}
+
+function summarizePlantCycles(
+    aggregateId: string,
+    positionIndex: number,
+    plantEvents: RaisedBedFieldPlantCycleEvent[],
+) {
+    return splitPlantCycleEvents(plantEvents)
+        .map((plantCycleEvents) =>
+            summarizePlantCycle(aggregateId, positionIndex, plantCycleEvents),
+        )
+        .filter((plantCycle): plantCycle is RaisedBedFieldPlantCycle =>
+            Boolean(plantCycle),
+        );
+}
+
+function plantCyclesOverlap(
+    sourcePlantCycle: Pick<RaisedBedFieldPlantCycle, 'startedAt' | 'endedAt'>,
+    targetPlantCycle: Pick<RaisedBedFieldPlantCycle, 'startedAt' | 'endedAt'>,
+) {
+    return (
+        sourcePlantCycle.startedAt.getTime() <=
+            targetPlantCycle.endedAt.getTime() &&
+        targetPlantCycle.startedAt.getTime() <=
+            sourcePlantCycle.endedAt.getTime()
+    );
+}
+
+async function getPlantCyclesForPosition(
+    tx: ReturnType<typeof storage>,
+    raisedBedId: number,
+    positionIndex: number,
+) {
+    const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
+    const plantEvents = await tx.query.events.findMany({
+        where: and(
+            eq(events.aggregateId, aggregateId),
+            inArray(events.type, [...PLANT_CYCLE_EVENT_TYPES]),
+        ),
+        orderBy: [asc(events.createdAt), asc(events.id)],
+    });
+
+    return summarizePlantCycles(aggregateId, positionIndex, plantEvents);
 }
 
 export async function createGarden(garden: InsertGarden) {
@@ -620,6 +956,57 @@ export async function getRaisedBed(raisedBedId: number) {
     };
 }
 
+export async function getRaisedBedFieldPlantCycles(raisedBedId: number) {
+    const fields = await storage().query.raisedBedFields.findMany({
+        where: and(
+            eq(raisedBedFields.raisedBedId, raisedBedId),
+            eq(raisedBedFields.isDeleted, false),
+        ),
+    });
+
+    const positionIndices = Array.from(
+        new Set(fields.map((field) => field.positionIndex)),
+    ).sort((left, right) => left - right);
+    if (positionIndices.length === 0) {
+        return [];
+    }
+
+    const aggregateIds = positionIndices.map(
+        (positionIndex) =>
+            `${raisedBedId.toString()}|${positionIndex.toString()}`,
+    );
+    const plantEvents = await getEvents(
+        [...PLANT_CYCLE_EVENT_TYPES],
+        aggregateIds,
+        0,
+        100000,
+    );
+
+    const plantEventsByAggregateId = new Map<
+        string,
+        RaisedBedFieldPlantCycleEvent[]
+    >();
+    for (const plantEvent of plantEvents) {
+        const aggregateEvents = plantEventsByAggregateId.get(
+            plantEvent.aggregateId,
+        );
+        if (aggregateEvents) {
+            aggregateEvents.push(plantEvent);
+        } else {
+            plantEventsByAggregateId.set(plantEvent.aggregateId, [plantEvent]);
+        }
+    }
+
+    return positionIndices.flatMap((positionIndex) => {
+        const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
+        return summarizePlantCycles(
+            aggregateId,
+            positionIndex,
+            plantEventsByAggregateId.get(aggregateId) ?? [],
+        );
+    });
+}
+
 // New: Retrieve all raised bed fields for a single raised bed, with event-sourced info
 export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
     const fields = await storage().query.raisedBedFields.findMany({
@@ -651,10 +1038,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
     return fields.map((field) => {
         const aggregateId = `${field.raisedBedId}|${field.positionIndex}`;
         const events = fieldsEvents.filter(
-            (event) =>
-                event.aggregateId === aggregateId &&
-                // 5000ms is offset for events - because events and fields are created in parallel
-                field.createdAt <= new Date(event.createdAt.getTime() + 5000),
+            (event) => event.aggregateId === aggregateId,
         );
 
         // Reduce events to get latest status, plant info, etc.
@@ -680,6 +1064,9 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 active = true;
                 toBeRemoved = false;
                 stoppedDate = undefined;
+                plantStatus = 'new';
+                plantSortId = undefined;
+                plantScheduledDate = undefined;
                 plantSowDate = undefined;
                 plantGrowthDate = undefined;
                 plantReadyDate = undefined;
@@ -711,9 +1098,6 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 ) {
                     plantScheduledDate = data?.scheduledDate;
                 }
-
-                // Set status to new when plant is placed
-                plantStatus = 'new';
             }
             // Handle plant schedule update event
             else if (
@@ -1239,29 +1623,98 @@ export async function upsertRaisedBedField(
         'id' | 'createdAt' | 'updatedAt' | 'isDeleted'
     >,
 ) {
-    const existingRaisedBedFields = await getRaisedBedFieldsWithEvents(
-        field.raisedBedId,
-    );
-    const existingField = existingRaisedBedFields.find(
-        (f) => f.positionIndex === field.positionIndex,
-    );
-    if (!existingField || !existingField.active) {
-        await storage()
-            .insert(raisedBedFields)
-            .values(field)
-            .onConflictDoNothing();
-    } else {
-        await storage()
-            .update(raisedBedFields)
-            .set({ ...field, updatedAt: new Date() })
-            .where(
-                and(
-                    eq(raisedBedFields.raisedBedId, field.raisedBedId),
-                    eq(raisedBedFields.positionIndex, field.positionIndex),
-                    eq(raisedBedFields.isDeleted, false),
-                ),
-            );
+    await storage().transaction(async (tx) => {
+        await syncRaisedBedFieldRow(tx, field);
+    });
+}
+
+export async function moveRaisedBedFieldPlantHistory({
+    raisedBedId,
+    sourcePositionIndex,
+    targetPositionIndex,
+    sourcePlantPlaceEventId,
+}: {
+    raisedBedId: number;
+    sourcePositionIndex: number;
+    targetPositionIndex: number;
+    sourcePlantPlaceEventId: number;
+}) {
+    if (sourcePositionIndex === targetPositionIndex) {
+        throw new Error('Source and target field positions must be different');
     }
+
+    if (sourcePositionIndex < 0 || targetPositionIndex < 0) {
+        throw new Error('Field positions must be zero or greater');
+    }
+
+    const sourceAggregateId = `${raisedBedId.toString()}|${sourcePositionIndex.toString()}`;
+    const targetAggregateId = `${raisedBedId.toString()}|${targetPositionIndex.toString()}`;
+
+    return storage().transaction(async (tx) => {
+        const sourceFieldRows = await getRaisedBedFieldRowsAtPosition(
+            tx,
+            raisedBedId,
+            sourcePositionIndex,
+        );
+        if (sourceFieldRows.length === 0) {
+            throw new Error(
+                `Source field ${sourcePositionIndex} not found in raised bed ${raisedBedId}`,
+            );
+        }
+
+        await syncRaisedBedFieldRow(tx, {
+            raisedBedId,
+            positionIndex: sourcePositionIndex,
+        });
+        await syncRaisedBedFieldRow(tx, {
+            raisedBedId,
+            positionIndex: targetPositionIndex,
+        });
+
+        const [sourcePlantCycles, targetPlantCycles] = await Promise.all([
+            getPlantCyclesForPosition(tx, raisedBedId, sourcePositionIndex),
+            getPlantCyclesForPosition(tx, raisedBedId, targetPositionIndex),
+        ]);
+
+        const sourcePlantCycle = sourcePlantCycles.find(
+            (plantCycle) =>
+                plantCycle.plantPlaceEventId === sourcePlantPlaceEventId,
+        );
+        if (!sourcePlantCycle) {
+            throw new Error('Selected source plant history was not found');
+        }
+
+        const overlappingTargetPlantCycles = targetPlantCycles.filter(
+            (targetPlantCycle) =>
+                plantCyclesOverlap(sourcePlantCycle, targetPlantCycle),
+        );
+        const shouldSwap = overlappingTargetPlantCycles.length > 0;
+
+        const sourcePlantCycleEventIds = sourcePlantCycle.eventIds;
+        const targetPlantCycleEventIds = overlappingTargetPlantCycles.flatMap(
+            (targetPlantCycle) => targetPlantCycle.eventIds,
+        );
+
+        await tx
+            .update(events)
+            .set({
+                aggregateId: targetAggregateId,
+            })
+            .where(inArray(events.id, sourcePlantCycleEventIds));
+
+        if (shouldSwap) {
+            await tx
+                .update(events)
+                .set({
+                    aggregateId: sourceAggregateId,
+                })
+                .where(inArray(events.id, targetPlantCycleEventIds));
+        }
+
+        return {
+            swapped: shouldSwap,
+        };
+    });
 }
 
 export async function deleteRaisedBedField(

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -12,7 +12,9 @@ import {
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     knownEvents,
+    knownEventTypes,
     mergeRaisedBeds,
+    moveRaisedBedFieldPlantHistory,
     storage,
     upsertOrRemoveCartItem,
     upsertRaisedBedField,
@@ -24,6 +26,22 @@ import {
     ensureFarmId,
 } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
+
+async function getPlantEventsForAggregate(aggregateId: string) {
+    return storage().query.events.findMany({
+        where: (events, { and, eq, inArray }) =>
+            and(
+                eq(events.aggregateId, aggregateId),
+                inArray(events.type, [
+                    knownEventTypes.raisedBedFields.plantPlace,
+                    knownEventTypes.raisedBedFields.plantSchedule,
+                    knownEventTypes.raisedBedFields.plantUpdate,
+                    knownEventTypes.raisedBedFields.plantReplaceSort,
+                ]),
+            ),
+        orderBy: (events, { asc }) => [asc(events.createdAt), asc(events.id)],
+    });
+}
 
 test('upsertRaisedBedField creates field, deleteRaisedBedField deletes the field', async () => {
     createTestDb();
@@ -319,7 +337,7 @@ test('mergeRaisedBeds preserves sparse source positions inside the appended bloc
     assert.ok(movedLastEvent);
 });
 
-test('getRaisedBed returns the latest plant cycle after a field is removed and replanted', async () => {
+test('moveRaisedBedFieldPlantHistory moves the selected active plant cycle to an empty position', async () => {
     createTestDb();
     const accountId = await createAccount();
     const farmId = await ensureFarmId();
@@ -371,6 +389,452 @@ test('getRaisedBed returns the latest plant cycle after a field is removed and r
         ),
     );
 
+    const sourceEventsBeforeMove = await getPlantEventsForAggregate(
+        `${raisedBedId.toString()}|0`,
+    );
+    assert.strictEqual(sourceEventsBeforeMove.length, 4);
+
+    const movedEventIds = sourceEventsBeforeMove
+        .slice(2)
+        .map((event) => event.id);
+    const sourcePlantPlaceEventId = sourceEventsBeforeMove[2]?.id;
+    const movedEventTimestampsById = new Map(
+        sourceEventsBeforeMove
+            .slice(2)
+            .map((event) => [event.id, event.createdAt.getTime()]),
+    );
+    assert.ok(sourcePlantPlaceEventId);
+
+    const result = await moveRaisedBedFieldPlantHistory({
+        raisedBedId,
+        sourcePositionIndex: 0,
+        targetPositionIndex: 2,
+        sourcePlantPlaceEventId,
+    });
+    assert.strictEqual(result.swapped, false);
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    assert.ok(raisedBed);
+
+    const sourceField = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    const targetField = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 2,
+    );
+
+    assert.ok(sourceField);
+    assert.strictEqual(sourceField?.active, false);
+    assert.strictEqual(sourceField?.plantStatus, 'removed');
+    assert.strictEqual(sourceField?.plantSortId, 101);
+
+    assert.ok(targetField);
+    assert.strictEqual(targetField?.active, true);
+    assert.strictEqual(targetField?.plantStatus, 'sprouted');
+    assert.strictEqual(targetField?.plantSortId, 202);
+
+    const movedEventsAfterMove = await storage().query.events.findMany({
+        where: (events, { inArray }) => inArray(events.id, movedEventIds),
+        orderBy: (events, { asc }) => [asc(events.createdAt), asc(events.id)],
+    });
+    assert.strictEqual(movedEventsAfterMove.length, movedEventIds.length);
+    assert.deepStrictEqual(
+        movedEventsAfterMove.map((event) => event.aggregateId),
+        Array.from(
+            { length: movedEventIds.length },
+            () => `${raisedBedId.toString()}|2`,
+        ),
+    );
+    assert.deepStrictEqual(
+        movedEventsAfterMove.map((event) => event.createdAt.getTime()),
+        movedEventsAfterMove.map(
+            (event) => movedEventTimestampsById.get(event.id) ?? -1,
+        ),
+    );
+});
+
+test('moveRaisedBedFieldPlantHistory moves the selected historical plant cycle to an empty position without touching newer source cycles', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-a');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '101',
+                scheduledDate: new Date(
+                    '2026-01-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'removed',
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '202',
+                scheduledDate: new Date(
+                    '2026-02-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'sprouted',
+            },
+        ),
+    );
+
+    const sourceEventsBeforeMove = await getPlantEventsForAggregate(
+        `${raisedBedId.toString()}|0`,
+    );
+    assert.strictEqual(sourceEventsBeforeMove.length, 4);
+
+    const movedEventIds = sourceEventsBeforeMove
+        .slice(0, 2)
+        .map((event) => event.id);
+    const sourcePlantPlaceEventId = sourceEventsBeforeMove[0]?.id;
+    const movedEventTimestampsById = new Map(
+        sourceEventsBeforeMove
+            .slice(0, 2)
+            .map((event) => [event.id, event.createdAt.getTime()]),
+    );
+    assert.ok(sourcePlantPlaceEventId);
+
+    const result = await moveRaisedBedFieldPlantHistory({
+        raisedBedId,
+        sourcePositionIndex: 0,
+        targetPositionIndex: 2,
+        sourcePlantPlaceEventId,
+    });
+    assert.strictEqual(result.swapped, false);
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    assert.ok(raisedBed);
+
+    const sourceField = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    const targetField = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 2,
+    );
+
+    assert.ok(sourceField);
+    assert.strictEqual(sourceField?.active, true);
+    assert.strictEqual(sourceField?.plantStatus, 'sprouted');
+    assert.strictEqual(sourceField?.plantSortId, 202);
+
+    assert.ok(targetField);
+    assert.strictEqual(targetField?.active, false);
+    assert.strictEqual(targetField?.plantStatus, 'removed');
+    assert.strictEqual(targetField?.plantSortId, 101);
+
+    const movedEventsAfterMove = await storage().query.events.findMany({
+        where: (events, { inArray }) => inArray(events.id, movedEventIds),
+        orderBy: (events, { asc }) => [asc(events.createdAt), asc(events.id)],
+    });
+    assert.strictEqual(movedEventsAfterMove.length, movedEventIds.length);
+    assert.deepStrictEqual(
+        movedEventsAfterMove.map((event) => event.aggregateId),
+        Array.from(
+            { length: movedEventIds.length },
+            () => `${raisedBedId.toString()}|2`,
+        ),
+    );
+    assert.deepStrictEqual(
+        movedEventsAfterMove.map((event) => event.createdAt.getTime()),
+        movedEventsAfterMove.map(
+            (event) => movedEventTimestampsById.get(event.id) ?? -1,
+        ),
+    );
+
+    const sourceEventsAfterMove = await getPlantEventsForAggregate(
+        `${raisedBedId.toString()}|0`,
+    );
+    assert.deepStrictEqual(
+        sourceEventsAfterMove.map((event) => event.id),
+        sourceEventsBeforeMove.slice(2).map((event) => event.id),
+    );
+});
+
+test('moveRaisedBedFieldPlantHistory swaps all overlapping target plant cycles and leaves non-overlapping target history in place', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-a');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await Promise.all([
+        upsertRaisedBedField({
+            raisedBedId,
+            positionIndex: 0,
+        }),
+        upsertRaisedBedField({
+            raisedBedId,
+            positionIndex: 1,
+        }),
+    ]);
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '101',
+                scheduledDate: new Date(
+                    '2026-01-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|1`,
+            {
+                plantSortId: '303',
+                scheduledDate: new Date(
+                    '2026-01-10T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|1`,
+            {
+                status: 'removed',
+            },
+        ),
+    );
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|1`,
+            {
+                plantSortId: '404',
+                scheduledDate: new Date(
+                    '2026-01-20T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'removed',
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|1`,
+            {
+                status: 'removed',
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|1`,
+            {
+                plantSortId: '505',
+                scheduledDate: new Date(
+                    '2026-03-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|1`,
+            {
+                status: 'planned',
+            },
+        ),
+    );
+
+    const [sourceEventsBeforeSwap, targetEventsBeforeSwap] = await Promise.all([
+        getPlantEventsForAggregate(`${raisedBedId.toString()}|0`),
+        getPlantEventsForAggregate(`${raisedBedId.toString()}|1`),
+    ]);
+    assert.strictEqual(sourceEventsBeforeSwap.length, 2);
+    assert.strictEqual(targetEventsBeforeSwap.length, 6);
+
+    const sourceCycleEventIds = sourceEventsBeforeSwap.map((event) => event.id);
+    const sourcePlantPlaceEventId = sourceEventsBeforeSwap[0]?.id;
+    const targetFirstOverlappingCycleEventIds = targetEventsBeforeSwap
+        .slice(0, 2)
+        .map((event) => event.id);
+    const targetSecondOverlappingCycleEventIds = targetEventsBeforeSwap
+        .slice(2, 4)
+        .map((event) => event.id);
+    const targetNonOverlappingCycleEventIds = targetEventsBeforeSwap
+        .slice(4)
+        .map((event) => event.id);
+    assert.ok(sourcePlantPlaceEventId);
+
+    const timestampsByEventId = new Map(
+        [...sourceEventsBeforeSwap, ...targetEventsBeforeSwap].map((event) => [
+            event.id,
+            event.createdAt.getTime(),
+        ]),
+    );
+
+    const result = await moveRaisedBedFieldPlantHistory({
+        raisedBedId,
+        sourcePositionIndex: 0,
+        targetPositionIndex: 1,
+        sourcePlantPlaceEventId,
+    });
+    assert.strictEqual(result.swapped, true);
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    assert.ok(raisedBed);
+
+    const sourceField = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    const targetField = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 1,
+    );
+
+    assert.ok(sourceField);
+    assert.strictEqual(sourceField?.active, false);
+    assert.strictEqual(sourceField?.plantStatus, 'removed');
+    assert.strictEqual(sourceField?.plantSortId, 404);
+
+    assert.ok(targetField);
+    assert.strictEqual(targetField?.active, true);
+    assert.strictEqual(targetField?.plantStatus, 'planned');
+    assert.strictEqual(targetField?.plantSortId, 505);
+
+    const movedEventsAfterSwap = await storage().query.events.findMany({
+        where: (events, { inArray }) =>
+            inArray(events.id, [
+                ...sourceCycleEventIds,
+                ...targetFirstOverlappingCycleEventIds,
+                ...targetSecondOverlappingCycleEventIds,
+                ...targetNonOverlappingCycleEventIds,
+            ]),
+        orderBy: (events, { asc }) => [asc(events.createdAt), asc(events.id)],
+    });
+    const aggregateByEventId = new Map(
+        movedEventsAfterSwap.map((event) => [event.id, event.aggregateId]),
+    );
+
+    for (const eventId of sourceCycleEventIds) {
+        assert.strictEqual(
+            aggregateByEventId.get(eventId),
+            `${raisedBedId.toString()}|1`,
+        );
+    }
+    for (const eventId of targetFirstOverlappingCycleEventIds) {
+        assert.strictEqual(
+            aggregateByEventId.get(eventId),
+            `${raisedBedId.toString()}|0`,
+        );
+    }
+    for (const eventId of targetSecondOverlappingCycleEventIds) {
+        assert.strictEqual(
+            aggregateByEventId.get(eventId),
+            `${raisedBedId.toString()}|0`,
+        );
+    }
+    for (const eventId of targetNonOverlappingCycleEventIds) {
+        assert.strictEqual(
+            aggregateByEventId.get(eventId),
+            `${raisedBedId.toString()}|1`,
+        );
+    }
+
+    assert.deepStrictEqual(
+        movedEventsAfterSwap.map((event) => event.createdAt.getTime()),
+        movedEventsAfterSwap.map(
+            (event) => timestampsByEventId.get(event.id) ?? -1,
+        ),
+    );
+});
+
+test('getRaisedBed returns the latest plant cycle after a field is removed and replanted', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-a');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+    const initialRaisedBed = await getRaisedBed(raisedBedId);
+    const initialField = initialRaisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.ok(initialField);
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '101',
+                scheduledDate: new Date(
+                    '2026-01-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'removed',
+            },
+        ),
+    );
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '202',
+                scheduledDate: null,
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                status: 'sprouted',
+            },
+        ),
+    );
+
     const raisedBed = await getRaisedBed(raisedBedId);
     assert.ok(raisedBed);
 
@@ -378,11 +842,73 @@ test('getRaisedBed returns the latest plant cycle after a field is removed and r
         (candidate) => candidate.positionIndex === 0,
     );
     assert.ok(field);
+    assert.strictEqual(raisedBed.fields.length, 1);
+    assert.strictEqual(field?.id, initialField.id);
     assert.strictEqual(field?.active, true);
     assert.strictEqual(field?.plantStatus, 'sprouted');
     assert.strictEqual(field?.plantSortId, 202);
-    assert.strictEqual(
-        field?.plantScheduledDate?.toISOString(),
-        '2026-02-01T00:00:00.000Z',
+    assert.strictEqual(field?.plantScheduledDate, undefined);
+    assert.strictEqual(field?.plantSowDate, undefined);
+    assert.ok(field?.plantGrowthDate instanceof Date);
+    assert.strictEqual(field?.plantDeadDate, undefined);
+    assert.strictEqual(field?.plantHarvestedDate, undefined);
+    assert.strictEqual(field?.plantRemovedDate, undefined);
+    assert.strictEqual(field?.stoppedDate, undefined);
+    assert.strictEqual(field?.toBeRemoved, false);
+});
+
+test('upsertRaisedBedField reuses the same row after a field is deleted and planted again', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-a');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+
+    const initialRaisedBed = await getRaisedBed(raisedBedId);
+    const initialField = initialRaisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
     );
+    assert.ok(initialField);
+
+    await createEvent(
+        knownEvents.raisedBedFields.deletedV1(`${raisedBedId.toString()}|0`),
+    );
+    await deleteRaisedBedField(raisedBedId, 0);
+
+    const deletedFields = await getRaisedBedFieldsWithEvents(raisedBedId);
+    assert.strictEqual(deletedFields.length, 0);
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|0`,
+            {
+                plantSortId: '303',
+                scheduledDate: new Date(
+                    '2026-03-01T00:00:00.000Z',
+                ).toISOString(),
+            },
+        ),
+    );
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    assert.ok(raisedBed);
+    assert.strictEqual(raisedBed.fields.length, 1);
+
+    const field = raisedBed.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.ok(field);
+    assert.strictEqual(field?.id, initialField.id);
+    assert.strictEqual(field?.active, true);
+    assert.strictEqual(field?.plantSortId, 303);
 });


### PR DESCRIPTION
- Add getRaisedBedFieldCycles import and alias for cycles.
- Fetch plant cycles together with sorts raised bed to avoid sequential requests.
- Build a map cycles grouped by positionIndex determine active and most-recent cycle per position.
- Use to filter and enrich field rendering logic, ensuring only fields with valid plantSortId are treated as active when needed.
- Introduce MoveRaisedBedFieldPlantModal import and prepare move target computation logic by preserving target.

This reduces client round-trips and enables accurate display ofplant cycle when rendering raised bed fields.