### PR TITLE
Fix attribute definition data type selection and range editing in app

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/CreateAttributeDefinitionButton.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/CreateAttributeDefinitionButton.tsx
@@ -31,12 +31,11 @@ export function CreateAttributeDefinitionButton({
     async function submitForm(formData: FormData) {
         const name = formData.get('name') as string;
         const label = formData.get('label') as string;
-        const selectedType = formData.get('dataType') as string;
         const defaultValue = formData.get('defaultValue') as string;
         const dataType =
-            selectedType === 'range'
+            selectedDataType === 'range'
                 ? buildRangeDataType(rangeMinValue, rangeMaxValue)
-                : selectedType;
+                : selectedDataType;
 
         await upsertAttributeDefinition({
             name,
@@ -72,7 +71,7 @@ export function CreateAttributeDefinitionButton({
                             <SelectItems
                                 name="dataType"
                                 label="Vrsta podatka"
-                                defaultValue={attributeDataTypeItems[0].value}
+                                value={selectedDataType}
                                 items={attributeDataTypeItems}
                                 onValueChange={setSelectedDataType}
                             />

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx
@@ -63,22 +63,26 @@ export function FormDataTypeSelect({
     definition: GetAttributeDefinition;
     value: string;
 }) {
-    const [internalValue, setValue] = useState(value);
-    const parsedRangeDataType = parseRangeDataType(internalValue);
+    const isInitialRangeDataType =
+        value === 'range' || value.startsWith('range|');
+    const [selectedDataType, setSelectedDataType] = useState(
+        isInitialRangeDataType ? 'range' : value,
+    );
+    const parsedRangeDataType = parseRangeDataType(value);
     const [rangeMinValue, setRangeMinValue] = useState(parsedRangeDataType.min);
     const [rangeMaxValue, setRangeMaxValue] = useState(parsedRangeDataType.max);
-    const isRangeDataType =
-        internalValue === 'range' || internalValue.startsWith('range|');
+    const isRangeDataType = selectedDataType === 'range';
 
     const handleValueChange = async (nextValue: string) => {
-        const normalizedValue =
+        setSelectedDataType(nextValue);
+
+        const nextDataType =
             nextValue === 'range'
                 ? buildRangeDataType(rangeMinValue, rangeMaxValue)
                 : nextValue;
-        setValue(normalizedValue);
         await upsertAttributeDefinition({
             id: definition.id,
-            dataType: normalizedValue,
+            dataType: nextDataType,
         });
     };
 
@@ -88,7 +92,6 @@ export function FormDataTypeSelect({
         }
 
         const rangeDataType = buildRangeDataType(rangeMinValue, rangeMaxValue);
-        setValue(rangeDataType);
         await upsertAttributeDefinition({
             id: definition.id,
             dataType: rangeDataType,
@@ -96,14 +99,14 @@ export function FormDataTypeSelect({
     };
 
     const items = attributeDataTypeItems.some(
-        (item) => item.value === internalValue,
+        (item) => item.value === selectedDataType,
     )
         ? attributeDataTypeItems
         : [
               ...attributeDataTypeItems,
               {
-                  value: internalValue,
-                  label: getAttributeDataTypeLabel(internalValue),
+                  value: selectedDataType,
+                  label: getAttributeDataTypeLabel(selectedDataType),
               },
           ];
 
@@ -111,7 +114,7 @@ export function FormDataTypeSelect({
         <Stack spacing={1} className="grow">
             <SelectItems
                 label="Tip podatka"
-                value={internalValue}
+                value={selectedDataType}
                 onValueChange={handleValueChange}
                 items={items}
                 placeholder={getAttributeDataTypeLabel(value)}


### PR DESCRIPTION
### Motivation
- The create-attribute modal did not use a controlled data-type value so the selected type could be lost or mis-submitted, and range types were not serialized reliably.
- The attribute-definition edit page treated the select value as the serialized `range|min|max`, which made editing min/max awkward and prevented correct persistence of updated bounds.

### Description
- Make the create modal (`CreateAttributeDefinitionButton.tsx`) use a controlled `selectedDataType` state and submit `dataType` based on that state (serializing `range` via `buildRangeDataType` when needed). 
- Bind the `SelectItems` in the create modal to `value={selectedDataType}` and show range min/max inputs only when `selectedDataType === 'range'` so range bounds are editable before submit. 
- Normalize edit-page selection in `FormDataTypeSelect` (`[id]/Form.tsx`) so the select shows `range` for any `range|min|max` data type, parse initial bounds from the persisted value, and persist changes as `range|min|max` on change/blur via `buildRangeDataType`. 
- Ensure unknown/serialized data types still appear in the select items by appending a labeled item when needed.

### Testing
- Ran `pnpm --filter app lint` which completed successfully (with a repository engine warning unrelated to the changes). 
- Ran `pnpm --filter app exec biome check "app/admin/directories/[entityType]/attribute-definitions/CreateAttributeDefinitionButton.tsx" "app/admin/directories/[entityType]/attribute-definitions/[id]/Form.tsx"` which passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea318b7784832f98e2fd7b5646ab78)