### PR TITLE
fix(app): await cookies() in gredice proxy route

### DIFF
--- a/apps/app/app/api/gredice/[...path]/route.ts
+++ b/apps/app/app/api/gredice/[...path]/route.ts
@@ -54,7 +54,7 @@ async function proxyRequest(request: NextRequest, params: { path: string[] }) {
     const url = `${API_BASE_URL}/${pathStr}${searchParams ? `?${searchParams}` : ''}`;
 
     // Forward cookies from the request
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     const cookieHeader = cookieStore
         .getAll()
         .map((cookie) => `${cookie.name}=${cookie.value}`)


### PR DESCRIPTION
### Motivation
- The proxy used `cookies()` synchronously which produced an invalid `cookieStore` and caused runtime errors like `TypeError: o.getAll is not a function` for requests such as `/api/gredice/api/auth/last-login`.

### Description
- Await `cookies()` in `apps/app/app/api/gredice/[...path]/route.ts` (changed `const cookieStore = cookies();` to `const cookieStore = await cookies();`) so `cookieStore.getAll()` and `cookieStore.set()` operate on the correct object.

### Testing
- Ran `pnpm lint --filter app` and `pnpm --filter app exec biome check app/api/gredice/[...path]/route.ts`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea306ad1f8832fb3b53818d02919a8)