### PR TITLE
fix(app): make logout resilient to refresh-token revoke errors

### DIFF
--- a/apps/app/app/api/logout/route.ts
+++ b/apps/app/app/api/logout/route.ts
@@ -8,8 +8,16 @@ import {
 export async function POST() {
     const refreshToken = await getRefreshTokenCookie();
     if (refreshToken) {
-        await revokeRefreshToken(refreshToken);
+        try {
+            await revokeRefreshToken(refreshToken);
+        } catch (cause) {
+            console.error(
+                'Failed to revoke refresh token during logout',
+                cause,
+            );
+        }
     }
+
     await clearCookie();
     await clearRefreshCookie();
 


### PR DESCRIPTION
### Motivation
- Ensure logout always completes for users even if revoking the refresh token fails, so a revocation error doesn't prevent clearing cookies and ending the session.

### Description
- Wrap the `revokeRefreshToken` call in `apps/app/app/api/logout/route.ts` with a `try/catch`, log any revocation error with `console.error`, and continue to clear auth and refresh cookies and return `200`.

### Testing
- Ran `pnpm --filter app lint` and `pnpm --filter app exec biome check app/api/logout/route.ts`, both succeeded (lint emitted a Node engine warning in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d0df66dc832fa67be0fa5c0f9c44)