### PR TITLE
✨ feat(game): add analytics tracking to several HUD componentsAdd GameAnalytics tracking calls across multiple UI to interactions and improve event telemetry:

### DIFF
--- a/apps/app/components/admin/navigation/LoginDialog.tsx
+++ b/apps/app/components/admin/navigation/LoginDialog.tsx
@@ -73,7 +73,7 @@ export function LoginDialog() {
     );
 
     const handleOAuthLogin = (provider: 'google' | 'facebook') => {
-        posthog?.capture('user_oauth_login_started', {
+        posthog?.capture('user_oauth_started', {
             provider,
             surface: 'app_admin',
         });

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -96,7 +96,7 @@ export function LoginDialog() {
         }
     }, null);
     const handleOAuthLogin = (provider: OAuthProvider) => {
-        posthog?.capture('user_oauth_login_started', {
+        posthog?.capture('user_oauth_started', {
             provider,
             surface: 'farm',
         });

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -1,7 +1,7 @@
-import { GameScene } from '@gredice/game';
 import { SignedOut } from '@signalco/auth-client/components';
 import type { ComponentProps } from 'react';
 import LoginModal from '../components/auth/LoginModal';
+import { GameSceneWithAnalytics } from '../components/game/GameSceneWithAnalytics';
 import {
     enableDebugHudFlag,
     lsystemPlantsFlag,
@@ -9,7 +9,7 @@ import {
 } from './flags';
 
 export default async function Home() {
-    const flags: ComponentProps<typeof GameScene>['flags'] = {
+    const flags: ComponentProps<typeof GameSceneWithAnalytics>['flags'] = {
         enableDebugHudFlag: await enableDebugHudFlag(),
         enablePlantGeneratorFlag: await lsystemPlantsFlag(),
         raisedBedImageAI: await raisedBedImageAIFlag(),
@@ -17,7 +17,7 @@ export default async function Home() {
 
     return (
         <div className="grid grid-cols-1 h-[100dvh] relative overflow-hidden">
-            <GameScene flags={flags} />
+            <GameSceneWithAnalytics flags={flags} />
             <SignedOut>
                 <div className="relative h-full">
                     <LoginModal />

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -139,7 +139,7 @@ export default function LoginModal() {
     };
 
     const handleOAuthLogin = (provider: 'google' | 'facebook') => {
-        posthog?.capture('user_oauth_login_started', {
+        posthog?.capture('user_oauth_started', {
             provider,
             surface: 'garden',
         });

--- a/apps/garden/components/game/GameSceneWithAnalytics.tsx
+++ b/apps/garden/components/game/GameSceneWithAnalytics.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import {
+    GameAnalyticsProvider,
+    GameScene,
+    type GameSceneProps,
+} from '@gredice/game';
+import { usePostHog } from '@posthog/next';
+
+export function GameSceneWithAnalytics(props: GameSceneProps) {
+    const posthog = usePostHog();
+
+    return (
+        <GameAnalyticsProvider
+            capture={(eventName, properties) => {
+                posthog?.capture(eventName, {
+                    surface: 'garden_game',
+                    ...properties,
+                });
+            }}
+        >
+            <GameScene {...props} />
+        </GameAnalyticsProvider>
+    );
+}

--- a/packages/game/src/analytics/GameAnalyticsContext.tsx
+++ b/packages/game/src/analytics/GameAnalyticsContext.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import {
+    createContext,
+    type PropsWithChildren,
+    useCallback,
+    useContext,
+} from 'react';
+
+export type GameAnalyticsProperties = Record<
+    string,
+    boolean | null | number | string | undefined
+>;
+
+type GameAnalyticsCapture = (
+    eventName: string,
+    properties?: GameAnalyticsProperties,
+) => void;
+
+const noopCapture: GameAnalyticsCapture = () => undefined;
+
+const GameAnalyticsContext = createContext<GameAnalyticsCapture>(noopCapture);
+
+function sanitizeProperties(properties?: GameAnalyticsProperties) {
+    if (!properties) {
+        return undefined;
+    }
+
+    const entries = Object.entries(properties).filter(
+        ([, value]) => value !== undefined,
+    );
+
+    if (!entries.length) {
+        return undefined;
+    }
+
+    return Object.fromEntries(entries) as GameAnalyticsProperties;
+}
+
+export function GameAnalyticsProvider({
+    capture,
+    children,
+}: PropsWithChildren<{ capture: GameAnalyticsCapture }>) {
+    return (
+        <GameAnalyticsContext.Provider value={capture}>
+            {children}
+        </GameAnalyticsContext.Provider>
+    );
+}
+
+export function useGameAnalytics() {
+    const capture = useContext(GameAnalyticsContext);
+
+    const track = useCallback(
+        (eventName: string, properties?: GameAnalyticsProperties) => {
+            capture(eventName, sanitizeProperties(properties));
+        },
+        [capture],
+    );
+
+    return {
+        track,
+    };
+}

--- a/packages/game/src/controls/RaisedBedSelectableGroup.tsx
+++ b/packages/game/src/controls/RaisedBedSelectableGroup.tsx
@@ -1,4 +1,5 @@
 import { type PropsWithChildren, useRef } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import type { Block } from '../types/Block';
 import {
     useRemoveRaisedBedCloseupParam,
@@ -12,6 +13,7 @@ export function RaisedBedSelectableGroup({
     raisedBedName,
 }: PropsWithChildren<{ block: Block; raisedBedName: string }>) {
     const groupRef = useRef(null);
+    const { track } = useGameAnalytics();
     const hovered = useHoveredBlockStore();
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
     const { mutate: removeRaisedBedCloseupParam } =
@@ -23,6 +25,10 @@ export function RaisedBedSelectableGroup({
 
     function handleOpenChange(open: boolean) {
         if (open) {
+            track('game_raised_bed_opened', {
+                block_id: block.id,
+                raised_bed_name: raisedBedName,
+            });
             setRaisedBedCloseupParam(raisedBedName);
             hovered.setHoveredBlock(null);
         } else {

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -30,6 +30,7 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Skeleton } from '@signalco/ui-primitives/Skeleton';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useGardens } from '../hooks/useGardens';
@@ -45,8 +46,12 @@ import { NotificationList } from './NotificationList';
 function NotificationsCard() {
     const [, setProfileModalOpen] = useSearchParam('pregled');
     const markAllNotificationsRead = useMarkAllNotificationsRead();
+    const { track } = useGameAnalytics();
 
     const handleMarkAllNotificationsRead = () => {
+        track('game_notifications_mark_all_read', {
+            source: 'quick_panel',
+        });
         markAllNotificationsRead.mutate({ readWhere: 'game' });
     };
 
@@ -79,7 +84,12 @@ function NotificationsCard() {
                     size="sm"
                     fullWidth
                     className="rounded-t-none"
-                    onClick={() => setProfileModalOpen('obavijesti')}
+                    onClick={() => {
+                        track('game_notifications_view_all_opened', {
+                            source: 'quick_panel',
+                        });
+                        setProfileModalOpen('obavijesti');
+                    }}
                 >
                     Prikaži sve obavijesti
                 </Button>
@@ -91,6 +101,7 @@ function NotificationsCard() {
 function ProfileCard() {
     const [, setProfileModalOpen] = useSearchParam('pregled');
     const [, setSelectedGardenId] = useCurrentGardenIdParam();
+    const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser();
     const { data: currentGarden } = useCurrentGarden();
     const { data: gardens, isLoading: gardensLoading } = useGardens();
@@ -112,7 +123,14 @@ function ProfileCard() {
                 <DropdownMenuItem
                     key={garden.id}
                     className="gap-3"
-                    onClick={() => setSelectedGardenId(garden.id)}
+                    onClick={() => {
+                        track('game_garden_switched', {
+                            from_garden_id: currentGarden?.id,
+                            to_garden_id: garden.id,
+                            to_garden_name: garden.name,
+                        });
+                        setSelectedGardenId(garden.id);
+                    }}
                 >
                     <Check
                         aria-hidden={garden.id !== currentGarden?.id}
@@ -167,6 +185,12 @@ function ProfileCard() {
             <DropdownMenuItem
                 className="gap-3 justify-between"
                 href={KnownPages.GredicePlants}
+                onClick={() =>
+                    track('game_external_link_opened', {
+                        destination: 'plant_database',
+                        source: 'profile_menu',
+                    })
+                }
             >
                 <Row spacing={1.5}>
                     <Sprout className="size-4" />
@@ -177,6 +201,12 @@ function ProfileCard() {
             <DropdownMenuItem
                 className="gap-3 justify-between"
                 href={KnownPages.GrediceContact}
+                onClick={() =>
+                    track('game_external_link_opened', {
+                        destination: 'contact',
+                        source: 'profile_menu',
+                    })
+                }
             >
                 <Row spacing={1.5}>
                     <Comment className="size-4" />
@@ -194,6 +224,7 @@ function ProfileCard() {
 }
 
 export function AccountHud() {
+    const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser();
     const { data: currentGarden, isLoading } = useCurrentGarden();
     const { data: gardens } = useGardens();
@@ -219,6 +250,7 @@ export function AccountHud() {
                             className="size-10 md:size-auto relative rounded-full p-0.5 aspect-square shrink-0 md:hover:outline outline-offset-2 outline-tertiary-foreground"
                             variant="plain"
                             title="Profil"
+                            onClick={() => track('game_profile_menu_opened')}
                         >
                             <ProfileAvatar variant="transparentOnMobile" />
                             {hasUnreadNotifications && (
@@ -245,6 +277,13 @@ export function AccountHud() {
                                     // Set to null when selecting the first garden (default)
                                     const isDefault =
                                         gardens?.[0]?.id === gardenId;
+                                    track('game_garden_switched', {
+                                        from_garden_id: currentGarden.id,
+                                        to_garden_id: gardenId,
+                                        to_garden_name: gardens?.find(
+                                            (garden) => garden.id === gardenId,
+                                        )?.name,
+                                    });
                                     setSelectedGardenId(
                                         isDefault ? null : gardenId,
                                     );
@@ -267,6 +306,11 @@ export function AccountHud() {
                                 className="relative rounded-full p-0 aspect-square"
                                 variant="plain"
                                 title="Obavijesti"
+                                onClick={() =>
+                                    track('game_notifications_opened', {
+                                        source: 'quick_panel',
+                                    })
+                                }
                             >
                                 {hasUnreadNotifications && (
                                     <div className="absolute right-1 top-1">

--- a/packages/game/src/hud/GameModeHud.tsx
+++ b/packages/game/src/hud/GameModeHud.tsx
@@ -1,6 +1,7 @@
 import { Check } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { useEffect } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { ShovelIcon } from '../icons/Shovel';
 import { useGameState } from '../useGameState';
 import { useGameModeParam } from '../useUrlState';
@@ -8,6 +9,7 @@ import { HudCard } from './components/HudCard';
 
 export function GameModeHud() {
     const [isEditMode, setIsEditMode] = useGameModeParam();
+    const { track } = useGameAnalytics();
     const mode = useGameState((state) => state.mode);
     const setMode = useGameState((state) => state.setMode);
 
@@ -21,6 +23,9 @@ export function GameModeHud() {
 
     const handleToggleMode = () => {
         const newEditMode = !isEditMode;
+        track('game_mode_changed', {
+            mode: newEditMode ? 'edit' : 'normal',
+        });
         setIsEditMode(newEditMode);
         setMode(newEditMode ? 'edit' : 'normal');
     };

--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -8,6 +8,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useMemo, useState } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useInventory } from '../hooks/useInventory';
 import { useOperations } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
@@ -181,6 +182,7 @@ function InventoryItemModal({
 export function InventoryHud() {
     const { data: inventory } = useInventory();
     const { data: operations } = useOperations();
+    const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useBackpackOpenParam();
     const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
 
@@ -245,6 +247,11 @@ export function InventoryHud() {
         : undefined;
 
     const handleOpenChange = (open: boolean) => {
+        if (open) {
+            track('game_inventory_opened', {
+                total_items: totalItems,
+            });
+        }
         setIsOpen(open);
         if (!open) setSelectedItemKey(null);
     };
@@ -319,6 +326,14 @@ export function InventoryHud() {
                                     operationData={itemOperationData}
                                     onClick={() => {
                                         if (item) {
+                                            track(
+                                                'game_inventory_item_opened',
+                                                {
+                                                    entity_id: item.entityId,
+                                                    entity_type:
+                                                        item.entityTypeName,
+                                                },
+                                            );
                                             setSelectedItemKey(key);
                                         }
                                     }}

--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -14,6 +14,7 @@ import type { Route } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useNotifications } from '../hooks/useNotifications';
@@ -43,6 +44,7 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
     const router = useRouter();
     const { id, header, content, linkUrl, readAt, timestamp, raisedBedId } =
         notification;
+    const { track } = useGameAnalytics();
     const setNotificationRead = useSetNotificationRead();
     const { data: currentGarden } = useCurrentGarden();
 
@@ -67,7 +69,15 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
         return '#';
     }, [linkUrl, raisedBedId, currentGarden]);
 
+    const isRead = Boolean(readAt);
+
     function handleSetNotificationRead() {
+        track('game_notification_read_toggled', {
+            has_link: computedLinkUrl !== '#',
+            notification_id: id,
+            raised_bed_id: raisedBedId,
+            read: !isRead,
+        });
         setNotificationRead.mutate({
             id,
             read: !readAt,
@@ -76,6 +86,13 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
     }
 
     function handleNotificationSelected() {
+        track('game_notification_opened', {
+            has_link: computedLinkUrl !== '#',
+            notification_id: id,
+            raised_bed_id: raisedBedId,
+            was_read: isRead,
+        });
+
         if (!readAt) {
             setNotificationRead.mutate({
                 id,
@@ -88,8 +105,6 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
             router.push(computedLinkUrl as Route);
         }
     }
-
-    const isRead = Boolean(readAt);
 
     return (
         <div className="relative">

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -5,7 +5,8 @@ import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import type { CSSProperties } from 'react';
+import { type CSSProperties, useState } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { ButtonGreen } from '../shared-ui/ButtonGreen';
 import { useGameState } from '../useGameState';
@@ -44,6 +45,8 @@ export function RaisedBedFieldHud(_props: {
     };
 }) {
     const { data: currentGarden } = useCurrentGarden();
+    const { track } = useGameAnalytics();
+    const [isInfoOpen, setIsInfoOpen] = useState(false);
     const view = useGameState((state) => state.view);
     const { mutate: removeRaisedBedCloseupParam } =
         useRemoveRaisedBedCloseupParam();
@@ -86,6 +89,17 @@ export function RaisedBedFieldHud(_props: {
             {currentGarden && raisedBed && (
                 <div className="absolute max-w-64 md:max-w-[312px] top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]">
                     <Modal
+                        open={isInfoOpen}
+                        onOpenChange={(open) => {
+                            if (open) {
+                                track('game_raised_bed_info_opened', {
+                                    garden_id: currentGarden.id,
+                                    raised_bed_id: raisedBed.id,
+                                    raised_bed_name: raisedBed.name,
+                                });
+                            }
+                            setIsInfoOpen(open);
+                        }}
                         title="Informacije o gredici"
                         modal={false}
                         className="md:border-tertiary md:border-b-4"
@@ -126,7 +140,14 @@ export function RaisedBedFieldHud(_props: {
                 <ButtonGreen
                     variant="plain"
                     className="rounded-full size-10 md:size-auto"
-                    onClick={removeRaisedBedCloseupParam}
+                    onClick={() => {
+                        track('game_raised_bed_closed', {
+                            garden_id: currentGarden?.id,
+                            raised_bed_id: raisedBed?.id,
+                            raised_bed_name: raisedBed?.name,
+                        });
+                        removeRaisedBedCloseupParam();
+                    }}
                     startDecorator={<Check className="size-5 shrink-0" />}
                     fullWidth
                 >

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -15,6 +15,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { isCompleteDeliverySelection, useCheckout } from '../hooks/useCheckout';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
 import { useShoppingCart } from '../hooks/useShoppingCart';
@@ -31,6 +32,7 @@ import { ShoppingCartItem } from './components/shopping-cart/ShoppingCartItem';
 export function ShoppingCart() {
     const { data: account } = useCurrentAccount();
     const { data: cart, isLoading, isError } = useShoppingCart();
+    const { track } = useGameAnalytics();
     const deleteCart = useShoppingCartDelete();
     const checkout = useCheckout();
 
@@ -51,13 +53,17 @@ export function ShoppingCart() {
         );
 
     function handleCheckout() {
-        if (!cart || !cart.id) {
+        if (!cart?.id) {
             console.error('No cart available for checkout');
             return;
         }
 
         // If cart contains deliverable items and user hasn't gone through delivery step yet
         if (cart.hasDeliverableItems && !deliverySelection) {
+            track('game_cart_delivery_opened', {
+                item_count: cart.items.length,
+                total: cart.total,
+            });
             setShowDeliveryStep(true);
             return;
         }
@@ -70,10 +76,21 @@ export function ShoppingCart() {
             }),
         };
 
+        track('game_cart_checkout_clicked', {
+            has_delivery_selection:
+                isCompleteDeliverySelection(deliverySelection),
+            item_count: cart.items.length,
+            total: cart.total,
+            total_sunflowers: cart.totalSunflowers,
+        });
         checkout.mutate(checkoutData);
     }
 
     function handleDeleteCart() {
+        track('game_cart_cleared', {
+            item_count: cart?.items.length,
+            total: cart?.total,
+        });
         deleteCart.mutate();
     }
 
@@ -82,6 +99,10 @@ export function ShoppingCart() {
     }
 
     function handleDelivery() {
+        track('game_cart_delivery_opened', {
+            item_count: cart?.items.length,
+            total: cart?.total,
+        });
         setShowDeliveryStep(true);
     }
 
@@ -322,9 +343,10 @@ function ButtonConfirmPayment({
 
 export function ShoppingCartHud() {
     const { data: cart } = useShoppingCart();
+    const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useShoppingCartOpenParam();
 
-    if (!cart || !cart.items.length) {
+    if (!cart?.items.length) {
         return null;
     }
 
@@ -333,7 +355,15 @@ export function ShoppingCartHud() {
             <Row spacing={1}>
                 <Modal
                     open={isOpen}
-                    onOpenChange={setIsOpen}
+                    onOpenChange={(open) => {
+                        if (open) {
+                            track('game_cart_opened', {
+                                item_count: cart.items.length,
+                                total: cart.total,
+                            });
+                        }
+                        setIsOpen(open);
+                    }}
                     title="Košarica"
                     className="border-tertiary border-b-4 md:max-w-2xl"
                     trigger={

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -15,6 +15,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { CSSProperties } from 'react';
+import { useGameAnalytics } from '../../../analytics/GameAnalyticsContext';
 import { useCurrentAccount } from '../../../hooks/useCurrentAccount';
 import { useCurrentGarden } from '../../../hooks/useCurrentGarden';
 import { useInventory } from '../../../hooks/useInventory';
@@ -27,6 +28,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const { data: garden } = useCurrentGarden();
     const { data: account } = useCurrentAccount();
     const { data: inventory } = useInventory();
+    const { track } = useGameAnalytics();
 
     const hasDiscount = typeof item.shopData.discountPrice === 'number';
     const hasRaisedBed = Boolean(item.raisedBedId);
@@ -52,6 +54,11 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     )?.amount;
 
     async function handleChangePaymentType(isSunflower: boolean) {
+        track('game_cart_payment_method_changed', {
+            entity_id: item.entityId,
+            entity_type: item.entityTypeName,
+            payment_method: isSunflower ? 'sunflower' : 'eur',
+        });
         await changeCurrencyShoppingCartItem.mutateAsync({
             id: item.id,
             amount: item.amount,
@@ -66,6 +73,11 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     }
 
     async function handleRemoveItem() {
+        track('game_cart_item_removed', {
+            entity_id: item.entityId,
+            entity_type: item.entityTypeName,
+            item_id: item.id,
+        });
         await removeShoppingCartItem.mutateAsync({
             id: item.id,
             amount: 0,
@@ -75,6 +87,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     }
 
     async function handleToggleInventory() {
+        track('game_cart_item_inventory_toggled', {
+            entity_id: item.entityId,
+            entity_type: item.entityTypeName,
+            item_id: item.id,
+            use_inventory: !usesInventory,
+        });
         await changeCurrencyShoppingCartItem.mutateAsync({
             id: item.id,
             amount: item.amount,

--- a/packages/game/src/hud/raisedBed/PlantsList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsList.tsx
@@ -14,6 +14,7 @@ import { List } from '@signalco/ui-primitives/List';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { usePlants } from '../../hooks/usePlants';
 import { KnownPages } from '../../knownPages';
 import { PlantListItemSkeleton } from './PlantListItemSkeleton';
@@ -23,6 +24,7 @@ export function PlantsList({
 }: {
     onChange: (plant: PlantData) => void;
 }) {
+    const { track } = useGameAnalytics();
     const { data: plants, isLoading, isError } = usePlants();
     const [search] = useSearchParam('pretraga', '');
     // Filter plants based on search query
@@ -73,7 +75,14 @@ export function PlantsList({
                             <Button
                                 variant="plain"
                                 className="justify-start text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal"
-                                onClick={() => onChange(plant)}
+                                onClick={() => {
+                                    track('game_plant_selected', {
+                                        is_recommended: plant.isRecommended,
+                                        plant_id: plant.id,
+                                        plant_name: plant.information.name,
+                                    });
+                                    onChange(plant);
+                                }}
                             >
                                 <PlantOrSortImage
                                     plant={plant}
@@ -125,6 +134,12 @@ export function PlantsList({
                                     href={KnownPages.GredicePlant(
                                         plant.information.name,
                                     )}
+                                    onClick={() =>
+                                        track('game_plant_details_opened', {
+                                            plant_id: plant.id,
+                                            plant_name: plant.information.name,
+                                        })
+                                    }
                                 >
                                     Više informacija...
                                 </Button>

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -11,6 +11,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useEffect } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { usePlantSorts } from '../../hooks/usePlantSorts';
 import {
     AnimateFlyToItem,
@@ -38,6 +39,7 @@ function PlantSortListItem({
     flyToShoppingCart?: boolean;
 }) {
     const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
+    const { track } = useGameAnalytics();
 
     useEffect(() => {
         if (flyToShoppingCart) {
@@ -59,7 +61,14 @@ function PlantSortListItem({
                 className={cx(
                     'justify-between text-start p-0 h-auto py-2 gap-3 px-4 rounded-none font-normal',
                 )}
-                onClick={() => onChange(sort)}
+                onClick={() => {
+                    track('game_plant_sort_selected', {
+                        plant_name: sort.information.plant.information?.name,
+                        sort_id: sort.id,
+                        sort_name: sort.information.name,
+                    });
+                    onChange(sort);
+                }}
             >
                 <Row spacing={1.5}>
                     <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
@@ -96,6 +105,14 @@ function PlantSortListItem({
                     )}
                     variant="link"
                     size="sm"
+                    onClick={() =>
+                        track('game_plant_sort_details_opened', {
+                            plant_name:
+                                sort.information.plant.information?.name,
+                            sort_id: sort.id,
+                            sort_name: sort.information.name,
+                        })
+                    }
                 >
                     Više informacija...
                 </Button>

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -9,6 +9,7 @@ import {
     useSensors,
 } from '@dnd-kit/core';
 import { rectSwappingStrategy, SortableContext } from '@dnd-kit/sortable';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { useSwapShoppingCartPositions } from '../../hooks/useSwapShoppingCartPositions';
@@ -28,6 +29,7 @@ export function RaisedBedField({
 }) {
     const { data: garden } = useCurrentGarden();
     const { data: cart } = useShoppingCart();
+    const { track } = useGameAnalytics();
     const swapPositions = useSwapShoppingCartPositions();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
 
@@ -123,6 +125,13 @@ export function RaisedBedField({
         // Don't allow moving to a planted position
         if (plantedPositions.has(overPos)) return;
 
+        track('game_raised_bed_field_moved', {
+            from_position_index: activePos,
+            garden_id: gardenId,
+            raised_bed_id: raisedBedId,
+            replaced_existing_cart_item: Boolean(overCartItem),
+            to_position_index: overPos,
+        });
         swapPositions.mutate({
             itemA: activeCartItem,
             itemB: overCartItem,

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -21,6 +21,7 @@ import {
 } from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
 import { KnownPages } from '../../knownPages';
@@ -43,6 +44,7 @@ export function RaisedBedFieldItemPlanted({
     positionIndex: number;
 }) {
     const { data: garden, isLoading: isGardenLoading } = useCurrentGarden();
+    const { track } = useGameAnalytics();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
     const field = findRaisedBedOccupiedField(raisedBed?.fields, positionIndex);
     const plantSortId = field?.plantSortId;
@@ -57,13 +59,14 @@ export function RaisedBedFieldItemPlanted({
         harvestPercentage,
     } = useRaisedBedFieldLifecycleData(raisedBedId, positionIndex);
     const isHarvested = field?.plantHarvestedDate;
+    const [open, setOpen] = useState(false);
     const [activeTab, setActiveTab] =
         useState<RaisedBedFieldTabValue>('lifecycle');
 
     if (!raisedBed) {
         return null;
     }
-    if (!field || !field.plantSortId) {
+    if (!field?.plantSortId) {
         console.error(
             `Field not found for raised bed ${raisedBedId} at position index ${positionIndex}`,
             raisedBed.fields,
@@ -137,6 +140,18 @@ export function RaisedBedFieldItemPlanted({
 
     return (
         <Modal
+            open={open}
+            onOpenChange={(nextOpen) => {
+                if (nextOpen) {
+                    track('game_planted_item_opened', {
+                        active_tab: activeTab,
+                        plant_sort_id: plantSort.id,
+                        position_index: positionIndex,
+                        raised_bed_id: raisedBedId,
+                    });
+                }
+                setOpen(nextOpen);
+            }}
             title={`Biljka "${plantSort.information.name}"`}
             modal={false}
             className="md:border-tertiary md:border-b-4 max-w-xl"
@@ -196,6 +211,13 @@ export function RaisedBedFieldItemPlanted({
                             target="_blank"
                             aria-label="Detalji o biljci"
                             className="inline-flex mb-1 items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-muted-foreground/60 shrink-0"
+                            onClick={() =>
+                                track('game_field_plant_details_opened', {
+                                    plant_sort_id: plantSort.id,
+                                    position_index: positionIndex,
+                                    raised_bed_id: raisedBedId,
+                                })
+                            }
                         >
                             <ExternalLink className="size-4" />
                             <span className="hidden sm:inline">Detalji</span>
@@ -205,6 +227,12 @@ export function RaisedBedFieldItemPlanted({
                 <Tabs
                     value={activeTab}
                     onValueChange={(value: string) => {
+                        track('game_raised_bed_tab_opened', {
+                            plant_sort_id: plantSort.id,
+                            position_index: positionIndex,
+                            raised_bed_id: raisedBedId,
+                            tab: value,
+                        });
                         setActiveTab(value as RaisedBedFieldTabValue);
                     }}
                     className="flex flex-col"

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -9,6 +9,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { type ReactElement, useState } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { SegmentedProgress } from '../../controls/components/SegmentedProgress';
 import { useInventory } from '../../hooks/useInventory';
 import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
@@ -51,6 +52,7 @@ export function PlantPicker({
     selectedPlantOptions: preselectedPlantOptions,
 }: PlantPickerProps) {
     const [open, setOpen] = useState(false);
+    const { track } = useGameAnalytics();
     const [, setSearch] = useSearchParam('pretraga', '');
     const steps = [
         {
@@ -116,6 +118,13 @@ export function PlantPicker({
     }
 
     async function handleRemove() {
+        track('game_planting_removed', {
+            garden_id: gardenId,
+            in_shopping_cart: inShoppingCart,
+            position_index: positionIndex,
+            raised_bed_id: raisedBedId,
+            sort_id: selectedSortId,
+        });
         setOpen(false);
         setSelectedPlantId(null);
         setSelectedSortId(null);
@@ -146,6 +155,16 @@ export function PlantPicker({
         }
 
         // Add new item to cart
+        track('game_planting_confirmed', {
+            garden_id: gardenId,
+            in_shopping_cart: inShoppingCart,
+            plant_id: selectedPlantId,
+            position_index: positionIndex,
+            raised_bed_id: raisedBedId,
+            scheduled_date: plantOptions?.scheduledDate?.toISOString(),
+            sort_id: selectedSortId,
+            use_inventory: useInventoryItem,
+        });
         setFlyToShoppingCart(true);
         await setCartItem.mutateAsync({
             entityTypeName: 'plantSort',
@@ -165,6 +184,14 @@ export function PlantPicker({
     }
 
     function handleOpenChange(open: boolean) {
+        if (open) {
+            track('game_plant_picker_opened', {
+                garden_id: gardenId,
+                in_shopping_cart: inShoppingCart,
+                position_index: positionIndex,
+                raised_bed_id: raisedBedId,
+            });
+        }
         setOpen(open);
         setSelectedPlantId(preselectedPlantId ?? null);
         setSelectedSortId(preselectedSortId ?? null);
@@ -281,11 +308,18 @@ export function PlantPicker({
                                     startDecorator={
                                         <BackpackIcon className="size-5 shrink-0" />
                                     }
-                                    onClick={() =>
+                                    onClick={() => {
+                                        track('game_plant_inventory_toggled', {
+                                            garden_id: gardenId,
+                                            position_index: positionIndex,
+                                            raised_bed_id: raisedBedId,
+                                            sort_id: selectedSortId,
+                                            use_inventory: !useInventoryItem,
+                                        });
                                         setUseInventoryItem(
                                             (previous) => !previous,
-                                        )
-                                    }
+                                        );
+                                    }}
                                 >
                                     {`U ruksaku (${availableFromInventory ?? 0})`}
                                 </Button>

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -1,3 +1,7 @@
+export {
+    GameAnalyticsProvider,
+    useGameAnalytics,
+} from './analytics/GameAnalyticsContext';
 export type { GameSceneProps } from './GameScene';
 export { GameSceneDynamic as GameScene } from './GameSceneDynamic';
 export { PlantEditor } from './generators/plant/editor/PlantEditor';

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -5,6 +5,8 @@ import { Modal } from '@signalco/ui-primitives/Modal';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useEffect } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { AccountUsersTab } from './components/AccountUsersTab';
 import { AchievementsTab } from './components/AchievementsTab';
@@ -92,6 +94,17 @@ const allNavItems = navGroups.flatMap((g) => g.items);
 
 export function OverviewModal() {
     const [settingsMode, setProfileModalOpen] = useSearchParam('pregled');
+    const { track } = useGameAnalytics();
+
+    useEffect(() => {
+        if (!settingsMode) {
+            return;
+        }
+
+        track('game_overview_section_opened', {
+            section: settingsMode,
+        });
+    }, [settingsMode, track]);
 
     const handleOpenChange = (open: boolean) => {
         if (!open) {

--- a/packages/game/src/modals/components/CreateGardenModal.tsx
+++ b/packages/game/src/modals/components/CreateGardenModal.tsx
@@ -3,6 +3,7 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { type SubmitEvent, useState } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCreateGarden } from '../../hooks/useCreateGarden';
 
 type CreateGardenModalProps = {
@@ -15,6 +16,7 @@ export function CreateGardenModal({
     onOpenChange,
 }: CreateGardenModalProps) {
     const createGarden = useCreateGarden();
+    const { track } = useGameAnalytics();
     const [newGardenName, setNewGardenName] = useState('');
 
     const trimmedNewGardenName = newGardenName.trim();
@@ -28,6 +30,9 @@ export function CreateGardenModal({
         }
 
         try {
+            track('game_garden_create_submitted', {
+                name_length: nextName.length,
+            });
             await createGarden.mutateAsync({ name: nextName });
             setNewGardenName('');
             onOpenChange(false);

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -7,6 +7,7 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useGardens } from '../../hooks/useGardens';
 import { useCurrentGardenIdParam } from '../../useUrlState';
 import { CreateGardenModal } from './CreateGardenModal';
@@ -14,6 +15,7 @@ import { GardenNameCard } from './GardenNameCard';
 
 function NoGardensCard() {
     const [createGardenModalOpen, setCreateGardenModalOpen] = useState(false);
+    const { track } = useGameAnalytics();
 
     return (
         <>
@@ -25,7 +27,12 @@ function NoGardensCard() {
                         </Typography>
                         <Button
                             variant="solid"
-                            onClick={() => setCreateGardenModalOpen(true)}
+                            onClick={() => {
+                                track('game_garden_create_opened', {
+                                    source: 'empty_state',
+                                });
+                                setCreateGardenModalOpen(true);
+                            }}
                             startDecorator={<Add className="size-4" />}
                         >
                             Kreiraj svoj prvi vrt
@@ -45,6 +52,7 @@ function GardensSelector() {
     const { data: gardens } = useGardens();
     const [createGardenModalOpen, setCreateGardenModalOpen] = useState(false);
     const [selectedGardenId, setSelectedGardenId] = useCurrentGardenIdParam();
+    const { track } = useGameAnalytics();
     const selectedGarden =
         gardens?.find((g) => g.id === selectedGardenId) ?? gardens?.[0];
 
@@ -57,9 +65,19 @@ function GardensSelector() {
                             selectedGardenId?.toString() ??
                             selectedGarden?.id.toString()
                         }
-                        onValueChange={(value) =>
-                            setSelectedGardenId(parseInt(value, 10) || 0)
-                        }
+                        onValueChange={(value) => {
+                            const nextGardenId =
+                                Number.parseInt(value, 10) || 0;
+                            const nextGarden = gardens?.find(
+                                (garden) => garden.id === nextGardenId,
+                            );
+                            track('game_garden_switched', {
+                                from_garden_id: selectedGarden?.id,
+                                to_garden_id: nextGardenId,
+                                to_garden_name: nextGarden?.name,
+                            });
+                            setSelectedGardenId(nextGardenId);
+                        }}
                         items={
                             gardens?.map((g) => ({
                                 label: (
@@ -78,7 +96,12 @@ function GardensSelector() {
                 <IconButton
                     title="Kreiraj novi vrt"
                     variant="plain"
-                    onClick={() => setCreateGardenModalOpen(true)}
+                    onClick={() => {
+                        track('game_garden_create_opened', {
+                            source: 'garden_tab',
+                        });
+                        setCreateGardenModalOpen(true);
+                    }}
                 >
                     <Add className="size-4" />
                 </IconButton>

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -6,14 +6,19 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useMarkAllNotificationsRead } from '../../hooks/useMarkAllNotificationsRead';
 import { NotificationList } from '../../hud/NotificationList';
 
 export function NotificationsTab() {
     const [notificationsFilter, setNotificationsFilter] = useState('unread');
     const markAllNotificationsRead = useMarkAllNotificationsRead();
+    const { track } = useGameAnalytics();
 
     const handleMarkAllNotificationsRead = () => {
+        track('game_notifications_mark_all_read', {
+            source: 'overview_tab',
+        });
         markAllNotificationsRead.mutate({ readWhere: 'game' });
     };
 
@@ -29,7 +34,12 @@ export function NotificationsTab() {
                     <Row justifyContent="space-between">
                         <SelectItems
                             value={notificationsFilter}
-                            onValueChange={setNotificationsFilter}
+                            onValueChange={(value) => {
+                                track('game_notifications_filter_changed', {
+                                    filter: value,
+                                });
+                                setNotificationsFilter(value);
+                            }}
                             items={[
                                 {
                                     label: 'Nepročitane',

--- a/packages/game/src/modals/components/TimeZoneSettingsCard.tsx
+++ b/packages/game/src/modals/components/TimeZoneSettingsCard.tsx
@@ -6,6 +6,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { getTimeZones } from '@vvo/tzdb';
 import { useMemo } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCurrentAccount } from '../../hooks/useCurrentAccount';
 import { useUpdateAccountTimeZone } from '../../hooks/useUpdateAccountTimeZone';
 
@@ -13,6 +14,7 @@ const timeZones = getTimeZones();
 
 export function TimeZoneSettingsCard() {
     const { data: currentAccount } = useCurrentAccount();
+    const { track } = useGameAnalytics();
     const updateTimeZone = useUpdateAccountTimeZone();
 
     const timeZoneOptions = useMemo(
@@ -25,6 +27,9 @@ export function TimeZoneSettingsCard() {
     );
 
     const handleTimeZoneChange = (value: string) => {
+        track('game_account_time_zone_changed', {
+            time_zone: value,
+        });
         updateTimeZone.mutate(value);
     };
 


### PR DESCRIPTION
-/game/src/modals/components/Notifications.tsx - Inject useGameAnalytics and track events when users mark all notifications read and when change the notifications filter.
 - Record event names: game_notifications_mark_all and game_notifications_changedinclude and source).

- packages/game/srcud/InventoryHud.ts - Inject useGameAnalytics and track when the inventory HUD,
 sending total_items.
 Track when a user opens an individual inventory item, sending entity_id and entity_type (event: game_inventory_item_open).
 - Record event: game_inventory_opened.

- packages/game/srcud/raised/PlantsSortList.ts - Inject useAnalytics track when a sort selected,
 sending plant_name, sort_id, and_name (event:
__sort).

Why:
- Instrument UX with analytics to better understand player behavior monitor feature usage, and guide product decisions.
- Keep telemetry lightweight and context-rich including relevant identifiers and attributes with each event.