### PR TITLE
Prevent navigation when reordering attribute definition categories and attributes

### DIFF
--- a/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
+++ b/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
@@ -36,7 +36,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import type { CSSProperties, HTMLAttributes, MouseEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
     reorderAttributeDefinition,
     reorderAttributeDefinitionCategory,
@@ -169,8 +169,10 @@ function AttributeDefinitionCategoryCard({
 
 function SortableCategory({
     category,
+    preventClick,
 }: {
     category: SelectAttributeDefinitionCategory;
+    preventClick: boolean;
 }) {
     const {
         attributes,
@@ -188,7 +190,7 @@ function SortableCategory({
         <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
             <AttributeDefinitionCategoryCard
                 attributeDefinitionCategory={category}
-                isDragging={isDragging}
+                isDragging={isDragging || preventClick}
             />
         </div>
     );
@@ -196,8 +198,10 @@ function SortableCategory({
 
 function SortableAttributeDefinition({
     attribute,
+    preventClick,
 }: {
     attribute: ExtendedAttributeDefinition;
+    preventClick: boolean;
 }) {
     const {
         attributes,
@@ -215,7 +219,7 @@ function SortableAttributeDefinition({
         <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
             <AttributeDefinitionCard
                 attributeDefinition={attribute}
-                isDragging={isDragging}
+                isDragging={isDragging || preventClick}
             />
         </div>
     );
@@ -231,7 +235,16 @@ function CategorySection({
     entityTypeName: string;
 }) {
     const [items, setItems] = useState(initialDefinitions);
+    const [preventClick, setPreventClick] = useState(false);
     const sensors = useSensors(useSensor(PointerSensor));
+
+    useEffect(() => {
+        if (!preventClick) return;
+        const timeout = setTimeout(() => {
+            setPreventClick(false);
+        }, 200);
+        return () => clearTimeout(timeout);
+    }, [preventClick]);
 
     async function handleDragEnd(event: DragEndEvent) {
         const { active, over } = event;
@@ -240,6 +253,7 @@ function CategorySection({
         const newIndex = items.findIndex((i) => i.id.toString() === over.id);
         const newItems = arrayMove(items, oldIndex, newIndex);
         setItems(newItems);
+        setPreventClick(true);
         const prev = newItems[newIndex - 1]?.order ?? null;
         const next = newItems[newIndex + 1]?.order ?? null;
         await reorderAttributeDefinition(
@@ -277,6 +291,7 @@ function CategorySection({
                         <SortableAttributeDefinition
                             key={attribute.id}
                             attribute={attribute}
+                            preventClick={preventClick}
                         />
                     ))}
                 </SortableContext>
@@ -295,7 +310,16 @@ export function AttributeDefinitionsListClient({
     attributeDefinitions: ExtendedAttributeDefinition[];
 }) {
     const [categories, setCategories] = useState(attributeDefinitionCategories);
+    const [preventCategoryClick, setPreventCategoryClick] = useState(false);
     const sensors = useSensors(useSensor(PointerSensor));
+
+    useEffect(() => {
+        if (!preventCategoryClick) return;
+        const timeout = setTimeout(() => {
+            setPreventCategoryClick(false);
+        }, 200);
+        return () => clearTimeout(timeout);
+    }, [preventCategoryClick]);
 
     async function handleCategoryDragEnd(event: DragEndEvent) {
         const { active, over } = event;
@@ -308,6 +332,7 @@ export function AttributeDefinitionsListClient({
         );
         const newItems = arrayMove(categories, oldIndex, newIndex);
         setCategories(newItems);
+        setPreventCategoryClick(true);
         const prev = newItems[newIndex - 1]?.order ?? null;
         const next = newItems[newIndex + 1]?.order ?? null;
         await reorderAttributeDefinitionCategory(
@@ -344,7 +369,11 @@ export function AttributeDefinitionsListClient({
                         <Stack spacing={1}>
                             {categories.length <= 0 && <NoDataPlaceholder />}
                             {categories.map((c) => (
-                                <SortableCategory key={c.id} category={c} />
+                                <SortableCategory
+                                    key={c.id}
+                                    category={c}
+                                    preventClick={preventCategoryClick}
+                                />
                             ))}
                         </Stack>
                     </SortableContext>


### PR DESCRIPTION
### Motivation
- Reordering categories in the Attribute Definitions admin view could accidentally open the category detail page because a click event fires after a drag-and-drop drop. 
- The same trailing click behavior can affect attributes inside categories, causing unintended navigation after reordering. 
- The intent is to suppress click navigation briefly after a successful drag to preserve normal click behavior while preventing accidental opens.

### Description
- Introduced short-lived click suppression state (`preventClick` / `preventCategoryClick`) and propagated it into sortable items so click handlers treat suppression like drag state. 
- Set the suppression flag when a reorder completes and clear it after a 200ms timeout using `useEffect`. 
- Passed the combined `isDragging || preventClick` into `AttributeDefinitionCategoryCard` and `AttributeDefinitionCard` so their existing `handleClick` prevents navigation when appropriate. 
- Changes are localized to `apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx`.

### Testing
- Ran the static check `pnpm --filter app exec biome check components/admin/directories/AttributeDefinitionsListClient.tsx`, which completed with no fixes applied and only a non-blocking Node engine warning in this environment. 
- No additional automated UI or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c8b183cc832f9c1959b8189cb1dc)