### PR TITLE
Replace weekday registrations progress list with bar chart and constrain card width

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -331,9 +331,11 @@ export function AdminDashboardClient({
             </Stack>
             <Stack spacing={1}>
                 <DashboardDivider>Registracije</DashboardDivider>
-                <UsersRegistrationWeekdayCard
-                    data={initialWeekdayRegistrations}
-                />
+                <div className="w-full lg:max-w-2xl">
+                    <UsersRegistrationWeekdayCard
+                        data={initialWeekdayRegistrations}
+                    />
+                </div>
             </Stack>
             <Stack spacing={1}>
                 <DashboardDivider>Radnje</DashboardDivider>

--- a/apps/app/components/admin/dashboard/UsersRegistrationWeekdayCard.tsx
+++ b/apps/app/components/admin/dashboard/UsersRegistrationWeekdayCard.tsx
@@ -1,9 +1,17 @@
 'use client';
 
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
 
 export type WeekdayRegistrationData = {
     label: string;
@@ -16,6 +24,7 @@ export function UsersRegistrationWeekdayCard({
     data: WeekdayRegistrationData[];
 }) {
     const maxCount = Math.max(0, ...data.map((item) => item.count));
+    const hasData = data.length > 0;
     const bestDay = data.find(
         (item) => item.count === maxCount && maxCount > 0,
     );
@@ -40,41 +49,66 @@ export function UsersRegistrationWeekdayCard({
                             Najčešći dan registracije u odabranom periodu
                         </Typography>
                     </Stack>
-                    <Stack spacing={1}>
-                        {data.map((item) => {
-                            const widthPercent =
-                                maxCount > 0
-                                    ? (item.count / maxCount) * 100
-                                    : 0;
-                            return (
-                                <Stack key={item.label} spacing={0.5}>
-                                    <Row justifyContent="space-between">
-                                        <Typography level="body3">
-                                            {item.label}
-                                        </Typography>
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            {item.count}
-                                        </Typography>
-                                    </Row>
-                                    <div
-                                        className="h-2 w-full rounded-full bg-primary/10"
-                                        role="img"
-                                        aria-label={`${item.label}: ${item.count}`}
-                                    >
-                                        <div
-                                            className="h-2 rounded-full bg-primary/60"
-                                            style={{
-                                                width: `${Math.max(widthPercent, item.count > 0 ? 4 : 0)}%`,
-                                            }}
-                                        />
-                                    </div>
-                                </Stack>
-                            );
-                        })}
-                    </Stack>
+                    {!hasData ? (
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Nema podataka za odabrani period.
+                        </Typography>
+                    ) : (
+                        <div className="h-64 w-full">
+                            <ResponsiveContainer width="100%" height="100%">
+                                <BarChart
+                                    data={data}
+                                    margin={{
+                                        top: 8,
+                                        right: 8,
+                                        left: -16,
+                                        bottom: 0,
+                                    }}
+                                >
+                                    <CartesianGrid
+                                        strokeDasharray="3 3"
+                                        className="stroke-border"
+                                    />
+                                    <XAxis
+                                        dataKey="label"
+                                        tickLine={false}
+                                        axisLine={false}
+                                        tick={{ fontSize: 12 }}
+                                    />
+                                    <YAxis
+                                        allowDecimals={false}
+                                        tickLine={false}
+                                        axisLine={false}
+                                        tick={{ fontSize: 12 }}
+                                        width={28}
+                                    />
+                                    <Tooltip
+                                        cursor={{
+                                            fill: 'hsl(var(--primary) / 0.08)',
+                                        }}
+                                        contentStyle={{
+                                            border: '1px solid hsl(var(--border))',
+                                            borderRadius: '0.5rem',
+                                            backgroundColor:
+                                                'hsl(var(--background))',
+                                        }}
+                                        formatter={(value) => [
+                                            `${value} registracija`,
+                                            'Korisnici',
+                                        ]}
+                                    />
+                                    <Bar
+                                        dataKey="count"
+                                        fill="hsl(var(--primary) / 0.6)"
+                                        radius={[6, 6, 0, 0]}
+                                    />
+                                </BarChart>
+                            </ResponsiveContainer>
+                        </div>
+                    )}
                 </Stack>
             </CardOverflow>
         </Card>


### PR DESCRIPTION
### Motivation

- Improve the visual representation of "Registracije korisnika po danu u tjednu" by using a proper chart instead of horizontal progress bars for easier comparison. 
- Prevent the registrations widget from stretching the full dashboard width on large screens to improve layout balance.

### Description

- Replaced the list of horizontal progress bars in `UsersRegistrationWeekdayCard` with a `recharts` `BarChart` using `ResponsiveContainer`, `XAxis`, `YAxis`, `CartesianGrid`, `Tooltip`, and `Bar` to render weekday registration counts. 
- Preserved the existing top-day summary and added an explicit empty-state message when there is no weekday data. 
- Constrained the widget width on desktop by wrapping the component in a `div` with `className="w-full lg:max-w-2xl"` in `AdminDashboardClient`. 
- Removed an unused `Row` import and applied light tooltip and chart styling to match the app theme.

### Testing

- Ran lint for the app with `pnpm --dir apps/app lint`, which completed and auto-fixed one file; no lint errors remain.
- No additional automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51103a9a0832f89dc3db089056318)