### PR TITLE
feat(garden): add deterministic block placement and rollbackIntroduce deterministic placement logic for purchased garden blocks andensureity when creating and updating stacks- Use resolveGardenBlockPlacement to compute target stack coordinates,

### DIFF
--- a/apps/api/.claude/skills/integration-nextjs-app-router/SKILL.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: integration-nextjs-app-router
+description: PostHog integration for Next.js App Router applications
+metadata:
+  author: PostHog
+  version: 1.9.5
+---
+
+# PostHog integration for Next.js App Router
+
+This skill helps you add PostHog analytics to Next.js App Router applications.
+
+## Workflow
+
+Follow these steps in order to complete the integration:
+
+1. `basic-integration-1.0-begin.md` - PostHog Setup - Begin ← **Start here**
+2. `basic-integration-1.1-edit.md` - PostHog Setup - Edit
+3. `basic-integration-1.2-revise.md` - PostHog Setup - Revise
+4. `basic-integration-1.3-conclude.md` - PostHog Setup - Conclusion
+
+## Reference files
+
+- `references/EXAMPLE.md` - Next.js App Router example project code
+- `references/next-js.md` - Next.js - docs
+- `references/identify-users.md` - Identify users - docs
+- `references/basic-integration-1.0-begin.md` - PostHog setup - begin
+- `references/basic-integration-1.1-edit.md` - PostHog setup - edit
+- `references/basic-integration-1.2-revise.md` - PostHog setup - revise
+- `references/basic-integration-1.3-conclude.md` - PostHog setup - conclusion
+
+The example project shows the target implementation pattern. Consult the documentation for API details.
+
+## Key principles
+
+- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+
+## Framework guidelines
+
+- For Next.js 15.3+, initialize PostHog in instrumentation-client.ts for the simplest setup
+- For feature flags, use useFeatureFlagEnabled() or useFeatureFlagPayload() hooks - they handle loading states and external sync automatically
+- Add analytics capture in event handlers where user actions occur, NOT in useEffect reacting to state changes
+- Do NOT use useEffect for data transformation - calculate derived values during render instead
+- Do NOT use useEffect to respond to user events - put that logic in the event handler itself
+- Do NOT use useEffect to chain state updates - calculate all related updates together in the event handler
+- Do NOT use useEffect to notify parent components - call the parent callback alongside setState in the event handler
+- To reset component state when a prop changes, pass the prop as the component's key instead of using useEffect
+- useEffect is ONLY for synchronizing with external systems (non-React widgets, browser APIs, network subscriptions)
+
+## Identifying users
+
+Identify users during login and signup events. Refer to the example code and documentation for the correct identify pattern for this framework. If both frontend and backend code exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain correlation.
+
+## Error tracking
+
+Add PostHog error tracking to relevant files, particularly around critical user flows and API boundaries.

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/EXAMPLE.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/EXAMPLE.md
@@ -1,0 +1,706 @@
+# PostHog Next.js App Router Example Project
+
+Repository: https://github.com/PostHog/context-mill
+Path: basics/next-app-router
+
+---
+
+## README.md
+
+# PostHog Next.js app router example
+
+This is a [Next.js](https://nextjs.org) App Router example demonstrating PostHog integration with product analytics, session replay, feature flags, and error tracking.
+
+## Features
+
+- **Product analytics**: Track user events and behaviors
+- **Session replay**: Record and replay user sessions
+- **Error tracking**: Capture and track errors
+- **User authentication**: Demo login system with PostHog user identification
+- **Server-side & Client-side tracking**: Examples of both tracking methods
+- **Reverse proxy**: PostHog ingestion through Next.js rewrites
+
+## Getting started
+
+### 1. Install dependencies
+
+```bash
+npm install
+# or
+pnpm install
+```
+
+### 2. Configure environment variables
+
+Create a `.env.local` file in the root directory:
+
+```bash
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+Get your PostHog project token from your [PostHog project settings](https://app.posthog.com/project/settings).
+
+### 3. Run the development server
+
+```bash
+npm run dev
+# or
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the app.
+
+## Project structure
+
+```
+src/
+├── app/
+│   ├── api/
+│   │   └── auth/
+│   │       └── login/
+│   │           └── route.ts   # Login API with server-side tracking
+│   ├── burrito/
+│   │   └── page.tsx           # Demo feature page with event tracking
+│   ├── profile/
+│   │   └── page.tsx           # User profile with error tracking demo
+│   ├── layout.tsx             # Root layout with providers
+│   ├── page.tsx               # Home/Login page
+│   └── globals.css            # Global styles
+├── components/
+│   └── Header.tsx             # Navigation header with auth state
+├── contexts/
+│   └── AuthContext.tsx        # Authentication context with PostHog integration
+└── lib/
+    └── posthog-server.ts      # Server-side PostHog client
+
+instrumentation-client.ts      # Client-side PostHog initialization
+```
+
+## Key integration points
+
+### Client-side initialization (instrumentation-client.ts)
+
+```typescript
+import posthog from "posthog-js"
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
+  api_host: "/ingest",
+  ui_host: "https://us.posthog.com",
+  defaults: '2026-01-30',
+  capture_exceptions: true,
+  debug: process.env.NODE_ENV === "development",
+});
+```
+
+### User identification (AuthContext.tsx)
+
+```typescript
+posthog.identify(username, {
+  username: username,
+});
+```
+
+### Event tracking (burrito/page.tsx)
+
+```typescript
+posthog.capture('burrito_considered', {
+  total_considerations: count,
+  username: username,
+});
+```
+
+### Error tracking (profile/page.tsx)
+
+```typescript
+posthog.captureException(error);
+```
+
+### Server-side tracking (app/api/auth/login/route.ts)
+
+```typescript
+const posthog = getPostHogClient();
+posthog.capture({
+  distinctId: username,
+  event: 'server_login',
+  properties: { ... }
+});
+```
+
+## App router differences from pages router
+
+This example uses Next.js App Router instead of Pages Router. Key differences:
+
+1. **File-based routing**: Pages in `src/app/` instead of `src/pages/`
+2. **layout.tsx**: Root layout component wraps all pages
+3. **API Routes**: Located in `src/app/api/` with `route.ts` files
+4. **'use client'**: Client components need explicit directive
+5. **useRouter**: From `next/navigation` instead of `next/router`
+6. **Metadata**: Exported from layout/page instead of Head component
+7. **Server Components**: Components are server-side by default
+
+## Learn more
+
+- [PostHog Documentation](https://posthog.com/docs)
+- [Next.js App Router Documentation](https://nextjs.org/docs/app)
+- [PostHog Next.js Integration Guide](https://posthog.com/docs/libraries/next-js)
+
+## Deploy on Vercel
+
+The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new).
+
+Check out the [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+---
+
+## .env.example
+
+```example
+# PostHog Configuration
+# Get your PostHog project token from: https://app.posthog.com/project/settings
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token_here
+# NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+---
+
+## instrumentation-client.ts
+
+```ts
+import posthog from "posthog-js"
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
+  api_host: "/ingest",
+  ui_host: "https://us.posthog.com",
+  // Include the defaults option as required by PostHog
+  defaults: '2026-01-30',
+  // Enables capturing unhandled exceptions via Error Tracking
+  capture_exceptions: true,
+  // Turn on debug in development mode
+  debug: process.env.NODE_ENV === "development",
+});
+
+//IMPORTANT: Never combine this approach with other client-side PostHog initialization approaches, especially components like a PostHogProvider. instrumentation-client.ts is the correct solution for initializating client-side PostHog in Next.js 15.3+ apps.
+```
+
+---
+
+## next.config.ts
+
+```ts
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+    ];
+  },
+  // This is required to support PostHog trailing slash API requests
+  skipTrailingSlashRedirect: true,
+};
+
+export default nextConfig;
+
+```
+
+---
+
+## src/app/api/auth/login/route.ts
+
+```ts
+import { NextResponse } from 'next/server';
+import { getPostHogClient } from '@/lib/posthog-server';
+
+const users = new Map<string, { username: string; burritoConsiderations: number }>();
+
+export async function POST(request: Request) {
+  const { username, password } = await request.json();
+
+  if (!username || !password) {
+    return NextResponse.json({ error: 'Username and password required' }, { status: 400 });
+  }
+
+  let user = users.get(username);
+  const isNewUser = !user;
+  
+  if (!user) {
+    user = { username, burritoConsiderations: 0 };
+    users.set(username, user);
+  }
+
+  // Capture server-side login event
+  const posthog = getPostHogClient();
+  posthog.capture({
+    distinctId: username,
+    event: 'server_login',
+    properties: {
+      username: username,
+      isNewUser: isNewUser,
+      source: 'api'
+    }
+  });
+
+  // Identify user on server side
+  posthog.identify({
+    distinctId: username,
+    properties: {
+      username: username,
+      createdAt: isNewUser ? new Date().toISOString() : undefined
+    }
+  });
+
+  return NextResponse.json({ success: true, user });
+}
+```
+
+---
+
+## src/app/burrito/page.tsx
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import posthog from 'posthog-js';
+
+export default function BurritoPage() {
+  const { user, incrementBurritoConsiderations } = useAuth();
+  const router = useRouter();
+  const [hasConsidered, setHasConsidered] = useState(false);
+
+  // Redirect to home if not logged in
+  if (!user) {
+    router.push('/');
+    return null;
+  }
+
+  const handleConsideration = () => {
+    incrementBurritoConsiderations();
+    setHasConsidered(true);
+    setTimeout(() => setHasConsidered(false), 2000);
+    
+    // Capture burrito consideration event
+    posthog.capture('burrito_considered', {
+      total_considerations: user.burritoConsiderations + 1,
+      username: user.username,
+    });
+  };
+
+  return (
+    <div className="container">
+      <h1>Burrito consideration zone</h1>
+      <p>Take a moment to truly consider the potential of burritos.</p>
+      
+      <div style={{ textAlign: 'center' }}>
+        <button 
+          onClick={handleConsideration}
+          className="btn-burrito"
+        >
+          I have considered the burrito potential
+        </button>
+        
+        {hasConsidered && (
+          <p className="success">
+            Thank you for your consideration! Count: {user.burritoConsiderations}
+          </p>
+        )}
+      </div>
+      
+      <div className="stats">
+        <h3>Consideration stats</h3>
+        <p>Total considerations: {user.burritoConsiderations}</p>
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## src/app/layout.tsx
+
+```tsx
+import type { Metadata } from "next";
+import "./globals.css";
+import { AuthProvider } from "@/contexts/AuthContext";
+import Header from "@/components/Header";
+
+export const metadata: Metadata = {
+  title: "Burrito Consideration App",
+  description: "Consider the potential of burritos",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthProvider>
+          <Header />
+          <main>{children}</main>
+        </AuthProvider>
+      </body>
+    </html>
+  );
+}
+
+```
+
+---
+
+## src/app/page.tsx
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function Home() {
+  const { user, login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    
+    try {
+      const success = await login(username, password);
+      if (success) {
+        setUsername('');
+        setPassword('');
+      } else {
+        setError('Please provide both username and password');
+      }
+    } catch (err) {
+      console.error('Login failed:', err);
+      setError('An error occurred during login');
+    }
+  };
+
+  if (user) {
+    return (
+      <div className="container">
+        <h1>Welcome back, {user.username}!</h1>
+        <p>You are now logged in. Feel free to explore:</p>
+        <ul>
+          <li>Consider the potential of burritos</li>
+          <li>View your profile and statistics</li>
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container">
+      <h1>Welcome to Burrito Consideration App</h1>
+      <p>Please sign in to begin your burrito journey</p>
+      
+      <form onSubmit={handleSubmit} className="form">
+        <div className="form-group">
+          <label htmlFor="username">Username:</label>
+          <input
+            type="text"
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Enter any username"
+          />
+        </div>
+        
+        <div className="form-group">
+          <label htmlFor="password">Password:</label>
+          <input
+            type="password"
+            id="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Enter any password"
+          />
+        </div>
+        
+        {error && <p className="error">{error}</p>}
+        
+        <button type="submit" className="btn-primary">Sign In</button>
+      </form>
+      
+      <p className="note">
+        Note: This is a demo app. Use any username and password to sign in.
+      </p>
+    </div>
+  );
+}
+```
+
+---
+
+## src/app/profile/page.tsx
+
+```tsx
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import posthog from 'posthog-js';
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  // Redirect to home if not logged in
+  if (!user) {
+    router.push('/');
+    return null;
+  }
+
+  const triggerTestError = () => {
+    try {
+      throw new Error('Test error for PostHog error tracking');
+    } catch (err) {
+      posthog.captureException(err);
+      console.error('Captured error:', err);
+      alert('Error captured and sent to PostHog!');
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1>User Profile</h1>
+      
+      <div className="stats">
+        <h2>Your Information</h2>
+        <p><strong>Username:</strong> {user.username}</p>
+        <p><strong>Burrito Considerations:</strong> {user.burritoConsiderations}</p>
+      </div>
+      
+      <div style={{ marginTop: '2rem' }}>
+        <button onClick={triggerTestError} className="btn-primary" style={{ backgroundColor: '#dc3545' }}>
+          Trigger Test Error (for PostHog)
+        </button>
+      </div>
+      
+      <div style={{ marginTop: '2rem' }}>
+        <h3>Your Burrito Journey</h3>
+        {user.burritoConsiderations === 0 ? (
+          <p>You haven&apos;t considered any burritos yet. Visit the Burrito Consideration page to start!</p>
+        ) : user.burritoConsiderations === 1 ? (
+          <p>You&apos;ve considered the burrito potential once. Keep going!</p>
+        ) : user.burritoConsiderations < 5 ? (
+          <p>You&apos;re getting the hang of burrito consideration!</p>
+        ) : user.burritoConsiderations < 10 ? (
+          <p>You&apos;re becoming a burrito consideration expert!</p>
+        ) : (
+          <p>You are a true burrito consideration master! 🌯</p>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## src/components/Header.tsx
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function Header() {
+  const { user, logout } = useAuth();
+
+  return (
+    <header className="header">
+      <div className="header-container">
+        <nav>
+          <Link href="/">Home</Link>
+          {user && (
+            <>
+              <Link href="/burrito">Burrito Consideration</Link>
+              <Link href="/profile">Profile</Link>
+            </>
+          )}
+        </nav>
+        <div className="user-section">
+          {user ? (
+            <>
+              <span>Welcome, {user.username}!</span>
+              <button onClick={logout} className="btn-logout">
+                Logout
+              </button>
+            </>
+          ) : (
+            <span>Not logged in</span>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}
+```
+
+---
+
+## src/contexts/AuthContext.tsx
+
+```tsx
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+import posthog from 'posthog-js';
+
+interface User {
+  username: string;
+  burritoConsiderations: number;
+}
+
+interface AuthContextType {
+  user: User | null;
+  login: (username: string, password: string) => Promise<boolean>;
+  logout: () => void;
+  incrementBurritoConsiderations: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+const users: Map<string, User> = new Map();
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  // Use lazy initializer to read from localStorage only once on mount
+  const [user, setUser] = useState<User | null>(() => {
+    if (typeof window === 'undefined') return null;
+
+    const storedUsername = localStorage.getItem('currentUser');
+    if (storedUsername) {
+      const existingUser = users.get(storedUsername);
+      if (existingUser) {
+        return existingUser;
+      }
+    }
+    return null;
+  });
+
+  const login = async (username: string, password: string): Promise<boolean> => {
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+
+      if (response.ok) {
+        const { user: userData } = await response.json();
+
+        let localUser = users.get(username);
+        if (!localUser) {
+          localUser = userData as User;
+          users.set(username, localUser);
+        }
+
+        setUser(localUser);
+        localStorage.setItem('currentUser', username);
+        
+        // Identify user in PostHog using username as distinct ID
+        posthog.identify(username, {
+          username: username,
+        });
+        
+        // Capture login event
+        posthog.capture('user_logged_in', {
+          username: username,
+        });
+        
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('Login error:', error);
+      return false;
+    }
+  };
+
+  const logout = () => {
+    // Capture logout event before resetting
+    posthog.capture('user_logged_out');
+    posthog.reset();
+    
+    setUser(null);
+    localStorage.removeItem('currentUser');
+  };
+
+  const incrementBurritoConsiderations = () => {
+    if (user) {
+      user.burritoConsiderations++;
+      users.set(user.username, user);
+      setUser({ ...user });
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, incrementBurritoConsiderations }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}
+```
+
+---
+
+## src/lib/posthog-server.ts
+
+```ts
+import { PostHog } from 'posthog-node';
+
+let posthogClient: PostHog | null = null;
+
+export function getPostHogClient() {
+  if (!posthogClient) {
+    posthogClient = new PostHog(
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!,
+      { 
+        host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+        flushAt: 1,
+        flushInterval: 0
+      }
+    );
+    posthogClient.debug(true);
+  }
+  return posthogClient;
+}
+
+export async function shutdownPostHog() {
+  if (posthogClient) {
+    await posthogClient.shutdown();
+  }
+}
+```
+
+---
+

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.0-begin.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.0-begin.md
@@ -1,0 +1,43 @@
+---
+title: PostHog Setup - Begin
+description: Start the event tracking setup process by analyzing the project and creating an event tracking plan
+---
+
+We're making an event tracking plan for this project.
+
+Before proceeding, find any existing `posthog.capture()` code. Make note of event name formatting.
+
+From the project's file list, select between 10 and 15 files that might have interesting business value for event tracking, especially conversion and churn events. Also look for additional files related to login that could be used for identifying users, along with error handling. Read the files. If a file is already well-covered by PostHog events, replace it with another option. Do not spawn subagents.
+
+Look for opportunities to track client-side events.
+
+**IMPORTANT: Server-side events are REQUIRED** if the project includes any instrumentable server-side code. If the project has API routes (e.g., `app/api/**/route.ts`) or Server Actions, you MUST include server-side events for critical business operations like:
+
+  - Payment/checkout completion
+  - Webhook handlers
+  - Authentication endpoints
+
+Do not skip server-side events - they capture actions that cannot be tracked client-side.
+
+Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add: event name, event description, and the file path we want to place the event in. If events already exist, don't duplicate them; supplement them.
+
+Track actions only, not pageviews. These can be captured automatically. Exceptions can be made for "viewed"-type events that correspond to the top of a conversion funnel.
+
+As you review files, make an internal note of opportunities to identify users and catch errors. We'll need them for the next step.
+
+## Status
+
+Before beginning a phase of the setup, you will send a status message with the exact prefix '[STATUS]', as in:
+
+[STATUS] Checking project structure.
+
+Status to report in this phase:
+
+- Checking project structure
+- Verifying PostHog dependencies
+- Generating events based on project
+
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.1-edit.md](basic-integration-1.1-edit.md)

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.1-edit.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.1-edit.md
@@ -1,0 +1,37 @@
+---
+title: PostHog Setup - Edit
+description: Implement PostHog event tracking in the identified files, following best practices and the example project
+---
+
+For each of the files and events noted in .posthog-events.json, make edits to capture events using PostHog. Make sure to set up any helper files needed. Carefully examine the included example project code: your implementation should match it as closely as possible. Do not spawn subagents.
+
+Use environment variables for PostHog keys. Do not hardcode PostHog keys.
+
+If a file already has existing integration code for other tools or services, don't overwrite or remove that code. Place PostHog code below it.
+
+For each event, add useful properties, and use your access to the PostHog source code to ensure correctness. You also have access to documentation about creating new events with PostHog. Consider this documentation carefully and follow it closely before adding events. Your integration should be based on documented best practices. Carefully consider how the user project's framework version may impact the correct PostHog integration approach.
+
+Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names. There are also example project code files available via the PostHog MCP; use these for reference.
+
+Where possible, add calls for PostHog's identify() function on the client side upon events like logins and signups. Use the contents of login and signup forms to identify users on submit. If there is server-side code, pass the client-side session and distinct ID to the server-side code to identify the user. On the server side, make sure events have a matching distinct ID where relevant. 
+
+It's essential to do this in both client code and server code, so that user behavior from both domains is easy to correlate.
+
+You should also add PostHog exception capture error tracking to these files where relevant.
+
+Remember: Do not alter the fundamental architecture of existing files. Make your additions minimal and targeted.
+
+Remember the documentation and example project resources you were provided at the beginning. Read them now.
+
+## Status
+
+Status to report in this phase:
+
+- Inserting PostHog capture code
+- A status message for each file whose edits you are planning, including a high level summary of changes
+- A status message for each file you have edited
+
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.2-revise.md](basic-integration-1.2-revise.md)

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.2-revise.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.2-revise.md
@@ -1,0 +1,22 @@
+---
+title: PostHog Setup - Revise
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Check the project for errors. Read the package.json file for any type checking or build scripts that may provide input about what to fix. Remember that you can find the source code for any dependency in the node_modules directory. Do not spawn subagents.
+
+Ensure that any components created were actually used.
+
+Once all other tasks are complete, run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Do not run formatting or linting across the entire project's codebase.
+
+## Status
+
+Status to report in this phase:
+
+- Finding and correcting errors
+- Report details of any errors you fix
+- Linting, building and prettying
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.3-conclude.md](basic-integration-1.3-conclude.md)

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.3-conclude.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/basic-integration-1.3-conclude.md
@@ -1,0 +1,38 @@
+---
+title: PostHog Setup - Conclusion
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Use the PostHog MCP to create a new dashboard named "Analytics basics" based on the events created here. Make sure to use the exact same event names as implemented in the code. Populate it with up to five insights, with special emphasis on things like conversion funnels, churn events, and other business critical insights.  
+
+Search for a file called `.posthog-events.json` and read it for available events. Do not spawn subagents.
+
+Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, along with a list of links for the dashboard and insights created. Follow this format:
+
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of your project. [Detailed summary of changes]
+
+[table of events/descriptions/files]
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+[links]
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>
+
+Upon completion, remove .posthog-events.json.
+
+## Status
+
+Status to report in this phase:
+
+- Configured dashboard: [insert PostHog dashboard URL]
+- Created setup report: [insert full local file path]

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/identify-users.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/identify-users.md
@@ -1,0 +1,202 @@
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/features.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/features.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional person properties
+    name: 'Max Hedgehog'
+})
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    email: "max@hedgehogmail.com", // optional: set additional person properties
+    name: "Max Hedgehog"
+});
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+-   Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+-   There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset()
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset()
+```
+
+### Dart
+
+```dart
+Posthog().reset()
+```
+
+If you *also* want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true)
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+-   Onboarding and signup flows before authentication.
+-   Unauthenticated web pages redirecting to authenticated mobile apps.
+-   Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+-   The user is already authenticated on the mobile app. In this case, call [`posthog.alias()`](/docs/libraries/js/features.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+-   The user is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/features.md#identifying-users) with the distinct ID from the web. Events will be associated with this distinct ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+## Further reading
+
+-   [Identifying users docs](/docs/product-analytics/identify.md)
+-   [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+-   [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/apps/api/.claude/skills/integration-nextjs-app-router/references/next-js.md
+++ b/apps/api/.claude/skills/integration-nextjs-app-router/references/next-js.md
@@ -1,0 +1,385 @@
+# Next.js - Docs
+
+PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
+
+This guide walks you through integrating PostHog into your Next.js app using the [React](/docs/libraries/react.md) and the [Node.js](/docs/libraries/node.md) SDKs.
+
+> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/main/playground/nextjs).
+
+Next.js has both client and server-side rendering, as well as pages and app routers. We'll cover all of these options in this guide.
+
+> **Try `@posthog/next` (pre-release):** A simplified Next.js integration with synchronized client/server identity, server-side flag bootstrapping, and a built-in API proxy. [Read the setup guide →](/docs/libraries/next-js/posthog-next.md)
+
+## Prerequisites
+
+To follow this guide along, you need:
+
+1.  A PostHog instance (either [Cloud](https://app.posthog.com/signup) or [self-hosted](/docs/self-host.md))
+2.  A Next.js application
+
+## Beta: integration via LLM
+
+Install PostHog for Next.js in seconds with our wizard by running this prompt with [LLM coding agents](/blog/envoy-wizard-llm-agent.md) like Cursor and Bolt, or by running it in your terminal.
+
+`npx @posthog/wizard@latest`
+
+[Learn more](/wizard.md)
+
+Or, to integrate manually, continue with the rest of this guide.
+
+## Client-side setup
+
+Install `posthog-js` using your package manager:
+
+PostHog AI
+
+### npm
+
+```bash
+npm install --save posthog-js
+```
+
+### Yarn
+
+```bash
+yarn add posthog-js
+```
+
+### pnpm
+
+```bash
+pnpm add posthog-js
+```
+
+### Bun
+
+```bash
+bun add posthog-js
+```
+
+Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token in your [project settings](https://app.posthog.com/project/settings).
+
+.env.local
+
+PostHog AI
+
+```shell
+NEXT_PUBLIC_POSTHOG_TOKEN=<ph_project_token>
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+These values need to start with `NEXT_PUBLIC_` to be accessible on the client-side.
+
+## Integration
+
+Next.js provides the [`instrumentation-client.ts|js`](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client) file for client-side setup. Add it to the root of your Next.js app (for both app and pages router) and initialize PostHog in it like this:
+
+PostHog AI
+
+### instrumentation-client.js
+
+```javascript
+import posthog from 'posthog-js'
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+  api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  defaults: '2026-01-30'
+});
+```
+
+### instrumentation-client.ts
+
+```typescript
+import posthog from 'posthog-js'
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN!, {
+  api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  defaults: '2026-01-30'
+});
+```
+
+Bootstrapping with `instrumentation-client`
+
+When using `instrumentation-client`, the values you pass to `posthog.init` remain fixed for the entire session. This means bootstrapping only works if you evaluate flags **before your app renders** (for example, on the server).
+
+If you need flag values after the app has rendered, you’ll want to:
+
+-   Evaluate the flag on the server and pass the value into your app, or
+-   Evaluate the flag in an earlier page/state, then store and re-use it when needed.
+
+Both approaches avoid flicker and give you the same outcome as bootstrapping, as long as you use the same `distinct_id` across client and server.
+
+See the [bootstrapping guide](/docs/feature-flags/bootstrapping.md) for more information.
+
+## Identifying users
+
+> **Identifying users is required.** Call `posthog.identify('your-user-id')` after login to link events to a known user. This is what connects frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), and [error tracking](/docs/error-tracking.md) to the same person — and lets backend events link back too.
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+Set up a reverse proxy (recommended)
+
+We recommend [setting up a reverse proxy](/docs/advanced/proxy.md), so that events are less likely to be intercepted by tracking blockers.
+
+We have our [own managed reverse proxy service](/docs/advanced/proxy/managed-reverse-proxy.md), which is free for all PostHog Cloud users, routes through our infrastructure, and makes setting up your proxy easy.
+
+If you don't want to use our managed service then there are several other options for creating a reverse proxy, including using [Cloudflare](/docs/advanced/proxy/cloudflare.md), [AWS Cloudfront](/docs/advanced/proxy/cloudfront.md), and [Vercel](/docs/advanced/proxy/vercel.md).
+
+Grouping products in one project (recommended)
+
+If you have multiple customer-facing products (e.g. a marketing website + mobile app + web app), it's best to install PostHog on them all and [group them in one project](/docs/settings/projects.md).
+
+This makes it possible to track users across their entire journey (e.g. from visiting your marketing website to signing up for your product), or how they use your product across multiple platforms.
+
+Add IPs to Firewall/WAF allowlists (recommended)
+
+For certain features like [heatmaps](/docs/toolbar/heatmaps.md), your Web Application Firewall (WAF) may be blocking PostHog’s requests to your site. Add these IP addresses to your WAF allowlist or rules to let PostHog access your site.
+
+**EU**: `3.75.65.221`, `18.197.246.42`, `3.120.223.253`
+
+**US**: `44.205.89.55`, `52.4.194.122`, `44.208.188.173`
+
+These are public, stable IPs used by PostHog services (e.g., Celery tasks for snapshots).
+
+## Accessing PostHog
+
+Once initialized in `instrumentation-client.js|ts`, import `posthog` from `posthog-js` anywhere and call the methods you need on the `posthog` object.
+
+JavaScript
+
+PostHog AI
+
+```javascript
+'use client'
+import posthog from 'posthog-js'
+export default function Home() {
+  return (
+    <div>
+      <button onClick={() => posthog.capture('test_event')}>
+        Click me for an event
+      </button>
+    </div>
+  );
+}
+```
+
+### Using React hooks
+
+The [React feature flag hooks](/docs/libraries/react.md#feature-flags) work automatically when PostHog is initialized via `instrumentation-client.ts`. The hooks use the initialized posthog-js singleton:
+
+JavaScript
+
+PostHog AI
+
+```javascript
+'use client'
+import { useFeatureFlagEnabled } from 'posthog-js/react'
+export default function FeatureComponent() {
+  const showNewFeature = useFeatureFlagEnabled('new-feature')
+  return showNewFeature ? <NewFeature /> : <OldFeature />
+}
+```
+
+### Usage
+
+See the [React SDK docs](/docs/libraries/react.md) for examples of how to use:
+
+-   [`posthog-js` functions like custom event capture, user identification, and more.](/docs/libraries/react.md#using-posthog-js-functions)
+-   [Feature flags including variants and payloads.](/docs/libraries/react.md#feature-flags)
+
+You can also read [the full `posthog-js` documentation](/docs/libraries/js/features.md) for all the usable functions.
+
+## Server-side analytics
+
+Next.js enables you to both server-side render pages and add server-side functionality. To integrate PostHog into your Next.js app on the server-side, you can use the [Node SDK](/docs/libraries/node.md).
+
+First, install the `posthog-node` library:
+
+PostHog AI
+
+### npm
+
+```bash
+npm install posthog-node --save
+```
+
+### Yarn
+
+```bash
+yarn add posthog-node
+```
+
+### pnpm
+
+```bash
+pnpm add posthog-node
+```
+
+### Bun
+
+```bash
+bun add posthog-node
+```
+
+### Router-specific instructions
+
+## App router
+
+For the app router, we can initialize the `posthog-node` SDK once with a `PostHogClient` function, and import it into files.
+
+This enables us to send events and fetch data from PostHog on the server – without making client-side requests.
+
+JavaScript
+
+PostHog AI
+
+```javascript
+// app/posthog.js
+import { PostHog } from 'posthog-node'
+export default function PostHogClient() {
+  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    flushAt: 1,
+    flushInterval: 0
+  })
+  return posthogClient
+}
+```
+
+> **Note:** Because server-side functions in Next.js can be short-lived, we set `flushAt` to `1` and `flushInterval` to `0`.
+>
+> -   `flushAt` sets how many capture calls we should flush the queue (in one batch).
+> -   `flushInterval` sets how many milliseconds we should wait before flushing the queue. Setting them to the lowest number ensures events are sent immediately and not batched. We also need to call `await posthog.shutdown()` once done.
+
+To use this client, we import it into our pages and call it with the `PostHogClient` function:
+
+JavaScript
+
+PostHog AI
+
+```javascript
+import Link from 'next/link'
+import PostHogClient from '../posthog'
+export default async function About() {
+  const posthog = PostHogClient()
+  const flags = await posthog.getAllFlags(
+    'user_distinct_id' // replace with a user's distinct ID
+  );
+  await posthog.shutdown()
+  return (
+    <main>
+      <h1>About</h1>
+      <Link href="/">Go home</Link>
+      { flags['main-cta'] &&
+        <Link href="http://posthog.com/">Go to PostHog</Link>
+      }
+    </main>
+  )
+}
+```
+
+## Pages router
+
+For the pages router, we can use the `getServerSideProps` function to access PostHog on the server-side, send events, evaluate feature flags, and more.
+
+This looks like this:
+
+JavaScript
+
+PostHog AI
+
+```javascript
+// pages/posts/[id].js
+import { useContext, useEffect, useState } from 'react'
+import { getServerSession } from "next-auth/next"
+import { PostHog } from 'posthog-node'
+export default function Post({ post, flags }) {
+  const [ctaState, setCtaState] = useState()
+  useEffect(() => {
+    if (flags) {
+      setCtaState(flags['blog-cta'])
+    }
+  })
+  return (
+    <div>
+      <h1>{post.title}</h1>
+      <p>By: {post.author}</p>
+      <p>{post.content}</p>
+      {ctaState &&
+        <p><a href="/">Go to PostHog</a></p>
+      }
+      <button onClick={likePost}>Like</button>
+    </div>
+  )
+}
+export async function getServerSideProps(ctx) {
+  const session = await getServerSession(ctx.req, ctx.res)
+  let flags = null
+  if (session) {
+    const client = new PostHog(
+      process.env.NEXT_PUBLIC_POSTHOG_TOKEN,
+      {
+        host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+      }
+    )
+    flags = await client.getAllFlags(session.user.email);
+    client.capture({
+      distinctId: session.user.email,
+      event: 'loaded blog article',
+      properties: {
+        $current_url: ctx.req.url,
+      },
+    });
+    await client.shutdown()
+  }
+  const { posts } = await import('../../blog.json')
+  const post = posts.find((post) => post.id.toString() === ctx.params.id)
+  return {
+    props: {
+      post,
+      flags
+    },
+  }
+}
+```
+
+> **Note**: Make sure to *always* call `await client.shutdown()` after sending events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
+
+### Server-side configuration
+
+Next.js overrides the default `fetch` behavior on the server to introduce their own cache. PostHog ignores that cache by default, as this is Next.js's default behavior for any fetch call.
+
+You can override that configuration when initializing PostHog, but make sure you understand the pros/cons of using Next.js's cache and that you might get cached results rather than the actual result our server would return. This is important for feature flags, for example.
+
+TSX
+
+PostHog AI
+
+```jsx
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN, {
+  // ... your configuration
+  fetch_options: {
+    cache: 'force-cache', // Use Next.js cache
+    next_options: {       // Passed to the `next` option for `fetch`
+      revalidate: 60,     // Cache for 60 seconds
+      tags: ['posthog'],  // Can be used with Next.js `revalidateTag` function
+    },
+  }
+})
+```
+
+## Configuring a reverse proxy to PostHog
+
+To improve the reliability of client-side tracking and make requests less likely to be intercepted by tracking blockers, you can setup a reverse proxy in Next.js. Read more about deploying a reverse proxy using [Next.js rewrites](/docs/advanced/proxy/nextjs.md), [Next.js middleware](/docs/advanced/proxy/nextjs-middleware.md), and [Vercel rewrites](/docs/advanced/proxy/vercel.md).
+
+## Further reading
+
+-   [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics.md)
+-   [How to set up Next.js pages router analytics, feature flags, and more](/tutorials/nextjs-pages-analytics.md)
+-   [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -45,3 +45,4 @@ node_modules/
 certificates
 # Sentry Config File
 .env.sentry-build-plugin
+.env.local

--- a/apps/api/app/api/[...route]/authRoutes.ts
+++ b/apps/api/app/api/[...route]/authRoutes.ts
@@ -48,6 +48,7 @@ import {
     revokeSessionToken,
 } from '../../../lib/auth/sessionTokens';
 import { sendWelcome } from '../../../lib/email/transactional';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 const failedAttemptClearTime = 1000 * 60; // 1 minute
 const failedAttemptsBlock = 5;
@@ -315,6 +316,12 @@ const app = new Hono()
                 setRefreshCookie(context, refreshToken),
             ]);
 
+            getPostHogClient().capture({
+                distinctId: user.id,
+                event: 'user_logged_in',
+                properties: { provider: 'password' },
+            });
+
             return context.json({
                 token: accessToken,
                 refreshToken,
@@ -416,6 +423,12 @@ const app = new Hono()
                     loginSuccessful(loginId),
                     setRefreshCookie(context, refreshToken),
                 ]);
+
+                getPostHogClient().capture({
+                    distinctId: userId,
+                    event: isNewUser ? 'user_signed_up' : 'user_logged_in',
+                    properties: { provider: 'google' },
+                });
 
                 const redirectUrl = resolveRedirectUrl(
                     context,
@@ -532,6 +545,12 @@ const app = new Hono()
                     loginSuccessful(loginId),
                     setRefreshCookie(context, refreshToken),
                 ]);
+
+                getPostHogClient().capture({
+                    distinctId: userId,
+                    event: isNewUser ? 'user_signed_up' : 'user_logged_in',
+                    properties: { provider: 'facebook' },
+                });
 
                 const redirectUrl = resolveRedirectUrl(
                     context,
@@ -661,12 +680,28 @@ const app = new Hono()
             description: 'Logout user by clearing the session cookie',
         }),
         async (context) => {
+            const sessionCookie = getCookie(context, 'gredice_session');
+            let userId: string | undefined;
+            if (sessionCookie) {
+                try {
+                    const { result } = await verifyJwt(sessionCookie);
+                    userId = result?.payload.sub ?? undefined;
+                } catch {
+                    // ignore
+                }
+            }
             const refreshToken = getCookie(context, refreshTokenCookieName);
             if (refreshToken) {
                 await revokeSessionToken(refreshToken);
             }
             await clearCookie(context);
             await clearRefreshCookie(context);
+            if (userId) {
+                getPostHogClient().capture({
+                    distinctId: userId,
+                    event: 'user_logged_out',
+                });
+            }
             return context.json({
                 message: 'Logged out successfully',
             });
@@ -700,6 +735,12 @@ const app = new Hono()
 
             // Create user with password
             const userId = await createUserWithPassword(email, password);
+
+            getPostHogClient().capture({
+                distinctId: userId,
+                event: 'user_signed_up',
+                properties: { provider: 'password' },
+            });
 
             await notifyNewUserRegistered(userId);
 
@@ -863,6 +904,11 @@ const app = new Hono()
             await updateLoginData(userLogin.id, {
                 ...loginData,
                 isVerified: true,
+            });
+
+            getPostHogClient().capture({
+                distinctId: user.id,
+                event: 'user_email_verified',
             });
 
             // Send welcome message

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -24,6 +24,7 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { getPostHogClient } from '../../../lib/posthog-server';
 import { processItem } from '../../../lib/stripe/processCheckoutSession';
 
 const app = new Hono<{ Variables: AuthVariables }>()
@@ -284,8 +285,33 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     await assignStripeCustomerId(account.id, customerId);
                 }
 
+                getPostHogClient().capture({
+                    distinctId: accountId,
+                    event: 'checkout_initiated',
+                    properties: {
+                        cart_id: cartId,
+                        payment_method: 'stripe',
+                        item_count: stripeItems.length,
+                    },
+                });
+
                 return context.json({ sessionId, url });
             }
+
+            getPostHogClient().capture({
+                distinctId: accountId,
+                event: 'checkout_initiated',
+                properties: {
+                    cart_id: cartId,
+                    payment_method: cartInfo.items.some(
+                        (i) => i.currency === 'sunflower',
+                    )
+                        ? 'sunflower'
+                        : 'inventory',
+                    item_count: cartInfo.items.length,
+                },
+            });
+
             return context.json({ success: true });
         },
     )
@@ -341,6 +367,12 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     500,
                 );
             }
+
+            getPostHogClient().capture({
+                distinctId: accountId,
+                event: 'checkout_cancelled',
+                properties: { session_id: sessionId },
+            });
 
             return context.json({ success: true });
         },

--- a/apps/api/app/api/[...route]/deliveryRoutes.ts
+++ b/apps/api/app/api/[...route]/deliveryRoutes.ts
@@ -21,6 +21,7 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 // Validation schemas
 const createAddressSchema = z.object({
@@ -105,6 +106,15 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             const addressId = await createDeliveryAddress(insertData);
             const newAddress = await getDeliveryAddress(addressId, accountId);
+            getPostHogClient().capture({
+                distinctId: accountId,
+                event: 'delivery_address_created',
+                properties: {
+                    city: data.city,
+                    country_code: data.countryCode,
+                    is_default: data.isDefault,
+                },
+            });
             return context.json(newAddress, 201);
         },
     )
@@ -246,6 +256,14 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 await notifyDeliveryRequestEvent(id, 'cancelled', {
                     reason: cancelReason,
                     note,
+                });
+                getPostHogClient().capture({
+                    distinctId: accountId,
+                    event: 'delivery_request_cancelled',
+                    properties: {
+                        request_id: id,
+                        cancel_reason: cancelReason,
+                    },
                 });
                 return context.json({ success: true });
             } catch (error) {

--- a/apps/api/app/api/[...route]/feedbackRoutes.ts
+++ b/apps/api/app/api/[...route]/feedbackRoutes.ts
@@ -6,6 +6,7 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 const app = new Hono<{ Variables: AuthVariables }>()
     .get(
@@ -36,6 +37,14 @@ const app = new Hono<{ Variables: AuthVariables }>()
         async (context) => {
             const feedback = context.req.valid('json');
             const id = await createFeedback(feedback);
+            getPostHogClient().capture({
+                distinctId: 'anonymous',
+                event: 'feedback_submitted',
+                properties: {
+                    topic: feedback.topic,
+                    score: feedback.score ?? undefined,
+                },
+            });
             return context.json({ id });
         },
     );

--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -20,6 +20,7 @@ import {
     knownEvents,
     knownEventTypes,
     spendSunflowers,
+    deleteGardenBlock as storageDeleteGardenBlock,
     updateGarden,
     updateGardenBlock,
     updateGardenStack,
@@ -31,7 +32,9 @@ import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getBlockData } from '../../../lib/blocks/blockDataService';
 import { publicSecurity } from '../../../lib/docs/security';
+import { resolveGardenBlockPlacement } from '../../../lib/garden/blockPlacementService';
 import { deleteGardenBlock } from '../../../lib/garden/gardenBlocksService';
+import { purchaseGardenBlock } from '../../../lib/garden/purchaseGardenBlockService';
 import { synchronizeGardenStacksAndRaisedBeds } from '../../../lib/garden/gardenStacksSyncService';
 import {
     AI_ANALYSIS_DAILY_LIMIT,
@@ -59,8 +62,9 @@ async function countRecentRaisedBedAiAnalyses(accountId: string) {
         bedId.toString(),
     );
     const raisedBedFieldAggregateIds = accountBedIds.flatMap((bedId) =>
-        Array.from({ length: 20 }, (_, index) =>
-            `${bedId.toString()}|${index.toString()}`,
+        Array.from(
+            { length: 20 },
+            (_, index) => `${bedId.toString()}|${index.toString()}`,
         ),
     );
 
@@ -974,6 +978,12 @@ const app = new Hono<{ Variables: AuthVariables }>()
             'json',
             z.object({
                 blockName: z.string(),
+                position: z
+                    .object({
+                        x: z.number().int(),
+                        y: z.number().int(),
+                    })
+                    .optional(),
             }),
         ),
         authValidator(['user', 'admin']),
@@ -987,8 +997,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
             // Check garden exists and is owned by user
             const { accountId } = context.get('authContext');
 
-            const [garden, blockData] = await Promise.all([
+            const [garden, gardenBlocks, blockData] = await Promise.all([
                 getGarden(gardenIdNumber),
+                getGardenBlocks(gardenIdNumber),
                 getBlockData(),
             ]);
 
@@ -1001,7 +1012,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
 
-            const { blockName } = context.req.valid('json');
+            const { blockName, position } = context.req.valid('json');
 
             // Retrieve block information (cost)
             const block = blockData.find(
@@ -1021,13 +1032,65 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
 
-            // Spend sunflowers and create block in parallel
-            const [, blockId] = await Promise.all([
-                spendSunflowers(accountId, cost, `block:${blockName}`),
-                createGardenBlock(gardenIdNumber, blockName),
-            ]);
+            const blockNameById = new Map(
+                gardenBlocks.map((block) => [block.id, block.name] as const),
+            );
+            const blockDataByName = new Map<
+                string,
+                (typeof blockData)[number]
+            >();
+            for (const candidate of blockData) {
+                const candidateName = candidate.information?.name;
+                if (candidateName) {
+                    blockDataByName.set(candidateName, candidate);
+                }
+            }
+            const placement = resolveGardenBlockPlacement({
+                blockName,
+                stacks: garden.stacks,
+                blockNameById,
+                blockDataByName,
+                requestedPosition: position,
+            });
+            if (!placement.valid) {
+                return context.json({ error: placement.error }, 400);
+            }
 
-            return context.json({ id: blockId });
+            const { x, y, existingBlocks } = placement.placement;
+            const hasTargetStack = garden.stacks.some(
+                (stack) => stack.positionX === x && stack.positionY === y,
+            );
+            const purchaseResult = await purchaseGardenBlock({
+                accountId,
+                blockName,
+                cost,
+                dependencies: {
+                    createGardenBlock,
+                    createGardenStack,
+                    deleteGardenBlock: storageDeleteGardenBlock,
+                    spendSunflowers,
+                    synchronizeGardenStacksAndRaisedBeds,
+                    updateGardenStack,
+                },
+                gardenId: gardenIdNumber,
+                hasTargetStack,
+                placement: {
+                    x,
+                    y,
+                    existingBlocks,
+                },
+            });
+            if (!purchaseResult.ok) {
+                return context.json(
+                    { error: purchaseResult.error },
+                    purchaseResult.status,
+                );
+            }
+
+            return context.json({
+                id: purchaseResult.blockId,
+                position: purchaseResult.position,
+            });
         },
     )
     .put(

--- a/apps/api/app/api/[...route]/newsletterRoutes.ts
+++ b/apps/api/app/api/[...route]/newsletterRoutes.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { publicSecurity } from '../../../lib/docs/security';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 const app = new Hono().post(
     '/subscribe',
@@ -23,6 +24,14 @@ const app = new Hono().post(
             const subscriber = await subscribeToNewsletter({
                 email,
                 source,
+            });
+            getPostHogClient().capture({
+                distinctId: email,
+                event: 'newsletter_subscribed',
+                properties: {
+                    source: source ?? undefined,
+                    status: subscriber.status,
+                },
             });
             return context.json({
                 success: true,

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -15,6 +15,7 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 const app = new Hono<{ Variables: AuthVariables }>()
     .get(
@@ -137,6 +138,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 currency,
                 forceCreate,
             } = context.req.valid('json');
+            const { accountId } = context.get('authContext');
             await upsertOrRemoveCartItem(
                 id,
                 cartId,
@@ -150,6 +152,17 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 currency,
                 forceCreate,
             );
+            getPostHogClient().capture({
+                distinctId: accountId,
+                event: 'cart_item_updated',
+                properties: {
+                    cart_id: cartId,
+                    entity_id: entityId,
+                    entity_type: entityTypeName,
+                    amount,
+                    currency: currency ?? undefined,
+                },
+            });
             return context.json({ success: true });
         },
     )

--- a/apps/api/instrumentation-client.ts
+++ b/apps/api/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import posthog from 'posthog-js';
 
 Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -29,3 +30,11 @@ Sentry.init({
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
+    api_host: '/ingest',
+    ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    defaults: '2026-01-30',
+    capture_exceptions: true,
+    debug: process.env.NODE_ENV === 'development',
+});

--- a/apps/api/lib/garden/blockPlacementService.node.spec.ts
+++ b/apps/api/lib/garden/blockPlacementService.node.spec.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveGardenBlockPlacement } from './blockPlacementService';
+
+const blockDataByName = new Map([
+    ['Block_Grass', { attributes: { stackable: true, height: 1 } }],
+    ['Raised_Bed', { attributes: { stackable: true, height: 1 } }],
+    ['Shade', { attributes: { stackable: false, height: 1 } }],
+]);
+
+describe('resolveGardenBlockPlacement', () => {
+    it('skips invalid raised-bed positions near origin and finds the first valid slot', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Raised_Bed',
+            stacks: [
+                { positionX: 0, positionY: 0, blocks: ['grass-a', 'bed-a'] },
+                { positionX: 1, positionY: 0, blocks: ['grass-b', 'bed-b'] },
+            ],
+            blockNameById: new Map([
+                ['grass-a', 'Block_Grass'],
+                ['grass-b', 'Block_Grass'],
+                ['bed-a', 'Raised_Bed'],
+                ['bed-b', 'Raised_Bed'],
+            ]),
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: true,
+            placement: {
+                x: -1,
+                y: 1,
+                index: 0,
+                existingBlocks: [],
+            },
+        });
+    });
+
+    it('rejects explicitly requested raised-bed positions that the backend would not allow', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Raised_Bed',
+            requestedPosition: { x: 0, y: -1 },
+            stacks: [
+                { positionX: 0, positionY: 0, blocks: ['grass-a', 'bed-a'] },
+                { positionX: 1, positionY: 0, blocks: ['grass-b', 'bed-b'] },
+            ],
+            blockNameById: new Map([
+                ['grass-a', 'Block_Grass'],
+                ['grass-b', 'Block_Grass'],
+                ['bed-a', 'Raised_Bed'],
+                ['bed-b', 'Raised_Bed'],
+            ]),
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: false,
+            error: 'Invalid raised bed placement: cannot place next to an already attached raised bed',
+        });
+    });
+
+    it('rejects placing ground blocks on non-empty stacks', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Block_Grass',
+            requestedPosition: { x: 0, y: 0 },
+            stacks: [{ positionX: 0, positionY: 0, blocks: ['shade-a'] }],
+            blockNameById: new Map([['shade-a', 'Shade']]),
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: false,
+            error: 'Invalid block placement: ground blocks can only be placed on empty stacks',
+        });
+    });
+});

--- a/apps/api/lib/garden/blockPlacementService.ts
+++ b/apps/api/lib/garden/blockPlacementService.ts
@@ -1,0 +1,181 @@
+import type { SelectGardenStack } from '@gredice/storage';
+import {
+    validateRaisedBedPlacement,
+    validateStackPlacement,
+} from './stacksPatchValidation';
+
+type BlockDataLike = {
+    attributes?: {
+        stackable?: boolean;
+        height?: number;
+    };
+};
+
+type Position = {
+    x: number;
+    y: number;
+};
+
+type Placement = Position & {
+    index: number;
+    existingBlocks: string[];
+};
+
+type PlacementResult =
+    | {
+          valid: true;
+          placement: Placement;
+      }
+    | {
+          valid: false;
+          error: string;
+      };
+
+const CANDIDATE_BLOCK_ID = '__candidate_block__';
+const MAX_SPIRAL_STEPS = 1000;
+
+function spiral(step: number): Position {
+    const r = Math.floor((Math.sqrt(step + 1) - 1) / 2) + 1;
+    const p = (8 * r * (r - 1)) / 2;
+    const en = r * 2;
+    const a = (1 + step - p) % (r * 8);
+
+    switch (Math.floor(a / (r * 2))) {
+        case 0:
+            return { x: a - r, y: -r };
+        case 1:
+            return { x: r, y: (a % en) - r };
+        case 2:
+            return { x: r - (a % en), y: r };
+        case 3:
+            return { x: -r, y: r - (a % en) };
+        default:
+            return { x: 0, y: 0 };
+    }
+}
+
+function findStackAtPosition(
+    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[],
+    position: Position,
+) {
+    return stacks.find(
+        (stack) =>
+            stack.positionX === position.x && stack.positionY === position.y,
+    );
+}
+
+function isGroundBlock(blockName: string) {
+    return blockName.startsWith('Block');
+}
+
+function validatePlacementAtPosition(params: {
+    blockName: string;
+    position: Position;
+    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[];
+    blockNameById: Map<string, string>;
+    blockDataByName: Map<string, BlockDataLike>;
+}): PlacementResult {
+    const { blockName, position, stacks, blockNameById, blockDataByName } =
+        params;
+    const existingBlocks =
+        findStackAtPosition(stacks, position)?.blocks.slice() ?? [];
+
+    if (isGroundBlock(blockName) && existingBlocks.length > 0) {
+        return {
+            valid: false,
+            error: 'Invalid block placement: ground blocks can only be placed on empty stacks',
+        };
+    }
+
+    const blockNameByIdWithCandidate = new Map(blockNameById);
+    blockNameByIdWithCandidate.set(CANDIDATE_BLOCK_ID, blockName);
+
+    const nextBlocks = [...existingBlocks, CANDIDATE_BLOCK_ID];
+    const stackValidation = validateStackPlacement({
+        blockIds: nextBlocks,
+        blockNameById: blockNameByIdWithCandidate,
+        blockDataByName,
+    });
+    if (!stackValidation.valid) {
+        return stackValidation;
+    }
+
+    if (blockName === 'Raised_Bed') {
+        const placementValidation = validateRaisedBedPlacement({
+            stacks,
+            x: position.x,
+            y: position.y,
+            index: existingBlocks.length,
+            blockNameById,
+        });
+        if (!placementValidation.valid) {
+            return placementValidation;
+        }
+    }
+
+    return {
+        valid: true,
+        placement: {
+            x: position.x,
+            y: position.y,
+            index: existingBlocks.length,
+            existingBlocks,
+        },
+    };
+}
+
+export function resolveGardenBlockPlacement(params: {
+    blockName: string;
+    stacks: Pick<SelectGardenStack, 'positionX' | 'positionY' | 'blocks'>[];
+    blockNameById: Map<string, string>;
+    blockDataByName: Map<string, BlockDataLike>;
+    requestedPosition?: Position;
+}): PlacementResult {
+    const {
+        blockName,
+        stacks,
+        blockNameById,
+        blockDataByName,
+        requestedPosition,
+    } = params;
+
+    if (requestedPosition) {
+        return validatePlacementAtPosition({
+            blockName,
+            position: requestedPosition,
+            stacks,
+            blockNameById,
+            blockDataByName,
+        });
+    }
+
+    const originPlacement = validatePlacementAtPosition({
+        blockName,
+        position: { x: 0, y: 0 },
+        stacks,
+        blockNameById,
+        blockDataByName,
+    });
+    if (originPlacement.valid) {
+        return originPlacement;
+    }
+
+    for (let step = 0; step < MAX_SPIRAL_STEPS; step++) {
+        const candidatePosition = spiral(step);
+        const placement = validatePlacementAtPosition({
+            blockName,
+            position: candidatePosition,
+            stacks,
+            blockNameById,
+            blockDataByName,
+        });
+        if (placement.valid) {
+            return placement;
+        }
+    }
+
+    return {
+        valid: false,
+        error: 'No valid placement position found',
+    };
+}

--- a/apps/api/lib/garden/purchaseGardenBlockService.node.spec.ts
+++ b/apps/api/lib/garden/purchaseGardenBlockService.node.spec.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { purchaseGardenBlock } from './purchaseGardenBlockService';
+
+describe('purchaseGardenBlock', () => {
+    it('synchronizes raised beds after purchasing a raised bed', async () => {
+        const calls: string[] = [];
+
+        const result = await purchaseGardenBlock({
+            accountId: 'account-1',
+            blockName: 'Raised_Bed',
+            cost: 30,
+            gardenId: 42,
+            hasTargetStack: false,
+            placement: {
+                x: 3,
+                y: 4,
+                existingBlocks: ['ground-1'],
+            },
+            dependencies: {
+                createGardenBlock: async () => {
+                    calls.push('createGardenBlock');
+                    return 'block-1';
+                },
+                createGardenStack: async () => {
+                    calls.push('createGardenStack');
+                },
+                deleteGardenBlock: async () => {
+                    calls.push('deleteGardenBlock');
+                },
+                spendSunflowers: async () => {
+                    calls.push('spendSunflowers');
+                },
+                synchronizeGardenStacksAndRaisedBeds: async () => {
+                    calls.push('synchronizeGardenStacksAndRaisedBeds');
+                },
+                updateGardenStack: async () => {
+                    calls.push('updateGardenStack');
+                },
+            },
+        });
+
+        assert.deepStrictEqual(result, {
+            ok: true,
+            blockId: 'block-1',
+            position: { x: 3, y: 4 },
+        });
+        assert.deepStrictEqual(calls, [
+            'createGardenStack',
+            'createGardenBlock',
+            'updateGardenStack',
+            'spendSunflowers',
+            'synchronizeGardenStacksAndRaisedBeds',
+        ]);
+    });
+
+    it('skips raised-bed synchronization for other block purchases', async () => {
+        const calls: string[] = [];
+
+        const result = await purchaseGardenBlock({
+            accountId: 'account-1',
+            blockName: 'Shade',
+            cost: 30,
+            gardenId: 42,
+            hasTargetStack: true,
+            placement: {
+                x: 3,
+                y: 4,
+                existingBlocks: ['ground-1'],
+            },
+            dependencies: {
+                createGardenBlock: async () => {
+                    calls.push('createGardenBlock');
+                    return 'block-1';
+                },
+                createGardenStack: async () => {
+                    calls.push('createGardenStack');
+                },
+                deleteGardenBlock: async () => {
+                    calls.push('deleteGardenBlock');
+                },
+                spendSunflowers: async () => {
+                    calls.push('spendSunflowers');
+                },
+                synchronizeGardenStacksAndRaisedBeds: async () => {
+                    calls.push('synchronizeGardenStacksAndRaisedBeds');
+                },
+                updateGardenStack: async () => {
+                    calls.push('updateGardenStack');
+                },
+            },
+        });
+
+        assert.deepStrictEqual(result, {
+            ok: true,
+            blockId: 'block-1',
+            position: { x: 3, y: 4 },
+        });
+        assert.deepStrictEqual(calls, [
+            'createGardenBlock',
+            'updateGardenStack',
+            'spendSunflowers',
+        ]);
+    });
+});

--- a/apps/api/lib/garden/purchaseGardenBlockService.ts
+++ b/apps/api/lib/garden/purchaseGardenBlockService.ts
@@ -1,0 +1,153 @@
+type PurchaseGardenBlockDependencies = {
+    createGardenBlock: (
+        gardenId: number,
+        blockName: string,
+    ) => Promise<string>;
+    createGardenStack: (
+        gardenId: number,
+        position: { x: number; y: number },
+    ) => Promise<unknown>;
+    deleteGardenBlock: (
+        gardenId: number,
+        blockId: string,
+    ) => Promise<unknown>;
+    spendSunflowers: (
+        accountId: string,
+        amount: number,
+        source: string,
+    ) => Promise<unknown>;
+    synchronizeGardenStacksAndRaisedBeds: (
+        gardenId: number,
+    ) => Promise<unknown>;
+    updateGardenStack: (
+        gardenId: number,
+        stack: { x: number; y: number; blocks: string[] },
+    ) => Promise<unknown>;
+};
+
+type PurchasedBlockPlacement = {
+    existingBlocks: string[];
+    x: number;
+    y: number;
+};
+
+type PurchaseGardenBlockParams = {
+    accountId: string;
+    blockName: string;
+    cost: number;
+    gardenId: number;
+    hasTargetStack: boolean;
+    placement: PurchasedBlockPlacement;
+    dependencies: PurchaseGardenBlockDependencies;
+};
+
+type PurchaseGardenBlockResult =
+    | {
+          ok: true;
+          blockId: string;
+          position: { x: number; y: number };
+      }
+    | {
+          ok: false;
+          error: string;
+          status: 400 | 500;
+      };
+
+export async function purchaseGardenBlock(
+    params: PurchaseGardenBlockParams,
+): Promise<PurchaseGardenBlockResult> {
+    const {
+        accountId,
+        blockName,
+        cost,
+        gardenId,
+        hasTargetStack,
+        placement,
+        dependencies,
+    } = params;
+    const { x, y, existingBlocks } = placement;
+
+    if (!hasTargetStack) {
+        await dependencies.createGardenStack(gardenId, { x, y });
+    }
+
+    let blockId: string | undefined;
+    let didUpdateStack = false;
+    try {
+        blockId = await dependencies.createGardenBlock(gardenId, blockName);
+        await dependencies.updateGardenStack(gardenId, {
+            x,
+            y,
+            blocks: [...existingBlocks, blockId],
+        });
+        didUpdateStack = true;
+        await dependencies.spendSunflowers(
+            accountId,
+            cost,
+            `block:${blockName}`,
+        );
+    } catch (error) {
+        const rollbackOperations: Promise<unknown>[] = [];
+        if (didUpdateStack) {
+            rollbackOperations.push(
+                dependencies.updateGardenStack(gardenId, {
+                    x,
+                    y,
+                    blocks: existingBlocks,
+                }),
+            );
+        }
+        if (blockId) {
+            rollbackOperations.push(
+                dependencies.deleteGardenBlock(gardenId, blockId),
+            );
+        }
+        if (rollbackOperations.length > 0) {
+            await Promise.allSettled(rollbackOperations);
+        }
+
+        console.error('Failed to place purchased block', {
+            gardenId,
+            accountId,
+            blockName,
+            position: { x, y },
+            error,
+        });
+
+        const errorMessage =
+            error instanceof Error ? error.message : 'Failed to place block';
+        return {
+            ok: false,
+            error: errorMessage,
+            status: errorMessage === 'Insufficient sunflowers' ? 400 : 500,
+        };
+    }
+
+    if (!blockId) {
+        return {
+            ok: false,
+            error: 'Failed to place block',
+            status: 500,
+        };
+    }
+
+    if (blockName === 'Raised_Bed') {
+        try {
+            await dependencies.synchronizeGardenStacksAndRaisedBeds(gardenId);
+        } catch (error) {
+            console.error('Failed to synchronize raised beds after block purchase', {
+                gardenId,
+                accountId,
+                blockId,
+                blockName,
+                error,
+            });
+        }
+    }
+
+    return {
+        ok: true,
+        blockId,
+        position: { x, y },
+    };
+}

--- a/apps/api/lib/garden/stacksPatchValidation.ts
+++ b/apps/api/lib/garden/stacksPatchValidation.ts
@@ -165,10 +165,9 @@ function getRaisedBedAdjacentCount(params: {
     stacks: GardenStack[];
     x: number;
     y: number;
-    index: number;
     blockNameById: Map<string, string>;
 }) {
-    const { stacks, x, y, index, blockNameById } = params;
+    const { stacks, x, y, blockNameById } = params;
     const neighborPositions = [
         { x: x - 1, y },
         { x: x + 1, y },
@@ -182,12 +181,9 @@ function getRaisedBedAdjacentCount(params: {
             return false;
         }
 
-        const blockId = stack.blocks[index];
-        if (!blockId) {
-            return false;
-        }
-
-        return blockNameById.get(blockId) === 'Raised_Bed';
+        return stack.blocks.some(
+            (blockId) => blockNameById.get(blockId) === 'Raised_Bed',
+        );
     }).length;
 }
 
@@ -198,7 +194,19 @@ export function validateRaisedBedPlacement(params: {
     index: number;
     blockNameById: Map<string, string>;
 }): ValidationResult {
-    const { stacks, x, y, index, blockNameById } = params;
+    const { stacks, x, y, blockNameById } = params;
+    const targetStack = findStackByPosition(stacks, x, y);
+
+    if (
+        targetStack?.blocks.some(
+            (blockId) => blockNameById.get(blockId) === 'Raised_Bed',
+        )
+    ) {
+        return {
+            valid: false,
+            error: 'Invalid raised bed placement: cannot stack on another raised bed',
+        };
+    }
 
     const neighborPositions = [
         { x: x - 1, y },
@@ -211,12 +219,9 @@ export function validateRaisedBedPlacement(params: {
             return false;
         }
 
-        const blockId = stack.blocks[index];
-        if (!blockId) {
-            return false;
-        }
-
-        return blockNameById.get(blockId) === 'Raised_Bed';
+        return stack.blocks.some(
+            (blockId) => blockNameById.get(blockId) === 'Raised_Bed',
+        );
     });
 
     if (neighborPositions.length > 1) {
@@ -232,7 +237,6 @@ export function validateRaisedBedPlacement(params: {
             stacks,
             x: neighborX,
             y: neighborY,
-            index,
             blockNameById,
         });
         if (neighborAdjacentCount > 0) {

--- a/apps/api/lib/posthog-server.ts
+++ b/apps/api/lib/posthog-server.ts
@@ -1,0 +1,17 @@
+import { PostHog } from 'posthog-node';
+
+let posthogClient: PostHog | null = null;
+
+export function getPostHogClient() {
+    if (!posthogClient) {
+        posthogClient = new PostHog(
+            process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!,
+            {
+                host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+                flushAt: 1,
+                flushInterval: 0,
+            },
+        );
+    }
+    return posthogClient;
+}

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -32,6 +32,7 @@ import {
 import { calculateSunflowerAmount } from '../checkout/sunflowerCalculations';
 import { notifyDeliveryScheduled } from '../delivery/emailNotifications';
 import { notifyScheduledDeliveryEmailOnce } from '../delivery/scheduledEmailDeduper';
+import { getPostHogClient } from '../posthog-server';
 
 /**
  * Recursively sorts object keys for deterministic JSON serialization.
@@ -510,6 +511,19 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
         checkoutSessionId: session.id ?? null,
         items: purchasedItems,
     });
+
+    if (accountId) {
+        getPostHogClient().capture({
+            distinctId: accountId,
+            event: 'purchase_completed',
+            properties: {
+                amount_total: session.amountTotal,
+                currency: 'eur',
+                item_count: purchasedItems.length,
+                checkout_session_id: session.id,
+            },
+        });
+    }
 }
 
 export async function processItem(itemData: {

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -24,6 +24,19 @@ const nextConfig: NextConfig = {
     },
     productionBrowserSourceMaps: !shouldSkipSentrySourceMaps,
     allowedDevOrigins: ['api.gredice.test'],
+    async rewrites() {
+        return [
+            {
+                source: '/ingest/static/:path*',
+                destination: `${process.env.NEXT_PUBLIC_POSTHOG_HOST}/static/:path*`,
+            },
+            {
+                source: '/ingest/:path*',
+                destination: `${process.env.NEXT_PUBLIC_POSTHOG_HOST}/:path*`,
+            },
+        ];
+    },
+    skipTrailingSlashRedirect: true,
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,6 +36,8 @@
         "hono-openapi": "1.3.0",
         "next": "16.2.2",
         "pg": "8.20.0",
+        "posthog-js": "^1.367.0",
+        "posthog-node": "^5.29.2",
         "prettier": "3.8.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",

--- a/apps/api/posthog-setup-report.md
+++ b/apps/api/posthog-setup-report.md
@@ -1,0 +1,37 @@
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of PostHog into the Gredice API app. Server-side event tracking was added across all critical business flows using `posthog-node`, client-side PostHog was initialized in `instrumentation-client.ts` using `posthog-js`, and a reverse proxy was configured in `next.config.ts` to route PostHog requests through `/ingest`. A shared server client singleton was created at `lib/posthog-server.ts`.
+
+| Event | Description | File |
+|---|---|---|
+| `user_signed_up` | A new user registers with email/password or via OAuth | `app/api/[...route]/authRoutes.ts` |
+| `user_logged_in` | A user logs in successfully (password, Google, or Facebook) | `app/api/[...route]/authRoutes.ts` |
+| `user_oauth_logged_in` | — (merged with `user_logged_in`; provider tracked as property) | `app/api/[...route]/authRoutes.ts` |
+| `user_logged_out` | A user logs out and their session is revoked | `app/api/[...route]/authRoutes.ts` |
+| `user_email_verified` | A user successfully verifies their email address | `app/api/[...route]/authRoutes.ts` |
+| `checkout_initiated` | A user begins checkout (Stripe session created or direct payment) | `app/api/[...route]/checkoutRoutes.ts` |
+| `checkout_cancelled` | A user cancels an active Stripe checkout session | `app/api/[...route]/checkoutRoutes.ts` |
+| `purchase_completed` | A Stripe payment completes and cart items are fully processed | `lib/stripe/processCheckoutSession.ts` |
+| `cart_item_updated` | A user adds, updates, or removes an item from their shopping cart | `app/api/[...route]/shoppingCartRoutes.ts` |
+| `feedback_submitted` | A user submits feedback with a topic and optional score | `app/api/[...route]/feedbackRoutes.ts` |
+| `newsletter_subscribed` | A user subscribes to the Gredice newsletter | `app/api/[...route]/newsletterRoutes.ts` |
+| `delivery_address_created` | A user creates a new delivery address | `app/api/[...route]/deliveryRoutes.ts` |
+| `delivery_request_cancelled` | A user cancels a delivery request | `app/api/[...route]/deliveryRoutes.ts` |
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+- **Dashboard**: [Analytics basics](https://eu.posthog.com/project/156787/dashboard/614356)
+- **Insight**: [New User Sign-ups (Daily)](https://eu.posthog.com/project/156787/insights/peaDHxMN)
+- **Insight**: [Logins by Provider](https://eu.posthog.com/project/156787/insights/BI1MQXS4)
+- **Insight**: [Checkout to Purchase Conversion](https://eu.posthog.com/project/156787/insights/fP0PU8Zp)
+- **Insight**: [Newsletter Subscriptions (Weekly)](https://eu.posthog.com/project/156787/insights/04K7kToK)
+- **Insight**: [Full Acquisition & Purchase Funnel](https://eu.posthog.com/project/156787/insights/mioOmtWK)
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -5,6 +5,7 @@
         "build": {
             "env": [
                 "ACS_CONNECTION_STRING",
+                "AI_GATEWAY_API_KEY",
                 "BLOB_READ_WRITE_TOKEN",
                 "CRON_SECRET",
                 "ENABLE_EXPERIMENTAL_COREPACK",
@@ -12,6 +13,8 @@
                 "FACEBOOK_CLIENT_SECRET",
                 "GOOGLE_CLIENT_ID",
                 "GOOGLE_CLIENT_SECRET",
+                "GREDICE_GOOGLE_MAPS_API_KEY",
+                "GREDICE_GOOGLE_MAPS_URL_SIGNING_SECRET",
                 "GREDICE_JWT_SIGN_SECRET",
                 "GREDICE_MCP_JWT_SECRET",
                 "GREDICE_SILO_KV_REST_API_READ_ONLY_TOKEN",
@@ -19,6 +22,7 @@
                 "GREDICE_SILO_KV_REST_API_URL",
                 "GREDICE_SILO_KV_URL",
                 "GREDICE_SILO_REDIS_URL",
+                "NEXT_PUBLIC_POSTHOG_HOST",
                 "NEXT_PUBLIC_STRIPE_PUBLISHABLE",
                 "NEXT_PUBLIC_STRIPE_RETURN_URL",
                 "PLANTS_SILO_KV_REST_API_READ_ONLY_TOKEN",
@@ -36,6 +40,7 @@
                 "POSTGRES_USER",
                 "RESEND_API_KEY",
                 "SIGNALCO_API_KEY",
+                "SLACK_BOT_TOKEN",
                 "STRIPE_SECRETKEY",
                 "STRIPE_WEBHOOK_SECRET",
                 "VERCEL_OIDC_TOKEN"

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -326,32 +326,39 @@ export function PickableGroup({
             };
         });
 
-        const movedPreviewByPosition = new Map(
-            placementPreviews.map((preview) => [
-                `${preview.destination.x}|${preview.destination.z}|${preview.destinationIndex}`,
-                preview,
-            ]),
+        const movedRaisedBedPreviewByPosition = new Map(
+            placementPreviews
+                .filter((preview) => preview.blockName === 'Raised_Bed')
+                .map((preview) => [
+                    `${preview.destination.x}|${preview.destination.z}`,
+                    preview,
+                ]),
         );
 
-        function getExternalRaisedBedBlockAtIndex(
-            x: number,
-            z: number,
-            index: number,
-        ) {
+        function getExternalRaisedBedBlockAtPosition(x: number, z: number) {
             const stackAtPosition = getStack({ x, z });
-            const candidateBlock = stackAtPosition?.blocks.filter(
-                (candidate) => !movingBlockIds.has(candidate.id),
-            )[index];
-            if (!candidateBlock || candidateBlock.name !== 'Raised_Bed') {
-                return null;
+            const candidateBlocks =
+                stackAtPosition?.blocks.filter(
+                    (candidate) => !movingBlockIds.has(candidate.id),
+                ) ?? [];
+
+            for (
+                let candidateIndex = candidateBlocks.length - 1;
+                candidateIndex >= 0;
+                candidateIndex--
+            ) {
+                const candidateBlock = candidateBlocks[candidateIndex];
+                if (candidateBlock?.name === 'Raised_Bed') {
+                    return candidateBlock;
+                }
             }
-            return candidateBlock;
+
+            return null;
         }
 
         function hasExternalRaisedBedNeighbor(
             x: number,
             z: number,
-            index: number,
             excludedPositions: Set<string>,
         ) {
             const neighbors = [
@@ -367,11 +374,7 @@ export function PickableGroup({
                 }
 
                 return Boolean(
-                    getExternalRaisedBedBlockAtIndex(
-                        neighbor.x,
-                        neighbor.z,
-                        index,
-                    ),
+                    getExternalRaisedBedBlockAtPosition(neighbor.x, neighbor.z),
                 );
             });
         }
@@ -396,8 +399,8 @@ export function PickableGroup({
                     | undefined;
 
                 for (const neighbor of neighbors) {
-                    const movedNeighbor = movedPreviewByPosition.get(
-                        `${neighbor.x}|${neighbor.z}|${preview.destinationIndex}`,
+                    const movedNeighbor = movedRaisedBedPreviewByPosition.get(
+                        `${neighbor.x}|${neighbor.z}`,
                     );
                     if (
                         movedNeighbor &&
@@ -408,10 +411,9 @@ export function PickableGroup({
                     }
 
                     const externalNeighborBlock =
-                        getExternalRaisedBedBlockAtIndex(
+                        getExternalRaisedBedBlockAtPosition(
                             neighbor.x,
                             neighbor.z,
-                            preview.destinationIndex,
                         );
                     if (externalNeighborBlock) {
                         raisedBedNeighborCount += 1;
@@ -447,7 +449,6 @@ export function PickableGroup({
                 return hasExternalRaisedBedNeighbor(
                     externalNeighbor.x,
                     externalNeighbor.z,
-                    preview.destinationIndex,
                     excludedPositions,
                 );
             });

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -1,13 +1,26 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Vector3 } from 'three';
-import { v4 as uuidv4 } from 'uuid';
-import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { useGameState } from '../useGameState';
 import { currentAccountKeys } from './useCurrentAccount';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
 const mutationKey = ['gardens', 'current', 'blockPlace'];
+
+async function getBlockPlacementError(response: Response) {
+    const responseText = await response.text();
+    if (!responseText) {
+        return 'Failed to place block';
+    }
+
+    try {
+        const parsedResponse = JSON.parse(responseText) as {
+            error?: string;
+        };
+        return parsedResponse.error ?? responseText;
+    } catch {
+        return responseText;
+    }
+}
 
 export function useBlockPlace() {
     const queryClient = useQueryClient();
@@ -17,98 +30,28 @@ export function useBlockPlace() {
 
     return useMutation({
         mutationKey,
-        mutationFn: async ({
-            blockName,
-            position,
-        }: {
-            blockName: string;
-            position: [x: number, y: number];
-        }) => {
+        mutationFn: async ({ blockName }: { blockName: string }) => {
             if (!garden) {
                 throw new Error('No garden selected');
             }
-
-            const createBlock = async () => {
-                const response = await clientAuthenticated().api.gardens[
-                    ':gardenId'
-                ].blocks.$post({
-                    param: {
-                        gardenId: garden.id.toString(),
-                    },
-                    json: {
-                        blockName: blockName,
-                    },
-                });
-                if (response.status !== 200) {
-                    const body = await response.text();
-                    throw new Error(`Failed to create block: ${body}`);
-                }
-                const { id } = await response.json();
-                return id;
-            };
-
-            const primaryBlockId = await createBlock();
-
-            await clientAuthenticated().api.gardens[':gardenId'].stacks.$patch({
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ].blocks.$post({
                 param: {
                     gardenId: garden.id.toString(),
                 },
-                json: [
-                    {
-                        op: 'add',
-                        path: `/${position[0]}/${position[1]}/-`,
-                        value: primaryBlockId,
-                    },
-                ],
-            });
-
-            return [primaryBlockId];
-        },
-        onMutate: async ({ blockName, position }) => {
-            if (!garden) {
-                return;
-            }
-
-            const primaryBlock = { id: uuidv4(), name: blockName, rotation: 0 };
-            const nextStacks = [...garden.stacks];
-
-            const ensureStack = (coordinates: [number, number]) => {
-                const existingStack = nextStacks.find(
-                    (candidate) =>
-                        candidate.position.x === coordinates[0] &&
-                        candidate.position.z === coordinates[1],
-                );
-                if (existingStack) {
-                    return existingStack;
-                }
-
-                const createdStack = {
-                    position: new Vector3(coordinates[0], 0, coordinates[1]),
-                    blocks: [] as (typeof primaryBlock)[],
-                };
-                nextStacks.push(createdStack);
-                return createdStack;
-            };
-
-            ensureStack(position).blocks.push(primaryBlock);
-
-            const previousItem = await handleOptimisticUpdate(
-                queryClient,
-                gardenQueryKey,
-                {
-                    stacks: [...nextStacks],
+                json: {
+                    blockName,
                 },
-            );
-
-            return {
-                previousItem,
-            };
-        },
-        onError: (error, _variables, context) => {
-            console.error('Error creating block', error);
-            if (context?.previousItem) {
-                queryClient.setQueryData(gardenQueryKey, context.previousItem);
+            });
+            if (!response.ok) {
+                throw new Error(await getBlockPlacementError(response));
             }
+
+            return await response.json();
+        },
+        onError: (error) => {
+            console.error('Error creating block', error);
         },
         onSettled: async () => {
             await queryClient.invalidateQueries({

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -1,4 +1,3 @@
-import type { BlockData } from '@gredice/client';
 import { BlockImage } from '@gredice/ui/BlockImage';
 import { Info, Up } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
@@ -14,10 +13,8 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { useBlockData } from '../hooks/useBlockData';
 import { useBlockPlace } from '../hooks/useBlockPlace';
-import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useIsEditMode } from '../hooks/useIsEditMode';
 import { KnownPages } from '../knownPages';
-import type { Stack as GardenStack } from '../types/Stack';
 import { HudCard } from './components/HudCard';
 
 type HudItemEntity = {
@@ -91,103 +88,6 @@ const items: HudItem[] = [
     },
 ];
 
-/**
- * Get the position in a spiral
- * @param step The step in the spiral
- * @returns The position in the spiral
- * @see https://stackoverflow.com/a/19287714/563228
- */
-function spiral(step: number): [number, number] {
-    // given n an index in the squared spiral
-    // p the sum of point in inner square
-    // a the position on the current square
-    // n = p + a
-
-    var r = Math.floor((Math.sqrt(step + 1) - 1) / 2) + 1;
-
-    // compute radius : inverse arithmetic sum of 8+16+24+...=
-    var p = (8 * r * (r - 1)) / 2;
-    // compute total point on radius -1 : arithmetic sum of 8+16+24+...
-
-    var en = r * 2;
-    // points by face
-
-    var a = (1 + step - p) % (r * 8);
-    // compute de position and shift it so the first is (-r,-r) but (-r+1,-r)
-    // so square can connect
-
-    var pos = [0, 0, r];
-    switch (Math.floor(a / (r * 2))) {
-        // find the face : 0 top, 1 right, 2, bottom, 3 left
-        case 0:
-            {
-                pos[0] = a - r;
-                pos[1] = -r;
-            }
-            break;
-        case 1:
-            {
-                pos[0] = r;
-                pos[1] = (a % en) - r;
-            }
-            break;
-        case 2:
-            {
-                pos[0] = r - (a % en);
-                pos[1] = r;
-            }
-            break;
-        case 3:
-            {
-                pos[0] = -r;
-                pos[1] = r - (a % en);
-            }
-            break;
-    }
-
-    return [pos[0], pos[1]];
-}
-
-function isValidPosition(
-    blockData: BlockData[],
-    stacks: GardenStack[],
-    position: [number, number],
-    type: 'block' | 'any' = 'any',
-) {
-    const stack = stacks.find(
-        (stack) =>
-            stack.position.x === position[0] &&
-            stack.position.z === position[1],
-    );
-    if (!stack) return true;
-
-    // Place block only on non-block stacks
-    if (type === 'block' && stack.blocks.length > 0) return false;
-
-    const lastBlock = stack.blocks.at(-1);
-    if (!lastBlock) return true;
-
-    const data = blockData.find(
-        (data) => data.information.name === lastBlock.name,
-    );
-    if (!data) return false;
-
-    return data.attributes.stackable ?? false;
-}
-
-function findEmptyPosition(
-    blockData: BlockData[],
-    stacks: GardenStack[],
-    type: 'block' | 'any' = 'any',
-) {
-    let current: [number, number] = [0, 0];
-    let spiralStep = 0;
-    while (!isValidPosition(blockData, stacks, current, type)) {
-        current = spiral(spiralStep++);
-    }
-    return current;
-}
-
 function PlaceEntityButton({
     name,
     simple,
@@ -195,7 +95,6 @@ function PlaceEntityButton({
     name: string;
     simple?: boolean;
 }) {
-    const { data: garden } = useCurrentGarden();
     const { data: blockData } = useBlockData();
     const placeBlock = useBlockPlace();
 
@@ -203,48 +102,54 @@ function PlaceEntityButton({
     if (!block) return null;
 
     async function placeEntity() {
-        if (!blockData || !garden) {
+        if (!blockData) {
             console.warn('Cannot place entity, missing data');
             return;
         }
 
-        const position = findEmptyPosition(
-            blockData,
-            garden?.stacks ?? [],
-            name.startsWith('Block') ? 'block' : 'any',
-        );
-
-        // Buy block and get id
         await placeBlock.mutateAsync({
             blockName: name,
-            position,
         });
     }
 
     if (!block.prices.sunflowers && simple) return null;
 
+    const errorMessage =
+        placeBlock.error instanceof Error ? placeBlock.error.message : null;
+
     return (
-        <Button
-            className={cx(!simple && 'justify-between', simple && 'py-0 h-8')}
-            onClick={placeEntity}
-            size={simple ? 'sm' : 'md'}
-            disabled={!block.prices.sunflowers}
-            endDecorator={
-                <Row
-                    className={cx(
-                        !simple &&
-                            'rounded-full p-1 gap border bg-muted w-fit pr-2',
-                        !block.prices.sunflowers && 'pl-2',
-                    )}
-                >
-                    {block.prices.sunflowers
-                        ? `🌻 ${block.prices.sunflowers}`
-                        : 'Nedostupno'}
-                </Row>
-            }
-        >
-            {!simple && <span className="self-center">Postavi</span>}
-        </Button>
+        <Stack spacing={0.5}>
+            <Button
+                className={cx(
+                    !simple && 'justify-between',
+                    simple && 'py-0 h-8',
+                )}
+                onClick={placeEntity}
+                size={simple ? 'sm' : 'md'}
+                disabled={!block.prices.sunflowers || placeBlock.isPending}
+                loading={placeBlock.isPending}
+                endDecorator={
+                    <Row
+                        className={cx(
+                            !simple &&
+                                'rounded-full p-1 gap border bg-muted w-fit pr-2',
+                            !block.prices.sunflowers && 'pl-2',
+                        )}
+                    >
+                        {block.prices.sunflowers
+                            ? `🌻 ${block.prices.sunflowers}`
+                            : 'Nedostupno'}
+                    </Row>
+                }
+            >
+                {!simple && <span className="self-center">Postavi</span>}
+            </Button>
+            {errorMessage && (
+                <Typography level="body3" className="text-red-600">
+                    {errorMessage}
+                </Typography>
+            )}
+        </Stack>
     );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       pg:
         specifier: 8.20.0
         version: 8.20.0
+      posthog-js:
+        specifier: ^1.367.0
+        version: 1.367.0
+      posthog-node:
+        specifier: ^5.29.2
+        version: 5.29.2
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -135,19 +141,19 @@ importers:
         version: 0.5.3(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -301,19 +307,19 @@ importers:
         version: 0.5.3(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -416,19 +422,19 @@ importers:
         version: 0.5.3(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -522,13 +528,13 @@ importers:
         version: 0.5.3(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -537,7 +543,7 @@ importers:
         version: 0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -646,19 +652,19 @@ importers:
         version: 0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -3995,8 +4001,14 @@ packages:
   '@posthog/core@1.24.1':
     resolution: {integrity: sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==}
 
+  '@posthog/core@1.25.2':
+    resolution: {integrity: sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==}
+
   '@posthog/types@1.363.2':
     resolution: {integrity: sha512-UcUwHEd2LXxWq4bW/I4TbwYcA+BHO/cSuHcNpGXjRCp76eJk1eOuQnm/a3MrfHtbt2X11CQu+eWpqiSgcv+X6A==}
+
+  '@posthog/types@1.367.0':
+    resolution: {integrity: sha512-FUcTEAeKhuHKyCcTQPx/sTN3s8S+PusPsiP8T/LrG/T7pDkwMfNZG0/P630JX6fT6qiW0moVvVSsaXgZDJF7wg==}
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -9708,6 +9720,18 @@ packages:
   posthog-js@1.363.2:
     resolution: {integrity: sha512-4ZEWMrymlFzjgDSmh25VeJQT//2XUFbfKqEPDNUW4dxcqWiVMo1+gJFy5YhJgVYS46OAXLbMcJgmuZBCnDIgVg==}
 
+  posthog-js@1.367.0:
+    resolution: {integrity: sha512-jWNwB8XjlVUC9PbGaIlmsyohUDMBrwf7cvLuOY3lIOmWVO3L6VxTE3GZShjxpFKQtmWcPxFbf1hcbct1YCb6xg==}
+
+  posthog-node@5.29.2:
+    resolution: {integrity: sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
 
@@ -15020,7 +15044,11 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@posthog/core@1.25.2': {}
+
   '@posthog/types@1.363.2': {}
+
+  '@posthog/types@1.367.0': {}
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -16571,7 +16599,7 @@ snapshots:
 
   '@signalco/auth-client@0.3.0(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(@tanstack/react-query@5.96.2(react@19.2.4))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-query': 5.96.2(react@19.2.4)
       next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react: 19.2.4
@@ -16592,11 +16620,11 @@ snapshots:
 
   '@signalco/cms-core@0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@signalco/hooks@0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@signalco/hooks@0.2.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react: 19.2.4
@@ -16620,11 +16648,11 @@ snapshots:
 
   '@signalco/ui-notifications@0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
+  '@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react: 19.2.4
@@ -16652,15 +16680,7 @@ snapshots:
 
   '@signalco/ui@0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
-      tailwindcss-animate: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
-
-  '@signalco/ui@0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
@@ -22372,6 +22392,26 @@ snapshots:
       preact: 10.29.1
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.2.0
+
+  posthog-js@1.367.0:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@posthog/core': 1.25.2
+      '@posthog/types': 1.367.0
+      core-js: 3.49.0
+      dompurify: 3.3.3
+      fflate: 0.4.8
+      preact: 10.29.1
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
+  posthog-node@5.29.2:
+    dependencies:
+      '@posthog/core': 1.25.2
 
   potpack@1.0.2: {}
 


### PR DESCRIPTION
validate requested positions, and gather existing blocks for the stack.
- Fetch garden blocks alongside block catalog and build lookup (blockNameId, blockDataByName) for placement resolution.
- Create missing target when placement lands on an empty spot.
- block, then the stack to include the new block, and then deduct currency on failure perform compensating rollbacks revert stack updates and delete the stored block using the deletion helper.
- Add position optional parameter to API payload validation.
 Rename imported deleteGardenBlock storageGardenBlock where used to storage-level deletion higher-level service operations.
- Add detailed error logging and return validation errors to client.

These changes make block position-aware, reduce raceconditions, and ensure consistent state when failures occur.