### PR TITLE
Count all sunflower earnings in analytics and update dashboard colors

### DIFF
--- a/apps/app/components/admin/dashboard/SunflowersDailyCard.tsx
+++ b/apps/app/components/admin/dashboard/SunflowersDailyCard.tsx
@@ -16,7 +16,7 @@ import {
 export type SunflowersDailyData = {
     date: string;
     spent: number;
-    gifted: number;
+    earned: number;
 };
 
 const dateFormatter = new Intl.DateTimeFormat('hr-HR', {
@@ -30,8 +30,8 @@ function formatDate(date: string) {
 
 export function SunflowersDailyCard({ data }: { data: SunflowersDailyData[] }) {
     const totalSpent = data.reduce((sum, day) => sum + day.spent, 0);
-    const totalGifted = data.reduce((sum, day) => sum + day.gifted, 0);
-    const hasData = data.some((day) => day.spent > 0 || day.gifted > 0);
+    const totalEarned = data.reduce((sum, day) => sum + day.earned, 0);
+    const hasData = data.some((day) => day.spent > 0 || day.earned > 0);
 
     return (
         <Card>
@@ -42,13 +42,13 @@ export function SunflowersDailyCard({ data }: { data: SunflowersDailyData[] }) {
                             Suncokreti po danu
                         </Typography>
                         <Typography level="h4" semiBold>
-                            Potrošeno {totalSpent} · Poklonjeno {totalGifted}
+                            Potrošeno {totalSpent} · Zarađeno {totalEarned}
                         </Typography>
                         <Typography
                             level="body3"
                             className="text-muted-foreground"
                         >
-                            Prikaz potrošnje i poklona kroz odabrani period
+                            Prikaz potrošnje i zarade kroz odabrani period
                         </Typography>
                     </Stack>
                     {!hasData ? (
@@ -105,13 +105,13 @@ export function SunflowersDailyCard({ data }: { data: SunflowersDailyData[] }) {
                                     <Bar
                                         dataKey="spent"
                                         name="Potrošeno"
-                                        fill="hsl(var(--destructive) / 0.7)"
+                                        fill="#f59e0b"
                                         radius={[4, 4, 0, 0]}
                                     />
                                     <Bar
-                                        dataKey="gifted"
-                                        name="Poklonjeno"
-                                        fill="hsl(var(--primary) / 0.7)"
+                                        dataKey="earned"
+                                        name="Zarađeno"
+                                        fill="#facc15"
                                         radius={[4, 4, 0, 0]}
                                     />
                                 </BarChart>

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -47,7 +47,7 @@ type DateRange = {
 type SunflowersDailyTotalsPoint = {
     date: string;
     spent: number;
-    gifted: number;
+    earned: number;
 };
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -368,7 +368,7 @@ export async function getAnalyticsData(
         return {
             date,
             spent: day?.spent ?? 0,
-            gifted: day?.gifted ?? 0,
+            earned: day?.earned ?? 0,
         };
     });
 

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -132,7 +132,7 @@ export async function getAiAnalysisTotals(filter?: { from?: Date; to?: Date }) {
 type SunflowersDailyPoint = {
     date: string;
     spent: number;
-    gifted: number;
+    earned: number;
 };
 
 export async function getSunflowersDailyTotals(filter?: {
@@ -155,7 +155,7 @@ export async function getSunflowersDailyTotals(filter?: {
 
     for (const event of results) {
         const key = event.createdAt.toISOString().split('T')[0];
-        const existing = byDay.get(key) ?? { date: key, spent: 0, gifted: 0 };
+        const existing = byDay.get(key) ?? { date: key, spent: 0, earned: 0 };
         const payload = event.data as
             | { amount?: unknown; reason?: unknown }
             | null
@@ -165,16 +165,10 @@ export async function getSunflowersDailyTotals(filter?: {
             Number.isFinite(payload.amount)
                 ? Math.max(0, payload.amount)
                 : 0;
-        const reason =
-            typeof payload?.reason === 'string' ? payload.reason : undefined;
-
         if (event.type === knownEventTypes.accounts.spendSunflowers) {
             existing.spent += amount;
-        } else if (
-            event.type === knownEventTypes.accounts.earnSunflowers &&
-            reason === 'gift'
-        ) {
-            existing.gifted += amount;
+        } else if (event.type === knownEventTypes.accounts.earnSunflowers) {
+            existing.earned += amount;
         }
 
         byDay.set(key, existing);


### PR DESCRIPTION
### Motivation
- The sunflower daily totals were missing routine earnings because only `earnSunflowers` events with `reason === 'gift'` were counted as gifted, so daily rewards and other earnings were omitted.
- The admin dashboard UI should reflect total earned sunflowers and use a distinct yellow/orange palette for the chart columns for better clarity.

### Description
- Change aggregation in `getSunflowersDailyTotals` to count all `knownEventTypes.accounts.earnSunflowers` events into an `earned` field instead of filtering by `reason === 'gift'` and rename the field from `gifted` to `earned` in `packages/storage/src/repositories/events/queries.ts`.
- Propagate the `gifted -> earned` shape change in the server action mapping in `apps/app/components/admin/dashboard/actions.ts` so analytics data maps correctly.
- Update the admin card component `SunflowersDailyCard.tsx` to show `Zarađeno` (earned) instead of `Poklonjeno` (gifted), use `earned` for calculations, and change bar fills to `#f59e0b` for spent and `#facc15` for earned.

### Testing
- Ran lint for the app with `pnpm --filter app lint` and it completed successfully (with a repository Node engine warning about `>=24` versus runner `v22.21.1`).
- Ran lint for the storage package with `pnpm --filter @gredice/storage lint` and it completed successfully.
- Ran focused Biome checks with `pnpm --filter app exec biome check components/admin/dashboard/SunflowersDailyCard.tsx components/admin/dashboard/actions.ts` and `pnpm --filter @gredice/storage exec biome check src/repositories/events/queries.ts` and both completed successfully; a broader `biome` invocation at the repo root failed due to environment/tool availability rather than code issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f671cbbc832fa0833db1d5fbfb28)