### PR TITLE
Require assignee before approving planting and operation tasks

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -201,6 +201,11 @@ export async function acceptOperationAction(operationId: number) {
     if (!operation) {
         throw new Error(`Operation with ID ${operationId} not found.`);
     }
+    if (!operation.assignedUserId) {
+        throw new Error(
+            'Radnja ne može biti potvrđena prije nego što korisnik bude dodijeljen.',
+        );
+    }
     await acceptOperation(operationId);
     await notifyOperationUpdate(operationId, 'approved');
     revalidatePath(KnownPages.Schedule);

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -311,6 +311,21 @@ export async function acceptRaisedBedFieldAction(
     positionIndex: number,
 ) {
     await auth(['admin']);
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (!raisedBed) {
+        throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
+    }
+    const field = raisedBed.fields.find(
+        (item) => item.positionIndex === positionIndex && item.active,
+    );
+    if (!field) {
+        throw new Error('Polje za sijanje nije pronađeno.');
+    }
+    if (!field.assignedUserId) {
+        throw new Error(
+            'Sijanje ne može biti potvrđeno prije nego što korisnik bude dodijeljen.',
+        );
+    }
     await raisedBedFieldUpdatePlant({
         raisedBedId,
         positionIndex,

--- a/apps/app/app/admin/schedule/AcceptOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptOperationModal.tsx
@@ -6,11 +6,13 @@ import { AcceptRequestModal } from './AcceptRequestModal';
 interface AcceptOperationModalProps {
     operationId: number;
     label: string;
+    disabled?: boolean;
 }
 
 export function AcceptOperationModal({
     operationId,
     label,
+    disabled = false,
 }: AcceptOperationModalProps) {
     const handleConfirm = async () => {
         try {
@@ -25,7 +27,11 @@ export function AcceptOperationModal({
             label={label}
             onConfirm={handleConfirm}
             trigger={
-                <IconButton variant="plain" title="Potvrdi operaciju">
+                <IconButton
+                    variant="plain"
+                    title="Potvrdi operaciju"
+                    disabled={disabled}
+                >
                     <Check className="size-4 shrink-0" />
                 </IconButton>
             }

--- a/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
@@ -10,12 +10,14 @@ interface AcceptRaisedBedFieldModalProps {
     raisedBedId: number;
     positionIndex: number;
     label: string;
+    disabled?: boolean;
 }
 
 export function AcceptRaisedBedFieldModal({
     raisedBedId,
     positionIndex,
     label,
+    disabled = false,
 }: AcceptRaisedBedFieldModalProps) {
     const [loading, setLoading] = useState(false);
     const handleConfirm = async () => {
@@ -38,6 +40,7 @@ export function AcceptRaisedBedFieldModal({
                     variant="plain"
                     title="Potvrdi sijanje"
                     loading={loading}
+                    disabled={disabled}
                 >
                     <Check className="size-4 shrink-0" />
                 </IconButton>

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -145,9 +145,16 @@ export function RaisedBedOperationsScheduleSection({
                 label,
             };
         });
-    const operationsToReschedule = operationsToApprove.map((operation) => ({
-        id: operation.id,
-    }));
+    const operationsToReschedule = dayOperations
+        .filter(
+            (operation) =>
+                !operation.isAccepted &&
+                !isOperationCompleted(operation.status) &&
+                !isOperationCancelled(operation.status),
+        )
+        .map((operation) => ({
+            id: operation.id,
+        }));
     const operationsToAssign = dayOperations
         .filter(
             (operation) =>

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -131,7 +131,8 @@ export function RaisedBedOperationsScheduleSection({
             (operation) =>
                 !operation.isAccepted &&
                 !isOperationCompleted(operation.status) &&
-                !isOperationCancelled(operation.status),
+                !isOperationCancelled(operation.status) &&
+                !!operation.assignedUserId,
         )
         .map((operation) => {
             const operationData = operationDataById.get(operation.entityId);
@@ -308,6 +309,7 @@ export function RaisedBedOperationsScheduleSection({
                                         <AcceptOperationModal
                                             operationId={operation.id}
                                             label={operationLabel}
+                                            disabled={!operation.assignedUserId}
                                         />
                                     )}
                                     <a

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -96,7 +96,8 @@ export function RaisedBedPlantingScheduleSection({
             (field) =>
                 !isFieldApproved(field.plantStatus) &&
                 !isFieldPendingVerification(field.plantStatus) &&
-                !isFieldCompleted(field.plantStatus),
+                !isFieldCompleted(field.plantStatus) &&
+                !!field.assignedUserId,
         )
         .map((field) => {
             const sortData = plantSorts?.find(
@@ -250,6 +251,7 @@ export function RaisedBedPlantingScheduleSection({
                                             raisedBedId={field.raisedBedId}
                                             positionIndex={field.positionIndex}
                                             label={fieldLabel}
+                                            disabled={!field.assignedUserId}
                                         />
                                     ) : (
                                         <CompletePlantingModal

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -116,10 +116,17 @@ export function RaisedBedPlantingScheduleSection({
                 label: `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`,
             };
         });
-    const fieldsToReschedule = fieldsToApprove.map((field) => ({
-        raisedBedId: field.raisedBedId,
-        positionIndex: field.positionIndex,
-    }));
+    const fieldsToReschedule = dayFields
+        .filter(
+            (field) =>
+                !isFieldApproved(field.plantStatus) &&
+                !isFieldPendingVerification(field.plantStatus) &&
+                !isFieldCompleted(field.plantStatus),
+        )
+        .map((field) => ({
+            raisedBedId: field.raisedBedId,
+            positionIndex: field.positionIndex,
+        }));
     const fieldsToAssign = dayFields
         .filter(
             (field) =>


### PR DESCRIPTION
### Motivation
- Prevent approving schedule tasks (planting and operations) before a responsible user is assigned to avoid accidental approvals and ensure accountability.
- Enforce the requirement both server-side and in the UI so actions cannot be performed by bypassing the client.

### Description
- Added server-side checks to `acceptOperationAction` and `acceptRaisedBedFieldAction` to throw if `assignedUserId` is missing (files: `apps/app/app/(actions)/operationActions.ts`, `apps/app/app/(actions)/raisedBedFieldsActions.ts`).
- Added optional `disabled` prop to `AcceptOperationModal` and `AcceptRaisedBedFieldModal` and wired the approve `IconButton` to respect it (files: `apps/app/app/admin/schedule/AcceptOperationModal.tsx`, `apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx`).
- Updated schedule list generation so bulk-approve lists exclude unassigned items and per-row approve buttons are disabled when no assignee is set (files: `apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx`, `apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx`).

### Testing
- Ran the workspace lint for the app with `pnpm --filter app lint`, which completed successfully but reported one pre-existing Biome warning; no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50ea767bc832faa9007e847072e24)