### PR TITLE
app: upgrade admin profile nav menu

### DIFF
--- a/apps/app/components/admin/navigation/ProfileNavItem.tsx
+++ b/apps/app/components/admin/navigation/ProfileNavItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { LogOut, UserCircle } from '@signalco/ui-icons';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { Bank, LogOut, User } from '@signalco/ui-icons';
 import { ListItem } from '@signalco/ui-primitives/ListItem';
 import {
     DropdownMenu,
@@ -8,22 +9,98 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@signalco/ui-primitives/Menu';
+import { useEffect, useMemo, useState } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
+
+type CurrentUser = {
+    id?: string;
+    userName?: string | null;
+    avatarUrl?: string | null;
+    accounts?: Array<{ accountId?: string | null }>;
+};
+
+function isCurrentUser(value: unknown): value is CurrentUser {
+    return typeof value === 'object' && value !== null;
+}
+
+function resolveAccountId(currentUser: CurrentUser | null): string | null {
+    const accountId = currentUser?.accounts?.[0]?.accountId;
+    return accountId ?? null;
+}
 
 export function ProfileNavItem({
     onItemClick,
 }: {
     onItemClick?: () => void;
 } = {}) {
+    const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const loadCurrentUser = async () => {
+            const response = await fetch('/api/users/current', {
+                cache: 'no-store',
+            });
+            if (!response.ok || cancelled) {
+                return;
+            }
+
+            const user = await response.json();
+            if (!cancelled && isCurrentUser(user)) {
+                setCurrentUser(user);
+            }
+        };
+
+        void loadCurrentUser();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const userName = currentUser?.userName ?? 'Korisnik';
+    const userHref = useMemo(
+        () =>
+            currentUser?.id
+                ? KnownPages.User(currentUser.id)
+                : KnownPages.Users,
+        [currentUser?.id],
+    );
+    const accountHref = useMemo(() => {
+        const accountId = resolveAccountId(currentUser);
+        return accountId ? KnownPages.Account(accountId) : KnownPages.Accounts;
+    }, [currentUser]);
+
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <ListItem
-                    startDecorator={<UserCircle className="size-5" />}
-                    label="Korisnik"
+                    startDecorator={
+                        <UserAvatar
+                            displayName={userName}
+                            avatarUrl={currentUser?.avatarUrl}
+                            size="sm"
+                        />
+                    }
+                    label={userName}
                 />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+                <DropdownMenuItem
+                    startDecorator={<User className="size-5" />}
+                    href={userHref}
+                    onClick={onItemClick}
+                >
+                    Detalji korisnika
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    startDecorator={<Bank className="size-5" />}
+                    href={accountHref}
+                    onClick={onItemClick}
+                >
+                    Detalji računa
+                </DropdownMenuItem>
                 <DropdownMenuItem
                     startDecorator={<LogOut className="size-5" />}
                     href={KnownPages.Logout}


### PR DESCRIPTION
### Motivation
- Replace the minimal profile nav trigger with a proper profile button that shows the current user's avatar and username and exposes quick account/user actions.
- Provide direct links to user details, account details and logout from the dropdown, each with an icon for clearer affordance.

### Description
- Replaced the simple icon trigger with a richer `ListItem` that uses `UserAvatar` and displays the username in `apps/app/components/admin/navigation/ProfileNavItem.tsx`.
- Added client-side loading of the current user from `/api/users/current` with a small `CurrentUser` type and a safe runtime guard, using `useEffect` and `useState` to populate the UI.
- Computed `userHref` and `accountHref` with safe fallbacks to the list pages when IDs are unavailable and added dropdown items for `Detalji korisnika`, `Detalji računa`, and `Odjava` with `User`, `Bank` and `LogOut` icons respectively.
- Kept the API usage and routing defensive (cancellation flag and runtime type check) to avoid hydration/runtime issues.

### Testing
- Ran `pnpm --dir apps/app lint` and it completed successfully with a single pre-existing Biome warning in an unrelated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5103c425c832fb16eb684ce722b5a)