### PR TITLE
Add sticky floating header for entity details page

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { cx } from '@signalco/ui-primitives/cx';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
+
+export type EntityDetailsStickyHeaderProps = {
+    breadcrumbs: ReactNode;
+    tabs: ReactNode;
+    actions: ReactNode;
+};
+
+export function EntityDetailsStickyHeader({
+    breadcrumbs,
+    tabs,
+    actions,
+}: EntityDetailsStickyHeaderProps) {
+    const sentinelRef = useRef<HTMLDivElement | null>(null);
+    const [isStuck, setIsStuck] = useState(false);
+
+    useEffect(() => {
+        const sentinel = sentinelRef.current;
+        if (!sentinel) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                setIsStuck(!entry.isIntersecting);
+            },
+            {
+                rootMargin: '-8px 0px 0px 0px',
+                threshold: 1,
+            },
+        );
+
+        observer.observe(sentinel);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, []);
+
+    return (
+        <>
+            <div aria-hidden className="h-px" ref={sentinelRef} />
+            <div
+                className={cx(
+                    'sticky top-2 z-20 transition-all duration-200',
+                    isStuck &&
+                        'rounded-2xl border border-muted/40 bg-background/90 px-3 py-2 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80',
+                )}
+            >
+                <div className="flex flex-row items-center justify-between gap-2">
+                    <div className="min-w-0">{breadcrumbs}</div>
+                    <div className="overflow-x-auto">{tabs}</div>
+                    <div className="shrink-0">{actions}</div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx
@@ -29,7 +29,7 @@ export function EntityDetailsStickyHeader({
             },
             {
                 rootMargin: '-8px 0px 0px 0px',
-                threshold: 1,
+                threshold: 0,
             },
         );
 
@@ -52,7 +52,7 @@ export function EntityDetailsStickyHeader({
             >
                 <div className="flex flex-row items-center justify-between gap-2">
                     <div className="min-w-0">{breadcrumbs}</div>
-                    <div className="overflow-x-auto">{tabs}</div>
+                    <div className="min-w-0 flex-1 overflow-x-auto">{tabs}</div>
                     <div className="shrink-0">{actions}</div>
                 </div>
             </div>

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -24,6 +24,7 @@ import { entityDisplayName } from '../../../../../src/entities/entityAttributes'
 import { KnownPages } from '../../../../../src/KnownPages';
 import { handleEntityDelete } from '../../../../(actions)/entityActions';
 import { AttributeCategoryDetails } from './AttributeCategoryDetails';
+import { EntityDetailsStickyHeader } from './EntityDetailsStickyHeader';
 import { EntityImportMenu } from './EntityImportMenu';
 import { EntityStateSelect } from './EntityStateSelect';
 
@@ -70,46 +71,52 @@ export default async function EntityDetailsPage(props: {
     return (
         <Tabs defaultValue={attributeCategories.at(0)?.name}>
             <Stack spacing={2}>
-                <div className="flex flex-row justify-between items-center">
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: entity.entityType.label,
-                                href: KnownPages.DirectoryEntityType(
-                                    params.entityType,
-                                ),
-                            },
-                            { label: entityDisplayName(entity) },
-                        ]}
-                    />
-                    <TabsList>
-                        {attributeCategories.map((category) => (
-                            <TabsTrigger
-                                key={category.name}
-                                value={category.name}
+                <EntityDetailsStickyHeader
+                    breadcrumbs={
+                        <Breadcrumbs
+                            items={[
+                                {
+                                    label: entity.entityType.label,
+                                    href: KnownPages.DirectoryEntityType(
+                                        params.entityType,
+                                    ),
+                                },
+                                { label: entityDisplayName(entity) },
+                            ]}
+                        />
+                    }
+                    tabs={
+                        <TabsList>
+                            {attributeCategories.map((category) => (
+                                <TabsTrigger
+                                    key={category.name}
+                                    value={category.name}
+                                >
+                                    {category.label}
+                                </TabsTrigger>
+                            ))}
+                        </TabsList>
+                    }
+                    actions={
+                        <Row className="self-end items-center" spacing={1}>
+                            <div className="w-28">
+                                <EntityAttributeProgress
+                                    entity={entity}
+                                    definitions={attributeDefinitions}
+                                />
+                            </div>
+                            <EntityStateSelect entity={entity} />
+                            <EntityImportMenu importAction={importAction} />
+                            <ServerActionIconButton
+                                title="Obriši"
+                                onClick={entityDeleteBound}
+                                variant="plain"
                             >
-                                {category.label}
-                            </TabsTrigger>
-                        ))}
-                    </TabsList>
-                    <Row className="self-end items-center" spacing={1}>
-                        <div className="w-28">
-                            <EntityAttributeProgress
-                                entity={entity}
-                                definitions={attributeDefinitions}
-                            />
-                        </div>
-                        <EntityStateSelect entity={entity} />
-                        <EntityImportMenu importAction={importAction} />
-                        <ServerActionIconButton
-                            title="Obriši"
-                            onClick={entityDeleteBound}
-                            variant="plain"
-                        >
-                            <Delete />
-                        </ServerActionIconButton>
-                    </Row>
-                </div>
+                                <Delete />
+                            </ServerActionIconButton>
+                        </Row>
+                    }
+                />
                 <Stack spacing={2}>
                     <FieldSet>
                         <Field

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -98,7 +98,7 @@ export default async function EntityDetailsPage(props: {
                         </TabsList>
                     }
                     actions={
-                        <Row className="self-end items-center" spacing={1}>
+                        <Row className="items-center" spacing={1}>
                             <div className="w-28">
                                 <EntityAttributeProgress
                                     entity={entity}


### PR DESCRIPTION
### Motivation
- Keep the entity header (breadcrumbs/name, tabs, and action controls) visible when users scroll past the top of the details page by rendering it as a floating, cloud/tooltip-like sticky element.

### Description
- Added a new client component `EntityDetailsStickyHeader` that accepts `breadcrumbs`, `tabs`, and `actions`, observes a sentinel via `IntersectionObserver`, and toggles a floating/sticky style when scrolled past (`apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx`).
- Updated the entity details page to render the breadcrumbs, tabs, and action controls through the new sticky wrapper instead of a static row, preserving existing components and server actions (`apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx`).
- The sticky component uses the repo `cx` helper and Tailwind classes to apply the rounded, bordered, blurred, and shadowed “cloud” appearance when stuck, and keeps layout accessibility (overflow handling for tabs and minimum widths for breadcrumbs/actions).
- No server-side logic or API behavior was changed; only client-side presentation and layout were modified.

### Testing
- Ran `pnpm --filter app lint` and the command completed successfully against the workspace.
- Ran `pnpm --filter app exec biome check` for the two modified files and the checks completed without required fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10ad8feb0832fa4bb1abbfaaa6ef3)