### PR TITLE
Support opening admin schedule from a specific date

### DIFF
--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -11,24 +11,38 @@ import { ScheduleDayPlantingsSkeleton } from './ScheduleDayPlantingsSkeleton';
 
 export const dynamic = 'force-dynamic';
 
-function parseDateParam(dateParam?: string): Date | undefined {
-    if (!dateParam) {
+function parseDateParam(dateParam?: string | string[]): Date | undefined {
+    const normalizedDateParam = Array.isArray(dateParam) ? dateParam[0] : dateParam;
+    if (!normalizedDateParam) {
         return undefined;
     }
 
-    const parsedDate = new Date(dateParam);
-    if (Number.isNaN(parsedDate.getTime())) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(normalizedDateParam);
+    if (!match) {
         return undefined;
     }
 
-    parsedDate.setHours(0, 0, 0, 0);
+    const year = Number.parseInt(match[1], 10);
+    const monthIndex = Number.parseInt(match[2], 10) - 1;
+    const day = Number.parseInt(match[3], 10);
+    const parsedDate = new Date(year, monthIndex, day);
+
+    if (
+        Number.isNaN(parsedDate.getTime()) ||
+        parsedDate.getFullYear() !== year ||
+        parsedDate.getMonth() !== monthIndex ||
+        parsedDate.getDate() !== day
+    ) {
+        return undefined;
+    }
+
     return parsedDate;
 }
 
 export default async function AdminSchedulePage({
     searchParams,
 }: {
-    searchParams?: Promise<{ date?: string }>;
+    searchParams?: Promise<{ date?: string | string[] }>;
 }) {
     await auth(['admin']);
     const resolvedSearchParams = await searchParams;

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -11,8 +11,28 @@ import { ScheduleDayPlantingsSkeleton } from './ScheduleDayPlantingsSkeleton';
 
 export const dynamic = 'force-dynamic';
 
-export default async function AdminSchedulePage() {
+function parseDateParam(dateParam?: string): Date | undefined {
+    if (!dateParam) {
+        return undefined;
+    }
+
+    const parsedDate = new Date(dateParam);
+    if (Number.isNaN(parsedDate.getTime())) {
+        return undefined;
+    }
+
+    parsedDate.setHours(0, 0, 0, 0);
+    return parsedDate;
+}
+
+export default async function AdminSchedulePage({
+    searchParams,
+}: {
+    searchParams?: Promise<{ date?: string }>;
+}) {
     await auth(['admin']);
+    const resolvedSearchParams = await searchParams;
+    const startDate = parseDateParam(resolvedSearchParams?.date);
 
     return (
         <Stack spacing={2}>
@@ -20,6 +40,7 @@ export default async function AdminSchedulePage() {
                 Rasprored
             </Typography>
             <DailySchedule
+                startDate={startDate}
                 renderDay={({ date, isToday }) => (
                     <Suspense
                         fallback={

--- a/packages/ui/src/DailySchedule/DailySchedule.tsx
+++ b/packages/ui/src/DailySchedule/DailySchedule.tsx
@@ -4,6 +4,7 @@ import { Fragment, type ReactNode } from 'react';
 
 interface DailyScheduleProps {
     days?: number;
+    startDate?: Date;
     renderDay: (options: {
         date: Date;
         isToday: boolean;
@@ -11,10 +12,19 @@ interface DailyScheduleProps {
     }) => ReactNode;
 }
 
-export function DailySchedule({ days = 7, renderDay }: DailyScheduleProps) {
+export function DailySchedule({
+    days = 7,
+    startDate,
+    renderDay,
+}: DailyScheduleProps) {
+    const normalizedStartDate = startDate ? new Date(startDate) : new Date();
+    normalizedStartDate.setHours(0, 0, 0, 0);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
     const dates = Array.from({ length: days }, (_, index) => {
-        const date = new Date();
-        date.setHours(0, 0, 0, 0);
+        const date = new Date(normalizedStartDate);
         date.setDate(date.getDate() + index);
         return date;
     });
@@ -25,7 +35,7 @@ export function DailySchedule({ days = 7, renderDay }: DailyScheduleProps) {
                 <Fragment key={date.toISOString()}>
                     {renderDay({
                         date,
-                        isToday: index === 0,
+                        isToday: date.toDateString() === today.toDateString(),
                         index,
                     })}
                     {index < dates.length - 1 && <Divider />}


### PR DESCRIPTION
### Motivation

- Allow the admin schedule page to be opened deep-linked to a specific calendar day via a `date` query parameter so users can share or navigate directly to a given date. 
- Ensure the rendered schedule correctly identifies which day is "today" even when the schedule start is not the current day.

### Description

- Added `parseDateParam` to `apps/app/app/admin/schedule/page.tsx` to parse and normalize an optional `searchParams.date` query parameter.
- Pass the parsed `startDate` into the `DailySchedule` component via a new optional `startDate` prop.
- Extended `packages/ui/src/DailySchedule/DailySchedule.tsx` with an optional `startDate` prop and normalized the start day to midnight before building the date range.
- Fixed `isToday` detection in `DailySchedule` to compare calendar days (`toDateString()`) against the actual current date instead of relying on the index being `0`.

### Testing

- Ran `pnpm --filter @gredice/ui lint` and it completed successfully.
- Ran `pnpm --filter app lint` and it completed successfully (biome fixed formatting once and reported one warning during the run but overall lint command succeeded).
- Ran targeted checks `pnpm --filter @gredice/ui exec biome check src/DailySchedule/DailySchedule.tsx` and `pnpm --filter app exec biome check app/admin/schedule/page.tsx` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f7120cc8832fb06bb82703fdd50e)