### PR TITLE
Improve bulk operation modal UX during bulk creation

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -77,82 +77,116 @@ export async function createOperationAction(formData: FormData) {
     return { success: true };
 }
 
-export async function bulkCreateOperationsAction(formData: FormData) {
-    const { userId } = await auth(['admin']);
-    const entityId = formData.get('entityId')
-        ? Number(formData.get('entityId'))
-        : undefined;
-    if (!entityId) {
-        throw new Error('Entity ID is required');
-    }
-    const scheduledDate = formData.get('scheduledDate')
-        ? new Date(formData.get('scheduledDate') as string)
-        : undefined;
-    const selectedAssignedUserId =
-        (formData.get('assignedUserId') as string | null)?.trim() || undefined;
-    const targets = formData.getAll('targets') as string[];
+export type BulkCreateOperationsActionState = {
+    success: boolean;
+    message: string;
+    createdCount?: number;
+    totalCount?: number;
+};
 
-    if (selectedAssignedUserId) {
-        const uniqueGardenIds = Array.from(
-            new Set(
-                targets
-                    .map((target) => target.split('|')[1])
-                    .filter((gardenId) => gardenId)
-                    .map((gardenId) => Number(gardenId))
-                    .filter((gardenId) => !Number.isNaN(gardenId)),
-            ),
-        );
-        const assignableFarmUsersByGardenId =
-            await getAssignableFarmUsersByGardenIds(uniqueGardenIds);
-        for (const gardenId of uniqueGardenIds) {
-            const isUserAssignableToGarden =
-                assignableFarmUsersByGardenId[gardenId]?.some(
-                    (user) => user.id === selectedAssignedUserId,
-                ) ?? false;
-            if (!isUserAssignableToGarden) {
-                throw new Error(
-                    'Odabrani korisnik nije dostupan za sve odabrane radnje.',
-                );
+export async function bulkCreateOperationsAction(
+    _previousState: BulkCreateOperationsActionState | null,
+    formData: FormData,
+): Promise<BulkCreateOperationsActionState> {
+    try {
+        const { userId } = await auth(['admin']);
+        const entityId = formData.get('entityId')
+            ? Number(formData.get('entityId'))
+            : undefined;
+        if (!entityId) {
+            throw new Error('Entity ID is required');
+        }
+        const scheduledDate = formData.get('scheduledDate')
+            ? new Date(formData.get('scheduledDate') as string)
+            : undefined;
+        const selectedAssignedUserId =
+            (formData.get('assignedUserId') as string | null)?.trim() ||
+            undefined;
+        const targets = formData.getAll('targets') as string[];
+        if (targets.length === 0) {
+            throw new Error('Odaberite barem jednu ciljnu lokaciju.');
+        }
+
+        if (selectedAssignedUserId) {
+            const uniqueGardenIds = Array.from(
+                new Set(
+                    targets
+                        .map((target) => target.split('|')[1])
+                        .filter((gardenId) => gardenId)
+                        .map((gardenId) => Number(gardenId))
+                        .filter((gardenId) => !Number.isNaN(gardenId)),
+                ),
+            );
+            const assignableFarmUsersByGardenId =
+                await getAssignableFarmUsersByGardenIds(uniqueGardenIds);
+            for (const gardenId of uniqueGardenIds) {
+                const isUserAssignableToGarden =
+                    assignableFarmUsersByGardenId[gardenId]?.some(
+                        (user) => user.id === selectedAssignedUserId,
+                    ) ?? false;
+                if (!isUserAssignableToGarden) {
+                    throw new Error(
+                        'Odabrani korisnik nije dostupan za sve odabrane radnje.',
+                    );
+                }
             }
         }
-    }
 
-    for (const target of targets) {
-        const [accountId, gardenId, raisedBedId, raisedBedFieldId] =
-            target.split('|');
-        const operation: InsertOperation = {
-            entityId,
-            entityTypeName: 'operation',
-            accountId: accountId || undefined,
-            gardenId: gardenId ? Number(gardenId) : undefined,
-            raisedBedId: raisedBedId ? Number(raisedBedId) : undefined,
-            raisedBedFieldId: raisedBedFieldId
-                ? Number(raisedBedFieldId)
-                : undefined,
-            timestamp: undefined,
-        };
-        const operationId = await createOperation(operation);
-        if (scheduledDate) {
-            await createEvent(
-                knownEvents.operations.scheduledV1(operationId.toString(), {
+        let createdCount = 0;
+        for (const target of targets) {
+            const [accountId, gardenId, raisedBedId, raisedBedFieldId] =
+                target.split('|');
+            const operation: InsertOperation = {
+                entityId,
+                entityTypeName: 'operation',
+                accountId: accountId || undefined,
+                gardenId: gardenId ? Number(gardenId) : undefined,
+                raisedBedId: raisedBedId ? Number(raisedBedId) : undefined,
+                raisedBedFieldId: raisedBedFieldId
+                    ? Number(raisedBedFieldId)
+                    : undefined,
+                timestamp: undefined,
+            };
+            const operationId = await createOperation(operation);
+            if (scheduledDate) {
+                await createEvent(
+                    knownEvents.operations.scheduledV1(operationId.toString(), {
+                        scheduledDate: scheduledDate.toISOString(),
+                    }),
+                );
+                await notifyOperationUpdate(operationId, 'scheduled', {
                     scheduledDate: scheduledDate.toISOString(),
-                }),
-            );
-            await notifyOperationUpdate(operationId, 'scheduled', {
-                scheduledDate: scheduledDate.toISOString(),
-            });
+                });
+            }
+            if (selectedAssignedUserId) {
+                await createEvent(
+                    knownEvents.operations.assignedV1(operationId.toString(), {
+                        assignedUserId: selectedAssignedUserId,
+                        assignedBy: userId,
+                    }),
+                );
+            }
+            createdCount += 1;
         }
-        if (selectedAssignedUserId) {
-            await createEvent(
-                knownEvents.operations.assignedV1(operationId.toString(), {
-                    assignedUserId: selectedAssignedUserId,
-                    assignedBy: userId,
-                }),
-            );
-        }
+
+        revalidatePath(KnownPages.Schedule);
+        revalidatePath(KnownPages.Operations);
+
+        return {
+            success: true,
+            message: `Uspješno kreirano ${createdCount} radnji.`,
+            createdCount,
+            totalCount: targets.length,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'Došlo je do greške pri kreiranju radnji.',
+        };
     }
-    revalidatePath(KnownPages.Schedule);
-    revalidatePath(KnownPages.Operations);
 }
 
 export async function rescheduleOperationAction(formData: FormData) {

--- a/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
@@ -5,7 +5,8 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useEffect, useMemo, useState } from 'react';
+import { useActionState, useEffect, useMemo, useRef, useState } from 'react';
+import { useFormStatus } from 'react-dom';
 import { getEntities } from '../../../components/shared/attributes/actions/entitiesActions';
 import { UserPickerField } from '../../../components/shared/fields/UserPickerField';
 import { bulkCreateOperationsAction } from '../../(actions)/operationActions';
@@ -13,6 +14,16 @@ import { SelectEntity } from '../raised-beds/[raisedBedId]/SelectEntity';
 import { TargetsSelectionList } from './TargetsSelectionList';
 
 const unassignedValue = '__unassigned__';
+
+function SubmitButton() {
+    const { pending } = useFormStatus();
+
+    return (
+        <Button type="submit" disabled={pending}>
+            {pending ? 'Kreiranje u tijeku...' : 'Kreiraj'}
+        </Button>
+    );
+}
 
 export type BulkOperationCreateModalProps = {
     gardens: Array<{
@@ -40,6 +51,7 @@ export function BulkOperationCreateModal({
     raisedBeds,
     assignableUsers,
 }: BulkOperationCreateModalProps) {
+    const [open, setOpen] = useState(false);
     const [selectedOperationId, setSelectedOperationId] = useState<
         string | null
     >(null);
@@ -47,6 +59,12 @@ export function BulkOperationCreateModal({
         useState<Awaited<ReturnType<typeof getEntities>>>();
     const [selectedAssignedUserId, setSelectedAssignedUserId] =
         useState(unassignedValue);
+    const [selectedTargetsCount, setSelectedTargetsCount] = useState(0);
+    const [state, formAction] = useActionState(
+        bulkCreateOperationsAction,
+        null,
+    );
+    const formRef = useRef<HTMLFormElement>(null);
 
     useEffect(() => {
         // Load operations metadata to determine application type
@@ -72,12 +90,29 @@ export function BulkOperationCreateModal({
         return 'raisedBed' as const;
     }, [operations, selectedOperationId]);
 
+    useEffect(() => {
+        if (!state?.success) return;
+
+        setOpen(false);
+        setSelectedOperationId(null);
+        setSelectedAssignedUserId(unassignedValue);
+        setSelectedTargetsCount(0);
+        formRef.current?.reset();
+    }, [state?.success]);
+
+    const handleSubmit = (formData: FormData) => {
+        setSelectedTargetsCount(formData.getAll('targets').length);
+        return formAction(formData);
+    };
+
     return (
         <Modal
             title={'Nova radnja'}
             trigger={<Button variant="outlined">Dodaj više</Button>}
+            open={open}
+            onOpenChange={setOpen}
         >
-            <form action={bulkCreateOperationsAction} className="space-y-4">
+            <form ref={formRef} action={handleSubmit} className="space-y-4">
                 <Stack spacing={2}>
                     <Typography level="h5">Nove radnje</Typography>
                     <SelectEntity
@@ -126,9 +161,41 @@ export function BulkOperationCreateModal({
                         raisedBeds={raisedBeds}
                         mode={selectionMode}
                     />
-                    <Button type="submit">Kreiraj</Button>
+                    <SubmitButton />
+                    {state?.message && (
+                        <Typography
+                            level="body2"
+                            className={
+                                state.success
+                                    ? 'text-green-600'
+                                    : 'text-red-600'
+                            }
+                        >
+                            {state.message}
+                        </Typography>
+                    )}
+                    {!state?.success && selectedTargetsCount > 0 && (
+                        <FormProgress
+                            selectedTargetsCount={selectedTargetsCount}
+                        />
+                    )}
                 </Stack>
             </form>
         </Modal>
+    );
+}
+
+function FormProgress({
+    selectedTargetsCount,
+}: {
+    selectedTargetsCount: number;
+}) {
+    const { pending } = useFormStatus();
+    if (!pending) return null;
+
+    return (
+        <Typography level="body2" className="text-muted-foreground">
+            Kreiranje {selectedTargetsCount} radnji je u tijeku...
+        </Typography>
     );
 }


### PR DESCRIPTION
### Motivation
- Provide visible progress and disable UI while bulk operations are being created so users know work is in progress.
- Ensure the create modal closes and form resets after a successful bulk create instead of staying open.
- Make the server action return structured state so the client can render success/error messages and counts reliably.

### Description
- Converted `bulkCreateOperationsAction` to return a structured `BulkCreateOperationsActionState` and accept the prior state for compatibility with `useActionState`, adding validation for empty `targets` and safe error handling.
- Added created/total counts and a success message from the server action to enable client-side reporting of results (`apps/app/app/(actions)/operationActions.ts`).
- Made the bulk-create modal controlled with `open`/`onOpenChange`, wired it to `useActionState`, and auto-closed/reset the form when the action reports success (`apps/app/app/admin/operations/BulkOperationCreateModal.tsx`).
- Improved UX during submission by using `useFormStatus` to disable the submit button and show a pending message and by rendering server success/error messages in the form.

### Testing
- Ran formatting and static checks with `pnpm --dir apps/app exec biome format --write app/admin/operations/BulkOperationCreateModal.tsx` and `pnpm --dir apps/app exec biome check app/admin/operations/BulkOperationCreateModal.tsx 'app/(actions)/operationActions.ts'`, and the checks completed successfully.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51469c140832f9c6fa5d3c02a7e4f)