### PR TITLE
Add per-user breakdown to Operations Duration card

### DIFF
--- a/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
+++ b/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
@@ -21,6 +21,12 @@ export type OperationsDurationData = {
     totalMinutes: number;
     operationsMinutes: number;
     sowingMinutes: number;
+    byUser: {
+        userId: string;
+        userName: string;
+        operationsMinutes: number;
+        operationsCount: number;
+    }[];
     daily: OperationsDurationPoint[];
 };
 
@@ -267,6 +273,38 @@ export function OperationsDurationCard({
                             </div>
                         </>
                     )}
+                    {data.byUser.length > 0 ? (
+                        <Stack spacing={1.5} className="pt-2">
+                            <Typography level="body3" className="font-medium">
+                                Po korisniku (dodijeljene radnje)
+                            </Typography>
+                            <Stack spacing={1}>
+                                {data.byUser.map((user) => (
+                                    <Row
+                                        key={user.userId}
+                                        className="items-center justify-between gap-3 rounded-md border border-border/40 px-2 py-1.5"
+                                    >
+                                        <Stack spacing={0}>
+                                            <Typography level="body3" semiBold>
+                                                {user.userName}
+                                            </Typography>
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Radnji: {user.operationsCount}
+                                            </Typography>
+                                        </Stack>
+                                        <Typography level="body3" semiBold>
+                                            {formatTooltipDuration(
+                                                user.operationsMinutes,
+                                            )}
+                                        </Typography>
+                                    </Row>
+                                ))}
+                            </Stack>
+                        </Stack>
+                    ) : null}
                 </Stack>
             </CardOverflow>
         </Card>

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -24,6 +24,12 @@ type OperationsDurationData = {
     totalMinutes: number;
     operationsMinutes: number;
     sowingMinutes: number;
+    byUser: {
+        userId: string;
+        userName: string;
+        operationsMinutes: number;
+        operationsCount: number;
+    }[];
     daily: OperationsDurationPoint[];
 };
 
@@ -110,6 +116,7 @@ function formatOperationsDurationData(
         totalMinutes,
         operationsMinutes,
         sowingMinutes,
+        byUser: [],
         daily,
     };
 }
@@ -228,6 +235,16 @@ export async function getAnalyticsData(
         operationDurations.set(operation.id, duration);
     }
 
+    const operationsByUser = new Map<
+        string,
+        {
+            userId: string;
+            userName: string;
+            operationsMinutes: number;
+            operationsCount: number;
+        }
+    >();
+
     for (const operation of operationsList) {
         if (operation.status !== 'completed' || !operation.completedAt) {
             continue;
@@ -247,6 +264,25 @@ export async function getAnalyticsData(
             key,
             (operationsTotals.get(key) ?? 0) + durationMinutes,
         );
+
+        const userId = operation.assignedUser?.id ?? 'unassigned';
+        const userName =
+            operation.assignedUser?.displayName ??
+            operation.assignedUser?.userName ??
+            'Nedodijeljeno';
+        const existingUserStats = operationsByUser.get(userId);
+        if (!existingUserStats) {
+            operationsByUser.set(userId, {
+                userId,
+                userName,
+                operationsMinutes: durationMinutes,
+                operationsCount: 1,
+            });
+            continue;
+        }
+
+        existingUserStats.operationsMinutes += durationMinutes;
+        existingUserStats.operationsCount += 1;
     }
 
     const sowingEvents = await getPlantUpdateEvents({
@@ -271,6 +307,10 @@ export async function getAnalyticsData(
         dateKeys,
         operationsTotals,
         sowingTotals,
+    );
+
+    operationsDuration.byUser = Array.from(operationsByUser.values()).sort(
+        (a, b) => b.operationsMinutes - a.operationsMinutes,
     );
 
     const weekdayRegistrations = WEEKDAY_LABELS.map((label, index) => ({


### PR DESCRIPTION
### Motivation
- Provide visibility into which assigned users contributed to overall operation time by surfacing per-user totals alongside existing daily totals in the admin dashboard.

### Description
- Extend the analytics payload by adding `byUser` to `OperationsDurationData` in `apps/app/components/admin/dashboard/actions.ts` and return a default `byUser: []` from `formatOperationsDurationData`.
- Aggregate completed operation durations into `operationsByUser` (tracking `userId`, `userName`, `operationsMinutes`, and `operationsCount`) while computing daily totals and attach a sorted `byUser` array (highest duration first) to the `operationsDuration` payload.
- Update `OperationsDurationCard` (`apps/app/components/admin/dashboard/OperationsDurationCard.tsx`) to accept the new `byUser` field and render a new "Po korisniku (dodijeljene radnje)" section listing each user, their number of assigned operations, and total duration.

### Testing
- Ran lint for the app with `pnpm --dir apps/app lint`, which passed; Biome reported one unrelated pre-existing warning in `ArchiveClosedSlotsButton.tsx` but no failures.
- No other automated tests were changed or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51139abb4832fbc46296a9893d8b1)