### PR TITLE
Show admin breadcrumbs in mobile header

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -82,7 +82,7 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                                 <div className="p-2 md:p-4 bg-background rounded-t-xl md:border-l md:border-t md:rounded-tr-none min-h-full">
                                     <AuthProtectedSection auth={authAdmin}>
                                         <Suspense>
-                                            <div className="mb-3">
+                                            <div className="mb-3 hidden md:block">
                                                 <AdminPageBreadcrumbs />
                                             </div>
                                             {children}

--- a/apps/app/components/admin/navigation/MobileHeader.tsx
+++ b/apps/app/components/admin/navigation/MobileHeader.tsx
@@ -1,4 +1,5 @@
 import { Row } from '@signalco/ui-primitives/Row';
+import { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 import { MobileNav } from './MobileNav';
 
 export function MobileHeader() {
@@ -7,6 +8,9 @@ export function MobileHeader() {
             <div className="flex h-14 items-center px-4">
                 <Row spacing={3} className="w-full items-center">
                     <MobileNav />
+                    <div className="min-w-0 flex-1 overflow-hidden">
+                        <AdminPageBreadcrumbs />
+                    </div>
                 </Row>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- On mobile the space to the right of the hamburger menu was empty, so breadcrumbs were not visible without opening the sidebar.

### Description
- Render `AdminPageBreadcrumbs` inside `MobileHeader` and hide the existing breadcrumb block on small screens by changing its wrapper to `hidden md:block`; modified `apps/app/components/admin/navigation/MobileHeader.tsx` and `apps/app/app/admin/layout.tsx`.

### Testing
- Ran `pnpm --filter app exec biome check app/admin/layout.tsx components/admin/navigation/MobileHeader.tsx` and `pnpm --filter app lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ed544cf4832f9b8849f4d64ede56)