### PR TITLE
Fix social icon colors in light theme

### DIFF
--- a/apps/www/components/social/InstagramCard.tsx
+++ b/apps/www/components/social/InstagramCard.tsx
@@ -25,7 +25,7 @@ export function InstagramCard() {
                             'bg-gradient-to-r from-[#833ab4] via-[#fd1d1d] to-[#fcb045]',
                         )}
                     >
-                        <CompanyInstagram className="size-10 fill-white" />
+                        <CompanyInstagram className="size-10 text-white" />
                     </div>
                     <CardTitle className="text-lg leading-tight font-bold text-gray-800 max-w-xs mx-auto">
                         Prati nas na Instagramu

--- a/apps/www/components/social/WhatsAppCard.tsx
+++ b/apps/www/components/social/WhatsAppCard.tsx
@@ -6,7 +6,7 @@ export function WhatsAppCard() {
         <SocialCard
             href="https://gredice.link/wa"
             ctaText="Pridruži se našoj WhatsApp zajednici"
-            icon={<CompanyWhatsApp className="size-10 fill-white" />}
+            icon={<CompanyWhatsApp className="size-10 text-white" />}
             bgColor="bg-gradient-to-br p-2 from-green-50 dark:from-green-200 to-emerald-50 dark:to-emerald-200 border-green-200 dark:border-green-700"
             bgIconColor="bg-green-500"
             navigateIconColor="text-green-600"


### PR DESCRIPTION
### Motivation
- Social icons on the landing page were inheriting the page foreground color in light theme and appearing inverted, so they need to explicitly render white to match the intended design.

### Description
- Replaced `fill-white` with `text-white` for `CompanyWhatsApp` and `CompanyInstagram` usages in `apps/www/components/social/WhatsAppCard.tsx` and `apps/www/components/social/InstagramCard.tsx` so the footer SVGs that use `fill="currentColor"` render white in light theme.

### Testing
- Ran `pnpm --filter www lint` which completed successfully (fixed one file) and reported no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7bdf7530832f95078acccc035289)