### PR TITLE
Render image display attributes as thumbnails on entity details page

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -13,6 +13,7 @@ import {
     TabsList,
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
+import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
@@ -31,6 +32,19 @@ import { EntityImportMenu } from './EntityImportMenu';
 import { EntityStateSelect } from './EntityStateSelect';
 
 export const dynamic = 'force-dynamic';
+
+function imageAttributeValue(value: string) {
+    try {
+        const data = JSON.parse(value);
+        if (data && typeof data.url === 'string') {
+            return data.url;
+        }
+    } catch {
+        // ignored intentionally
+    }
+
+    return null;
+}
 
 export default async function EntityDetailsPage(props: {
     params: Promise<{ entityType: string; entityId: string }>;
@@ -139,13 +153,34 @@ export default async function EntityDetailsPage(props: {
                                 <Field
                                     key={d.id}
                                     name={d.label}
-                                    value={
-                                        entity.attributes.find(
+                                    value={(() => {
+                                        const value = entity.attributes.find(
                                             (a) =>
                                                 a.attributeDefinitionId ===
                                                 d.id,
-                                        )?.value ?? '-'
-                                    }
+                                        )?.value;
+                                        if (!value) {
+                                            return '-';
+                                        }
+
+                                        if (d.dataType === 'image') {
+                                            const imageUrl =
+                                                imageAttributeValue(value);
+                                            if (imageUrl) {
+                                                return (
+                                                    <Image
+                                                        src={imageUrl}
+                                                        alt={d.label}
+                                                        width={40}
+                                                        height={40}
+                                                        className="size-10 rounded-md object-cover"
+                                                    />
+                                                );
+                                            }
+                                        }
+
+                                        return value;
+                                    })()}
                                 />
                             ))}
                         </FieldSet>


### PR DESCRIPTION
### Motivation
- The entity details header displayed image attributes as raw JSON while the entities table shows thumbnails, causing inconsistent UX.
- The change aims to align top-of-page attribute display with the table behavior by rendering thumbnails for image-typed attributes.

### Description
- Import `next/image` and add a small helper `imageAttributeValue(value: string)` that safely parses stored JSON and extracts the `url` field.
- Update the header display mapping (`displayDefinitions.map`) to detect `d.dataType === 'image'` and render a 40×40 thumbnail using `Image` when a valid URL is available.
- Preserve existing fallbacks so missing values render `'-'` and non-image or invalid payloads render the raw value.

### Testing
- Ran `pnpm --filter app lint`, which completed successfully and reported a pre-existing Biome warning in an unrelated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e256e4cd5c832fbaa2dd5f29af35fc)