### PR TITLE
Link raised bed labels to detail pages in schedule sections

### DIFF
--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -9,6 +9,7 @@ import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 import { KnownPages } from '../../../src/KnownPages';
 import { AcceptOperationModal } from './AcceptOperationModal';
@@ -55,6 +56,10 @@ export function RaisedBedOperationsScheduleSection({
     }
 
     const sortedRaisedBeds = [...raisedBeds].sort((a, b) => a.id - b.id);
+    const firstRaisedBed = sortedRaisedBeds.at(0);
+    const raisedBedDetailsLink = firstRaisedBed
+        ? KnownPages.RaisedBed(firstRaisedBed.id)
+        : null;
 
     const operationDataById = new Map<number, EntityStandardized>();
     if (operationsData) {
@@ -201,7 +206,13 @@ export function RaisedBedOperationsScheduleSection({
                     spacing={0.5}
                     className="min-w-0 grow items-center flex-wrap gap-y-1"
                 >
-                    <RaisedBedLabel physicalId={physicalId} />
+                    {raisedBedDetailsLink ? (
+                        <Link href={raisedBedDetailsLink}>
+                            <RaisedBedLabel physicalId={physicalId} />
+                        </Link>
+                    ) : (
+                        <RaisedBedLabel physicalId={physicalId} />
+                    )}
                     <Typography level="body2" className="text-muted-foreground">
                         Vrijeme: {formatMinutes(durations.completed, true)} /{' '}
                         {formatMinutes(durations.approved)} (

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -10,7 +10,9 @@ import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
+import { KnownPages } from '../../../src/KnownPages';
 import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
 import { AcceptRaisedBedFieldModal } from './AcceptRaisedBedFieldModal';
 import { AssignRaisedBedFieldModal } from './AssignRaisedBedFieldModal';
@@ -54,6 +56,10 @@ export function RaisedBedPlantingScheduleSection({
     }
 
     const sortedRaisedBeds = [...raisedBeds].sort((a, b) => a.id - b.id);
+    const firstRaisedBed = sortedRaisedBeds.at(0);
+    const raisedBedDetailsLink = firstRaisedBed
+        ? KnownPages.RaisedBed(firstRaisedBed.id)
+        : null;
 
     const dayFields = scheduledFields
         .filter((field) =>
@@ -164,7 +170,13 @@ export function RaisedBedPlantingScheduleSection({
                     spacing={0.5}
                     className="min-w-0 grow items-center flex-wrap gap-y-1"
                 >
-                    <RaisedBedLabel physicalId={physicalId} />
+                    {raisedBedDetailsLink ? (
+                        <Link href={raisedBedDetailsLink}>
+                            <RaisedBedLabel physicalId={physicalId} />
+                        </Link>
+                    ) : (
+                        <RaisedBedLabel physicalId={physicalId} />
+                    )}
                     <Typography level="body2" className="text-muted-foreground">
                         Vrijeme: {formatMinutes(durations.completed, true)} /{' '}
                         {formatMinutes(durations.approved)} (


### PR DESCRIPTION
### Motivation

- Improve navigability from the schedule views by making raised bed labels clickable so users can jump to the raised bed details page for the grouped raised bed section.
- Keep route generation consistent by reusing the existing `KnownPages.RaisedBed` helper.

### Description

- Import `next/link` and `KnownPages` and resolve the first raised bed id in each grouped section to compute a details link in both planting and operations schedule components (`RaisedBedPlantingScheduleSection.tsx` and `RaisedBedOperationsScheduleSection.tsx`).
- Wrap the `RaisedBedLabel` component with a `<Link>` to `KnownPages.RaisedBed(firstRaisedBed.id)` when a first raised bed is available, otherwise render the label as before.
- Files modified: `apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx` and `apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx`.

### Testing

- Ran `pnpm --dir apps/app exec biome check app/admin/schedule/RaisedBedPlantingScheduleSection.tsx app/admin/schedule/RaisedBedOperationsScheduleSection.tsx`, which completed with no fixes applied and no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e578eb9b10832f9fb30b6d04488b41)