### PR TITLE
Add explicit camera capture action for schedule task photo uploads

### DIFF
--- a/apps/app/app/admin/schedule/CompleteOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CompleteOperationModal.tsx
@@ -100,6 +100,7 @@ export function CompleteOperationModal({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const cameraInputRef = useRef<HTMLInputElement>(null);
 
     const attachImages = conditions?.completionAttachImages;
     const attachRequired = conditions?.completionAttachImagesRequired;
@@ -113,6 +114,7 @@ export function CompleteOperationModal({
         if (!open) {
             setUploadItems([]);
             if (fileInputRef.current) fileInputRef.current.value = '';
+            if (cameraInputRef.current) cameraInputRef.current.value = '';
         }
     };
 
@@ -128,6 +130,7 @@ export function CompleteOperationModal({
             setErrorMessage(null);
         }
         if (fileInputRef.current) fileInputRef.current.value = '';
+        if (cameraInputRef.current) cameraInputRef.current.value = '';
     };
 
     const updateUploadItem = (
@@ -314,6 +317,22 @@ export function CompleteOperationModal({
                             className="hidden"
                             onChange={handleFileChange}
                         />
+                        <input
+                            ref={cameraInputRef}
+                            type="file"
+                            accept="image/*"
+                            capture="environment"
+                            className="hidden"
+                            onChange={handleFileChange}
+                        />
+                        <Button
+                            variant="outlined"
+                            type="button"
+                            onClick={() => cameraInputRef.current?.click()}
+                            disabled={isSubmitting}
+                        >
+                            Uslikaj fotografiju
+                        </Button>
                         <Button
                             variant="outlined"
                             type="button"

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -100,6 +100,7 @@ export function CompleteOperationModal({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const cameraInputRef = useRef<HTMLInputElement>(null);
 
     const attachImages = conditions?.completionAttachImages;
     const attachRequired = conditions?.completionAttachImagesRequired;
@@ -113,6 +114,7 @@ export function CompleteOperationModal({
         if (!open) {
             setUploadItems([]);
             if (fileInputRef.current) fileInputRef.current.value = '';
+            if (cameraInputRef.current) cameraInputRef.current.value = '';
         }
     };
 
@@ -128,6 +130,7 @@ export function CompleteOperationModal({
             setErrorMessage(null);
         }
         if (fileInputRef.current) fileInputRef.current.value = '';
+        if (cameraInputRef.current) cameraInputRef.current.value = '';
     };
 
     const updateUploadItem = (
@@ -309,6 +312,22 @@ export function CompleteOperationModal({
                             className="hidden"
                             onChange={handleFileChange}
                         />
+                        <input
+                            ref={cameraInputRef}
+                            type="file"
+                            accept="image/*"
+                            capture="environment"
+                            className="hidden"
+                            onChange={handleFileChange}
+                        />
+                        <Button
+                            variant="outlined"
+                            type="button"
+                            onClick={() => cameraInputRef.current?.click()}
+                            disabled={isSubmitting}
+                        >
+                            Uslikaj fotografiju
+                        </Button>
                         <Button
                             variant="outlined"
                             type="button"


### PR DESCRIPTION
### Motivation
- Mobile and tablet users could only open the gallery/file picker when completing schedule tasks that require photos, making direct camera capture inconvenient or unavailable.
- Provide a clear, separate action to invoke the device camera so photos can be taken inline when completing tasks.

### Description
- Added a new `cameraInputRef` and a hidden file input with `capture="environment"` to both schedule completion modals (`apps/app/app/admin/schedule/CompleteOperationModal.tsx` and `apps/farm/app/schedule/CompleteOperationModal.tsx`).
- Added a dedicated `Uslikaj fotografiju` button that triggers the camera input and preserves the existing `Dodaj slike` gallery/file picker flow.
- Cleared both the gallery and camera inputs on modal close and after selection to allow re-selecting the same file(s) reliably.
- Changes are limited to the two schedule completion modal components and reuse the existing `handleFileChange` and upload logic.

### Testing
- Ran `pnpm lint --filter app --filter farm` which completed successfully but reported an environment engine warning and one unrelated pre-existing Biome warning.
- Ran `pnpm --dir apps/app exec biome check app/admin/schedule/CompleteOperationModal.tsx` which passed with no fixes required.
- Ran `pnpm --dir apps/farm exec biome check app/schedule/CompleteOperationModal.tsx` which passed with no fixes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c4745ee0832f83a390b5c557b96b)