### PR TITLE
feat: add public link for usersAdd a Known entry for GredUser and display link to the user'spublic profile on the admin user page Convert userId topublicId using userIdToId and build the profile URL viaKnown.GrediceUser. Render the link as open-in-new-tab inthe user details FieldSet.

### DIFF
--- a/apps/app/app/admin/users/[userId]/page.tsx
+++ b/apps/app/app/admin/users/[userId]/page.tsx
@@ -1,3 +1,4 @@
+import { userIdToPublicId } from '@gredice/js/publicId';
 import { getUser, getUserWithLogins } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
@@ -48,6 +49,7 @@ export default async function UserPage({
         avatarUrl,
         displayName,
     } = user;
+    const publicProfileUrl = KnownPages.GrediceUser(userIdToPublicId(id));
 
     return (
         <Stack spacing={4}>
@@ -65,6 +67,18 @@ export default async function UserPage({
                     <FieldSet>
                         <Field name="ID korisnika" value={id} mono />
                         <Field name="Korisničko ime" value={userName} />
+                        <Field
+                            name="Javni profil"
+                            value={
+                                <Link
+                                    href={publicProfileUrl}
+                                    rel="noreferrer"
+                                    target="_blank"
+                                >
+                                    Otvori javni profil
+                                </Link>
+                            }
+                        />
                         <Field
                             name="Avatar"
                             value={

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -94,4 +94,6 @@ export const KnownPages = {
     GrediceOperations: `https://www.gredice.com/radnje`,
     GrediceOperation: (operationAlias: string) =>
         `https://www.gredice.com/radnje/${slugify(operationAlias)}`,
+    GrediceUser: (publicId: string) =>
+        `https://www.gredice.com/korisnici/${publicId}`,
 } as const;


### PR DESCRIPTION
This makes it easy for admins to jump directly to a user's publicprofile for verification and quick inspection.