### PR TITLE
admin: add drag-and-drop ordering for table-visible entity attributes

### DIFF
--- a/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
+++ b/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
@@ -46,6 +46,7 @@ import { KnownPages } from '../../../src/KnownPages';
 import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
 import { CreateAttributeDefinitionButton } from '../buttons/CreateAttributeDefinitionButton';
 import { CreateAttributeDefinitionCategoryButton } from '../buttons/CreateAttributeDefinitionCategoryButton';
+import { TableAttributeOrderSection } from './TableAttributeOrderSection';
 
 function AttributeDataTypeIcon({
     dataType,
@@ -388,6 +389,10 @@ export function AttributeDefinitionsListClient({
                 </DndContext>
             </Stack>
             <Stack spacing={2} className="ml-4">
+                <TableAttributeOrderSection
+                    entityTypeName={entityTypeName}
+                    attributeDefinitions={attributeDefinitions}
+                />
                 {categories.length <= 0 && <NoDataPlaceholder />}
                 {categories.map((category) => (
                     <CategorySection

--- a/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
+++ b/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import {
+    closestCenter,
+    DndContext,
+    type DragEndEvent,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { ExtendedAttributeDefinition } from '@gredice/storage';
+import { Table } from '@signalco/ui-icons';
+import { Card } from '@signalco/ui-primitives/Card';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
+import type { CSSProperties, MouseEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { reorderAttributeDefinition } from '../../../app/(actions)/definitionActions';
+import { KnownPages } from '../../../src/KnownPages';
+
+function SortableTableAttributeRow({
+    attribute,
+    preventClick,
+}: {
+    attribute: ExtendedAttributeDefinition;
+    preventClick: boolean;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: attribute.id.toString() });
+
+    const style: CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    const handleClick = (e: MouseEvent) => {
+        if (isDragging || preventClick) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    };
+
+    return (
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+            <Link
+                href={KnownPages.DirectoryEntityTypeAttributeDefinition(
+                    attribute.entityTypeName,
+                    attribute.id,
+                )}
+                onClick={handleClick}
+            >
+                <Card>
+                    <Row spacing={1} justifyContent="space-between">
+                        <Typography level="body2">{attribute.label}</Typography>
+                        <Chip>{attribute.categoryDefinition?.label}</Chip>
+                    </Row>
+                </Card>
+            </Link>
+        </div>
+    );
+}
+
+export function TableAttributeOrderSection({
+    entityTypeName,
+    attributeDefinitions,
+}: {
+    entityTypeName: string;
+    attributeDefinitions: ExtendedAttributeDefinition[];
+}) {
+    const [displayAttributes, setDisplayAttributes] = useState(
+        attributeDefinitions.filter((attribute) => attribute.display),
+    );
+    const [preventClick, setPreventClick] = useState(false);
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    useEffect(() => {
+        setDisplayAttributes(
+            attributeDefinitions.filter((attribute) => attribute.display),
+        );
+    }, [attributeDefinitions]);
+
+    useEffect(() => {
+        if (!preventClick) return;
+        const timeout = setTimeout(() => {
+            setPreventClick(false);
+        }, 200);
+        return () => clearTimeout(timeout);
+    }, [preventClick]);
+
+    async function handleDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+
+        const oldIndex = displayAttributes.findIndex(
+            (attribute) => attribute.id.toString() === active.id,
+        );
+        const newIndex = displayAttributes.findIndex(
+            (attribute) => attribute.id.toString() === over.id,
+        );
+
+        const newItems = arrayMove(displayAttributes, oldIndex, newIndex);
+        setDisplayAttributes(newItems);
+        setPreventClick(true);
+
+        const prev = newItems[newIndex - 1]?.order ?? null;
+        const next = newItems[newIndex + 1]?.order ?? null;
+
+        await reorderAttributeDefinition(
+            entityTypeName,
+            Number(active.id),
+            prev,
+            next,
+        );
+    }
+
+    if (displayAttributes.length <= 0) {
+        return null;
+    }
+
+    return (
+        <Stack spacing={1}>
+            <Row spacing={1}>
+                <Table className="size-5 text-tertiary-foreground" />
+                <Typography level="body2">
+                    Poredak atributa u tablici
+                </Typography>
+            </Row>
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+            >
+                <SortableContext
+                    items={displayAttributes.map((attribute) =>
+                        attribute.id.toString(),
+                    )}
+                    strategy={verticalListSortingStrategy}
+                >
+                    <Stack spacing={1}>
+                        {displayAttributes.map((attribute) => (
+                            <SortableTableAttributeRow
+                                key={attribute.id}
+                                attribute={attribute}
+                                preventClick={preventClick}
+                            />
+                        ))}
+                    </Stack>
+                </SortableContext>
+            </DndContext>
+        </Stack>
+    );
+}

--- a/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
+++ b/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
@@ -4,6 +4,7 @@ import {
     closestCenter,
     DndContext,
     type DragEndEvent,
+    KeyboardSensor,
     PointerSensor,
     useSensor,
     useSensors,
@@ -11,6 +12,7 @@ import {
 import {
     arrayMove,
     SortableContext,
+    sortableKeyboardCoordinates,
     useSortable,
     verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
@@ -35,6 +37,8 @@ function SortableTableAttributeRow({
     attribute: ExtendedAttributeDefinition;
     preventClick: boolean;
 }) {
+    const categoryLabel =
+        attribute.categoryDefinition?.label ?? attribute.category;
     const {
         attributes,
         listeners,
@@ -68,7 +72,7 @@ function SortableTableAttributeRow({
                 <Card>
                     <Row spacing={1} justifyContent="space-between">
                         <Typography level="body2">{attribute.label}</Typography>
-                        <Chip>{attribute.categoryDefinition?.label}</Chip>
+                        {categoryLabel ? <Chip>{categoryLabel}</Chip> : null}
                     </Row>
                 </Card>
             </Link>
@@ -87,7 +91,16 @@ export function TableAttributeOrderSection({
         attributeDefinitions.filter((attribute) => attribute.display),
     );
     const [preventClick, setPreventClick] = useState(false);
-    const sensors = useSensors(useSensor(PointerSensor));
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: {
+                distance: 8,
+            },
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        }),
+    );
 
     useEffect(() => {
         setDisplayAttributes(
@@ -105,6 +118,7 @@ export function TableAttributeOrderSection({
 
     async function handleDragEnd(event: DragEndEvent) {
         const { active, over } = event;
+        setPreventClick(true);
         if (!over || active.id === over.id) return;
 
         const oldIndex = displayAttributes.findIndex(
@@ -116,7 +130,6 @@ export function TableAttributeOrderSection({
 
         const newItems = arrayMove(displayAttributes, oldIndex, newIndex);
         setDisplayAttributes(newItems);
-        setPreventClick(true);
 
         const prev = newItems[newIndex - 1]?.order ?? null;
         const next = newItems[newIndex + 1]?.order ?? null;
@@ -144,6 +157,8 @@ export function TableAttributeOrderSection({
             <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
+                onDragStart={() => setPreventClick(true)}
+                onDragCancel={() => setPreventClick(true)}
                 onDragEnd={handleDragEnd}
             >
                 <SortableContext

--- a/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
+++ b/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
@@ -18,7 +18,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { ExtendedAttributeDefinition } from '@gredice/storage';
-import { Table } from '@signalco/ui-icons';
+import { Tablet } from '@signalco/ui-icons';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -149,7 +149,7 @@ export function TableAttributeOrderSection({
     return (
         <Stack spacing={1}>
             <Row spacing={1}>
-                <Table className="size-5 text-tertiary-foreground" />
+                <Tablet className="size-5 text-tertiary-foreground" />
                 <Typography level="body2">
                     Poredak atributa u tablici
                 </Typography>


### PR DESCRIPTION
### Motivation
- Provide admins a way to define the column order for attributes that are marked to appear in entity tables, because previously only selection (`display`) was available without a way to reorder them.

### Description
- Add a new client component `apps/app/components/admin/directories/TableAttributeOrderSection.tsx` that lists all attributes with `display = true` and exposes a draggable ordering UI using `@dnd-kit`.
- Reordering persists by calling the existing server action `reorderAttributeDefinition` with surrounding `order` keys so the storage layer keeps the new sequence.
- Guard link navigation while dragging to avoid accidental route changes and show attribute category context via a `Chip` in each row.
- Mount the new section in `AttributeDefinitionsListClient` (`apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx`) above the per-category lists so admins can configure table column order from the attribute definitions page.

### Testing
- Ran the workspace lint for the app with `pnpm --dir apps/app lint`, which completed successfully (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10a5a9ccc832f9b0b9e2658cdb3a7)