### PR TITLE
Admin breadcrumbs dropdown: group items and add icons

### DIFF
--- a/apps/app/components/admin/navigation/AdminPageBreadcrumbs.tsx
+++ b/apps/app/components/admin/navigation/AdminPageBreadcrumbs.tsx
@@ -1,17 +1,42 @@
 'use client';
 
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
-import { ArrowDown } from '@signalco/ui-icons';
+import {
+    AI,
+    ArrowDown,
+    Bank,
+    Calendar,
+    Euro,
+    Fence,
+    File,
+    Hammer,
+    Home,
+    Inbox,
+    Mail,
+    Map as MapIcon,
+    Megaphone,
+    Settings,
+    ShoppingCart,
+    SmileHappy,
+    Success,
+    Tally3,
+    Truck,
+    User,
+} from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@signalco/ui-primitives/Menu';
 import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
-import { adminBreadcrumbPages } from './adminPages';
+import { adminBreadcrumbPages, adminPages } from './adminPages';
 
 function resolveCurrentTopLevel(pathname: string) {
     const exact = adminBreadcrumbPages.find((page) => page.href === pathname);
@@ -33,6 +58,111 @@ function resolveCurrentTopLevel(pathname: string) {
         return bestMatch;
     }, undefined);
 }
+
+const breadcrumbSections: {
+    title: string;
+    pages: {
+        href: string;
+        label: string;
+        icon: ReactNode;
+    }[];
+}[] = [
+    {
+        title: 'Osnovno',
+        pages: [
+            {
+                ...adminPages.Dashboard,
+                icon: <Home className="size-4" />,
+            },
+        ],
+    },
+    {
+        title: 'Zapisi',
+        pages: [
+            {
+                ...adminPages.Directories,
+                icon: <File className="size-4" />,
+            },
+        ],
+    },
+    {
+        title: 'Administracija',
+        pages: [
+            { ...adminPages.Accounts, icon: <Bank className="size-4" /> },
+            {
+                ...adminPages.Achievements,
+                icon: <Success className="size-4" />,
+            },
+            {
+                ...adminPages.ShoppingCarts,
+                icon: <ShoppingCart className="size-4" />,
+            },
+            { ...adminPages.Invoices, icon: <File className="size-4" /> },
+            {
+                ...adminPages.Transactions,
+                icon: <Euro className="size-4" />,
+            },
+            { ...adminPages.Receipts, icon: <File className="size-4" /> },
+            { ...adminPages.Users, icon: <User className="size-4" /> },
+            { ...adminPages.Farms, icon: <MapIcon className="size-4" /> },
+            { ...adminPages.Gardens, icon: <Fence className="size-4" /> },
+            {
+                ...adminPages.RaisedBeds,
+                icon: <RaisedBedIcon className="size-4" physicalId={null} />,
+            },
+            { ...adminPages.Operations, icon: <Hammer className="size-4" /> },
+        ],
+    },
+    {
+        title: 'Upravljanje',
+        pages: [
+            { ...adminPages.Inventory, icon: <Tally3 className="size-4" /> },
+            { ...adminPages.Occasions, icon: <Calendar className="size-4" /> },
+            { ...adminPages.Schedule, icon: <Calendar className="size-4" /> },
+            { ...adminPages.DeliverySlots, icon: <Truck className="size-4" /> },
+            {
+                ...adminPages.DeliveryRequests,
+                icon: <Truck className="size-4" />,
+            },
+        ],
+    },
+    {
+        title: 'Komunikacija',
+        pages: [
+            {
+                ...adminPages.CommunicationInbox,
+                icon: <Inbox className="size-4" />,
+            },
+            {
+                ...adminPages.CommunicationEmails,
+                icon: <Mail className="size-4" />,
+            },
+            {
+                ...adminPages.CommunicationSlack,
+                icon: <Mail className="size-4" />,
+            },
+            {
+                ...adminPages.Notifications,
+                icon: <Megaphone className="size-4" />,
+            },
+            { ...adminPages.Feedback, icon: <SmileHappy className="size-4" /> },
+        ],
+    },
+    {
+        title: 'Postavke',
+        pages: [
+            { ...adminPages.Settings, icon: <Settings className="size-4" /> },
+        ],
+    },
+    {
+        title: 'Sustavi',
+        pages: [
+            { ...adminPages.Sensors, icon: <File className="size-4" /> },
+            { ...adminPages.Cache, icon: <File className="size-4" /> },
+            { ...adminPages.AiAnalytics, icon: <AI className="size-4" /> },
+        ],
+    },
+];
 
 export function AdminPageBreadcrumbs() {
     const pathname = usePathname();
@@ -68,14 +198,33 @@ export function AdminPageBreadcrumbs() {
                                     </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent>
-                                    {adminBreadcrumbPages.map((page) => (
-                                        <DropdownMenuItem
-                                            key={page.href}
-                                            href={page.href}
-                                        >
-                                            {page.label}
-                                        </DropdownMenuItem>
-                                    ))}
+                                    {breadcrumbSections.map(
+                                        (section, index) => (
+                                            <div key={section.title}>
+                                                <DropdownMenuLabel className="text-muted-foreground text-xs">
+                                                    {section.title}
+                                                </DropdownMenuLabel>
+                                                {section.pages.map((page) => (
+                                                    <DropdownMenuItem
+                                                        key={page.href}
+                                                        href={page.href}
+                                                    >
+                                                        <div className="flex items-center gap-2">
+                                                            {page.icon}
+                                                            <span>
+                                                                {page.label}
+                                                            </span>
+                                                        </div>
+                                                    </DropdownMenuItem>
+                                                ))}
+                                                {index <
+                                                    breadcrumbSections.length -
+                                                        1 && (
+                                                    <DropdownMenuSeparator />
+                                                )}
+                                            </div>
+                                        ),
+                                    )}
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         ),


### PR DESCRIPTION
### Motivation

- Make the admin breadcrumbs dropdown visually match the left navigation by adding the same icons to each item. 
- Improve discoverability by grouping breadcrumb entries into the same sections used in the left menu (Osnovno, Zapisi, Administracija, Upravljanje, Komunikacija, Postavke, Sustavi).

### Description

- Updated `apps/app/components/admin/navigation/AdminPageBreadcrumbs.tsx` to import the nav icons and the `RaisedBedIcon` and to include a new `breadcrumbSections` structure describing grouped pages with icons.
- Render the dropdown as grouped sections using `DropdownMenuLabel` and `DropdownMenuSeparator`, and render each item with its icon alongside the label inside `DropdownMenuItem`.
- Kept the existing top-level resolution logic from `resolveCurrentTopLevel` and preserved the current dropdown trigger behavior.

### Testing

- Ran lint with `pnpm --dir apps/app lint`, which completed successfully and auto-fixed one file and reported one remaining warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e577fb66e8832f87a34761229f2f0c)