### PR TITLE
Add public user profile page with readonly garden preview

### DIFF
--- a/apps/api/app/api/[...route]/usersRoutes.ts
+++ b/apps/api/app/api/[...route]/usersRoutes.ts
@@ -1,4 +1,7 @@
+import { publicIdToUserId, userIdToPublicId } from '@gredice/js/publicId';
 import {
+    getAccountAchievements,
+    getAccountGardens,
     getLastBirthdayRewardEvent,
     getUser,
     getUserWithLogins,
@@ -100,6 +103,69 @@ function getUpdatedProfileFields(input: {
 }
 
 const app = new Hono<{ Variables: AuthVariables }>()
+    .get(
+        '/public/:publicId/profile',
+        describeRoute({
+            description: 'Get public user profile information by public ID.',
+            security: [{}, { bearerAuth: [] }, { cookieAuth: [] }],
+        }),
+        zValidator(
+            'param',
+            z.object({
+                publicId: z.string(),
+            }),
+        ),
+        async (context) => {
+            const { publicId } = context.req.valid('param');
+            const userId = publicIdToUserId(publicId);
+            if (!userId) {
+                return context.json({ error: 'User not found' }, 404);
+            }
+
+            const dbUser = await getUser(userId);
+            if (!dbUser) {
+                return context.json({ error: 'User not found' }, 404);
+            }
+
+            const primaryAccountId = dbUser.accounts[0]?.accountId;
+            if (!primaryAccountId) {
+                return context.json({ error: 'User not found' }, 404);
+            }
+
+            const [gardens, achievements] = await Promise.all([
+                getAccountGardens(primaryAccountId),
+                getAccountAchievements(primaryAccountId),
+            ]);
+
+            return context.json({
+                user: {
+                    id: dbUser.id,
+                    publicId: userIdToPublicId(dbUser.id),
+                    userName: dbUser.userName,
+                    displayName: dbUser.displayName ?? dbUser.userName,
+                    avatarUrl: dbUser.avatarUrl,
+                    createdAt: dbUser.createdAt,
+                },
+                gardens: gardens.map((garden) => ({
+                    id: garden.id,
+                    name: garden.name,
+                    createdAt: garden.createdAt,
+                })),
+                achievements: achievements.map((achievement) => ({
+                    id: achievement.id,
+                    key: achievement.achievementKey,
+                    status: achievement.status,
+                    rewardSunflowers: achievement.rewardSunflowers,
+                    progressValue: achievement.progressValue,
+                    threshold: achievement.threshold,
+                    rewardGrantedAt:
+                        achievement.rewardGrantedAt?.toISOString() ?? null,
+                    createdAt: achievement.createdAt,
+                    updatedAt: achievement.updatedAt,
+                })),
+            });
+        },
+    )
     .get(
         '/current',
         describeRoute({

--- a/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
+++ b/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { clientPublic } from '@gredice/client';
+import { getAchievementDefinition } from '@gredice/js/achievements';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
+
+type ProfilePageClientProps = {
+    publicId: string;
+};
+
+function mapStacks(
+    stacks: Record<
+        string,
+        Record<
+            string,
+            {
+                id: string;
+                name: string;
+                rotation?: number | null;
+                variant?: number | null;
+            }[]
+        >
+    >,
+) {
+    return Object.entries(stacks).flatMap(([x, rows]) =>
+        Object.entries(rows).map(([y, blocks]) => ({
+            x: Number(x),
+            y: Number(y),
+            blocks: blocks.map((block) => ({
+                id: block.id,
+                name: block.name,
+                rotation: block.rotation ?? 0,
+                variant: block.variant,
+            })),
+        })),
+    );
+}
+
+export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
+    const profileQuery = useQuery({
+        queryKey: ['public-profile', publicId],
+        queryFn: async () => {
+            const response = await clientPublic().api.users.public[
+                ':publicId'
+            ].profile.$get({
+                param: { publicId },
+            });
+            if (!response.ok) {
+                throw new Error('Profil nije pronađen.');
+            }
+            return response.json();
+        },
+    });
+
+    const [selectedGardenId, setSelectedGardenId] = useState<number | null>(
+        null,
+    );
+
+    const activeGardenId =
+        selectedGardenId ?? profileQuery.data?.gardens[0]?.id ?? null;
+
+    const gardenQuery = useQuery({
+        queryKey: ['public-garden', activeGardenId],
+        enabled: Boolean(activeGardenId),
+        queryFn: async () => {
+            const response = await clientPublic().api.gardens[
+                ':gardenId'
+            ].public.$get({
+                param: {
+                    gardenId: String(activeGardenId),
+                },
+            });
+            if (!response.ok) {
+                throw new Error('Vrt nije dostupan.');
+            }
+            return response.json();
+        },
+    });
+
+    const approvedAchievements =
+        profileQuery.data?.achievements.filter(
+            (achievement) => achievement.status === 'approved',
+        ) ?? [];
+
+    const gardenStacks = useMemo(
+        () => (gardenQuery.data ? mapStacks(gardenQuery.data.stacks) : []),
+        [gardenQuery.data],
+    );
+
+    if (profileQuery.isLoading) {
+        return <p>Učitavanje profila...</p>;
+    }
+
+    if (profileQuery.error || !profileQuery.data) {
+        return <p>Traženi profil ne postoji ili nije javno dostupan.</p>;
+    }
+
+    const { user, gardens } = profileQuery.data;
+
+    return (
+        <Stack spacing={6} className="pb-12">
+            <section className="rounded-2xl border border-black/10 bg-background/90 p-6">
+                <h1 className="text-3xl font-semibold">{user.displayName}</h1>
+                <p className="text-sm text-muted-foreground">
+                    @{user.userName} · {gardens.length} vrtova
+                </p>
+            </section>
+
+            <section className="rounded-2xl border border-black/10 bg-background/90 p-6">
+                <h2 className="text-xl font-semibold mb-4">Postignuća</h2>
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {approvedAchievements.length > 0 ? (
+                        approvedAchievements.map((achievement) => {
+                            const definition = getAchievementDefinition(
+                                achievement.key,
+                            );
+                            return (
+                                <article
+                                    key={achievement.id}
+                                    className="rounded-xl border border-black/10 bg-emerald-50/70 p-4"
+                                >
+                                    <p className="font-medium">
+                                        {definition?.title ?? achievement.key}
+                                    </p>
+                                    <p className="text-sm text-muted-foreground">
+                                        {definition?.description ??
+                                            'Postignuće otključano.'}
+                                    </p>
+                                </article>
+                            );
+                        })
+                    ) : (
+                        <p className="text-sm text-muted-foreground">
+                            Još nema otključanih postignuća.
+                        </p>
+                    )}
+                </div>
+            </section>
+
+            <section className="rounded-2xl border border-black/10 bg-background/90 p-4 sm:p-6">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+                    <h2 className="text-xl font-semibold">Vrt</h2>
+                    <label className="text-sm flex items-center gap-2">
+                        <span>Odaberi vrt:</span>
+                        <select
+                            className="rounded-md border border-black/20 bg-background px-2 py-1"
+                            value={activeGardenId ?? ''}
+                            onChange={(event) =>
+                                setSelectedGardenId(
+                                    Number.parseInt(event.target.value, 10),
+                                )
+                            }
+                        >
+                            {gardens.map((garden) => (
+                                <option key={garden.id} value={garden.id}>
+                                    {garden.name}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                </div>
+
+                <div className="h-[520px] rounded-2xl overflow-hidden border border-black/10">
+                    {gardenQuery.isLoading ? (
+                        <p className="p-4">Učitavanje vrta...</p>
+                    ) : gardenQuery.error || !gardenQuery.data ? (
+                        <p className="p-4">Vrt trenutno nije dostupan.</p>
+                    ) : (
+                        <PublicGardenViewerDynamic
+                            className="h-full"
+                            stacks={gardenStacks}
+                        />
+                    )}
+                </div>
+                <p className="mt-3 text-sm text-muted-foreground">
+                    Prikaz je samo za gledanje (bez HUD-a i uređivanja).
+                </p>
+            </section>
+        </Stack>
+    );
+}

--- a/apps/www/app/korisnici/[publicId]/PublicGardenViewerDynamic.tsx
+++ b/apps/www/app/korisnici/[publicId]/PublicGardenViewerDynamic.tsx
@@ -1,0 +1,12 @@
+import type { PublicGardenViewerProps } from '@gredice/game';
+import dynamic from 'next/dynamic';
+
+export const PublicGardenViewerDynamic = dynamic<PublicGardenViewerProps>(
+    () => import('@gredice/game').then((mod) => mod.PublicGardenViewer),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-[520px] rounded-2xl border border-black/10 bg-background/60 animate-pulse" />
+        ),
+    },
+);

--- a/apps/www/app/korisnici/[publicId]/page.tsx
+++ b/apps/www/app/korisnici/[publicId]/page.tsx
@@ -1,0 +1,13 @@
+import { ProfilePageClient } from './ProfilePageClient';
+
+type ProfilePageProps = {
+    params: Promise<{
+        publicId: string;
+    }>;
+};
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+    const { publicId } = await params;
+
+    return <ProfilePageClient publicId={publicId} />;
+}

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -34,3 +34,9 @@ export {
     PlantViewer,
     plantTypes,
 } from './viewers/PlantViewer';
+export type {
+    PublicGardenBlock,
+    PublicGardenStack,
+    PublicGardenViewerProps,
+} from './viewers/PublicGardenViewer';
+export { PublicGardenViewer } from './viewers/PublicGardenViewer';

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { OrbitControls } from '@react-three/drei';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type HTMLAttributes, useMemo, useRef } from 'react';
+import { Vector3 } from 'three';
+import { EntityFactory } from '../entities/EntityFactory';
+import {
+    EntityInstances,
+    instancedBlockNames,
+} from '../entities/EntityInstances';
+import { Scene } from '../scene/Scene';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import {
+    createGameState,
+    GameStateContext,
+    type GameStateStore,
+} from '../useGameState';
+
+export type PublicGardenBlock = Block;
+
+export type PublicGardenStack = {
+    x: number;
+    y: number;
+    blocks: PublicGardenBlock[];
+};
+
+export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
+    stacks: PublicGardenStack[];
+    appBaseUrl?: string;
+    className?: string;
+};
+
+function normalizeStacks(stacks: PublicGardenStack[]): Stack[] {
+    return stacks.map((stack) => ({
+        position: new Vector3(stack.x, stack.y, 0),
+        blocks: stack.blocks,
+    }));
+}
+
+export function PublicGardenViewer({
+    appBaseUrl,
+    stacks,
+    className,
+}: PublicGardenViewerProps) {
+    const storeRef = useRef<GameStateStore>(null);
+    if (!storeRef.current) {
+        storeRef.current = createGameState({
+            appBaseUrl: appBaseUrl || '',
+            freezeTime: new Date(2024, 5, 21, 12, 0, 0),
+            isMock: true,
+            winterMode: 'summer',
+        });
+    }
+
+    const client = new QueryClient();
+    const normalizedStacks = useMemo(() => normalizeStacks(stacks), [stacks]);
+
+    return (
+        <QueryClientProvider client={client}>
+            <GameStateContext.Provider value={storeRef.current}>
+                <Scene
+                    position={[-100, 100, -100]}
+                    zoom={90}
+                    className={className}
+                >
+                    <color attach="background" args={['#d9f2dc']} />
+                    <ambientLight intensity={2} />
+                    <hemisphereLight intensity={3} />
+                    <directionalLight position={[5, 20, 10]} intensity={2.8} />
+                    <group>
+                        {normalizedStacks.map((stack) =>
+                            stack.blocks.map((block) => (
+                                <EntityFactory
+                                    key={`${stack.position.x}|${stack.position.y}|${block.id}-${block.name}`}
+                                    name={block.name}
+                                    stack={stack}
+                                    block={block}
+                                    rotation={block.rotation}
+                                    variant={block.variant}
+                                    noRenderInView={instancedBlockNames}
+                                    noControl
+                                />
+                            )),
+                        )}
+                        <EntityInstances stacks={normalizedStacks} />
+                    </group>
+                    <OrbitControls
+                        enableRotate={false}
+                        screenSpacePanning={false}
+                        enablePan
+                        minZoom={50}
+                        maxZoom={500}
+                    />
+                </Scene>
+            </GameStateContext.Provider>
+        </QueryClientProvider>
+    );
+}

--- a/packages/js/src/publicId/index.ts
+++ b/packages/js/src/publicId/index.ts
@@ -1,0 +1,39 @@
+const UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const USER_PUBLIC_ID_PREFIX = 'u_';
+
+function assertUuid(value: string) {
+    if (!UUID_REGEX.test(value)) {
+        throw new Error('Invalid user id format');
+    }
+}
+
+export function userIdToPublicId(userId: string): string {
+    assertUuid(userId);
+    const hex = userId.replaceAll('-', '');
+    const encoded = Buffer.from(hex, 'hex').toString('base64url');
+    return `${USER_PUBLIC_ID_PREFIX}${encoded}`;
+}
+
+export function publicIdToUserId(publicId: string): string | null {
+    if (!publicId.startsWith(USER_PUBLIC_ID_PREFIX)) {
+        return null;
+    }
+
+    const encoded = publicId.slice(USER_PUBLIC_ID_PREFIX.length);
+    if (encoded.length <= 0) {
+        return null;
+    }
+
+    try {
+        const hex = Buffer.from(encoded, 'base64url').toString('hex');
+        if (hex.length !== 32) {
+            return null;
+        }
+
+        const userId = `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+        return UUID_REGEX.test(userId) ? userId : null;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow viewing other users' profiles with a page-like layout that shows profile info, achievements and a read-only 3D preview of their garden(s). 
- Expose multiple gardens per account and default to the first garden while allowing switching between gardens. 
- Use short, URL-friendly public IDs instead of raw UUIDs to keep profile URLs compact and safe to share.

### Description
- Added a public API endpoint `GET /api/users/public/:publicId/profile` that decodes a URL-safe public ID, looks up the user, and returns public profile info, gardens and achievements (`apps/api/app/api/[...route]/usersRoutes.ts`).
- Implemented `@gredice/js/publicId` utility with `userIdToPublicId` and `publicIdToUserId` for encoding/decoding UUIDs to compact `u_...` Base64URL IDs (`packages/js/src/publicId/index.ts`).
- Added `PublicGardenViewer` to `@gredice/game` which renders garden stacks in a read-only 3D scene with movement (pan/zoom) but no HUD or edit controls, and exported it from the game package index (`packages/game/src/viewers/PublicGardenViewer.tsx`, `packages/game/src/index.ts`).
- Introduced a new dynamic route in the `www` app at `/korisnici/[publicId]` with a client component `ProfilePageClient` that fetches the public profile endpoint, shows profile header and achievements, and renders the read-only garden preview with a garden selector (defaults to the first garden) using a dynamic client-only import of the viewer (`apps/www/app/korisnici/*`).
- The viewer consumes the existing public garden data via the existing garden public endpoint and maps stacks into the viewer format; dynamic import avoids SSR issues for the 3D scene.

### Testing
- Ran linter: `pnpm lint --filter @gredice/game --filter @gredice/js --filter api --filter www`, which completed (no blocking errors); a small non-blocking lint warning from `www` was observed.
- Built affected apps: `pnpm build --filter www --filter api`, which completed successfully; the build logs include expected external fetch/network warnings in this environment but the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57a7686a8832faf20445356c9b917)