### PR TITLE
chore(env): add PostHog public env to configAdd NEXT_PUBLICHOG_HOST and NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN toturbo for: www, farm,, garden, and app.

### DIFF
--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -23,6 +23,7 @@
                 "GREDICE_SILO_KV_URL",
                 "GREDICE_SILO_REDIS_URL",
                 "NEXT_PUBLIC_POSTHOG_HOST",
+                "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
                 "NEXT_PUBLIC_STRIPE_PUBLISHABLE",
                 "NEXT_PUBLIC_STRIPE_RETURN_URL",
                 "PLANTS_SILO_KV_REST_API_READ_ONLY_TOKEN",

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -22,6 +22,8 @@
                 "HYPERTUNE_INCLUDE_INIT_DATA",
                 "HYPERTUNE_OUTPUT_DIRECTORY_PATH",
                 "NEXT_PUBLIC_HYPERTUNE_TOKEN",
+                "NEXT_PUBLIC_POSTHOG_HOST",
+                "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
                 "PLANTS_SILO_KV_REST_API_READ_ONLY_TOKEN",
                 "PLANTS_SILO_KV_REST_API_TOKEN",
                 "PLANTS_SILO_KV_REST_API_URL",

--- a/apps/farm/turbo.json
+++ b/apps/farm/turbo.json
@@ -11,6 +11,8 @@
                 "HYPERTUNE_INCLUDE_INIT_DATA",
                 "HYPERTUNE_OUTPUT_DIRECTORY_PATH",
                 "NEXT_PUBLIC_HYPERTUNE_TOKEN",
+                "NEXT_PUBLIC_POSTHOG_HOST",
+                "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
                 "POSTGRES_DATABASE",
                 "POSTGRES_HOST",
                 "POSTGRES_PASSWORD",

--- a/apps/garden/turbo.json
+++ b/apps/garden/turbo.json
@@ -12,6 +12,8 @@
                 "HYPERTUNE_INCLUDE_INIT_DATA",
                 "HYPERTUNE_OUTPUT_DIRECTORY_PATH",
                 "NEXT_PUBLIC_HYPERTUNE_TOKEN",
+                "NEXT_PUBLIC_POSTHOG_HOST",
+                "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
                 "NEXT_PUBLIC_STRIPE_PUBLISHABLE",
                 "NEXT_PUBLIC_VERCEL_ENV",
                 "POSTGRES_DATABASE",

--- a/apps/www/turbo.json
+++ b/apps/www/turbo.json
@@ -15,6 +15,8 @@
                 "HYPERTUNE_INCLUDE_INIT_DATA",
                 "HYPERTUNE_OUTPUT_DIRECTORY_PATH",
                 "NEXT_PUBLIC_HYPERTUNE_TOKEN",
+                "NEXT_PUBLIC_POSTHOG_HOST",
+                "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
                 "NEXT_PUBLIC_VERCEL_ENV",
                 "POSTGRES_DATABASE",
                 "POSTGRES_HOST",


### PR DESCRIPTION
These environment variables are needed to enable the frontend to Postog analytics in different deployments. Including themin the turborepo pipeline config ensures the variables are recognizedand propagated during builds and previews across all affected apps.