### PR TITLE
Show directory sidebar sections publicly in app navigation

### DIFF
--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -17,7 +17,6 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import type { SelectEntityType } from '@gredice/storage';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
-import { AuthProtectedSection } from '@signalco/auth-client/components';
 import {
     AI,
     Bank,
@@ -185,51 +184,47 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                 ))}
             </List>
             <Stack spacing={1}>
-                <AuthProtectedSection>
-                    {/* Categories with their entity types */}
-                    {categorizedTypes.map((category) => (
-                        <Stack key={category.id} spacing={1}>
-                            <ListHeader header={category.label} />
-                            <EntityTypeList
-                                items={category.entityTypes}
-                                onItemClick={onItemClick}
-                            />
-                        </Stack>
-                    ))}
-                </AuthProtectedSection>
-
-                <ListHeader header="Zapisi" />
-                <AuthProtectedSection>
-                    {/* Shadow entity types */}
-                    {shadowTypes.length > 0 && (
-                        <ListTreeItem label="Ostalo">
-                            {shadowTypes.map((entityType) => (
-                                <NavItem
-                                    key={entityType.id}
-                                    href={KnownPages.DirectoryEntityType(
-                                        entityType.name,
-                                    )}
-                                    label={entityType.label}
-                                    icon={
-                                        <EntityTypeIcon
-                                            icon={entityType.icon}
-                                            className="size-5"
-                                        />
-                                    }
-                                    onClick={onItemClick}
-                                />
-                            ))}
-                        </ListTreeItem>
-                    )}
-
-                    {/* Entity types without category come first */}
-                    {uncategorizedTypes.length > 0 && (
+                {/* Categories with their entity types */}
+                {categorizedTypes.map((category) => (
+                    <Stack key={category.id} spacing={1}>
+                        <ListHeader header={category.label} />
                         <EntityTypeList
-                            items={uncategorizedTypes}
+                            items={category.entityTypes}
                             onItemClick={onItemClick}
                         />
-                    )}
-                </AuthProtectedSection>
+                    </Stack>
+                ))}
+
+                <ListHeader header="Zapisi" />
+                {/* Shadow entity types */}
+                {shadowTypes.length > 0 && (
+                    <ListTreeItem label="Ostalo">
+                        {shadowTypes.map((entityType) => (
+                            <NavItem
+                                key={entityType.id}
+                                href={KnownPages.DirectoryEntityType(
+                                    entityType.name,
+                                )}
+                                label={entityType.label}
+                                icon={
+                                    <EntityTypeIcon
+                                        icon={entityType.icon}
+                                        className="size-5"
+                                    />
+                                }
+                                onClick={onItemClick}
+                            />
+                        ))}
+                    </ListTreeItem>
+                )}
+
+                {/* Entity types without category come first */}
+                {uncategorizedTypes.length > 0 && (
+                    <EntityTypeList
+                        items={uncategorizedTypes}
+                        onItemClick={onItemClick}
+                    />
+                )}
             </Stack>
             <Stack spacing={1}>
                 <ListHeader header="Administracija" />


### PR DESCRIPTION
### Motivation
- Directory listings are public data and should be visible without client-side auth gating so they can be prerendered and accessible to unauthenticated users.
- The nav component previously wrapped categorized, uncategorized and shadow directory sections with an auth-only wrapper which prevented public rendering.

### Description
- Removed `AuthProtectedSection` import and the auth wrapper around the categorized entity types section in `apps/app/components/admin/navigation/Nav.tsx`.
- Removed the auth wrapper around the shadow and uncategorized entity type rendering so categorized, shadow and uncategorized lists always render in the sidebar.
- Kept existing rendering and drag/reorder logic for `EntityTypeList` and `SortableNavItem` unchanged so functionality is preserved.

### Testing
- Ran `pnpm lint --filter app` from the repo root and the command completed successfully (Biome fixed two files and reported one unrelated warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d1454140832f8fb1ed4896c92e78)