### PR TITLE
Add saving indicator to entity details

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx
@@ -9,6 +9,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { AttributeInput } from '../../../../../components/shared/attributes/AttributeInput';
 import { handleValueSave } from '../../../../(actions)/entityActions';
+import { useEntityDetailsSave } from './EntityDetailsSaveContext';
 
 type AttributeCategoryDefinitionItemProps = {
     entity: {
@@ -23,6 +24,16 @@ export function AttributeCategoryDefinitionItem({
     attributeDefinition,
     entity,
 }: AttributeCategoryDefinitionItemProps) {
+    const { trackSave } = useEntityDetailsSave();
+
+    function handleAdd() {
+        void trackSave(() =>
+            handleValueSave(entity.entityTypeName, entity.id, attributeDefinition),
+        ).catch((error) => {
+            console.error('AttributeCategoryDefinitionItem handleAdd error', error);
+        });
+    }
+
     return (
         <Stack key={attributeDefinition.id} spacing={1}>
             <Stack>
@@ -68,15 +79,7 @@ export function AttributeCategoryDefinitionItem({
                     />
                 )}
                 {attributeDefinition.multiple && (
-                    <Button
-                        onClick={() =>
-                            handleValueSave(
-                                entity.entityTypeName,
-                                entity.id,
-                                attributeDefinition,
-                            )
-                        }
-                    >
+                    <Button onClick={handleAdd}>
                         Dodaj
                     </Button>
                 )}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveContext.ts
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveContext.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export type EntityDetailsSaveContextValue = {
+    pendingSaveCount: number;
+    lastSavedAt: number | null;
+    trackSave: <T>(operation: () => Promise<T>) => Promise<T>;
+};
+
+async function runOperation<T>(operation: () => Promise<T>) {
+    return operation();
+}
+
+export const EntityDetailsSaveContext =
+    createContext<EntityDetailsSaveContextValue>({
+        pendingSaveCount: 0,
+        lastSavedAt: null,
+        trackSave: runOperation,
+    });
+
+export function useEntityDetailsSave() {
+    return useContext(EntityDetailsSaveContext);
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveIndicator.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveIndicator.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Check, LoaderSpinner } from '@signalco/ui-icons';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import { useEffect, useState } from 'react';
+import { useEntityDetailsSave } from './EntityDetailsSaveContext';
+
+const SAVED_STATE_DURATION_MS = 2000;
+
+export function EntityDetailsSaveIndicator() {
+    const { pendingSaveCount, lastSavedAt } = useEntityDetailsSave();
+    const [showSaved, setShowSaved] = useState(false);
+    const isSaving = pendingSaveCount > 0;
+
+    useEffect(() => {
+        if (isSaving) {
+            setShowSaved(false);
+            return;
+        }
+
+        if (!lastSavedAt) {
+            return;
+        }
+
+        setShowSaved(true);
+        const timeout = window.setTimeout(() => {
+            setShowSaved(false);
+        }, SAVED_STATE_DURATION_MS);
+
+        return () => {
+            window.clearTimeout(timeout);
+        };
+    }, [isSaving, lastSavedAt]);
+
+    if (!isSaving && !showSaved) {
+        return null;
+    }
+
+    return (
+        <Chip color={isSaving ? 'info' : 'success'}>
+            <span className="flex items-center gap-1 text-xs">
+                {isSaving ? (
+                    <LoaderSpinner className="size-3 animate-spin" />
+                ) : (
+                    <Check className="size-3" />
+                )}
+                {isSaving ? 'Spremanje…' : 'Spremljeno'}
+            </span>
+        </Chip>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveProvider.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveProvider.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { EntityDetailsSaveContext } from './EntityDetailsSaveContext';
+
+export function EntityDetailsSaveProvider({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    const [pendingSaveCount, setPendingSaveCount] = useState(0);
+    const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+
+    async function trackSave<T>(operation: () => Promise<T>) {
+        setPendingSaveCount((current) => current + 1);
+
+        try {
+            const result = await operation();
+            setLastSavedAt(Date.now());
+            return result;
+        } finally {
+            setPendingSaveCount((current) => Math.max(0, current - 1));
+        }
+    }
+
+    return (
+        <EntityDetailsSaveContext.Provider
+            value={{
+                pendingSaveCount,
+                lastSavedAt,
+                trackSave,
+            }}
+        >
+            {children}
+        </EntityDetailsSaveContext.Provider>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityStateSelect.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityStateSelect.tsx
@@ -5,16 +5,20 @@ import { Edit, Megaphone } from '@signalco/ui-icons';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { useState } from 'react';
 import { updateEntity } from '../../../../(actions)/entityActions';
+import { useEntityDetailsSave } from './EntityDetailsSaveContext';
 
 export function EntityStateSelect({ entity }: { entity: SelectEntity }) {
     const [state, setState] = useState(entity.state);
+    const { trackSave } = useEntityDetailsSave();
 
     async function handleStateChange(newState: string) {
         setState(newState);
-        await updateEntity({
-            id: entity.id,
-            state: newState,
-        });
+        await trackSave(() =>
+            updateEntity({
+                id: entity.id,
+                state: newState,
+            }),
+        );
     }
 
     const items = [

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -24,6 +24,8 @@ import { entityDisplayName } from '../../../../../src/entities/entityAttributes'
 import { KnownPages } from '../../../../../src/KnownPages';
 import { handleEntityDelete } from '../../../../(actions)/entityActions';
 import { AttributeCategoryDetails } from './AttributeCategoryDetails';
+import { EntityDetailsSaveIndicator } from './EntityDetailsSaveIndicator';
+import { EntityDetailsSaveProvider } from './EntityDetailsSaveProvider';
 import { EntityDetailsStickyHeader } from './EntityDetailsStickyHeader';
 import { EntityImportMenu } from './EntityImportMenu';
 import { EntityStateSelect } from './EntityStateSelect';
@@ -69,88 +71,96 @@ export default async function EntityDetailsPage(props: {
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
 
     return (
-        <Tabs defaultValue={attributeCategories.at(0)?.name}>
-            <Stack spacing={2}>
-                <EntityDetailsStickyHeader
-                    breadcrumbs={
-                        <Breadcrumbs
-                            items={[
-                                {
-                                    label: entity.entityType.label,
-                                    href: KnownPages.DirectoryEntityType(
-                                        params.entityType,
-                                    ),
-                                },
-                                { label: entityDisplayName(entity) },
-                            ]}
-                        />
-                    }
-                    tabs={
-                        <TabsList>
-                            {attributeCategories.map((category) => (
-                                <TabsTrigger
-                                    key={category.name}
-                                    value={category.name}
-                                >
-                                    {category.label}
-                                </TabsTrigger>
-                            ))}
-                        </TabsList>
-                    }
-                    actions={
-                        <Row className="items-center" spacing={1}>
-                            <div className="w-28">
-                                <EntityAttributeProgress
-                                    entity={entity}
-                                    definitions={attributeDefinitions}
-                                />
-                            </div>
-                            <EntityStateSelect entity={entity} />
-                            <EntityImportMenu importAction={importAction} />
-                            <ServerActionIconButton
-                                title="Obriši"
-                                onClick={entityDeleteBound}
-                                variant="plain"
-                            >
-                                <Delete />
-                            </ServerActionIconButton>
-                        </Row>
-                    }
-                />
+        <EntityDetailsSaveProvider>
+            <Tabs defaultValue={attributeCategories.at(0)?.name}>
                 <Stack spacing={2}>
-                    <FieldSet>
-                        <Field
-                            name="Datum kreiranja"
-                            value={entity.createdAt}
-                        />
-                        <Field
-                            name="Datum zadnje izmjene"
-                            value={entity.updatedAt}
-                        />
-                        <Field name="Datum objave" value={entity.publishedAt} />
-                        {displayDefinitions.map((d) => (
-                            <Field
-                                key={d.id}
-                                name={d.label}
-                                value={
-                                    entity.attributes.find(
-                                        (a) => a.attributeDefinitionId === d.id,
-                                    )?.value ?? '-'
-                                }
+                    <EntityDetailsStickyHeader
+                        breadcrumbs={
+                            <Breadcrumbs
+                                items={[
+                                    {
+                                        label: entity.entityType.label,
+                                        href: KnownPages.DirectoryEntityType(
+                                            params.entityType,
+                                        ),
+                                    },
+                                    { label: entityDisplayName(entity) },
+                                ]}
                             />
-                        ))}
-                    </FieldSet>
+                        }
+                        tabs={
+                            <TabsList>
+                                {attributeCategories.map((category) => (
+                                    <TabsTrigger
+                                        key={category.name}
+                                        value={category.name}
+                                    >
+                                        {category.label}
+                                    </TabsTrigger>
+                                ))}
+                            </TabsList>
+                        }
+                        actions={
+                            <Row className="items-center" spacing={1}>
+                                <EntityDetailsSaveIndicator />
+                                <div className="w-28">
+                                    <EntityAttributeProgress
+                                        entity={entity}
+                                        definitions={attributeDefinitions}
+                                    />
+                                </div>
+                                <EntityStateSelect entity={entity} />
+                                <EntityImportMenu importAction={importAction} />
+                                <ServerActionIconButton
+                                    title="Obriši"
+                                    onClick={entityDeleteBound}
+                                    variant="plain"
+                                >
+                                    <Delete />
+                                </ServerActionIconButton>
+                            </Row>
+                        }
+                    />
+                    <Stack spacing={2}>
+                        <FieldSet>
+                            <Field
+                                name="Datum kreiranja"
+                                value={entity.createdAt}
+                            />
+                            <Field
+                                name="Datum zadnje izmjene"
+                                value={entity.updatedAt}
+                            />
+                            <Field
+                                name="Datum objave"
+                                value={entity.publishedAt}
+                            />
+                            {displayDefinitions.map((d) => (
+                                <Field
+                                    key={d.id}
+                                    name={d.label}
+                                    value={
+                                        entity.attributes.find(
+                                            (a) =>
+                                                a.attributeDefinitionId ===
+                                                d.id,
+                                        )?.value ?? '-'
+                                    }
+                                />
+                            ))}
+                        </FieldSet>
+                    </Stack>
+                    {attributeCategories.map((category) => (
+                        <TabsContent value={category.name} key={category.name}>
+                            <AttributeCategoryDetails
+                                entity={entity}
+                                category={category}
+                                attributeDefinitions={attributeDefinitions}
+                            />
+                        </TabsContent>
+                    ))}
                 </Stack>
-                {attributeCategories.map((category) => (
-                    <TabsContent value={category.name} key={category.name}>
-                        <AttributeCategoryDetails
-                            entity={entity}
-                            category={category}
-                            attributeDefinitions={attributeDefinitions}
-                        />
-                    </TabsContent>
-                ))}
-            </Stack>
-        </Tabs>
+            </Tabs>
+        </EntityDetailsSaveProvider>
     );
 }

--- a/apps/app/components/shared/attributes/AttributeInput.tsx
+++ b/apps/app/components/shared/attributes/AttributeInput.tsx
@@ -13,6 +13,7 @@ import {
     handleValueDelete,
     handleValueSave,
 } from '../../../app/(actions)/entityActions';
+import { useEntityDetailsSave } from '../../../app/admin/directories/[entityType]/[entityId]/EntityDetailsSaveContext';
 import type { AttributeInputProps } from './AttributeInputProps';
 import { BarcodeInput } from './typed/BarcodeInput';
 import { BooleanInput } from './typed/BooleanInput';
@@ -44,6 +45,8 @@ export function AttributeInput({
     attributeDefinition: SelectAttributeDefinition;
     attributeValue: SelectAttributeValue | undefined | null;
 }) {
+    const { trackSave } = useEntityDetailsSave();
+
     const handleChange = async (value: string | null) => {
         console.debug(
             'AttributeInput handleChange',
@@ -62,12 +65,14 @@ export function AttributeInput({
         }
 
         try {
-            await handleValueSave(
-                entityType,
-                entityId,
-                attributeDefinition,
-                attributeValue?.id,
-                value,
+            await trackSave(() =>
+                handleValueSave(
+                    entityType,
+                    entityId,
+                    attributeDefinition,
+                    attributeValue?.id,
+                    value,
+                ),
             );
         } catch (error) {
             console.error('AttributeInput handleChange error', error);
@@ -79,7 +84,13 @@ export function AttributeInput({
         if (!attributeValue) {
             return;
         }
-        await handleValueDelete(attributeValue);
+
+        try {
+            await trackSave(() => handleValueDelete(attributeValue));
+        } catch (error) {
+            console.error('AttributeInput handleDelete error', error);
+            // TODO: Display error notification
+        }
     };
 
     let AttributeInputComponent: ComponentType<AttributeInputProps> = TextInput;


### PR DESCRIPTION
## Summary
- Add a page-scoped save tracker for entity details edits.
- Show a sticky `Spremanje…` / `Spremljeno` indicator while entity state and attribute changes are being persisted.
- Wire the tracker into entity state updates, attribute saves/deletes, and multi-value attribute creation.

## Testing
- Not run (not requested)