### PR TITLE
Add shared avatar selector and enable avatar updates in app user details

### DIFF
--- a/apps/app/app/(actions)/userActions.ts
+++ b/apps/app/app/(actions)/userActions.ts
@@ -2,6 +2,7 @@
 
 import {
     clearLoginFailedAttempts,
+    updateUser as storageUpdateUser,
     updateUserRole as storageUpdateUserRole,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
@@ -19,5 +20,19 @@ export async function unblockUserLogin(loginId: number) {
     await auth(['admin']);
 
     await clearLoginFailedAttempts(loginId);
+    revalidatePath(KnownPages.Users);
+}
+
+export async function updateUserAvatar(
+    userId: string,
+    avatarUrl: string | null,
+) {
+    await auth(['admin']);
+
+    await storageUpdateUser({
+        id: userId,
+        avatarUrl,
+    });
+    revalidatePath(KnownPages.User(userId));
     revalidatePath(KnownPages.Users);
 }

--- a/apps/app/app/admin/users/SelectUserAvatar.tsx
+++ b/apps/app/app/admin/users/SelectUserAvatar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { AvatarSelectionMenu } from '@gredice/ui/AvatarSelectionMenu';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { useTransition } from 'react';
+import { updateUserAvatar } from '../../(actions)/userActions';
+
+export function SelectUserAvatar({
+    userId,
+    avatarUrl,
+    displayName,
+}: {
+    userId: string;
+    avatarUrl: string | null;
+    displayName: string | null;
+}) {
+    const [isPending, startTransition] = useTransition();
+
+    const handleAvatarChange = (nextAvatarUrl: string | null) => {
+        startTransition(() => {
+            void updateUserAvatar(userId, nextAvatarUrl);
+        });
+    };
+
+    return (
+        <AvatarSelectionMenu
+            displayName={displayName}
+            onChange={handleAvatarChange}
+        >
+            <button
+                type="button"
+                className="cursor-pointer rounded-full disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isPending}
+            >
+                <UserAvatar
+                    avatarUrl={avatarUrl}
+                    username={displayName ?? undefined}
+                    size="lg"
+                />
+            </button>
+        </AvatarSelectionMenu>
+    );
+}

--- a/apps/app/app/admin/users/SelectUserAvatar.tsx
+++ b/apps/app/app/admin/users/SelectUserAvatar.tsx
@@ -34,7 +34,7 @@ export function SelectUserAvatar({
             >
                 <UserAvatar
                     avatarUrl={avatarUrl}
-                    username={displayName ?? undefined}
+                    displayName={displayName ?? ''}
                     size="lg"
                 />
             </button>

--- a/apps/app/app/admin/users/SelectUserAvatar.tsx
+++ b/apps/app/app/admin/users/SelectUserAvatar.tsx
@@ -34,7 +34,7 @@ export function SelectUserAvatar({
             >
                 <UserAvatar
                     avatarUrl={avatarUrl}
-                    displayName={displayName ?? ''}
+                    displayName={displayName ?? 'User'}
                     size="lg"
                 />
             </button>

--- a/apps/app/app/admin/users/[userId]/page.tsx
+++ b/apps/app/app/admin/users/[userId]/page.tsx
@@ -22,6 +22,7 @@ import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
 import { unblockUserLogin } from '../../../(actions)/userActions';
 import { ButtonImpersonateUser } from '../ButtonImpersonateUser';
+import { SelectUserAvatar } from '../SelectUserAvatar';
 import { SelectUserRole } from '../SelectUserRole';
 
 export default async function UserPage({
@@ -38,7 +39,15 @@ export default async function UserPage({
 
     const logins = await getUserWithLogins(user.userName);
 
-    const { id, createdAt, updatedAt, userName, accounts } = user;
+    const {
+        id,
+        createdAt,
+        updatedAt,
+        userName,
+        accounts,
+        avatarUrl,
+        displayName,
+    } = user;
 
     return (
         <Stack spacing={4}>
@@ -56,6 +65,16 @@ export default async function UserPage({
                     <FieldSet>
                         <Field name="ID korisnika" value={id} mono />
                         <Field name="Korisničko ime" value={userName} />
+                        <Field
+                            name="Avatar"
+                            value={
+                                <SelectUserAvatar
+                                    userId={id}
+                                    avatarUrl={avatarUrl}
+                                    displayName={displayName ?? userName}
+                                />
+                            }
+                        />
                         <Field
                             name="Uloga"
                             value={<SelectUserRole user={user} />}

--- a/packages/game/src/modals/components/UserProfileCard.tsx
+++ b/packages/game/src/modals/components/UserProfileCard.tsx
@@ -46,10 +46,16 @@ export function UserProfileCard() {
                                     displayName={currentUser.data?.displayName}
                                     onChange={handleAvatarChange}
                                 >
-                                    <ProfileAvatar
-                                        size="lg"
-                                        className="[&_img]:size-auto hover:outline min-w-20 min-h-20 shrink-0"
-                                    />
+                                    <button
+                                        type="button"
+                                        className="cursor-pointer rounded-full disabled:cursor-not-allowed disabled:opacity-60"
+                                        disabled={updateUser.isPending}
+                                    >
+                                        <ProfileAvatar
+                                            size="lg"
+                                            className="[&_img]:size-auto hover:outline min-w-20 min-h-20 shrink-0"
+                                        />
+                                    </button>
                                 </AvatarSelectionMenu>
                                 <Stack spacing={1}>
                                     <Input

--- a/packages/game/src/modals/components/UserProfileCard.tsx
+++ b/packages/game/src/modals/components/UserProfileCard.tsx
@@ -1,16 +1,7 @@
-import { initials } from '@signalco/js';
-import { Avatar } from '@signalco/ui-primitives/Avatar';
+import { AvatarSelectionMenu } from '@gredice/ui/AvatarSelectionMenu';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card, CardActions, CardContent } from '@signalco/ui-primitives/Card';
 import { Input } from '@signalco/ui-primitives/Input';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from '@signalco/ui-primitives/Menu';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
@@ -51,73 +42,15 @@ export function UserProfileCard() {
                     <form onSubmit={handleProfileUpdate}>
                         <Stack spacing={2}>
                             <Row spacing={2}>
-                                <DropdownMenu>
-                                    <DropdownMenuTrigger>
-                                        <ProfileAvatar
-                                            size="lg"
-                                            className="[&_img]:size-auto hover:outline min-w-20 min-h-20 shrink-0"
-                                        />
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent>
-                                        <DropdownMenuLabel>
-                                            Odaberi avatar
-                                        </DropdownMenuLabel>
-                                        <DropdownMenuSeparator />
-                                        <DropdownMenuItem
-                                            onClick={() =>
-                                                handleAvatarChange(null)
-                                            }
-                                            startDecorator={
-                                                <Avatar size="lg">
-                                                    {initials(
-                                                        currentUser.data
-                                                            ?.displayName ?? '',
-                                                    )}
-                                                </Avatar>
-                                            }
-                                        >
-                                            <DropdownMenuLabel>
-                                                Prazno
-                                            </DropdownMenuLabel>
-                                        </DropdownMenuItem>
-                                        <DropdownMenuItem
-                                            onClick={() =>
-                                                handleAvatarChange(
-                                                    'https://cdn.gredice.com/avatars/farmer-male.png',
-                                                )
-                                            }
-                                            startDecorator={
-                                                <Avatar
-                                                    src="https://cdn.gredice.com/avatars/farmer-male.png"
-                                                    alt="Farmer Avatar"
-                                                    size="lg"
-                                                />
-                                            }
-                                        >
-                                            <DropdownMenuLabel>
-                                                Farmer
-                                            </DropdownMenuLabel>
-                                        </DropdownMenuItem>
-                                        <DropdownMenuItem
-                                            onClick={() =>
-                                                handleAvatarChange(
-                                                    'https://cdn.gredice.com/avatars/farmer-female.png',
-                                                )
-                                            }
-                                            startDecorator={
-                                                <Avatar
-                                                    src="https://cdn.gredice.com/avatars/farmer-female.png"
-                                                    alt="Farmer Avatar"
-                                                    size="lg"
-                                                />
-                                            }
-                                        >
-                                            <DropdownMenuLabel>
-                                                Farmerka
-                                            </DropdownMenuLabel>
-                                        </DropdownMenuItem>
-                                    </DropdownMenuContent>
-                                </DropdownMenu>
+                                <AvatarSelectionMenu
+                                    displayName={currentUser.data?.displayName}
+                                    onChange={handleAvatarChange}
+                                >
+                                    <ProfileAvatar
+                                        size="lg"
+                                        className="[&_img]:size-auto hover:outline min-w-20 min-h-20 shrink-0"
+                                    />
+                                </AvatarSelectionMenu>
                                 <Stack spacing={1}>
                                     <Input
                                         name="displayName"

--- a/packages/ui/src/AvatarSelectionMenu/AvatarSelectionMenu.tsx
+++ b/packages/ui/src/AvatarSelectionMenu/AvatarSelectionMenu.tsx
@@ -10,12 +10,12 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@signalco/ui-primitives/Menu';
-import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { AVATAR_OPTIONS } from './avatarOptions';
 
 export type AvatarSelectionMenuProps = {
     displayName?: string | null;
-    children: ReactNode;
+    children: ReactElement;
     onChange: (avatarUrl: string | null) => void;
     title?: string;
     emptyLabel?: string;
@@ -30,7 +30,7 @@ export function AvatarSelectionMenu({
 }: AvatarSelectionMenuProps) {
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger>{children}</DropdownMenuTrigger>
+            <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
             <DropdownMenuContent>
                 <DropdownMenuLabel>{title}</DropdownMenuLabel>
                 <DropdownMenuSeparator />
@@ -47,11 +47,17 @@ export function AvatarSelectionMenu({
                         key={option.label}
                         onClick={() => onChange(option.avatarUrl)}
                         startDecorator={
-                            <Avatar
-                                src={option.avatarUrl ?? undefined}
-                                alt={option.label}
-                                size="lg"
-                            />
+                            option.avatarUrl ? (
+                                <Avatar
+                                    src={option.avatarUrl}
+                                    alt={option.label}
+                                    size="lg"
+                                />
+                            ) : (
+                                <Avatar size="lg">
+                                    {initials(option.label)}
+                                </Avatar>
+                            )
                         }
                     >
                         <DropdownMenuLabel>{option.label}</DropdownMenuLabel>

--- a/packages/ui/src/AvatarSelectionMenu/AvatarSelectionMenu.tsx
+++ b/packages/ui/src/AvatarSelectionMenu/AvatarSelectionMenu.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { initials } from '@signalco/js';
+import { Avatar } from '@signalco/ui-primitives/Avatar';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@signalco/ui-primitives/Menu';
+import type { ReactNode } from 'react';
+import { AVATAR_OPTIONS } from './avatarOptions';
+
+export type AvatarSelectionMenuProps = {
+    displayName?: string | null;
+    children: ReactNode;
+    onChange: (avatarUrl: string | null) => void;
+    title?: string;
+    emptyLabel?: string;
+};
+
+export function AvatarSelectionMenu({
+    displayName,
+    children,
+    onChange,
+    title = 'Odaberi avatar',
+    emptyLabel = 'Prazno',
+}: AvatarSelectionMenuProps) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger>{children}</DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuLabel>{title}</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                    onClick={() => onChange(null)}
+                    startDecorator={
+                        <Avatar size="lg">{initials(displayName ?? '')}</Avatar>
+                    }
+                >
+                    <DropdownMenuLabel>{emptyLabel}</DropdownMenuLabel>
+                </DropdownMenuItem>
+                {AVATAR_OPTIONS.map((option) => (
+                    <DropdownMenuItem
+                        key={option.label}
+                        onClick={() => onChange(option.avatarUrl)}
+                        startDecorator={
+                            <Avatar
+                                src={option.avatarUrl ?? undefined}
+                                alt={option.label}
+                                size="lg"
+                            />
+                        }
+                    >
+                        <DropdownMenuLabel>{option.label}</DropdownMenuLabel>
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/packages/ui/src/AvatarSelectionMenu/avatarOptions.ts
+++ b/packages/ui/src/AvatarSelectionMenu/avatarOptions.ts
@@ -1,0 +1,15 @@
+export type AvatarOption = {
+    label: string;
+    avatarUrl: string | null;
+};
+
+export const AVATAR_OPTIONS: readonly AvatarOption[] = [
+    {
+        label: 'Farmer',
+        avatarUrl: 'https://cdn.gredice.com/avatars/farmer-male.png',
+    },
+    {
+        label: 'Farmerka',
+        avatarUrl: 'https://cdn.gredice.com/avatars/farmer-female.png',
+    },
+];

--- a/packages/ui/src/AvatarSelectionMenu/index.ts
+++ b/packages/ui/src/AvatarSelectionMenu/index.ts
@@ -1,0 +1,2 @@
+export * from './AvatarSelectionMenu';
+export * from './avatarOptions';


### PR DESCRIPTION
### Motivation
- Centralize avatar selection UI so new avatars can be added once and used across the game and admin apps. 
- Allow admins to change a user's avatar from the app user details page using the same UX as the in-game profile editor.

### Description
- Added a reusable `AvatarSelectionMenu` component and exported `AVATAR_OPTIONS` in `@gredice/ui` (`packages/ui/src/AvatarSelectionMenu`).
- Replaced the hardcoded dropdown in the in-game `UserProfileCard` with `AvatarSelectionMenu` to reuse the shared avatar picker.
- Added a server action `updateUserAvatar` in `apps/app` that updates the user record (via `updateUser`) and revalidates `KnownPages.User` and `KnownPages.Users`.
- Implemented a client `SelectUserAvatar` component and wired it into the admin user details page (`apps/app/app/admin/users/[userId]/page.tsx`) to let admins change avatars inline.

### Testing
- Ran `pnpm lint --filter app --filter @gredice/ui --filter @gredice/game` and the lint run completed successfully with only existing unrelated workspace warnings.
- No database schema changes or migrations were required and no additional automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e257dd401c832faab65216c64ea926)