### PR TITLE
app: indicate missing required attributes on entity detail tabs

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -84,17 +84,18 @@ export default async function EntityDetailsPage(props: {
     }
 
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
+    const populatedAttributeDefinitionIds = new Set(
+        entity.attributes
+            .filter((attribute) => (attribute.value?.length ?? 0) > 0)
+            .map((attribute) => attribute.attributeDefinitionId),
+    );
     const categoriesWithMissingRequiredAttributes = new Set(
         attributeDefinitions
             .filter(
                 (definition) =>
                     definition.required &&
                     !definition.defaultValue &&
-                    !entity.attributes.some(
-                        (attribute) =>
-                            attribute.attributeDefinitionId === definition.id &&
-                            (attribute.value?.length ?? 0) > 0,
-                    ),
+                    !populatedAttributeDefinitionIds.has(definition.id),
             )
             .map((definition) => definition.category),
     );

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -132,10 +132,15 @@ export default async function EntityDetailsPage(props: {
                                             {categoriesWithMissingRequiredAttributes.has(
                                                 category.name,
                                             ) && (
-                                                <span
-                                                    className="size-2 rounded-full bg-red-500"
-                                                    aria-hidden
-                                                />
+                                                <>
+                                                    <span
+                                                        className="size-2 rounded-full bg-red-500"
+                                                        aria-hidden
+                                                    />
+                                                    <span className="sr-only">
+                                                        Nedostaju obavezni atributi
+                                                    </span>
+                                                </>
                                             )}
                                         </Row>
                                     </TabsTrigger>

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -84,6 +84,20 @@ export default async function EntityDetailsPage(props: {
     }
 
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
+    const categoriesWithMissingRequiredAttributes = new Set(
+        attributeDefinitions
+            .filter(
+                (definition) =>
+                    definition.required &&
+                    !definition.defaultValue &&
+                    !entity.attributes.some(
+                        (attribute) =>
+                            attribute.attributeDefinitionId === definition.id &&
+                            (attribute.value?.length ?? 0) > 0,
+                    ),
+            )
+            .map((definition) => definition.category),
+    );
 
     return (
         <EntityDetailsSaveProvider>
@@ -110,7 +124,20 @@ export default async function EntityDetailsPage(props: {
                                         key={category.name}
                                         value={category.name}
                                     >
-                                        {category.label}
+                                        <Row
+                                            spacing={1}
+                                            className="items-center"
+                                        >
+                                            <span>{category.label}</span>
+                                            {categoriesWithMissingRequiredAttributes.has(
+                                                category.name,
+                                            ) && (
+                                                <span
+                                                    className="size-2 rounded-full bg-red-500"
+                                                    aria-hidden
+                                                />
+                                            )}
+                                        </Row>
                                     </TabsTrigger>
                                 ))}
                             </TabsList>


### PR DESCRIPTION
### Motivation

- Make it obvious on `directories/{entityType}/{id}` which attribute category tabs contain required fields that are not yet filled so editors can quickly find missing data.

### Description

- Added a category-level detection set computed from `attributeDefinitions` and `entity.attributes` to find categories with required but empty attributes in `apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx`.
- Updated each `TabsTrigger` to render the category label and a small red dot (`<span className="size-2 rounded-full bg-red-500">`) when that category has missing required attributes.
- Reused the same required-value semantics as the existing progress indicator (`required`, no `defaultValue`, and no non-empty saved value), and made this purely a UI change with no schema or API modifications.

### Testing

- Ran linting with `pnpm --filter app lint`, which completed successfully; a pre-existing Biome suppression warning in an unrelated file was reported but did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e7ca6230832f93300c1b6e7c7125)