### PR TITLE
Add operations handbook page for farm users

### DIFF
--- a/apps/farm/app/operations/OperationsHandbook.tsx
+++ b/apps/farm/app/operations/OperationsHandbook.tsx
@@ -1,0 +1,198 @@
+import type { EntityStandardized } from '@gredice/storage';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import {
+    formatMinutes,
+    getOperationDurationMinutes,
+} from '../schedule/scheduleShared';
+
+interface OperationsHandbookProps {
+    operationsData: EntityStandardized[];
+}
+
+function formatAttributeLabel(attributeName: string) {
+    return attributeName
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/^./, (value) => value.toUpperCase());
+}
+
+function formatAttributeValue(value: unknown) {
+    if (typeof value === 'boolean') {
+        return value ? 'Da' : 'Ne';
+    }
+
+    if (typeof value === 'number') {
+        return value.toLocaleString('hr-HR');
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        value &&
+        typeof value === 'object' &&
+        'information' in value &&
+        value.information &&
+        typeof value.information === 'object' &&
+        'label' in value.information &&
+        typeof value.information.label === 'string'
+    ) {
+        return value.information.label;
+    }
+
+    return null;
+}
+
+export function OperationsHandbook({
+    operationsData,
+}: OperationsHandbookProps) {
+    const sortedOperations = [...operationsData].sort((left, right) =>
+        (
+            left.information?.label ??
+            left.information?.name ??
+            `${left.id}`
+        ).localeCompare(
+            right.information?.label ??
+                right.information?.name ??
+                `${right.id}`,
+            undefined,
+            { numeric: true },
+        ),
+    );
+
+    return (
+        <Stack spacing={2}>
+            {sortedOperations.map((operation) => {
+                const durationMinutes = getOperationDurationMinutes(operation);
+                const attributes = Object.entries(
+                    operation.attributes ?? {},
+                ).filter(
+                    ([attributeName, attributeValue]) =>
+                        attributeName !== 'duration' &&
+                        attributeValue !== null &&
+                        attributeValue !== undefined,
+                );
+                const attachImages =
+                    operation.conditions?.completionAttachImages;
+                const attachImagesRequired =
+                    operation.conditions?.completionAttachImagesRequired;
+
+                return (
+                    <Card key={operation.id}>
+                        <CardHeader>
+                            <CardTitle>
+                                {operation.information?.label ??
+                                    operation.information?.name ??
+                                    `Operacija #${operation.id}`}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent noHeader>
+                            <Stack spacing={1}>
+                                {operation.information?.shortDescription && (
+                                    <Typography className="text-muted-foreground">
+                                        {operation.information.shortDescription}
+                                    </Typography>
+                                )}
+                                {operation.information?.description && (
+                                    <Typography level="body2">
+                                        {operation.information.description}
+                                    </Typography>
+                                )}
+                                {operation.information?.instructions && (
+                                    <div className="rounded-md border bg-muted/40 p-3">
+                                        <Typography level="body2" semiBold>
+                                            Upute
+                                        </Typography>
+                                        <Typography
+                                            level="body2"
+                                            className="whitespace-pre-wrap"
+                                        >
+                                            {operation.information.instructions}
+                                        </Typography>
+                                    </div>
+                                )}
+                                <div className="grid gap-2 text-sm sm:grid-cols-2">
+                                    <div className="rounded-md border bg-white p-3">
+                                        <Typography level="body2" semiBold>
+                                            Trajanje
+                                        </Typography>
+                                        <Typography
+                                            level="body2"
+                                            className="text-muted-foreground"
+                                        >
+                                            {durationMinutes > 0
+                                                ? formatMinutes(durationMinutes)
+                                                : 'Nije definirano'}
+                                        </Typography>
+                                    </div>
+                                    <div className="rounded-md border bg-white p-3">
+                                        <Typography level="body2" semiBold>
+                                            Dokaz fotografijom
+                                        </Typography>
+                                        <Typography
+                                            level="body2"
+                                            className="text-muted-foreground"
+                                        >
+                                            {!attachImages
+                                                ? 'Nije potrebno'
+                                                : attachImagesRequired
+                                                  ? 'Obavezno priložiti fotografije'
+                                                  : 'Preporučeno priložiti fotografije'}
+                                        </Typography>
+                                    </div>
+                                </div>
+                                {attributes.length > 0 && (
+                                    <div className="rounded-md border bg-white p-3">
+                                        <Typography level="body2" semiBold>
+                                            Dodatni detalji
+                                        </Typography>
+                                        <dl className="mt-2 grid gap-x-3 gap-y-1 text-sm sm:grid-cols-[1fr_2fr]">
+                                            {attributes.map(
+                                                ([
+                                                    attributeName,
+                                                    attributeValue,
+                                                ]) => {
+                                                    const formattedValue =
+                                                        formatAttributeValue(
+                                                            attributeValue,
+                                                        );
+
+                                                    if (!formattedValue) {
+                                                        return null;
+                                                    }
+
+                                                    return (
+                                                        <div
+                                                            key={`${operation.id}-${attributeName}`}
+                                                            className="contents"
+                                                        >
+                                                            <dt className="text-muted-foreground">
+                                                                {formatAttributeLabel(
+                                                                    attributeName,
+                                                                )}
+                                                            </dt>
+                                                            <dd>
+                                                                {formattedValue}
+                                                            </dd>
+                                                        </div>
+                                                    );
+                                                },
+                                            )}
+                                        </dl>
+                                    </div>
+                                )}
+                            </Stack>
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </Stack>
+    );
+}

--- a/apps/farm/app/operations/page.tsx
+++ b/apps/farm/app/operations/page.tsx
@@ -1,0 +1,56 @@
+import {
+    AuthProtectedSection,
+    SignedOut,
+} from '@signalco/auth-server/components';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import LoginDialog from '../../components/auth/LoginDialog';
+import { HomeButton } from '../../components/HomeButton';
+import { auth } from '../../lib/auth/auth';
+import { getFarmScheduleOperationsData } from '../schedule/scheduleData';
+import { OperationsHandbook } from './OperationsHandbook';
+
+export const dynamic = 'force-dynamic';
+
+async function OperationsHandbookContent() {
+    await auth(['farmer', 'admin']);
+    const operationsData = (await getFarmScheduleOperationsData()) ?? [];
+
+    return (
+        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+            <div className="space-y-2">
+                <HomeButton />
+                <Typography level="h4" component="h1" semiBold>
+                    Priručnik operacija
+                </Typography>
+                <Typography className="text-muted-foreground">
+                    Pregled svih operacija i ključnih detalja za brži rad na
+                    farmi.
+                </Typography>
+            </div>
+            {operationsData.length > 0 ? (
+                <OperationsHandbook operationsData={operationsData} />
+            ) : (
+                <div className="rounded-lg border bg-white p-6">
+                    <Typography className="text-muted-foreground">
+                        Trenutno nema dostupnih operacija.
+                    </Typography>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default function OperationsHandbookPage() {
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-muted">
+            <AuthProtectedSection auth={authFarmer}>
+                <OperationsHandbookContent />
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -134,6 +134,14 @@ async function FarmerDashboard() {
                             >
                                 Pregled dnevnih zadataka
                             </Button>
+                            <Button
+                                variant="soft"
+                                size="lg"
+                                className="justify-start"
+                                href="/operations"
+                            >
+                                Priručnik operacija
+                            </Button>
                         </Stack>
                     </CardOverflow>
                 </Card>


### PR DESCRIPTION
### Motivation
- Farmers need a quick reference that documents available operations and their details to speed up on-field work and reduce mistakes.
- Surface operation definitions (instructions, duration, photo requirements, attributes) in the app so users can access them without developer or admin help.

### Description
- Add a new authenticated route at `apps/farm/app/operations/page.tsx` that is protected for `farmer`/`admin` users and loads operation definitions via `getFarmScheduleOperationsData`.
- Implement `OperationsHandbook` in `apps/farm/app/operations/OperationsHandbook.tsx` which renders a handbook-style list of operations with label, short description, full description, instructions, estimated duration (via `getOperationDurationMinutes` / `formatMinutes`), completion-photo requirements, and other structured attributes.
- Reuse existing `scheduleShared` helpers and `getFarmScheduleOperationsData` so the handbook reflects the same entity model as the schedule UI.
- Add a dashboard quick-action button linking to `/operations` in `apps/farm/app/page.tsx` for faster access.

### Testing
- Ran lint for the farm package with `pnpm lint --filter farm`, which completed successfully (Biome check fixed one file automatically).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50f7b27c8832fb4e2100072b04107)