### PR TITLE
fix(--pages validate plant sort and log errorsAdd defensive checks reading sort and plant names in two SSR/SSGpaths the plant detail page (/blokovi/biljke/[alias]) and the plantsort static params generator (/biljke/[alias]/sorte/[sort]).

### DIFF
--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -55,12 +55,32 @@ export async function generateMetadata(
 export async function generateStaticParams() {
     const sorts = await getPlantSortsData();
     return (
-        sorts?.map((entity) => ({
-            alias: toPageAlias(
-                String(entity.information.plant.information?.name),
-            ),
-            sortAlias: toPageAlias(String(entity.information.name)),
-        })) ?? []
+        sorts?.map((entity, index) => {
+            const sortName = entity?.information?.name;
+            const plantName = entity?.information?.plant?.information?.name;
+
+            if (!sortName || !plantName) {
+                console.error(
+                    'Invalid plant sort while generating static params for plant sort page',
+                    {
+                        index,
+                        sortId: entity?.id ?? null,
+                        sortName: sortName ?? null,
+                        plantId: entity?.information?.plant?.id ?? null,
+                        plantName: plantName ?? null,
+                    },
+                );
+
+                throw new Error(
+                    'Invalid plant sort data while generating static params for /biljke/[alias]/sorte/[sortAlias]',
+                );
+            }
+
+            return {
+                alias: toPageAlias(String(plantName)),
+                sortAlias: toPageAlias(String(sortName)),
+            };
+        }) ?? []
     );
 }
 

--- a/apps/www/app/blokovi/biljke/[alias]/page.tsx
+++ b/apps/www/app/blokovi/biljke/[alias]/page.tsx
@@ -70,9 +70,34 @@ export default async function BlockPlantDetailPage(
 
     const sorts = (
         allSorts?.filter(
-            (sort) =>
-                sort.information.plant.information?.name?.toLowerCase() ===
-                plant.information.name.toLowerCase(),
+            (sort, index) => {
+                const sortName = sort?.information?.name;
+                const sortPlantName = sort?.information?.plant?.information?.name;
+
+                if (!sortName || !sortPlantName) {
+                    console.error(
+                        'Invalid plant sort while filtering sorts for block plant detail page',
+                        {
+                            plantAlias: alias,
+                            plantName: plant.information.name,
+                            index,
+                            sortId: sort?.id ?? null,
+                            sortName: sortName ?? null,
+                            plantId: sort?.information?.plant?.id ?? null,
+                            sortPlantName: sortPlantName ?? null,
+                        },
+                    );
+
+                    throw new Error(
+                        'Invalid plant sort data while rendering /blokovi/biljke/[alias]',
+                    );
+                }
+
+                return (
+                    sortPlantName.toLowerCase() ===
+                    plant.information.name.toLowerCase()
+                );
+            },
         ) ?? []
     ).sort((a, b) => a.information.name.localeCompare(b.information.name));
 


### PR DESCRIPTION
- Validate that sort.information.name and sort.information.plant.information.name exist comparing or generating aliases.
- Log detailed console.error entries including index, ids names to aid when data is malformed.
- Throw descriptive Errors invalid data to fail fast during rendering static params generation- Keep existing sorting of sorts by name.

This prevents silent runtime failures and ensures invalid backend datais noticed early during build or request time.