### PR TITLE
Add bulk rescheduling for unapproved raised bed schedule tasks

### DIFF
--- a/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { Calendar } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useState } from 'react';
+import { rescheduleOperationAction } from '../../(actions)/operationActions';
+import { rescheduleRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
+
+type FieldRescheduleTarget = {
+    raisedBedId: number;
+    positionIndex: number;
+};
+
+type OperationRescheduleTarget = {
+    id: number;
+};
+
+interface BulkRescheduleRaisedBedButtonProps {
+    physicalId: string;
+    fields: FieldRescheduleTarget[];
+    operations: OperationRescheduleTarget[];
+}
+
+function formatLocalDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+export function BulkRescheduleRaisedBedButton({
+    physicalId,
+    fields,
+    operations,
+}: BulkRescheduleRaisedBedButtonProps) {
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const totalItems = fields.length + operations.length;
+    const disabled = totalItems === 0 || isSubmitting;
+
+    const today = new Date();
+    const tomorrow = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() + 1,
+    );
+    const threeMonthsFromTomorrow = new Date(
+        tomorrow.getFullYear(),
+        tomorrow.getMonth() + 3,
+        tomorrow.getDate(),
+    );
+
+    const min = formatLocalDate(tomorrow);
+    const max = formatLocalDate(threeMonthsFromTomorrow);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (totalItems === 0) {
+            return;
+        }
+
+        const formData = new FormData(event.currentTarget);
+        const scheduledDate = formData.get('scheduledDate') as string;
+
+        if (!scheduledDate) {
+            return;
+        }
+
+        setIsSubmitting(true);
+        try {
+            await Promise.all([
+                ...fields.map((field) => {
+                    const targetFormData = new FormData();
+                    targetFormData.set(
+                        'raisedBedId',
+                        field.raisedBedId.toString(),
+                    );
+                    targetFormData.set(
+                        'positionIndex',
+                        field.positionIndex.toString(),
+                    );
+                    targetFormData.set('scheduledDate', scheduledDate);
+                    return rescheduleRaisedBedFieldAction(targetFormData);
+                }),
+                ...operations.map((operation) => {
+                    const targetFormData = new FormData();
+                    targetFormData.set('operationId', operation.id.toString());
+                    targetFormData.set('scheduledDate', scheduledDate);
+                    return rescheduleOperationAction(targetFormData);
+                }),
+            ]);
+            setOpen(false);
+        } catch (error) {
+            console.error('Failed to reschedule all raised bed items:', error);
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <Modal
+            title="Skupno zakazivanje zadataka"
+            open={open}
+            onOpenChange={setOpen}
+            trigger={
+                <IconButton
+                    variant="plain"
+                    title="Zakaži sve nepotvrđene zadatke gredice"
+                    disabled={disabled}
+                    aria-disabled={disabled}
+                    loading={isSubmitting}
+                >
+                    <Calendar className="size-4 shrink-0" />
+                </IconButton>
+            }
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={2}>
+                    <Typography level="h5">Skupno zakazivanje</Typography>
+                    <Typography>
+                        Odaberite datum za sve nepotvrđene zadatke ({totalItems}
+                        ) za gredicu <strong>{physicalId}</strong>.
+                    </Typography>
+
+                    <Input
+                        type="date"
+                        name="scheduledDate"
+                        label="Datum"
+                        className="w-full bg-card"
+                        min={min}
+                        max={max}
+                        required
+                        defaultValue={min}
+                        disabled={isSubmitting}
+                    />
+
+                    <Row spacing={1} justifyContent="end">
+                        <Button
+                            variant="outlined"
+                            onClick={() => setOpen(false)}
+                            disabled={isSubmitting}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={isSubmitting}
+                            disabled={isSubmitting}
+                            startDecorator={
+                                <Calendar className="size-5 shrink-0" />
+                            }
+                        >
+                            Zakaži sve
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}
+
+export default BulkRescheduleRaisedBedButton;

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -14,6 +14,7 @@ import { KnownPages } from '../../../src/KnownPages';
 import { AcceptOperationModal } from './AcceptOperationModal';
 import { AssignOperationModal } from './AssignOperationModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkRescheduleRaisedBedButton } from './BulkRescheduleRaisedBedButton';
 import { CancelOperationModal } from './CancelOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { CopyTasksButton } from './CopyTasksButton';
@@ -142,6 +143,9 @@ export function RaisedBedOperationsScheduleSection({
                 label,
             };
         });
+    const operationsToReschedule = operationsToApprove.map((operation) => ({
+        id: operation.id,
+    }));
 
     const durations = dayOperations.reduce(
         (acc, operation) => {
@@ -172,6 +176,11 @@ export function RaisedBedOperationsScheduleSection({
                     physicalId={physicalId.toString()}
                     fields={[]}
                     operations={operationsToApprove}
+                />
+                <BulkRescheduleRaisedBedButton
+                    physicalId={physicalId.toString()}
+                    fields={[]}
+                    operations={operationsToReschedule}
                 />
                 <RaisedBedLabel physicalId={physicalId} />
                 <Typography level="body2" className="text-muted-foreground">

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -13,6 +13,7 @@ import type { EntityStandardized } from '../../../lib/@types/EntityStandardized'
 import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
 import { AcceptRaisedBedFieldModal } from './AcceptRaisedBedFieldModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkRescheduleRaisedBedButton } from './BulkRescheduleRaisedBedButton';
 import { CancelRaisedBedFieldModal } from './CancelRaisedBedFieldModal';
 import { CompletePlantingModal } from './CompletePlantingModal';
 import { CopyTasksButton } from './CopyTasksButton';
@@ -106,6 +107,10 @@ export function RaisedBedPlantingScheduleSection({
                 label: `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`,
             };
         });
+    const fieldsToReschedule = fieldsToApprove.map((field) => ({
+        raisedBedId: field.raisedBedId,
+        positionIndex: field.positionIndex,
+    }));
 
     const durations = dayFields.reduce(
         (acc, field) => {
@@ -127,6 +132,11 @@ export function RaisedBedPlantingScheduleSection({
                 <BulkApproveRaisedBedButton
                     physicalId={physicalId.toString()}
                     fields={fieldsToApprove}
+                    operations={[]}
+                />
+                <BulkRescheduleRaisedBedButton
+                    physicalId={physicalId.toString()}
+                    fields={fieldsToReschedule}
                     operations={[]}
                 />
                 <RaisedBedLabel physicalId={physicalId} />


### PR DESCRIPTION
### Motivation
- Provide a bulk-schedule option on the schedule view to set a scheduled date for all not-yet-approved operations and sowing tasks for a raised bed, matching the existing bulk-approve UX.

### Description
- Add a new client component `BulkRescheduleRaisedBedButton` that shows a modal date picker and submits a single date for multiple targets. 
- Reuse existing server actions by calling `rescheduleOperationAction` and `rescheduleRaisedBedFieldAction` with per-target `FormData` entries built in the component. 
- Wire the new bulk reschedule button into `RaisedBedOperationsScheduleSection` and `RaisedBedPlantingScheduleSection`, deriving reschedulable targets from the same unapproved sets used for bulk approve. 
- Enforce the same date bounds as single rescheduling (default to tomorrow, max tomorrow + 3 months) and disable the trigger when there are no targets or while submitting.

### Testing
- Ran the workspace linter with `pnpm --dir apps/app lint`, which completed (the run adjusted one file and reported one lint warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25883676c832fbff681da371db49d)