### PR TITLE
Add assignee selection to bulk operation creation

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -8,6 +8,7 @@ import {
     createNotification,
     createOperation,
     earnSunflowers,
+    getAssignableFarmUsersByGardenIds,
     getAssignableFarmUsersByOperationIds,
     getEntityFormatted,
     getFarmUserAcceptedOperationById,
@@ -77,7 +78,7 @@ export async function createOperationAction(formData: FormData) {
 }
 
 export async function bulkCreateOperationsAction(formData: FormData) {
-    await auth(['admin']);
+    const { userId } = await auth(['admin']);
     const entityId = formData.get('entityId')
         ? Number(formData.get('entityId'))
         : undefined;
@@ -87,7 +88,34 @@ export async function bulkCreateOperationsAction(formData: FormData) {
     const scheduledDate = formData.get('scheduledDate')
         ? new Date(formData.get('scheduledDate') as string)
         : undefined;
+    const selectedAssignedUserId =
+        (formData.get('assignedUserId') as string | null)?.trim() || undefined;
     const targets = formData.getAll('targets') as string[];
+
+    if (selectedAssignedUserId) {
+        const uniqueGardenIds = Array.from(
+            new Set(
+                targets
+                    .map((target) => target.split('|')[1])
+                    .filter((gardenId) => gardenId)
+                    .map((gardenId) => Number(gardenId))
+                    .filter((gardenId) => !Number.isNaN(gardenId)),
+            ),
+        );
+        const assignableFarmUsersByGardenId =
+            await getAssignableFarmUsersByGardenIds(uniqueGardenIds);
+        for (const gardenId of uniqueGardenIds) {
+            const isUserAssignableToGarden =
+                assignableFarmUsersByGardenId[gardenId]?.some(
+                    (user) => user.id === selectedAssignedUserId,
+                ) ?? false;
+            if (!isUserAssignableToGarden) {
+                throw new Error(
+                    'Odabrani korisnik nije dostupan za sve odabrane radnje.',
+                );
+            }
+        }
+    }
 
     for (const target of targets) {
         const [accountId, gardenId, raisedBedId, raisedBedFieldId] =
@@ -113,6 +141,14 @@ export async function bulkCreateOperationsAction(formData: FormData) {
             await notifyOperationUpdate(operationId, 'scheduled', {
                 scheduledDate: scheduledDate.toISOString(),
             });
+        }
+        if (selectedAssignedUserId) {
+            await createEvent(
+                knownEvents.operations.assignedV1(operationId.toString(), {
+                    assignedUserId: selectedAssignedUserId,
+                    assignedBy: userId,
+                }),
+            );
         }
     }
     revalidatePath(KnownPages.Schedule);

--- a/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
@@ -7,9 +7,12 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useEffect, useMemo, useState } from 'react';
 import { getEntities } from '../../../components/shared/attributes/actions/entitiesActions';
+import { UserPickerField } from '../../../components/shared/fields/UserPickerField';
 import { bulkCreateOperationsAction } from '../../(actions)/operationActions';
 import { SelectEntity } from '../raised-beds/[raisedBedId]/SelectEntity';
 import { TargetsSelectionList } from './TargetsSelectionList';
+
+const unassignedValue = '__unassigned__';
 
 export type BulkOperationCreateModalProps = {
     gardens: Array<{
@@ -25,17 +28,25 @@ export type BulkOperationCreateModalProps = {
         gardenId?: number | null;
         fields: Array<{ id: number; positionIndex: number }>;
     }>;
+    assignableUsers: Array<{
+        id: string;
+        userName: string;
+        displayName: string | null;
+    }>;
 };
 
 export function BulkOperationCreateModal({
     gardens,
     raisedBeds,
+    assignableUsers,
 }: BulkOperationCreateModalProps) {
     const [selectedOperationId, setSelectedOperationId] = useState<
         string | null
     >(null);
     const [operations, setOperations] =
         useState<Awaited<ReturnType<typeof getEntities>>>();
+    const [selectedAssignedUserId, setSelectedAssignedUserId] =
+        useState(unassignedValue);
 
     useEffect(() => {
         // Load operations metadata to determine application type
@@ -81,6 +92,33 @@ export function BulkOperationCreateModal({
                         name="scheduledDate"
                         type="datetime-local"
                         label="Planirani datum (opcionalno)"
+                    />
+                    <UserPickerField
+                        users={assignableUsers.map((user) => ({
+                            id: user.id,
+                            label: user.displayName
+                                ? `${user.displayName} (${user.userName})`
+                                : user.userName,
+                            searchText: `${user.displayName ?? ''} ${
+                                user.userName
+                            }`,
+                        }))}
+                        value={selectedAssignedUserId}
+                        onValueChange={setSelectedAssignedUserId}
+                        label="Dodijeljeni korisnik (opcionalno)"
+                        emptyOption={{
+                            value: unassignedValue,
+                            label: 'Bez dodjele',
+                        }}
+                    />
+                    <input
+                        type="hidden"
+                        name="assignedUserId"
+                        value={
+                            selectedAssignedUserId === unassignedValue
+                                ? ''
+                                : selectedAssignedUserId
+                        }
                     />
                     <TargetsSelectionList
                         name="targets"

--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -1,7 +1,7 @@
 import {
     getAllRaisedBeds,
-    getAssignableFarmUsersByGardenIds,
     getGardens,
+    getUniqueAssignableFarmUsersByGardenIds,
 } from '@gredice/storage';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -25,24 +25,15 @@ export default async function OperationsPage({
         getGardens(),
         getAllRaisedBeds(),
     ]);
-    const assignableFarmUsersByGardenId =
-        await getAssignableFarmUsersByGardenIds(
+    const assignableUsers = (
+        await getUniqueAssignableFarmUsersByGardenIds(
             gardens.map((garden) => garden.id),
-        );
-    const assignableUsers = Array.from(
-        new Map(
-            Object.values(assignableFarmUsersByGardenId)
-                .flat()
-                .map((user) => [
-                    user.id,
-                    {
-                        id: user.id,
-                        userName: user.userName,
-                        displayName: user.displayName,
-                    },
-                ]),
-        ).values(),
-    );
+        )
+    ).map((user) => ({
+        id: user.id,
+        userName: user.userName,
+        displayName: user.displayName,
+    }));
 
     const params = await searchParams;
     const fromFilter =

--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -1,4 +1,8 @@
-import { getAllRaisedBeds, getGardens } from '@gredice/storage';
+import {
+    getAllRaisedBeds,
+    getAssignableFarmUsersByGardenIds,
+    getGardens,
+} from '@gredice/storage';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -21,6 +25,24 @@ export default async function OperationsPage({
         getGardens(),
         getAllRaisedBeds(),
     ]);
+    const assignableFarmUsersByGardenId =
+        await getAssignableFarmUsersByGardenIds(
+            gardens.map((garden) => garden.id),
+        );
+    const assignableUsers = Array.from(
+        new Map(
+            Object.values(assignableFarmUsersByGardenId)
+                .flat()
+                .map((user) => [
+                    user.id,
+                    {
+                        id: user.id,
+                        userName: user.userName,
+                        displayName: user.displayName,
+                    },
+                ]),
+        ).values(),
+    );
 
     const params = await searchParams;
     const fromFilter =
@@ -36,6 +58,7 @@ export default async function OperationsPage({
                 <BulkOperationCreateModal
                     gardens={gardens}
                     raisedBeds={raisedBeds}
+                    assignableUsers={assignableUsers}
                 />
             </Row>
             <OperationsFilters />

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -80,7 +80,7 @@ export type RaisedBedFieldPlantCycle = {
     assignedAt?: Date;
 };
 
-export type RaisedBedFieldAssignableFarmUser = {
+export type AssignableFarmUser = {
     id: string;
     userName: string;
     displayName: string | null;
@@ -88,13 +88,11 @@ export type RaisedBedFieldAssignableFarmUser = {
     farmId: number;
 };
 
-export type GardenAssignableFarmUser = {
-    id: string;
-    userName: string;
-    displayName: string | null;
-    avatarUrl: string | null;
-    farmId: number;
-};
+export type RaisedBedFieldAssignableFarmUser = AssignableFarmUser;
+
+export type GardenAssignableFarmUser = AssignableFarmUser;
+
+export type UniqueGardenAssignableFarmUser = Omit<AssignableFarmUser, 'farmId'>;
 
 type FarmAssignableUserRow = {
     farmId: number;
@@ -153,12 +151,9 @@ export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
         gardenFarmRows.map((row) => row.farmId),
     );
 
-    const assignableFarmUsersByFarmId: Record<
-        number,
-        GardenAssignableFarmUser[]
-    > = {};
+    const usersByFarmId: Record<number, GardenAssignableFarmUser[]> = {};
     for (const row of farmUserRows) {
-        const existingUsers = assignableFarmUsersByFarmId[row.farmId] ?? [];
+        const existingUsers = usersByFarmId[row.farmId] ?? [];
         existingUsers.push({
             id: row.userId,
             userName: row.userName,
@@ -166,7 +161,7 @@ export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
             avatarUrl: row.avatarUrl,
             farmId: row.farmId,
         });
-        assignableFarmUsersByFarmId[row.farmId] = existingUsers;
+        usersByFarmId[row.farmId] = existingUsers;
     }
 
     const assignableFarmUsersByGardenId: Record<
@@ -176,7 +171,7 @@ export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
 
     for (const row of gardenFarmRows) {
         assignableFarmUsersByGardenId[row.gardenId] =
-            assignableFarmUsersByFarmId[row.farmId] ?? [];
+            usersByFarmId[row.farmId] ?? [];
     }
 
     return assignableFarmUsersByGardenId;
@@ -187,7 +182,7 @@ export async function getUniqueAssignableFarmUsersByGardenIds(
 ) {
     const uniqueGardenIds = Array.from(new Set(gardenIds));
     if (uniqueGardenIds.length === 0) {
-        return [] as GardenAssignableFarmUser[];
+        return [] as UniqueGardenAssignableFarmUser[];
     }
 
     const gardenFarmRows = await storage()
@@ -214,7 +209,6 @@ export async function getUniqueAssignableFarmUsersByGardenIds(
                     userName: row.userName,
                     displayName: row.displayName,
                     avatarUrl: row.avatarUrl,
-                    farmId: row.farmId,
                 },
             ]),
         ).values(),

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -96,6 +96,34 @@ export type GardenAssignableFarmUser = {
     farmId: number;
 };
 
+type FarmAssignableUserRow = {
+    farmId: number;
+    userId: string;
+    userName: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+};
+
+async function getAssignableFarmUserRowsByFarmIds(farmIds: number[]) {
+    const uniqueFarmIds = Array.from(new Set(farmIds));
+    if (uniqueFarmIds.length === 0) {
+        return [] as FarmAssignableUserRow[];
+    }
+
+    return storage()
+        .selectDistinct({
+            farmId: farmUsers.farmId,
+            userId: users.id,
+            userName: users.userName,
+            displayName: users.displayName,
+            avatarUrl: users.avatarUrl,
+        })
+        .from(farmUsers)
+        .innerJoin(users, eq(farmUsers.userId, users.id))
+        .where(inArray(farmUsers.farmId, uniqueFarmIds))
+        .orderBy(asc(farmUsers.farmId), asc(users.userName));
+}
+
 export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
     const uniqueGardenIds = Array.from(new Set(gardenIds));
     if (uniqueGardenIds.length === 0) {
@@ -107,33 +135,30 @@ export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
         return emptyAssignableFarmUsersByGardenId;
     }
 
-    const rows = await storage()
-        .selectDistinct({
+    const gardenFarmRows = await storage()
+        .select({
             gardenId: gardens.id,
-            farmId: farmUsers.farmId,
-            userId: users.id,
-            userName: users.userName,
-            displayName: users.displayName,
-            avatarUrl: users.avatarUrl,
+            farmId: gardens.farmId,
         })
         .from(gardens)
-        .innerJoin(farmUsers, eq(gardens.farmId, farmUsers.farmId))
-        .innerJoin(users, eq(farmUsers.userId, users.id))
         .where(
             and(
                 inArray(gardens.id, uniqueGardenIds),
                 eq(gardens.isDeleted, false),
             ),
         )
-        .orderBy(asc(gardens.id), asc(users.userName));
+        .orderBy(asc(gardens.id));
 
-    const assignableFarmUsersByGardenId: Record<
+    const farmUserRows = await getAssignableFarmUserRowsByFarmIds(
+        gardenFarmRows.map((row) => row.farmId),
+    );
+
+    const assignableFarmUsersByFarmId: Record<
         number,
         GardenAssignableFarmUser[]
     > = {};
-
-    for (const row of rows) {
-        const existingUsers = assignableFarmUsersByGardenId[row.gardenId] ?? [];
+    for (const row of farmUserRows) {
+        const existingUsers = assignableFarmUsersByFarmId[row.farmId] ?? [];
         existingUsers.push({
             id: row.userId,
             userName: row.userName,
@@ -141,10 +166,59 @@ export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
             avatarUrl: row.avatarUrl,
             farmId: row.farmId,
         });
-        assignableFarmUsersByGardenId[row.gardenId] = existingUsers;
+        assignableFarmUsersByFarmId[row.farmId] = existingUsers;
+    }
+
+    const assignableFarmUsersByGardenId: Record<
+        number,
+        GardenAssignableFarmUser[]
+    > = {};
+
+    for (const row of gardenFarmRows) {
+        assignableFarmUsersByGardenId[row.gardenId] =
+            assignableFarmUsersByFarmId[row.farmId] ?? [];
     }
 
     return assignableFarmUsersByGardenId;
+}
+
+export async function getUniqueAssignableFarmUsersByGardenIds(
+    gardenIds: number[],
+) {
+    const uniqueGardenIds = Array.from(new Set(gardenIds));
+    if (uniqueGardenIds.length === 0) {
+        return [] as GardenAssignableFarmUser[];
+    }
+
+    const gardenFarmRows = await storage()
+        .select({
+            farmId: gardens.farmId,
+        })
+        .from(gardens)
+        .where(
+            and(
+                inArray(gardens.id, uniqueGardenIds),
+                eq(gardens.isDeleted, false),
+            ),
+        );
+    const farmUserRows = await getAssignableFarmUserRowsByFarmIds(
+        gardenFarmRows.map((row) => row.farmId),
+    );
+
+    return Array.from(
+        new Map(
+            farmUserRows.map((row) => [
+                row.userId,
+                {
+                    id: row.userId,
+                    userName: row.userName,
+                    displayName: row.displayName,
+                    avatarUrl: row.avatarUrl,
+                    farmId: row.farmId,
+                },
+            ]),
+        ).values(),
+    );
 }
 
 export async function getAssignableFarmUsersByRaisedBedFieldIds(

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -88,6 +88,65 @@ export type RaisedBedFieldAssignableFarmUser = {
     farmId: number;
 };
 
+export type GardenAssignableFarmUser = {
+    id: string;
+    userName: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    farmId: number;
+};
+
+export async function getAssignableFarmUsersByGardenIds(gardenIds: number[]) {
+    const uniqueGardenIds = Array.from(new Set(gardenIds));
+    if (uniqueGardenIds.length === 0) {
+        const emptyAssignableFarmUsersByGardenId: Record<
+            number,
+            GardenAssignableFarmUser[]
+        > = {};
+
+        return emptyAssignableFarmUsersByGardenId;
+    }
+
+    const rows = await storage()
+        .selectDistinct({
+            gardenId: gardens.id,
+            farmId: farmUsers.farmId,
+            userId: users.id,
+            userName: users.userName,
+            displayName: users.displayName,
+            avatarUrl: users.avatarUrl,
+        })
+        .from(gardens)
+        .innerJoin(farmUsers, eq(gardens.farmId, farmUsers.farmId))
+        .innerJoin(users, eq(farmUsers.userId, users.id))
+        .where(
+            and(
+                inArray(gardens.id, uniqueGardenIds),
+                eq(gardens.isDeleted, false),
+            ),
+        )
+        .orderBy(asc(gardens.id), asc(users.userName));
+
+    const assignableFarmUsersByGardenId: Record<
+        number,
+        GardenAssignableFarmUser[]
+    > = {};
+
+    for (const row of rows) {
+        const existingUsers = assignableFarmUsersByGardenId[row.gardenId] ?? [];
+        existingUsers.push({
+            id: row.userId,
+            userName: row.userName,
+            displayName: row.displayName,
+            avatarUrl: row.avatarUrl,
+            farmId: row.farmId,
+        });
+        assignableFarmUsersByGardenId[row.gardenId] = existingUsers;
+    }
+
+    return assignableFarmUsersByGardenId;
+}
+
 export async function getAssignableFarmUsersByRaisedBedFieldIds(
     raisedBedFieldIds: number[],
 ) {


### PR DESCRIPTION
### Motivation
- Allow admins to optionally assign a user to all operations created via the bulk-create UI so assignments can be applied at creation time and recorded in the event stream.
- Validate assignment eligibility per garden to avoid creating operations with invalid assignees.

### Description
- Update server action `bulkCreateOperationsAction` to read `assignedUserId`, validate the user is assignable for every selected garden using a new helper, and emit `knownEvents.operations.assignedV1` for each created operation.
- Add a `UserPickerField` to the bulk-create modal (`BulkOperationCreateModal.tsx`) with an `emptyOption` and a hidden `assignedUserId` input so the selected assignee is submitted with the form.
- Load assignable users on the operations page via `getAssignableFarmUsersByGardenIds` and pass a deduplicated list into the modal (`page.tsx`).
- Add `GardenAssignableFarmUser` type and `getAssignableFarmUsersByGardenIds` implementation to `packages/storage/src/repositories/gardensRepo.ts` to efficiently fetch assignable farm users per garden.

### Testing
- Ran `pnpm lint --filter app`, which completed successfully (one lint warning reported but run succeeded).
- Ran `pnpm build --filter app` (Next.js build), which completed successfully and compiled the app without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c52caaa4832fa42fad8e1f2ed012)