### PR TITLE
✨ feat: add user picker field and back button UI a reusable UserPickerField and replace the ad-hocselect in the AssignFarmUserForm with the new field. Add a PageBackButtoncomponent for consistent back navigation.

### DIFF
--- a/apps/app/app/admin/farms/[farmId]/AssignFarmUserForm.tsx
+++ b/apps/app/app/admin/farms/[farmId]/AssignFarmUserForm.tsx
@@ -1,20 +1,18 @@
 'use client';
 
 import { Button } from '@signalco/ui-primitives/Button';
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { useActionState, useEffect, useMemo, useState } from 'react';
 import { useFormStatus } from 'react-dom';
+import {
+    UserPickerField,
+    type UserPickerOption,
+} from '../../../../components/shared/fields/UserPickerField';
 import { assignFarmUserAction } from '../../../(actions)/farmActions';
-
-type UserOption = {
-    id: string;
-    label: string;
-};
 
 type AssignFarmUserFormProps = {
     farmId: number;
-    users: UserOption[];
+    users: UserPickerOption[];
     assignedUserIds: string[];
 };
 
@@ -62,15 +60,11 @@ export function AssignFarmUserForm({
     return (
         <form action={formAction} className="space-y-2">
             <Stack spacing={1}>
-                <SelectItems
-                    label="Korisnik"
-                    placeholder="Odaberi korisnika"
+                <UserPickerField
+                    users={availableUsers}
                     value={selectedUser}
                     onValueChange={setSelectedUser}
-                    items={availableUsers.map((user) => ({
-                        value: user.id,
-                        label: user.label,
-                    }))}
+                    resetKey={state}
                 />
                 <input type="hidden" name="farmId" value={farmId} />
                 <input type="hidden" name="userId" value={selectedUser} />

--- a/apps/app/app/admin/schedule/AssignOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AssignOperationModal.tsx
@@ -10,10 +10,13 @@ import { Button } from '@signalco/ui-primitives/Button';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useEffect, useMemo, useState } from 'react';
+import {
+    UserPickerField,
+    type UserPickerOption,
+} from '../../../components/shared/fields/UserPickerField';
 import { assignOperationUserAction } from '../../(actions)/operationActions';
 
 const unassignedValue = '__unassigned__';
@@ -64,6 +67,16 @@ export function AssignOperationModal({
 
         return [...usersById.values()];
     }, [farmUsers, assignedUser]);
+
+    const pickerUsers = useMemo<UserPickerOption[]>(
+        () =>
+            selectableUsers.map((user) => ({
+                id: user.id,
+                label: getUserLabel(user),
+                searchText: `${user.displayName ?? ''} ${user.userName}`,
+            })),
+        [selectableUsers],
+    );
 
     const initialSelection = assignedUser?.id ?? unassignedValue;
     const canOpen = !disabled && (selectableUsers.length > 0 || !!assignedUser);
@@ -135,21 +148,15 @@ export function AssignOperationModal({
                 </Typography>
 
                 {selectableUsers.length > 0 ? (
-                    <SelectItems
-                        label="Korisnik"
-                        placeholder="Odaberi korisnika"
+                    <UserPickerField
+                        users={pickerUsers}
                         value={selectedUserId}
                         onValueChange={setSelectedUserId}
-                        items={[
-                            {
-                                value: unassignedValue,
-                                label: 'Bez dodjele',
-                            },
-                            ...selectableUsers.map((user) => ({
-                                value: user.id,
-                                label: getUserLabel(user),
-                            })),
-                        ]}
+                        emptyOption={{
+                            value: unassignedValue,
+                            label: 'Bez dodjele',
+                        }}
+                        resetKey={open}
                     />
                 ) : (
                     <Typography level="body2" className="text-muted-foreground">

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -282,17 +282,6 @@ export function RaisedBedOperationsScheduleSection({
                                             {operationLabel}
                                         </Typography>
                                     </a>
-                                    <AssignOperationModal
-                                        operationId={operation.id}
-                                        label={operationLabel}
-                                        farmUsers={
-                                            assignableFarmUsersByOperationId[
-                                                operation.id
-                                            ] ?? []
-                                        }
-                                        assignedUser={operation.assignedUser}
-                                        disabled={operationInactive}
-                                    />
                                     <Typography
                                         level="body2"
                                         className={`ml-1 italic ${operationStatusClassName}`}
@@ -324,6 +313,17 @@ export function RaisedBedOperationsScheduleSection({
                                     </Typography>
                                 </Row>
                                 <Row>
+                                    <AssignOperationModal
+                                        operationId={operation.id}
+                                        label={operationLabel}
+                                        farmUsers={
+                                            assignableFarmUsersByOperationId[
+                                                operation.id
+                                            ] ?? []
+                                        }
+                                        assignedUser={operation.assignedUser}
+                                        disabled={operationInactive}
+                                    />
                                     <RescheduleOperationModal
                                         operation={{
                                             id: operation.id,
@@ -340,8 +340,8 @@ export function RaisedBedOperationsScheduleSection({
                                                 variant="plain"
                                                 title={
                                                     operation.scheduledDate
-                                                        ? 'Prerasporedi operaciju'
-                                                        : 'Zakaži operaciju'
+                                                        ? 'Prerasporedi radnju'
+                                                        : 'Zakaži radnju'
                                                 }
                                                 disabled={operationInactive}
                                             >

--- a/apps/app/components/shared/fields/UserPickerField.tsx
+++ b/apps/app/components/shared/fields/UserPickerField.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { Input } from '@signalco/ui-primitives/Input';
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+export type UserPickerOption = {
+    id: string;
+    label: string;
+    searchText?: string;
+};
+
+type UserPickerFieldProps = {
+    users: UserPickerOption[];
+    value: string;
+    onValueChange: (value: string) => void;
+    label?: string;
+    placeholder?: string;
+    searchPlaceholder?: string;
+    searchAriaLabel?: string;
+    emptyOption?: {
+        value: string;
+        label: string;
+    };
+    noResultsMessage?: string;
+    resetKey?: unknown;
+};
+
+function normalizeSearchValue(value: string) {
+    return value
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+}
+
+export function UserPickerField({
+    users,
+    value,
+    onValueChange,
+    label = 'Korisnik',
+    placeholder = 'Odaberi korisnika',
+    searchPlaceholder = 'Pretraži korisnike',
+    searchAriaLabel = 'Pretraži korisnike',
+    emptyOption,
+    noResultsMessage = 'Nema korisnika koji odgovara pretrazi.',
+    resetKey,
+}: UserPickerFieldProps) {
+    const [searchQuery, setSearchQuery] = useState('');
+    const deferredSearchQuery = useDeferredValue(searchQuery);
+
+    useEffect(() => {
+        void resetKey;
+        setSearchQuery('');
+    }, [resetKey]);
+
+    const normalizedSearchQuery = useMemo(
+        () => normalizeSearchValue(deferredSearchQuery.trim()),
+        [deferredSearchQuery],
+    );
+
+    const matchingUsers = useMemo(() => {
+        if (!normalizedSearchQuery) {
+            return users;
+        }
+
+        return users.filter((user) => {
+            const searchableText = `${user.label} ${user.searchText ?? ''}`;
+            return normalizeSearchValue(searchableText).includes(
+                normalizedSearchQuery,
+            );
+        });
+    }, [normalizedSearchQuery, users]);
+
+    const selectedUser = useMemo(
+        () => users.find((user) => user.id === value),
+        [users, value],
+    );
+
+    const selectableUsers = useMemo(() => {
+        const usersById = new Map<string, UserPickerOption>();
+
+        if (selectedUser) {
+            usersById.set(selectedUser.id, selectedUser);
+        }
+
+        for (const user of matchingUsers) {
+            usersById.set(user.id, user);
+        }
+
+        return [...usersById.values()];
+    }, [matchingUsers, selectedUser]);
+
+    const items = useMemo(
+        () => [
+            ...(emptyOption ? [emptyOption] : []),
+            ...selectableUsers.map((user) => ({
+                value: user.id,
+                label: user.label,
+            })),
+        ],
+        [emptyOption, selectableUsers],
+    );
+
+    const hasNoMatches =
+        normalizedSearchQuery.length > 0 && matchingUsers.length === 0;
+
+    return (
+        <Stack spacing={1}>
+            <Input
+                aria-label={searchAriaLabel}
+                placeholder={searchPlaceholder}
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                autoComplete="off"
+                autoCapitalize="none"
+                spellCheck={false}
+            />
+
+            {items.length > 0 ? (
+                <SelectItems
+                    label={label}
+                    placeholder={placeholder}
+                    value={value}
+                    onValueChange={onValueChange}
+                    items={items}
+                />
+            ) : (
+                <Typography level="body2" className="text-muted-foreground">
+                    {noResultsMessage}
+                </Typography>
+            )}
+
+            {hasNoMatches && items.length > 0 && (
+                <Typography level="body2" className="text-muted-foreground">
+                    {noResultsMessage}
+                </Typography>
+            )}
+        </Stack>
+    );
+}

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -3,12 +3,10 @@ import {
     AuthProtectedSection,
     SignedOut,
 } from '@signalco/auth-server/components';
-import { ArrowLeft } from '@signalco/ui-icons';
-import { Button } from '@signalco/ui-primitives/Button';
-import { Stack } from '@signalco/ui-primitives/Stack';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { LogoutButton } from '../../components/auth/LogoutButton';
+import { PageBackButton } from '../../components/PageBackButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmScheduleDay } from './FarmScheduleDay';
 
@@ -20,26 +18,12 @@ async function FarmScheduleContent() {
     return (
         <div className="max-w-5xl mx-auto w-full px-4 py-10 space-y-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
-                <Stack spacing={1}>
+                <Row spacing={1}>
+                    <PageBackButton />
                     <Typography level="h1" className="text-3xl" semiBold>
                         Raspored
                     </Typography>
-                    <Typography className="text-muted-foreground">
-                        Pregledaj dnevne zadatke i planiraj nadolazeće
-                        aktivnosti.
-                    </Typography>
-                </Stack>
-                <Stack spacing={2} className="items-end">
-                    <Button
-                        variant="outlined"
-                        size="sm"
-                        href="/"
-                        startDecorator={<ArrowLeft className="size-4" />}
-                    >
-                        Povratak na početnu
-                    </Button>
-                    <LogoutButton />
-                </Stack>
+                </Row>
             </div>
             <DailySchedule
                 renderDay={({ date, isToday }) => (

--- a/apps/farm/components/PageBackButton.tsx
+++ b/apps/farm/components/PageBackButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ArrowLeft } from '@signalco/ui-icons';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { useRouter } from 'next/dist/client/components/navigation';
+
+export function PageBackButton() {
+    const router = useRouter();
+
+    return (
+        <IconButton
+            title="Povratak"
+            variant="plain"
+            size="sm"
+            onClick={() => router.back()}
+        >
+            <ArrowLeft className="size-4 shrink-0" />
+        </IconButton>
+    );
+}


### PR DESCRIPTION
- Add apps/app/sharedfieldsPickerField.tsx - Implement searchable debounced user filtering withac-
 insensitive normalization.
 - Support label, placeholder empty option, no-results messaging and a resetKey prop to clear search when needed.
 - Export UserPickerOption for use by forms.

 Update AssignFarmForm to usePickerField - Replace SelectItems usage with UserPickerField and pass typed users.
 Wire resetKey to action state to clear search after submissions.
 - Remove local UserOption type in favor of shared UserPickerOption.

- Add PageBackButton component - New apps/farm/components/PageBackButton.ts using IconButton and next/router.back for consistent small back across pages.

These changes improve UX by providing a consistent, accessible user with search and keep navigation via shared backbutton component.