### PR TITLE
Add Product SEO structured data to plants, sorts and operations pages

### DIFF
--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { RecipeList } from '../../../components/recipes/RecipeList';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
+import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getPlantsData } from '../../../lib/plants/getPlantsData';
 import { getRecipesData } from '../../../lib/recipes/getRecipesData';
 import { KnownPages } from '../../../src/KnownPages';
@@ -93,6 +94,34 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
 
     return (
         <div className="py-8">
+            <StructuredDataScript
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'Product',
+                    name: plant.information.name,
+                    description: plant.information.description,
+                    category: 'Biljka',
+                    image: plant.image?.cover?.url,
+                    brand: {
+                        '@type': 'Brand',
+                        name: 'Gredice',
+                    },
+                    url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
+                    offers:
+                        typeof plant.prices?.perPlant === 'number'
+                            ? {
+                                  '@type': 'Offer',
+                                  price: plant.prices.perPlant.toFixed(2),
+                                  priceCurrency: 'EUR',
+                                  availability:
+                                      plant.store?.availableInStore === false
+                                          ? 'https://schema.org/OutOfStock'
+                                          : 'https://schema.org/InStock',
+                                  url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
+                              }
+                            : undefined,
+                }}
+            />
             <Stack spacing={4}>
                 <Breadcrumbs
                     items={[

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -6,6 +6,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { FeedbackModal } from '../../../../../components/shared/feedback/FeedbackModal';
+import { StructuredDataScript } from '../../../../../components/shared/seo/StructuredDataScript';
 import { getPlantSortsData } from '../../../../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../../../../lib/plants/getPlantsData';
 import { KnownPages } from '../../../../../src/KnownPages';
@@ -160,6 +161,46 @@ export default async function PlantSortPage(
 
     return (
         <div className="py-8">
+            <StructuredDataScript
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'Product',
+                    name: sortData.information.name,
+                    description:
+                        sortData.information.shortDescription ??
+                        sortData.information.description ??
+                        basePlantData.information.description,
+                    category: 'Sorta biljke',
+                    image:
+                        sortData.image?.cover?.url ??
+                        basePlantData.image?.cover?.url,
+                    brand: {
+                        '@type': 'Brand',
+                        name: 'Gredice',
+                    },
+                    isVariantOf: {
+                        '@type': 'Product',
+                        name: basePlantData.information.name,
+                        url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
+                    },
+                    url: `https://www.gredice.com${KnownPages.PlantSort(alias, sortData.information.name)}`,
+                    offers:
+                        typeof basePlantData.prices?.perPlant === 'number'
+                            ? {
+                                  '@type': 'Offer',
+                                  price: basePlantData.prices.perPlant.toFixed(
+                                      2,
+                                  ),
+                                  priceCurrency: 'EUR',
+                                  availability:
+                                      sortData.store?.availableInStore === false
+                                          ? 'https://schema.org/OutOfStock'
+                                          : 'https://schema.org/InStock',
+                                  url: `https://www.gredice.com${KnownPages.PlantSort(alias, sortData.information.name)}`,
+                              }
+                            : undefined,
+                }}
+            />
             <Stack spacing={4}>
                 <Breadcrumbs
                     items={[

--- a/apps/www/app/biljke/page.tsx
+++ b/apps/www/app/biljke/page.tsx
@@ -1,3 +1,4 @@
+import { orderBy } from '@signalco/js';
 import { Calendar, LayoutGrid } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -15,7 +16,9 @@ import { Suspense } from 'react';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { PageHeader } from '../../components/shared/PageHeader';
+import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { KnownPages } from '../../src/KnownPages';
 import { PlantsCalendar } from './PlantsCalendar';
 import { PlantsGallery } from './PlantsGallery';
 import { PlantsSeedTimeFilterToggle } from './PlantsSeedTimeFilterToggle';
@@ -38,8 +41,41 @@ export default async function PlantsPage({
         (Array.isArray(seedTimeFilter) ? seedTimeFilter[0] : seedTimeFilter) ===
         '1';
     const entities = await getPlantsData();
+    const isCanonicalView = !search && !isSeedTimeFilterEnabled;
+    const sortedEntities = orderBy(entities ?? [], (a, b) =>
+        a.information.name.localeCompare(b.information.name),
+    );
     return (
         <Stack>
+            {isCanonicalView && (
+                <StructuredDataScript
+                    data={{
+                        '@context': 'https://schema.org',
+                        '@type': 'ItemList',
+                        name: 'Biljke',
+                        itemListElement: sortedEntities.map((plant, index) => ({
+                            '@type': 'ListItem',
+                            position: index + 1,
+                            item: {
+                                '@type': 'Product',
+                                name: plant.information.name,
+                                url: `https://www.gredice.com${KnownPages.Plant(plant.information.name)}`,
+                                image: plant.image?.cover?.url,
+                                offers:
+                                    typeof plant.prices?.perPlant === 'number'
+                                        ? {
+                                              '@type': 'Offer',
+                                              price: plant.prices.perPlant.toFixed(
+                                                  2,
+                                              ),
+                                              priceCurrency: 'EUR',
+                                          }
+                                        : undefined,
+                            },
+                        })),
+                    }}
+                />
+            )}
             <PageHeader
                 padded
                 header="Biljke"

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -11,6 +11,7 @@ import { notFound } from 'next/navigation';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { PageHeader } from '../../../components/shared/PageHeader';
+import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getOperationsData } from '../../../lib/plants/getOperationsData';
 import { KnownPages } from '../../../src/KnownPages';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
@@ -64,6 +65,30 @@ export default async function OperationPage(
 
     return (
         <div className="operation-page py-8">
+            <StructuredDataScript
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'Product',
+                    name: operation.information.label,
+                    description:
+                        operation.information.shortDescription ??
+                        operation.information.description,
+                    category: 'Radnja',
+                    image: operation.image?.cover?.url,
+                    brand: {
+                        '@type': 'Brand',
+                        name: 'Gredice',
+                    },
+                    url: `https://www.gredice.com${KnownPages.Operation(operation.information.label)}`,
+                    offers: {
+                        '@type': 'Offer',
+                        price: operation.prices.perOperation.toFixed(2),
+                        priceCurrency: 'EUR',
+                        availability: 'https://schema.org/InStock',
+                        url: `https://www.gredice.com${KnownPages.Operation(operation.information.label)}`,
+                    },
+                }}
+            />
             <Stack spacing={4}>
                 <Breadcrumbs
                     items={[

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -20,7 +20,9 @@ import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { NoDataPlaceholder } from '../../components/shared/placeholders/NoDataPlaceholder';
+import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
+import { KnownPages } from '../../src/KnownPages';
 import { OperationCard } from './OperationCard';
 
 const stageIcons: Record<
@@ -68,9 +70,56 @@ export default async function OperationsPage({
     const availableStages = PLANT_STAGES.filter((stage) =>
         stageNamesInOperations.has(stage.name),
     );
+    const stageOperations = new Map<
+        PlantStageName,
+        NonNullable<typeof filteredOperations>
+    >(
+        availableStages.map<
+            [PlantStageName, NonNullable<typeof filteredOperations>]
+        >((stage) => [
+            stage.name,
+            filteredOperations
+                ?.filter(
+                    (op) =>
+                        op.attributes.stage?.information?.name === stage.name,
+                )
+                .sort((a, b) =>
+                    a.information.label.localeCompare(b.information.label),
+                ) ?? [],
+        ]),
+    );
+    const orderedOperations = availableStages.flatMap(
+        (stage) => stageOperations.get(stage.name) ?? [],
+    );
 
     return (
         <Stack spacing={4}>
+            <StructuredDataScript
+                data={{
+                    '@context': 'https://schema.org',
+                    '@type': 'ItemList',
+                    name: 'Radnje',
+                    itemListElement: orderedOperations.map(
+                        (operation, index) => ({
+                            '@type': 'ListItem',
+                            position: index + 1,
+                            item: {
+                                '@type': 'Product',
+                                name: operation.information.label,
+                                url: `https://www.gredice.com${KnownPages.Operation(operation.information.label)}`,
+                                image: operation.image?.cover?.url,
+                                offers: {
+                                    '@type': 'Offer',
+                                    price: operation.prices.perOperation.toFixed(
+                                        2,
+                                    ),
+                                    priceCurrency: 'EUR',
+                                },
+                            },
+                        }),
+                    ),
+                }}
+            />
             <PageHeader header="Radnje" subHeader={pageDescription} padded>
                 <Suspense>
                     <PageFilterInput
@@ -109,18 +158,8 @@ export default async function OperationsPage({
                     </div>
                 )}
                 {availableStages.map((stage) => {
-                    const stageOperations =
-                        filteredOperations
-                            ?.filter(
-                                (op) =>
-                                    op.attributes.stage?.information?.name ===
-                                    stage.name,
-                            )
-                            .sort((a, b) =>
-                                a.information.label.localeCompare(
-                                    b.information.label,
-                                ),
-                            ) || [];
+                    const operationsForStage =
+                        stageOperations.get(stage.name) ?? [];
                     const Icon = stageIcons[stage.name];
                     return (
                         <Stack
@@ -136,7 +175,7 @@ export default async function OperationsPage({
                                 </Typography>
                             </Row>
                             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                                {stageOperations.map((operation) => (
+                                {operationsForStage.map((operation) => (
                                     <OperationCard
                                         key={operation.id}
                                         operation={operation}

--- a/apps/www/components/shared/seo/StructuredDataScript.tsx
+++ b/apps/www/components/shared/seo/StructuredDataScript.tsx
@@ -1,0 +1,15 @@
+type StructuredDataScriptProps = {
+    data: Record<string, unknown> | Record<string, unknown>[];
+};
+
+export function StructuredDataScript({ data }: StructuredDataScriptProps) {
+    return (
+        <script
+            type="application/ld+json"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD script injection is expected for structured data
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+            }}
+        />
+    );
+}


### PR DESCRIPTION
### Motivation
- Improve Google/Product SEO by emitting JSON-LD structured data for plants, plant sorts and operations so search engines can surface product and offer information.

### Description
- Added a reusable `StructuredDataScript` component that safely renders JSON-LD payloads into the page. 
- Injected `@type: Product` JSON-LD into the plant detail page (`/biljke/[alias]`) including `name`, `description`, `image`, `brand`, `url` and conditional `offers` when `prices.perPlant` is available. 
- Injected `@type: Product` JSON-LD into the plant sort detail page (`/biljke/[alias]/sorte/[sortAlias]`) including `isVariantOf` linking back to the base plant and `availability` derived from `sort.store.availableInStore`. 
- Injected `@type: Product` JSON-LD into the operation detail page (`/radnje/[alias]`) and added `ItemList` JSON-LD to plants listing (`/biljke`) and operations listing (`/radnje`) that map list entries to `Product` items and `Offer`s using `KnownPages` URLs. 

### Testing
- Ran lint with `pnpm --filter www lint`, which completed successfully but reported one unrelated `any` usage warning. 
- Built the site with `pnpm --filter www build`, which completed successfully (static page generation and `next-sitemap` postbuild ran; some upstream fetch logs appeared during prerendering but the build finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e603ebc6f0832f9b32d97db4d140f7)