### PR TITLE
Fix missing Typography import on admin inventory page

### DIFF
--- a/apps/app/app/admin/inventory/page.tsx
+++ b/apps/app/app/admin/inventory/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';


### PR DESCRIPTION
### Motivation
- Resolve a server-side runtime crash (`ReferenceError: Typography is not defined`) on the `/admin/inventory` page caused by using `Typography` without importing it.

### Description
- Add the missing `import { Typography } from '@signalco/ui-primitives/Typography';` to `apps/app/app/admin/inventory/page.tsx` so the component is defined where used.

### Testing
- Ran `pnpm --filter app exec biome check app/admin/inventory/page.tsx`, which completed successfully (note: the environment showed a local Node engine version warning unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f78847e4832fa048a0100fc105de)