### PR TITLE
Call API auth endpoint directly for app admin OAuth initiation

### DIFF
--- a/apps/app/components/admin/navigation/LoginDialog.tsx
+++ b/apps/app/components/admin/navigation/LoginDialog.tsx
@@ -82,11 +82,18 @@ export function LoginDialog() {
                 ? '/prijava/google-prijava/povratak'
                 : '/prijava/facebook-prijava/povratak';
         const redirectUrl = `${window.location.origin}${callbackPath}`;
-        const authUrl = new URL(
-            `/api/gredice/api/auth/${provider}`,
-            window.location.origin,
-        );
+        const apiBaseUrl =
+            window.location.hostname.endsWith('.test') ||
+            window.location.hostname === 'localhost' ||
+            window.location.hostname === '127.0.0.1'
+                ? 'https://api.gredice.test'
+                : 'https://api.gredice.com';
+        const authUrl = new URL(`/api/auth/${provider}`, apiBaseUrl);
         authUrl.searchParams.set('redirect', redirectUrl);
+        authUrl.searchParams.set(
+            'timeZone',
+            Intl.DateTimeFormat().resolvedOptions().timeZone,
+        );
         window.location.href = authUrl.toString();
     };
 


### PR DESCRIPTION
### Motivation
- Prevent OAuth cookie/redirect failures caused by initiating OAuth through the app proxy so the API-host-scoped cookies and redirects work correctly and timezone is preserved.

### Description
- Update `handleOAuthLogin` in `apps/app/components/admin/navigation/LoginDialog.tsx` to compute an `apiBaseUrl` (using `https://api.gredice.test` for local/test hosts and `https://api.gredice.com` in production) and call `/api/auth/{provider}` on that domain instead of proxying to `/api/gredice/api/auth/{provider}`.
- Add a `timeZone` query parameter using `Intl.DateTimeFormat().resolvedOptions().timeZone` and continue to pass the `redirect` callback URL to preserve API-side timezone handling and callback behavior.

### Testing
- Ran `pnpm lint --filter app` which completed successfully and reported only an unrelated Biome warning in a different file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2560e5858832fb2002388fff841bd)