### PR TITLE
Use linked-page icons for admin quick links

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -49,6 +49,7 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
         quickActionEntityTypes.map((entityType) => ({
             name: entityType.name,
             label: entityType.label,
+            icon: entityType.icon,
         })),
     );
     const configuredQuickActions = getDashboardQuickActionsFromConfig(

--- a/apps/app/app/admin/settings/page.tsx
+++ b/apps/app/app/admin/settings/page.tsx
@@ -88,6 +88,7 @@ export default async function SettingsPage() {
         entityTypes.map((entityType) => ({
             name: entityType.name,
             label: entityType.label,
+            icon: entityType.icon,
         })),
     );
 

--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -35,6 +35,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
         entityTypes.map((entityType) => ({
             name: entityType.name,
             label: entityType.label,
+            icon: entityType.icon,
         })),
     );
 

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -52,6 +52,27 @@ import { NavContext } from './NavContext';
 import { NavItem } from './NavItem';
 import { ProfileNavItem } from './ProfileNavItem';
 
+function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
+    if (quickAction.icon) {
+        return <EntityTypeIcon icon={quickAction.icon} className="size-5" />;
+    }
+
+    switch (quickAction.href) {
+        case KnownPages.Schedule:
+            return <Calendar className="size-5" />;
+        case KnownPages.RaisedBeds:
+            return <RaisedBedIcon className="size-5" />;
+        case KnownPages.Operations:
+            return <Hammer className="size-5" />;
+        case KnownPages.DeliveryRequests:
+            return <Truck className="size-5" />;
+        case KnownPages.Transactions:
+            return <Euro className="size-5" />;
+        default:
+            return <File className="size-5" />;
+    }
+}
+
 function SortableNavItem({
     entityType,
     onClick,
@@ -156,7 +177,7 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                         key={quickAction.id}
                         href={quickAction.href}
                         label={quickAction.label}
-                        icon={<File className="size-5" />}
+                        icon={quickActionIcon(quickAction)}
                         onClick={onItemClick}
                     />
                 ))}

--- a/apps/app/src/dashboardQuickActions.ts
+++ b/apps/app/src/dashboardQuickActions.ts
@@ -7,11 +7,13 @@ export type DashboardQuickActionOption = {
     label: string;
     href: Route;
     description: string;
+    icon?: string | null;
 };
 
 type DashboardEntityTypeOption = {
     name: string;
     label: string;
+    icon?: string | null;
 };
 
 const DASHBOARD_BUILTIN_QUICK_ACTIONS = [
@@ -113,6 +115,7 @@ export function buildDashboardQuickActionOptions(
             label: entityType.label,
             href: KnownPages.DirectoryEntityType(entityType.name),
             description: `Otvara zapise tipa „${entityType.label}”.`,
+            icon: entityType.icon,
         }),
     );
 


### PR DESCRIPTION
### Motivation
- Make dashboard/admin quick links visually match the pages they point to by using the linked page or entity-type icon where available.
- Improve discoverability of directory quick links by carrying each entity type's configured icon into the quick action entries.

### Description
- Added an optional `icon` field to `DashboardQuickActionOption` and `DashboardEntityTypeOption` and include `entityType.icon` when building quick action options in `src/dashboardQuickActions.ts`.
- Wired `entityType.icon` into quick action option construction in admin layout, dashboard, and settings flows (`app/admin/layout.tsx`, `components/admin/dashboard/AdminDashboard.tsx`, `app/admin/settings/page.tsx`).
- Render quick action icons in the admin navigation by using the entity icon when present, otherwise map specific pages to page-specific icons (`Schedule`, `RaisedBeds`, `Operations`, `DeliveryRequests`, `Transactions`) and fallback to a generic file icon in `components/admin/navigation/Nav.tsx`.

### Testing
- Ran `pnpm --filter app lint` and the workspace linter completed successfully with warnings only.
- Ran `pnpm --filter app exec biome check src/dashboardQuickActions.ts components/admin/navigation/Nav.tsx app/admin/layout.tsx components/admin/dashboard/AdminDashboard.tsx app/admin/settings/page.tsx` and the specified files passed the Biome checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ed05bdbc832fb16965f4b5f0224f)