### PR TITLE
Add configurable dashboard quick actions (storage, server action, admin UI, client)

### DIFF
--- a/apps/app/app/(actions)/dashboardSettingsActions.ts
+++ b/apps/app/app/(actions)/dashboardSettingsActions.ts
@@ -1,0 +1,84 @@
+'use server';
+
+import { getEntityTypes, SettingsKeys, upsertSetting } from '@gredice/storage';
+import { revalidatePath } from 'next/cache';
+import { auth } from '../../lib/auth/auth';
+import {
+    buildDashboardQuickActionOptions,
+    type DashboardQuickActionOption,
+    parseQuickActionId,
+} from '../../src/dashboardQuickActions';
+import { KnownPages } from '../../src/KnownPages';
+
+type UpdateDashboardQuickActionsState =
+    | { success: true; message: string }
+    | { success: false; message: string }
+    | null;
+
+function isActionAllowed(
+    actionId: string,
+    options: DashboardQuickActionOption[],
+): boolean {
+    return options.some((option) => option.id === actionId);
+}
+
+export async function updateDashboardQuickActionsAction(
+    _prevState: UpdateDashboardQuickActionsState,
+    formData: FormData,
+): Promise<UpdateDashboardQuickActionsState> {
+    await auth(['admin']);
+
+    const entityTypes = await getEntityTypes();
+
+    const options: DashboardQuickActionOption[] =
+        buildDashboardQuickActionOptions(
+            entityTypes.map((entityType) => ({
+                name: entityType.name,
+                label: entityType.label,
+            })),
+        );
+
+    const values = formData
+        .getAll('quickActions')
+        .filter((value): value is string => typeof value === 'string');
+
+    const uniqueValues = [...new Set(values)];
+
+    if (uniqueValues.some((value) => !isActionAllowed(value, options))) {
+        return {
+            success: false,
+            message: 'Jedna ili više odabranih brzih poveznica nije valjana.',
+        };
+    }
+
+    const actions = uniqueValues
+        .map((value) => parseQuickActionId(value))
+        .filter((value): value is NonNullable<typeof value> => Boolean(value));
+
+    const shouldDisable = actions.length === 0;
+
+    await upsertSetting({
+        key: SettingsKeys.DashboardQuickActions,
+        value: {
+            actions,
+        },
+    });
+
+    if (shouldDisable) {
+        revalidatePath(KnownPages.Dashboard);
+        revalidatePath(KnownPages.Settings);
+
+        return {
+            success: true,
+            message: 'Brze poveznice su isključene.',
+        };
+    }
+
+    revalidatePath(KnownPages.Dashboard);
+    revalidatePath(KnownPages.Settings);
+
+    return {
+        success: true,
+        message: 'Brze poveznice su uspješno spremljene.',
+    };
+}

--- a/apps/app/app/admin/settings/DashboardQuickActionsSettingForm.tsx
+++ b/apps/app/app/admin/settings/DashboardQuickActionsSettingForm.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+import type { DashboardQuickActionOption } from '../../../src/dashboardQuickActions';
+import { updateDashboardQuickActionsAction } from '../../(actions)/dashboardSettingsActions';
+
+type DashboardQuickActionsSettingFormProps = {
+    options: DashboardQuickActionOption[];
+    selectedActionIds: string[];
+};
+
+function SubmitButton() {
+    const { pending } = useFormStatus();
+
+    return (
+        <Button type="submit" disabled={pending}>
+            {pending ? 'Spremanje…' : 'Spremi brze poveznice'}
+        </Button>
+    );
+}
+
+export function DashboardQuickActionsSettingForm({
+    options,
+    selectedActionIds,
+}: DashboardQuickActionsSettingFormProps) {
+    const [state, formAction] = useActionState(
+        updateDashboardQuickActionsAction,
+        null,
+    );
+
+    return (
+        <form action={formAction} className="space-y-3">
+            <Stack spacing={1}>
+                {options.map((option) => {
+                    const inputId = `dashboard-quick-action-${option.id}`;
+
+                    return (
+                        <label
+                            key={option.id}
+                            htmlFor={inputId}
+                            className="flex cursor-pointer items-start gap-3 rounded-md border p-3"
+                        >
+                            <Checkbox
+                                id={inputId}
+                                name="quickActions"
+                                value={option.id}
+                                defaultChecked={selectedActionIds.includes(
+                                    option.id,
+                                )}
+                                className="mt-0.5"
+                            />
+                            <div>
+                                <Typography level="h5" semiBold>
+                                    {option.label}
+                                </Typography>
+                                <Typography level="body2" secondary>
+                                    {option.description}
+                                </Typography>
+                            </div>
+                        </label>
+                    );
+                })}
+            </Stack>
+            <SubmitButton />
+            {state && (
+                <p
+                    className={`text-sm ${
+                        state.success ? 'text-green-600' : 'text-red-600'
+                    }`}
+                >
+                    {state.message}
+                </p>
+            )}
+        </form>
+    );
+}

--- a/apps/app/app/admin/settings/page.tsx
+++ b/apps/app/app/admin/settings/page.tsx
@@ -1,9 +1,12 @@
 import {
     getEntityTypeCategories,
+    getEntityTypes,
     getNotificationSetting,
+    getSetting,
     IntegrationTypes,
     NotificationSettingKeys,
     type SelectNotificationSetting,
+    SettingsKeys,
     type SlackConfig,
 } from '@gredice/storage';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
@@ -21,8 +24,13 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { auth } from '../../../lib/auth/auth';
+import {
+    buildDashboardQuickActionOptions,
+    getQuickActionIdsFromConfig,
+} from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
 import { SlackChannelSettingForm } from '../communication/slack/SlackChannelSettingForm';
+import { DashboardQuickActionsSettingForm } from './DashboardQuickActionsSettingForm';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,6 +38,10 @@ const SETTINGS_SECTIONS = [
     {
         id: 'directory-settings',
         title: 'Zapisi',
+    },
+    {
+        id: 'dashboard-settings',
+        title: 'Kontrolna ploča',
     },
     {
         id: 'notification-settings',
@@ -56,12 +68,32 @@ function getSlackChannelId(
 export default async function SettingsPage() {
     await auth(['admin']);
 
-    const [delivery, newUsers, shopping, categories] = await Promise.all([
+    const [
+        delivery,
+        newUsers,
+        shopping,
+        categories,
+        entityTypes,
+        dashboardQuickActionsSetting,
+    ] = await Promise.all([
         getNotificationSetting(NotificationSettingKeys.SlackDeliveryChannel),
         getNotificationSetting(NotificationSettingKeys.SlackNewUsersChannel),
         getNotificationSetting(NotificationSettingKeys.SlackShoppingChannel),
         getEntityTypeCategories(),
+        getEntityTypes(),
+        getSetting(SettingsKeys.DashboardQuickActions),
     ]);
+
+    const dashboardQuickActionOptions = buildDashboardQuickActionOptions(
+        entityTypes.map((entityType) => ({
+            name: entityType.name,
+            label: entityType.label,
+        })),
+    );
+
+    const selectedDashboardQuickActionIds = getQuickActionIdsFromConfig(
+        dashboardQuickActionsSetting?.value,
+    );
 
     return (
         <Stack spacing={4}>
@@ -173,6 +205,42 @@ export default async function SettingsPage() {
                             )}
                         </Stack>
                     </section>
+
+                    <section
+                        id="dashboard-settings"
+                        className="scroll-mt-28"
+                        aria-labelledby="dashboard-settings-heading"
+                    >
+                        <Stack spacing={3}>
+                            <Stack spacing={1}>
+                                <Typography
+                                    id="dashboard-settings-heading"
+                                    level="h2"
+                                    semiBold
+                                >
+                                    Kontrolna ploča
+                                </Typography>
+                                <Typography level="body1">
+                                    Odaberi koje će se brze poveznice
+                                    prikazivati na vrhu početne kontrolne ploče.
+                                </Typography>
+                            </Stack>
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle>Brze poveznice</CardTitle>
+                                </CardHeader>
+                                <CardContent className="space-y-3">
+                                    <DashboardQuickActionsSettingForm
+                                        options={dashboardQuickActionOptions}
+                                        selectedActionIds={
+                                            selectedDashboardQuickActionIds
+                                        }
+                                    />
+                                </CardContent>
+                            </Card>
+                        </Stack>
+                    </section>
+
                     <section
                         id="notification-settings"
                         className="scroll-mt-28"

--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -1,4 +1,10 @@
+import { getEntityTypes, getSetting, SettingsKeys } from '@gredice/storage';
 import { auth } from '../../../lib/auth/auth';
+import {
+    buildDashboardQuickActionOptions,
+    getDashboardQuickActionsFromConfig,
+    getDefaultDashboardQuickActions,
+} from '../../../src/dashboardQuickActions';
 import { AdminDashboardClient } from './AdminDashboardClient';
 import { getAnalyticsData } from './actions';
 
@@ -11,11 +17,36 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
     const params = await searchParams;
     const selectedPeriod = params?.period || '7';
 
-    const data = await getAnalyticsData(
-        selectedPeriod === 'custom' ? undefined : Number(selectedPeriod),
-        params?.from,
-        params?.to,
+    const [data, entityTypes, dashboardQuickActionsSetting] = await Promise.all(
+        [
+            getAnalyticsData(
+                selectedPeriod === 'custom'
+                    ? undefined
+                    : Number(selectedPeriod),
+                params?.from,
+                params?.to,
+            ),
+            getEntityTypes(),
+            getSetting(SettingsKeys.DashboardQuickActions),
+        ],
     );
+
+    const quickActionOptions = buildDashboardQuickActionOptions(
+        entityTypes.map((entityType) => ({
+            name: entityType.name,
+            label: entityType.label,
+        })),
+    );
+
+    const configuredQuickActions = getDashboardQuickActionsFromConfig(
+        dashboardQuickActionsSetting?.value,
+        quickActionOptions,
+    );
+
+    const quickActions =
+        configuredQuickActions.length > 0
+            ? configuredQuickActions
+            : getDefaultDashboardQuickActions(quickActionOptions);
 
     return (
         <AdminDashboardClient
@@ -24,6 +55,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
             initialOperationsDurationData={data.operationsDuration}
             initialWeekdayRegistrations={data.weekdayRegistrations}
             initialAiData={data.ai}
+            initialQuickActions={quickActions}
             initialPeriod={selectedPeriod}
             initialFrom={params?.from}
             initialTo={params?.to}

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import type { getAnalyticsTotals } from '@gredice/storage';
-import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
-import { Calendar } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -11,6 +9,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, useTransition } from 'react';
+import type { DashboardQuickActionOption } from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
 import { FactCard } from '../cards/FactCard';
 import { DashboardDivider } from './DashboardDivider';
@@ -45,6 +44,7 @@ type AiData = {
 export function AdminDashboardClient({
     initialAnalyticsData,
     initialEntitiesData,
+    initialQuickActions,
     initialPeriod = '7',
     initialOperationsDurationData,
     initialWeekdayRegistrations,
@@ -53,6 +53,7 @@ export function AdminDashboardClient({
     initialTo,
 }: {
     initialAnalyticsData: Awaited<ReturnType<typeof getAnalyticsTotals>>;
+    initialQuickActions: DashboardQuickActionOption[];
     initialEntitiesData: EntityData[];
     initialPeriod?: string;
     initialOperationsDurationData: OperationsDurationData;
@@ -163,30 +164,18 @@ export function AdminDashboardClient({
 
     return (
         <Stack spacing={2}>
-            <Row spacing={1}>
-                <Button
-                    variant="outlined"
-                    className="rounded-full"
-                    size="sm"
-                    startDecorator={<Calendar className="size-4 shrink-0" />}
-                    href={KnownPages.Schedule}
-                >
-                    Raspored
-                </Button>
-                <Button
-                    variant="outlined"
-                    size="sm"
-                    className="rounded-full"
-                    startDecorator={
-                        <RaisedBedIcon
-                            className="size-4 shrink-0"
-                            physicalId={null}
-                        />
-                    }
-                    href={KnownPages.RaisedBeds}
-                >
-                    Gredice
-                </Button>
+            <Row spacing={1} className="flex-wrap">
+                {initialQuickActions.map((quickAction) => (
+                    <Button
+                        key={quickAction.id}
+                        variant="outlined"
+                        className="rounded-full"
+                        size="sm"
+                        href={quickAction.href}
+                    >
+                        {quickAction.label}
+                    </Button>
+                ))}
             </Row>
             <Stack spacing={1}>
                 <Row justifyContent="space-between">

--- a/apps/app/src/dashboardQuickActions.ts
+++ b/apps/app/src/dashboardQuickActions.ts
@@ -1,0 +1,205 @@
+import type { DashboardQuickActionConfigItem } from '@gredice/storage';
+import { KnownPages } from './KnownPages';
+
+export type DashboardQuickActionOption = {
+    id: string;
+    label: string;
+    href: string;
+    description: string;
+};
+
+type DashboardEntityTypeOption = {
+    name: string;
+    label: string;
+};
+
+const DASHBOARD_BUILTIN_QUICK_ACTIONS = [
+    {
+        key: 'schedule',
+        label: 'Raspored',
+        href: KnownPages.Schedule,
+        description: 'Otvara raspored radnji i planiranja.',
+    },
+    {
+        key: 'raised-beds',
+        label: 'Gredice',
+        href: KnownPages.RaisedBeds,
+        description: 'Pregled i upravljanje svim gredicama.',
+    },
+    {
+        key: 'operations',
+        label: 'Radnje',
+        href: KnownPages.Operations,
+        description: 'Brzi pristup listi radnji.',
+    },
+    {
+        key: 'delivery-requests',
+        label: 'Zahtjevi za dostavu',
+        href: KnownPages.DeliveryRequests,
+        description: 'Pregled zahtjeva za dostavu.',
+    },
+    {
+        key: 'transactions',
+        label: 'Transakcije',
+        href: KnownPages.Transactions,
+        description: 'Pregled nedavnih transakcija.',
+    },
+] as const;
+
+type DashboardBuiltinQuickActionKey =
+    (typeof DASHBOARD_BUILTIN_QUICK_ACTIONS)[number]['key'];
+
+function isBuiltinQuickActionKey(
+    value: string,
+): value is DashboardBuiltinQuickActionKey {
+    return DASHBOARD_BUILTIN_QUICK_ACTIONS.some((item) => item.key === value);
+}
+
+export function encodeBuiltinQuickActionId(
+    key: DashboardBuiltinQuickActionKey,
+): string {
+    return `builtin:${key}`;
+}
+
+export function encodeEntityQuickActionId(entityTypeName: string): string {
+    return `entity:${entityTypeName}`;
+}
+
+export function parseQuickActionId(
+    value: string,
+): DashboardQuickActionConfigItem | null {
+    if (value.startsWith('builtin:')) {
+        const builtinKey = value.slice('builtin:'.length);
+        if (!isBuiltinQuickActionKey(builtinKey)) {
+            return null;
+        }
+
+        return {
+            type: 'builtin',
+            value: builtinKey,
+        };
+    }
+
+    if (value.startsWith('entity:')) {
+        const entityTypeName = value.slice('entity:'.length).trim();
+        if (!entityTypeName) {
+            return null;
+        }
+
+        return {
+            type: 'entity',
+            value: entityTypeName,
+        };
+    }
+
+    return null;
+}
+
+export function buildDashboardQuickActionOptions(
+    entityTypes: DashboardEntityTypeOption[],
+): DashboardQuickActionOption[] {
+    const builtinOptions: DashboardQuickActionOption[] =
+        DASHBOARD_BUILTIN_QUICK_ACTIONS.map((item) => ({
+            id: encodeBuiltinQuickActionId(item.key),
+            label: item.label,
+            href: item.href,
+            description: item.description,
+        }));
+
+    const entityOptions: DashboardQuickActionOption[] = entityTypes.map(
+        (entityType) => ({
+            id: encodeEntityQuickActionId(entityType.name),
+            label: entityType.label,
+            href: KnownPages.DirectoryEntityType(entityType.name),
+            description: `Otvara zapise tipa „${entityType.label}”.`,
+        }),
+    );
+
+    return [...builtinOptions, ...entityOptions];
+}
+
+function parseQuickActionConfig(
+    config: unknown,
+): DashboardQuickActionConfigItem[] {
+    if (typeof config !== 'object' || config === null) {
+        return [];
+    }
+
+    if (!('actions' in config) || !Array.isArray(config.actions)) {
+        return [];
+    }
+
+    const parsed: DashboardQuickActionConfigItem[] = [];
+
+    for (const action of config.actions) {
+        if (typeof action !== 'object' || action === null) {
+            continue;
+        }
+
+        if (!('type' in action) || !('value' in action)) {
+            continue;
+        }
+
+        if (
+            (action.type === 'builtin' || action.type === 'entity') &&
+            typeof action.value === 'string' &&
+            action.value.length > 0
+        ) {
+            parsed.push({
+                type: action.type,
+                value: action.value,
+            });
+        }
+    }
+
+    return parsed;
+}
+
+function toQuickActionId(action: DashboardQuickActionConfigItem): string {
+    if (action.type === 'builtin') {
+        return `builtin:${action.value}`;
+    }
+
+    return `entity:${action.value}`;
+}
+
+export function getDashboardQuickActionsFromConfig(
+    config: unknown,
+    options: DashboardQuickActionOption[],
+): DashboardQuickActionOption[] {
+    const actions = parseQuickActionConfig(config);
+    const optionsMap = new Map(options.map((option) => [option.id, option]));
+    const selected: DashboardQuickActionOption[] = [];
+
+    for (const action of actions) {
+        const option = optionsMap.get(toQuickActionId(action));
+        if (option) {
+            selected.push(option);
+        }
+    }
+
+    return selected;
+}
+
+export function getDefaultDashboardQuickActions(
+    options: DashboardQuickActionOption[],
+): DashboardQuickActionOption[] {
+    const defaults = [
+        encodeBuiltinQuickActionId('schedule'),
+        encodeBuiltinQuickActionId('raised-beds'),
+    ];
+
+    const optionsMap = new Map(options.map((option) => [option.id, option]));
+
+    return defaults
+        .map((defaultAction) => optionsMap.get(defaultAction))
+        .filter((option): option is DashboardQuickActionOption =>
+            Boolean(option),
+        );
+}
+
+export function getQuickActionIdsFromConfig(config: unknown): string[] {
+    return parseQuickActionConfig(config).map((action) =>
+        toQuickActionId(action),
+    );
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -33,6 +33,7 @@ export * from './repositories/occasionsRepo';
 export * from './repositories/operationsRepo';
 export * from './repositories/pickupLocationsRepo';
 export * from './repositories/refreshTokensRepo';
+export * from './repositories/settingsRepo';
 export * from './repositories/shoppingCartRepo';
 export * from './repositories/timeSlotsRepo';
 export * from './repositories/transactionsRepo';

--- a/packages/storage/src/migrations/0019_black_green_goblin.sql
+++ b/packages/storage/src/migrations/0019_black_green_goblin.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "settings" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/packages/storage/src/migrations/meta/0019_snapshot.json
+++ b/packages/storage/src/migrations/meta/0019_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "87ba4425-c201-4be0-af5a-124149b6c965",
-  "prevId": "2702ad13-1767-4cd1-ab29-3800aa529585",
+  "id": "d12fceb0-9e7d-4c07-a70e-735cf7898f67",
+  "prevId": "87ba4425-c201-4be0-af5a-124149b6c965",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -4872,6 +4872,45 @@
           "onUpdate": "no action"
         }
       },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1775001600000,
       "tag": "0018_backfill_operation_verify_events",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1776621478472,
+      "tag": "0019_black_green_goblin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/settingsRepo.ts
+++ b/packages/storage/src/repositories/settingsRepo.ts
@@ -1,0 +1,57 @@
+import 'server-only';
+
+import { eq, inArray } from 'drizzle-orm';
+import { storage } from '..';
+import {
+    type InsertSetting,
+    type SelectSetting,
+    type SettingKey,
+    SettingsKeys,
+    settings,
+} from '../schema';
+
+export function isSettingKey(value: unknown): value is SettingKey {
+    return Object.values(SettingsKeys).includes(value as SettingKey);
+}
+
+export async function getSetting(
+    key: SettingKey,
+): Promise<SelectSetting | undefined> {
+    return storage().query.settings.findFirst({
+        where: eq(settings.key, key),
+    });
+}
+
+export async function getSettings(
+    keys?: SettingKey[],
+): Promise<SelectSetting[]> {
+    if (Array.isArray(keys) && keys.length > 0) {
+        return storage().query.settings.findMany({
+            where: inArray(settings.key, keys),
+        });
+    }
+
+    return storage().query.settings.findMany();
+}
+
+export async function upsertSetting(
+    values: InsertSetting,
+): Promise<SelectSetting> {
+    const [result] = await storage()
+        .insert(settings)
+        .values(values)
+        .onConflictDoUpdate({
+            target: settings.key,
+            set: {
+                value: values.value,
+                updatedAt: new Date(),
+            },
+        })
+        .returning();
+
+    return result;
+}
+
+export async function deleteSetting(key: SettingKey): Promise<void> {
+    await storage().delete(settings).where(eq(settings.key, key));
+}

--- a/packages/storage/src/schema/index.ts
+++ b/packages/storage/src/schema/index.ts
@@ -14,6 +14,7 @@ export * from './notificationSettingsSchema';
 export * from './notificationsSchema';
 export * from './operationsSchema';
 export * from './refreshTokensSchema';
+export * from './settingsSchema';
 export * from './shoppingCartSchema';
 export * from './transactionSchema';
 export * from './usersSchema';

--- a/packages/storage/src/schema/settingsSchema.ts
+++ b/packages/storage/src/schema/settingsSchema.ts
@@ -1,0 +1,34 @@
+import { jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const SettingsKeys = {
+    DashboardQuickActions: 'dashboard.quick_actions',
+} as const;
+
+export type SettingKey = (typeof SettingsKeys)[keyof typeof SettingsKeys];
+
+export type DashboardQuickActionConfigItem = {
+    type: 'builtin' | 'entity';
+    value: string;
+};
+
+export type DashboardQuickActionsSettingValue = {
+    actions: DashboardQuickActionConfigItem[];
+};
+
+export type SettingValue = DashboardQuickActionsSettingValue;
+
+export const settings = pgTable('settings', {
+    key: text('key').primaryKey().$type<SettingKey>(),
+    value: jsonb('value').$type<SettingValue>().notNull(),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at')
+        .notNull()
+        .defaultNow()
+        .$onUpdate(() => new Date()),
+});
+
+export type SelectSetting = typeof settings.$inferSelect;
+export type InsertSetting = Omit<
+    typeof settings.$inferInsert,
+    'createdAt' | 'updatedAt'
+>;


### PR DESCRIPTION
### Motivation

- Provide configurable quick links on the admin dashboard so admins can choose which shortcuts appear at the top of the dashboard.
- Store the configuration in the database so selections persist across deployments and can be toggled on/off. 
- Validate and default selections to a sensible set when no configuration exists.

### Description

- Add a new `settings` table schema and types in `packages/storage/src/schema/settingsSchema.ts` and expose CRUD helpers in `packages/storage/src/repositories/settingsRepo.ts`, and export the repo from `packages/storage/src/index.ts`.
- Introduce `apps/app/src/dashboardQuickActions.ts` which implements quick-action option building, id encoding/decoding, config parsing, default actions, and helpers to map stored config to renderable options.
- Add a server action `apps/app/app/(actions)/dashboardSettingsActions.ts` to validate submitted quick-action ids, persist them via `upsertSetting`, and revalidate relevant Next.js paths; the action enforces admin auth.
- Implement admin UI components and integration: `DashboardQuickActionsSettingForm.tsx` for the form, integration into the settings page `apps/app/app/admin/settings/page.tsx`, and pass configured/default quick actions into the dashboard client via `AdminDashboard.tsx` and `AdminDashboardClient.tsx` so buttons render on the dashboard.

### Testing

- Ran type-check with `pnpm -w -s tsc --noEmit`, which completed successfully.
- Ran unit tests with `pnpm -w test`, which completed successfully.
- Ran linter with `pnpm -w lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e512f90550832fb7e90a81666a6e85)