### PR TITLE
Make assigned user avatars perfectly round in Schedules

### DIFF
--- a/apps/app/app/admin/schedule/AssignOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AssignOperationModal.tsx
@@ -116,7 +116,7 @@ export function AssignOperationModal({
             <UserAvatar
                 avatarUrl={assignedUser.avatarUrl}
                 displayName={assignedUser.displayName ?? assignedUser.userName}
-                className="size-7"
+                className="size-7 rounded-full"
             />
         </button>
     ) : (

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -128,7 +128,7 @@ export function AssignRaisedBedFieldModal({
             <UserAvatar
                 avatarUrl={selectedUser.avatarUrl}
                 displayName={selectedUser.displayName ?? selectedUser.userName}
-                className="size-7"
+                className="size-7 rounded-full"
             />
         </button>
     ) : (

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -294,7 +294,7 @@ export function FarmScheduleOperationsSection({
                                                                     .assignedUser
                                                                     .userName
                                                             }
-                                                            className="size-7"
+                                                            className="size-7 rounded-full"
                                                         />
                                                     </div>
                                                 )}

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -257,7 +257,7 @@ export function FarmSchedulePlantingsSection({
                                                                 assignedUser.displayName ??
                                                                 assignedUser.userName
                                                             }
-                                                            className="size-7"
+                                                            className="size-7 rounded-full"
                                                         />
                                                     </div>
                                                 )}


### PR DESCRIPTION
### Motivation
- Assigned user avatars in Schedule UIs were rendering slightly oval/wider than intended, so the UI needs the avatar elements to be explicitly circular.

### Description
- Add `rounded-full` to the `UserAvatar` `className` in schedule UIs to force fully circular avatars in `apps/app/app/admin/schedule/AssignOperationModal.tsx`, `apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx`, `apps/farm/app/schedule/FarmScheduleOperationsSection.tsx`, and `apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx`.

### Testing
- Ran `pnpm -C apps/app lint` and `pnpm -C apps/farm lint`, both checks completed successfully (the `apps/app` lint run reported one warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50f036464832fab0540975bf5490f)