### PR TITLE
✨ layout: reorganize action buttons and in raised bedRefactor Raised schedule sections to horizontal layoutand spacing of action buttons, labels and. Wrap the label,

### DIFF
--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -183,32 +183,39 @@ export function RaisedBedOperationsScheduleSection({
 
     return (
         <Stack key={physicalId} spacing={1}>
-            <Row spacing={0.5} className="items-center flex-wrap gap-y-1">
+            <Row spacing={1} className="w-full items-center flex-wrap gap-y-1">
                 <BulkApproveRaisedBedButton
                     physicalId={physicalId.toString()}
                     fields={[]}
                     operations={operationsToApprove}
                 />
-                <BulkRescheduleRaisedBedButton
-                    physicalId={physicalId.toString()}
-                    fields={[]}
-                    operations={operationsToReschedule}
-                />
-                <BulkAssignRaisedBedButton
-                    physicalId={physicalId.toString()}
-                    fields={[]}
-                    operations={operationsToAssign}
-                />
-                <RaisedBedLabel physicalId={physicalId} />
-                <Typography level="body2" className="text-muted-foreground">
-                    Vrijeme: {formatMinutes(durations.completed, true)} /{' '}
-                    {formatMinutes(durations.approved)} (
-                    {formatMinutes(durations.total)})
-                </Typography>
-                <CopyTasksButton
-                    physicalId={physicalId.toString()}
-                    tasks={copyTasks}
-                />
+                <Row
+                    spacing={0.5}
+                    className="min-w-0 grow items-center flex-wrap gap-y-1"
+                >
+                    <RaisedBedLabel physicalId={physicalId} />
+                    <Typography level="body2" className="text-muted-foreground">
+                        Vrijeme: {formatMinutes(durations.completed, true)} /{' '}
+                        {formatMinutes(durations.approved)} (
+                        {formatMinutes(durations.total)})
+                    </Typography>
+                    <CopyTasksButton
+                        physicalId={physicalId.toString()}
+                        tasks={copyTasks}
+                    />
+                </Row>
+                <Row spacing={0.5} className="ml-auto shrink-0 items-center">
+                    <BulkAssignRaisedBedButton
+                        physicalId={physicalId.toString()}
+                        fields={[]}
+                        operations={operationsToAssign}
+                    />
+                    <BulkRescheduleRaisedBedButton
+                        physicalId={physicalId.toString()}
+                        fields={[]}
+                        operations={operationsToReschedule}
+                    />
+                </Row>
             </Row>
             <Stack spacing={1}>
                 {!dayOperations.length && (

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -146,32 +146,39 @@ export function RaisedBedPlantingScheduleSection({
 
     return (
         <Stack key={physicalId} spacing={1}>
-            <Row spacing={0.5} className="items-center flex-wrap gap-y-1">
+            <Row spacing={1} className="w-full items-center flex-wrap gap-y-1">
                 <BulkApproveRaisedBedButton
                     physicalId={physicalId.toString()}
                     fields={fieldsToApprove}
                     operations={[]}
                 />
-                <BulkRescheduleRaisedBedButton
-                    physicalId={physicalId.toString()}
-                    fields={fieldsToReschedule}
-                    operations={[]}
-                />
-                <BulkAssignRaisedBedButton
-                    physicalId={physicalId.toString()}
-                    fields={fieldsToAssign}
-                    operations={[]}
-                />
-                <RaisedBedLabel physicalId={physicalId} />
-                <Typography level="body2" className="text-muted-foreground">
-                    Vrijeme: {formatMinutes(durations.completed, true)} /{' '}
-                    {formatMinutes(durations.approved)} (
-                    {formatMinutes(durations.total)})
-                </Typography>
-                <CopyTasksButton
-                    physicalId={physicalId.toString()}
-                    tasks={copyTasks}
-                />
+                <Row
+                    spacing={0.5}
+                    className="min-w-0 grow items-center flex-wrap gap-y-1"
+                >
+                    <RaisedBedLabel physicalId={physicalId} />
+                    <Typography level="body2" className="text-muted-foreground">
+                        Vrijeme: {formatMinutes(durations.completed, true)} /{' '}
+                        {formatMinutes(durations.approved)} (
+                        {formatMinutes(durations.total)})
+                    </Typography>
+                    <CopyTasksButton
+                        physicalId={physicalId.toString()}
+                        tasks={copyTasks}
+                    />
+                </Row>
+                <Row spacing={0.5} className="ml-auto shrink-0 items-center">
+                    <BulkAssignRaisedBedButton
+                        physicalId={physicalId.toString()}
+                        fields={fieldsToAssign}
+                        operations={[]}
+                    />
+                    <BulkRescheduleRaisedBedButton
+                        physicalId={physicalId.toString()}
+                        fields={fieldsToReschedule}
+                        operations={[]}
+                    />
+                </Row>
             </Row>
             <Stack spacing={1}>
                 {!dayFields.length && (


### PR DESCRIPTION
time text and copy button inside a growing Row to allow truncation(min-w- grow) and push assign/reschedule controls to a right-alignedRow (ml-auto shrink-0). Increase outer Row spacing to1 and ensure fullwidth so align consistently.

This change improves responsiveness and prevents overflow on while keeping the bulk approve on left and groupingother on the right.