### PR TITLE
perf(garden): optimize 2D OG raised bed rendering

### DIFF
--- a/apps/garden/components/GardenDisplay2D.tsx
+++ b/apps/garden/components/GardenDisplay2D.tsx
@@ -41,10 +41,22 @@ export function GardenDisplay2D({
     // Block snapshots have margins so we need to adjust the size
     const ySize = blockSize - blockSize * 0.538;
     const xSize = blockSize - blockSize * 0.154;
+    const blockHeightByName = new Map<string, number>();
+    for (const block of blockData) {
+        const name = block.information?.name;
+        if (!name) {
+            continue;
+        }
+
+        blockHeightByName.set(name, block.attributes?.height ?? 0);
+    }
 
     // Expand the garden data to a flat array of stacks
     const stacks: {
+        key: string;
         position: { x: number; y: number };
+        projectedTop: number;
+        projectedLeft: number;
         blocks: { id: string; name: string; rotation?: number | null }[];
     }[] = [];
     const xPositions = Object.keys(garden.stacks);
@@ -52,8 +64,17 @@ export function GardenDisplay2D({
         const yPositions = Object.keys(garden.stacks[x]);
         for (const y of yPositions) {
             const blocks = garden.stacks[x][y];
+            const positionX = Number(x);
+            const positionY = Number(y);
+            const projectedTop =
+                viewportSize / 2 + (-positionY - positionX) * (ySize / 2);
+            const projectedLeft =
+                viewportSize / 2 - (-positionY + positionX) * (xSize / 2);
             stacks.push({
-                position: { x: Number(x), y: Number(y) },
+                key: `${positionX}_${positionY}`,
+                position: { x: positionX, y: positionY },
+                projectedTop,
+                projectedLeft,
                 blocks: blocks
                     ? blocks.map((block) => {
                           return {
@@ -69,33 +90,64 @@ export function GardenDisplay2D({
 
     // Filter stacks that are in view
     const inViewStacks = stacks.filter((stack) => {
-        const top =
-            viewportSize / 2 +
-            (-stack.position.y - stack.position.x) * (ySize / 2);
-        const left =
-            viewportSize / 2 -
-            (-stack.position.y + stack.position.x) * (xSize / 2);
-
         // Basic check for stacks overlapping the viewport
         return (
-            top + blockSize > 0 &&
-            left + blockSize > 0 &&
-            top - blockSize < viewportSize &&
-            left - blockSize < viewportSize
+            stack.projectedTop + blockSize > 0 &&
+            stack.projectedLeft + blockSize > 0 &&
+            stack.projectedTop - blockSize < viewportSize &&
+            stack.projectedLeft - blockSize < viewportSize
         );
     });
 
     // Order stacks by y position and then by x position to get the correct z-index
-    const orderedStacks = orderBy(
-        orderBy(inViewStacks, (a, b) => b.position.y - a.position.y),
-        (a, b) => b.position.x - a.position.x,
-    );
+    const orderedStacks = orderBy(inViewStacks, (a, b) => {
+        if (a.position.y !== b.position.y) {
+            return b.position.y - a.position.y;
+        }
+        return b.position.x - a.position.x;
+    });
+
+    const renderedStacks = orderedStacks.map((stack) => {
+        let underStackHeight = 0;
+        const renderedBlocks = stack.blocks.map((block) => {
+            const blockHeight = blockHeightByName.get(block.name) ?? 0;
+            const currentUnderStackHeight = underStackHeight;
+            underStackHeight += blockHeight;
+
+            // Large blocks do snapshots with zoomed view so we need to compensate with 1.5x size and -0.25x offset
+            const isLargeBlock = blockHeight > 1.5;
+            const realizedBlockSize = isLargeBlock
+                ? blockSize * 1.5
+                : blockSize;
+            const horizontalOffset = isLargeBlock
+                ? -((realizedBlockSize - blockSize) / 2)
+                : 0;
+
+            const rotationIndex = (((block.rotation ?? 0) % 4) + 4) % 4;
+            const rotationSuffix = rotationIndex + 1;
+
+            return {
+                id: block.id,
+                name: block.name,
+                src: `https://www.gredice.com/assets/blocks/${block.name}_${rotationSuffix}.png`,
+                realizedBlockSize,
+                horizontalOffset,
+                underStackHeight: currentUnderStackHeight,
+            };
+        });
+
+        return {
+            key: stack.key,
+            position: stack.position,
+            renderedBlocks,
+        };
+    });
 
     return (
         <div {...rest}>
-            {orderedStacks.map((stack) => (
+            {renderedStacks.map((stack) => (
                 <div
-                    key={`${stack.position.x}_${stack.position.y}`}
+                    key={stack.key}
                     style={{
                         display: 'flex',
                         position: 'absolute',
@@ -113,49 +165,21 @@ export function GardenDisplay2D({
                         height: blockSize,
                     }}
                 >
-                    {stack.blocks.map((block) => {
-                        let underStackHeight = 0;
-                        for (const currentBlock of stack.blocks) {
-                            if (currentBlock.id === block.id) {
-                                break;
-                            }
-                            underStackHeight +=
-                                blockData?.find(
-                                    (b) =>
-                                        b.information?.name ===
-                                        currentBlock.name,
-                                )?.attributes?.height ?? 0;
-                        }
-
-                        // Large blocks do snaphots with zoomed view so we need to compensite with 1.5x size and -0.25x offset
-                        const isLargeBlock =
-                            (blockData?.find(
-                                (b) => b.information?.name === block.name,
-                            )?.attributes?.height ?? 0) > 1.5;
-                        const realizedBlockSize = isLargeBlock
-                            ? blockSize * 1.5
-                            : blockSize;
-                        const horizontalOffset = isLargeBlock
-                            ? -((realizedBlockSize - blockSize) / 2)
-                            : 0;
-
-                        const rotationIndex =
-                            (((block.rotation ?? 0) % 4) + 4) % 4;
-                        const rotationSuffix = rotationIndex + 1;
+                    {stack.renderedBlocks.map((block) => {
                         return (
                             // biome-ignore lint/performance/noImgElement: Not part of NextJS app - OG image generation doesn't support next image
                             <img
                                 key={block.id}
-                                src={`https://www.gredice.com/assets/blocks/${block.name}_${rotationSuffix}.png`}
+                                src={block.src}
                                 alt={`${block.name}`}
-                                width={realizedBlockSize}
-                                height={realizedBlockSize}
+                                width={block.realizedBlockSize}
+                                height={block.realizedBlockSize}
                                 style={{
                                     position: 'absolute',
-                                    bottom: underStackHeight * ySize,
-                                    left: horizontalOffset,
-                                    width: realizedBlockSize,
-                                    height: realizedBlockSize,
+                                    bottom: block.underStackHeight * ySize,
+                                    left: block.horizontalOffset,
+                                    width: block.realizedBlockSize,
+                                    height: block.realizedBlockSize,
                                 }}
                             />
                         );


### PR DESCRIPTION
### Motivation
- OG image generation for raised beds was slow due to repeated lookups over `blockData` and duplicated projection math in hot code paths.
- The goal is to reduce per-block and per-stack work during server-side rendering to speed up ImageResponse generation for gardens.

### Description
- Build a `Map` cache (`blockHeightByName`) from `blockData` to avoid scanning `blockData` for every block during render.
- Precompute isometric projection coordinates (`projectedTop`, `projectedLeft`) for each stack while flattening garden data and reuse them for viewport filtering.
- Replace nested per-render work with a precomputed `renderedStacks` payload that contains per-block render props (`src`, `realizedBlockSize`, `horizontalOffset`, `underStackHeight`) to minimize work inside JSX.
- Simplify stack ordering to a single comparator and use stable per-stack `key` values for iteration and rendering.

### Testing
- Ran linting with `pnpm --filter garden lint` which completed successfully (biome fixed one file); the run produced a non-blocking engine warning about the local Node version.
- No other automated tests were changed or required for this refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e579085d90832f961f56cf93e1d80e)