### PR TITLE
feat: add PostHog tracking and profile diffing utilities- apps/farm/auth/LoginDialog.tsx - Integrate Postog client viaPostHog and emit analytics events password and OAuth login flows:

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -32,12 +32,19 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 const dailyRewards = [5, 10, 15, 20, 25, 50];
 const DAILY_REWARD_TIME_ZONE = 'Europe/Zagreb';
 
 function rewardForDay(day: number) {
     return dailyRewards[Math.min(day, dailyRewards.length) - 1] ?? 0;
+}
+
+function getEmailDomain(email: string) {
+    const normalizedEmail = email.trim().toLowerCase();
+    const [, domain] = normalizedEmail.split('@');
+    return domain ?? 'unknown';
 }
 
 async function getDailyRewardState(accountId: string) {
@@ -440,6 +447,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
 
+            await (await getPostHogClient()).capture({
+                distinctId: userId,
+                event: 'account_invitation_sent',
+                properties: {
+                    account_id: accountId,
+                    invitation_id: invitation.id,
+                    invited_email_domain: getEmailDomain(email),
+                },
+            });
+
             return context.json(
                 {
                     id: invitation.id,
@@ -543,6 +560,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 sameSite: 'Lax',
                 domain: cookieDomain,
                 maxAge: 365 * 24 * 60 * 60, // 1 year
+            });
+
+            await (await getPostHogClient()).capture({
+                distinctId: userId,
+                event: 'account_invitation_accepted',
+                properties: {
+                    account_id: result.accountId,
+                    invitation_id: invitation.id,
+                    invited_by_user_id: invitation.invitedByUserId,
+                },
             });
 
             return context.json({ success: true, accountId: result.accountId });

--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -52,6 +52,7 @@ import {
     authValidator,
 } from '../../../lib/hono/authValidator';
 import { openAdventGiftBox } from '../../../lib/occasions/adventGiftBox';
+import { getPostHogClient } from '../../../lib/posthog-server';
 
 const DEFAULT_TIMEZONE = 'Europe/Paris';
 
@@ -82,6 +83,23 @@ async function countRecentRaisedBedAiAnalyses(accountId: string) {
     ]);
 
     return raisedBedCount + raisedBedFieldCount;
+}
+
+async function trackGardenCreated(input: {
+    accountId: string;
+    gardenId: number;
+    name?: string;
+    userId: string;
+}) {
+    await (await getPostHogClient()).capture({
+        distinctId: input.userId,
+        event: 'garden_created',
+        properties: {
+            account_id: input.accountId,
+            garden_id: input.gardenId,
+            has_custom_name: Boolean(input.name?.trim()),
+        },
+    });
 }
 
 const app = new Hono<{ Variables: AuthVariables }>()
@@ -116,12 +134,13 @@ const app = new Hono<{ Variables: AuthVariables }>()
         ),
         authValidator(['user', 'admin']),
         async (context) => {
-            const { accountId } = context.get('authContext');
+            const { accountId, userId } = context.get('authContext');
             const { name } = context.req.valid('json');
             const gardenId = await createDefaultGardenForAccount({
                 accountId,
                 name,
             });
+            await trackGardenCreated({ accountId, gardenId, name, userId });
             return context.json({ id: gardenId }, 201);
         },
     )
@@ -138,12 +157,13 @@ const app = new Hono<{ Variables: AuthVariables }>()
         ),
         authValidator(['user', 'admin']),
         async (context) => {
-            const { accountId } = context.get('authContext');
+            const { accountId, userId } = context.get('authContext');
             const { name } = context.req.valid('json');
             const gardenId = await createDefaultGardenForAccount({
                 accountId,
                 name,
             });
+            await trackGardenCreated({ accountId, gardenId, name, userId });
             return context.json({ id: gardenId }, 201);
         },
     )

--- a/apps/api/app/api/[...route]/usersRoutes.ts
+++ b/apps/api/app/api/[...route]/usersRoutes.ts
@@ -11,6 +11,7 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { getPostHogClient } from '../../../lib/posthog-server';
 import {
     type BirthdayRewardUser,
     grantBirthdayReward,
@@ -37,6 +38,66 @@ const birthdaySchema = z
             .nullable(),
     })
     .strict();
+
+function getUpdatedProfileFields(input: {
+    dbUser: Awaited<ReturnType<typeof getUser>>;
+    userInfo: {
+        userName?: string;
+        displayName?: string;
+        avatarUrl?: string | null;
+        birthday?: {
+            day: number;
+            month: number;
+            year?: number | null;
+        } | null;
+    };
+}) {
+    const updatedFields: string[] = [];
+
+    if (
+        input.userInfo.displayName !== undefined &&
+        input.userInfo.displayName !== input.dbUser?.displayName
+    ) {
+        updatedFields.push('display_name');
+    }
+
+    if (
+        input.userInfo.avatarUrl !== undefined &&
+        input.userInfo.avatarUrl !== input.dbUser?.avatarUrl
+    ) {
+        updatedFields.push('avatar_url');
+    }
+
+    if (
+        input.userInfo.userName !== undefined &&
+        input.userInfo.userName !== input.dbUser?.userName
+    ) {
+        updatedFields.push('user_name');
+    }
+
+    if (Object.hasOwn(input.userInfo, 'birthday')) {
+        const nextBirthday = input.userInfo.birthday;
+
+        if (nextBirthday === undefined) {
+            return updatedFields;
+        }
+
+        const birthdayChanged =
+            nextBirthday === null ||
+            !input.dbUser ||
+            nextBirthday.day !== input.dbUser.birthdayDay ||
+            nextBirthday.month !== input.dbUser.birthdayMonth ||
+            (nextBirthday.year ?? null) !== (input.dbUser.birthdayYear ?? null);
+
+        if (birthdayChanged) {
+            updatedFields.push(
+                nextBirthday === null ? 'birthday_cleared' : 'birthday',
+            );
+        }
+    }
+
+    return updatedFields;
+}
 
 const app = new Hono<{ Variables: AuthVariables }>()
     .get(
@@ -281,6 +342,25 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     user: updatedUser,
                     rewardDate,
                     isLate: rewardIsLate,
+                });
+            }
+
+            const updatedFields = getUpdatedProfileFields({
+                dbUser,
+                userInfo,
+            });
+
+            if (updatedFields.length > 0) {
+                await (await getPostHogClient()).capture({
+                    distinctId: userId,
+                    event: 'user_profile_updated',
+                    properties: {
+                        updated_fields: updatedFields,
+                        birthday_reward_granted: Boolean(
+                            rewardResult?.rewarded,
+                        ),
+                        birthday_reward_late: rewardIsLate,
+                    },
                 });
             }
 

--- a/apps/api/lib/posthog-server.ts
+++ b/apps/api/lib/posthog-server.ts
@@ -68,7 +68,11 @@ export async function flushPostHogLogs(): Promise<void> {
         return;
     }
 
-    await loggerProvider.forceFlush();
+    try {
+        await loggerProvider.forceFlush();
+    } catch (error) {
+        console.warn('PostHog log flush failed', error);
+    }
 }
 
 export async function getPostHogClient(): Promise<PostHogCaptureClient> {

--- a/apps/app/components/admin/navigation/LoginDialog.tsx
+++ b/apps/app/components/admin/navigation/LoginDialog.tsx
@@ -5,6 +5,7 @@ import {
     GoogleLoginButton,
     useLastLoginProvider,
 } from '@gredice/ui/auth';
+import { usePostHog } from '@posthog/next';
 import { authCurrentUserQueryKeys } from '@signalco/auth-client';
 import { Alert } from '@signalco/ui/Alert';
 import { Warning } from '@signalco/ui-icons';
@@ -19,6 +20,7 @@ import { invalidatePage } from '../../../app/(actions)/sharedActions';
 import { queryClient } from '../../providers/ClientAppProvider';
 
 export function LoginDialog() {
+    const posthog = usePostHog();
     const fetchLastLogin = useCallback(
         () => fetch('/api/gredice/api/auth/last-login'),
         [],
@@ -38,6 +40,10 @@ export function LoginDialog() {
             const password = passwordValue;
 
             // Send the form data to the server
+            posthog?.capture('user_login_started', {
+                provider: 'password',
+                surface: 'app_admin',
+            });
             const response = await fetch('/api/login', {
                 method: 'POST',
                 headers: {
@@ -46,6 +52,12 @@ export function LoginDialog() {
                 body: JSON.stringify({ email, password }),
             });
             if (response.status !== 200) {
+                posthog?.capture('user_login_failed', {
+                    provider: 'password',
+                    reason: 'invalid_credentials_or_access',
+                    status: response.status,
+                    surface: 'app_admin',
+                });
                 console.error('Login failed with status', response.status);
                 return { error: true };
             }
@@ -61,6 +73,10 @@ export function LoginDialog() {
     );
 
     const handleOAuthLogin = (provider: 'google' | 'facebook') => {
+        posthog?.capture('user_oauth_login_started', {
+            provider,
+            surface: 'app_admin',
+        });
         const callbackPath =
             provider === 'google'
                 ? '/prijava/google-prijava/povratak'

--- a/apps/app/lib/posthog-server.ts
+++ b/apps/app/lib/posthog-server.ts
@@ -68,7 +68,11 @@ export async function flushPostHogLogs(): Promise<void> {
         return;
     }
 
-    await loggerProvider.forceFlush();
+    try {
+        await loggerProvider.forceFlush();
+    } catch (error) {
+        console.warn('PostHog log flush failed', error);
+    }
 }
 
 export async function getPostHogClient(): Promise<PostHogCaptureClient> {

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -39,7 +39,14 @@ function formatDate(date?: Date | string | null) {
     });
 }
 
-const roleConfig: Record<string, { label: string; icon: typeof Fence; color: 'neutral' | 'success' | 'warning' }> = {
+const roleConfig: Record<
+    string,
+    {
+        label: string;
+        icon: typeof Fence;
+        color: 'neutral' | 'success' | 'warning';
+    }
+> = {
     user: { label: 'Korisnik', icon: User, color: 'neutral' },
     farmer: { label: 'Poljoprivrednik', icon: Fence, color: 'success' },
     admin: { label: 'Administrator', icon: Shield, color: 'warning' },

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -5,6 +5,7 @@ import {
     GoogleLoginButton,
     useLastLoginProvider,
 } from '@gredice/ui/auth';
+import { usePostHog } from '@posthog/next';
 import { authCurrentUserQueryKeys } from '@signalco/auth-client';
 import { Alert } from '@signalco/ui/Alert';
 import { Warning } from '@signalco/ui-icons';
@@ -22,6 +23,7 @@ import { queryClient } from '../providers/ClientAppProvider';
 type OAuthProvider = 'google' | 'facebook';
 
 export function LoginDialog() {
+    const posthog = usePostHog();
     const router = useRouter();
     const fetchLastLogin = useCallback(
         () => fetch('/api/gredice/api/auth/last-login'),
@@ -40,6 +42,10 @@ export function LoginDialog() {
         }
 
         try {
+            posthog?.capture('user_login_started', {
+                provider: 'password',
+                surface: 'farm',
+            });
             const response = await fetch('/api/login', {
                 method: 'POST',
                 headers: {
@@ -49,6 +55,12 @@ export function LoginDialog() {
             });
 
             if (!response.ok) {
+                posthog?.capture('user_login_failed', {
+                    provider: 'password',
+                    reason: 'invalid_credentials_or_access',
+                    status: response.status,
+                    surface: 'farm',
+                });
                 console.error('Login failed with status', response.status);
                 return 'Prijava nije uspjela. Provjeri podatke i pokušaj ponovno.';
             }
@@ -59,6 +71,12 @@ export function LoginDialog() {
 
             const currentUserResponse = await fetch('/api/users/current');
             if (!currentUserResponse.ok) {
+                posthog?.capture('user_login_failed', {
+                    provider: 'password',
+                    reason: 'no_farm_access',
+                    status: currentUserResponse.status,
+                    surface: 'farm',
+                });
                 return 'Tvoj korisnički račun nema pristup Gredice farmi.';
             }
 
@@ -68,11 +86,20 @@ export function LoginDialog() {
             router.refresh();
             return null;
         } catch (cause) {
+            posthog?.capture('user_login_failed', {
+                provider: 'password',
+                reason: 'unexpected_error',
+                surface: 'farm',
+            });
             console.error('Login request failed', cause);
             return 'Dogodila se neočekivana greška. Pokušaj ponovno kasnije.';
         }
     }, null);
     const handleOAuthLogin = (provider: OAuthProvider) => {
+        posthog?.capture('user_oauth_login_started', {
+            provider,
+            surface: 'farm',
+        });
         const callbackPath =
             provider === 'google'
                 ? '/prijava/google-prijava/povratak'

--- a/apps/farm/lib/posthog-server.ts
+++ b/apps/farm/lib/posthog-server.ts
@@ -68,7 +68,11 @@ export async function flushPostHogLogs(): Promise<void> {
         return;
     }
 
-    await loggerProvider.forceFlush();
+    try {
+        await loggerProvider.forceFlush();
+    } catch (error) {
+        console.warn('PostHog log flush failed', error);
+    }
 }
 
 export async function getPostHogClient(): Promise<PostHogCaptureClient> {

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -6,6 +6,7 @@ import {
     GoogleLoginButton,
     useLastLoginProvider,
 } from '@gredice/ui/auth';
+import { usePostHog } from '@posthog/next';
 import { Alert } from '@signalco/ui/Alert';
 import { Divider } from '@signalco/ui-primitives/Divider';
 import { Modal } from '@signalco/ui-primitives/Modal';
@@ -23,6 +24,7 @@ import { EmailPasswordForm } from './EmailPasswordForm';
 import LoginBanner from './LoginBanner';
 
 export default function LoginModal() {
+    const posthog = usePostHog();
     const router = useRouter();
     const queryClient = useQueryClient();
     const [error, setError] = useState<string>();
@@ -34,6 +36,10 @@ export default function LoginModal() {
 
     const handleLogin = async (email: string, password: string) => {
         setError(undefined);
+        posthog?.capture('user_login_started', {
+            provider: 'password',
+            surface: 'garden',
+        });
         const response = await clientPublic().api.auth.login.$post({
             json: {
                 email,
@@ -49,6 +55,12 @@ export default function LoginModal() {
             const json = await response.json();
             if ('errorCode' in json) {
                 if (json.errorCode === 'verify_email') {
+                    posthog?.capture('user_login_failed', {
+                        provider: 'password',
+                        reason: 'verify_email',
+                        status: response.status,
+                        surface: 'garden',
+                    });
                     console.debug('User email not verified', email);
                     router.push(
                         `/prijava/potvrda-emaila/posalji?email=${email}`,
@@ -61,6 +73,12 @@ export default function LoginModal() {
                     json.blockedUntil &&
                     typeof json.blockedUntil === 'string'
                 ) {
+                    posthog?.capture('user_login_failed', {
+                        provider: 'password',
+                        reason: 'user_blocked',
+                        status: response.status,
+                        surface: 'garden',
+                    });
                     console.debug('User is blocked until', json.blockedUntil);
                     setError(
                         `Korisnik je blokiran do ${new Date(json.blockedUntil).toLocaleString('hr-HR')}. Pokušaj ponovno kasnije.`,
@@ -68,6 +86,13 @@ export default function LoginModal() {
                     return;
                 }
                 if ('leftAttempts' in json) {
+                    posthog?.capture('user_login_failed', {
+                        left_attempts: json.leftAttempts,
+                        provider: 'password',
+                        reason: 'invalid_credentials',
+                        status: response.status,
+                        surface: 'garden',
+                    });
                     console.debug(
                         'Login failed with left attempts',
                         json.leftAttempts,
@@ -79,6 +104,12 @@ export default function LoginModal() {
                 }
             }
 
+            posthog?.capture('user_login_failed', {
+                provider: 'password',
+                reason: 'unknown',
+                status: response.status,
+                surface: 'garden',
+            });
             console.error('Login failed with status', response.status);
             setError('Prijava nije uspjela. Pokušaj ponovno.');
             return;
@@ -87,6 +118,10 @@ export default function LoginModal() {
 
     const handleRegister = async (email: string, password: string) => {
         setError(undefined);
+        posthog?.capture('user_signup_started', {
+            provider: 'password',
+            surface: 'garden',
+        });
         const response = await clientPublic().api.auth.register.$post({
             json: {
                 email,
@@ -104,6 +139,10 @@ export default function LoginModal() {
     };
 
     const handleOAuthLogin = (provider: 'google' | 'facebook') => {
+        posthog?.capture('user_oauth_login_started', {
+            provider,
+            surface: 'garden',
+        });
         window.location.href = `https://api.gredice.com/api/auth/${provider}`;
     };
 

--- a/apps/garden/lib/posthog-server.ts
+++ b/apps/garden/lib/posthog-server.ts
@@ -68,7 +68,11 @@ export async function flushPostHogLogs(): Promise<void> {
         return;
     }
 
-    await loggerProvider.forceFlush();
+    try {
+        await loggerProvider.forceFlush();
+    } catch (error) {
+        console.warn('PostHog log flush failed', error);
+    }
 }
 
 export async function getPostHogClient(): Promise<PostHogCaptureClient> {

--- a/apps/www/lib/posthog-server.ts
+++ b/apps/www/lib/posthog-server.ts
@@ -68,7 +68,11 @@ export async function flushPostHogLogs(): Promise<void> {
         return;
     }
 
-    await loggerProvider.forceFlush();
+    try {
+        await loggerProvider.forceFlush();
+    } catch (error) {
+        console.warn('PostHog log flush failed', error);
+    }
 }
 
 export async function getPostHogClient(): Promise<PostHogCaptureClient> {


### PR DESCRIPTION
- user_login_started when password login begins - user_oauth_started when an OAuth provider login begins user_login_failed on various failure paths with reasons status include provider and='farm' to aid funnel and error analysis.
 - Preserve existing behavior and error messages while improving observ of authentication outcomes.

- apps/farm/lib/posthog-server.ts Wrap loggerProvider.forceFlush in/catch and warn on failure to un exceptions server-side flush operations.

- apps/api/app/api/[route]/usersRoutes.ts - Add getPostHogClient import (unused in this diff) implement a helperUpdatedFields computes profile fields changed between an incoming userInfo object and the DB user.
 - The function detects changes for display name, avatar URL, user name and a nuanced birthday comparison (including clearing vs updates) and returns a list of updated field identifiers for use in conditional updates, auditing, or analytics.

Why:
- Improve observability of authentication to track starts, failures and provider for the farm surface, enabling faster debugging and insights.
- Make server-side PostHog resilient to errors to prevent during handling.
- Centralize-change detection to avoid repeated logic and support accurate change tracking (e.g., for, auditing,
 or conditional DB updates).