### PR TITLE
Add Garden Operations HUD + paginated operations API

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -122,6 +122,65 @@ function serializeAppliedRaisedBedOperation(
     };
 }
 
+function serializeGardenOperation(
+    operation: Awaited<ReturnType<typeof getOperations>>[number],
+    targetsByRaisedBedFieldId: Map<number, string>,
+    targetsByRaisedBedId: Map<number, string>,
+) {
+    const statusHistory = [
+        {
+            status: 'new',
+            changedAt: operation.createdAt.toISOString(),
+        },
+        operation.scheduledDate
+            ? {
+                  status: 'planned',
+                  changedAt: operation.scheduledDate.toISOString(),
+              }
+            : null,
+        operation.completedAt
+            ? {
+                  status: 'pendingVerification',
+                  changedAt: operation.completedAt.toISOString(),
+              }
+            : null,
+        operation.verifiedAt
+            ? {
+                  status: 'completed',
+                  changedAt: operation.verifiedAt.toISOString(),
+              }
+            : null,
+        operation.canceledAt
+            ? {
+                  status: 'canceled',
+                  changedAt: operation.canceledAt.toISOString(),
+              }
+            : null,
+    ].filter(Boolean);
+
+    return {
+        id: operation.id,
+        entityId: operation.entityId,
+        raisedBedId: operation.raisedBedId,
+        raisedBedFieldId: operation.raisedBedFieldId,
+        status: operation.status,
+        createdAt: operation.createdAt.toISOString(),
+        scheduledDate: operation.scheduledDate?.toISOString() ?? null,
+        completedAt: operation.completedAt?.toISOString() ?? null,
+        verifiedAt: operation.verifiedAt?.toISOString() ?? null,
+        canceledAt: operation.canceledAt?.toISOString() ?? null,
+        targetLabel:
+            (operation.raisedBedFieldId
+                ? targetsByRaisedBedFieldId.get(operation.raisedBedFieldId)
+                : null) ??
+            (operation.raisedBedId
+                ? targetsByRaisedBedId.get(operation.raisedBedId)
+                : null) ??
+            'Vrt',
+        statusHistory,
+    };
+}
+
 const app = new Hono<{ Variables: AuthVariables }>()
     .get(
         '/',
@@ -164,27 +223,91 @@ const app = new Hono<{ Variables: AuthVariables }>()
             return context.json({ id: gardenId }, 201);
         },
     )
-    .post(
-        '/',
+    .get(
+        '/:gardenId/operations',
         describeRoute({
-            description: 'Create a new garden for current account',
+            description:
+                'Get garden operations for timeline and history with cursor pagination',
         }),
         zValidator(
-            'json',
+            'param',
             z.object({
-                name: z.string().trim().min(1).optional(),
+                gardenId: z.string(),
+            }),
+        ),
+        zValidator(
+            'query',
+            z.object({
+                cursor: z.coerce.number().int().min(0).optional(),
+                limit: z.coerce.number().int().min(1).max(50).optional(),
+                includeCompleted: z.coerce.boolean().optional(),
             }),
         ),
         authValidator(['user', 'admin']),
         async (context) => {
-            const { accountId, userId } = context.get('authContext');
-            const { name } = context.req.valid('json');
-            const gardenId = await createDefaultGardenForAccount({
-                accountId,
-                name,
+            const { gardenId } = context.req.valid('param');
+            const { cursor, limit, includeCompleted } =
+                context.req.valid('query');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const { accountId } = context.get('authContext');
+            const [garden, operations] = await Promise.all([
+                getGarden(gardenIdNumber),
+                getOperations(accountId, gardenIdNumber),
+            ]);
+
+            if (!garden || garden.accountId !== accountId) {
+                return context.json({ error: 'Garden not found' }, 404);
+            }
+
+            const targetsByRaisedBedId = new Map(
+                garden.raisedBeds.map((raisedBed) => [
+                    raisedBed.id,
+                    `Gredica: ${raisedBed.name}`,
+                ]),
+            );
+            const targetsByRaisedBedFieldId = new Map(
+                garden.raisedBeds.flatMap((raisedBed) =>
+                    raisedBed.fields.map((field) => [
+                        field.id,
+                        `Polje ${field.positionIndex + 1} • ${raisedBed.name}`,
+                    ]),
+                ),
+            );
+
+            const sorted = operations.sort((a, b) => {
+                const aDate = a.scheduledDate ?? a.createdAt;
+                const bDate = b.scheduledDate ?? b.createdAt;
+                return aDate.getTime() - bDate.getTime();
             });
-            await trackGardenCreated({ accountId, gardenId, name, userId });
-            return context.json({ id: gardenId }, 201);
+
+            const filtered = includeCompleted
+                ? sorted
+                : sorted.filter(
+                      (operation) => operation.status !== 'completed',
+                  );
+
+            const pageSize = limit ?? 20;
+            const offset = cursor ?? 0;
+            const paginated = filtered.slice(offset, offset + pageSize);
+            const nextCursor =
+                offset + pageSize < filtered.length ? offset + pageSize : null;
+
+            return context.json({
+                items: paginated.map((operation) =>
+                    serializeGardenOperation(
+                        operation,
+                        targetsByRaisedBedFieldId,
+                        targetsByRaisedBedId,
+                    ),
+                ),
+                nextCursor,
+                total: filtered.length,
+            });
         },
     )
     .get(

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -6,10 +6,8 @@ import { AccountHud } from './hud/AccountHud';
 import { AdventHud } from './hud/AdventHud';
 import { AudioHud } from './hud/AudioHud';
 import { CameraHud } from './hud/CameraHud';
-import { DayNightCycleHud } from './hud/DayNightCycleHud';
 import { DebugHud } from './hud/DebugHud';
 import { GameModeHud } from './hud/GameModeHud';
-import { GardenOperationsHud } from './hud/GardenOperationsHud';
 import { InventoryHud } from './hud/InventoryHud';
 import { ItemsHud } from './hud/ItemsHud';
 import { PaymentSuccessfulMessage } from './hud/PaymentSuccessfulMessage';
@@ -35,10 +33,7 @@ export function GameHud({
     return (
         <>
             <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
-                <div className="flex items-start gap-2">
-                    <AccountHud />
-                    <GardenOperationsHud />
-                </div>
+                <AccountHud />
                 {!isCloseup && <GameModeHud />}
                 {!isCloseup && <AdventHud />}
                 {!isCloseup && <InventoryHud />}
@@ -50,7 +45,6 @@ export function GameHud({
                 </div>
                 <SunflowersHud />
             </div>
-            {!isCloseup && <DayNightCycleHud />}
             <div className="absolute bottom-0 flex flex-col left-0 right-0 md:flex-row md:justify-between md:items-end pointer-events-none">
                 <div className="p-2 flex flex-row">
                     <CameraHud />

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -9,6 +9,7 @@ import { CameraHud } from './hud/CameraHud';
 import { DayNightCycleHud } from './hud/DayNightCycleHud';
 import { DebugHud } from './hud/DebugHud';
 import { GameModeHud } from './hud/GameModeHud';
+import { GardenOperationsHud } from './hud/GardenOperationsHud';
 import { InventoryHud } from './hud/InventoryHud';
 import { ItemsHud } from './hud/ItemsHud';
 import { PaymentSuccessfulMessage } from './hud/PaymentSuccessfulMessage';
@@ -34,7 +35,10 @@ export function GameHud({
     return (
         <>
             <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
-                <AccountHud />
+                <div className="flex items-start gap-2">
+                    <AccountHud />
+                    <GardenOperationsHud />
+                </div>
                 {!isCloseup && <GameModeHud />}
                 {!isCloseup && <AdventHud />}
                 {!isCloseup && <InventoryHud />}

--- a/packages/game/src/controls/components/SegmentedProgress.tsx
+++ b/packages/game/src/controls/components/SegmentedProgress.tsx
@@ -1,4 +1,4 @@
-import { Check } from '@signalco/ui-icons';
+import { Check, Close } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { Fragment, type HTMLAttributes } from 'react';
 import { Progress } from './Progress';
@@ -8,7 +8,9 @@ export type SegmentedProgressProps = {
         value: number;
         indeterminate?: boolean;
         highlighted?: boolean;
+        failed?: boolean;
         label?: string;
+        title?: string;
         onClick?: () => void;
     }[];
 } & HTMLAttributes<HTMLDivElement>;
@@ -43,10 +45,14 @@ export function SegmentedProgress({
                         <CircleComponent
                             onClick={segment.onClick}
                             type={segment.onClick ? 'button' : undefined}
+                            title={segment.title}
                             className={cx(
                                 'relative size-4 rounded-full -ml-1 -mt-1 bg-background border-2 border-tertiary shrink-0 z-10',
-                                segment.value >= 100 && 'bg-green-500',
-                                segment.value >= 100 && 'border-green-600',
+                                segment.value >= 100 &&
+                                    !segment.failed &&
+                                    'bg-green-500 border-green-600',
+                                segment.failed &&
+                                    'bg-red-500/10 border-red-400',
                                 segment.indeterminate && 'border-none',
                                 segment.onClick &&
                                     'cursor-pointer hover:outline outline-offset-1 outline-2',
@@ -60,16 +66,22 @@ export function SegmentedProgress({
                                         'border-green-500 border-2 rounded-full animate-pulse',
                                 )}
                             >
-                                <Check
-                                    className={cx(
-                                        'size-3 text-white',
-                                        segment.value < 100 && 'hidden',
-                                    )}
-                                />
+                                {segment.failed ? (
+                                    <Close className="size-3 text-red-500" />
+                                ) : (
+                                    <Check
+                                        className={cx(
+                                            'size-3 text-white',
+                                            segment.value < 100 && 'hidden',
+                                        )}
+                                    />
+                                )}
                             </div>
-                            <div className="select-none text-xs text-center absolute left-1/2 top-full transform -translate-x-1/2 pt-1">
-                                {segment.label}
-                            </div>
+                            {segment.label && (
+                                <div className="select-none text-xs text-center absolute left-1/2 top-full transform -translate-x-1/2 pt-1">
+                                    {segment.label}
+                                </div>
+                            )}
                         </CircleComponent>
                     </Fragment>
                 );

--- a/packages/game/src/hooks/useGardenOperations.ts
+++ b/packages/game/src/hooks/useGardenOperations.ts
@@ -3,19 +3,23 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCurrentGarden } from './useCurrentGarden';
 
 const DEFAULT_PAGE_SIZE = 20;
-const gardenOperationStatuses = new Set<string>([
-    'new',
-    'planned',
-    'pendingVerification',
-    'completed',
-    'failed',
-    'canceled',
-]);
+
+const backendStatusMap: Record<string, GardenOperationStatus> = {
+    new: 'new',
+    planned: 'planned',
+    assigned: 'assigned',
+    pendingVerification: 'confirmed',
+    confirmed: 'confirmed',
+    completed: 'completed',
+    failed: 'failed',
+    canceled: 'canceled',
+};
 
 export type GardenOperationStatus =
     | 'new'
     | 'planned'
-    | 'pendingVerification'
+    | 'assigned'
+    | 'confirmed'
     | 'completed'
     | 'failed'
     | 'canceled';
@@ -59,18 +63,13 @@ type GardenOperationsPageResponse = Omit<GardenOperationsPage, 'items'> & {
     items: GardenOperationItemResponse[];
 };
 
-function isGardenOperationStatus(
-    value: string,
-): value is GardenOperationStatus {
-    return gardenOperationStatuses.has(value);
-}
-
 function parseGardenOperationStatus(status: string): GardenOperationStatus {
-    if (!isGardenOperationStatus(status)) {
+    const mapped = backendStatusMap[status];
+    if (!mapped) {
         throw new Error(`Unknown garden operation status: ${status}`);
     }
 
-    return status;
+    return mapped;
 }
 
 function parseGardenOperationItem(

--- a/packages/game/src/hooks/useGardenOperations.ts
+++ b/packages/game/src/hooks/useGardenOperations.ts
@@ -1,0 +1,169 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useCurrentGarden } from './useCurrentGarden';
+
+const DEFAULT_PAGE_SIZE = 20;
+const gardenOperationStatuses = new Set<string>([
+    'new',
+    'planned',
+    'pendingVerification',
+    'completed',
+    'failed',
+    'canceled',
+]);
+
+export type GardenOperationStatus =
+    | 'new'
+    | 'planned'
+    | 'pendingVerification'
+    | 'completed'
+    | 'failed'
+    | 'canceled';
+
+export type GardenOperationItem = {
+    id: number;
+    entityId: number;
+    raisedBedId: number | null;
+    raisedBedFieldId: number | null;
+    status: GardenOperationStatus;
+    createdAt: string;
+    scheduledDate: string | null;
+    completedAt: string | null;
+    verifiedAt: string | null;
+    canceledAt: string | null;
+    targetLabel: string;
+    statusHistory: {
+        status: GardenOperationStatus;
+        changedAt: string;
+    }[];
+};
+
+type GardenOperationsPage = {
+    items: GardenOperationItem[];
+    nextCursor: number | null;
+    total: number;
+};
+
+type GardenOperationItemResponse = Omit<
+    GardenOperationItem,
+    'status' | 'statusHistory'
+> & {
+    status: string;
+    statusHistory: ({
+        status: string;
+        changedAt: string;
+    } | null)[];
+};
+
+type GardenOperationsPageResponse = Omit<GardenOperationsPage, 'items'> & {
+    items: GardenOperationItemResponse[];
+};
+
+function isGardenOperationStatus(
+    value: string,
+): value is GardenOperationStatus {
+    return gardenOperationStatuses.has(value);
+}
+
+function parseGardenOperationStatus(status: string): GardenOperationStatus {
+    if (!isGardenOperationStatus(status)) {
+        throw new Error(`Unknown garden operation status: ${status}`);
+    }
+
+    return status;
+}
+
+function parseGardenOperationItem(
+    item: GardenOperationItemResponse,
+): GardenOperationItem {
+    return {
+        ...item,
+        status: parseGardenOperationStatus(item.status),
+        statusHistory: item.statusHistory.flatMap((entry) => {
+            if (!entry) {
+                return [];
+            }
+
+            return [
+                {
+                    status: parseGardenOperationStatus(entry.status),
+                    changedAt: entry.changedAt,
+                },
+            ];
+        }),
+    };
+}
+
+function parseGardenOperationsPage(
+    page: GardenOperationsPageResponse,
+): GardenOperationsPage {
+    return {
+        items: page.items.map(parseGardenOperationItem),
+        nextCursor: page.nextCursor,
+        total: page.total,
+    };
+}
+
+async function getGardenOperationsPage(input: {
+    gardenId: number;
+    includeCompleted: boolean;
+    pageSize: number;
+    cursor: number;
+}): Promise<GardenOperationsPage> {
+    const response = await clientAuthenticated().api.gardens[
+        ':gardenId'
+    ].operations.$get({
+        param: {
+            gardenId: input.gardenId.toString(),
+        },
+        query: {
+            cursor: input.cursor.toString(),
+            limit: input.pageSize.toString(),
+            includeCompleted: input.includeCompleted.toString(),
+        },
+    });
+
+    if (response.status !== 200) {
+        throw new Error('Failed to fetch garden operations');
+    }
+
+    return parseGardenOperationsPage(await response.json());
+}
+
+export function useGardenOperations({
+    includeCompleted,
+    pageSize = DEFAULT_PAGE_SIZE,
+}: {
+    includeCompleted: boolean;
+    pageSize?: number;
+}) {
+    const { data: currentGarden } = useCurrentGarden();
+
+    return useInfiniteQuery({
+        queryKey: [
+            'garden-operations',
+            currentGarden?.id,
+            includeCompleted,
+            pageSize,
+        ],
+        queryFn: async ({ pageParam }) => {
+            if (!currentGarden?.id) {
+                return {
+                    items: [],
+                    nextCursor: null,
+                    total: 0,
+                } satisfies GardenOperationsPage;
+            }
+
+            return getGardenOperationsPage({
+                gardenId: currentGarden.id,
+                includeCompleted,
+                pageSize,
+                cursor: pageParam,
+            });
+        },
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+        enabled: Boolean(currentGarden?.id),
+    });
+}

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -41,6 +41,7 @@ import { ProfileAvatar } from '../shared-ui/ProfileAvatar';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { useCurrentGardenIdParam } from '../useUrlState';
 import { HudCard } from './components/HudCard';
+import { GardenOperationsHud } from './GardenOperationsHud';
 import { NotificationList } from './NotificationList';
 
 function NotificationsCard() {
@@ -262,7 +263,10 @@ export function AccountHud() {
                     </DropdownMenuTrigger>
                     <ProfileCard />
                 </DropdownMenu>
-                <div className="hidden md:block">
+                <div className="md:order-3">
+                    <GardenOperationsHud />
+                </div>
+                <div className="hidden md:block md:order-1">
                     {isLoading ? (
                         <Skeleton className="w-32 h-7" />
                     ) : (
@@ -296,7 +300,7 @@ export function AccountHud() {
                         )
                     )}
                 </div>
-                <div className="hidden md:block">
+                <div className="hidden md:block md:order-2">
                     <Popper
                         className="overflow-hidden border-tertiary border-b-4 w-96"
                         side="bottom"

--- a/packages/game/src/hud/DayNightCycleHud.tsx
+++ b/packages/game/src/hud/DayNightCycleHud.tsx
@@ -21,7 +21,7 @@ export function DayNightCycleHud() {
                 className="w-64 -left-8 top-0"
                 position="top"
             >
-                <TimeDisplay />
+                <TimeDisplay variant="overlay" />
             </HudCard>
             <svg
                 viewBox="0 0 100 20"

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1,111 +1,308 @@
 import { OperationImage } from '@gredice/ui/OperationImage';
+import {
+    Approved,
+    Calendar,
+    Close,
+    Error as ErrorIcon,
+    History,
+    Hourglass,
+    Inbox,
+    ListTodo,
+    MailCheck,
+} from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
+import { cx } from '@signalco/ui-primitives/cx';
+import { Divider } from '@signalco/ui-primitives/Divider';
+import { DotIndicator } from '@signalco/ui-primitives/DotIndicator';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Popper } from '@signalco/ui-primitives/Popper';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useMemo, useRef } from 'react';
+import { type ComponentType, useCallback, useMemo, useRef } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { SegmentedProgress } from '../controls/components/SegmentedProgress';
 import {
     type GardenOperationItem,
     type GardenOperationStatus,
     useGardenOperations,
 } from '../hooks/useGardenOperations';
 import { useOperations } from '../hooks/useOperations';
-import { HudCard } from './components/HudCard';
 
 type OperationData = NonNullable<
     ReturnType<typeof useOperations>['data']
 >[number];
 
-const statusOrder: GardenOperationStatus[] = [
+const uiPipeline: GardenOperationStatus[] = [
     'new',
     'planned',
-    'pendingVerification',
+    'assigned',
+    'confirmed',
+    'completed',
+];
+
+const terminalFailureStatuses = new Set<GardenOperationStatus>([
+    'failed',
+    'canceled',
+]);
+
+const hiddenFromActive = new Set<GardenOperationStatus>([
     'completed',
     'failed',
     'canceled',
-];
+]);
 
-const statusLabel: Record<GardenOperationStatus, string> = {
-    new: 'Kreirano',
-    planned: 'Planirano',
-    pendingVerification: 'Čeka potvrdu',
-    completed: 'Završeno',
-    failed: 'Neuspjelo',
-    canceled: 'Otkazano',
+type StatusConfig = {
+    label: string;
+    icon: ComponentType<{ className?: string }>;
+    colorClass: string;
+    nextStep: string;
 };
 
-const nextStepLabel: Record<GardenOperationStatus, string> = {
-    new: 'Sljedeći korak: zakazivanje',
-    planned: 'Sljedeći korak: izvršenje radnje',
-    pendingVerification: 'Sljedeći korak: verifikacija',
-    completed: 'Radnja završena',
-    failed: 'Sljedeći korak: ponovni pokušaj',
-    canceled: 'Radnja je otkazana',
+const statusConfig: Record<GardenOperationStatus, StatusConfig> = {
+    new: {
+        label: 'Kreirano',
+        icon: Inbox,
+        colorClass: 'text-sky-600',
+        nextStep: 'Sljedeći korak: zakazivanje',
+    },
+    planned: {
+        label: 'Planirano',
+        icon: Calendar,
+        colorClass: 'text-indigo-600',
+        nextStep: 'Sljedeći korak: dodjela',
+    },
+    assigned: {
+        label: 'Dodijeljeno',
+        icon: MailCheck,
+        colorClass: 'text-violet-600',
+        nextStep: 'Sljedeći korak: potvrda',
+    },
+    confirmed: {
+        label: 'Potvrđeno',
+        icon: Hourglass,
+        colorClass: 'text-amber-600',
+        nextStep: 'Sljedeći korak: verifikacija',
+    },
+    completed: {
+        label: 'Završeno',
+        icon: Approved,
+        colorClass: 'text-green-600',
+        nextStep: 'Radnja završena',
+    },
+    failed: {
+        label: 'Neuspjelo',
+        icon: ErrorIcon,
+        colorClass: 'text-red-600',
+        nextStep: 'Sljedeći korak: ponovni pokušaj',
+    },
+    canceled: {
+        label: 'Otkazano',
+        icon: Close,
+        colorClass: 'text-neutral-500',
+        nextStep: 'Radnja je otkazana',
+    },
 };
+
+function formatDate(value?: string | null) {
+    if (!value) return null;
+    return new Date(value).toLocaleDateString('hr-HR', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+    });
+}
 
 function formatDateTime(value?: string | null) {
-    if (!value) return '—';
+    if (!value) return null;
     return new Date(value).toLocaleString('hr-HR');
+}
+
+function StatusBadge({
+    status,
+    size = 'sm',
+}: {
+    status: GardenOperationStatus;
+    size?: 'sm' | 'md';
+}) {
+    const config = statusConfig[status];
+    const Icon = config.icon;
+    const iconSize = size === 'md' ? 'size-4' : 'size-3.5';
+    const textLevel = size === 'md' ? 'body2' : 'body3';
+    return (
+        <Row spacing={0.5} className={config.colorClass}>
+            <Icon className={cx(iconSize, 'shrink-0')} />
+            <Typography level={textLevel} semiBold>
+                {config.label}
+            </Typography>
+        </Row>
+    );
 }
 
 function useInfiniteScroll(fetchNextPage: () => void, hasNextPage?: boolean) {
     const observerRef = useRef<IntersectionObserver | null>(null);
 
-    return (node: HTMLDivElement | null) => {
-        if (observerRef.current) {
-            observerRef.current.disconnect();
+    return useCallback(
+        (node: HTMLDivElement | null) => {
+            if (observerRef.current) {
+                observerRef.current.disconnect();
+                observerRef.current = null;
+            }
+
+            if (!node) return;
+
+            const scrollRoot = node.closest<HTMLElement>(
+                '[data-infinite-scroll-root]',
+            );
+
+            observerRef.current = new IntersectionObserver(
+                (entries) => {
+                    if (entries[0]?.isIntersecting && hasNextPage) {
+                        fetchNextPage();
+                    }
+                },
+                {
+                    root: scrollRoot ?? null,
+                    rootMargin: '0px 0px 200px 0px',
+                },
+            );
+
+            observerRef.current.observe(node);
+        },
+        [fetchNextPage, hasNextPage],
+    );
+}
+
+function buildSegments(operation: GardenOperationItem) {
+    const historyByStatus = new Map(
+        operation.statusHistory.map((entry) => [entry.status, entry.changedAt]),
+    );
+    const isTerminalFailure = terminalFailureStatuses.has(operation.status);
+
+    const hasReached = (status: GardenOperationStatus) => {
+        if (historyByStatus.has(status)) return true;
+        const idx = uiPipeline.indexOf(status);
+        if (idx === -1) return false;
+        return uiPipeline
+            .slice(idx + 1)
+            .some((later) => historyByStatus.has(later));
+    };
+
+    const currentIdx = uiPipeline.indexOf(operation.status);
+
+    const pipelineToShow = uiPipeline.filter((status, idx) => {
+        if (hasReached(status)) return true;
+        if (isTerminalFailure) return true;
+        if (currentIdx >= 0 && idx >= currentIdx) return true;
+        return false;
+    });
+
+    const firstPendingIdx = pipelineToShow.findIndex((s) => !hasReached(s));
+
+    const segments = pipelineToShow.map((status, idx) => {
+        const reached = hasReached(status);
+        const config = statusConfig[status];
+        const date = historyByStatus.get(status);
+        const tooltipParts = [config.label];
+        const dateStr = formatDateTime(date ?? null);
+        if (dateStr) tooltipParts.push(dateStr);
+        const title = tooltipParts.join(' — ');
+
+        if (reached) {
+            return {
+                value: 100,
+                label: config.label,
+                title,
+            };
         }
 
-        observerRef.current = new IntersectionObserver((entries) => {
-            if (entries[0]?.isIntersecting && hasNextPage) {
-                fetchNextPage();
-            }
-        });
+        if (isTerminalFailure) {
+            return {
+                value: 0,
+                failed: true,
+                label: config.label,
+                title: `${config.label} — preskočeno`,
+            };
+        }
 
-        if (node) observerRef.current.observe(node);
-    };
+        const isNextPending = idx === firstPendingIdx;
+        return {
+            value: isNextPending ? 50 : 0,
+            indeterminate: isNextPending,
+            highlighted: isNextPending,
+            label: config.label,
+            title,
+        };
+    });
+
+    if (isTerminalFailure) {
+        const terminalConfig = statusConfig[operation.status];
+        segments.push({
+            value: 0,
+            failed: true,
+            label: terminalConfig.label,
+            title: `${terminalConfig.label} — ${
+                formatDateTime(
+                    operation.canceledAt ?? operation.completedAt ?? null,
+                ) ?? ''
+            }`.trim(),
+        });
+    }
+
+    return segments;
 }
 
 function OperationProgress({ operation }: { operation: GardenOperationItem }) {
-    const currentStep = statusOrder.indexOf(operation.status);
-    const maxIndex = statusOrder.indexOf('completed');
-    const progress = Math.max(0, Math.min(100, (currentStep / maxIndex) * 100));
+    const segments = useMemo(() => buildSegments(operation), [operation]);
 
     return (
-        <Stack spacing={0.5}>
-            <div className="h-2 rounded-full bg-muted overflow-hidden">
-                <div
-                    className="h-full bg-primary rounded-full transition-all"
-                    style={{ width: `${progress}%` }}
-                />
-            </div>
-            <Row justifyContent="space-between">
+        <Stack spacing={1}>
+            <SegmentedProgress className="pb-5 pr-4" segments={segments} />
+            <Row
+                justifyContent="space-between"
+                spacing={1}
+                className="flex-wrap"
+            >
+                <StatusBadge status={operation.status} />
                 <Typography level="body3" secondary>
-                    {statusLabel[operation.status]}
-                </Typography>
-                <Typography level="body3" secondary>
-                    {nextStepLabel[operation.status]}
+                    {statusConfig[operation.status].nextStep}
                 </Typography>
             </Row>
         </Stack>
     );
 }
 
+function OperationDates({ operation }: { operation: GardenOperationItem }) {
+    const createdAt = formatDate(operation.createdAt);
+    const scheduledDate = formatDate(operation.scheduledDate);
+
+    return (
+        <Row spacing={1} className="flex-wrap">
+            {createdAt && (
+                <Typography level="body3" secondary>
+                    Kreirano: {createdAt}
+                </Typography>
+            )}
+            {scheduledDate && (
+                <Typography level="body3" secondary>
+                    Zakazano: {scheduledDate}
+                </Typography>
+            )}
+        </Row>
+    );
+}
+
 function OperationCard({
     operation,
-    showStatusHistory,
     operationName,
     operationData,
 }: {
     operation: GardenOperationItem;
-    showStatusHistory?: boolean;
     operationName?: string;
     operationData?: OperationData;
 }) {
     return (
-        <div className="rounded-xl border p-2">
+        <div className="rounded-xl border p-3">
             <Row spacing={1.5} alignItems="start">
                 <div className="size-12 rounded-lg bg-card flex items-center justify-center overflow-hidden shrink-0">
                     {operationData ? (
@@ -116,38 +313,94 @@ function OperationCard({
                         </Typography>
                     )}
                 </div>
-                <Stack spacing={0.5} className="min-w-0 flex-1">
-                    <Typography level="body2" semiBold noWrap>
-                        {operationName ?? `Radnja #${operation.id}`}
-                    </Typography>
-                    <Typography level="body3" secondary>
-                        {operation.targetLabel}
-                    </Typography>
+                <Stack spacing={0.75} className="min-w-0 flex-1">
+                    <Stack spacing={0.25}>
+                        <Typography level="body2" semiBold noWrap>
+                            {operationName ?? `Radnja #${operation.id}`}
+                        </Typography>
+                        <Typography level="body3" secondary>
+                            {operation.targetLabel}
+                        </Typography>
+                    </Stack>
+                    <OperationDates operation={operation} />
                     <OperationProgress operation={operation} />
-                    {showStatusHistory && (
-                        <div className="pt-1">
-                            {operation.statusHistory.map((entry) => (
-                                <Row
-                                    key={`${operation.id}-${entry.status}-${entry.changedAt}`}
-                                    justifyContent="space-between"
-                                >
-                                    <Typography level="body3" secondary>
-                                        {statusLabel[entry.status]}
-                                    </Typography>
-                                    <Typography level="body3" secondary>
-                                        {formatDateTime(entry.changedAt)}
-                                    </Typography>
-                                </Row>
-                            ))}
-                        </div>
-                    )}
                 </Stack>
             </Row>
         </div>
     );
 }
 
+function HistoryModal({
+    trigger,
+    operations,
+    operationDataById,
+    listRef,
+}: {
+    trigger: React.ReactElement;
+    operations: GardenOperationItem[];
+    operationDataById: Map<number, OperationData>;
+    listRef: (node: HTMLDivElement | null) => void;
+}) {
+    return (
+        <Modal
+            title="Povijest radnji"
+            trigger={trigger}
+            className="md:max-w-4xl"
+        >
+            <Stack spacing={2}>
+                <Stack spacing={0.5}>
+                    <Typography level="h5">Povijest radnji</Typography>
+                    <Typography level="body2" secondary>
+                        Pregled svih radnji u tvom vrtu. Zadrži pokazivač iznad
+                        točke napretka za datum promjene statusa.
+                    </Typography>
+                </Stack>
+                <Divider />
+                <Stack
+                    spacing={1.5}
+                    data-infinite-scroll-root
+                    className="max-h-[70vh] overflow-y-auto pr-1"
+                >
+                    {operations.length === 0 ? (
+                        <Typography level="body3" secondary>
+                            Nema radnji.
+                        </Typography>
+                    ) : (
+                        operations.map((operation) => (
+                            <OperationCard
+                                key={operation.id}
+                                operation={operation}
+                                operationName={
+                                    operationDataById.get(operation.entityId)
+                                        ?.information.label
+                                }
+                                operationData={operationDataById.get(
+                                    operation.entityId,
+                                )}
+                            />
+                        ))
+                    )}
+                    <div ref={listRef} className="h-1" />
+                </Stack>
+            </Stack>
+        </Modal>
+    );
+}
+
+function sortNewestFirst(operations: GardenOperationItem[]) {
+    return [...operations].sort((a, b) => {
+        const aDate = new Date(
+            a.canceledAt ?? a.verifiedAt ?? a.completedAt ?? a.createdAt,
+        ).getTime();
+        const bDate = new Date(
+            b.canceledAt ?? b.verifiedAt ?? b.completedAt ?? b.createdAt,
+        ).getTime();
+        return bDate - aDate;
+    });
+}
+
 export function GardenOperationsHud() {
+    const { track } = useGameAnalytics();
     const { data: operationsData } = useOperations();
     const pending = useGardenOperations({
         includeCompleted: false,
@@ -159,11 +412,21 @@ export function GardenOperationsHud() {
     });
 
     const pendingOperations = useMemo(
-        () => pending.data?.pages.flatMap((page) => page.items) ?? [],
+        () =>
+            sortNewestFirst(
+                (
+                    pending.data?.pages.flatMap((page) => page.items) ?? []
+                ).filter(
+                    (operation) => !hiddenFromActive.has(operation.status),
+                ),
+            ),
         [pending.data?.pages],
     );
     const historyOperations = useMemo(
-        () => history.data?.pages.flatMap((page) => page.items) ?? [],
+        () =>
+            sortNewestFirst(
+                history.data?.pages.flatMap((page) => page.items) ?? [],
+            ),
         [history.data?.pages],
     );
 
@@ -188,88 +451,84 @@ export function GardenOperationsHud() {
     );
 
     return (
-        <HudCard open position="floating" className="p-0.5 static">
-            <Popper
-                side="bottom"
-                sideOffset={12}
-                className="w-[28rem] max-w-[90vw] border-tertiary border-b-4"
-                trigger={
-                    <Button
-                        variant="plain"
-                        className="rounded-full px-3 h-10"
-                        title="Status radnji"
-                    >
-                        Radnje{' '}
-                        {pendingOperations.length > 0
-                            ? `(${pendingOperations.length})`
-                            : ''}
-                    </Button>
-                }
-            >
-                <Stack spacing={1.5} className="p-3">
-                    <Row justifyContent="space-between" alignItems="center">
-                        <Typography level="body1" semiBold>
-                            Aktivne radnje
+        <Popper
+            side="bottom"
+            sideOffset={12}
+            className="w-[28rem] max-w-[90vw] overflow-hidden border-tertiary border-b-4"
+            trigger={
+                <Button
+                    variant="plain"
+                    className="relative rounded-full p-0 aspect-square"
+                    title="Status radnji"
+                    onClick={() =>
+                        track('game_operations_opened', {
+                            source: 'quick_panel',
+                        })
+                    }
+                >
+                    {pendingOperations.length > 0 && (
+                        <div className="absolute right-1 top-1">
+                            <DotIndicator color={'success'} />
+                        </div>
+                    )}
+                    <ListTodo className="size-5" />
+                </Button>
+            }
+        >
+            <Stack>
+                <Row
+                    className="bg-background px-4 py-2"
+                    justifyContent="space-between"
+                >
+                    <Typography level="body2" bold>
+                        Aktivne radnje
+                    </Typography>
+                </Row>
+                <Divider />
+                <Stack
+                    spacing={1}
+                    data-infinite-scroll-root
+                    className="max-h-[50vh] overflow-y-auto p-3"
+                >
+                    {pendingOperations.length === 0 ? (
+                        <Typography level="body3" secondary>
+                            Nema nedovršenih radnji.
                         </Typography>
-                        <Modal
-                            title="Historija radnji"
-                            trigger={
-                                <Button size="sm" variant="plain">
-                                    Sva historija
-                                </Button>
-                            }
-                        >
-                            <Stack
-                                spacing={1.5}
-                                className="max-h-[70vh] overflow-y-auto pr-1"
-                            >
-                                {historyOperations.map((operation) => (
-                                    <OperationCard
-                                        key={operation.id}
-                                        operation={operation}
-                                        showStatusHistory
-                                        operationName={
-                                            operationDataById.get(
-                                                operation.entityId,
-                                            )?.information.label
-                                        }
-                                        operationData={operationDataById.get(
-                                            operation.entityId,
-                                        )}
-                                    />
-                                ))}
-                                <div ref={historyRef} className="h-1" />
-                            </Stack>
-                        </Modal>
-                    </Row>
-                    <Stack
-                        spacing={1}
-                        className="max-h-[50vh] overflow-y-auto pr-1"
-                    >
-                        {pendingOperations.length === 0 ? (
-                            <Typography level="body3" secondary>
-                                Nema nedovršenih radnji.
-                            </Typography>
-                        ) : (
-                            pendingOperations.map((operation) => (
-                                <OperationCard
-                                    key={operation.id}
-                                    operation={operation}
-                                    operationName={
-                                        operationDataById.get(
-                                            operation.entityId,
-                                        )?.information.label
-                                    }
-                                    operationData={operationDataById.get(
-                                        operation.entityId,
-                                    )}
-                                />
-                            ))
-                        )}
-                        <div ref={pendingRef} className="h-1" />
-                    </Stack>
+                    ) : (
+                        pendingOperations.map((operation) => (
+                            <OperationCard
+                                key={operation.id}
+                                operation={operation}
+                                operationName={
+                                    operationDataById.get(operation.entityId)
+                                        ?.information.label
+                                }
+                                operationData={operationDataById.get(
+                                    operation.entityId,
+                                )}
+                            />
+                        ))
+                    )}
+                    <div ref={pendingRef} className="h-1" />
                 </Stack>
-            </Popper>
-        </HudCard>
+                <Divider />
+                <HistoryModal
+                    operations={historyOperations}
+                    operationDataById={operationDataById}
+                    listRef={historyRef}
+                    trigger={
+                        <Button
+                            variant="plain"
+                            size="sm"
+                            fullWidth
+                            className="rounded-t-none"
+                            startDecorator={<History className="size-4" />}
+                        >
+                            Prikaži sve radnje
+                        </Button>
+                    }
+                />
+            </Stack>
+        </Popper>
     );
 }

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1,0 +1,275 @@
+import { OperationImage } from '@gredice/ui/OperationImage';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Popper } from '@signalco/ui-primitives/Popper';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useMemo, useRef } from 'react';
+import {
+    type GardenOperationItem,
+    type GardenOperationStatus,
+    useGardenOperations,
+} from '../hooks/useGardenOperations';
+import { useOperations } from '../hooks/useOperations';
+import { HudCard } from './components/HudCard';
+
+type OperationData = NonNullable<
+    ReturnType<typeof useOperations>['data']
+>[number];
+
+const statusOrder: GardenOperationStatus[] = [
+    'new',
+    'planned',
+    'pendingVerification',
+    'completed',
+    'failed',
+    'canceled',
+];
+
+const statusLabel: Record<GardenOperationStatus, string> = {
+    new: 'Kreirano',
+    planned: 'Planirano',
+    pendingVerification: 'Čeka potvrdu',
+    completed: 'Završeno',
+    failed: 'Neuspjelo',
+    canceled: 'Otkazano',
+};
+
+const nextStepLabel: Record<GardenOperationStatus, string> = {
+    new: 'Sljedeći korak: zakazivanje',
+    planned: 'Sljedeći korak: izvršenje radnje',
+    pendingVerification: 'Sljedeći korak: verifikacija',
+    completed: 'Radnja završena',
+    failed: 'Sljedeći korak: ponovni pokušaj',
+    canceled: 'Radnja je otkazana',
+};
+
+function formatDateTime(value?: string | null) {
+    if (!value) return '—';
+    return new Date(value).toLocaleString('hr-HR');
+}
+
+function useInfiniteScroll(fetchNextPage: () => void, hasNextPage?: boolean) {
+    const observerRef = useRef<IntersectionObserver | null>(null);
+
+    return (node: HTMLDivElement | null) => {
+        if (observerRef.current) {
+            observerRef.current.disconnect();
+        }
+
+        observerRef.current = new IntersectionObserver((entries) => {
+            if (entries[0]?.isIntersecting && hasNextPage) {
+                fetchNextPage();
+            }
+        });
+
+        if (node) observerRef.current.observe(node);
+    };
+}
+
+function OperationProgress({ operation }: { operation: GardenOperationItem }) {
+    const currentStep = statusOrder.indexOf(operation.status);
+    const maxIndex = statusOrder.indexOf('completed');
+    const progress = Math.max(0, Math.min(100, (currentStep / maxIndex) * 100));
+
+    return (
+        <Stack spacing={0.5}>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                    className="h-full bg-primary rounded-full transition-all"
+                    style={{ width: `${progress}%` }}
+                />
+            </div>
+            <Row justifyContent="space-between">
+                <Typography level="body3" secondary>
+                    {statusLabel[operation.status]}
+                </Typography>
+                <Typography level="body3" secondary>
+                    {nextStepLabel[operation.status]}
+                </Typography>
+            </Row>
+        </Stack>
+    );
+}
+
+function OperationCard({
+    operation,
+    showStatusHistory,
+    operationName,
+    operationData,
+}: {
+    operation: GardenOperationItem;
+    showStatusHistory?: boolean;
+    operationName?: string;
+    operationData?: OperationData;
+}) {
+    return (
+        <div className="rounded-xl border p-2">
+            <Row spacing={1.5} alignItems="start">
+                <div className="size-12 rounded-lg bg-card flex items-center justify-center overflow-hidden shrink-0">
+                    {operationData ? (
+                        <OperationImage operation={operationData} size={40} />
+                    ) : (
+                        <Typography level="body3" secondary>
+                            🌱
+                        </Typography>
+                    )}
+                </div>
+                <Stack spacing={0.5} className="min-w-0 flex-1">
+                    <Typography level="body2" semiBold noWrap>
+                        {operationName ?? `Radnja #${operation.id}`}
+                    </Typography>
+                    <Typography level="body3" secondary>
+                        {operation.targetLabel}
+                    </Typography>
+                    <OperationProgress operation={operation} />
+                    {showStatusHistory && (
+                        <div className="pt-1">
+                            {operation.statusHistory.map((entry) => (
+                                <Row
+                                    key={`${operation.id}-${entry.status}-${entry.changedAt}`}
+                                    justifyContent="space-between"
+                                >
+                                    <Typography level="body3" secondary>
+                                        {statusLabel[entry.status]}
+                                    </Typography>
+                                    <Typography level="body3" secondary>
+                                        {formatDateTime(entry.changedAt)}
+                                    </Typography>
+                                </Row>
+                            ))}
+                        </div>
+                    )}
+                </Stack>
+            </Row>
+        </div>
+    );
+}
+
+export function GardenOperationsHud() {
+    const { data: operationsData } = useOperations();
+    const pending = useGardenOperations({
+        includeCompleted: false,
+        pageSize: 10,
+    });
+    const history = useGardenOperations({
+        includeCompleted: true,
+        pageSize: 20,
+    });
+
+    const pendingOperations = useMemo(
+        () => pending.data?.pages.flatMap((page) => page.items) ?? [],
+        [pending.data?.pages],
+    );
+    const historyOperations = useMemo(
+        () => history.data?.pages.flatMap((page) => page.items) ?? [],
+        [history.data?.pages],
+    );
+
+    const pendingRef = useInfiniteScroll(
+        () => pending.fetchNextPage(),
+        pending.hasNextPage,
+    );
+    const historyRef = useInfiniteScroll(
+        () => history.fetchNextPage(),
+        history.hasNextPage,
+    );
+
+    const operationDataById = useMemo(
+        () =>
+            new Map(
+                (operationsData ?? []).map((operation) => [
+                    operation.id,
+                    operation,
+                ]),
+            ),
+        [operationsData],
+    );
+
+    return (
+        <HudCard open position="floating" className="p-0.5 static">
+            <Popper
+                side="bottom"
+                sideOffset={12}
+                className="w-[28rem] max-w-[90vw] border-tertiary border-b-4"
+                trigger={
+                    <Button
+                        variant="plain"
+                        className="rounded-full px-3 h-10"
+                        title="Status radnji"
+                    >
+                        Radnje{' '}
+                        {pendingOperations.length > 0
+                            ? `(${pendingOperations.length})`
+                            : ''}
+                    </Button>
+                }
+            >
+                <Stack spacing={1.5} className="p-3">
+                    <Row justifyContent="space-between" alignItems="center">
+                        <Typography level="body1" semiBold>
+                            Aktivne radnje
+                        </Typography>
+                        <Modal
+                            title="Historija radnji"
+                            trigger={
+                                <Button size="sm" variant="plain">
+                                    Sva historija
+                                </Button>
+                            }
+                        >
+                            <Stack
+                                spacing={1.5}
+                                className="max-h-[70vh] overflow-y-auto pr-1"
+                            >
+                                {historyOperations.map((operation) => (
+                                    <OperationCard
+                                        key={operation.id}
+                                        operation={operation}
+                                        showStatusHistory
+                                        operationName={
+                                            operationDataById.get(
+                                                operation.entityId,
+                                            )?.information.label
+                                        }
+                                        operationData={operationDataById.get(
+                                            operation.entityId,
+                                        )}
+                                    />
+                                ))}
+                                <div ref={historyRef} className="h-1" />
+                            </Stack>
+                        </Modal>
+                    </Row>
+                    <Stack
+                        spacing={1}
+                        className="max-h-[50vh] overflow-y-auto pr-1"
+                    >
+                        {pendingOperations.length === 0 ? (
+                            <Typography level="body3" secondary>
+                                Nema nedovršenih radnji.
+                            </Typography>
+                        ) : (
+                            pendingOperations.map((operation) => (
+                                <OperationCard
+                                    key={operation.id}
+                                    operation={operation}
+                                    operationName={
+                                        operationDataById.get(
+                                            operation.entityId,
+                                        )?.information.label
+                                    }
+                                    operationData={operationDataById.get(
+                                        operation.entityId,
+                                    )}
+                                />
+                            ))
+                        )}
+                        <div ref={pendingRef} className="h-1" />
+                    </Stack>
+                </Stack>
+            </Popper>
+        </HudCard>
+    );
+}

--- a/packages/game/src/hud/PaymentSuccessfulMessage.tsx
+++ b/packages/game/src/hud/PaymentSuccessfulMessage.tsx
@@ -71,6 +71,7 @@ export function PaymentSuccessfulMessage() {
                             alt="Suncokret"
                             width={160}
                             height={160}
+                            loading="eager"
                         />
                     </div>
                 </div>

--- a/packages/game/src/hud/WeatherHud.tsx
+++ b/packages/game/src/hud/WeatherHud.tsx
@@ -8,6 +8,7 @@ import { useWeatherForecast } from '../hooks/useWeatherForecast';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import { useGameState } from '../useGameState';
 import { HudCard } from './components/HudCard';
+import { TimeDisplay } from './components/TimeDisplay';
 import { WeatherForecastDetails } from './components/weather/WeatherForecastDetails';
 import { weatherIcons } from './components/weather/WeatherIcons';
 import { WeatherNowDetails } from './components/weather/WeatherNowDetails';
@@ -16,51 +17,57 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
     const weatherVisualizationDisabled = useGameState(
         (state) => state.weatherVisualizationDisabled,
     );
+    const currentTime = useGameState((state) => state.currentTime);
     const weatherEnabled = !noWeather && !weatherVisualizationDisabled;
     const { data: weatherData } = useWeatherNow(weatherEnabled);
     const { data: forecastData } = useWeatherForecast(weatherEnabled);
     if (!weatherEnabled) return null;
-    if (!forecastData || !weatherData) return null;
     // TODO: Add loading indicator
     // TODO: Add error message
     // TODO: Show night icons when it's night for weather
 
     const WeatherIcon = weatherData ? weatherIcons[weatherData.symbol] : null;
+    const formattedTime = currentTime?.toLocaleTimeString('hr-HR', {
+        hour: '2-digit',
+        minute: '2-digit',
+    });
 
     return (
         <HudCard open position="floating" className="static md:px-1">
             <Row spacing={1}>
-                <Popper
-                    side="bottom"
-                    sideOffset={12}
-                    className="overflow-hidden border-tertiary border-b-4 w-full"
-                    trigger={
-                        <Button
-                            title="Trenutno vrijeme"
-                            variant="plain"
-                            className="rounded-full px-2 justify-between pr-4 md:pr-2"
-                        >
-                            <Row>
-                                {WeatherIcon && (
-                                    <WeatherIcon.day className="size-6" />
-                                )}
-                                <Typography
-                                    level="body2"
-                                    className="text-base pl-0.5"
-                                >
-                                    {weatherData?.measuredTemperature?.toFixed(
-                                        1,
-                                    ) ?? weatherData?.temperature}
-                                    °C
-                                </Typography>
-                            </Row>
-                        </Button>
-                    }
-                >
-                    <WeatherNowDetails />
-                </Popper>
-                {forecastData && weatherData && (
-                    <div className="w-[1px] h-4 border-r hidden md:inline" />
+                {weatherData && (
+                    <Popper
+                        side="bottom"
+                        sideOffset={12}
+                        className="overflow-hidden border-tertiary border-b-4 w-full"
+                        trigger={
+                            <Button
+                                title="Trenutno vrijeme"
+                                variant="plain"
+                                className="rounded-full px-2 justify-between pr-4 md:pr-2"
+                            >
+                                <Row>
+                                    {WeatherIcon && (
+                                        <WeatherIcon.day className="size-6" />
+                                    )}
+                                    <Typography
+                                        level="body2"
+                                        className="text-base pl-0.5"
+                                    >
+                                        {weatherData.measuredTemperature?.toFixed(
+                                            1,
+                                        ) ?? weatherData.temperature}
+                                        °C
+                                    </Typography>
+                                </Row>
+                            </Button>
+                        }
+                    >
+                        <WeatherNowDetails />
+                    </Popper>
+                )}
+                {weatherData && (forecastData || formattedTime) && (
+                    <div className="w-[1px] h-4 border-r" />
                 )}
                 {forecastData && (
                     <Popper
@@ -90,6 +97,29 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
                         }
                     >
                         <WeatherForecastDetails />
+                    </Popper>
+                )}
+                {forecastData && formattedTime && (
+                    <div className="w-[1px] h-4 border-r hidden md:inline" />
+                )}
+                {formattedTime && (
+                    <Popper
+                        side="bottom"
+                        sideOffset={12}
+                        className="overflow-hidden border-tertiary border-b-4"
+                        trigger={
+                            <Button
+                                title="Doba dana"
+                                variant="plain"
+                                className="rounded-full px-2"
+                            >
+                                <Typography level="body2" className="text-base">
+                                    {formattedTime}
+                                </Typography>
+                            </Button>
+                        }
+                    >
+                        <TimeDisplay variant="card" />
                     </Popper>
                 )}
             </Row>

--- a/packages/game/src/hud/WelcomeMessage.tsx
+++ b/packages/game/src/hud/WelcomeMessage.tsx
@@ -205,6 +205,7 @@ export function WelcomeMessage() {
                             alt="Suncokret"
                             width={160}
                             height={160}
+                            loading="eager"
                         />
                     </div>
                 </div>

--- a/packages/game/src/hud/components/TimeDisplay.tsx
+++ b/packages/game/src/hud/components/TimeDisplay.tsx
@@ -5,7 +5,11 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useGameState } from '../../useGameState';
 
-export function TimeDisplay() {
+export function TimeDisplay({
+    variant = 'overlay',
+}: {
+    variant?: 'card' | 'overlay';
+}) {
     const currentTime = useGameState((state) => state.currentTime);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const sunrise = useGameState((state) => state.sunriseTime);
@@ -14,7 +18,7 @@ export function TimeDisplay() {
     const isDaytime = timeOfDay > 0.2 && timeOfDay < 0.8;
 
     return (
-        <Stack className="pt-16 pb-2 px-4">
+        <Stack className={variant === 'overlay' ? 'pt-16 pb-2 px-4' : 'px-4 py-3'}>
             <Row justifyContent="space-between">
                 <Typography level="body3">
                     {(isDaytime ? sunrise : sunset)?.toLocaleTimeString(

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -1,5 +1,6 @@
 import { cx } from '@signalco/ui-primitives/cx';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useEffect } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
@@ -206,29 +207,44 @@ export function RaisedBedFieldSuggestions({
         useShoppingCart();
     const { data: allSorts, isLoading: isLoadingSorts } = useAllSorts();
     const setCartItem = useSetShoppingCartItem();
-    const currentTime = useGameState((state) => state.currentTime);
-    if (!currentGarden || !raisedBed || !shoppingCart) return null;
-
-    // Only show suggestions if the raised bed is valid
-    if (!raisedBed.isValid) return null;
+    const season = useGameState((state) => getSeasonForDate(state.currentTime));
+    const hasRequiredData = Boolean(currentGarden && raisedBed && shoppingCart);
+    const isRaisedBedValid = raisedBed?.isValid ?? false;
 
     // Check if there are already 18 plants in the cart or planted for this raised bed (2 blocks × 9 fields)
-    const cartItems = shoppingCart?.items.filter(
-        (item) => item.raisedBedId === raisedBedId,
-    );
-    const cartPlantItems = cartItems?.filter(
+    const cartItems =
+        shoppingCart?.items.filter((item) => item.raisedBedId === raisedBedId) ??
+        [];
+    const cartPlantItems = cartItems.filter(
         (item) => item.entityTypeName === 'plantSort' && item.status === 'new',
     );
-    const plantedFieldsCount = countRaisedBedOccupiedFields(raisedBed.fields);
-    if (plantedFieldsCount + (cartPlantItems?.length ?? 0) >= 18) {
-        console.debug('Skipping planting suggestions: raised bed is full', {
-            plantedFieldsCount,
-            cartPlantItemsCount: cartPlantItems?.length ?? 0,
-        });
-        return null;
-    }
+    const plantedFieldsCount = raisedBed
+        ? countRaisedBedOccupiedFields(raisedBed.fields)
+        : 0;
+    const cartPlantItemsCount = cartPlantItems.length;
+    const isRaisedBedFull =
+        isRaisedBedValid && plantedFieldsCount + cartPlantItemsCount >= 18;
 
-    const season = getSeasonForDate(currentTime);
+    useEffect(() => {
+        if (!hasRequiredData || !isRaisedBedValid || !isRaisedBedFull) return;
+
+        console.debug('Skipping planting suggestions: raised bed is full', {
+            raisedBedId,
+            plantedFieldsCount,
+            cartPlantItemsCount,
+        });
+    }, [
+        cartPlantItemsCount,
+        hasRequiredData,
+        isRaisedBedFull,
+        isRaisedBedValid,
+        plantedFieldsCount,
+        raisedBedId,
+    ]);
+
+    if (!hasRequiredData || !isRaisedBedValid) return null;
+
+    if (isRaisedBedFull) return null;
 
     // Get seasonal option and standard options
     const seasonalOption = quickSeedOptions[season];

--- a/packages/game/src/modals/advent/AdventAwardScreen.tsx
+++ b/packages/game/src/modals/advent/AdventAwardScreen.tsx
@@ -56,6 +56,7 @@ function AwardImage({ award }: { award: AdventAward }) {
                         alt="Suncokret"
                         width={120}
                         height={120}
+                        loading="eager"
                     />
                 </div>
             );

--- a/packages/game/src/modals/advent/AdventWelcomeScreen.tsx
+++ b/packages/game/src/modals/advent/AdventWelcomeScreen.tsx
@@ -24,6 +24,7 @@ export function AdventWelcomeScreen({ onContinue }: AdventWelcomeScreenProps) {
                     alt="Suncokret"
                     width={160}
                     height={160}
+                    loading="eager"
                     className="relative"
                 />
             </div>

--- a/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
+++ b/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
@@ -84,7 +84,10 @@ function sunflowerReasonToDescription(reason: string) {
             label: 'Plaćanje',
         };
     }
-    if (reason.startsWith('shoppingCartItem')) {
+    if (
+        reason.startsWith('shoppingCart:') ||
+        reason.startsWith('shoppingCartItem:')
+    ) {
         return {
             icon: <span className="text-4xl text-center size-10">🛒</span>,
             label: 'Kupnja',

--- a/packages/js/src/achievements/definitions.ts
+++ b/packages/js/src/achievements/definitions.ts
@@ -24,7 +24,10 @@ const plantingThresholds: Array<[threshold: number, reward: number]> = [
     [20, 400],
     [50, 750],
     [100, 1_200],
-    [200, 2_000],
+    [150, 2_000],
+    [200, 5_000],
+    [300, 10_000],
+    [500, 50_000],
 ];
 
 // TODO: Balance the rewards
@@ -34,7 +37,10 @@ const wateringThresholds: Array<[threshold: number, reward: number]> = [
     [20, 300],
     [50, 600],
     [100, 900],
-    [200, 1_500],
+    [150, 1_200],
+    [200, 2_000],
+    [300, 5_000],
+    [500, 10_000],
 ];
 
 // TODO: Balance the rewards
@@ -44,14 +50,17 @@ const harvestThresholds: Array<[threshold: number, reward: number]> = [
     [20, 600],
     [50, 1_200],
     [100, 2_000],
-    [200, 3_500],
+    [150, 3_000],
+    [200, 5_000],
+    [300, 10_000],
+    [500, 50_000],
 ];
 
 function plantingTitle(threshold: number) {
     if (threshold === 1) {
         return 'Prvo sjeme';
     }
-    return `Posađeno ${threshold} biljaka`;
+    return ` ${threshold} biljaka`;
 }
 
 function wateringTitle(threshold: number) {


### PR DESCRIPTION
### Motivation
- Surface active (not-completed) garden operations in-game next to the account HUD so players can see upcoming tasks and progress at a glance.
- Provide a full operations history modal with per-status timestamps and infinite scroll for inspection of past operations.
- Expose a server endpoint that supplies ordered, paginated operation data and per-operation status history to back the HUD and history view.

### Description
- Added an authenticated API endpoint `GET /api/gardens/:gardenId/operations` with query params `cursor`, `limit`, and `includeCompleted` that returns ordered, cursor-paginated operation pages and per-operation `statusHistory` and `targetLabel` (apps/api/app/api/[...route]/gardensRoutes.ts). 
- Implemented `serializeGardenOperation` on the API to emit operation timestamps (`createdAt`, `scheduledDate`, `completedAt`, `verifiedAt`, `canceledAt`) and a `statusHistory` array for UI consumption. 
- Added a new client hook `useGardenOperations` that uses `useInfiniteQuery` and the generated client to fetch paged operation lists for the current garden (packages/game/src/hooks/useGardenOperations.ts). 
- Added `GardenOperationsHud` UI component that renders a compact top-row HUD button next to `AccountHud`, a popup of active operations (icon/image, name, target, progress/status bar, next-step label), and a modal for full history; both popup and modal use infinite scroll and the `useGardenOperations` hook (packages/game/src/hud/GardenOperationsHud.tsx). 
- Wired the new HUD into `GameHud` top-left cluster so it appears next to the account control (packages/game/src/GameHud.tsx). 

### Testing
- Ran Biome checks on the modified API file with `pnpm --filter api exec biome check app/api/[...route]/gardensRoutes.ts`, which passed with no remaining fixes. 
- Ran Biome checks and lint on game package files with `pnpm --filter @gredice/game exec biome check src/GameHud.tsx src/hooks/useGardenOperations.ts src/hud/GardenOperationsHud.tsx` and `pnpm --filter @gredice/game lint`, which completed successfully (Biome applied formatting fixes where needed). 
- Verified the new endpoint and client hook return shapes via the code changes; no automated UI screenshot/tests were executed because the browser environment is unavailable in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f33242c8832fbb937570e756de76)