### PR TITLE
✨ feat: add type to blokovi page fileAnnotate metadata with Next.js type to improvesafety and catch mismatches at compile time. the Metadatatype 'next' and it the metadata constant.

### DIFF
--- a/apps/www/app/blokovi/page.tsx
+++ b/apps/www/app/blokovi/page.tsx
@@ -1,12 +1,13 @@
 import { directoriesClient } from '@gredice/client';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { BlockGallery } from './BlockGallery';
 
 export const revalidate = 3600; // 1 hour
-export const metadata = {
+export const metadata: Metadata = {
     title: 'Blokovi',
     description: 'Pregledaj sve blokove koje možeš koristiti u svom vrtu.',
 };


### PR DESCRIPTION
changes the blok page (apps/app/blokovi/pagex) by:
- adding `import type Metadata from 'next`- changing `export const metadata = { ...` to ` const metadata: Metadata = { ...`

No runtime is; the update tightens typing andhelps prevent future errors when modifying page metadata.