### PR TITLE
fix(storage): robust parsing entity attributesImprove resilience when parsing JSON attribute values inentities repository. Add tryParseJson to centralize JSONparsing with/c and error logging including theattribute definition (id, category,,Type).

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,7 +11,7 @@
         "build": "next build",
         "postbuild": "next-sitemap --config next-sitemap.config.cjs",
         "start": "next start -p 3000",
-        "test": "pnpm run /^test:.*/",
+        "test": "pnpm run test:run",
         "test:prepare": "pnpm --dir ../.. exec turbo build --filter=www && node --experimental-strip-types ./tests/populate-test-cases.ts",
         "test:run": "pnpm run test:prepare && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -268,6 +268,7 @@ async function expandValue(
         if (!value) return null;
         return tryParseAttributeJson(value, attributeDefinition);
     } else if (attributeDefinition.dataType === 'image') {
+        if (!value) return null;
         const data = tryParseAttributeJson(value, attributeDefinition);
         if (!data || typeof data !== 'object') {
             return null;

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -19,6 +19,24 @@ import {
 
 const entityCacheTtl = 60 * 60; // 1 hour
 
+function tryParseAttributeJson(
+    value: string,
+    attributeDefinition: SelectAttributeDefinition,
+) {
+    try {
+        return JSON.parse(value) as unknown;
+    } catch (error) {
+        console.error('Failed to parse entity attribute JSON value', {
+            attributeDefinitionId: attributeDefinition.id,
+            category: attributeDefinition.category,
+            name: attributeDefinition.name,
+            dataType: attributeDefinition.dataType,
+            error,
+        });
+        return null;
+    }
+}
+
 function populateMissingAttributes(
     entity: SelectEntity & {
         attributes: (SelectAttributeValue & {
@@ -248,14 +266,15 @@ async function expandValue(
         return value === 'true';
     } else if (attributeDefinition.dataType.startsWith('json')) {
         if (!value) return null;
-        return JSON.parse(value);
+        return tryParseAttributeJson(value, attributeDefinition);
     } else if (attributeDefinition.dataType === 'image') {
-        // Assuming the value is a URL or path to the image
-        const data = JSON.parse(value) as unknown;
+        const data = tryParseAttributeJson(value, attributeDefinition);
+        if (!data || typeof data !== 'object') {
+            return null;
+        }
+
         let url = '';
         if (
-            typeof data === 'object' &&
-            data !== null &&
             'url' in data &&
             typeof data.url === 'string'
         ) {


### PR DESCRIPTION
this helper for attributes with and image data types tosafely handle malformed missing JSON and nullof throwing Also image attribute handling validates thatparsed data is an object with a string url before returning.

ore(www): normalize test script nameRename the test in apps/www/package.json from a regex-basedcommand the explicit test:run to avoid unexpected shellbehavior and ensure the prepared test workflow is executed.