### PR TITLE
Show dashboard quick links at top of admin navigation

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -1,6 +1,8 @@
 import {
     getEntityTypesOrganizedByCategories,
     getPendingAchievementsCount,
+    getSetting,
+    SettingsKeys,
 } from '@gredice/storage';
 import { SignedOut } from '@signalco/auth-client/components';
 import { AuthProtectedSection } from '@signalco/auth-server/components';
@@ -14,6 +16,11 @@ import {
 import { AdminClientProvider } from '../../components/admin/providers';
 import { AuthAppProvider } from '../../components/providers/AuthAppProvider';
 import { auth } from '../../lib/auth/auth';
+import {
+    buildDashboardQuickActionOptions,
+    getDashboardQuickActionsFromConfig,
+    getDefaultDashboardQuickActions,
+} from '../../src/dashboardQuickActions';
 
 export const dynamic = 'force-dynamic';
 
@@ -26,10 +33,32 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
     const [
         { categorizedTypes, uncategorizedTypes, shadowTypes },
         pendingAchievementsCount,
+        dashboardQuickActionsSetting,
     ] = await Promise.all([
         getEntityTypesOrganizedByCategories(),
         isAdmin ? getPendingAchievementsCount() : Promise.resolve(0),
+        getSetting(SettingsKeys.DashboardQuickActions),
     ]);
+
+    const quickActionEntityTypes = [
+        ...categorizedTypes.flatMap((category) => category.entityTypes),
+        ...uncategorizedTypes,
+        ...shadowTypes,
+    ];
+    const quickActionOptions = buildDashboardQuickActionOptions(
+        quickActionEntityTypes.map((entityType) => ({
+            name: entityType.name,
+            label: entityType.label,
+        })),
+    );
+    const configuredQuickActions = getDashboardQuickActionsFromConfig(
+        dashboardQuickActionsSetting?.value,
+        quickActionOptions,
+    );
+    const quickActions =
+        configuredQuickActions.length > 0
+            ? configuredQuickActions
+            : getDefaultDashboardQuickActions(quickActionOptions);
 
     return (
         <AuthAppProvider>
@@ -38,6 +67,7 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                 uncategorizedTypes={uncategorizedTypes}
                 shadowTypes={shadowTypes}
                 pendingAchievementsCount={pendingAchievementsCount}
+                quickActions={quickActions}
             >
                 <div className="grow bg-secondary">
                     <MobileHeader />

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -138,6 +138,7 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
     const uncategorizedTypes = navContext?.uncategorizedTypes || [];
     const shadowTypes = navContext?.shadowTypes || [];
     const pendingAchievementsCount = navContext?.pendingAchievementsCount ?? 0;
+    const quickActions = navContext?.quickActions || [];
 
     return (
         <Stack spacing={2}>
@@ -150,6 +151,15 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                     strictMatch
                     onClick={onItemClick}
                 />
+                {quickActions.map((quickAction) => (
+                    <NavItem
+                        key={quickAction.id}
+                        href={quickAction.href}
+                        label={quickAction.label}
+                        icon={<File className="size-5" />}
+                        onClick={onItemClick}
+                    />
+                ))}
             </List>
             <Stack spacing={1}>
                 <AuthProtectedSection>

--- a/apps/app/components/admin/navigation/NavContext.ts
+++ b/apps/app/components/admin/navigation/NavContext.ts
@@ -2,11 +2,13 @@
 
 import type { getEntityTypesOrganizedByCategories } from '@gredice/storage';
 import { createContext } from 'react';
+import type { DashboardQuickActionOption } from '../../../src/dashboardQuickActions';
 
 export type NavContextType = Awaited<
     ReturnType<typeof getEntityTypesOrganizedByCategories>
 > & {
     pendingAchievementsCount: number;
+    quickActions: DashboardQuickActionOption[];
 };
 
 export const NavContext = createContext<NavContextType | undefined>(undefined);

--- a/apps/app/components/admin/providers/AdminClientProvider.tsx
+++ b/apps/app/components/admin/providers/AdminClientProvider.tsx
@@ -7,12 +7,14 @@ export function AdminClientProvider({
     uncategorizedTypes,
     shadowTypes,
     pendingAchievementsCount,
+    quickActions,
     children,
 }: {
     categorizedTypes: NavContextType['categorizedTypes'];
     uncategorizedTypes: NavContextType['uncategorizedTypes'];
     shadowTypes: NavContextType['shadowTypes'];
     pendingAchievementsCount: number;
+    quickActions: NavContextType['quickActions'];
     children: React.ReactNode;
 }) {
     return (
@@ -22,6 +24,7 @@ export function AdminClientProvider({
                 uncategorizedTypes,
                 shadowTypes,
                 pendingAchievementsCount,
+                quickActions,
             }}
         >
             {children}

--- a/apps/app/src/dashboardQuickActions.ts
+++ b/apps/app/src/dashboardQuickActions.ts
@@ -1,10 +1,11 @@
 import type { DashboardQuickActionConfigItem } from '@gredice/storage';
+import type { Route } from 'next';
 import { KnownPages } from './KnownPages';
 
 export type DashboardQuickActionOption = {
     id: string;
     label: string;
-    href: string;
+    href: Route;
     description: string;
 };
 


### PR DESCRIPTION
### Motivation
- Make dashboard-configured quick links accessible from every admin page by surfacing them in the global admin navigation under the Dashboard (`Početna`) item.

### Description
- Load the dashboard quick actions setting in `apps/app/app/admin/layout.tsx`, build options from entity types, and resolve configured or default quick actions.
- Extend the admin nav context with `quickActions` and pass them through `AdminClientProvider` so every page can consume the links (`NavContext`, `AdminClientProvider`).
- Render the quick-action links directly below the Dashboard nav item in `Nav.tsx` so they appear at the top of the navigation.
- Tighten quick-action typing by changing `href` to a Next.js `Route` in `apps/app/src/dashboardQuickActions.ts` for compatibility with `NavItem`.

### Testing
- Ran `pnpm --filter app lint`, which completed successfully but reported one pre-existing suppression warning in `app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx`.
- Built the app with `pnpm --filter app build`, and the Next.js build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e577ce230c832f9b6459b47786c309)