### PR TITLE
Fix invalid cache tag header on slug routes

### DIFF
--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -1,4 +1,5 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
+import { decodeRouteParam } from '@gredice/js/uri';
 import { postHogMiddleware } from '@posthog/next';
 import {
     type NextFetchEvent,
@@ -12,6 +13,7 @@ import {
     isPostHogLoggingEnabled,
     POSTHOG_SERVICE_NAME,
 } from './lib/posthog-server';
+import { toPageAlias } from './src/pageAliases';
 
 const postHogApiKey =
     process.env.NEXT_PUBLIC_POSTHOG_KEY ??
@@ -26,6 +28,55 @@ const postHogProxyHost =
         .replace('://eu.posthog.com', '://eu.i.posthog.com');
 
 const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
+
+function normalizeSlugSegment(segment: string): string {
+    return toPageAlias(decodeRouteParam(segment));
+}
+
+function getCanonicalPathname(pathname: string): string | null {
+    const segments = pathname.split('/').filter(Boolean);
+
+    if (segments.length === 2 && segments[0] === 'biljke') {
+        return `/biljke/${normalizeSlugSegment(segments[1])}`;
+    }
+
+    if (
+        segments.length === 4 &&
+        segments[0] === 'biljke' &&
+        segments[2] === 'sorte'
+    ) {
+        return [
+            '',
+            'biljke',
+            normalizeSlugSegment(segments[1]),
+            'sorte',
+            normalizeSlugSegment(segments[3]),
+        ].join('/');
+    }
+
+    if (segments.length === 2 && segments[0] === 'radnje') {
+        return `/radnje/${normalizeSlugSegment(segments[1])}`;
+    }
+
+    if (
+        segments.length === 2 &&
+        segments[0] === 'blokovi' &&
+        segments[1] !== 'biljke'
+    ) {
+        return `/blokovi/${normalizeSlugSegment(segments[1])}`;
+    }
+
+    if (
+        segments.length === 3 &&
+        segments[0] === 'blokovi' &&
+        segments[1] === 'biljke' &&
+        segments[2] !== 'generator'
+    ) {
+        return `/blokovi/biljke/${normalizeSlugSegment(segments[2])}`;
+    }
+
+    return null;
+}
 
 function getProxyAttributes(response: Response) {
     const rewriteTarget = response.headers.get('x-middleware-rewrite');
@@ -63,8 +114,18 @@ const proxyHandler: NextProxy = async (
     request: NextRequest,
     event: NextFetchEvent,
 ) => {
-    const response =
-        (await baseProxyHandler(request, event)) ?? NextResponse.next();
+    const canonicalPathname = getCanonicalPathname(request.nextUrl.pathname);
+    let response: Response;
+    if (canonicalPathname && canonicalPathname !== request.nextUrl.pathname) {
+        const url = request.nextUrl.clone();
+        // Next derives implicit cache tags from the pathname.
+        // Redirect slug-backed routes before rendering so headers stay ASCII-safe.
+        url.pathname = canonicalPathname;
+        response = NextResponse.redirect(url, 308);
+    } else {
+        response =
+            (await baseProxyHandler(request, event)) ?? NextResponse.next();
+    }
 
     if (isPostHogLoggingEnabled()) {
         requestLogger.emit({

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -1,5 +1,5 @@
-import { SeverityNumber } from '@opentelemetry/api-logs';
 import { decodeRouteParam } from '@gredice/js/uri';
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { postHogMiddleware } from '@posthog/next';
 import {
     type NextFetchEvent,
@@ -29,15 +29,17 @@ const postHogProxyHost =
 
 const requestLogger = getPostHogLogger(`${POSTHOG_SERVICE_NAME}.request`);
 
-function normalizeSlugSegment(segment: string): string {
-    return toPageAlias(decodeRouteParam(segment));
+function normalizeSlugSegment(segment: string): string | null {
+    const normalized = toPageAlias(decodeRouteParam(segment));
+    return normalized.length > 0 ? normalized : null;
 }
 
 function getCanonicalPathname(pathname: string): string | null {
     const segments = pathname.split('/').filter(Boolean);
 
     if (segments.length === 2 && segments[0] === 'biljke') {
-        return `/biljke/${normalizeSlugSegment(segments[1])}`;
+        const plantAlias = normalizeSlugSegment(segments[1]);
+        return plantAlias ? `/biljke/${plantAlias}` : null;
     }
 
     if (
@@ -45,17 +47,17 @@ function getCanonicalPathname(pathname: string): string | null {
         segments[0] === 'biljke' &&
         segments[2] === 'sorte'
     ) {
-        return [
-            '',
-            'biljke',
-            normalizeSlugSegment(segments[1]),
-            'sorte',
-            normalizeSlugSegment(segments[3]),
-        ].join('/');
+        const plantAlias = normalizeSlugSegment(segments[1]);
+        const sortAlias = normalizeSlugSegment(segments[3]);
+        if (!plantAlias || !sortAlias) {
+            return null;
+        }
+        return ['', 'biljke', plantAlias, 'sorte', sortAlias].join('/');
     }
 
     if (segments.length === 2 && segments[0] === 'radnje') {
-        return `/radnje/${normalizeSlugSegment(segments[1])}`;
+        const operationAlias = normalizeSlugSegment(segments[1]);
+        return operationAlias ? `/radnje/${operationAlias}` : null;
     }
 
     if (
@@ -63,7 +65,8 @@ function getCanonicalPathname(pathname: string): string | null {
         segments[0] === 'blokovi' &&
         segments[1] !== 'biljke'
     ) {
-        return `/blokovi/${normalizeSlugSegment(segments[1])}`;
+        const blockAlias = normalizeSlugSegment(segments[1]);
+        return blockAlias ? `/blokovi/${blockAlias}` : null;
     }
 
     if (
@@ -72,7 +75,8 @@ function getCanonicalPathname(pathname: string): string | null {
         segments[1] === 'biljke' &&
         segments[2] !== 'generator'
     ) {
-        return `/blokovi/biljke/${normalizeSlugSegment(segments[2])}`;
+        const plantAlias = normalizeSlugSegment(segments[2]);
+        return plantAlias ? `/blokovi/biljke/${plantAlias}` : null;
     }
 
     return null;


### PR DESCRIPTION
## Summary
- Redirect slug-backed routes to their canonical ASCII form before Next renders them
- Normalize plant, sort, operation, and block aliases in `apps/www/proxy.ts`
- Avoid `x-next-cache-tags` header failures caused by decoded non-ASCII pathnames

## Testing
- Not run (not requested)