### PR TITLE
✨ feat(schedule): stream day data with boundariesIntroduce UI for a farm schedule day by converting thesynchronous data fetch + conditional rendering into Suspense-backedcontent components. logic that awaited/plant/operations datainto two async components and add lightweight skeleton + emptystate.

### DIFF
--- a/apps/farm/app/schedule/FarmScheduleDay.tsx
+++ b/apps/farm/app/schedule/FarmScheduleDay.tsx
@@ -1,57 +1,48 @@
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { FarmScheduleOperationsSection } from './FarmScheduleOperationsSection';
-import { FarmSchedulePlantingsSection } from './FarmSchedulePlantingsSection';
+import { Suspense } from 'react';
+import { FarmScheduleEmptyState } from './FarmScheduleEmptyState';
+import { FarmScheduleOperationsSectionContent } from './FarmScheduleOperationsSectionContent';
+import { FarmSchedulePlantingsSectionContent } from './FarmSchedulePlantingsSectionContent';
+import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import {
-    getFarmScheduleDayData,
-    getFarmScheduleOperationsData,
+    type FarmScheduleDayData,
     getFarmSchedulePlantSorts,
 } from './scheduleData';
 
 interface FarmScheduleDayProps {
-    date: Date;
-    isToday: boolean;
+    dayDataPromise: Promise<FarmScheduleDayData>;
+    operationsDataPromise: ReturnType<
+        typeof import('./scheduleData').getFarmScheduleOperationsData
+    >;
     userId: string;
 }
 
-export async function FarmScheduleDay({
-    date,
-    isToday,
+export function FarmScheduleDay({
+    dayDataPromise,
+    operationsDataPromise,
     userId,
 }: FarmScheduleDayProps) {
-    const [
-        { raisedBeds, scheduledFields, scheduledOperations },
-        plantSorts,
-        operationsData,
-    ] = await Promise.all([
-        getFarmScheduleDayData(userId, date.toISOString(), isToday),
-        getFarmSchedulePlantSorts(),
-        getFarmScheduleOperationsData(),
-    ]);
+    const plantSortsPromise = getFarmSchedulePlantSorts();
 
     return (
         <Stack spacing={4}>
-            {scheduledFields.length > 0 && (
-                <FarmSchedulePlantingsSection
-                    raisedBeds={raisedBeds}
-                    scheduledFields={scheduledFields}
-                    plantSorts={plantSorts}
+            <Suspense fallback={null}>
+                <FarmScheduleEmptyState dayDataPromise={dayDataPromise} />
+            </Suspense>
+            <Suspense fallback={<FarmScheduleSectionSkeleton />}>
+                <FarmSchedulePlantingsSectionContent
+                    dayDataPromise={dayDataPromise}
+                    plantSortsPromise={plantSortsPromise}
                 />
-            )}
-            {scheduledOperations.length > 0 && (
-                <FarmScheduleOperationsSection
-                    raisedBeds={raisedBeds}
-                    scheduledOperations={scheduledOperations}
-                    plantSorts={plantSorts}
-                    operationsData={operationsData}
+            </Suspense>
+            <Suspense fallback={<FarmScheduleSectionSkeleton />}>
+                <FarmScheduleOperationsSectionContent
+                    dayDataPromise={dayDataPromise}
+                    plantSortsPromise={plantSortsPromise}
+                    operationsDataPromise={operationsDataPromise}
                     userId={userId}
                 />
-            )}
-            {scheduledFields.length === 0 &&
-                scheduledOperations.length === 0 && (
-                    <div className="px-6 pb-6 text-sm text-muted-foreground">
-                        Nema zakazanih zadataka za ovaj dan.
-                    </div>
-                )}
+            </Suspense>
         </Stack>
     );
 }

--- a/apps/farm/app/schedule/FarmScheduleEmptyState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleEmptyState.tsx
@@ -1,0 +1,21 @@
+import type { FarmScheduleDayData } from './scheduleData';
+
+interface FarmScheduleEmptyStateProps {
+    dayDataPromise: Promise<FarmScheduleDayData>;
+}
+
+export async function FarmScheduleEmptyState({
+    dayDataPromise,
+}: FarmScheduleEmptyStateProps) {
+    const { scheduledFields, scheduledOperations } = await dayDataPromise;
+
+    if (scheduledFields.length + scheduledOperations.length > 0) {
+        return null;
+    }
+
+    return (
+        <div className="px-6 pb-6 text-sm text-muted-foreground">
+            Nema zakazanih zadataka za ovaj dan.
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -91,7 +91,7 @@ export function FarmScheduleOperationsSection({
     );
 
     return (
-        <Stack spacing={2} className="px-6 pb-6">
+        <Stack spacing={2}>
             {raisedBedGroups.map(
                 ({ key, physicalId, raisedBeds: groupedRaisedBeds }) => {
                     const dayOperations = scheduledOperations
@@ -132,7 +132,7 @@ export function FarmScheduleOperationsSection({
                     );
 
                     return (
-                        <Stack key={key} spacing={1.5}>
+                        <Stack key={key} spacing={1}>
                             <Row
                                 spacing={1}
                                 className="items-center flex-wrap gap-y-1"
@@ -173,7 +173,7 @@ export function FarmScheduleOperationsSection({
                                     return (
                                         <div
                                             key={operation.id}
-                                            className="rounded-lg border border-border/60 bg-background/70 px-3 py-2"
+                                            className="rounded-lg border bg-white px-3 py-2"
                                         >
                                             <Row
                                                 spacing={1}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSectionContent.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSectionContent.tsx
@@ -1,0 +1,41 @@
+import { FarmScheduleOperationsSection } from './FarmScheduleOperationsSection';
+import type { FarmScheduleDayData } from './scheduleData';
+
+interface FarmScheduleOperationsSectionContentProps {
+    dayDataPromise: Promise<FarmScheduleDayData>;
+    plantSortsPromise: ReturnType<
+        typeof import('./scheduleData').getFarmSchedulePlantSorts
+    >;
+    operationsDataPromise: ReturnType<
+        typeof import('./scheduleData').getFarmScheduleOperationsData
+    >;
+    userId: string;
+}
+
+export async function FarmScheduleOperationsSectionContent({
+    dayDataPromise,
+    plantSortsPromise,
+    operationsDataPromise,
+    userId,
+}: FarmScheduleOperationsSectionContentProps) {
+    const { raisedBeds, scheduledOperations } = await dayDataPromise;
+
+    if (scheduledOperations.length === 0) {
+        return null;
+    }
+
+    const [plantSorts, operationsData] = await Promise.all([
+        plantSortsPromise,
+        operationsDataPromise,
+    ]);
+
+    return (
+        <FarmScheduleOperationsSection
+            raisedBeds={raisedBeds}
+            scheduledOperations={scheduledOperations}
+            plantSorts={plantSorts}
+            operationsData={operationsData}
+            userId={userId}
+        />
+    );
+}

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -59,7 +59,7 @@ export function FarmSchedulePlantingsSection({
     );
 
     return (
-        <Stack spacing={2} className="px-6 pb-6">
+        <Stack spacing={2}>
             {raisedBedGroups.map(
                 ({ key, physicalId, raisedBeds: groupedRaisedBeds }) => {
                     const dayFields = scheduledFields
@@ -82,7 +82,7 @@ export function FarmSchedulePlantingsSection({
                         dayFields.length * PLANTING_TASK_DURATION_MINUTES;
 
                     return (
-                        <Stack key={key} spacing={1.5}>
+                        <Stack key={key} spacing={1}>
                             <Row
                                 spacing={1}
                                 className="items-center flex-wrap gap-y-1"
@@ -128,7 +128,7 @@ export function FarmSchedulePlantingsSection({
                                     return (
                                         <div
                                             key={field.id}
-                                            className="rounded-lg border border-border/60 bg-background/70 px-3 py-2"
+                                            className="rounded-lg border bg-white px-3 py-2"
                                         >
                                             <Row
                                                 spacing={1}

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx
@@ -1,0 +1,30 @@
+import { FarmSchedulePlantingsSection } from './FarmSchedulePlantingsSection';
+import type { FarmScheduleDayData } from './scheduleData';
+
+interface FarmSchedulePlantingsSectionContentProps {
+    dayDataPromise: Promise<FarmScheduleDayData>;
+    plantSortsPromise: ReturnType<
+        typeof import('./scheduleData').getFarmSchedulePlantSorts
+    >;
+}
+
+export async function FarmSchedulePlantingsSectionContent({
+    dayDataPromise,
+    plantSortsPromise,
+}: FarmSchedulePlantingsSectionContentProps) {
+    const { raisedBeds, scheduledFields } = await dayDataPromise;
+
+    if (scheduledFields.length === 0) {
+        return null;
+    }
+
+    const plantSorts = await plantSortsPromise;
+
+    return (
+        <FarmSchedulePlantingsSection
+            raisedBeds={raisedBeds}
+            scheduledFields={scheduledFields}
+            plantSorts={plantSorts}
+        />
+    );
+}

--- a/apps/farm/app/schedule/FarmScheduleSectionSkeleton.tsx
+++ b/apps/farm/app/schedule/FarmScheduleSectionSkeleton.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from '@signalco/ui-primitives/Skeleton';
+import { Stack } from '@signalco/ui-primitives/Stack';
+
+export function FarmScheduleSectionSkeleton() {
+    return (
+        <Stack spacing={2} className="px-6 pb-6">
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+        </Stack>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleDaySummarySection.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummarySection.tsx
@@ -1,0 +1,23 @@
+import { ScheduleDaySummary } from './ScheduleDaySummary';
+import type { FarmScheduleDayData } from './scheduleData';
+
+interface ScheduleDaySummarySectionProps {
+    dayDataPromise: Promise<FarmScheduleDayData>;
+    operationsDataPromise: ReturnType<
+        typeof import('./scheduleData').getFarmScheduleOperationsData
+    >;
+}
+
+export async function ScheduleDaySummarySection({
+    dayDataPromise,
+    operationsDataPromise,
+}: ScheduleDaySummarySectionProps) {
+    const [dayData, operationsData] = await Promise.all([
+        dayDataPromise,
+        operationsDataPromise,
+    ]);
+
+    return (
+        <ScheduleDaySummary dayData={dayData} operationsData={operationsData} />
+    );
+}

--- a/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
@@ -1,0 +1,21 @@
+import { Row } from '@signalco/ui-primitives/Row';
+import { Skeleton } from '@signalco/ui-primitives/Skeleton';
+
+function SummaryItemSkeleton() {
+    return (
+        <div className="text-center space-y-1">
+            <Skeleton className="mx-auto h-4 w-8" />
+            <Skeleton className="mx-auto h-4 w-14" />
+        </div>
+    );
+}
+
+export function ScheduleDaySummarySkeleton() {
+    return (
+        <Row spacing={4}>
+            <SummaryItemSkeleton />
+            <SummaryItemSkeleton />
+            <SummaryItemSkeleton />
+        </Row>
+    );
+}

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -4,12 +4,14 @@ import {
 } from '@signalco/auth-server/components';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { Suspense } from 'react';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { PageBackButton } from '../../components/PageBackButton';
+import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmScheduleDay } from './FarmScheduleDay';
 import { ScheduleDateNavigation } from './ScheduleDateNavigation';
-import { ScheduleDaySummary } from './ScheduleDaySummary';
+import { ScheduleDaySummarySection } from './ScheduleDaySummarySection';
+import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 import {
     getFarmScheduleDayData,
     getFarmScheduleOperationsData,
@@ -20,28 +22,32 @@ export const dynamic = 'force-dynamic';
 async function FarmScheduleContent({ date }: { date: Date }) {
     const { userId } = await auth(['farmer', 'admin']);
     const isToday = new Date().toDateString() === date.toDateString();
-
-    const [dayData, operationsData] = await Promise.all([
-        getFarmScheduleDayData(userId, date.toISOString(), isToday),
-        getFarmScheduleOperationsData(),
-    ]);
+    const dateKey = date.toISOString();
+    const dayDataPromise = getFarmScheduleDayData(userId, dateKey, isToday);
+    const operationsDataPromise = getFarmScheduleOperationsData();
 
     return (
-        <div className="max-w-5xl mx-auto w-full px-4 py-10 space-y-6">
+        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
             <Row spacing={2} justifyContent="space-between">
                 <Row spacing={1}>
-                    <PageBackButton />
+                    <HomeButton />
                     <Typography level="h4" component="h1">
                         Raspored
                     </Typography>
                 </Row>
                 <ScheduleDateNavigation date={date} />
-                <ScheduleDaySummary
-                    dayData={dayData}
-                    operationsData={operationsData}
-                />
+                <Suspense fallback={<ScheduleDaySummarySkeleton />}>
+                    <ScheduleDaySummarySection
+                        dayDataPromise={dayDataPromise}
+                        operationsDataPromise={operationsDataPromise}
+                    />
+                </Suspense>
             </Row>
-            <FarmScheduleDay date={date} isToday={isToday} userId={userId} />
+            <FarmScheduleDay
+                dayDataPromise={dayDataPromise}
+                operationsDataPromise={operationsDataPromise}
+                userId={userId}
+            />
         </div>
     );
 }

--- a/apps/farm/components/HomeButton.tsx
+++ b/apps/farm/components/HomeButton.tsx
@@ -4,12 +4,12 @@ import { ArrowLeft } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { useRouter } from 'next/dist/client/components/navigation';
 
-export function PageBackButton() {
+export function HomeButton() {
     const router = useRouter();
 
     return (
         <IconButton
-            title="Povratak"
+            title="Povratak na početnu"
             variant="plain"
             onClick={() => router.push('/')}
         >


### PR DESCRIPTION
- Replace direct data fetching in FarmScheduleDay with promises:
 accept dayDataPromise and operationsData props create a plants. This enables concurrent streaming and avoids blocking the render.
- Add FarmScheduleOperationsSectionContent to await only the data it needs and render null when no operations exist.
- Add FarmPlantSectionContent usage (imported earlier and render both content sections inside Suspense boundaries with a shared FarmScheduleSkeleton fallback.
- Add FarmScheduleEmptyState display inside a Suspense boundary to surface empty-day UI while content streams in.
 Remove in-component conditional checks and the old immediate "no tasks" message; the empty state now that.

This change improves perceived by streaming sections astheir data resolves and provides consistent skeleton/-state UX.