### PR TITLE
ci: remove explicit pnpm versions from action-setup steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,6 @@ jobs:
 
       - uses: pnpm/action-setup@v6.0.0
         name: ✨ Install pnpm
-        with:
-          version: 10.33.0
 
       - name: ✨ Setup Node
         uses: actions/setup-node@v6.3.0

--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -34,8 +34,6 @@ jobs:
 
       - uses: pnpm/action-setup@v6.0.0
         name: ✨ Install pnpm
-        with:
-          version: 10.33.0
 
       - name: ✨ Setup Node
         uses: actions/setup-node@v6.3.0
@@ -71,8 +69,6 @@ jobs:
 
       - uses: pnpm/action-setup@v6.0.0
         name: ✨ Install pnpm
-        with:
-          version: 10.33.0
 
       - name: ✨ Setup Node
         uses: actions/setup-node@v6.3.0


### PR DESCRIPTION
### Motivation
- CI runs failed with `ERR_PNPM_BAD_PM_VERSION` due to multiple pnpm versions being specified in workflows and `package.json`.
- Make the repository `packageManager` field the single source of truth for pnpm to avoid checksum/version mismatches.

### Description
- Removed `with.version: 10.33.0` from `pnpm/action-setup@v6.0.0` steps in ` .github/workflows/ci.yml` and `.github/workflows/nextjs_ci_reusable.yml` so the action will defer to the repo `packageManager` value.
- Kept the checksum-pinned pnpm entry in `package.json` (`packageManager: "pnpm@10.33.0+sha512..."`) as the authoritative version.
- Changes eliminate the previous conflict between the workflow-level numeric version and the checksum-pinned package manager.

### Testing
- Ran `rg -n "pnpm/action-setup|version:\s*10\.33\.0|packageManager" .github/workflows package.json` to locate relevant entries and confirm removals, which returned expected results.
- Inspected the modified workflows with `nl`/`sed` to verify the `with.version` lines were removed and that `pnpm/action-setup@v6.0.0` steps remain present, which succeeded. 
- Verified no remaining explicit `version: 10.33.0` entries for `pnpm/action-setup` across workflow files using search; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e114fcfa50832f8e9fef19f821d296)