### PR TITLE
✨feat: forward server console Postog logs and flushingAdd console forwarding to PostHog logging, preserve original consolemethods, and improve log flush handling.

### DIFF
--- a/apps/api/instrumentation.ts
+++ b/apps/api/instrumentation.ts
@@ -6,6 +6,7 @@ import {
     getPostHogLogger,
     isPostHogLoggingEnabled,
     POSTHOG_SERVICE_NAME,
+    registerPostHogConsoleForwarding,
     registerPostHogLoggerProvider,
 } from './lib/posthog-server';
 
@@ -13,6 +14,7 @@ const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
 
 export async function register() {
     registerPostHogLoggerProvider();
+    registerPostHogConsoleForwarding();
 }
 
 export const onRequestError: Instrumentation.onRequestError = async (

--- a/apps/api/lib/posthog-server.ts
+++ b/apps/api/lib/posthog-server.ts
@@ -1,4 +1,4 @@
-import { type Logger, logs } from '@opentelemetry/api-logs';
+import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
@@ -16,6 +16,10 @@ type PostHogCaptureClient = {
 
 export const POSTHOG_SERVICE_NAME = 'gredice-api';
 
+const postHogConsoleForwardingKey = Symbol.for(
+    `${POSTHOG_SERVICE_NAME}.console-forwarding`,
+);
+
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
@@ -27,6 +31,16 @@ const postHogLogsUrl = process.env.NEXT_PUBLIC_POSTHOG_HOST
 const noopPostHogClient: PostHogCaptureClient = {
     capture: () => undefined,
 };
+
+const originalConsole = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+};
+
+let pendingLogFlush: Promise<void> | null = null;
 
 const postHogLogsProcessor =
     postHogApiKey && postHogLogsUrl
@@ -63,6 +77,99 @@ export function getPostHogLogger(scope = POSTHOG_SERVICE_NAME): Logger {
     return loggerProvider.getLogger(scope);
 }
 
+function stringifyConsoleArgument(value: unknown): string {
+    if (value instanceof Error) {
+        return value.stack ?? `${value.name}: ${value.message}`;
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        typeof value === 'bigint' ||
+        typeof value === 'symbol' ||
+        value === null ||
+        value === undefined
+    ) {
+        return String(value);
+    }
+
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return Object.prototype.toString.call(value);
+    }
+}
+
+function schedulePostHogLogFlush(): void {
+    if (!isPostHogLoggingEnabled() || pendingLogFlush) {
+        return;
+    }
+
+    pendingLogFlush = loggerProvider.forceFlush().catch((error) => {
+        originalConsole.warn('PostHog log flush failed', error);
+    });
+
+    void pendingLogFlush.finally(() => {
+        pendingLogFlush = null;
+    });
+}
+
+export function registerPostHogConsoleForwarding(): void {
+    if (!isPostHogLoggingEnabled()) {
+        return;
+    }
+
+    const globalState = globalThis as typeof globalThis & {
+        [postHogConsoleForwardingKey]?: boolean;
+    };
+
+    if (globalState[postHogConsoleForwardingKey]) {
+        return;
+    }
+
+    const consoleLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.console`);
+
+    const wrapConsoleMethod = (
+        method: keyof typeof originalConsole,
+        severityNumber: SeverityNumber,
+        severityText: string,
+    ) => {
+        const originalMethod = originalConsole[method];
+
+        console[method] = (...args: unknown[]) => {
+            originalMethod(...args);
+
+            if (!isPostHogLoggingEnabled()) {
+                return;
+            }
+
+            consoleLogger.emit({
+                attributes: {
+                    'console.method': method,
+                    'posthog.log_type': 'console',
+                },
+                body: args.map(stringifyConsoleArgument).join(' '),
+                severityNumber,
+                severityText,
+            });
+
+            schedulePostHogLogFlush();
+        };
+    };
+
+    wrapConsoleMethod('debug', SeverityNumber.DEBUG, 'DEBUG');
+    wrapConsoleMethod('log', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('info', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('warn', SeverityNumber.WARN, 'WARN');
+    wrapConsoleMethod('error', SeverityNumber.ERROR, 'ERROR');
+
+    globalState[postHogConsoleForwardingKey] = true;
+}
+
 export async function flushPostHogLogs(): Promise<void> {
     if (!isPostHogLoggingEnabled()) {
         return;
@@ -71,7 +178,7 @@ export async function flushPostHogLogs(): Promise<void> {
     try {
         await loggerProvider.forceFlush();
     } catch (error) {
-        console.warn('PostHog log flush failed', error);
+        originalConsole.warn('PostHog log flush failed', error);
     }
 }
 

--- a/apps/api/proxy.ts
+++ b/apps/api/proxy.ts
@@ -1,11 +1,49 @@
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+    type NextFetchEvent,
+    type NextProxy,
+    type NextRequest,
+    NextResponse,
+} from 'next/server';
+import {
+    flushPostHogLogs,
+    getPostHogLogger,
+    isPostHogLoggingEnabled,
+    POSTHOG_SERVICE_NAME,
+} from './lib/posthog-server';
 
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const POSTHOG_TRANSPORT_PATH_PREFIX = '/ingest';
 
-const proxyHandler = postHogApiKey
+const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
+
+function getProxyAttributes(response: Response) {
+    const rewriteTarget = response.headers.get('x-middleware-rewrite');
+    const redirectTarget = response.headers.get('location');
+
+    if (redirectTarget) {
+        return {
+            'http.response.header.location': redirectTarget,
+            'next.proxy_result': 'redirect',
+        };
+    }
+
+    if (rewriteTarget) {
+        return {
+            'next.proxy_result': 'rewrite',
+            'next.rewrite_target': rewriteTarget,
+        };
+    }
+
+    return {
+        'next.proxy_result': 'next',
+    };
+}
+
+const baseProxyHandler: NextProxy = postHogApiKey
     ? postHogMiddleware({
           apiKey: postHogApiKey,
           proxy: true,
@@ -13,6 +51,48 @@ const proxyHandler = postHogApiKey
     : function proxy(_request: NextRequest) {
           return NextResponse.next();
       };
+
+const proxyHandler: NextProxy = async (
+    request: NextRequest,
+    event: NextFetchEvent,
+) => {
+    const response =
+        (await baseProxyHandler(request, event)) ?? NextResponse.next();
+
+    if (
+        isPostHogLoggingEnabled() &&
+        !request.nextUrl.pathname.startsWith(POSTHOG_TRANSPORT_PATH_PREFIX)
+    ) {
+        requestLogger.emit({
+            attributes: {
+                'http.method': request.method,
+                'posthog.log_type': 'request',
+                'server.address': request.nextUrl.hostname,
+                'url.path': request.nextUrl.pathname,
+                ...getProxyAttributes(response),
+                ...(request.headers.get('referer')
+                    ? {
+                          'http.request.header.referer':
+                              request.headers.get('referer'),
+                      }
+                    : {}),
+                ...(request.headers.get('user-agent')
+                    ? {
+                          'user_agent.original':
+                              request.headers.get('user-agent'),
+                      }
+                    : {}),
+            },
+            body: `${request.method} ${request.nextUrl.pathname}`,
+            severityNumber: SeverityNumber.INFO,
+            severityText: 'INFO',
+        });
+
+        event.waitUntil(flushPostHogLogs());
+    }
+
+    return response;
+};
 
 export default proxyHandler;
 

--- a/apps/app/instrumentation.ts
+++ b/apps/app/instrumentation.ts
@@ -6,6 +6,7 @@ import {
     getPostHogLogger,
     isPostHogLoggingEnabled,
     POSTHOG_SERVICE_NAME,
+    registerPostHogConsoleForwarding,
     registerPostHogLoggerProvider,
 } from './lib/posthog-server';
 
@@ -13,6 +14,7 @@ const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
 
 export async function register() {
     registerPostHogLoggerProvider();
+    registerPostHogConsoleForwarding();
 }
 
 export const onRequestError: Instrumentation.onRequestError = async (

--- a/apps/app/lib/posthog-server.ts
+++ b/apps/app/lib/posthog-server.ts
@@ -1,4 +1,4 @@
-import { type Logger, logs } from '@opentelemetry/api-logs';
+import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
@@ -16,6 +16,10 @@ type PostHogCaptureClient = {
 
 export const POSTHOG_SERVICE_NAME = 'gredice-app';
 
+const postHogConsoleForwardingKey = Symbol.for(
+    `${POSTHOG_SERVICE_NAME}.console-forwarding`,
+);
+
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
@@ -27,6 +31,16 @@ const postHogLogsUrl = process.env.NEXT_PUBLIC_POSTHOG_HOST
 const noopPostHogClient: PostHogCaptureClient = {
     capture: () => undefined,
 };
+
+const originalConsole = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+};
+
+let pendingLogFlush: Promise<void> | null = null;
 
 const postHogLogsProcessor =
     postHogApiKey && postHogLogsUrl
@@ -63,6 +77,99 @@ export function getPostHogLogger(scope = POSTHOG_SERVICE_NAME): Logger {
     return loggerProvider.getLogger(scope);
 }
 
+function stringifyConsoleArgument(value: unknown): string {
+    if (value instanceof Error) {
+        return value.stack ?? `${value.name}: ${value.message}`;
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        typeof value === 'bigint' ||
+        typeof value === 'symbol' ||
+        value === null ||
+        value === undefined
+    ) {
+        return String(value);
+    }
+
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return Object.prototype.toString.call(value);
+    }
+}
+
+function schedulePostHogLogFlush(): void {
+    if (!isPostHogLoggingEnabled() || pendingLogFlush) {
+        return;
+    }
+
+    pendingLogFlush = loggerProvider.forceFlush().catch((error) => {
+        originalConsole.warn('PostHog log flush failed', error);
+    });
+
+    void pendingLogFlush.finally(() => {
+        pendingLogFlush = null;
+    });
+}
+
+export function registerPostHogConsoleForwarding(): void {
+    if (!isPostHogLoggingEnabled()) {
+        return;
+    }
+
+    const globalState = globalThis as typeof globalThis & {
+        [postHogConsoleForwardingKey]?: boolean;
+    };
+
+    if (globalState[postHogConsoleForwardingKey]) {
+        return;
+    }
+
+    const consoleLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.console`);
+
+    const wrapConsoleMethod = (
+        method: keyof typeof originalConsole,
+        severityNumber: SeverityNumber,
+        severityText: string,
+    ) => {
+        const originalMethod = originalConsole[method];
+
+        console[method] = (...args: unknown[]) => {
+            originalMethod(...args);
+
+            if (!isPostHogLoggingEnabled()) {
+                return;
+            }
+
+            consoleLogger.emit({
+                attributes: {
+                    'console.method': method,
+                    'posthog.log_type': 'console',
+                },
+                body: args.map(stringifyConsoleArgument).join(' '),
+                severityNumber,
+                severityText,
+            });
+
+            schedulePostHogLogFlush();
+        };
+    };
+
+    wrapConsoleMethod('debug', SeverityNumber.DEBUG, 'DEBUG');
+    wrapConsoleMethod('log', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('info', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('warn', SeverityNumber.WARN, 'WARN');
+    wrapConsoleMethod('error', SeverityNumber.ERROR, 'ERROR');
+
+    globalState[postHogConsoleForwardingKey] = true;
+}
+
 export async function flushPostHogLogs(): Promise<void> {
     if (!isPostHogLoggingEnabled()) {
         return;
@@ -71,7 +178,7 @@ export async function flushPostHogLogs(): Promise<void> {
     try {
         await loggerProvider.forceFlush();
     } catch (error) {
-        console.warn('PostHog log flush failed', error);
+        originalConsole.warn('PostHog log flush failed', error);
     }
 }
 

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -1,11 +1,49 @@
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+    type NextFetchEvent,
+    type NextProxy,
+    type NextRequest,
+    NextResponse,
+} from 'next/server';
+import {
+    flushPostHogLogs,
+    getPostHogLogger,
+    isPostHogLoggingEnabled,
+    POSTHOG_SERVICE_NAME,
+} from './lib/posthog-server';
 
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const POSTHOG_TRANSPORT_PATH_PREFIX = '/ingest';
 
-const proxyHandler = postHogApiKey
+const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
+
+function getProxyAttributes(response: Response) {
+    const rewriteTarget = response.headers.get('x-middleware-rewrite');
+    const redirectTarget = response.headers.get('location');
+
+    if (redirectTarget) {
+        return {
+            'http.response.header.location': redirectTarget,
+            'next.proxy_result': 'redirect',
+        };
+    }
+
+    if (rewriteTarget) {
+        return {
+            'next.proxy_result': 'rewrite',
+            'next.rewrite_target': rewriteTarget,
+        };
+    }
+
+    return {
+        'next.proxy_result': 'next',
+    };
+}
+
+const baseProxyHandler: NextProxy = postHogApiKey
     ? postHogMiddleware({
           apiKey: postHogApiKey,
           proxy: true,
@@ -13,6 +51,48 @@ const proxyHandler = postHogApiKey
     : function proxy(_request: NextRequest) {
           return NextResponse.next();
       };
+
+const proxyHandler: NextProxy = async (
+    request: NextRequest,
+    event: NextFetchEvent,
+) => {
+    const response =
+        (await baseProxyHandler(request, event)) ?? NextResponse.next();
+
+    if (
+        isPostHogLoggingEnabled() &&
+        !request.nextUrl.pathname.startsWith(POSTHOG_TRANSPORT_PATH_PREFIX)
+    ) {
+        requestLogger.emit({
+            attributes: {
+                'http.method': request.method,
+                'posthog.log_type': 'request',
+                'server.address': request.nextUrl.hostname,
+                'url.path': request.nextUrl.pathname,
+                ...getProxyAttributes(response),
+                ...(request.headers.get('referer')
+                    ? {
+                          'http.request.header.referer':
+                              request.headers.get('referer'),
+                      }
+                    : {}),
+                ...(request.headers.get('user-agent')
+                    ? {
+                          'user_agent.original':
+                              request.headers.get('user-agent'),
+                      }
+                    : {}),
+            },
+            body: `${request.method} ${request.nextUrl.pathname}`,
+            severityNumber: SeverityNumber.INFO,
+            severityText: 'INFO',
+        });
+
+        event.waitUntil(flushPostHogLogs());
+    }
+
+    return response;
+};
 
 export default proxyHandler;
 

--- a/apps/farm/instrumentation.ts
+++ b/apps/farm/instrumentation.ts
@@ -6,6 +6,7 @@ import {
     getPostHogLogger,
     isPostHogLoggingEnabled,
     POSTHOG_SERVICE_NAME,
+    registerPostHogConsoleForwarding,
     registerPostHogLoggerProvider,
 } from './lib/posthog-server';
 
@@ -13,6 +14,7 @@ const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
 
 export async function register() {
     registerPostHogLoggerProvider();
+    registerPostHogConsoleForwarding();
 }
 
 export const onRequestError: Instrumentation.onRequestError = async (

--- a/apps/farm/lib/posthog-server.ts
+++ b/apps/farm/lib/posthog-server.ts
@@ -1,4 +1,4 @@
-import { type Logger, logs } from '@opentelemetry/api-logs';
+import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
@@ -16,6 +16,10 @@ type PostHogCaptureClient = {
 
 export const POSTHOG_SERVICE_NAME = 'gredice-farm';
 
+const postHogConsoleForwardingKey = Symbol.for(
+    `${POSTHOG_SERVICE_NAME}.console-forwarding`,
+);
+
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
@@ -27,6 +31,16 @@ const postHogLogsUrl = process.env.NEXT_PUBLIC_POSTHOG_HOST
 const noopPostHogClient: PostHogCaptureClient = {
     capture: () => undefined,
 };
+
+const originalConsole = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+};
+
+let pendingLogFlush: Promise<void> | null = null;
 
 const postHogLogsProcessor =
     postHogApiKey && postHogLogsUrl
@@ -63,6 +77,99 @@ export function getPostHogLogger(scope = POSTHOG_SERVICE_NAME): Logger {
     return loggerProvider.getLogger(scope);
 }
 
+function stringifyConsoleArgument(value: unknown): string {
+    if (value instanceof Error) {
+        return value.stack ?? `${value.name}: ${value.message}`;
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        typeof value === 'bigint' ||
+        typeof value === 'symbol' ||
+        value === null ||
+        value === undefined
+    ) {
+        return String(value);
+    }
+
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return Object.prototype.toString.call(value);
+    }
+}
+
+function schedulePostHogLogFlush(): void {
+    if (!isPostHogLoggingEnabled() || pendingLogFlush) {
+        return;
+    }
+
+    pendingLogFlush = loggerProvider.forceFlush().catch((error) => {
+        originalConsole.warn('PostHog log flush failed', error);
+    });
+
+    void pendingLogFlush.finally(() => {
+        pendingLogFlush = null;
+    });
+}
+
+export function registerPostHogConsoleForwarding(): void {
+    if (!isPostHogLoggingEnabled()) {
+        return;
+    }
+
+    const globalState = globalThis as typeof globalThis & {
+        [postHogConsoleForwardingKey]?: boolean;
+    };
+
+    if (globalState[postHogConsoleForwardingKey]) {
+        return;
+    }
+
+    const consoleLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.console`);
+
+    const wrapConsoleMethod = (
+        method: keyof typeof originalConsole,
+        severityNumber: SeverityNumber,
+        severityText: string,
+    ) => {
+        const originalMethod = originalConsole[method];
+
+        console[method] = (...args: unknown[]) => {
+            originalMethod(...args);
+
+            if (!isPostHogLoggingEnabled()) {
+                return;
+            }
+
+            consoleLogger.emit({
+                attributes: {
+                    'console.method': method,
+                    'posthog.log_type': 'console',
+                },
+                body: args.map(stringifyConsoleArgument).join(' '),
+                severityNumber,
+                severityText,
+            });
+
+            schedulePostHogLogFlush();
+        };
+    };
+
+    wrapConsoleMethod('debug', SeverityNumber.DEBUG, 'DEBUG');
+    wrapConsoleMethod('log', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('info', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('warn', SeverityNumber.WARN, 'WARN');
+    wrapConsoleMethod('error', SeverityNumber.ERROR, 'ERROR');
+
+    globalState[postHogConsoleForwardingKey] = true;
+}
+
 export async function flushPostHogLogs(): Promise<void> {
     if (!isPostHogLoggingEnabled()) {
         return;
@@ -71,7 +178,7 @@ export async function flushPostHogLogs(): Promise<void> {
     try {
         await loggerProvider.forceFlush();
     } catch (error) {
-        console.warn('PostHog log flush failed', error);
+        originalConsole.warn('PostHog log flush failed', error);
     }
 }
 

--- a/apps/farm/proxy.ts
+++ b/apps/farm/proxy.ts
@@ -1,11 +1,49 @@
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+    type NextFetchEvent,
+    type NextProxy,
+    type NextRequest,
+    NextResponse,
+} from 'next/server';
+import {
+    flushPostHogLogs,
+    getPostHogLogger,
+    isPostHogLoggingEnabled,
+    POSTHOG_SERVICE_NAME,
+} from './lib/posthog-server';
 
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const POSTHOG_TRANSPORT_PATH_PREFIX = '/ingest';
 
-const proxyHandler = postHogApiKey
+const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
+
+function getProxyAttributes(response: Response) {
+    const rewriteTarget = response.headers.get('x-middleware-rewrite');
+    const redirectTarget = response.headers.get('location');
+
+    if (redirectTarget) {
+        return {
+            'http.response.header.location': redirectTarget,
+            'next.proxy_result': 'redirect',
+        };
+    }
+
+    if (rewriteTarget) {
+        return {
+            'next.proxy_result': 'rewrite',
+            'next.rewrite_target': rewriteTarget,
+        };
+    }
+
+    return {
+        'next.proxy_result': 'next',
+    };
+}
+
+const baseProxyHandler: NextProxy = postHogApiKey
     ? postHogMiddleware({
           apiKey: postHogApiKey,
           proxy: true,
@@ -13,6 +51,48 @@ const proxyHandler = postHogApiKey
     : function proxy(_request: NextRequest) {
           return NextResponse.next();
       };
+
+const proxyHandler: NextProxy = async (
+    request: NextRequest,
+    event: NextFetchEvent,
+) => {
+    const response =
+        (await baseProxyHandler(request, event)) ?? NextResponse.next();
+
+    if (
+        isPostHogLoggingEnabled() &&
+        !request.nextUrl.pathname.startsWith(POSTHOG_TRANSPORT_PATH_PREFIX)
+    ) {
+        requestLogger.emit({
+            attributes: {
+                'http.method': request.method,
+                'posthog.log_type': 'request',
+                'server.address': request.nextUrl.hostname,
+                'url.path': request.nextUrl.pathname,
+                ...getProxyAttributes(response),
+                ...(request.headers.get('referer')
+                    ? {
+                          'http.request.header.referer':
+                              request.headers.get('referer'),
+                      }
+                    : {}),
+                ...(request.headers.get('user-agent')
+                    ? {
+                          'user_agent.original':
+                              request.headers.get('user-agent'),
+                      }
+                    : {}),
+            },
+            body: `${request.method} ${request.nextUrl.pathname}`,
+            severityNumber: SeverityNumber.INFO,
+            severityText: 'INFO',
+        });
+
+        event.waitUntil(flushPostHogLogs());
+    }
+
+    return response;
+};
 
 export default proxyHandler;
 

--- a/apps/garden/instrumentation.ts
+++ b/apps/garden/instrumentation.ts
@@ -6,6 +6,7 @@ import {
     getPostHogLogger,
     isPostHogLoggingEnabled,
     POSTHOG_SERVICE_NAME,
+    registerPostHogConsoleForwarding,
     registerPostHogLoggerProvider,
 } from './lib/posthog-server';
 
@@ -13,6 +14,7 @@ const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
 
 export async function register() {
     registerPostHogLoggerProvider();
+    registerPostHogConsoleForwarding();
 }
 
 export const onRequestError: Instrumentation.onRequestError = async (

--- a/apps/garden/lib/posthog-server.ts
+++ b/apps/garden/lib/posthog-server.ts
@@ -1,4 +1,4 @@
-import { type Logger, logs } from '@opentelemetry/api-logs';
+import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
@@ -16,6 +16,10 @@ type PostHogCaptureClient = {
 
 export const POSTHOG_SERVICE_NAME = 'gredice-garden';
 
+const postHogConsoleForwardingKey = Symbol.for(
+    `${POSTHOG_SERVICE_NAME}.console-forwarding`,
+);
+
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
@@ -27,6 +31,16 @@ const postHogLogsUrl = process.env.NEXT_PUBLIC_POSTHOG_HOST
 const noopPostHogClient: PostHogCaptureClient = {
     capture: () => undefined,
 };
+
+const originalConsole = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+};
+
+let pendingLogFlush: Promise<void> | null = null;
 
 const postHogLogsProcessor =
     postHogApiKey && postHogLogsUrl
@@ -63,6 +77,99 @@ export function getPostHogLogger(scope = POSTHOG_SERVICE_NAME): Logger {
     return loggerProvider.getLogger(scope);
 }
 
+function stringifyConsoleArgument(value: unknown): string {
+    if (value instanceof Error) {
+        return value.stack ?? `${value.name}: ${value.message}`;
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        typeof value === 'bigint' ||
+        typeof value === 'symbol' ||
+        value === null ||
+        value === undefined
+    ) {
+        return String(value);
+    }
+
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return Object.prototype.toString.call(value);
+    }
+}
+
+function schedulePostHogLogFlush(): void {
+    if (!isPostHogLoggingEnabled() || pendingLogFlush) {
+        return;
+    }
+
+    pendingLogFlush = loggerProvider.forceFlush().catch((error) => {
+        originalConsole.warn('PostHog log flush failed', error);
+    });
+
+    void pendingLogFlush.finally(() => {
+        pendingLogFlush = null;
+    });
+}
+
+export function registerPostHogConsoleForwarding(): void {
+    if (!isPostHogLoggingEnabled()) {
+        return;
+    }
+
+    const globalState = globalThis as typeof globalThis & {
+        [postHogConsoleForwardingKey]?: boolean;
+    };
+
+    if (globalState[postHogConsoleForwardingKey]) {
+        return;
+    }
+
+    const consoleLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.console`);
+
+    const wrapConsoleMethod = (
+        method: keyof typeof originalConsole,
+        severityNumber: SeverityNumber,
+        severityText: string,
+    ) => {
+        const originalMethod = originalConsole[method];
+
+        console[method] = (...args: unknown[]) => {
+            originalMethod(...args);
+
+            if (!isPostHogLoggingEnabled()) {
+                return;
+            }
+
+            consoleLogger.emit({
+                attributes: {
+                    'console.method': method,
+                    'posthog.log_type': 'console',
+                },
+                body: args.map(stringifyConsoleArgument).join(' '),
+                severityNumber,
+                severityText,
+            });
+
+            schedulePostHogLogFlush();
+        };
+    };
+
+    wrapConsoleMethod('debug', SeverityNumber.DEBUG, 'DEBUG');
+    wrapConsoleMethod('log', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('info', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('warn', SeverityNumber.WARN, 'WARN');
+    wrapConsoleMethod('error', SeverityNumber.ERROR, 'ERROR');
+
+    globalState[postHogConsoleForwardingKey] = true;
+}
+
 export async function flushPostHogLogs(): Promise<void> {
     if (!isPostHogLoggingEnabled()) {
         return;
@@ -71,7 +178,7 @@ export async function flushPostHogLogs(): Promise<void> {
     try {
         await loggerProvider.forceFlush();
     } catch (error) {
-        console.warn('PostHog log flush failed', error);
+        originalConsole.warn('PostHog log flush failed', error);
     }
 }
 

--- a/apps/garden/proxy.ts
+++ b/apps/garden/proxy.ts
@@ -1,11 +1,49 @@
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+    type NextFetchEvent,
+    type NextProxy,
+    type NextRequest,
+    NextResponse,
+} from 'next/server';
+import {
+    flushPostHogLogs,
+    getPostHogLogger,
+    isPostHogLoggingEnabled,
+    POSTHOG_SERVICE_NAME,
+} from './lib/posthog-server';
 
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const POSTHOG_TRANSPORT_PATH_PREFIX = '/ingest';
 
-const proxyHandler = postHogApiKey
+const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
+
+function getProxyAttributes(response: Response) {
+    const rewriteTarget = response.headers.get('x-middleware-rewrite');
+    const redirectTarget = response.headers.get('location');
+
+    if (redirectTarget) {
+        return {
+            'http.response.header.location': redirectTarget,
+            'next.proxy_result': 'redirect',
+        };
+    }
+
+    if (rewriteTarget) {
+        return {
+            'next.proxy_result': 'rewrite',
+            'next.rewrite_target': rewriteTarget,
+        };
+    }
+
+    return {
+        'next.proxy_result': 'next',
+    };
+}
+
+const baseProxyHandler: NextProxy = postHogApiKey
     ? postHogMiddleware({
           apiKey: postHogApiKey,
           proxy: true,
@@ -13,6 +51,48 @@ const proxyHandler = postHogApiKey
     : function proxy(_request: NextRequest) {
           return NextResponse.next();
       };
+
+const proxyHandler: NextProxy = async (
+    request: NextRequest,
+    event: NextFetchEvent,
+) => {
+    const response =
+        (await baseProxyHandler(request, event)) ?? NextResponse.next();
+
+    if (
+        isPostHogLoggingEnabled() &&
+        !request.nextUrl.pathname.startsWith(POSTHOG_TRANSPORT_PATH_PREFIX)
+    ) {
+        requestLogger.emit({
+            attributes: {
+                'http.method': request.method,
+                'posthog.log_type': 'request',
+                'server.address': request.nextUrl.hostname,
+                'url.path': request.nextUrl.pathname,
+                ...getProxyAttributes(response),
+                ...(request.headers.get('referer')
+                    ? {
+                          'http.request.header.referer':
+                              request.headers.get('referer'),
+                      }
+                    : {}),
+                ...(request.headers.get('user-agent')
+                    ? {
+                          'user_agent.original':
+                              request.headers.get('user-agent'),
+                      }
+                    : {}),
+            },
+            body: `${request.method} ${request.nextUrl.pathname}`,
+            severityNumber: SeverityNumber.INFO,
+            severityText: 'INFO',
+        });
+
+        event.waitUntil(flushPostHogLogs());
+    }
+
+    return response;
+};
 
 export default proxyHandler;
 

--- a/apps/www/instrumentation.ts
+++ b/apps/www/instrumentation.ts
@@ -6,6 +6,7 @@ import {
     getPostHogLogger,
     isPostHogLoggingEnabled,
     POSTHOG_SERVICE_NAME,
+    registerPostHogConsoleForwarding,
     registerPostHogLoggerProvider,
 } from './lib/posthog-server';
 
@@ -13,6 +14,7 @@ const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
 
 export async function register() {
     registerPostHogLoggerProvider();
+    registerPostHogConsoleForwarding();
 }
 
 export const onRequestError: Instrumentation.onRequestError = async (

--- a/apps/www/lib/posthog-server.ts
+++ b/apps/www/lib/posthog-server.ts
@@ -1,4 +1,4 @@
-import { type Logger, logs } from '@opentelemetry/api-logs';
+import { type Logger, logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
@@ -16,6 +16,10 @@ type PostHogCaptureClient = {
 
 export const POSTHOG_SERVICE_NAME = 'gredice-www';
 
+const postHogConsoleForwardingKey = Symbol.for(
+    `${POSTHOG_SERVICE_NAME}.console-forwarding`,
+);
+
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
@@ -27,6 +31,16 @@ const postHogLogsUrl = process.env.NEXT_PUBLIC_POSTHOG_HOST
 const noopPostHogClient: PostHogCaptureClient = {
     capture: () => undefined,
 };
+
+const originalConsole = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+};
+
+let pendingLogFlush: Promise<void> | null = null;
 
 const postHogLogsProcessor =
     postHogApiKey && postHogLogsUrl
@@ -63,6 +77,99 @@ export function getPostHogLogger(scope = POSTHOG_SERVICE_NAME): Logger {
     return loggerProvider.getLogger(scope);
 }
 
+function stringifyConsoleArgument(value: unknown): string {
+    if (value instanceof Error) {
+        return value.stack ?? `${value.name}: ${value.message}`;
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        typeof value === 'bigint' ||
+        typeof value === 'symbol' ||
+        value === null ||
+        value === undefined
+    ) {
+        return String(value);
+    }
+
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return Object.prototype.toString.call(value);
+    }
+}
+
+function schedulePostHogLogFlush(): void {
+    if (!isPostHogLoggingEnabled() || pendingLogFlush) {
+        return;
+    }
+
+    pendingLogFlush = loggerProvider.forceFlush().catch((error) => {
+        originalConsole.warn('PostHog log flush failed', error);
+    });
+
+    void pendingLogFlush.finally(() => {
+        pendingLogFlush = null;
+    });
+}
+
+export function registerPostHogConsoleForwarding(): void {
+    if (!isPostHogLoggingEnabled()) {
+        return;
+    }
+
+    const globalState = globalThis as typeof globalThis & {
+        [postHogConsoleForwardingKey]?: boolean;
+    };
+
+    if (globalState[postHogConsoleForwardingKey]) {
+        return;
+    }
+
+    const consoleLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.console`);
+
+    const wrapConsoleMethod = (
+        method: keyof typeof originalConsole,
+        severityNumber: SeverityNumber,
+        severityText: string,
+    ) => {
+        const originalMethod = originalConsole[method];
+
+        console[method] = (...args: unknown[]) => {
+            originalMethod(...args);
+
+            if (!isPostHogLoggingEnabled()) {
+                return;
+            }
+
+            consoleLogger.emit({
+                attributes: {
+                    'console.method': method,
+                    'posthog.log_type': 'console',
+                },
+                body: args.map(stringifyConsoleArgument).join(' '),
+                severityNumber,
+                severityText,
+            });
+
+            schedulePostHogLogFlush();
+        };
+    };
+
+    wrapConsoleMethod('debug', SeverityNumber.DEBUG, 'DEBUG');
+    wrapConsoleMethod('log', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('info', SeverityNumber.INFO, 'INFO');
+    wrapConsoleMethod('warn', SeverityNumber.WARN, 'WARN');
+    wrapConsoleMethod('error', SeverityNumber.ERROR, 'ERROR');
+
+    globalState[postHogConsoleForwardingKey] = true;
+}
+
 export async function flushPostHogLogs(): Promise<void> {
     if (!isPostHogLoggingEnabled()) {
         return;
@@ -71,7 +178,7 @@ export async function flushPostHogLogs(): Promise<void> {
     try {
         await loggerProvider.forceFlush();
     } catch (error) {
-        console.warn('PostHog log flush failed', error);
+        originalConsole.warn('PostHog log flush failed', error);
     }
 }
 

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -1,11 +1,49 @@
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+    type NextFetchEvent,
+    type NextProxy,
+    type NextRequest,
+    NextResponse,
+} from 'next/server';
+import {
+    flushPostHogLogs,
+    getPostHogLogger,
+    isPostHogLoggingEnabled,
+    POSTHOG_SERVICE_NAME,
+} from './lib/posthog-server';
 
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const POSTHOG_TRANSPORT_PATH_PREFIX = '/ingest';
 
-const proxyHandler = postHogApiKey
+const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
+
+function getProxyAttributes(response: Response) {
+    const rewriteTarget = response.headers.get('x-middleware-rewrite');
+    const redirectTarget = response.headers.get('location');
+
+    if (redirectTarget) {
+        return {
+            'http.response.header.location': redirectTarget,
+            'next.proxy_result': 'redirect',
+        };
+    }
+
+    if (rewriteTarget) {
+        return {
+            'next.proxy_result': 'rewrite',
+            'next.rewrite_target': rewriteTarget,
+        };
+    }
+
+    return {
+        'next.proxy_result': 'next',
+    };
+}
+
+const baseProxyHandler: NextProxy = postHogApiKey
     ? postHogMiddleware({
           apiKey: postHogApiKey,
           proxy: true,
@@ -13,6 +51,48 @@ const proxyHandler = postHogApiKey
     : function proxy(_request: NextRequest) {
           return NextResponse.next();
       };
+
+const proxyHandler: NextProxy = async (
+    request: NextRequest,
+    event: NextFetchEvent,
+) => {
+    const response =
+        (await baseProxyHandler(request, event)) ?? NextResponse.next();
+
+    if (
+        isPostHogLoggingEnabled() &&
+        !request.nextUrl.pathname.startsWith(POSTHOG_TRANSPORT_PATH_PREFIX)
+    ) {
+        requestLogger.emit({
+            attributes: {
+                'http.method': request.method,
+                'posthog.log_type': 'request',
+                'server.address': request.nextUrl.hostname,
+                'url.path': request.nextUrl.pathname,
+                ...getProxyAttributes(response),
+                ...(request.headers.get('referer')
+                    ? {
+                          'http.request.header.referer':
+                              request.headers.get('referer'),
+                      }
+                    : {}),
+                ...(request.headers.get('user-agent')
+                    ? {
+                          'user_agent.original':
+                              request.headers.get('user-agent'),
+                      }
+                    : {}),
+            },
+            body: `${request.method} ${request.nextUrl.pathname}`,
+            severityNumber: SeverityNumber.INFO,
+            severityText: 'INFO',
+        });
+
+        event.waitUntil(flushPostHogLogs());
+    }
+
+    return response;
+};
 
 export default proxyHandler;
 


### PR DESCRIPTION
- import SeverityNumber OpenTelemetry logs to map levels to Open severity values.
 keep references to original console so console prints to stdout/stderr- a Symbol-based guard to avoid double-registering console forwarding across modules.
- implement stringifyConsoleArgument to safely serialize console args handling Errors, primitives, and non-serializable.
- implementPostHogLogFlush and pendingLogFlush tracking to debounce/ loggerProvider.forceFlush is called and errors are routed toConsole.warn.
- registerPostHogConsoleForwarding wraps console.debug/log/info/warn/error emit structured logs to PostHog (attributes body, severity) and scheduled flushes.
- replace direct console.warn calls in flushPostog with originalConsole.warn to recursion when console forwarding is active.
 begin wiring PostHog logging into proxy (add imports, request logger, and transport path prefix) to prepare for request-level log attributes.

These changes ensure server console is captured and toPostHog reliably while normal console behavior avoidingduplicate or recursive logging.