### PR TITLE
Show image thumbnails in app entity table

### DIFF
--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -9,6 +9,7 @@ import { Duplicate } from '@signalco/ui-icons';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import Image from 'next/image';
 import Link from 'next/link';
 import { KnownPages } from '../../../src/KnownPages';
 import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
@@ -76,12 +77,10 @@ export function EntitiesTable({
                         </Table.Cell>
                         {displayDefinitions.map((d) => (
                             <Table.Cell key={d.id}>
-                                <Typography secondary>
-                                    {entityAttributeValueByDefinitionId(
-                                        entity,
-                                        d.id,
-                                    ) ?? '-'}
-                                </Typography>
+                                <EntityAttributeValueCell
+                                    entity={entity}
+                                    definition={d}
+                                />
                             </Table.Cell>
                         ))}
                         <Table.Cell>
@@ -131,6 +130,36 @@ export function EntitiesTable({
     );
 }
 
+function EntityAttributeValueCell({
+    entity,
+    definition,
+}: {
+    entity: Entities[number];
+    definition: SelectAttributeDefinition;
+}) {
+    const value = entityAttributeValueByDefinitionId(entity, definition.id);
+    if (!value) {
+        return <Typography secondary>-</Typography>;
+    }
+
+    if (definition.dataType === 'image') {
+        const imageUrl = imageAttributeValue(value);
+        if (imageUrl) {
+            return (
+                <Image
+                    src={imageUrl}
+                    alt={definition.label}
+                    width={40}
+                    height={40}
+                    className="size-10 rounded-md object-cover"
+                />
+            );
+        }
+    }
+
+    return <Typography secondary>{value}</Typography>;
+}
+
 function entityDisplayName(entity: Entities[number]) {
     return (
         entityAttributeValue(entity, 'information', 'label') ??
@@ -158,4 +187,17 @@ function entityAttributeValueByDefinitionId(
     return entity.attributes.find(
         (a) => a.attributeDefinitionId === definitionId,
     )?.value;
+}
+
+function imageAttributeValue(value: string) {
+    try {
+        const data = JSON.parse(value);
+        if (data && typeof data.url === 'string') {
+            return data.url;
+        }
+    } catch {
+        // ignored intentionally
+    }
+
+    return null;
 }


### PR DESCRIPTION
### Motivation
- Entity attribute values of type `image` were rendered as raw JSON in the admin entity table, which is not user friendly.
- The table should surface a small visual preview (thumbnail) for image attributes to make lists easier to scan.

### Description
- Replaced direct text rendering in `apps/app/components/admin/tables/EntitiesTable.tsx` with a dedicated `EntityAttributeValueCell` renderer to branch by attribute type.
- Added `next/image` import and render a 40x40 rounded thumbnail when `definition.dataType === 'image'` and the attribute value JSON contains a `url`.
- Added a safe parser helper `imageAttributeValue` that extracts `url` from stored JSON and gracefully returns `null` for malformed or non-image values.
- Preserved fallback behavior to display `-` when no value exists and to render the original text value when parsing fails or the attribute is not an image.

### Testing
- Ran `pnpm --dir apps/app lint` and the linter completed successfully; reported pre-existing warnings unrelated to these changes.
- No new automated test failures were observed during the lint run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e109ae0358832f80810fa766bb5504)