### PR TITLE
✨ refactor: remove hardcoded helper texts from formsRemove hardcoded helperText strings three admin forms so thatcomponents consistently rely on `Text` props or defaultbehavior:

### DIFF
--- a/apps/app/app/admin/communication/slack/SlackChannelSettingForm.tsx
+++ b/apps/app/app/admin/communication/slack/SlackChannelSettingForm.tsx
@@ -56,10 +56,7 @@ export function SlackChannelSettingForm({
                     placeholder="npr. C1234567890"
                     value={channelValue}
                     onChange={(event) => setChannelValue(event.target.value)}
-                    helperText={
-                        helperText ??
-                        'Unesi ID Slack kanala na koji šaljemo obavijesti.'
-                    }
+                    helperText={helperText}
                 />
                 <input type="hidden" name="settingKey" value={settingKey} />
                 <SubmitButton />

--- a/apps/app/app/admin/farms/[farmId]/FarmSlackChannelForm.tsx
+++ b/apps/app/app/admin/farms/[farmId]/FarmSlackChannelForm.tsx
@@ -46,7 +46,6 @@ export function FarmSlackChannelForm({
                     placeholder="npr. C1234567890"
                     value={channelValue}
                     onChange={(event) => setChannelValue(event.target.value)}
-                    helperText="Unesi ID Slack kanala na koji šaljemo obavijesti."
                 />
                 <input type="hidden" name="farmId" value={farmId} />
                 <SubmitButton />

--- a/apps/app/app/admin/farms/[farmId]/FarmSnowAccumulationForm.tsx
+++ b/apps/app/app/admin/farms/[farmId]/FarmSnowAccumulationForm.tsx
@@ -51,7 +51,6 @@ export function FarmSnowAccumulationForm({
                     placeholder="0.0"
                     value={accumulation}
                     onChange={(event) => setAccumulation(event.target.value)}
-                    helperText="Unesite visinu snijega u centimetrima."
                 />
                 <input type="hidden" name="farmId" value={farmId} />
                 <SubmitButton />


### PR DESCRIPTION
-SlackChannelForm: drop inline "Unesi ID Slack kanala..." helper- SlackChannelSettingForm: stop falling back to the same hardcoded message and pass through `helperText` directly.
- FarmSnowAccumulation: inlineUnesite visinu snijega..." helper.

This up, unexpected fallback text, and makesthe forms' guidance configurable from components or i18n systems.