### PR TITLE
farm: improve planting schedule task details and assignment controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             app_farm:
               - apps/farm/**
               - packages/client/**
+              - packages/js/**
               - packages/storage/**
               - packages/ui/**
               - .github/workflows/**
@@ -162,7 +163,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: changes
-    if: success() && github.event_name == 'pull_request' && needs.changes.outputs.packages_storage == 'true'
+    if: success() && github.event_name == 'pull_request' &&
+      needs.changes.outputs.packages_storage == 'true'
     env:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -199,7 +201,8 @@ jobs:
         run: npm i --g vercel@latest
 
       - name: ⚙️ Pull Vercel Environment Information
-        run: vercel env pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel env pull --yes --environment=preview --token=${{
+          secrets.VERCEL_TOKEN }}
         working-directory: ./packages/storage/
 
       - name: ⚒️ Test app
@@ -236,4 +239,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: exit 1
-        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+        if: ${{ always() && (contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')) }}

--- a/apps/farm/app/flags.ts
+++ b/apps/farm/app/flags.ts
@@ -16,6 +16,4 @@ const hypertuneAdapter = createHypertuneAdapter<FlagValues, Context>({
     identify,
 });
 
-export const showUIFlag = flag(
-    hypertuneAdapter.declarations.showUI,
-);
+export const showUIFlag = flag(hypertuneAdapter.declarations.showUI);

--- a/apps/farm/app/schedule/FarmScheduleDay.tsx
+++ b/apps/farm/app/schedule/FarmScheduleDay.tsx
@@ -33,6 +33,7 @@ export function FarmScheduleDay({
                 <FarmSchedulePlantingsSectionContent
                     dayDataPromise={dayDataPromise}
                     plantSortsPromise={plantSortsPromise}
+                    userId={userId}
                 />
             </Suspense>
             <Suspense fallback={<FarmScheduleSectionSkeleton />}>

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -1,6 +1,11 @@
-import type { EntityStandardized } from '@gredice/storage';
+import { calculatePlantsPerField } from '@gredice/js/plants';
+import type {
+    EntityStandardized,
+    RaisedBedFieldAssignableFarmUser,
+} from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
+import { UserAvatar } from '@gredice/ui/users';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -21,6 +26,8 @@ interface FarmSchedulePlantingsSectionProps {
     raisedBeds: FarmScheduleDayData['raisedBeds'];
     scheduledFields: FarmScheduleDayData['scheduledFields'];
     plantSorts: EntityStandardized[] | null | undefined;
+    userId: string;
+    assignedUserByFieldId: Map<number, RaisedBedFieldAssignableFarmUser>;
 }
 
 function buildFieldLabel(
@@ -30,13 +37,18 @@ function buildFieldLabel(
     const sort = field.plantSortId
         ? plantSortById.get(field.plantSortId)
         : null;
-    return `${field.positionIndex + 1} - sijanje${sort ? `: ${sort.information?.name ?? 'Nepoznato'}` : ''}`;
+    const { totalPlants } = calculatePlantsPerField(
+        sort?.information?.plant?.attributes?.seedingDistance,
+    );
+    return `${field.positionIndex + 1} - sijanje: ${totalPlants}${sort ? ` ${sort.information?.name ?? 'Nepoznato'}` : ''}`;
 }
 
 export function FarmSchedulePlantingsSection({
     raisedBeds,
     scheduledFields,
     plantSorts,
+    userId,
+    assignedUserByFieldId,
 }: FarmSchedulePlantingsSectionProps) {
     if (scheduledFields.length === 0) {
         return null;
@@ -116,11 +128,17 @@ export function FarmSchedulePlantingsSection({
                                     const approved = isFieldApproved(
                                         field.plantStatus,
                                     );
+                                    const canComplete =
+                                        !completed &&
+                                        (!field.assignedUserId ||
+                                            field.assignedUserId === userId);
+                                    const assignedUser =
+                                        assignedUserByFieldId.get(field.id);
 
                                     return (
                                         <div
                                             key={field.id}
-                                            className="rounded-lg border bg-white px-3 py-2"
+                                            className={`rounded-lg border bg-white px-3 py-2 ${!canComplete ? 'opacity-70' : ''}`}
                                         >
                                             <Row
                                                 spacing={1}
@@ -136,7 +154,7 @@ export function FarmSchedulePlantingsSection({
                                                             checked
                                                             disabled
                                                         />
-                                                    ) : (
+                                                    ) : canComplete ? (
                                                         <CompletePlantingModal
                                                             label={field.label}
                                                             raisedBedId={
@@ -146,6 +164,13 @@ export function FarmSchedulePlantingsSection({
                                                                 field.positionIndex
                                                             }
                                                         />
+                                                    ) : (
+                                                        <div title="Sijanje je dodijeljeno drugom korisniku.">
+                                                            <Checkbox
+                                                                className="size-5"
+                                                                disabled
+                                                            />
+                                                        </div>
                                                     )}
                                                     <Stack
                                                         spacing={0.5}
@@ -211,6 +236,23 @@ export function FarmSchedulePlantingsSection({
                                                         </Row>
                                                     </Stack>
                                                 </Row>
+                                                {assignedUser && (
+                                                    <div
+                                                        className="shrink-0"
+                                                        title={`Dodijeljeno: ${assignedUser.displayName ?? assignedUser.userName}`}
+                                                    >
+                                                        <UserAvatar
+                                                            avatarUrl={
+                                                                assignedUser.avatarUrl
+                                                            }
+                                                            displayName={
+                                                                assignedUser.displayName ??
+                                                                assignedUser.userName
+                                                            }
+                                                            className="size-7"
+                                                        />
+                                                    </div>
+                                                )}
                                             </Row>
                                         </div>
                                     );

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -37,10 +37,7 @@ function buildFieldLabel(
     const sort = field.plantSortId
         ? plantSortById.get(field.plantSortId)
         : null;
-    if (!field.plantSortId) {
-        return `${field.positionIndex + 1} - sijanje: ?`;
-    }
-    if (!sort) {
+    if (!field.plantSortId || !sort) {
         return `${field.positionIndex + 1} - sijanje: ? Nepoznato`;
     }
 
@@ -48,8 +45,8 @@ function buildFieldLabel(
         sort.information?.plant?.attributes?.seedingDistance;
     const totalPlants = seedingDistance
         ? calculatePlantsPerField(seedingDistance).totalPlants
-        : '?';
-    return `${field.positionIndex + 1} - sijanje: ${totalPlants} ${sort.information?.name ?? 'Nepoznato'}`;
+        : null;
+    return `${field.positionIndex + 1} - sijanje: ${totalPlants ?? '?'} ${sort.information?.name ?? 'Nepoznato'}`;
 }
 
 export function FarmSchedulePlantingsSection({

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -5,7 +5,7 @@ import type {
 } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
-import { UserAvatar } from '@gredice/ui/users';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -37,10 +37,19 @@ function buildFieldLabel(
     const sort = field.plantSortId
         ? plantSortById.get(field.plantSortId)
         : null;
-    const { totalPlants } = calculatePlantsPerField(
-        sort?.information?.plant?.attributes?.seedingDistance,
-    );
-    return `${field.positionIndex + 1} - sijanje: ${totalPlants}${sort ? ` ${sort.information?.name ?? 'Nepoznato'}` : ''}`;
+    if (!field.plantSortId) {
+        return `${field.positionIndex + 1} - sijanje: ?`;
+    }
+    if (!sort) {
+        return `${field.positionIndex + 1} - sijanje: ? Nepoznato`;
+    }
+
+    const seedingDistance =
+        sort.information?.plant?.attributes?.seedingDistance;
+    const totalPlants = seedingDistance
+        ? calculatePlantsPerField(seedingDistance).totalPlants
+        : '?';
+    return `${field.positionIndex + 1} - sijanje: ${totalPlants} ${sort.information?.name ?? 'Nepoznato'}`;
 }
 
 export function FarmSchedulePlantingsSection({
@@ -128,17 +137,19 @@ export function FarmSchedulePlantingsSection({
                                     const approved = isFieldApproved(
                                         field.plantStatus,
                                     );
-                                    const canComplete =
+                                    const lockedByAssignment =
                                         !completed &&
-                                        (!field.assignedUserId ||
-                                            field.assignedUserId === userId);
+                                        !!field.assignedUserId &&
+                                        field.assignedUserId !== userId;
+                                    const canComplete =
+                                        !completed && !lockedByAssignment;
                                     const assignedUser =
                                         assignedUserByFieldId.get(field.id);
 
                                     return (
                                         <div
                                             key={field.id}
-                                            className={`rounded-lg border bg-white px-3 py-2 ${!canComplete ? 'opacity-70' : ''}`}
+                                            className={`rounded-lg border bg-white px-3 py-2 ${lockedByAssignment ? 'opacity-70' : ''}`}
                                         >
                                             <Row
                                                 spacing={1}

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx
@@ -1,3 +1,7 @@
+import {
+    getAssignableFarmUsersByRaisedBedFieldIds,
+    type RaisedBedFieldAssignableFarmUser,
+} from '@gredice/storage';
 import { FarmSchedulePlantingsSection } from './FarmSchedulePlantingsSection';
 import type { FarmScheduleDayData } from './scheduleData';
 
@@ -6,11 +10,13 @@ interface FarmSchedulePlantingsSectionContentProps {
     plantSortsPromise: ReturnType<
         typeof import('./scheduleData').getFarmSchedulePlantSorts
     >;
+    userId: string;
 }
 
 export async function FarmSchedulePlantingsSectionContent({
     dayDataPromise,
     plantSortsPromise,
+    userId,
 }: FarmSchedulePlantingsSectionContentProps) {
     const { raisedBeds, scheduledFields } = await dayDataPromise;
 
@@ -18,13 +24,36 @@ export async function FarmSchedulePlantingsSectionContent({
         return null;
     }
 
-    const plantSorts = await plantSortsPromise;
+    const [plantSorts, assignableFarmUsersByRaisedBedFieldId] =
+        await Promise.all([
+            plantSortsPromise,
+            getAssignableFarmUsersByRaisedBedFieldIds(
+                scheduledFields.map((field) => field.id),
+            ),
+        ]);
+    const assignedUserByFieldId = new Map<
+        number,
+        RaisedBedFieldAssignableFarmUser
+    >();
+    for (const field of scheduledFields) {
+        if (!field.assignedUserId) {
+            continue;
+        }
+        const assignedUser = (
+            assignableFarmUsersByRaisedBedFieldId[field.id] ?? []
+        ).find((user) => user.id === field.assignedUserId);
+        if (assignedUser) {
+            assignedUserByFieldId.set(field.id, assignedUser);
+        }
+    }
 
     return (
         <FarmSchedulePlantingsSection
             raisedBeds={raisedBeds}
             scheduledFields={scheduledFields}
             plantSorts={plantSorts}
+            userId={userId}
+            assignedUserByFieldId={assignedUserByFieldId}
         />
     );
 }

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -45,6 +45,10 @@ async function assertFarmerCanCompletePlanting(
         throw new Error('Nemaš dozvolu za označavanje ovog sijanja.');
     }
 
+    if (field.assignedUserId && field.assignedUserId !== userId) {
+        throw new Error('Ovo sijanje je dodijeljeno drugom korisniku.');
+    }
+
     return field;
 }
 

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -37,6 +37,7 @@
     "devDependencies": {
         "@biomejs/biome": "2.4.12",
         "@gredice/client": "workspace:*",
+        "@gredice/js": "workspace:*",
         "@gredice/storage": "workspace:*",
         "@gredice/ui": "workspace:*",
         "@mdxeditor/editor": "3.54.1",

--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -19,6 +19,4 @@ const hypertuneAdapter = createHypertuneAdapter<FlagValues, Context>({
 export const lSystemPlantsFlag = flag(
     hypertuneAdapter.declarations.lSystemPlants,
 );
-export const recipesFlag = flag(
-    hypertuneAdapter.declarations.recipes,
-);
+export const recipesFlag = flag(hypertuneAdapter.declarations.recipes);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       '@gredice/client':
         specifier: workspace:*
         version: link:../../packages/client
+      '@gredice/js':
+        specifier: workspace:*
+        version: link:../../packages/js
       '@gredice/storage':
         specifier: workspace:*
         version: link:../../packages/storage


### PR DESCRIPTION
### Motivation

- Planting rows in the farm schedule should show the number of plants like the admin UI so users can see task details at a glance. 
- Planting tasks that are assigned to a specific user should display the assignee and be visually and interactively gated for other users. 
- The server-side action for completing planting must enforce assignment restrictions to prevent unauthorized completions.

### Description

- Show calculated plant counts and sort name in planting labels by using `calculatePlantsPerField` and updating `buildFieldLabel` in `apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx`.
- Fetch assignable users for scheduled fields with `getAssignableFarmUsersByRaisedBedFieldIds` in `apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx` and map `assignedUserId` to a concrete user object passed down to the planting section.
- Pass the current `userId` from `FarmScheduleDay` into the plantings content and section so UI can determine whether the current user may complete a task (`apps/farm/app/schedule/FarmScheduleDay.tsx`, `FarmSchedulePlantingsSectionContent.tsx`, `FarmSchedulePlantingsSection.tsx`).
- Update planting task cards to show the assigned user's avatar, disable the completion control for tasks assigned to another user, and dim those cards (`apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx`).
- Enforce assignment authorization on the server by rejecting attempts to complete a planting assigned to someone else in `assertFarmerCanCompletePlanting` inside `apps/farm/app/schedule/actions.ts`.
- Minor formatting tweak applied by linting to `apps/farm/app/flags.ts` during autofix.

### Testing

- Ran `pnpm lint --filter farm`, which completed successfully (lint autofixed formatting and reported no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c415b7d8832f9da5ecb288f94701)