### PR TITLE
Convert CreateAttributeDefinitionButton to client component with form state

### DIFF
--- a/apps/app/app/(actions)/definitionActions.ts
+++ b/apps/app/app/(actions)/definitionActions.ts
@@ -20,15 +20,17 @@ import { KnownPages } from '../../src/KnownPages';
 
 export async function upsertAttributeDefinition(
     definition: InsertAttributeDefinition | UpdateAttributeDefinition,
-) {
+): Promise<{ id: number }> {
     await auth(['admin']);
 
     const id = definition.id;
+    let resultId: number;
     if (id) {
         await storageUpdateAttributeDefinition({
             ...definition,
             id,
         });
+        resultId = id;
     } else {
         // Validate required fields
         const name = definition.name;
@@ -47,7 +49,7 @@ export async function upsertAttributeDefinition(
             throw new Error('Missing required fields.');
         }
 
-        await storageCreateAttributeDefinition({
+        resultId = await storageCreateAttributeDefinition({
             ...definition,
             name,
             label,
@@ -74,6 +76,8 @@ export async function upsertAttributeDefinition(
             ),
         );
     }
+
+    return { id: resultId };
 }
 
 export async function deleteAttributeDefinition(
@@ -154,26 +158,6 @@ export async function reorderAttributeDefinition(
     revalidatePath(
         KnownPages.DirectoryEntityTypeAttributeDefinitions(entityTypeName),
     );
-}
-
-export async function createAttributeDefinitionFromForm(
-    entityTypeName: string,
-    categoryName: string,
-    formData: FormData,
-) {
-    await auth(['admin']);
-
-    const name = formData.get('name') as string;
-    const label = formData.get('label') as string;
-    const dataType = formData.get('dataType') as string;
-
-    await upsertAttributeDefinition({
-        name,
-        label,
-        dataType,
-        entityTypeName,
-        category: categoryName,
-    });
 }
 
 export async function createAttributeDefinitionCategoryFromForm(

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/AttributeDataTypes.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/AttributeDataTypes.tsx
@@ -9,7 +9,13 @@ import {
 } from '@signalco/ui-icons';
 import type { HTMLAttributes, ReactNode } from 'react';
 
-export const attributeDataTypeItems = [
+export type AttributeDataTypeItem = {
+    value: string;
+    label: string;
+    icon?: ReactNode;
+};
+
+export const attributeDataTypeItems: AttributeDataTypeItem[] = [
     {
         value: 'text',
         label: 'Tekst',
@@ -50,7 +56,7 @@ export const attributeDataTypeItems = [
         label: 'JSON',
         icon: <Code className="size-5" />,
     },
-] as const;
+];
 
 export function AttributeDataTypeIcon({
     dataType,

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx
@@ -4,6 +4,7 @@ import type { getAttributeDefinition } from '@gredice/storage';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Input } from '@signalco/ui-primitives/Input';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { Stack } from '@signalco/ui-primitives/Stack';
 import { type ChangeEvent, useState } from 'react';
 import { upsertAttributeDefinition } from '../../../../../(actions)/definitionActions';
 import {
@@ -107,7 +108,7 @@ export function FormDataTypeSelect({
           ];
 
     return (
-        <>
+        <Stack spacing={1} className="grow">
             <SelectItems
                 label="Tip podatka"
                 value={internalValue}
@@ -137,7 +138,7 @@ export function FormDataTypeSelect({
                     />
                 </div>
             )}
-        </>
+        </Stack>
     );
 }
 

--- a/apps/app/components/admin/buttons/CreateAttributeDefinitionButton.tsx
+++ b/apps/app/components/admin/buttons/CreateAttributeDefinitionButton.tsx
@@ -1,11 +1,21 @@
+'use client';
+
 import { Add } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { createAttributeDefinitionFromForm } from '../../../app/(actions)/definitionActions';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useState } from 'react';
+import { upsertAttributeDefinition } from '../../../app/(actions)/definitionActions';
+import {
+    attributeDataTypeItems,
+    buildRangeDataType,
+} from '../../../app/admin/directories/[entityType]/attribute-definitions/AttributeDataTypes';
+import { KnownPages } from '../../../src/KnownPages';
 
 export function CreateAttributeDefinitionButton({
     entityTypeName,
@@ -14,14 +24,63 @@ export function CreateAttributeDefinitionButton({
     entityTypeName: string;
     categoryName: string;
 }) {
-    const submitForm = createAttributeDefinitionFromForm.bind(
-        null,
-        entityTypeName,
-        categoryName,
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState('');
+    const [label, setLabel] = useState('');
+    const [selectedDataType, setSelectedDataType] = useState<string>(
+        attributeDataTypeItems[0].value,
     );
+    const [rangeMinValue, setRangeMinValue] = useState('0');
+    const [rangeMaxValue, setRangeMaxValue] = useState('100');
+    const [submitting, setSubmitting] = useState(false);
+
+    function resetForm() {
+        setName('');
+        setLabel('');
+        setSelectedDataType(attributeDataTypeItems[0].value);
+        setRangeMinValue('0');
+        setRangeMaxValue('100');
+    }
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (submitting) return;
+        const dataType =
+            selectedDataType === 'range'
+                ? buildRangeDataType(rangeMinValue, rangeMaxValue)
+                : selectedDataType;
+        setSubmitting(true);
+        try {
+            const { id } = await upsertAttributeDefinition({
+                name,
+                label,
+                dataType,
+                entityTypeName,
+                category: categoryName,
+            });
+            setOpen(false);
+            resetForm();
+            router.push(
+                KnownPages.DirectoryEntityTypeAttributeDefinition(
+                    entityTypeName,
+                    id,
+                ),
+            );
+        } finally {
+            setSubmitting(false);
+        }
+    }
 
     return (
         <Modal
+            open={open}
+            onOpenChange={(nextOpen) => {
+                setOpen(nextOpen);
+                if (!nextOpen) {
+                    resetForm();
+                }
+            }}
             trigger={
                 <IconButton variant="plain" title="Dodaj atribut">
                     <Add className="size-5" />
@@ -36,14 +95,61 @@ export function CreateAttributeDefinitionButton({
                         Unesite podatke za novi atribut.
                     </Typography>
                 </Stack>
-                <form action={submitForm}>
+                <form onSubmit={handleSubmit}>
                     <Stack spacing={4}>
                         <Stack spacing={1}>
-                            <Input name="name" label="Naziv" />
-                            <Input name="label" label="Labela" />
-                            <Input name="dataType" label="Vrsta podatka" />
+                            <Input
+                                name="name"
+                                label="Naziv"
+                                value={name}
+                                onChange={(event) =>
+                                    setName(event.target.value)
+                                }
+                            />
+                            <Input
+                                name="label"
+                                label="Labela"
+                                value={label}
+                                onChange={(event) =>
+                                    setLabel(event.target.value)
+                                }
+                            />
+                            <SelectItems
+                                name="dataType"
+                                label="Vrsta podatka"
+                                value={selectedDataType}
+                                items={attributeDataTypeItems}
+                                onValueChange={setSelectedDataType}
+                            />
+                            {selectedDataType === 'range' && (
+                                <div className="grid grid-cols-2 gap-2">
+                                    <Input
+                                        type="number"
+                                        name="rangeMin"
+                                        label="Minimalna vrijednost"
+                                        value={rangeMinValue}
+                                        onChange={(event) =>
+                                            setRangeMinValue(event.target.value)
+                                        }
+                                    />
+                                    <Input
+                                        type="number"
+                                        name="rangeMax"
+                                        label="Maksimalna vrijednost"
+                                        value={rangeMaxValue}
+                                        onChange={(event) =>
+                                            setRangeMaxValue(event.target.value)
+                                        }
+                                    />
+                                </div>
+                            )}
                         </Stack>
-                        <Button variant="solid" type="submit">
+                        <Button
+                            variant="solid"
+                            type="submit"
+                            loading={submitting}
+                            disabled={submitting}
+                        >
                             Kreiraj
                         </Button>
                     </Stack>

--- a/packages/storage/src/repositories/attributeDefinitionsRepo.ts
+++ b/packages/storage/src/repositories/attributeDefinitionsRepo.ts
@@ -39,10 +39,14 @@ export function getAttributeDefinition(id: number) {
     });
 }
 
-export function createAttributeDefinition(
+export async function createAttributeDefinition(
     definition: InsertAttributeDefinition,
-) {
-    return storage().insert(attributeDefinitions).values(definition);
+): Promise<number> {
+    const [inserted] = await storage()
+        .insert(attributeDefinitions)
+        .values(definition)
+        .returning({ id: attributeDefinitions.id });
+    return inserted.id;
 }
 
 export function updateAttributeDefinition(


### PR DESCRIPTION
## Summary
Converted the `CreateAttributeDefinitionButton` component from a server action-based form to a client component with local state management. This enables better UX with client-side form handling, conditional rendering based on data type selection, and automatic navigation after successful creation.

## Key Changes

- **Made component a client component** by adding `'use client'` directive to enable React hooks and event handlers
- **Replaced server action form submission** with client-side `handleSubmit` handler that calls `upsertAttributeDefinition` and handles the response
- **Implemented local state management** for form fields (name, label, selectedDataType, rangeMinValue, rangeMaxValue) and submission state
- **Added conditional range input fields** that appear only when "range" data type is selected
- **Improved UX** with form reset on modal close, loading state on submit button, and automatic navigation to the created definition
- **Updated `upsertAttributeDefinition` action** to return the created/updated definition ID for client-side navigation
- **Modified `createAttributeDefinition` storage function** to return the inserted ID instead of void
- **Removed `createAttributeDefinitionFromForm` server action** as it's no longer needed with client-side form handling
- **Enhanced `AttributeDataTypes`** by exporting `AttributeDataTypeItem` type and removing `as const` assertion for better type flexibility
- **Improved Form component layout** by wrapping data type select in a Stack for consistent spacing

## Implementation Details

The component now manages its own modal open state and form data, providing immediate visual feedback during submission. The range data type conditionally renders min/max input fields with a two-column grid layout. After successful creation, the modal closes, form resets, and the user is navigated to the newly created attribute definition's detail page.

https://claude.ai/code/session_018VEojivXzThRPJEfUXa1rx