### PR TITLE
farm: add raised beds list and per-bed detail pages

### DIFF
--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -151,6 +151,14 @@ async function FarmerDashboard() {
                             >
                                 Priručnik operacija
                             </Button>
+                            <Button
+                                variant="soft"
+                                size="lg"
+                                className="justify-start"
+                                href="/operations"
+                            >
+                                Priručnik operacija
+                            </Button>
                         </Stack>
                     </CardOverflow>
                 </Card>

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -135,6 +135,15 @@ async function FarmerDashboard() {
                                 Pregled dnevnih zadataka
                             </Button>
                             <Button
+                                variant="outlined"
+                                size="lg"
+                                className="justify-start"
+                                startDecorator={<Fence className="size-4" />}
+                                href="/raised-beds"
+                            >
+                                Pregled svih gredica
+                            </Button>
+                            <Button
                                 variant="soft"
                                 size="lg"
                                 className="justify-start"

--- a/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
@@ -1,0 +1,194 @@
+import {
+    type EntityStandardized,
+    getEntitiesFormatted,
+    getFarmUserRaisedBeds,
+} from '@gredice/storage';
+import {
+    AuthProtectedSection,
+    SignedOut,
+} from '@signalco/auth-server/components';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { notFound } from 'next/navigation';
+import LoginDialog from '../../../components/auth/LoginDialog';
+import { HomeButton } from '../../../components/HomeButton';
+import { auth } from '../../../lib/auth/auth';
+
+export const dynamic = 'force-dynamic';
+
+function formatDate(value?: Date | string | null) {
+    if (!value) {
+        return '—';
+    }
+
+    const date = typeof value === 'string' ? new Date(value) : value;
+    if (Number.isNaN(date.getTime())) {
+        return '—';
+    }
+
+    return date.toLocaleDateString('hr-HR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+    });
+}
+
+function resolvePlantName(
+    plantSortId: number | null | undefined,
+    sorts: EntityStandardized[] | null | undefined,
+) {
+    if (!plantSortId) {
+        return 'Prazno';
+    }
+
+    const name = sorts?.find((sort) => sort.id === plantSortId)?.attributes
+        ?.information?.name;
+
+    return name ? String(name) : `Sorta #${plantSortId}`;
+}
+
+async function RaisedBedDetailPageContent({
+    raisedBedId,
+}: {
+    raisedBedId: number;
+}) {
+    const { userId } = await auth(['farmer', 'admin']);
+    const [raisedBeds, plantSorts] = await Promise.all([
+        getFarmUserRaisedBeds(userId),
+        getEntitiesFormatted<EntityStandardized>('plantSort'),
+    ]);
+
+    const raisedBed = raisedBeds.find((item) => item.id === raisedBedId);
+    if (!raisedBed) {
+        notFound();
+    }
+
+    const highestPositionIndex = Math.max(
+        8,
+        ...raisedBed.fields.map((field) => field.positionIndex),
+    );
+    const orderedPositions = Array.from(
+        { length: highestPositionIndex + 1 },
+        (_, index) => index,
+    );
+
+    return (
+        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+            <Row spacing={1}>
+                <HomeButton />
+                <Typography level="h4" component="h1">
+                    {raisedBed.name || `Gredica #${raisedBed.id}`}
+                </Typography>
+            </Row>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Detalji polja</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={2}>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Pregled svih pozicija i stanja biljaka u odabranoj
+                            gredici.
+                        </Typography>
+                        <Table>
+                            <Table.Header>
+                                <Table.Row>
+                                    <Table.Head>Pozicija</Table.Head>
+                                    <Table.Head>Biljka</Table.Head>
+                                    <Table.Head>Status</Table.Head>
+                                    <Table.Head>Planirano</Table.Head>
+                                    <Table.Head>Posijano</Table.Head>
+                                    <Table.Head>Spremno</Table.Head>
+                                    <Table.Head>Ubrano</Table.Head>
+                                </Table.Row>
+                            </Table.Header>
+                            <Table.Body>
+                                {orderedPositions.map((positionIndex) => {
+                                    const field = raisedBed.fields.find(
+                                        (item) =>
+                                            item.positionIndex ===
+                                                positionIndex && item.active,
+                                    );
+
+                                    return (
+                                        <Table.Row key={positionIndex}>
+                                            <Table.Cell>
+                                                {positionIndex + 1}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {resolvePlantName(
+                                                    field?.plantSortId,
+                                                    plantSorts,
+                                                )}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {field?.plantStatus || '—'}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {formatDate(
+                                                    field?.plantScheduledDate,
+                                                )}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {formatDate(
+                                                    field?.plantSowDate,
+                                                )}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {formatDate(
+                                                    field?.plantReadyDate,
+                                                )}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {formatDate(
+                                                    field?.plantHarvestedDate,
+                                                )}
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    );
+                                })}
+                            </Table.Body>
+                        </Table>
+                    </Stack>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+export default async function RaisedBedDetailPage({
+    params,
+}: {
+    params: Promise<{ raisedBedId: string }>;
+}) {
+    const { raisedBedId } = await params;
+    const parsedRaisedBedId = Number(raisedBedId);
+    if (!Number.isInteger(parsedRaisedBedId)) {
+        notFound();
+    }
+
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-muted">
+            <AuthProtectedSection auth={authFarmer}>
+                <RaisedBedDetailPageContent raisedBedId={parsedRaisedBedId} />
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
@@ -43,14 +43,13 @@ function formatDate(value?: Date | string | null) {
 
 function resolvePlantName(
     plantSortId: number | null | undefined,
-    sorts: EntityStandardized[] | null | undefined,
+    plantSortNamesById: Map<number, string>,
 ) {
     if (!plantSortId) {
         return 'Prazno';
     }
 
-    const name = sorts?.find((sort) => sort.id === plantSortId)?.attributes
-        ?.information?.name;
+    const name = plantSortNamesById.get(plantSortId);
 
     return name ? String(name) : `Sorta #${plantSortId}`;
 }
@@ -65,6 +64,15 @@ async function RaisedBedDetailPageContent({
         getFarmUserRaisedBeds(userId),
         getEntitiesFormatted<EntityStandardized>('plantSort'),
     ]);
+    const plantSortNamesById = new Map<number, string>();
+    if (plantSorts) {
+        for (const plantSort of plantSorts) {
+            const name = plantSort.information?.name;
+            if (name) {
+                plantSortNamesById.set(plantSort.id, name);
+            }
+        }
+    }
 
     const raisedBed = raisedBeds.find((item) => item.id === raisedBedId);
     if (!raisedBed) {
@@ -78,6 +86,11 @@ async function RaisedBedDetailPageContent({
     const orderedPositions = Array.from(
         { length: highestPositionIndex + 1 },
         (_, index) => index,
+    );
+    const activeFieldsByPosition = new Map(
+        raisedBed.fields
+            .filter((field) => field.active)
+            .map((field) => [field.positionIndex, field]),
     );
 
     return (
@@ -116,11 +129,10 @@ async function RaisedBedDetailPageContent({
                             </Table.Header>
                             <Table.Body>
                                 {orderedPositions.map((positionIndex) => {
-                                    const field = raisedBed.fields.find(
-                                        (item) =>
-                                            item.positionIndex ===
-                                                positionIndex && item.active,
-                                    );
+                                    const field =
+                                        activeFieldsByPosition.get(
+                                            positionIndex,
+                                        );
 
                                     return (
                                         <Table.Row key={positionIndex}>
@@ -130,7 +142,7 @@ async function RaisedBedDetailPageContent({
                                             <Table.Cell>
                                                 {resolvePlantName(
                                                     field?.plantSortId,
-                                                    plantSorts,
+                                                    plantSortNamesById,
                                                 )}
                                             </Table.Cell>
                                             <Table.Cell>

--- a/apps/farm/app/raised-beds/page.tsx
+++ b/apps/farm/app/raised-beds/page.tsx
@@ -29,12 +29,23 @@ function getPlantPreview(
     fields: Awaited<ReturnType<typeof getFarmUserRaisedBeds>>[number]['fields'],
     sorts: EntityStandardized[] | null | undefined,
 ) {
+    const plantSortNamesById = new Map<number, string>();
+    if (sorts) {
+        for (const sort of sorts) {
+            const name = sort.information?.name;
+            if (name) {
+                plantSortNamesById.set(sort.id, name);
+            }
+        }
+    }
+
     const activePlants = fields
-        .filter((field) => field.active && field.plantSortId)
+        .filter(
+            (field): field is typeof field & { plantSortId: number } =>
+                field.active && typeof field.plantSortId === 'number',
+        )
         .map((field) => {
-            const plantName = sorts?.find(
-                (sort) => sort.id === field.plantSortId,
-            )?.attributes?.information?.name;
+            const plantName = plantSortNamesById.get(field.plantSortId);
 
             return plantName
                 ? String(plantName)

--- a/apps/farm/app/raised-beds/page.tsx
+++ b/apps/farm/app/raised-beds/page.tsx
@@ -1,0 +1,166 @@
+import {
+    type EntityStandardized,
+    getEntitiesFormatted,
+    getFarmUserRaisedBeds,
+} from '@gredice/storage';
+import {
+    AuthProtectedSection,
+    SignedOut,
+} from '@signalco/auth-server/components';
+import { Fence } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import LoginDialog from '../../components/auth/LoginDialog';
+import { HomeButton } from '../../components/HomeButton';
+import { auth } from '../../lib/auth/auth';
+
+export const dynamic = 'force-dynamic';
+
+function getPlantPreview(
+    fields: Awaited<ReturnType<typeof getFarmUserRaisedBeds>>[number]['fields'],
+    sorts: EntityStandardized[] | null | undefined,
+) {
+    const activePlants = fields
+        .filter((field) => field.active && field.plantSortId)
+        .map((field) => {
+            const plantName = sorts?.find(
+                (sort) => sort.id === field.plantSortId,
+            )?.attributes?.information?.name;
+
+            return plantName
+                ? String(plantName)
+                : `Sorta #${field.plantSortId}`;
+        });
+
+    return Array.from(new Set(activePlants));
+}
+
+async function RaisedBedsPageContent() {
+    const { userId } = await auth(['farmer', 'admin']);
+    const [raisedBeds, plantSorts] = await Promise.all([
+        getFarmUserRaisedBeds(userId),
+        getEntitiesFormatted<EntityStandardized>('plantSort'),
+    ]);
+
+    return (
+        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+            <Row spacing={1}>
+                <HomeButton />
+                <Typography level="h4" component="h1">
+                    Gredice
+                </Typography>
+            </Row>
+
+            {raisedBeds.length === 0 ? (
+                <Card>
+                    <CardContent noHeader>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Trenutno nema dostupnih gredica za vaš korisnički
+                            račun.
+                        </Typography>
+                    </CardContent>
+                </Card>
+            ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                    {raisedBeds.map((raisedBed) => {
+                        const plantPreview = getPlantPreview(
+                            raisedBed.fields,
+                            plantSorts,
+                        );
+                        const previewVisible = plantPreview.slice(0, 4);
+                        const hiddenCount = Math.max(
+                            plantPreview.length - previewVisible.length,
+                            0,
+                        );
+
+                        return (
+                            <Card key={raisedBed.id}>
+                                <CardHeader>
+                                    <Stack spacing={1}>
+                                        <CardTitle>
+                                            <Row
+                                                spacing={1}
+                                                alignItems="center"
+                                            >
+                                                <Fence className="size-4" />
+                                                <Typography level="h6" semiBold>
+                                                    {raisedBed.name ||
+                                                        `Gredica #${raisedBed.id}`}
+                                                </Typography>
+                                            </Row>
+                                        </CardTitle>
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            ID: {raisedBed.id} · Polja:{' '}
+                                            {raisedBed.fields.length}
+                                        </Typography>
+                                    </Stack>
+                                </CardHeader>
+                                <CardContent>
+                                    <Stack spacing={2}>
+                                        <Row spacing={1} className="flex-wrap">
+                                            {previewVisible.length > 0 ? (
+                                                previewVisible.map((label) => (
+                                                    <Chip
+                                                        key={`${raisedBed.id}-${label}`}
+                                                        color="success"
+                                                        className="max-w-full"
+                                                    >
+                                                        {label}
+                                                    </Chip>
+                                                ))
+                                            ) : (
+                                                <Chip color="neutral">
+                                                    Nema aktivnih biljaka
+                                                </Chip>
+                                            )}
+                                            {hiddenCount > 0 && (
+                                                <Chip color="neutral">
+                                                    +{hiddenCount} više
+                                                </Chip>
+                                            )}
+                                        </Row>
+                                        <Button
+                                            href={`/raised-beds/${raisedBed.id}`}
+                                        >
+                                            Otvori detalje
+                                        </Button>
+                                    </Stack>
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default async function RaisedBedsPage() {
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-muted">
+            <AuthProtectedSection auth={authFarmer}>
+                <RaisedBedsPageContent />
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/src/KnownPages.ts
+++ b/apps/farm/src/KnownPages.ts
@@ -1,3 +1,6 @@
 export const KnownPages = {
     Landing: '/',
+    RaisedBeds: '/raised-beds',
+    RaisedBed: (raisedBedId: number) => `/raised-beds/${raisedBedId}`,
+    Schedule: '/schedule',
 };


### PR DESCRIPTION
### Motivation
- Provide farm users with a dedicated overview of all raised beds and a per-bed detail view so they can quickly see plant previews and field status without switching to the admin app. 
- Reuse existing farm-side data sources and auth patterns so the new pages show only beds the user can access and follow platform conventions.

### Description
- Added a new raised beds index page at `apps/farm/app/raised-beds/page.tsx` that fetches beds via `getFarmUserRaisedBeds` and shows per-bed active plant previews and a CTA to open details at ` /raised-beds/:id`.
- Added a per-bed detail page at `apps/farm/app/raised-beds/[raisedBedId]/page.tsx` that lists all positions and plant status/date information in a table, using `getFarmUserRaisedBeds` and `getEntitiesFormatted` for plant sort names and mirroring the admin-style field overview.
- Added a quick-action button on the farm dashboard (`apps/farm/app/page.tsx`) linking to ` /raised-beds` for faster navigation.
- Extended route helpers in `apps/farm/src/KnownPages.ts` with `RaisedBeds`, `RaisedBed` and `Schedule` entries.
- All pages are protected with the existing farm auth guard via `auth(['farmer','admin'])` and use the same UI primitives and patterns already used in the app.

### Testing
- Ran linting with `pnpm lint --filter farm`, which completed successfully (Biome/Turbo checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50f4a89dc832f8c8119572d732ed2)