### PR TITLE
Add incoming-entity links page and header shortcut

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/links/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/links/page.tsx
@@ -20,14 +20,12 @@ export default async function EntityLinksPage(props: {
 }) {
     const params = await props.params;
     const entityId = parseInt(params.entityId, 10);
-    const [entity, incomingLinks] = await Promise.all([
-        getEntityRaw(entityId),
-        getEntityIncomingLinks(entityId),
-    ]);
+    const entity = await getEntityRaw(entityId);
 
     if (!entity) {
         notFound();
     }
+    const incomingLinks = await getEntityIncomingLinks(entityId, entity);
 
     return (
         <Stack spacing={2}>

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/links/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/links/page.tsx
@@ -1,0 +1,118 @@
+import {
+    getEntityIncomingLinks,
+    getEntityRaw,
+    type IncomingEntityLinkGroup,
+} from '@gredice/storage';
+import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
+import { Card } from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { entityDisplayName } from '../../../../../../src/entities/entityAttributes';
+import { KnownPages } from '../../../../../../src/KnownPages';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EntityLinksPage(props: {
+    params: Promise<{ entityType: string; entityId: string }>;
+}) {
+    const params = await props.params;
+    const entityId = parseInt(params.entityId, 10);
+    const [entity, incomingLinks] = await Promise.all([
+        getEntityRaw(entityId),
+        getEntityIncomingLinks(entityId),
+    ]);
+
+    if (!entity) {
+        notFound();
+    }
+
+    return (
+        <Stack spacing={2}>
+            <Breadcrumbs
+                items={[
+                    {
+                        label: entity.entityType.label,
+                        href: KnownPages.DirectoryEntityType(params.entityType),
+                    },
+                    {
+                        label: entityDisplayName(entity),
+                        href: KnownPages.DirectoryEntity(
+                            params.entityType,
+                            entity.id,
+                        ),
+                    },
+                    { label: 'Povezani zapisi' },
+                ]}
+            />
+            <Typography level="h1" className="text-2xl" semiBold>
+                Povezani zapisi za {entityDisplayName(entity)}
+            </Typography>
+            {incomingLinks.length === 0 ? (
+                <Card className="p-4">
+                    <Typography secondary>
+                        Nema zapisa koji trenutno referenciraju ovaj zapis.
+                    </Typography>
+                </Card>
+            ) : (
+                incomingLinks.map((group) => (
+                    <IncomingLinksGroupTable
+                        key={group.entityTypeName}
+                        group={group}
+                    />
+                ))
+            )}
+        </Stack>
+    );
+}
+
+function IncomingLinksGroupTable({
+    group,
+}: {
+    group: IncomingEntityLinkGroup;
+}) {
+    return (
+        <Card className="p-4">
+            <Stack spacing={2}>
+                <Typography level="h5" semiBold>
+                    {group.entityTypeLabel}
+                </Typography>
+                <Table>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.Head>Zapis</Table.Head>
+                            <Table.Head>Povezani atributi</Table.Head>
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {group.entities.map((sourceEntity) => (
+                            <Table.Row key={sourceEntity.id}>
+                                <Table.Cell>
+                                    <Link
+                                        href={KnownPages.DirectoryEntity(
+                                            group.entityTypeName,
+                                            sourceEntity.id,
+                                        )}
+                                    >
+                                        <Typography>
+                                            {sourceEntity.displayName}
+                                        </Typography>
+                                    </Link>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Typography secondary>
+                                        {sourceEntity.linkedBy
+                                            .map((attribute) => attribute.label)
+                                            .join(', ')}
+                                    </Typography>
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table>
+            </Stack>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -5,6 +5,7 @@ import {
 } from '@gredice/storage';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Delete } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import {
@@ -13,6 +14,7 @@ import {
     TabsList,
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
@@ -110,6 +112,16 @@ export default async function EntityDetailsPage(props: {
                                     />
                                 </div>
                                 <EntityStateSelect entity={entity} />
+                                <Link
+                                    href={KnownPages.DirectoryEntityLinks(
+                                        params.entityType,
+                                        parseInt(params.entityId, 10),
+                                    )}
+                                >
+                                    <Button variant="plain">
+                                        Povezani zapisi
+                                    </Button>
+                                </Link>
                                 <EntityImportMenu importAction={importAction} />
                                 <ServerActionIconButton
                                     title="Obriši"

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -14,7 +14,6 @@ import {
     TabsList,
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
@@ -112,16 +111,15 @@ export default async function EntityDetailsPage(props: {
                                     />
                                 </div>
                                 <EntityStateSelect entity={entity} />
-                                <Link
+                                <Button
+                                    variant="plain"
                                     href={KnownPages.DirectoryEntityLinks(
                                         params.entityType,
                                         parseInt(params.entityId, 10),
                                     )}
                                 >
-                                    <Button variant="plain">
-                                        Povezani zapisi
-                                    </Button>
-                                </Link>
+                                    Povezani zapisi
+                                </Button>
                                 <EntityImportMenu importAction={importAction} />
                                 <ServerActionIconButton
                                     title="Obriši"

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -24,6 +24,8 @@ export const KnownPages = {
         `/admin/directories/${entityTypeName}/attribute-definitions/${id}` as Route,
     DirectoryEntity: (entityTypeName: string, entityId: number) =>
         `/admin/directories/${entityTypeName}/${entityId}` as Route,
+    DirectoryEntityLinks: (entityTypeName: string, entityId: number) =>
+        `/admin/directories/${entityTypeName}/${entityId}/links` as Route,
     DirectoryEntityPath: '/admin/directories/[entityType]/[entityId]',
     DirectoryCategoryCreate: '/admin/directories/categories/create',
     DirectoryCategoryEdit: (categoryId: number) =>

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { and, count, desc, eq, inArray, like, or } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, like } from 'drizzle-orm';
 import {
     attributeDefinitions,
     attributeValues,
@@ -475,8 +475,9 @@ function attributeValueContainsEntityName(
 
 export async function getEntityIncomingLinks(
     entityId: number,
+    sourceEntity?: NonNullable<Awaited<ReturnType<typeof getEntityRaw>>>,
 ): Promise<IncomingEntityLinkGroup[]> {
-    const entity = await getEntityRaw(entityId);
+    const entity = sourceEntity ?? (await getEntityRaw(entityId));
     if (!entity) {
         return [];
     }
@@ -498,19 +499,46 @@ export async function getEntityIncomingLinks(
 
     const definitionById = new Map(refDefinitions.map((d) => [d.id, d]));
     const definitionIds = refDefinitions.map((d) => d.id);
-    const escapedName = escapeForLike(entityName);
-
-    const linkAttributeValues = await storage().query.attributeValues.findMany({
+    const exactValueMatches = await storage().query.attributeValues.findMany({
         where: and(
             inArray(attributeValues.attributeDefinitionId, definitionIds),
             eq(attributeValues.isDeleted, false),
-            or(
-                eq(attributeValues.value, entityName),
-                like(attributeValues.value, `%"${escapedName}"%`),
-            ),
+            eq(attributeValues.value, entityName),
         ),
     });
 
+    const multipleDefinitionIds = refDefinitions
+        .filter((definition) => definition.multiple)
+        .map((definition) => definition.id);
+    const linkAttributeValues = [...exactValueMatches];
+    if (multipleDefinitionIds.length > 0) {
+        const escapedJsonEncodedName = escapeForLike(
+            JSON.stringify(entityName),
+        );
+        const legacyJsonArrayMatches =
+            await storage().query.attributeValues.findMany({
+                where: and(
+                    inArray(
+                        attributeValues.attributeDefinitionId,
+                        multipleDefinitionIds,
+                    ),
+                    eq(attributeValues.isDeleted, false),
+                    like(attributeValues.value, `%${escapedJsonEncodedName}%`),
+                ),
+            });
+
+        const seenAttributeValueIds = new Set(
+            linkAttributeValues.map((v) => v.id),
+        );
+        for (const legacyJsonArrayMatch of legacyJsonArrayMatches) {
+            if (seenAttributeValueIds.has(legacyJsonArrayMatch.id)) {
+                continue;
+            }
+
+            linkAttributeValues.push(legacyJsonArrayMatch);
+            seenAttributeValueIds.add(legacyJsonArrayMatch.id);
+        }
+    }
     const entityToDefinitionIds = new Map<number, Set<number>>();
     for (const attributeValue of linkAttributeValues) {
         if (attributeValue.entityId === entityId) {

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { and, count, desc, eq } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, like, or } from 'drizzle-orm';
 import {
     attributeDefinitions,
     attributeValues,
@@ -127,6 +127,19 @@ interface EntityWithAttributesAndType extends SelectEntity {
 interface EntityTypeCache {
     [key: string]: Promise<EntityWithAttributesAndType[]>;
 }
+
+export type IncomingEntityLinkGroup = {
+    entityTypeName: string;
+    entityTypeLabel: string;
+    entities: {
+        id: number;
+        displayName: string;
+        linkedBy: {
+            name: string;
+            label: string;
+        }[];
+    }[];
+};
 
 // Update expandEntity to accept a cache
 async function expandEntity(
@@ -393,6 +406,201 @@ export async function getEntityRaw(id: number) {
         return undefined;
     }
     return populateMissingAttributes(entity);
+}
+
+function escapeForLike(value: string) {
+    return value.replace(/[\\%_]/g, '\\$&');
+}
+
+function entityNameFromAttributes(
+    entity: SelectEntity & {
+        attributes: (SelectAttributeValue & {
+            attributeDefinition: SelectAttributeDefinition;
+        })[];
+    },
+) {
+    return (
+        entity.attributes.find(
+            (a) =>
+                a.attributeDefinition.category === 'information' &&
+                a.attributeDefinition.name === 'name',
+        )?.value ?? null
+    );
+}
+
+function entityDisplayNameFromAttributes(
+    entity: SelectEntity & {
+        entityType: SelectEntityType;
+        attributes: (SelectAttributeValue & {
+            attributeDefinition: SelectAttributeDefinition;
+        })[];
+    },
+) {
+    const label = entity.attributes.find(
+        (a) =>
+            a.attributeDefinition.category === 'information' &&
+            a.attributeDefinition.name === 'label',
+    )?.value;
+    const name = entityNameFromAttributes(entity);
+    return label ?? name ?? `${entity.entityType.label} ${entity.id}`;
+}
+
+function attributeValueContainsEntityName(
+    value: string | null,
+    entityName: string,
+    multiple: boolean,
+) {
+    if (!value) {
+        return false;
+    }
+    if (!multiple) {
+        return value === entityName;
+    }
+
+    try {
+        const parsed = JSON.parse(value);
+        if (!Array.isArray(parsed)) {
+            return value === entityName;
+        }
+
+        return parsed.some((item) =>
+            typeof item === 'string'
+                ? item === entityName
+                : JSON.stringify(item) === entityName,
+        );
+    } catch {
+        return value === entityName;
+    }
+}
+
+export async function getEntityIncomingLinks(
+    entityId: number,
+): Promise<IncomingEntityLinkGroup[]> {
+    const entity = await getEntityRaw(entityId);
+    if (!entity) {
+        return [];
+    }
+
+    const entityName = entityNameFromAttributes(entity);
+    if (!entityName) {
+        return [];
+    }
+
+    const refDefinitions = await storage().query.attributeDefinitions.findMany({
+        where: and(
+            eq(attributeDefinitions.isDeleted, false),
+            eq(attributeDefinitions.dataType, `ref:${entity.entityTypeName}`),
+        ),
+    });
+    if (refDefinitions.length === 0) {
+        return [];
+    }
+
+    const definitionById = new Map(refDefinitions.map((d) => [d.id, d]));
+    const definitionIds = refDefinitions.map((d) => d.id);
+    const escapedName = escapeForLike(entityName);
+
+    const linkAttributeValues = await storage().query.attributeValues.findMany({
+        where: and(
+            inArray(attributeValues.attributeDefinitionId, definitionIds),
+            eq(attributeValues.isDeleted, false),
+            or(
+                eq(attributeValues.value, entityName),
+                like(attributeValues.value, `%"${escapedName}"%`),
+            ),
+        ),
+    });
+
+    const entityToDefinitionIds = new Map<number, Set<number>>();
+    for (const attributeValue of linkAttributeValues) {
+        if (attributeValue.entityId === entityId) {
+            continue;
+        }
+        const definition = definitionById.get(
+            attributeValue.attributeDefinitionId,
+        );
+        if (!definition) {
+            continue;
+        }
+        if (
+            !attributeValueContainsEntityName(
+                attributeValue.value,
+                entityName,
+                definition.multiple,
+            )
+        ) {
+            continue;
+        }
+
+        const definitionIdsByEntity =
+            entityToDefinitionIds.get(attributeValue.entityId) ?? new Set();
+        definitionIdsByEntity.add(definition.id);
+        entityToDefinitionIds.set(
+            attributeValue.entityId,
+            definitionIdsByEntity,
+        );
+    }
+
+    const sourceEntityIds = Array.from(entityToDefinitionIds.keys());
+    if (sourceEntityIds.length === 0) {
+        return [];
+    }
+
+    const sourceEntities = await storage().query.entities.findMany({
+        where: and(
+            inArray(entities.id, sourceEntityIds),
+            eq(entities.isDeleted, false),
+        ),
+        with: {
+            attributes: {
+                where: eq(attributeValues.isDeleted, false),
+                with: {
+                    attributeDefinition: true,
+                },
+            },
+            entityType: true,
+        },
+    });
+
+    const grouped = new Map<string, IncomingEntityLinkGroup>();
+    for (const sourceEntity of sourceEntities) {
+        const linkedByIds = entityToDefinitionIds.get(sourceEntity.id);
+        if (!linkedByIds) {
+            continue;
+        }
+
+        const linkedBy = Array.from(linkedByIds)
+            .map((definitionId) => definitionById.get(definitionId))
+            .filter((definition): definition is SelectAttributeDefinition =>
+                Boolean(definition),
+            )
+            .map((definition) => ({
+                name: definition.name,
+                label: definition.label,
+            }))
+            .sort((a, b) => a.label.localeCompare(b.label));
+
+        const group = grouped.get(sourceEntity.entityTypeName) ?? {
+            entityTypeName: sourceEntity.entityTypeName,
+            entityTypeLabel: sourceEntity.entityType.label,
+            entities: [],
+        };
+        group.entities.push({
+            id: sourceEntity.id,
+            displayName: entityDisplayNameFromAttributes(sourceEntity),
+            linkedBy,
+        });
+        grouped.set(sourceEntity.entityTypeName, group);
+    }
+
+    return Array.from(grouped.values())
+        .map((group) => ({
+            ...group,
+            entities: group.entities.sort((a, b) =>
+                a.displayName.localeCompare(b.displayName),
+            ),
+        }))
+        .sort((a, b) => a.entityTypeLabel.localeCompare(b.entityTypeLabel));
 }
 
 export async function createEntity(entityTypeName: string) {

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -512,7 +512,7 @@ export async function getEntityIncomingLinks(
         .map((definition) => definition.id);
     const linkAttributeValues = [...exactValueMatches];
     if (multipleDefinitionIds.length > 0) {
-        const escapedEntityNameJson = escapeForLike(JSON.stringify(entityName));
+        const escapedJsonEntityName = escapeForLike(JSON.stringify(entityName));
         const legacyJsonArrayMatches =
             await storage().query.attributeValues.findMany({
                 where: and(
@@ -521,7 +521,7 @@ export async function getEntityIncomingLinks(
                         multipleDefinitionIds,
                     ),
                     eq(attributeValues.isDeleted, false),
-                    like(attributeValues.value, `%${escapedEntityNameJson}%`),
+                    like(attributeValues.value, `%${escapedJsonEntityName}%`),
                 ),
             });
 

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -512,9 +512,7 @@ export async function getEntityIncomingLinks(
         .map((definition) => definition.id);
     const linkAttributeValues = [...exactValueMatches];
     if (multipleDefinitionIds.length > 0) {
-        const escapedJsonEncodedName = escapeForLike(
-            JSON.stringify(entityName),
-        );
+        const escapedEntityNameJson = escapeForLike(JSON.stringify(entityName));
         const legacyJsonArrayMatches =
             await storage().query.attributeValues.findMany({
                 where: and(
@@ -523,7 +521,7 @@ export async function getEntityIncomingLinks(
                         multipleDefinitionIds,
                     ),
                     eq(attributeValues.isDeleted, false),
-                    like(attributeValues.value, `%${escapedJsonEncodedName}%`),
+                    like(attributeValues.value, `%${escapedEntityNameJson}%`),
                 ),
             });
 


### PR DESCRIPTION
### Motivation
- Provide a way in the entity details header to quickly inspect all other entities that reference the current entity. 
- Present backlinks grouped by source entity type and surface which attribute(s) on the source entity reference this entity so admins can navigate and understand relations.

### Description
- Added a new route helper `KnownPages.DirectoryEntityLinks(entityTypeName, entityId)` to centralize navigation to the incoming-links page. 
- Added a `Povezani zapisi` button to the entity details header that opens the incoming-links view via `KnownPages.DirectoryEntityLinks`. 
- Implemented a new page at `/admin/directories/[entityType]/[entityId]/links` (`apps/app/app/admin/directories/[entityType]/[entityId]/links/page.tsx`) which shows breadcrumbs, groups incoming links by source entity type, lists source entities with links to their detail pages, and displays the attribute labels that reference the current entity. 
- Implemented `getEntityIncomingLinks(entityId)` in `packages/storage/src/repositories/entitiesRepo.ts` which discovers `ref:<entityType>` attribute definitions, matches both single and multi-reference values (including JSON arrays), filters and validates matches, groups results by source entity type, and returns source entity display names and the linking attribute metadata.

### Testing
- Ran lint with `pnpm lint --filter app --filter @gredice/storage`, which completed successfully but reported an existing unrelated suppression warning; lint run exited successfully. 
- Built the app with `pnpm build --filter app`, which completed successfully and the new route `/admin/directories/[entityType]/[entityId]/links` was included in the generated routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e256a71084832f9b963c834543ad6c)