### PR TITLE
Add attribute completion indicator to entity details header

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@signalco/ui-primitives/Tabs';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
+import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
 import { Field } from '../../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../../components/shared/fields/FieldSet';
 import { ServerActionIconButton } from '../../../../../components/shared/ServerActionIconButton';
@@ -91,7 +92,13 @@ export default async function EntityDetailsPage(props: {
                             </TabsTrigger>
                         ))}
                     </TabsList>
-                    <Row className="self-end" spacing={1}>
+                    <Row className="self-end items-center" spacing={1}>
+                        <div className="w-28">
+                            <EntityAttributeProgress
+                                entity={entity}
+                                definitions={attributeDefinitions}
+                            />
+                        </div>
                         <EntityStateSelect entity={entity} />
                         <EntityImportMenu importAction={importAction} />
                         <ServerActionIconButton


### PR DESCRIPTION
### Motivation
- Surface the same "Ispunjenost" attribute completion indicator from the entities table in the entity details view so admins can see required-attribute completion next to the published state.

### Description
- Imported `EntityAttributeProgress` and rendered it in `apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx` inside the top action row next to `EntityStateSelect`, added `items-center` to the `Row` for vertical alignment, and wrapped the indicator in a fixed-width `w-28` container for consistent layout.

### Testing
- Ran `pnpm --filter app lint`, which completed successfully with Biome formatting fixes applied and no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1090e520c832fbbf6295401dc0bb1)