### PR TITLE
fix(farm): avoid passing server handlers to client modal

### DIFF
--- a/apps/farm/app/schedule/CompletePlantingModal.tsx
+++ b/apps/farm/app/schedule/CompletePlantingModal.tsx
@@ -7,15 +7,18 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
+import { completeFarmPlanting } from './actions';
 
 interface CompletePlantingModalProps {
     label: string;
-    onConfirm: () => Promise<void>;
+    raisedBedId: number;
+    positionIndex: number;
 }
 
 export function CompletePlantingModal({
     label,
-    onConfirm,
+    raisedBedId,
+    positionIndex,
 }: CompletePlantingModalProps) {
     const [open, setOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -23,7 +26,7 @@ export function CompletePlantingModal({
     const handleConfirm = async () => {
         try {
             setIsSubmitting(true);
-            await onConfirm();
+            await completeFarmPlanting(raisedBedId, positionIndex);
             setOpen(false);
         } catch (error) {
             console.error('Error completing planting:', error);

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -5,7 +5,6 @@ import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { completeFarmPlanting } from './actions';
 import { CompletePlantingModal } from './CompletePlantingModal';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
@@ -118,13 +117,6 @@ export function FarmSchedulePlantingsSection({
                                         field.plantStatus,
                                     );
 
-                                    const handleConfirm = async () => {
-                                        await completeFarmPlanting(
-                                            field.raisedBedId,
-                                            field.positionIndex,
-                                        );
-                                    };
-
                                     return (
                                         <div
                                             key={field.id}
@@ -147,8 +139,11 @@ export function FarmSchedulePlantingsSection({
                                                     ) : (
                                                         <CompletePlantingModal
                                                             label={field.label}
-                                                            onConfirm={
-                                                                handleConfirm
+                                                            raisedBedId={
+                                                                field.raisedBedId
+                                                            }
+                                                            positionIndex={
+                                                                field.positionIndex
                                                             }
                                                         />
                                                     )}


### PR DESCRIPTION
### Motivation
- Fix a Next.js server/client serialization error caused by passing an event handler from a Server Component into a Client Component (`Event handlers cannot be passed to Client Component props`).
- Ensure `/schedule` can render without runtime failures by only passing serializable props across the server/client boundary.

### Description
- Stop passing an inline `onConfirm` function from `FarmSchedulePlantingsSection` into the client `CompletePlantingModal` and remove the now-unused import of `completeFarmPlanting` from the server component file (`apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx`).
- Change `CompletePlantingModal` props to accept `raisedBedId` and `positionIndex` (serializable numbers) instead of a callback, and call `completeFarmPlanting` directly inside the client confirm handler (`apps/farm/app/schedule/CompletePlantingModal.tsx`).
- Update types and the confirm flow so the client modal handles the server action invocation and submission state without crossing the server/client boundary with functions.

### Testing
- Ran lint for the `farm` package with `pnpm lint --filter farm`, which completed successfully and applied a small automatic fix.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e373ca0e0c832fbf3e4a35b6a76483)