### PR TITLE
Fix missing icons in app dashboard quick links

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import type { getAnalyticsTotals } from '@gredice/storage';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
+import { Calendar, Euro, File, Hammer, Truck } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -12,6 +14,7 @@ import { useEffect, useMemo, useState, useTransition } from 'react';
 import type { DashboardQuickActionOption } from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
 import { FactCard } from '../cards/FactCard';
+import { EntityTypeIcon } from '../directories/EntityTypeIcon';
 import { DashboardDivider } from './DashboardDivider';
 import {
     OperationsDurationCard,
@@ -44,6 +47,27 @@ type AiData = {
     count: number;
     totalTokens: number;
 };
+
+function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
+    if (quickAction.icon) {
+        return <EntityTypeIcon icon={quickAction.icon} className="size-4" />;
+    }
+
+    switch (quickAction.href) {
+        case KnownPages.Schedule:
+            return <Calendar className="size-4" />;
+        case KnownPages.RaisedBeds:
+            return <RaisedBedIcon className="size-4" />;
+        case KnownPages.Operations:
+            return <Hammer className="size-4" />;
+        case KnownPages.DeliveryRequests:
+            return <Truck className="size-4" />;
+        case KnownPages.Transactions:
+            return <Euro className="size-4" />;
+        default:
+            return <File className="size-4" />;
+    }
+}
 
 export function AdminDashboardClient({
     initialAnalyticsData,
@@ -179,7 +203,10 @@ export function AdminDashboardClient({
                         size="sm"
                         href={quickAction.href}
                     >
-                        {quickAction.label}
+                        <Row spacing={0.5} className="items-center">
+                            {quickActionIcon(quickAction)}
+                            <span>{quickAction.label}</span>
+                        </Row>
                     </Button>
                 ))}
             </Row>


### PR DESCRIPTION
### Motivation
- Dashboard quick link buttons on the admin dashboard were displaying only labels and not their expected icons, making quick actions harder to scan. 
- The navigation already resolved built-in and entity-type icons, so the dashboard quick links should mirror that behavior for consistency.

### Description
- Added a `quickActionIcon` helper in `AdminDashboardClient` to map built-in `KnownPages` routes to the appropriate icon components and to render entity-type icons when `quickAction.icon` is present. 
- Imported `EntityTypeIcon` and the relevant icon components (`RaisedBedIcon`, `Calendar`, `Hammer`, `Truck`, `Euro`, `File`) and used them in the resolver. 
- Updated quick-link `Button` content to render an inline `Row` with the icon and label together so each chip shows its icon alongside the text.

### Testing
- Ran `pnpm --dir apps/app exec biome check --write components/admin/dashboard/AdminDashboardClient.tsx`, which completed successfully and fixed formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7022e330c832faa55dbb7e6ef889a)