### PR TITLE
Add configurable range attribute data type

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/AttributeDataTypes.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/AttributeDataTypes.tsx
@@ -21,6 +21,11 @@ export const attributeDataTypeItems = [
         icon: <Hash className="size-5" />,
     },
     {
+        value: 'range',
+        label: 'Raspon',
+        icon: <RangeIcon className="size-5" />,
+    },
+    {
         value: 'boolean',
         label: 'Da / Ne',
         icon: <ToggleRight className="size-5" />,
@@ -58,12 +63,17 @@ export function AttributeDataTypeIcon({
     if (dataType === 'json' || dataType.startsWith('json|')) {
         return <Code {...rest} />;
     }
+    if (dataType === 'range' || dataType.startsWith('range|')) {
+        return <RangeIcon {...rest} />;
+    }
 
     switch (dataType) {
         case 'text':
             return <FontType {...rest} />;
         case 'number':
             return <Hash {...rest} />;
+        case 'range':
+            return <RangeIcon {...rest} />;
         case 'boolean':
             return <ToggleRight {...rest} />;
         case 'barcode':
@@ -92,8 +102,27 @@ export function getAttributeDataTypeLabel(dataType: string) {
     if (dataType.startsWith('json|')) {
         return 'JSON';
     }
+    if (dataType.startsWith('range|')) {
+        const parsedRangeDataType = parseRangeDataType(dataType);
+        return `Raspon (${parsedRangeDataType.min} - ${parsedRangeDataType.max})`;
+    }
 
     return dataType;
+}
+
+export function parseRangeDataType(dataType: string): {
+    min: string;
+    max: string;
+} {
+    const [, min, max] = dataType.split('|');
+    return {
+        min: min ?? '0',
+        max: max ?? '100',
+    };
+}
+
+export function buildRangeDataType(min: string, max: string): string {
+    return `range|${min}|${max}`;
 }
 
 function AttributeMarkdownIcon(props: HTMLAttributes<SVGElement>): ReactNode {
@@ -136,6 +165,28 @@ function AttributeImageIcon(props: HTMLAttributes<SVGElement>): ReactNode {
             <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
             <circle cx="8.5" cy="8.5" r="1.5" />
             <path d="m21 15-5-5L5 21" />
+        </svg>
+    );
+}
+
+function RangeIcon(props: HTMLAttributes<SVGElement>): ReactNode {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            {...props}
+        >
+            <title>Range</title>
+            <path d="M4 6h16" />
+            <path d="M8 12h8" />
+            <path d="M11 18h2" />
         </svg>
     );
 }

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/CreateAttributeDefinitionButton.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/CreateAttributeDefinitionButton.tsx
@@ -8,8 +8,12 @@ import { Modal } from '@signalco/ui-primitives/Modal';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useState } from 'react';
 import { upsertAttributeDefinition } from '../../../../(actions)/definitionActions';
-import { attributeDataTypeItems } from './AttributeDataTypes';
+import {
+    attributeDataTypeItems,
+    buildRangeDataType,
+} from './AttributeDataTypes';
 
 export function CreateAttributeDefinitionButton({
     entityTypeName,
@@ -18,11 +22,21 @@ export function CreateAttributeDefinitionButton({
     entityTypeName: string;
     categoryName: string;
 }) {
+    const [selectedDataType, setSelectedDataType] = useState(
+        attributeDataTypeItems[0].value,
+    );
+    const [rangeMinValue, setRangeMinValue] = useState('0');
+    const [rangeMaxValue, setRangeMaxValue] = useState('100');
+
     async function submitForm(formData: FormData) {
         const name = formData.get('name') as string;
         const label = formData.get('label') as string;
-        const dataType = formData.get('dataType') as string;
+        const selectedType = formData.get('dataType') as string;
         const defaultValue = formData.get('defaultValue') as string;
+        const dataType =
+            selectedType === 'range'
+                ? buildRangeDataType(rangeMinValue, rangeMaxValue)
+                : selectedType;
 
         await upsertAttributeDefinition({
             name,
@@ -60,7 +74,30 @@ export function CreateAttributeDefinitionButton({
                                 label="Vrsta podatka"
                                 defaultValue={attributeDataTypeItems[0].value}
                                 items={attributeDataTypeItems}
+                                onValueChange={setSelectedDataType}
                             />
+                            {selectedDataType === 'range' && (
+                                <div className="grid grid-cols-2 gap-2">
+                                    <Input
+                                        type="number"
+                                        name="rangeMin"
+                                        label="Minimalna vrijednost"
+                                        value={rangeMinValue}
+                                        onChange={(event) =>
+                                            setRangeMinValue(event.target.value)
+                                        }
+                                    />
+                                    <Input
+                                        type="number"
+                                        name="rangeMax"
+                                        label="Maksimalna vrijednost"
+                                        value={rangeMaxValue}
+                                        onChange={(event) =>
+                                            setRangeMaxValue(event.target.value)
+                                        }
+                                    />
+                                </div>
+                            )}
                             <Input
                                 name="defaultValue"
                                 label="Zadana vrijednost"

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx
@@ -8,7 +8,9 @@ import { type ChangeEvent, useState } from 'react';
 import { upsertAttributeDefinition } from '../../../../../(actions)/definitionActions';
 import {
     attributeDataTypeItems,
+    buildRangeDataType,
     getAttributeDataTypeLabel,
+    parseRangeDataType,
 } from '../AttributeDataTypes';
 
 type GetAttributeDefinition = Exclude<
@@ -61,12 +63,34 @@ export function FormDataTypeSelect({
     value: string;
 }) {
     const [internalValue, setValue] = useState(value);
+    const parsedRangeDataType = parseRangeDataType(internalValue);
+    const [rangeMinValue, setRangeMinValue] = useState(parsedRangeDataType.min);
+    const [rangeMaxValue, setRangeMaxValue] = useState(parsedRangeDataType.max);
+    const isRangeDataType =
+        internalValue === 'range' || internalValue.startsWith('range|');
 
     const handleValueChange = async (nextValue: string) => {
-        setValue(nextValue);
+        const normalizedValue =
+            nextValue === 'range'
+                ? buildRangeDataType(rangeMinValue, rangeMaxValue)
+                : nextValue;
+        setValue(normalizedValue);
         await upsertAttributeDefinition({
             id: definition.id,
-            dataType: nextValue,
+            dataType: normalizedValue,
+        });
+    };
+
+    const handleRangeBlur = async () => {
+        if (!isRangeDataType) {
+            return;
+        }
+
+        const rangeDataType = buildRangeDataType(rangeMinValue, rangeMaxValue);
+        setValue(rangeDataType);
+        await upsertAttributeDefinition({
+            id: definition.id,
+            dataType: rangeDataType,
         });
     };
 
@@ -83,13 +107,37 @@ export function FormDataTypeSelect({
           ];
 
     return (
-        <SelectItems
-            label="Tip podatka"
-            value={internalValue}
-            onValueChange={handleValueChange}
-            items={items}
-            placeholder={getAttributeDataTypeLabel(value)}
-        />
+        <>
+            <SelectItems
+                label="Tip podatka"
+                value={internalValue}
+                onValueChange={handleValueChange}
+                items={items}
+                placeholder={getAttributeDataTypeLabel(value)}
+            />
+            {isRangeDataType && (
+                <div className="grid grid-cols-2 gap-2">
+                    <Input
+                        type="number"
+                        label="Minimalna vrijednost"
+                        value={rangeMinValue}
+                        onChange={(event) =>
+                            setRangeMinValue(event.target.value)
+                        }
+                        onBlur={handleRangeBlur}
+                    />
+                    <Input
+                        type="number"
+                        label="Maksimalna vrijednost"
+                        value={rangeMaxValue}
+                        onChange={(event) =>
+                            setRangeMaxValue(event.target.value)
+                        }
+                        onBlur={handleRangeBlur}
+                    />
+                </div>
+            )}
+        </>
     );
 }
 

--- a/apps/app/components/shared/attributes/AttributeInput.tsx
+++ b/apps/app/components/shared/attributes/AttributeInput.tsx
@@ -20,6 +20,7 @@ import { BooleanInput } from './typed/BooleanInput';
 import { ImageInput } from './typed/ImageInput';
 import { JsonInput } from './typed/JsonInput';
 import { NumberInput } from './typed/NumberInput';
+import { RangeInput } from './typed/RangeInput';
 import { SelectEntity } from './typed/SelectEntity';
 import { TextInput } from './typed/TextInput';
 
@@ -103,6 +104,11 @@ export function AttributeInput({
         AttributeInputComponent = MarkdownInput;
     } else if (attributeDefinition.dataType === 'number') {
         AttributeInputComponent = NumberInput;
+    } else if (
+        attributeDefinition.dataType === 'range' ||
+        attributeDefinition.dataType.startsWith('range|')
+    ) {
+        AttributeInputComponent = RangeInput;
     } else if (attributeDefinition.dataType === 'barcode') {
         AttributeInputComponent = BarcodeInput;
     } else if (attributeDefinition.dataType === 'image') {

--- a/apps/app/components/shared/attributes/typed/RangeInput.tsx
+++ b/apps/app/components/shared/attributes/typed/RangeInput.tsx
@@ -1,0 +1,99 @@
+import { Input } from '@signalco/ui-primitives/Input';
+import { Row } from '@signalco/ui-primitives/Row';
+import { useMemo, useState } from 'react';
+import type { AttributeInputProps } from '../AttributeInputProps';
+
+function parseRangeDefinition(dataType: string | undefined): {
+    minBound: number;
+    maxBound: number;
+} {
+    const [, minRaw, maxRaw] = (dataType ?? '').split('|');
+    const parsedMin = Number.parseFloat(minRaw ?? '');
+    const parsedMax = Number.parseFloat(maxRaw ?? '');
+    return {
+        minBound: Number.isNaN(parsedMin) ? 0 : parsedMin,
+        maxBound: Number.isNaN(parsedMax) ? 100 : parsedMax,
+    };
+}
+
+function parseValue(value: string | null | undefined): {
+    min: string;
+    max: string;
+} {
+    if (!value) {
+        return { min: '', max: '' };
+    }
+
+    try {
+        const parsedValue = JSON.parse(value) as unknown;
+        if (
+            parsedValue &&
+            typeof parsedValue === 'object' &&
+            'min' in parsedValue &&
+            'max' in parsedValue
+        ) {
+            const minValue = parsedValue.min;
+            const maxValue = parsedValue.max;
+            return {
+                min: typeof minValue === 'number' ? minValue.toString() : '',
+                max: typeof maxValue === 'number' ? maxValue.toString() : '',
+            };
+        }
+    } catch {
+        // Ignore invalid values and fallback to empty input
+    }
+
+    return { min: '', max: '' };
+}
+
+export function RangeInput({
+    value,
+    onChange,
+    attributeDefinition,
+}: AttributeInputProps) {
+    const initialValue = useMemo(() => parseValue(value), [value]);
+    const [rangeMinValue, setRangeMinValue] = useState(initialValue.min);
+    const [rangeMaxValue, setRangeMaxValue] = useState(initialValue.max);
+    const bounds = parseRangeDefinition(attributeDefinition?.dataType);
+
+    const handleBlur = () => {
+        if (rangeMinValue.length === 0 || rangeMaxValue.length === 0) {
+            onChange(null);
+            return;
+        }
+
+        onChange(
+            JSON.stringify({
+                min: Number.parseFloat(rangeMinValue),
+                max: Number.parseFloat(rangeMaxValue),
+            }),
+        );
+    };
+
+    return (
+        <Row className="gap-2">
+            <Input
+                className="w-24"
+                type="number"
+                label="Min"
+                placeholder={'NA'}
+                min={bounds.minBound}
+                max={bounds.maxBound}
+                value={rangeMinValue}
+                onChange={(event) => setRangeMinValue(event.target.value)}
+                onBlur={handleBlur}
+            />
+            <Input
+                className="w-24"
+                type="number"
+                label="Maks"
+                placeholder={'NA'}
+                min={bounds.minBound}
+                max={bounds.maxBound}
+                value={rangeMaxValue}
+                onChange={(event) => setRangeMaxValue(event.target.value)}
+                onBlur={handleBlur}
+            />
+        </Row>
+    );
+}

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -37,6 +37,17 @@ function tryParseAttributeJson(
     }
 }
 
+function isRangeValue(value: unknown): value is { min: number; max: number } {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'min' in value &&
+        'max' in value &&
+        typeof value.min === 'number' &&
+        typeof value.max === 'number'
+    );
+}
+
 function populateMissingAttributes(
     entity: SelectEntity & {
         attributes: (SelectAttributeValue & {
@@ -262,6 +273,18 @@ async function expandValue(
     }
     if (attributeDefinition.dataType === 'number') {
         return parseFloat(value);
+    } else if (
+        attributeDefinition.dataType === 'range' ||
+        attributeDefinition.dataType.startsWith('range|')
+    ) {
+        const parsedRangeValue = tryParseAttributeJson(
+            value,
+            attributeDefinition,
+        );
+        if (isRangeValue(parsedRangeValue)) {
+            return parsedRangeValue;
+        }
+        return null;
     } else if (attributeDefinition.dataType === 'boolean') {
         return value === 'true';
     } else if (attributeDefinition.dataType.startsWith('json')) {
@@ -275,10 +298,7 @@ async function expandValue(
         }
 
         let url = '';
-        if (
-            'url' in data &&
-            typeof data.url === 'string'
-        ) {
+        if ('url' in data && typeof data.url === 'string') {
             url = data.url;
         }
         return {


### PR DESCRIPTION
### Motivation
- Introduce a new `range` attribute data type to represent numeric min/max pairs for attributes that require a bounded numeric interval. 
- Allow each `range` attribute to specify per-definition bounds (e.g. `0-1`, `1-100`) so inputs can be constrained in the UI and persisted consistently.

### Description
- Added `range` to the attribute type catalog and icon handling in `apps/app/app/admin/directories/[entityType]/attribute-definitions/AttributeDataTypes.tsx`, and implemented `parseRangeDataType` / `buildRangeDataType` helpers that encode metadata as `range|min|max`.
- Updated the attribute definition create form `apps/app/app/admin/directories/[entityType]/attribute-definitions/CreateAttributeDefinitionButton.tsx` to let admins configure `range` min/max before saving and serialize them into the `dataType` field.
- Updated the attribute definition edit form `apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx` to edit and persist range bounds and show human-readable labels (e.g. `Raspon (min - max)`).
- Implemented a `RangeInput` component at `apps/app/components/shared/attributes/typed/RangeInput.tsx` that exposes two numeric inputs (`min` / `max`), constrained by definition bounds, serializes values as JSON `{ min, max }`, and wired `AttributeInput` to render it when `dataType` is `range` or `range|...`.
- Updated storage expansion in `packages/storage/src/repositories/entitiesRepo.ts` to parse stored JSON range values and return typed `{ min: number; max: number }` objects when expanding entity attributes.

### Testing
- Ran `pnpm lint --filter app` which completed (lint ran and reported a warning during the run). 
- Ran targeted formatting/type checks with `pnpm --filter app exec biome check --write <changed files>` which completed without errors.
- Ran `pnpm --filter @gredice/storage exec biome check --write src/repositories/entitiesRepo.ts` which completed and applied fixes where needed.
- Ran `pnpm lint --filter @gredice/storage` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60177f11c832f86bf93cee6afad8a)