### PR TITLE
feat(sprite): add dynamic lighting and wind wobble billboardsIntroduce-of-day and weather-based brightness sprite billboardsmatch ambient conditions. Compute a sunlight factor and combine it withcloudy/foggy/rainy weather to derive a clamped sprite brightness, thenapply as a Color scalarAdd procedural windble driven by a RNG per sprite instance.

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
     experimental: {
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,
+        turbopackFileSystemCacheForBuild: true,
     },
     images: {
         remotePatterns: [

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
     experimental: {
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,
-        turbopackFileSystemCacheForBuild: true,
     },
     images: {
         remotePatterns: [

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx
@@ -28,9 +28,16 @@ export function AttributeCategoryDefinitionItem({
 
     function handleAdd() {
         void trackSave(() =>
-            handleValueSave(entity.entityTypeName, entity.id, attributeDefinition),
+            handleValueSave(
+                entity.entityTypeName,
+                entity.id,
+                attributeDefinition,
+            ),
         ).catch((error) => {
-            console.error('AttributeCategoryDefinitionItem handleAdd error', error);
+            console.error(
+                'AttributeCategoryDefinitionItem handleAdd error',
+                error,
+            );
         });
     }
 
@@ -79,9 +86,7 @@ export function AttributeCategoryDefinitionItem({
                     />
                 )}
                 {attributeDefinition.multiple && (
-                    <Button onClick={handleAdd}>
-                        Dodaj
-                    </Button>
+                    <Button onClick={handleAdd}>Dodaj</Button>
                 )}
             </Stack>
         </Stack>

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -7,6 +7,14 @@ const nextConfig: NextConfig = {
     experimental: {
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,
+        turbopackFileSystemCacheForBuild: true,
+        optimizePackageImports: [
+            '@signalco/ui-primitives',
+            '@signalco/ui-icons',
+            'three',
+            '@react-three/drei',
+            '@react-three/fiber',
+        ],
         serverActions: {
             bodySizeLimit: '10mb',
         },

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -7,7 +7,6 @@ const nextConfig: NextConfig = {
     experimental: {
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,
-        turbopackFileSystemCacheForBuild: true,
         optimizePackageImports: [
             '@signalco/ui-primitives',
             '@signalco/ui-icons',

--- a/apps/farm/next.config.ts
+++ b/apps/farm/next.config.ts
@@ -6,7 +6,6 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
     experimental: {
         turbopackFileSystemCacheForDev: true,
-        turbopackFileSystemCacheForBuild: true,
         typedEnv: true,
         optimizePackageImports: [
             '@signalco/ui-primitives',

--- a/apps/farm/next.config.ts
+++ b/apps/farm/next.config.ts
@@ -6,7 +6,12 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
     experimental: {
         turbopackFileSystemCacheForDev: true,
+        turbopackFileSystemCacheForBuild: true,
         typedEnv: true,
+        optimizePackageImports: [
+            '@signalco/ui-primitives',
+            '@signalco/ui-icons',
+        ],
     },
     expireTime: 10800, // CDN ISR expiration time: 3 hour in seconds
     productionBrowserSourceMaps: !process.env.CI,

--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -22,7 +22,15 @@ const nextConfig: NextConfig = {
     },
     experimental: {
         turbopackFileSystemCacheForDev: true,
+        turbopackFileSystemCacheForBuild: true,
         typedEnv: true,
+        optimizePackageImports: [
+            '@signalco/ui-primitives',
+            '@signalco/ui-icons',
+            'three',
+            '@react-three/drei',
+            '@react-three/fiber',
+        ],
     },
     expireTime: 10800, // CDN ISR expiration time: 3 hour in seconds
     productionBrowserSourceMaps: !process.env.CI,

--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -22,7 +22,6 @@ const nextConfig: NextConfig = {
     },
     experimental: {
         turbopackFileSystemCacheForDev: true,
-        turbopackFileSystemCacheForBuild: true,
         typedEnv: true,
         optimizePackageImports: [
             '@signalco/ui-primitives',

--- a/apps/www/app/legalno/politika-privatnosti/page.tsx
+++ b/apps/www/app/legalno/politika-privatnosti/page.tsx
@@ -157,13 +157,13 @@ export default function PolitikaPrivatnostiPage() {
                     <p>
                         Za potrebe dijagnostike, praćenja grešaka i poboljšanja
                         stabilnosti naše platforme koristimo uslugu{' '}
-                        <strong>Sentry</strong> (Functional Software, Inc.).
-                        Sentry nam pomaže identificirati i otkloniti tehničke
+                        <strong>Posthog</strong>
+                        Posthog nam pomaže identificirati i otkloniti tehničke
                         probleme kako bismo vam pružili bolju i pouzdaniju
                         uslugu.
                     </p>
                     <p>
-                        Prilikom praćenja grešaka, Sentry može prikupljati
+                        Prilikom praćenja grešaka, Posthog može prikupljati
                         sljedeće osobne podatke:
                     </p>
                     <ul>
@@ -186,10 +186,10 @@ export default function PolitikaPrivatnostiPage() {
                     </ul>
                     <p>
                         <strong>Sigurnost i usklađenost s GDPR-om:</strong> Svi
-                        podaci prikupljeni putem Sentry usluge pohranjuju se na
+                        podaci prikupljeni putem Posthog usluge pohranjuju se na
                         poslužiteljima unutar <strong>Europske unije</strong>,
                         čime osiguravamo usklađenost s Općom uredbom o zaštiti
-                        podataka (GDPR). Sentry je certificiran prema
+                        podataka (GDPR). Posthog je certificiran prema
                         standardima zaštite podataka i primjenjuje odgovarajuće
                         tehničke i organizacijske mjere za zaštitu vaših
                         podataka.

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -22,7 +22,6 @@ const nextConfig: NextConfig = {
     },
     experimental: {
         turbopackFileSystemCacheForDev: true,
-        turbopackFileSystemCacheForBuild: true,
         typedEnv: true,
         optimizePackageImports: [
             '@signalco/ui-primitives',

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -22,7 +22,12 @@ const nextConfig: NextConfig = {
     },
     experimental: {
         turbopackFileSystemCacheForDev: true,
+        turbopackFileSystemCacheForBuild: true,
         typedEnv: true,
+        optimizePackageImports: [
+            '@signalco/ui-primitives',
+            '@signalco/ui-icons',
+        ],
     },
     expireTime: 10800, // CDN ISR expiration time: 3 hour in seconds
     images: {

--- a/packages/game/src/entities/groundDecorations/BlockSurfaceDecorationSprites.tsx
+++ b/packages/game/src/entities/groundDecorations/BlockSurfaceDecorationSprites.tsx
@@ -2,13 +2,26 @@
 
 import { useMemo } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useWeatherNow } from '../../hooks/useWeatherNow';
 import { SpriteAtlasBillboard } from '../../sprites/SpriteAtlasBillboard';
 import type { Block } from '../../types/Block';
+import { useGameState } from '../../useGameState';
 import { getBlockSurfaceDecorations } from './getBlockSurfaceDecorations';
 import {
     type GroundDecorationSurface,
     groundDecorationAtlasBasePath,
 } from './groundDecorationConfig';
+
+const compassToDirection: Record<string, number> = {
+    E: 90,
+    N: 0,
+    NE: 45,
+    NW: 315,
+    S: 180,
+    SE: 135,
+    SW: 225,
+    W: 270,
+};
 
 type BlockSurfaceDecorationSpritesProps = {
     block: Block;
@@ -20,6 +33,8 @@ export function BlockSurfaceDecorationSprites({
     surface,
 }: BlockSurfaceDecorationSpritesProps) {
     const { data: garden } = useCurrentGarden();
+    const gameWeather = useGameState((state) => state.weather);
+    const { data: weatherNow } = useWeatherNow();
     const placements = useMemo(
         () =>
             getBlockSurfaceDecorations({
@@ -29,6 +44,16 @@ export function BlockSurfaceDecorationSprites({
             }),
         [block, garden?.id, surface],
     );
+    const windSpeed =
+        typeof gameWeather?.windSpeed === 'number'
+            ? gameWeather.windSpeed
+            : (weatherNow?.windSpeed ?? 0);
+    const windDirection =
+        typeof gameWeather?.windDirection === 'number'
+            ? gameWeather.windDirection
+            : typeof weatherNow?.windDirection === 'string'
+              ? (compassToDirection[weatherNow.windDirection] ?? 0)
+              : 0;
 
     return placements.map((placement) => {
         const positionKey = placement.position
@@ -45,6 +70,8 @@ export function BlockSurfaceDecorationSprites({
                 position={placement.position}
                 renderOrder={20}
                 spriteName={placement.spriteName}
+                windDirection={windDirection}
+                windSpeed={windSpeed}
             />
         );
     });

--- a/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
+++ b/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
@@ -13,6 +13,18 @@ export type BlockSurfaceDecorationPlacement = {
     spriteName: string;
 };
 
+function resolveDecorationBaseY(
+    block: Block,
+    options: (typeof groundDecorationOptions)[GroundDecorationSurface],
+    z: number,
+) {
+    if (!block.name.endsWith('_Angle')) {
+        return options.baseY;
+    }
+
+    return options.baseY + z * options.angleLiftPerUnit;
+}
+
 function getDecorationCount(
     rng: SeededRNG,
     options: (typeof groundDecorationOptions)[GroundDecorationSurface],
@@ -98,7 +110,12 @@ export function getBlockSurfaceDecorations(options: {
                 decorationOptions.opacityRange[0],
                 decorationOptions.opacityRange[1],
             ),
-            position: [x, decorationOptions.baseY + index * 0.002, z],
+            position: [
+                x,
+                resolveDecorationBaseY(block, decorationOptions, z) +
+                    index * 0.002,
+                z,
+            ],
             spriteName: pickSpriteName(rng, surface),
         });
     }

--- a/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
+++ b/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
@@ -32,7 +32,7 @@ export const groundDecorationOptions: Record<
         minDistance: 0.17,
         opacityRange: [0.8, 0.9],
         positionRange: 0.25,
-        spawnChance: 2,
+        spawnChance: 1,
     },
     sand: {
         angleLiftPerUnit: 0.3,

--- a/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
+++ b/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
@@ -1,6 +1,7 @@
 export type GroundDecorationSurface = 'grass' | 'sand';
 
 type GroundDecorationOptions = {
+    angleLiftPerUnit: number;
     baseY: number;
     clusterChance: number;
     heightRange: [number, number];
@@ -23,24 +24,26 @@ export const groundDecorationOptions: Record<
     GroundDecorationOptions
 > = {
     grass: {
-        baseY: 0.04,
-        clusterChance: 0.22,
-        heightRange: [0.32, 0.44],
-        maxCount: 2,
+        angleLiftPerUnit: 0.3,
+        baseY: 0.16,
+        clusterChance: 0.42,
+        heightRange: [0.09, 0.14],
+        maxCount: 5,
         minDistance: 0.17,
-        opacityRange: [0.92, 1],
-        positionRange: 0.28,
-        spawnChance: 0.8,
+        opacityRange: [0.8, 0.9],
+        positionRange: 0.25,
+        spawnChance: 2,
     },
     sand: {
-        baseY: 0.035,
-        clusterChance: 0.08,
-        heightRange: [0.22, 0.32],
+        angleLiftPerUnit: 0.3,
+        baseY: 0.2,
+        clusterChance: 0.1,
+        heightRange: [0.09, 0.25],
         maxCount: 2,
         minDistance: 0.2,
-        opacityRange: [0.88, 0.98],
+        opacityRange: [0.8, 0.9],
         positionRange: 0.26,
-        spawnChance: 0.42,
+        spawnChance: 1,
     },
 };
 

--- a/packages/game/src/scene/Rain/Drops.tsx
+++ b/packages/game/src/scene/Rain/Drops.tsx
@@ -169,6 +169,7 @@ export const Drops = ({ count = 2000 }: DropsProps) => {
                 <CSM
                     key={vertexShader + fragmentShader}
                     baseMaterial={THREE.MeshBasicMaterial}
+                    depthWrite={false}
                     vertexShader={vertexShader}
                     fragmentShader={fragmentShader}
                     uniforms={uniforms}

--- a/packages/game/src/sprites/SpriteAtlasBillboard.tsx
+++ b/packages/game/src/sprites/SpriteAtlasBillboard.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { Billboard } from '@react-three/drei';
-import { useEffect, useMemo } from 'react';
-import { PlaneGeometry } from 'three';
+import { useFrame } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import type { Mesh } from 'three';
+import { Color, DoubleSide, PlaneGeometry } from 'three';
+import { SeededRNG } from '../generators/plant/lib/rng';
+import { useGameState } from '../useGameState';
 import { resolveSpriteAtlasAssetPaths } from './resolveSpriteAtlasAssetPaths';
 import type { SpriteAtlasPage } from './types';
 import { useSpriteAtlasManifest } from './useSpriteAtlasManifest';
@@ -18,10 +22,51 @@ type SpriteAtlasBillboardProps = {
     position?: [number, number, number];
     renderOrder?: number;
     spriteName: string;
+    windDirection?: number;
+    windSpeed?: number;
 };
 
 function resolvePageBasePath(atlasBasePath: string, pageIndex: number) {
     return pageIndex === 0 ? atlasBasePath : `${atlasBasePath}.${pageIndex}`;
+}
+
+function getSunlightFactor(timeOfDay: number) {
+    if (timeOfDay <= 0.2 || timeOfDay >= 0.81) {
+        return 0;
+    }
+
+    if (timeOfDay < 0.225) {
+        return (timeOfDay - 0.2) / 0.025;
+    }
+
+    if (timeOfDay <= 0.75) {
+        return 1;
+    }
+
+    return 1 - (timeOfDay - 0.75) / 0.06;
+}
+
+function getSpriteBrightness(
+    timeOfDay: number,
+    weather:
+        | {
+              cloudy: number;
+              foggy: number;
+              rainy: number;
+          }
+        | undefined,
+) {
+    const daylightFactor = getSunlightFactor(timeOfDay);
+    const cloudy = weather?.cloudy ?? 0;
+    const foggy = weather?.foggy ?? 0;
+    const rainy = weather?.rainy ?? 0;
+    const weatherShade = Math.min(
+        0.35,
+        cloudy * 0.18 + foggy * 0.22 + rainy * 0.08,
+    );
+    const baseBrightness = 0.28 + daylightFactor * 0.42;
+
+    return Math.max(0.3, baseBrightness * (1 - weatherShade));
 }
 
 export function SpriteAtlasBillboard({
@@ -34,11 +79,34 @@ export function SpriteAtlasBillboard({
     position = [0, 0, 0],
     renderOrder,
     spriteName,
+    windDirection = 0,
+    windSpeed = 0,
 }: SpriteAtlasBillboardProps) {
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const weather = useGameState((state) => state.weather);
+    const meshRef = useRef<Mesh | null>(null);
     const assetPaths = useMemo(
         () => resolveSpriteAtlasAssetPaths(atlasBasePath),
         [atlasBasePath],
     );
+    const brightness = getSpriteBrightness(timeOfDay, weather);
+    const color = useMemo(() => {
+        return new Color().setScalar(brightness);
+    }, [brightness]);
+    const wobbleProfile = useMemo(() => {
+        const positionKey = position.map((value) => value.toFixed(3)).join(':');
+        const rng = new SeededRNG(
+            `${atlasBasePath}:${spriteName}:${positionKey}`,
+        );
+
+        return {
+            amplitude: rng.nextRange(1.15, 1.75),
+            gust: rng.nextRange(0.7, 1.25),
+            phase: rng.nextRange(0, Math.PI * 2),
+            secondaryPhase: rng.nextRange(0, Math.PI * 2),
+            speed: rng.nextRange(0.9, 1.35),
+        };
+    }, [atlasBasePath, position, spriteName]);
     const { error: manifestError, manifest } = useSpriteAtlasManifest(
         assetPaths.manifestUrl,
     );
@@ -108,11 +176,67 @@ export function SpriteAtlasBillboard({
         };
     }, [geometry]);
 
+    useFrame(({ clock }) => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        const windStrength = Math.max(0, Math.min(1, windSpeed / 16));
+        if (windStrength <= 0.001) {
+            mesh.rotation.x = 0;
+            mesh.rotation.z = 0;
+            return;
+        }
+
+        const time = clock.getElapsedTime();
+        const windDirectionRadians = (windDirection * Math.PI) / 180;
+        const directionX = Math.sin(windDirectionRadians);
+        const directionZ = -Math.cos(windDirectionRadians);
+        const directionalWave =
+            Math.sin(
+                time * (1.35 + windStrength * 1.45) * wobbleProfile.speed +
+                    wobbleProfile.phase,
+            ) *
+                0.9 +
+            Math.cos(
+                time * (1 + windStrength * 0.9) * (2 - wobbleProfile.speed) +
+                    wobbleProfile.secondaryPhase,
+            ) *
+                0.35 +
+            Math.sin(
+                time * (0.6 + windStrength * 0.8) + wobbleProfile.phase * 0.5,
+            ) *
+                wobbleProfile.gust *
+                windStrength *
+                0.7;
+        const crossWave =
+            Math.sin(
+                time * (1.1 + windStrength * 0.6) +
+                    wobbleProfile.secondaryPhase * 0.7,
+            ) *
+                0.75 +
+            Math.cos(
+                time * (0.58 + windStrength * 0.4) + wobbleProfile.phase,
+            ) *
+                0.3;
+        const wobbleAmplitude =
+            (0.035 + windStrength * 0.2) * wobbleProfile.amplitude;
+
+        mesh.rotation.x =
+            directionZ * directionalWave * wobbleAmplitude +
+            directionX * crossWave * wobbleAmplitude * 0.55;
+        mesh.rotation.z =
+            -directionX * directionalWave * wobbleAmplitude +
+            directionZ * crossWave * wobbleAmplitude * 0.55;
+    });
+
     if (manifestError) {
         console.error(
             `Failed to load sprite atlas manifest "${atlasBasePath}":`,
             manifestError,
         );
+
         return null;
     }
 
@@ -140,15 +264,16 @@ export function SpriteAtlasBillboard({
     }
 
     return (
-        <Billboard follow={follow} lockX lockZ position={position}>
-            <mesh renderOrder={renderOrder}>
+        <Billboard follow={follow} position={position}>
+            <mesh ref={meshRef} renderOrder={renderOrder} receiveShadow>
                 <primitive attach="geometry" object={geometry} />
-                <meshBasicMaterial
+                <meshLambertMaterial
                     alphaTest={alphaTest}
+                    color={color}
                     depthWrite={depthWrite}
                     map={texture}
                     opacity={opacity}
-                    toneMapped={false}
+                    side={DoubleSide}
                     transparent
                 />
             </mesh>

--- a/packages/game/src/sprites/SpriteAtlasBillboard.tsx
+++ b/packages/game/src/sprites/SpriteAtlasBillboard.tsx
@@ -296,7 +296,7 @@ export function SpriteAtlasBillboard({
     }
 
     return (
-        <Billboard follow={follow} lockX lockZ position={position}>
+        <Billboard follow={follow} position={position}>
             <mesh ref={meshRef} renderOrder={renderOrder} receiveShadow>
                 <primitive attach="geometry" object={geometry} />
                 <meshLambertMaterial

--- a/packages/game/src/sprites/SpriteAtlasBillboard.tsx
+++ b/packages/game/src/sprites/SpriteAtlasBillboard.tsx
@@ -107,6 +107,31 @@ export function SpriteAtlasBillboard({
             speed: rng.nextRange(0.9, 1.35),
         };
     }, [atlasBasePath, position, spriteName]);
+    const wobbleAnimation = useMemo(() => {
+        const windStrength = Math.max(0, Math.min(1, windSpeed / 16));
+        if (windStrength <= 0.001) {
+            return null;
+        }
+
+        const windDirectionRadians = (windDirection * Math.PI) / 180;
+
+        return {
+            crossPrimaryFrequency: 1.1 + windStrength * 0.6,
+            crossSecondaryFrequency: 0.58 + windStrength * 0.4,
+            directionX: Math.sin(windDirectionRadians),
+            directionZ: -Math.cos(windDirectionRadians),
+            directionalPrimaryFrequency:
+                (1.35 + windStrength * 1.45) * wobbleProfile.speed,
+            directionalSecondaryFrequency:
+                (1 + windStrength * 0.9) * (2 - wobbleProfile.speed),
+            gustFrequency: 0.6 + windStrength * 0.8,
+            gustScale: wobbleProfile.gust * windStrength * 0.7,
+            phase: wobbleProfile.phase,
+            secondaryPhase: wobbleProfile.secondaryPhase,
+            wobbleAmplitude:
+                (0.035 + windStrength * 0.2) * wobbleProfile.amplitude,
+        };
+    }, [windDirection, windSpeed, wobbleProfile]);
     const { error: manifestError, manifest } = useSpriteAtlasManifest(
         assetPaths.manifestUrl,
     );
@@ -176,60 +201,67 @@ export function SpriteAtlasBillboard({
         };
     }, [geometry]);
 
-    useFrame(({ clock }) => {
-        const mesh = meshRef.current;
-        if (!mesh) {
-            return;
-        }
+    useFrame(
+        ({ clock }) => {
+            const mesh = meshRef.current;
+            if (!mesh) {
+                return;
+            }
 
-        const windStrength = Math.max(0, Math.min(1, windSpeed / 16));
-        if (windStrength <= 0.001) {
-            mesh.rotation.x = 0;
-            mesh.rotation.z = 0;
-            return;
-        }
+            if (!wobbleAnimation) {
+                mesh.rotation.x = 0;
+                mesh.rotation.z = 0;
+                return;
+            }
 
-        const time = clock.getElapsedTime();
-        const windDirectionRadians = (windDirection * Math.PI) / 180;
-        const directionX = Math.sin(windDirectionRadians);
-        const directionZ = -Math.cos(windDirectionRadians);
-        const directionalWave =
-            Math.sin(
-                time * (1.35 + windStrength * 1.45) * wobbleProfile.speed +
-                    wobbleProfile.phase,
-            ) *
-                0.9 +
-            Math.cos(
-                time * (1 + windStrength * 0.9) * (2 - wobbleProfile.speed) +
-                    wobbleProfile.secondaryPhase,
-            ) *
-                0.35 +
-            Math.sin(
-                time * (0.6 + windStrength * 0.8) + wobbleProfile.phase * 0.5,
-            ) *
-                wobbleProfile.gust *
-                windStrength *
-                0.7;
-        const crossWave =
-            Math.sin(
-                time * (1.1 + windStrength * 0.6) +
-                    wobbleProfile.secondaryPhase * 0.7,
-            ) *
-                0.75 +
-            Math.cos(
-                time * (0.58 + windStrength * 0.4) + wobbleProfile.phase,
-            ) *
-                0.3;
-        const wobbleAmplitude =
-            (0.035 + windStrength * 0.2) * wobbleProfile.amplitude;
+            const time = clock.getElapsedTime();
+            const directionalWave =
+                Math.sin(
+                    time * wobbleAnimation.directionalPrimaryFrequency +
+                        wobbleAnimation.phase,
+                ) *
+                    0.9 +
+                Math.cos(
+                    time * wobbleAnimation.directionalSecondaryFrequency +
+                        wobbleAnimation.secondaryPhase,
+                ) *
+                    0.35 +
+                Math.sin(
+                    time * wobbleAnimation.gustFrequency +
+                        wobbleAnimation.phase * 0.5,
+                ) *
+                    wobbleAnimation.gustScale;
+            const crossWave =
+                Math.sin(
+                    time * wobbleAnimation.crossPrimaryFrequency +
+                        wobbleAnimation.secondaryPhase * 0.7,
+                ) *
+                    0.75 +
+                Math.cos(
+                    time * wobbleAnimation.crossSecondaryFrequency +
+                        wobbleAnimation.phase,
+                ) *
+                    0.3;
 
-        mesh.rotation.x =
-            directionZ * directionalWave * wobbleAmplitude +
-            directionX * crossWave * wobbleAmplitude * 0.55;
-        mesh.rotation.z =
-            -directionX * directionalWave * wobbleAmplitude +
-            directionZ * crossWave * wobbleAmplitude * 0.55;
-    });
+            mesh.rotation.x =
+                wobbleAnimation.directionZ *
+                    directionalWave *
+                    wobbleAnimation.wobbleAmplitude +
+                wobbleAnimation.directionX *
+                    crossWave *
+                    wobbleAnimation.wobbleAmplitude *
+                    0.55;
+            mesh.rotation.z =
+                -wobbleAnimation.directionX *
+                    directionalWave *
+                    wobbleAnimation.wobbleAmplitude +
+                wobbleAnimation.directionZ *
+                    crossWave *
+                    wobbleAnimation.wobbleAmplitude *
+                    0.55;
+        },
+        [wobbleAnimation],
+    );
 
     if (manifestError) {
         console.error(
@@ -264,7 +296,7 @@ export function SpriteAtlasBillboard({
     }
 
     return (
-        <Billboard follow={follow} position={position}>
+        <Billboard follow={follow} lockX lockZ position={position}>
             <mesh ref={meshRef} renderOrder={renderOrder} receiveShadow>
                 <primitive attach="geometry" object={geometry} />
                 <meshLambertMaterial

--- a/packages/game/src/sprites/SpriteAtlasBillboard.tsx
+++ b/packages/game/src/sprites/SpriteAtlasBillboard.tsx
@@ -201,67 +201,64 @@ export function SpriteAtlasBillboard({
         };
     }, [geometry]);
 
-    useFrame(
-        ({ clock }) => {
-            const mesh = meshRef.current;
-            if (!mesh) {
-                return;
-            }
+    useFrame(({ clock }) => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
 
-            if (!wobbleAnimation) {
-                mesh.rotation.x = 0;
-                mesh.rotation.z = 0;
-                return;
-            }
+        if (!wobbleAnimation) {
+            mesh.rotation.x = 0;
+            mesh.rotation.z = 0;
+            return;
+        }
 
-            const time = clock.getElapsedTime();
-            const directionalWave =
-                Math.sin(
-                    time * wobbleAnimation.directionalPrimaryFrequency +
-                        wobbleAnimation.phase,
-                ) *
-                    0.9 +
-                Math.cos(
-                    time * wobbleAnimation.directionalSecondaryFrequency +
-                        wobbleAnimation.secondaryPhase,
-                ) *
-                    0.35 +
-                Math.sin(
-                    time * wobbleAnimation.gustFrequency +
-                        wobbleAnimation.phase * 0.5,
-                ) *
-                    wobbleAnimation.gustScale;
-            const crossWave =
-                Math.sin(
-                    time * wobbleAnimation.crossPrimaryFrequency +
-                        wobbleAnimation.secondaryPhase * 0.7,
-                ) *
-                    0.75 +
-                Math.cos(
-                    time * wobbleAnimation.crossSecondaryFrequency +
-                        wobbleAnimation.phase,
-                ) *
-                    0.3;
+        const time = clock.getElapsedTime();
+        const directionalWave =
+            Math.sin(
+                time * wobbleAnimation.directionalPrimaryFrequency +
+                    wobbleAnimation.phase,
+            ) *
+                0.9 +
+            Math.cos(
+                time * wobbleAnimation.directionalSecondaryFrequency +
+                    wobbleAnimation.secondaryPhase,
+            ) *
+                0.35 +
+            Math.sin(
+                time * wobbleAnimation.gustFrequency +
+                    wobbleAnimation.phase * 0.5,
+            ) *
+                wobbleAnimation.gustScale;
+        const crossWave =
+            Math.sin(
+                time * wobbleAnimation.crossPrimaryFrequency +
+                    wobbleAnimation.secondaryPhase * 0.7,
+            ) *
+                0.75 +
+            Math.cos(
+                time * wobbleAnimation.crossSecondaryFrequency +
+                    wobbleAnimation.phase,
+            ) *
+                0.3;
 
-            mesh.rotation.x =
-                wobbleAnimation.directionZ *
-                    directionalWave *
-                    wobbleAnimation.wobbleAmplitude +
-                wobbleAnimation.directionX *
-                    crossWave *
-                    wobbleAnimation.wobbleAmplitude *
-                    0.55;
-            mesh.rotation.z =
-                -wobbleAnimation.directionX *
-                    directionalWave *
-                    wobbleAnimation.wobbleAmplitude +
-                wobbleAnimation.directionZ *
-                    crossWave *
-                    wobbleAnimation.wobbleAmplitude *
-                    0.55;
-        },
-        [wobbleAnimation],
-    );
+        mesh.rotation.x =
+            wobbleAnimation.directionZ *
+                directionalWave *
+                wobbleAnimation.wobbleAmplitude +
+            wobbleAnimation.directionX *
+                crossWave *
+                wobbleAnimation.wobbleAmplitude *
+                0.55;
+        mesh.rotation.z =
+            -wobbleAnimation.directionX *
+                directionalWave *
+                wobbleAnimation.wobbleAmplitude +
+            wobbleAnimation.directionZ *
+                crossWave *
+                wobbleAnimation.wobbleAmplitude *
+                0.55;
+    });
 
     if (manifestError) {
         console.error(
@@ -305,7 +302,6 @@ export function SpriteAtlasBillboard({
                     depthWrite={depthWrite}
                     map={texture}
                     opacity={opacity}
-                    side={DoubleSide}
                     transparent
                 />
             </mesh>


### PR DESCRIPTION
Expose windDirection and windSpeed props and use a useFrame loop toanimate mesh rotation based on strength, direction and a randomizedwobble profile (amplitude/gust/phase/speed Store the mesh ref forruntime.

Also import state hooks, RNG, and Three types/utilities, and wiresprite asset path resolution and manifest usage into thecomponent. changes improve visual realism by responding to world and making plant/sprite motion varied and deterministic.