### PR TITLE
Use daily reward events for DAU/WAU/MAU analytics

### DIFF
--- a/packages/storage/src/repositories/analyticsRepo.ts
+++ b/packages/storage/src/repositories/analyticsRepo.ts
@@ -1,6 +1,7 @@
-import { and, count, gte, isNotNull, lt, lte, sql } from 'drizzle-orm';
+import { and, count, eq, gte, lt, lte, sql } from 'drizzle-orm';
 import {
     accounts,
+    accountUsers,
     deliveryRequests,
     events,
     farms,
@@ -8,14 +9,14 @@ import {
     gardens,
     raisedBeds,
     transactions,
-    userLogins,
     users,
 } from '../schema';
 import { storage } from '../storage';
+import { knownEventTypes } from './events/knownEventTypes';
 
 type ActiveUserRow = {
     userId: string;
-    lastLogin: Date | null;
+    activityDate: Date | string;
 };
 
 type ActiveUsersMetrics = {
@@ -38,19 +39,15 @@ function calculateActiveUsersMetrics(
     const monthlyActiveUsers = new Set<string>();
 
     for (const row of rows) {
-        if (!row.lastLogin) {
-            continue;
-        }
+        const activityDate = new Date(row.activityDate);
 
-        const lastLoginDate = new Date(row.lastLogin);
-
-        if (lastLoginDate >= lastDayThreshold) {
+        if (activityDate >= lastDayThreshold) {
             dailyActiveUsers.add(row.userId);
         }
-        if (lastLoginDate >= lastWeekThreshold) {
+        if (activityDate >= lastWeekThreshold) {
             weeklyActiveUsers.add(row.userId);
         }
-        if (lastLoginDate >= monthlyThreshold) {
+        if (activityDate >= monthlyThreshold) {
             monthlyActiveUsers.add(row.userId);
         }
     }
@@ -137,16 +134,19 @@ export async function getAnalyticsTotals(days: number = 7) {
             .where(lt(deliveryRequests.createdAt, beforeDate)),
         storage()
             .select({
-                userId: userLogins.userId,
-                lastLogin: userLogins.lastLogin,
+                userId: accountUsers.userId,
+                activityDate: sql<Date>`max(${events.createdAt})`,
             })
-            .from(userLogins)
+            .from(accountUsers)
+            .innerJoin(events, eq(events.aggregateId, accountUsers.accountId))
             .where(
                 and(
-                    gte(userLogins.lastLogin, lastMonthThreshold),
-                    isNotNull(userLogins.lastLogin),
+                    eq(events.type, knownEventTypes.accounts.earnSunflowers),
+                    gte(events.createdAt, lastMonthThreshold),
+                    sql`${events.data}->>'reason' like 'daily:%'`,
                 ),
-            ),
+            )
+            .groupBy(accountUsers.userId),
     ]);
 
     const activeUsers = calculateActiveUsersMetrics(


### PR DESCRIPTION
### Motivation
- DAU/WAU/MAU should be based on actual daily activity (daily reward claims) rather than `lastLogin` because `lastLogin` only updates on session renewal which can be much longer than a day.

### Description
- Replaced `userLogins.lastLogin` usage with event-based activity in `packages/storage/src/repositories/analyticsRepo.ts` and changed the active row shape to `{ userId, activityDate }`.
- Switched the active-user query to join `accountUsers` with `events` and filter on `events.type === knownEventTypes.accounts.earnSunflowers` and `events.data->>'reason' like 'daily:%'` to capture daily reward events.
- Updated metric calculation to derive DAU/WAU/MAU from `activityDate` (event `createdAt`) and added necessary imports (`accountUsers`, `eq`, `knownEventTypes`) while removing the `userLogins` dependency.

### Testing
- Ran `pnpm lint --filter @gredice/storage`, which completed successfully (one fixable warning was applied by the linter). 
- Attempted `pnpm --filter @gredice/storage test -- analyticsRepo.node.spec.ts` but it could not run in this environment because the test DB startup requires Docker (not available), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3886f8c2c832f9f2304759ef02ac9)