### PR TITLE
Add daily sunflower spend/gifted analytics to admin dashboard

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -55,6 +55,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
             initialOperationsDurationData={data.operationsDuration}
             initialWeekdayRegistrations={data.weekdayRegistrations}
             initialAiData={data.ai}
+            initialSunflowersData={data.sunflowers}
             initialQuickActions={quickActions}
             initialPeriod={selectedPeriod}
             initialFrom={params?.from}

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -18,6 +18,10 @@ import {
     type OperationsDurationData,
 } from './OperationsDurationCard';
 import {
+    SunflowersDailyCard,
+    type SunflowersDailyData,
+} from './SunflowersDailyCard';
+import {
     UsersRegistrationWeekdayCard,
     type WeekdayRegistrationData,
 } from './UsersRegistrationWeekdayCard';
@@ -49,6 +53,7 @@ export function AdminDashboardClient({
     initialOperationsDurationData,
     initialWeekdayRegistrations,
     initialAiData,
+    initialSunflowersData,
     initialFrom,
     initialTo,
 }: {
@@ -59,6 +64,7 @@ export function AdminDashboardClient({
     initialOperationsDurationData: OperationsDurationData;
     initialWeekdayRegistrations: WeekdayRegistrationData[];
     initialAiData: AiData;
+    initialSunflowersData: SunflowersDailyData[];
     initialFrom?: string;
     initialTo?: string;
 }) {
@@ -346,6 +352,10 @@ export function AdminDashboardClient({
                         ),
                     )}
                 </div>
+            </Stack>
+            <Stack spacing={1}>
+                <DashboardDivider>Suncokreti</DashboardDivider>
+                <SunflowersDailyCard data={initialSunflowersData} />
             </Stack>
         </Stack>
     );

--- a/apps/app/components/admin/dashboard/SunflowersDailyCard.tsx
+++ b/apps/app/components/admin/dashboard/SunflowersDailyCard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
+
+export type SunflowersDailyData = {
+    date: string;
+    spent: number;
+    gifted: number;
+};
+
+const dateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: '2-digit',
+    month: '2-digit',
+});
+
+function formatDate(date: string) {
+    return dateFormatter.format(new Date(date));
+}
+
+export function SunflowersDailyCard({ data }: { data: SunflowersDailyData[] }) {
+    const totalSpent = data.reduce((sum, day) => sum + day.spent, 0);
+    const totalGifted = data.reduce((sum, day) => sum + day.gifted, 0);
+    const hasData = data.some((day) => day.spent > 0 || day.gifted > 0);
+
+    return (
+        <Card>
+            <CardOverflow>
+                <Stack spacing={2} className="p-4">
+                    <Stack spacing={0.5}>
+                        <Typography level="body3">
+                            Suncokreti po danu
+                        </Typography>
+                        <Typography level="h4" semiBold>
+                            Potrošeno {totalSpent} · Poklonjeno {totalGifted}
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Prikaz potrošnje i poklona kroz odabrani period
+                        </Typography>
+                    </Stack>
+                    {!hasData ? (
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Nema podataka za odabrani period.
+                        </Typography>
+                    ) : (
+                        <div className="h-64 w-full">
+                            <ResponsiveContainer width="100%" height="100%">
+                                <BarChart
+                                    data={data}
+                                    margin={{
+                                        top: 8,
+                                        right: 8,
+                                        left: -16,
+                                        bottom: 0,
+                                    }}
+                                >
+                                    <CartesianGrid
+                                        strokeDasharray="3 3"
+                                        className="stroke-border"
+                                    />
+                                    <XAxis
+                                        dataKey="date"
+                                        tickFormatter={formatDate}
+                                        tickLine={false}
+                                        axisLine={false}
+                                        tick={{ fontSize: 12 }}
+                                    />
+                                    <YAxis
+                                        allowDecimals={false}
+                                        tickLine={false}
+                                        axisLine={false}
+                                        tick={{ fontSize: 12 }}
+                                        width={28}
+                                    />
+                                    <Tooltip
+                                        cursor={{
+                                            fill: 'hsl(var(--primary) / 0.08)',
+                                        }}
+                                        labelFormatter={(value) =>
+                                            formatDate(String(value))
+                                        }
+                                        contentStyle={{
+                                            border: '1px solid hsl(var(--border))',
+                                            borderRadius: '0.5rem',
+                                            backgroundColor:
+                                                'hsl(var(--background))',
+                                        }}
+                                    />
+                                    <Bar
+                                        dataKey="spent"
+                                        name="Potrošeno"
+                                        fill="hsl(var(--destructive) / 0.7)"
+                                        radius={[4, 4, 0, 0]}
+                                    />
+                                    <Bar
+                                        dataKey="gifted"
+                                        name="Poklonjeno"
+                                        fill="hsl(var(--primary) / 0.7)"
+                                        radius={[4, 4, 0, 0]}
+                                    />
+                                </BarChart>
+                            </ResponsiveContainer>
+                        </div>
+                    )}
+                </Stack>
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -9,6 +9,7 @@ import {
     getEntitiesRaw,
     getEntityTypes,
     getPlantUpdateEvents,
+    getSunflowersDailyTotals,
     getUserRegistrationsByWeekday,
 } from '@gredice/storage';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
@@ -36,6 +37,12 @@ type OperationsDurationData = {
 type DateRange = {
     startDate: Date;
     endDate: Date;
+};
+
+type SunflowersDailyTotalsPoint = {
+    date: string;
+    spent: number;
+    gifted: number;
 };
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -197,6 +204,7 @@ export async function getAnalyticsData(
         weekdayRegistrationsRaw,
         aiTotals,
         aiEvents,
+        sunflowersDailyTotalsRaw,
     ] = await Promise.all([
         getAnalyticsTotals(rangeDays),
         getEntityTypes(),
@@ -208,6 +216,7 @@ export async function getAnalyticsData(
         getUserRegistrationsByWeekday(startDate, endDate),
         getAiAnalysisTotals({ from: startDate, to: endDate }),
         getAiAnalysisEvents({ from: startDate, to: endDate }),
+        getSunflowersDailyTotals({ from: startDate, to: endDate }),
     ]);
 
     const entitiesCounts = await Promise.all(
@@ -318,6 +327,19 @@ export async function getAnalyticsData(
         count: weekdayRegistrationsRaw[index] ?? 0,
     }));
 
+    const sunflowersByDate = new Map<string, SunflowersDailyTotalsPoint>();
+    for (const day of sunflowersDailyTotalsRaw) {
+        sunflowersByDate.set(day.date, day);
+    }
+    const sunflowersDailyTotals = dateKeys.map((date) => {
+        const day = sunflowersByDate.get(date);
+        return {
+            date,
+            spent: day?.spent ?? 0,
+            gifted: day?.gifted ?? 0,
+        };
+    });
+
     const aiTotalTokens = aiEvents.reduce(
         (sum, e) => sum + (e.data?.totalTokens ?? 0),
         0,
@@ -332,5 +354,6 @@ export async function getAnalyticsData(
             count: aiTotals.count,
             totalTokens: aiTotalTokens,
         },
+        sunflowers: sunflowersDailyTotals,
     };
 }

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -15,6 +15,7 @@ export {
     getLastBirthdayRewardEvent,
     getPlantPlaceEventsCount,
     getPlantUpdateEvents,
+    getSunflowersDailyTotals,
 } from './queries';
 export type {
     // Account

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -129,6 +129,62 @@ export async function getAiAnalysisTotals(filter?: { from?: Date; to?: Date }) {
     };
 }
 
+type SunflowersDailyPoint = {
+    date: string;
+    spent: number;
+    gifted: number;
+};
+
+export async function getSunflowersDailyTotals(filter?: {
+    from?: Date;
+    to?: Date;
+}) {
+    const results = await storage().query.events.findMany({
+        where: and(
+            inArray(events.type, [
+                knownEventTypes.accounts.earnSunflowers,
+                knownEventTypes.accounts.spendSunflowers,
+            ]),
+            filter?.from ? gte(events.createdAt, filter.from) : undefined,
+            filter?.to ? lte(events.createdAt, filter.to) : undefined,
+        ),
+        orderBy: [asc(events.createdAt)],
+    });
+
+    const byDay = new Map<string, SunflowersDailyPoint>();
+
+    for (const event of results) {
+        const key = event.createdAt.toISOString().split('T')[0];
+        const existing = byDay.get(key) ?? { date: key, spent: 0, gifted: 0 };
+        const payload = event.data as
+            | { amount?: unknown; reason?: unknown }
+            | null
+            | undefined;
+        const amount =
+            typeof payload?.amount === 'number' &&
+            Number.isFinite(payload.amount)
+                ? Math.max(0, payload.amount)
+                : 0;
+        const reason =
+            typeof payload?.reason === 'string' ? payload.reason : undefined;
+
+        if (event.type === knownEventTypes.accounts.spendSunflowers) {
+            existing.spent += amount;
+        } else if (
+            event.type === knownEventTypes.accounts.earnSunflowers &&
+            reason === 'gift'
+        ) {
+            existing.gifted += amount;
+        }
+
+        byDay.set(key, existing);
+    }
+
+    return Array.from(byDay.values()).sort((a, b) =>
+        a.date.localeCompare(b.date),
+    );
+}
+
 export function deleteEventById(eventId: number) {
     return storage().delete(events).where(eq(events.id, eventId));
 }


### PR DESCRIPTION
### Motivation
- Provide visibility into daily sunflower activity by showing how many sunflowers were spent and how many were gifted each day on the admin dashboard.

### Description
- Added a storage query `getSunflowersDailyTotals` in `packages/storage/src/repositories/events/queries.ts` that aggregates `account.spendSunflowers` and `account.earnSunflowers` (with `reason === 'gift'`) into per-day `spent` and `gifted` totals.
- Exported the new query from the events repository index in `packages/storage/src/repositories/events/index.ts` so it is available through `@gredice/storage`.
- Wired the new totals into server analytics loading in `apps/app/components/admin/dashboard/actions.ts`, aligning results to the dashboard date buckets and returning them as `sunflowers` in the analytics payload.
- Plumbed `initialSunflowersData` through `AdminDashboard` (`apps/app/components/admin/dashboard/AdminDashboard.tsx`) into `AdminDashboardClient` and added a new `SunflowersDailyCard` component (`apps/app/components/admin/dashboard/SunflowersDailyCard.tsx`) that renders a Recharts bar chart for daily `spent` vs `gifted` values and a period summary.
- Updated `AdminDashboardClient` (`apps/app/components/admin/dashboard/AdminDashboardClient.tsx`) to accept and render the new card.

### Testing
- Ran lint for the affected packages with `pnpm lint --filter app --filter @gredice/storage`, which completed successfully; a pre-existing warning in `apps/app/app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx` remains unrelated to these changes.
- No other automated test failures were observed during the change validation steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57980e498832f821fc2e838c9b444)