### PR TITLE
Improve optimistic completion flow in schedule modals

### DIFF
--- a/apps/app/app/admin/schedule/CompleteOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CompleteOperationModal.tsx
@@ -231,6 +231,7 @@ export function CompleteOperationModal({
         try {
             setErrorMessage(null);
             setIsSubmitting(true);
+            let shouldResetModalState = false;
             if (attachImages && uploadItems.length > 0) {
                 const imageUrls: string[] = [];
                 for (const uploadItem of uploadItems) {
@@ -252,14 +253,21 @@ export function CompleteOperationModal({
 
                     imageUrls.push(uploadedUrl);
                 }
+                setIsOpen(false);
                 await completeOperationWithImageUrls(operationId, imageUrls);
+                shouldResetModalState = true;
             } else {
+                setIsOpen(false);
                 await completeOperation(operationId);
+                shouldResetModalState = true;
             }
-            handleOpenChange(false);
+            if (shouldResetModalState) {
+                handleOpenChange(false);
+            }
         } catch (error) {
             console.error('Error completing operation:', error);
-            setErrorMessage('Spremanje slika nije uspjelo. Pokušajte ponovno.');
+            setIsOpen(true);
+            setErrorMessage('Spremanje nije uspjelo. Pokušajte ponovno.');
         } finally {
             setIsSubmitting(false);
         }
@@ -395,12 +403,12 @@ export function CompleteOperationModal({
                                 Učitavanje slika u tijeku...
                             </Typography>
                         )}
-                        {errorMessage && (
-                            <Typography level="body2" className="text-red-600">
-                                {errorMessage}
-                            </Typography>
-                        )}
                     </Stack>
+                )}
+                {errorMessage && (
+                    <Typography level="body2" className="text-red-600">
+                        {errorMessage}
+                    </Typography>
                 )}
                 <Row spacing={1} justifyContent="end">
                     <Button

--- a/apps/app/app/admin/schedule/CompletePlantingModal.tsx
+++ b/apps/app/app/admin/schedule/CompletePlantingModal.tsx
@@ -34,6 +34,7 @@ export function CompletePlantingModal({
             setIsSubmitting(true);
             setOpen(false);
             await onConfirm();
+            handleOpenChange(false);
         } catch (error) {
             console.error('Error completing planting:', error);
             setErrorMessage('Spremanje nije uspjelo. Pokušajte ponovno.');

--- a/apps/app/app/admin/schedule/CompletePlantingModal.tsx
+++ b/apps/app/app/admin/schedule/CompletePlantingModal.tsx
@@ -32,7 +32,7 @@ export function CompletePlantingModal({
         try {
             setErrorMessage(null);
             setIsSubmitting(true);
-            setOpen(false);
+            handleOpenChange(false);
             await onConfirm();
             handleOpenChange(false);
         } catch (error) {

--- a/apps/app/app/admin/schedule/CompletePlantingModal.tsx
+++ b/apps/app/app/admin/schedule/CompletePlantingModal.tsx
@@ -19,14 +19,25 @@ export function CompletePlantingModal({
 }: CompletePlantingModalProps) {
     const [open, setOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            setErrorMessage(null);
+        }
+    };
 
     const handleConfirm = async () => {
         try {
+            setErrorMessage(null);
             setIsSubmitting(true);
-            await onConfirm();
             setOpen(false);
+            await onConfirm();
         } catch (error) {
             console.error('Error completing planting:', error);
+            setErrorMessage('Spremanje nije uspjelo. Pokušajte ponovno.');
+            setOpen(true);
         } finally {
             setIsSubmitting(false);
         }
@@ -36,12 +47,14 @@ export function CompletePlantingModal({
         <Modal
             title="Potvrda sijanja"
             open={open}
-            onOpenChange={setOpen}
+            onOpenChange={handleOpenChange}
             trigger={
                 <Checkbox
                     className="size-5 mx-2"
                     checked={open}
-                    onCheckedChange={(checked: boolean) => setOpen(checked)}
+                    onCheckedChange={(checked: boolean) =>
+                        handleOpenChange(checked)
+                    }
                 />
             }
         >
@@ -53,7 +66,7 @@ export function CompletePlantingModal({
                 <Row spacing={1} justifyContent="end">
                     <Button
                         variant="outlined"
-                        onClick={() => setOpen(false)}
+                        onClick={() => handleOpenChange(false)}
                         disabled={isSubmitting}
                     >
                         Odustani
@@ -67,6 +80,11 @@ export function CompletePlantingModal({
                         Potvrdi
                     </Button>
                 </Row>
+                {errorMessage && (
+                    <Typography level="body2" className="text-red-600">
+                        {errorMessage}
+                    </Typography>
+                )}
             </Stack>
         </Modal>
     );


### PR DESCRIPTION
### Motivation
- Keep schedule completion interactions responsive by optimistically dismissing confirmation modals immediately and only showing an inline error (and reopening the modal) if the server request fails.

### Description
- `CompletePlantingModal`: added `errorMessage` state and `handleOpenChange`, close the modal before awaiting `onConfirm`, and reopen with an inline error message when the request fails.
- `CompleteOperationModal`: optimistically call `setIsOpen(false)` before invoking `completeOperation` / `completeOperationWithImageUrls`, reopen on error, and use a `shouldResetModalState` flag to ensure modal state resets only on success.
- Moved the operation error rendering out of the image-only section so errors are visible even when no images are attached and consolidated the failure message text.

### Testing
- Ran the Biome checks with `pnpm --dir apps/app exec biome check app/admin/schedule/CompletePlantingModal.tsx app/admin/schedule/CompleteOperationModal.tsx` and it reported no fixes required (checked 2 files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e116de87a8832fb572e787260c68be)