### PR TITLE
Fix delivery overview ordering (newest groups first)

### DIFF
--- a/packages/game/src/shared-ui/delivery/DeliveryRequestsSection.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryRequestsSection.tsx
@@ -17,6 +17,7 @@ type DeliveryRequestGroup = {
     key: string;
     requests: DeliveryRequestData[];
     slotStart?: string | null;
+    newestRequestCreatedAt?: string | Date | null;
 };
 
 function getGroupKey(request: DeliveryRequestData): string {
@@ -36,6 +37,14 @@ function getGroupKey(request: DeliveryRequestData): string {
     return `${slotPart}-${request.id}`;
 }
 
+function getTimestamp(value?: string | Date | null): number {
+    if (!value) {
+        return Number.NEGATIVE_INFINITY;
+    }
+
+    return new Date(value).getTime();
+}
+
 function groupRequestsBySlotAndDestination(
     requests: DeliveryRequestData[],
 ): DeliveryRequestGroup[] {
@@ -47,29 +56,34 @@ function groupRequestsBySlotAndDestination(
 
         if (existing) {
             existing.requests.push(request);
+            if (
+                getTimestamp(request.createdAt) >
+                getTimestamp(existing.newestRequestCreatedAt)
+            ) {
+                existing.newestRequestCreatedAt = request.createdAt;
+            }
         } else {
             map.set(key, {
                 key,
                 requests: [request],
                 slotStart: request.slot?.startAt ?? null,
+                newestRequestCreatedAt: request.createdAt,
             });
         }
     }
 
-    // Convert map to array and sort by slot start time
-    const groups = Array.from(map.values()).sort((a, b) => {
-        if (a.slotStart && b.slotStart) {
-            return (
-                new Date(a.slotStart).getTime() -
-                new Date(b.slotStart).getTime()
-            );
+    return Array.from(map.values()).sort((a, b) => {
+        const slotDifference =
+            getTimestamp(b.slotStart) - getTimestamp(a.slotStart);
+        if (slotDifference !== 0) {
+            return slotDifference;
         }
-        if (a.slotStart) return -1;
-        if (b.slotStart) return 1;
-        return 0;
-    });
 
-    return groups;
+        return (
+            getTimestamp(b.newestRequestCreatedAt) -
+            getTimestamp(a.newestRequestCreatedAt)
+        );
+    });
 }
 
 export function DeliveryRequestsSection() {


### PR DESCRIPTION
### Motivation
- The deliveries list in the overview was not showing groups ordered from newest to oldest, making recent deliveries harder to find.
- The UI groups delivery requests by slot and destination but previously sorted groups incorrectly (older-first or unstable order) when slots matched or were missing.

### Description
- Update `packages/game/src/shared-ui/delivery/DeliveryRequestsSection.tsx` to track a `newestRequestCreatedAt` on each `DeliveryRequestGroup` while grouping requests.
- Add a `getTimestamp` helper and change `groupRequestsBySlotAndDestination` to sort groups primarily by `slot.startAt` (descending) and secondarily by the newest `createdAt` inside the group (descending) so recent groups appear first.
- Preserve existing grouping behavior (by slot + address/location/fallback to individual) while making group ordering deterministic and newest-first when appropriate.

### Testing
- Ran `pnpm lint src/shared-ui/delivery/DeliveryRequestsSection.tsx` which completed and applied formatting fixes where needed, and the lint run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad18edcf8832f94adf0945cde55e0)