### PR TITLE
Add admin sowing statistics report page

### DIFF
--- a/apps/app/app/admin/statistics/sowing/page.tsx
+++ b/apps/app/app/admin/statistics/sowing/page.tsx
@@ -1,0 +1,150 @@
+import {
+    getAllRaisedBeds,
+    getEntitiesFormatted,
+    getRaisedBedFieldPlantCycles,
+} from '@gredice/storage';
+import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
+import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
+import { auth } from '../../../../lib/auth/auth';
+
+export const dynamic = 'force-dynamic';
+
+type SortSowingSummary = {
+    sortId: number;
+    name: string;
+    sowingCount: number;
+    lastSowedAt: Date | null;
+};
+
+function compareSortSowingSummary(
+    left: SortSowingSummary,
+    right: SortSowingSummary,
+) {
+    if (left.sowingCount !== right.sowingCount) {
+        return right.sowingCount - left.sowingCount;
+    }
+
+    return left.name.localeCompare(right.name, 'hr-HR');
+}
+
+export default async function SowingStatisticsPage() {
+    await auth(['admin']);
+
+    const [raisedBeds, plantSorts] = await Promise.all([
+        getAllRaisedBeds(),
+        getEntitiesFormatted<EntityStandardized>('plantSort'),
+    ]);
+
+    const allPlantCycles = (
+        await Promise.all(
+            raisedBeds.map((raisedBed) =>
+                getRaisedBedFieldPlantCycles(raisedBed.id),
+            ),
+        )
+    ).flat();
+
+    const sortNameById = new Map(
+        (plantSorts ?? []).map((plantSort) => [
+            plantSort.id,
+            plantSort.information?.name?.trim() || `Sorta ${plantSort.id}`,
+        ]),
+    );
+    const sownBySort = new Map<number, SortSowingSummary>();
+
+    for (const cycle of allPlantCycles) {
+        if (!cycle.plantSowDate || !cycle.plantSortId) {
+            continue;
+        }
+
+        const existingSummary = sownBySort.get(cycle.plantSortId);
+        if (existingSummary) {
+            existingSummary.sowingCount += 1;
+            if (
+                !existingSummary.lastSowedAt ||
+                existingSummary.lastSowedAt < cycle.plantSowDate
+            ) {
+                existingSummary.lastSowedAt = cycle.plantSowDate;
+            }
+            continue;
+        }
+
+        sownBySort.set(cycle.plantSortId, {
+            sortId: cycle.plantSortId,
+            name:
+                sortNameById.get(cycle.plantSortId) ||
+                `Nepoznata sorta #${cycle.plantSortId}`,
+            sowingCount: 1,
+            lastSowedAt: cycle.plantSowDate,
+        });
+    }
+
+    const sortedSowingSummary = Array.from(sownBySort.values()).sort(
+        compareSortSowingSummary,
+    );
+    const totalSowings = sortedSowingSummary.reduce(
+        (sum, item) => sum + item.sowingCount,
+        0,
+    );
+
+    return (
+        <Stack spacing={2}>
+            <Typography level="h4" component="h1">
+                Statistika sijanja po sortama
+            </Typography>
+            <Stack spacing={1} className="md:flex-row">
+                <Chip color="primary">Ukupno sijanja: {totalSowings}</Chip>
+                <Chip>Sorti sa sijanjem: {sortedSowingSummary.length}</Chip>
+            </Stack>
+            <Card>
+                <CardOverflow>
+                    <Table>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Head>#</Table.Head>
+                                <Table.Head>Sorta</Table.Head>
+                                <Table.Head className="text-right">
+                                    Broj sijanja
+                                </Table.Head>
+                                <Table.Head className="text-right">
+                                    Zadnje sijanje
+                                </Table.Head>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {sortedSowingSummary.length === 0 && (
+                                <Table.Row>
+                                    <Table.Cell colSpan={4}>
+                                        <NoDataPlaceholder>
+                                            Nema evidentiranih sijanja.
+                                        </NoDataPlaceholder>
+                                    </Table.Cell>
+                                </Table.Row>
+                            )}
+                            {sortedSowingSummary.map((summary, index) => (
+                                <Table.Row key={summary.sortId}>
+                                    <Table.Cell>{index + 1}</Table.Cell>
+                                    <Table.Cell>{summary.name}</Table.Cell>
+                                    <Table.Cell className="text-right">
+                                        {summary.sowingCount}
+                                    </Table.Cell>
+                                    <Table.Cell className="text-right">
+                                        {summary.lastSowedAt
+                                            ? summary.lastSowedAt.toLocaleDateString(
+                                                  'hr-HR',
+                                              )
+                                            : '-'}
+                                    </Table.Cell>
+                                </Table.Row>
+                            ))}
+                        </Table.Body>
+                    </Table>
+                </CardOverflow>
+            </Card>
+        </Stack>
+    );
+}

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -336,6 +336,12 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                         onClick={onItemClick}
                     />
                     <NavItem
+                        href={adminPages.SowingStatistics.href}
+                        label={adminPages.SowingStatistics.label}
+                        icon={<Tally3 className="size-5" />}
+                        onClick={onItemClick}
+                    />
+                    <NavItem
                         href={adminPages.DeliverySlots.href}
                         label={adminPages.DeliverySlots.label}
                         icon={<Truck className="size-5" />}

--- a/apps/app/components/admin/navigation/adminPages.ts
+++ b/apps/app/components/admin/navigation/adminPages.ts
@@ -18,6 +18,10 @@ export const adminPages = {
     Inventory: { href: KnownPages.Inventory, label: 'Zalihe' },
     Occasions: { href: KnownPages.Occasions, label: 'Prigode' },
     Schedule: { href: KnownPages.Schedule, label: 'Raspored' },
+    SowingStatistics: {
+        href: KnownPages.SowingStatistics,
+        label: 'Statistika sijanja',
+    },
     DeliverySlots: {
         href: KnownPages.DeliverySlots,
         label: 'Dostava - Slotovi',
@@ -61,6 +65,7 @@ export const adminBreadcrumbPages = [
     adminPages.Inventory,
     adminPages.Occasions,
     adminPages.Schedule,
+    adminPages.SowingStatistics,
     adminPages.DeliverySlots,
     adminPages.DeliveryRequests,
     adminPages.CommunicationInbox,

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -33,6 +33,7 @@ export const KnownPages = {
     Users: '/admin/users',
     User: (userId: string) => `/admin/users/${userId}` as Route,
     Schedule: '/admin/schedule',
+    SowingStatistics: '/admin/statistics/sowing',
     Accounts: '/admin/accounts',
     Account: (accountId: string) => `/admin/accounts/${accountId}` as Route,
     Farms: '/admin/farms',


### PR DESCRIPTION
### Motivation
- Provide administrators with a simple report to see how many times each plant sort has been sown across all raised beds using event-sourced plant-cycle data.
- Surface quick totals and a ranked list so staff can evaluate popular or recently used sorts.

### Description
- Added a new server-rendered admin page at `apps/app/app/admin/statistics/sowing/page.tsx` which aggregates plant cycles via `getAllRaisedBeds` and `getRaisedBedFieldPlantCycles` and shows per-sort sowing counts and last sow date.
- Introduced a shared route constant `KnownPages.SowingStatistics` in `apps/app/src/KnownPages.ts` for centralized routing.
- Registered the page in admin metadata and breadcrumbs in `apps/app/components/admin/navigation/adminPages.ts` and added a left-nav entry in `apps/app/components/admin/navigation/Nav.tsx` labeled "Statistika sijanja".
- UI uses existing primitives (`Card`, `Table`, `Chip`, etc.) and resolves sort names via `getEntitiesFormatted<'plantSort'>` with fallbacks for unknown sorts.

### Testing
- Ran the workspace lint for the modified files with `pnpm --dir apps/app lint app/admin/statistics/sowing/page.tsx src/KnownPages.ts components/admin/navigation/adminPages.ts components/admin/navigation/Nav.tsx`, which completed successfully and auto-fixed one formatting/biome issue.
- No new unit or integration tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66611ed78832f8f987e917cf0a52b)