### PR TITLE
Add API-driven pricing page and link it from footer

### DIFF
--- a/apps/www/app/Footer.tsx
+++ b/apps/www/app/Footer.tsx
@@ -44,6 +44,7 @@ const sectionsData: SectionData[] = [
                 header: 'Informacije',
                 ctas: [
                     { label: 'Dostava', href: KnownPages.Delivery },
+                    { label: 'Cjenik', href: KnownPages.Pricing },
                     {
                         label: 'Termini dostave',
                         href: KnownPages.DeliverySlots,

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -10,6 +10,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageHeader } from '../../components/shared/PageHeader';
+import { formatPrice } from '../../lib/formatPrice';
 import { getHqLocationsData } from '../../lib/getHqLocationsData';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
@@ -19,10 +20,6 @@ export const metadata: Metadata = {
     description:
         'Pregled svih cijena: biljke, radnje i dostava na jednom mjestu.',
 };
-
-function formatPrice(price: number): string {
-    return `${price.toFixed(2).replace('.', ',')} €`;
-}
 
 export default async function PricingPage() {
     const [plantsData, operationsData, hqLocations] = await Promise.all([
@@ -45,7 +42,7 @@ export default async function PricingPage() {
             a.information.label.localeCompare(b.information.label, 'hr-HR'),
         );
 
-    const sortedHqLocations = hqLocations.sort((a, b) =>
+    const sortedHqLocations = [...hqLocations].sort((a, b) =>
         a.information.label.localeCompare(b.information.label, 'hr-HR'),
     );
 

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -1,4 +1,3 @@
-import { Alert } from '@signalco/ui/Alert';
 import {
     Card,
     CardContent,
@@ -7,7 +6,9 @@ import {
 } from '@signalco/ui-primitives/Card';
 import { Container } from '@signalco/ui-primitives/Container';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
+import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { getHqLocationsData } from '../../lib/getHqLocationsData';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
@@ -57,14 +58,10 @@ export default async function PricingPage() {
                     subHeader="Sve cijene na jednom mjestu: biljke, radnje i dostava"
                 />
 
-                <Alert startDecorator={'ℹ️'} color="info">
-                    Cijene na ovoj stranici učitavaju se direktno iz API-ja i
-                    redovito se osvježavaju.
-                </Alert>
-
                 <Card>
-                    <CardHeader>
+                    <CardHeader className="flex-row items-center justify-between">
                         <CardTitle>Cijene biljaka (po biljci)</CardTitle>
+                        <FeedbackModal topic="www/pricing/plants" />
                     </CardHeader>
                     <CardContent>
                         <div className="overflow-x-auto">
@@ -102,8 +99,9 @@ export default async function PricingPage() {
                 </Card>
 
                 <Card>
-                    <CardHeader>
+                    <CardHeader className="flex-row items-center justify-between">
                         <CardTitle>Cijene radnji (po radnji)</CardTitle>
+                        <FeedbackModal topic="www/pricing/operations" />
                     </CardHeader>
                     <CardContent>
                         <div className="overflow-x-auto">
@@ -142,8 +140,9 @@ export default async function PricingPage() {
                 </Card>
 
                 <Card>
-                    <CardHeader>
+                    <CardHeader className="flex-row items-center justify-between">
                         <CardTitle>Cijene dostave</CardTitle>
+                        <FeedbackModal topic="www/pricing/delivery" />
                     </CardHeader>
                     <CardContent>
                         <div className="overflow-x-auto">
@@ -192,6 +191,19 @@ export default async function PricingPage() {
                                 </tbody>
                             </table>
                         </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Podijeli povratnu informaciju</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex items-center justify-between gap-4">
+                        <Typography level="body2" secondary>
+                            Nedostaje li cijena ili želiš predložiti poboljšanje
+                            cjenika?
+                        </Typography>
+                        <FeedbackModal topic="www/pricing" />
                     </CardContent>
                 </Card>
             </Stack>

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -1,0 +1,200 @@
+import { Alert } from '@signalco/ui/Alert';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Container } from '@signalco/ui-primitives/Container';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import type { Metadata } from 'next';
+import { PageHeader } from '../../components/shared/PageHeader';
+import { getHqLocationsData } from '../../lib/getHqLocationsData';
+import { getOperationsData } from '../../lib/plants/getOperationsData';
+import { getPlantsData } from '../../lib/plants/getPlantsData';
+
+export const metadata: Metadata = {
+    title: 'Cjenik',
+    description:
+        'Pregled svih cijena: biljke, radnje i dostava na jednom mjestu.',
+};
+
+function formatPrice(price: number): string {
+    return `${price.toFixed(2).replace('.', ',')} €`;
+}
+
+export default async function PricingPage() {
+    const [plantsData, operationsData, hqLocations] = await Promise.all([
+        getPlantsData(),
+        getOperationsData(),
+        getHqLocationsData(),
+    ]);
+
+    const plantsWithPrices = plantsData
+        .filter((plant) => typeof plant.prices?.perPlant === 'number')
+        .sort((a, b) =>
+            a.information.name.localeCompare(b.information.name, 'hr-HR'),
+        );
+
+    const operationsWithPrices = operationsData
+        .filter(
+            (operation) => typeof operation.prices?.perOperation === 'number',
+        )
+        .sort((a, b) =>
+            a.information.label.localeCompare(b.information.label, 'hr-HR'),
+        );
+
+    const sortedHqLocations = hqLocations.sort((a, b) =>
+        a.information.label.localeCompare(b.information.label, 'hr-HR'),
+    );
+
+    return (
+        <Container maxWidth="lg">
+            <Stack spacing={2}>
+                <PageHeader
+                    padded
+                    header="💶 Cjenik"
+                    subHeader="Sve cijene na jednom mjestu: biljke, radnje i dostava"
+                />
+
+                <Alert startDecorator={'ℹ️'} color="info">
+                    Cijene na ovoj stranici učitavaju se direktno iz API-ja i
+                    redovito se osvježavaju.
+                </Alert>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Cijene biljaka (po biljci)</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="overflow-x-auto">
+                            <table className="w-full border-collapse">
+                                <thead>
+                                    <tr className="border-b">
+                                        <th className="text-left py-2 pr-4">
+                                            Biljka
+                                        </th>
+                                        <th className="text-right py-2">
+                                            Cijena
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {plantsWithPrices.map((plant) => (
+                                        <tr
+                                            key={plant.id}
+                                            className="border-b last:border-b-0"
+                                        >
+                                            <td className="py-2 pr-4">
+                                                {plant.information.name}
+                                            </td>
+                                            <td className="py-2 text-right font-medium">
+                                                {formatPrice(
+                                                    plant.prices.perPlant,
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Cijene radnji (po radnji)</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="overflow-x-auto">
+                            <table className="w-full border-collapse">
+                                <thead>
+                                    <tr className="border-b">
+                                        <th className="text-left py-2 pr-4">
+                                            Radnja
+                                        </th>
+                                        <th className="text-right py-2">
+                                            Cijena
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {operationsWithPrices.map((operation) => (
+                                        <tr
+                                            key={operation.id}
+                                            className="border-b last:border-b-0"
+                                        >
+                                            <td className="py-2 pr-4">
+                                                {operation.information.label}
+                                            </td>
+                                            <td className="py-2 text-right font-medium">
+                                                {formatPrice(
+                                                    operation.prices
+                                                        .perOperation,
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Cijene dostave</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="overflow-x-auto">
+                            <table className="w-full border-collapse">
+                                <thead>
+                                    <tr className="border-b">
+                                        <th className="text-left py-2 pr-4">
+                                            Lokacija
+                                        </th>
+                                        <th className="text-right py-2 pr-4">
+                                            Besplatna zona
+                                        </th>
+                                        <th className="text-right py-2 pr-4">
+                                            Maks. zona
+                                        </th>
+                                        <th className="text-right py-2">
+                                            Cijena po km
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {sortedHqLocations.map((location) => (
+                                        <tr
+                                            key={location.id}
+                                            className="border-b last:border-b-0"
+                                        >
+                                            <td className="py-2 pr-4">
+                                                {location.information.label}
+                                            </td>
+                                            <td className="py-2 text-right pr-4">
+                                                {location.delivery.freeRadius}{' '}
+                                                km
+                                            </td>
+                                            <td className="py-2 text-right pr-4">
+                                                {location.delivery.zoneRadius}{' '}
+                                                km
+                                            </td>
+                                            <td className="py-2 text-right font-medium">
+                                                {formatPrice(
+                                                    location.prices
+                                                        .pricePerKilometer,
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </CardContent>
+                </Card>
+            </Stack>
+        </Container>
+    );
+}

--- a/apps/www/app/dostava/page.tsx
+++ b/apps/www/app/dostava/page.tsx
@@ -16,6 +16,7 @@ import type { Metadata } from 'next';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { WhatsAppCard } from '../../components/social/WhatsAppCard';
+import { formatPrice } from '../../lib/formatPrice';
 import { KnownPages } from '../../src/KnownPages';
 
 export const metadata: Metadata = {
@@ -32,10 +33,6 @@ const deliveryLocations = [
     { name: 'Sisak', distance: 60 },
     { name: 'Varaždin', distance: 90 },
 ] as const;
-
-function formatPrice(price: number): string {
-    return `${price.toFixed(2).replace('.', ',')} €`;
-}
 
 export default function DeliveryPage() {
     return (

--- a/apps/www/lib/formatPrice.ts
+++ b/apps/www/lib/formatPrice.ts
@@ -1,0 +1,3 @@
+export function formatPrice(price: number): string {
+    return `${price.toFixed(2).replace('.', ',')} €`;
+}

--- a/apps/www/lib/getHqLocationsData.ts
+++ b/apps/www/lib/getHqLocationsData.ts
@@ -1,0 +1,27 @@
+import { directoriesClient } from '@gredice/client';
+import { unstable_cache } from 'next/cache';
+
+export const getHqLocationsData = unstable_cache(
+    async () => {
+        try {
+            const { data, error } = await directoriesClient().GET(
+                '/entities/hqLocations',
+            );
+
+            if (error) {
+                console.error('Failed to fetch HQ locations data', error);
+                return [];
+            }
+
+            return data ?? [];
+        } catch (error) {
+            console.error('Failed to fetch HQ locations data', error);
+            return [];
+        }
+    },
+    ['hqLocationsData'],
+    {
+        revalidate: 60 * 60, // 1 hour
+        tags: ['hqLocationsData'],
+    },
+);

--- a/apps/www/src/KnownPages.ts
+++ b/apps/www/src/KnownPages.ts
@@ -27,6 +27,7 @@ export const KnownPages = {
     AboutUs: '/o-nama',
     FAQ: '/cesta-pitanja',
     Contact: '/kontakt',
+    Pricing: '/cjenik',
 
     LegalPrivacy: '/legalno/politika-privatnosti',
     LegalTerms: '/legalno/uvjeti-koristenja',


### PR DESCRIPTION
### Motivation

- Provide a single, authoritative pricing page that lists per-plant, per-operation and delivery prices in one place.
- Ensure displayed prices are always up-to-date by fetching them from the API instead of using hardcoded constants.

### Description

- Added a new pricing page at `apps/www/app/cjenik/page.tsx` that fetches and renders plant, operation and delivery prices in separate tables and sorts entries for readability.
- Introduced `apps/www/lib/getHqLocationsData.ts`, a cached server helper that calls `directoriesClient().GET('/entities/hqLocations')` and uses `unstable_cache` with a 1-hour revalidate to load delivery pricing and zones.
- Reused existing `getPlantsData` and `getOperationsData` helpers on the pricing page and added a `formatPrice` helper for consistent formatting.
- Exposed the route as `KnownPages.Pricing` in `apps/www/src/KnownPages.ts` and added a `Cjenik` link to the footer in `apps/www/app/Footer.tsx` under the `Informacije` section.

### Testing

- Ran linting with `pnpm --filter www lint` which completed successfully.
- Performed a production build with `pnpm --filter www build`, which completed successfully; the build logged some network fetch errors from existing data fetchers in this environment but completed SSG and page generation successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10615c9c8832f94fffb15f947b9ed)