### PR TITLE
Support assigning farm users to planting tasks on Admin Schedule

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -6,6 +6,8 @@ import {
     createNotification,
     deleteRaisedBedField,
     earnSunflowers,
+    getAllRaisedBeds,
+    getAssignableFarmUsersByRaisedBedFieldIds,
     getEntityFormatted,
     getFarmUserRaisedBeds,
     getRaisedBed,
@@ -446,6 +448,58 @@ export async function cancelRaisedBedFieldAction(formData: FormData) {
     if (raisedBed.gardenId)
         revalidatePath(KnownPages.Garden(raisedBed.gardenId));
     revalidatePath(KnownPages.RaisedBed(raisedBedId));
+
+    return { success: true };
+}
+
+export async function assignRaisedBedFieldUserAction(
+    raisedBedFieldId: number,
+    assignedUserId: string | null,
+) {
+    const { userId } = await auth(['admin']);
+    const allRaisedBeds = await getAllRaisedBeds();
+    const matchedRaisedBed = allRaisedBeds.find((item) =>
+        item.fields.some((field) => field.id === raisedBedFieldId),
+    );
+    const matchedField = matchedRaisedBed?.fields.find(
+        (field) => field.id === raisedBedFieldId,
+    );
+
+    if (!matchedRaisedBed || !matchedField) {
+        throw new Error('Polje za sijanje nije pronađeno.');
+    }
+
+    const normalizedAssignedUserId = assignedUserId?.trim() || null;
+    if (matchedField.assignedUserId === normalizedAssignedUserId) {
+        return { success: true };
+    }
+
+    if (normalizedAssignedUserId) {
+        const assignableFarmUsersByRaisedBedFieldId =
+            await getAssignableFarmUsersByRaisedBedFieldIds([raisedBedFieldId]);
+        const assignableFarmUsers =
+            assignableFarmUsersByRaisedBedFieldId[raisedBedFieldId] ?? [];
+
+        if (
+            !assignableFarmUsers.some(
+                (farmUser) => farmUser.id === normalizedAssignedUserId,
+            )
+        ) {
+            throw new Error('Odabrani korisnik nije dostupan za ovo sijanje.');
+        }
+    }
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(
+            `${matchedRaisedBed.id.toString()}|${matchedField.positionIndex.toString()}`,
+            {
+                assignedUserId: normalizedAssignedUserId,
+                assignedBy: userId,
+            },
+        ),
+    );
+
+    await revalidateRaisedBedPaths(matchedRaisedBed);
 
     return { success: true };
 }

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -6,11 +6,12 @@ import {
     createNotification,
     deleteRaisedBedField,
     earnSunflowers,
-    getAllRaisedBeds,
     getAssignableFarmUsersByRaisedBedFieldIds,
     getEntityFormatted,
     getFarmUserRaisedBeds,
     getRaisedBed,
+    getRaisedBedFieldContext,
+    getRaisedBedFieldsWithEvents,
     knownEvents,
     moveRaisedBedFieldPlantHistory,
 } from '@gredice/storage';
@@ -457,13 +458,12 @@ export async function assignRaisedBedFieldUserAction(
     assignedUserId: string | null,
 ) {
     const { userId } = await auth(['admin']);
-    const allRaisedBeds = await getAllRaisedBeds();
-    const matchedRaisedBed = allRaisedBeds.find((item) =>
-        item.fields.some((field) => field.id === raisedBedFieldId),
-    );
-    const matchedField = matchedRaisedBed?.fields.find(
-        (field) => field.id === raisedBedFieldId,
-    );
+    const matchedRaisedBed = await getRaisedBedFieldContext(raisedBedFieldId);
+    const matchedField = matchedRaisedBed
+        ? (await getRaisedBedFieldsWithEvents(matchedRaisedBed.id)).find(
+              (field) => field.id === raisedBedFieldId,
+          )
+        : undefined;
 
     if (!matchedRaisedBed || !matchedField) {
         throw new Error('Polje za sijanje nije pronađeno.');

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -17,6 +17,7 @@ import {
 import { assignRaisedBedFieldUserAction } from '../../(actions)/raisedBedFieldsActions';
 
 const unassignedValue = '__unassigned__';
+const missingAssignedUserLabel = 'Trenutno dodijeljeni korisnik';
 
 type AssignableUser = Pick<
     RaisedBedFieldAssignableFarmUser,
@@ -57,8 +58,17 @@ export function AssignRaisedBedFieldModal({
             usersById.set(farmUser.id, farmUser);
         }
 
+        if (assignedUserId && !usersById.has(assignedUserId)) {
+            usersById.set(assignedUserId, {
+                id: assignedUserId,
+                userName: missingAssignedUserLabel,
+                displayName: null,
+                avatarUrl: null,
+            });
+        }
+
         return [...usersById.values()];
-    }, [farmUsers]);
+    }, [assignedUserId, farmUsers]);
 
     const pickerUsers = useMemo<UserPickerOption[]>(
         () =>
@@ -112,6 +122,7 @@ export function AssignRaisedBedFieldModal({
             type="button"
             className="rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
             title={`Dodjela: ${getUserLabel(selectedUser)}`}
+            aria-label={`Dodjela: ${getUserLabel(selectedUser)}`}
             disabled={!canOpen}
         >
             <UserAvatar
@@ -124,6 +135,11 @@ export function AssignRaisedBedFieldModal({
         <IconButton
             variant="plain"
             title={
+                canOpen
+                    ? 'Dodijeli korisnika'
+                    : 'Nema dostupnih korisnika za dodjelu'
+            }
+            aria-label={
                 canOpen
                     ? 'Dodijeli korisnika'
                     : 'Nema dostupnih korisnika za dodjelu'

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import type { RaisedBedFieldAssignableFarmUser } from '@gredice/storage';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { User } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useEffect, useMemo, useState } from 'react';
+import {
+    UserPickerField,
+    type UserPickerOption,
+} from '../../../components/shared/fields/UserPickerField';
+import { assignRaisedBedFieldUserAction } from '../../(actions)/raisedBedFieldsActions';
+
+const unassignedValue = '__unassigned__';
+
+type AssignableUser = Pick<
+    RaisedBedFieldAssignableFarmUser,
+    'id' | 'userName' | 'displayName' | 'avatarUrl'
+>;
+
+interface AssignRaisedBedFieldModalProps {
+    raisedBedFieldId: number;
+    label: string;
+    farmUsers: AssignableUser[];
+    assignedUserId?: string | null;
+    disabled?: boolean;
+}
+
+function getUserLabel(user: AssignableUser) {
+    return user.displayName
+        ? `${user.displayName} (${user.userName})`
+        : user.userName;
+}
+
+export function AssignRaisedBedFieldModal({
+    raisedBedFieldId,
+    label,
+    farmUsers,
+    assignedUserId,
+    disabled = false,
+}: AssignRaisedBedFieldModalProps) {
+    const [open, setOpen] = useState(false);
+    const [selectedUserId, setSelectedUserId] = useState(
+        assignedUserId ?? unassignedValue,
+    );
+    const [isLoading, setIsLoading] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    const selectableUsers = useMemo(() => {
+        const usersById = new Map<string, AssignableUser>();
+        for (const farmUser of farmUsers) {
+            usersById.set(farmUser.id, farmUser);
+        }
+
+        return [...usersById.values()];
+    }, [farmUsers]);
+
+    const pickerUsers = useMemo<UserPickerOption[]>(
+        () =>
+            selectableUsers.map((user) => ({
+                id: user.id,
+                label: getUserLabel(user),
+                searchText: `${user.displayName ?? ''} ${user.userName}`,
+            })),
+        [selectableUsers],
+    );
+
+    const initialSelection = assignedUserId ?? unassignedValue;
+    const canOpen =
+        !disabled && (selectableUsers.length > 0 || !!assignedUserId);
+
+    useEffect(() => {
+        if (!open) {
+            setSelectedUserId(initialSelection);
+            setErrorMessage(null);
+        }
+    }, [initialSelection, open]);
+
+    const selectedUser = useMemo(
+        () =>
+            assignedUserId
+                ? selectableUsers.find((user) => user.id === assignedUserId)
+                : undefined,
+        [assignedUserId, selectableUsers],
+    );
+
+    const handleSubmit = async () => {
+        setIsLoading(true);
+        setErrorMessage(null);
+
+        try {
+            await assignRaisedBedFieldUserAction(
+                raisedBedFieldId,
+                selectedUserId === unassignedValue ? null : selectedUserId,
+            );
+            setOpen(false);
+        } catch (error) {
+            console.error('Error assigning planting user:', error);
+            setErrorMessage('Greška pri spremanju dodjele korisnika.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const trigger = selectedUser ? (
+        <button
+            type="button"
+            className="rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+            title={`Dodjela: ${getUserLabel(selectedUser)}`}
+            disabled={!canOpen}
+        >
+            <UserAvatar
+                avatarUrl={selectedUser.avatarUrl}
+                displayName={selectedUser.displayName ?? selectedUser.userName}
+                className="size-7"
+            />
+        </button>
+    ) : (
+        <IconButton
+            variant="plain"
+            title={
+                canOpen
+                    ? 'Dodijeli korisnika'
+                    : 'Nema dostupnih korisnika za dodjelu'
+            }
+            disabled={!canOpen}
+        >
+            <User className="size-4 shrink-0" />
+        </IconButton>
+    );
+
+    return (
+        <Modal
+            trigger={trigger}
+            title={`Dodjela: ${label}`}
+            open={open}
+            onOpenChange={setOpen}
+        >
+            <Stack spacing={2}>
+                <Typography level="h5">Dodjela sijanja</Typography>
+                <Typography>
+                    Odaberi korisnika kojem želiš dodijeliti zadatak{' '}
+                    <strong>{label}</strong>.
+                </Typography>
+
+                {selectableUsers.length > 0 ? (
+                    <UserPickerField
+                        users={pickerUsers}
+                        value={selectedUserId}
+                        onValueChange={setSelectedUserId}
+                        emptyOption={{
+                            value: unassignedValue,
+                            label: 'Bez dodjele',
+                        }}
+                        resetKey={open}
+                    />
+                ) : (
+                    <Typography level="body2" className="text-muted-foreground">
+                        Na ovu farmu još nije dodijeljen nijedan korisnik.
+                    </Typography>
+                )}
+
+                {errorMessage && (
+                    <Typography level="body2" className="text-red-600">
+                        {errorMessage}
+                    </Typography>
+                )}
+
+                <Row spacing={1} justifyContent="end">
+                    <Button
+                        variant="outlined"
+                        onClick={() => setOpen(false)}
+                        disabled={isLoading}
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        variant="solid"
+                        onClick={handleSubmit}
+                        loading={isLoading}
+                        disabled={
+                            isLoading ||
+                            selectedUserId === initialSelection ||
+                            (selectableUsers.length === 0 && !assignedUserId)
+                        }
+                    >
+                        Spremi dodjelu
+                    </Button>
+                </Row>
+            </Stack>
+        </Modal>
+    );
+}

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { calculatePlantsPerField, FIELD_SIZE_CM } from '@gredice/js/plants';
+import type { RaisedBedFieldAssignableFarmUser } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Calendar, Close } from '@signalco/ui-icons';
@@ -12,6 +13,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
 import { AcceptRaisedBedFieldModal } from './AcceptRaisedBedFieldModal';
+import { AssignRaisedBedFieldModal } from './AssignRaisedBedFieldModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { CancelRaisedBedFieldModal } from './CancelRaisedBedFieldModal';
 import { CompletePlantingModal } from './CompletePlantingModal';
@@ -32,6 +34,10 @@ interface RaisedBedPlantingScheduleSectionProps {
     raisedBeds: RaisedBed[];
     scheduledFields: RaisedBedField[];
     plantSorts: EntityStandardized[] | null | undefined;
+    assignableFarmUsersByRaisedBedFieldId: Record<
+        number,
+        RaisedBedFieldAssignableFarmUser[]
+    >;
 }
 
 export function RaisedBedPlantingScheduleSection({
@@ -39,6 +45,7 @@ export function RaisedBedPlantingScheduleSection({
     raisedBeds,
     scheduledFields,
     plantSorts,
+    assignableFarmUsersByRaisedBedFieldId,
 }: RaisedBedPlantingScheduleSectionProps) {
     if (raisedBeds.length === 0) {
         return null;
@@ -246,6 +253,17 @@ export function RaisedBedPlantingScheduleSection({
                                     </Typography>
                                 </Row>
                                 <Row>
+                                    <AssignRaisedBedFieldModal
+                                        raisedBedFieldId={field.id}
+                                        label={fieldLabel}
+                                        farmUsers={
+                                            assignableFarmUsersByRaisedBedFieldId[
+                                                field.id
+                                            ] ?? []
+                                        }
+                                        assignedUserId={field.assignedUserId}
+                                        disabled={fieldLocked}
+                                    />
                                     <RescheduleRaisedBedFieldModal
                                         field={{
                                             raisedBedId: field.raisedBedId,

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
@@ -1,3 +1,4 @@
+import { getAssignableFarmUsersByRaisedBedFieldIds } from '@gredice/storage';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { RaisedBedPlantingScheduleSection } from './RaisedBedPlantingScheduleSection';
@@ -24,6 +25,10 @@ export async function ScheduleDayPlantingsSection({
     const affectedRaisedBedIds = [
         ...new Set(scheduledFields.map((field) => field.raisedBedId)),
     ];
+    const assignableFarmUsersByRaisedBedFieldId =
+        await getAssignableFarmUsersByRaisedBedFieldIds(
+            scheduledFields.map((field) => field.id),
+        );
     const raisedBedGroups = groupRaisedBedsForSchedule(
         raisedBeds,
         affectedRaisedBedIds,
@@ -40,6 +45,9 @@ export async function ScheduleDayPlantingsSection({
                         raisedBeds={beds}
                         scheduledFields={scheduledFields}
                         plantSorts={plantSorts}
+                        assignableFarmUsersByRaisedBedFieldId={
+                            assignableFarmUsersByRaisedBedFieldId
+                        }
                     />
                 );
             })}

--- a/apps/app/app/admin/schedule/types.ts
+++ b/apps/app/app/admin/schedule/types.ts
@@ -11,6 +11,9 @@ export type RaisedBedField = {
     plantSowDate?: Date;
     plantGrowthDate?: Date;
     plantReadyDate?: Date;
+    assignedUserId?: string | null;
+    assignedBy?: string;
+    assignedAt?: Date;
     createdAt: Date;
     updatedAt: Date;
     isDeleted: boolean;

--- a/apps/app/app/admin/schedule/types.ts
+++ b/apps/app/app/admin/schedule/types.ts
@@ -12,7 +12,7 @@ export type RaisedBedField = {
     plantGrowthDate?: Date;
     plantReadyDate?: Date;
     assignedUserId?: string | null;
-    assignedBy?: string;
+    assignedBy?: string | null;
     assignedAt?: Date;
     createdAt: Date;
     updatedAt: Date;

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -236,6 +236,9 @@ function mockRaisedBedField(
         plantDeadDate: undefined,
         plantHarvestedDate: undefined,
         plantRemovedDate: undefined,
+        assignedUserId: null,
+        assignedBy: null,
+        assignedAt: undefined,
         createdAt: plantSowDate,
         updatedAt: plantReadyDate ?? plantGrowthDate,
     };

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -158,11 +158,22 @@ export type RaisedBedFieldPlantSchedulePayload = {
     scheduledDate: string | null | undefined;
 };
 
-export type RaisedBedFieldPlantUpdatePayload = {
-    status?: string;
-    assignedUserId?: string | null;
-    assignedBy?: string;
-};
+export type RaisedBedFieldPlantUpdatePayload =
+    | {
+          status: string;
+          assignedUserId?: string | null;
+          assignedBy?: string | null;
+      }
+    | {
+          status?: string;
+          assignedUserId: string;
+          assignedBy: string;
+      }
+    | {
+          status?: string;
+          assignedUserId: null;
+          assignedBy?: string | null;
+      };
 
 export type RaisedBedFieldPlantReplaceSortPayload = {
     plantSortId: string;

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -161,8 +161,8 @@ export type RaisedBedFieldPlantSchedulePayload = {
 export type RaisedBedFieldPlantUpdatePayload =
     | {
           status: string;
-          assignedUserId?: string | null;
-          assignedBy?: string | null;
+          assignedUserId?: undefined;
+          assignedBy?: undefined;
       }
     | {
           status?: string;

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -159,7 +159,9 @@ export type RaisedBedFieldPlantSchedulePayload = {
 };
 
 export type RaisedBedFieldPlantUpdatePayload = {
-    status: string;
+    status?: string;
+    assignedUserId?: string | null;
+    assignedBy?: string;
 };
 
 export type RaisedBedFieldPlantReplaceSortPayload = {

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -22,6 +22,7 @@ import {
     type UpdateGardenBlock,
     type UpdateGardenStack,
     type UpdateRaisedBed,
+    users,
 } from '../schema';
 import {
     type InsertRaisedBedField,
@@ -74,7 +75,81 @@ export type RaisedBedFieldPlantCycle = {
     plantRemovedDate?: Date;
     stoppedDate?: Date;
     toBeRemoved: boolean;
+    assignedUserId?: string | null;
+    assignedBy?: string;
+    assignedAt?: Date;
 };
+
+export type RaisedBedFieldAssignableFarmUser = {
+    id: string;
+    userName: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    farmId: number;
+};
+
+export async function getAssignableFarmUsersByRaisedBedFieldIds(
+    raisedBedFieldIds: number[],
+) {
+    const uniqueRaisedBedFieldIds = Array.from(new Set(raisedBedFieldIds));
+    if (uniqueRaisedBedFieldIds.length === 0) {
+        const emptyAssignableFarmUsersByRaisedBedFieldId: Record<
+            number,
+            RaisedBedFieldAssignableFarmUser[]
+        > = {};
+
+        return emptyAssignableFarmUsersByRaisedBedFieldId;
+    }
+
+    const rows = await storage()
+        .select({
+            raisedBedFieldId: raisedBedFields.id,
+            farmId: farmUsers.farmId,
+            userId: users.id,
+            userName: users.userName,
+            displayName: users.displayName,
+            avatarUrl: users.avatarUrl,
+        })
+        .from(raisedBedFields)
+        .innerJoin(raisedBeds, eq(raisedBedFields.raisedBedId, raisedBeds.id))
+        .innerJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
+        .innerJoin(farmUsers, eq(gardens.farmId, farmUsers.farmId))
+        .innerJoin(users, eq(farmUsers.userId, users.id))
+        .where(
+            and(
+                inArray(raisedBedFields.id, uniqueRaisedBedFieldIds),
+                eq(raisedBedFields.isDeleted, false),
+                eq(raisedBeds.isDeleted, false),
+                eq(gardens.isDeleted, false),
+            ),
+        )
+        .orderBy(asc(raisedBedFields.id), asc(users.userName));
+
+    const assignableFarmUsersByRaisedBedFieldId: Record<
+        number,
+        RaisedBedFieldAssignableFarmUser[]
+    > = {};
+
+    for (const row of rows) {
+        const existingUsers =
+            assignableFarmUsersByRaisedBedFieldId[row.raisedBedFieldId] ?? [];
+        if (existingUsers.some((user) => user.id === row.userId)) {
+            continue;
+        }
+
+        existingUsers.push({
+            id: row.userId,
+            userName: row.userName,
+            displayName: row.displayName,
+            avatarUrl: row.avatarUrl,
+            farmId: row.farmId,
+        });
+        assignableFarmUsersByRaisedBedFieldId[row.raisedBedFieldId] =
+            existingUsers;
+    }
+
+    return assignableFarmUsersByRaisedBedFieldId;
+}
 
 function fieldRowPriority(
     field: SelectRaisedBedField,
@@ -396,6 +471,9 @@ function summarizePlantCycle(
     let active = false;
     let toBeRemoved = false;
     let stoppedDate: Date | undefined;
+    let assignedUserId: string | null | undefined;
+    let assignedBy: string | undefined;
+    let assignedAt: Date | undefined;
 
     for (const plantCycleEvent of plantCycleEvents) {
         const data = plantCycleEvent.data as
@@ -429,6 +507,9 @@ function summarizePlantCycle(
             plantDeadDate = undefined;
             plantHarvestedDate = undefined;
             plantRemovedDate = undefined;
+            assignedUserId = undefined;
+            assignedBy = undefined;
+            assignedAt = undefined;
             continue;
         }
 
@@ -466,6 +547,16 @@ function summarizePlantCycle(
         ) {
             plantStatus =
                 typeof data?.status === 'string' ? data.status : plantStatus;
+            if (
+                typeof data?.assignedUserId === 'string' ||
+                data?.assignedUserId === null
+            ) {
+                assignedUserId = data.assignedUserId;
+                assignedAt = plantCycleEvent.createdAt;
+            }
+            if (typeof data?.assignedBy === 'string') {
+                assignedBy = data.assignedBy;
+            }
 
             if (
                 plantStatus === 'pendingVerification' ||
@@ -518,6 +609,9 @@ function summarizePlantCycle(
         plantRemovedDate,
         stoppedDate,
         toBeRemoved,
+        assignedUserId,
+        assignedBy,
+        assignedAt,
     };
 }
 
@@ -1107,6 +1201,9 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
         let active = true;
         let toBeRemoved = false;
         let stoppedDate: Date | undefined;
+        let assignedUserId: string | null | undefined;
+        let assignedBy: string | undefined;
+        let assignedAt: Date | undefined;
 
         for (const event of events) {
             const data = event.data as Record<string, unknown> | undefined;
@@ -1126,6 +1223,9 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 plantDeadDate = undefined;
                 plantHarvestedDate = undefined;
                 plantRemovedDate = undefined;
+                assignedUserId = undefined;
+                assignedBy = undefined;
+                assignedAt = undefined;
 
                 // Parse plant sort ID if provided
                 if (typeof data?.plantSortId === 'number') {
@@ -1179,6 +1279,16 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                     typeof data?.status === 'string'
                         ? data?.status
                         : plantStatus;
+                if (
+                    typeof data?.assignedUserId === 'string' ||
+                    data?.assignedUserId === null
+                ) {
+                    assignedUserId = data.assignedUserId;
+                    assignedAt = event.createdAt;
+                }
+                if (typeof data?.assignedBy === 'string') {
+                    assignedBy = data.assignedBy;
+                }
                 if (
                     plantStatus === 'pendingVerification' ||
                     plantStatus === 'sowed'
@@ -1239,6 +1349,9 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
             active,
             toBeRemoved,
             stoppedDate,
+            assignedUserId,
+            assignedBy,
+            assignedAt,
         };
     });
 }

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -570,9 +570,11 @@ function summarizePlantCycle(
                 data?.assignedUserId === null
             ) {
                 assignedUserId = data.assignedUserId;
-                assignedAt = plantCycleEvent.createdAt;
                 if (data.assignedUserId === null) {
                     assignedBy = null;
+                    assignedAt = undefined;
+                } else {
+                    assignedAt = plantCycleEvent.createdAt;
                 }
             }
             if (typeof data?.assignedBy === 'string') {
@@ -1305,9 +1307,11 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                     data?.assignedUserId === null
                 ) {
                     assignedUserId = data.assignedUserId;
-                    assignedAt = event.createdAt;
                     if (data.assignedUserId === null) {
                         assignedBy = null;
+                        assignedAt = undefined;
+                    } else {
+                        assignedAt = event.createdAt;
                     }
                 }
                 if (typeof data?.assignedBy === 'string') {

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -76,7 +76,7 @@ export type RaisedBedFieldPlantCycle = {
     stoppedDate?: Date;
     toBeRemoved: boolean;
     assignedUserId?: string | null;
-    assignedBy?: string;
+    assignedBy?: string | null;
     assignedAt?: Date;
 };
 
@@ -133,10 +133,6 @@ export async function getAssignableFarmUsersByRaisedBedFieldIds(
     for (const row of rows) {
         const existingUsers =
             assignableFarmUsersByRaisedBedFieldId[row.raisedBedFieldId] ?? [];
-        if (existingUsers.some((user) => user.id === row.userId)) {
-            continue;
-        }
-
         existingUsers.push({
             id: row.userId,
             userName: row.userName,
@@ -149,6 +145,28 @@ export async function getAssignableFarmUsersByRaisedBedFieldIds(
     }
 
     return assignableFarmUsersByRaisedBedFieldId;
+}
+
+export async function getRaisedBedFieldContext(raisedBedFieldId: number) {
+    const rows = await storage()
+        .select({
+            id: raisedBeds.id,
+            gardenId: raisedBeds.gardenId,
+            accountId: raisedBeds.accountId,
+            positionIndex: raisedBedFields.positionIndex,
+        })
+        .from(raisedBedFields)
+        .innerJoin(raisedBeds, eq(raisedBedFields.raisedBedId, raisedBeds.id))
+        .where(
+            and(
+                eq(raisedBedFields.id, raisedBedFieldId),
+                eq(raisedBedFields.isDeleted, false),
+                eq(raisedBeds.isDeleted, false),
+            ),
+        )
+        .limit(1);
+
+    return rows[0] ?? null;
 }
 
 function fieldRowPriority(
@@ -472,7 +490,7 @@ function summarizePlantCycle(
     let toBeRemoved = false;
     let stoppedDate: Date | undefined;
     let assignedUserId: string | null | undefined;
-    let assignedBy: string | undefined;
+    let assignedBy: string | null | undefined;
     let assignedAt: Date | undefined;
 
     for (const plantCycleEvent of plantCycleEvents) {
@@ -553,6 +571,9 @@ function summarizePlantCycle(
             ) {
                 assignedUserId = data.assignedUserId;
                 assignedAt = plantCycleEvent.createdAt;
+                if (data.assignedUserId === null) {
+                    assignedBy = null;
+                }
             }
             if (typeof data?.assignedBy === 'string') {
                 assignedBy = data.assignedBy;
@@ -1202,7 +1223,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
         let toBeRemoved = false;
         let stoppedDate: Date | undefined;
         let assignedUserId: string | null | undefined;
-        let assignedBy: string | undefined;
+        let assignedBy: string | null | undefined;
         let assignedAt: Date | undefined;
 
         for (const event of events) {
@@ -1285,6 +1306,9 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 ) {
                     assignedUserId = data.assignedUserId;
                     assignedAt = event.createdAt;
+                    if (data.assignedUserId === null) {
+                        assignedBy = null;
+                    }
                 }
                 if (typeof data?.assignedBy === 'string') {
                     assignedBy = data.assignedBy;

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -102,7 +102,7 @@ export async function getAssignableFarmUsersByRaisedBedFieldIds(
     }
 
     const rows = await storage()
-        .select({
+        .selectDistinct({
             raisedBedFieldId: raisedBedFields.id,
             farmId: farmUsers.farmId,
             userId: users.id,

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -944,13 +944,13 @@ test('raised bed field assignment metadata is projected for assign and unassign 
     assert.ok(plantCycle);
     assert.strictEqual(plantCycle.assignedUserId, null);
     assert.strictEqual(plantCycle.assignedBy, null);
-    assert.ok(plantCycle.assignedAt instanceof Date);
+    assert.strictEqual(plantCycle.assignedAt, undefined);
 
     [field] = await getRaisedBedFieldsWithEvents(raisedBedId);
     assert.ok(field);
     assert.strictEqual(field.assignedUserId, null);
     assert.strictEqual(field.assignedBy, null);
-    assert.ok(field.assignedAt instanceof Date);
+    assert.strictEqual(field.assignedAt, undefined);
 });
 
 test('upsertRaisedBedField reuses the same row after a field is deleted and planted again', async () => {

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -1,15 +1,18 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    assignUserToFarm,
     createAccount,
     createEvent,
     createNotification,
     createOperation,
+    createUserWithPassword,
     deleteRaisedBedField,
     getAllOperations,
     getNotifications,
     getOrCreateShoppingCart,
     getRaisedBed,
+    getRaisedBedFieldPlantCycles,
     getRaisedBedFieldsWithEvents,
     knownEvents,
     knownEventTypes,
@@ -878,6 +881,76 @@ test('getRaisedBed returns the latest plant cycle after a field is removed and r
     assert.strictEqual(field?.plantRemovedDate, undefined);
     assert.strictEqual(field?.stoppedDate, undefined);
     assert.strictEqual(field?.toBeRemoved, false);
+});
+
+test('raised bed field assignment metadata is projected for assign and unassign updates', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-assignment');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    const assignedUserId = await createUserWithPassword(
+        'assigned-user@example.com',
+        'password',
+    );
+    const assignedByUserId = await createUserWithPassword(
+        'assigned-by@example.com',
+        'password',
+    );
+
+    await Promise.all([
+        assignUserToFarm(farmId, assignedUserId),
+        assignUserToFarm(farmId, assignedByUserId),
+        upsertRaisedBedField({
+            raisedBedId,
+            positionIndex: 0,
+        }),
+    ]);
+
+    const aggregateId = `${raisedBedId.toString()}|0`;
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            plantSortId: '101',
+            scheduledDate: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            assignedUserId,
+            assignedBy: assignedByUserId,
+        }),
+    );
+
+    let [plantCycle] = await getRaisedBedFieldPlantCycles(raisedBedId);
+    assert.ok(plantCycle);
+    assert.strictEqual(plantCycle.assignedUserId, assignedUserId);
+    assert.strictEqual(plantCycle.assignedBy, assignedByUserId);
+    assert.ok(plantCycle.assignedAt instanceof Date);
+
+    let [field] = await getRaisedBedFieldsWithEvents(raisedBedId);
+    assert.ok(field);
+    assert.strictEqual(field.assignedUserId, assignedUserId);
+    assert.strictEqual(field.assignedBy, assignedByUserId);
+    assert.ok(field.assignedAt instanceof Date);
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            assignedUserId: null,
+        }),
+    );
+
+    [plantCycle] = await getRaisedBedFieldPlantCycles(raisedBedId);
+    assert.ok(plantCycle);
+    assert.strictEqual(plantCycle.assignedUserId, null);
+    assert.strictEqual(plantCycle.assignedBy, null);
+    assert.ok(plantCycle.assignedAt instanceof Date);
+
+    [field] = await getRaisedBedFieldsWithEvents(raisedBedId);
+    assert.ok(field);
+    assert.strictEqual(field.assignedUserId, null);
+    assert.strictEqual(field.assignedBy, null);
+    assert.ok(field.assignedAt instanceof Date);
 });
 
 test('upsertRaisedBedField reuses the same row after a field is deleted and planted again', async () => {


### PR DESCRIPTION
### Motivation

- Planting (sowing) tasks in the Admin Schedule were missing farm user assignments while operations already supported assignees; planting tasks need the same per-field assignment UX and server-side handling.

### Description

- Added a client assignment UI: new `AssignRaisedBedFieldModal` to assign/unassign a farm user to a planting row and show avatar when assigned.
- Wired schedule UI to load and pass per-field assignable users into planting rows by calling `getAssignableFarmUsersByRaisedBedFieldIds` from the schedule loader and rendering the modal in `RaisedBedPlantingScheduleSection`.
- Implemented server action `assignRaisedBedFieldUserAction` to validate assignment against farm membership and emit a `plantUpdate` event containing `assignedUserId` / `assignedBy` (supports unassigning with `null`).
- Extended storage and projections to persist and expose assignment metadata: added `assignedUserId`, `assignedBy`, and `assignedAt` to raised-bed field event payloads and to the raised-bed field projections, and added query helper `getAssignableFarmUsersByRaisedBedFieldIds`.
- Updated schedule types to include `assignedUserId`, `assignedBy`, and `assignedAt` so assignment state is available to the UI.

### Testing

- Ran `pnpm lint --filter app --filter @gredice/storage`, which completed successfully (auto-fixes applied and a single lint warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e257453c38832f9ced8367fb4fee5e)