### PR TITLE
Move multi-value attribute "Dodaj" button to top-right on entity details

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx
@@ -5,6 +5,7 @@ import type {
     SelectAttributeValue,
 } from '@gredice/storage';
 import { Button } from '@signalco/ui-primitives/Button';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { AttributeInput } from '../../../../../components/shared/attributes/AttributeInput';
@@ -43,19 +44,24 @@ export function AttributeCategoryDefinitionItem({
 
     return (
         <Stack key={attributeDefinition.id} spacing={1}>
-            <Stack>
-                <Typography level="body1" semiBold>
-                    {attributeDefinition.label}
-                    {attributeDefinition.required && (
-                        <span className="text-red-600/60 ml-1">*</span>
-                    )}
-                </Typography>
-                {Boolean(attributeDefinition.description?.length) && (
-                    <Typography level="body2">
-                        {attributeDefinition.description}
+            <Row justifyContent="space-between" alignItems="flex-start">
+                <Stack>
+                    <Typography level="body1" semiBold>
+                        {attributeDefinition.label}
+                        {attributeDefinition.required && (
+                            <span className="text-red-600/60 ml-1">*</span>
+                        )}
                     </Typography>
+                    {Boolean(attributeDefinition.description?.length) && (
+                        <Typography level="body2">
+                            {attributeDefinition.description}
+                        </Typography>
+                    )}
+                </Stack>
+                {attributeDefinition.multiple && (
+                    <Button onClick={handleAdd}>Dodaj</Button>
                 )}
-            </Stack>
+            </Row>
             <Stack spacing={1}>
                 {attributeDefinition.multiple ? (
                     entity.attributes
@@ -84,9 +90,6 @@ export function AttributeCategoryDefinitionItem({
                                 attributeDefinition.id,
                         )}
                     />
-                )}
-                {attributeDefinition.multiple && (
-                    <Button onClick={handleAdd}>Dodaj</Button>
                 )}
             </Stack>
         </Stack>


### PR DESCRIPTION
### Motivation
- Improve layout and usability by aligning the add action for multi-value attributes with the attribute label/description in the entity details view.

### Description
- Added `Row` from `@signalco/ui-primitives/Row` and wrapped the label/description into a header row with `justifyContent="space-between"` to place actions at the top-right.
- Moved the `Dodaj` button for `attributeDefinition.multiple` from the values list footer into the header row while keeping the existing `handleAdd` behavior unchanged.
- Removed the previously duplicated bottom-positioned `Dodaj` button so the action appears only in the header.
- Change is purely UI/layout and does not modify data models or APIs.

### Testing
- Ran `pnpm --filter app exec biome check app/admin/directories/[entityType]/[entityId]/AttributeCategoryDefinitionItem.tsx`, which completed successfully with no fixes required (only a workspace Node engine warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5eebcee34832fb0d635f9763c170d)