### PR TITLE
✨ feat): add pag garden operations endpoint and bool parsing a dedicated paginated fetch and stricter boolean parsing.

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -14,6 +14,7 @@ import {
     getGardenBlocks,
     getGardenStack,
     getOperations,
+    getOperationsPage,
     getRaisedBed,
     getRaisedBedDiaryEntries,
     getRaisedBedFieldDiaryEntries,
@@ -53,6 +54,7 @@ import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
+import { queryBooleanSchema } from '../../../lib/http/queryBoolean';
 import { openAdventGiftBox } from '../../../lib/occasions/adventGiftBox';
 import { getPostHogClient } from '../../../lib/posthog-server';
 
@@ -135,7 +137,9 @@ function serializeGardenOperation(
         operation.scheduledDate
             ? {
                   status: 'planned',
-                  changedAt: operation.scheduledDate.toISOString(),
+                  changedAt:
+                      operation.scheduledAt?.toISOString() ??
+                      operation.scheduledDate.toISOString(),
               }
             : null,
         operation.completedAt
@@ -166,6 +170,7 @@ function serializeGardenOperation(
         status: operation.status,
         createdAt: operation.createdAt.toISOString(),
         scheduledDate: operation.scheduledDate?.toISOString() ?? null,
+        scheduledAt: operation.scheduledAt?.toISOString() ?? null,
         completedAt: operation.completedAt?.toISOString() ?? null,
         verifiedAt: operation.verifiedAt?.toISOString() ?? null,
         canceledAt: operation.canceledAt?.toISOString() ?? null,
@@ -240,7 +245,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             z.object({
                 cursor: z.coerce.number().int().min(0).optional(),
                 limit: z.coerce.number().int().min(1).max(50).optional(),
-                includeCompleted: z.coerce.boolean().optional(),
+                includeCompleted: queryBooleanSchema.optional(),
             }),
         ),
         authValidator(['user', 'admin']),
@@ -255,14 +260,19 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }
 
             const { accountId } = context.get('authContext');
-            const [garden, operations] = await Promise.all([
-                getGarden(gardenIdNumber),
-                getOperations(accountId, gardenIdNumber),
-            ]);
+            const garden = await getGarden(gardenIdNumber);
 
             if (!garden || garden.accountId !== accountId) {
                 return context.json({ error: 'Garden not found' }, 404);
             }
+
+            const operationsPage = await getOperationsPage({
+                accountId,
+                gardenId: gardenIdNumber,
+                cursor,
+                limit,
+                includeCompleted,
+            });
 
             const targetsByRaisedBedId = new Map(
                 garden.raisedBeds.map((raisedBed) => [
@@ -279,34 +289,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 ),
             );
 
-            const sorted = operations.sort((a, b) => {
-                const aDate = a.scheduledDate ?? a.createdAt;
-                const bDate = b.scheduledDate ?? b.createdAt;
-                return aDate.getTime() - bDate.getTime();
-            });
-
-            const filtered = includeCompleted
-                ? sorted
-                : sorted.filter(
-                      (operation) => operation.status !== 'completed',
-                  );
-
-            const pageSize = limit ?? 20;
-            const offset = cursor ?? 0;
-            const paginated = filtered.slice(offset, offset + pageSize);
-            const nextCursor =
-                offset + pageSize < filtered.length ? offset + pageSize : null;
-
             return context.json({
-                items: paginated.map((operation) =>
+                items: operationsPage.items.map((operation) =>
                     serializeGardenOperation(
                         operation,
                         targetsByRaisedBedFieldId,
                         targetsByRaisedBedId,
                     ),
                 ),
-                nextCursor,
-                total: filtered.length,
+                nextCursor: operationsPage.nextCursor,
+                total: operationsPage.total,
             });
         },
     )

--- a/apps/api/lib/http/queryBoolean.node.spec.ts
+++ b/apps/api/lib/http/queryBoolean.node.spec.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ZodError } from 'zod';
+import { queryBooleanSchema } from './queryBoolean';
+
+describe('queryBooleanSchema', () => {
+    it('parses the true string as true', () => {
+        assert.strictEqual(queryBooleanSchema.parse('true'), true);
+    });
+
+    it('parses the false string as false', () => {
+        assert.strictEqual(queryBooleanSchema.parse('false'), false);
+    });
+
+    it('rejects other values instead of using JavaScript truthiness', () => {
+        assert.throws(() => queryBooleanSchema.parse('0'), ZodError);
+    });
+});

--- a/apps/api/lib/http/queryBoolean.ts
+++ b/apps/api/lib/http/queryBoolean.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const queryBooleanSchema = z
+    .enum(['true', 'false'])
+    .transform((value) => value === 'true');

--- a/packages/game/src/hooks/useGardenOperations.ts
+++ b/packages/game/src/hooks/useGardenOperations.ts
@@ -32,6 +32,7 @@ export type GardenOperationItem = {
     status: GardenOperationStatus;
     createdAt: string;
     scheduledDate: string | null;
+    scheduledAt: string | null;
     completedAt: string | null;
     verifiedAt: string | null;
     canceledAt: string | null;

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -149,7 +149,7 @@ function useInfiniteScroll(fetchNextPage: () => void, hasNextPage?: boolean) {
                 observerRef.current = null;
             }
 
-            if (!node) return;
+            if (!node || !hasNextPage) return;
 
             const scrollRoot = node.closest<HTMLElement>(
                 '[data-infinite-scroll-root]',

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, lte } from 'drizzle-orm';
+import { and, asc, count, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
 import {
     events,
     farmUsers,
@@ -39,6 +39,13 @@ export type OperationAssignedUser = {
 
 export type OperationAssignableFarmUser = OperationAssignedUser & {
     farmId: number;
+};
+
+type GetOperationsInput = {
+    accountId: string;
+    gardenId?: number;
+    raisedBedId?: number;
+    raisedBedFieldIds?: number[];
 };
 
 function parseOperationEventData(value: unknown): OperationEventsAnyPayload {
@@ -95,6 +102,10 @@ function parseOperationEventData(value: unknown): OperationEventsAnyPayload {
 }
 
 async function fillOperationAggregates(operations: SelectOperation[]) {
+    if (operations.length === 0) {
+        return [];
+    }
+
     const aggregateIds = operations.map((op) => op.id.toString());
     const aggregatesEvents = await getEvents(
         [
@@ -110,17 +121,24 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
         10000,
     );
 
-    const operationsWithAggregates = operations.map((op) => {
-        const events = aggregatesEvents.filter(
-            (event) => event.aggregateId === op.id.toString(),
-        );
+    const eventsByAggregateId = new Map<string, typeof aggregatesEvents>();
+    for (const event of aggregatesEvents) {
+        const operationEvents =
+            eventsByAggregateId.get(event.aggregateId) ?? [];
+        operationEvents.push(event);
+        eventsByAggregateId.set(event.aggregateId, operationEvents);
+    }
 
-        let status = 'new';
+    const operationsWithAggregates = operations.map((op) => {
+        const operationEvents = eventsByAggregateId.get(op.id.toString()) ?? [];
+
+        let status: OperationStatus = 'new';
         let assignedUserId: string | null | undefined;
         let assignedUserIds: string[] | undefined;
         let assignedBy: string | undefined;
         let assignedAt: Date | undefined;
         let scheduledDate: Date | undefined;
+        let scheduledAt: Date | undefined;
         let completedAt: Date | undefined;
         let completedBy: string | undefined;
         let verifiedAt: Date | undefined;
@@ -136,7 +154,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
         const asString = (v: unknown): string | undefined =>
             typeof v === 'string' ? v : undefined;
 
-        for (const event of events) {
+        for (const event of operationEvents) {
             const data = parseOperationEventData(event.data);
             if (event.type === knownEventTypes.operations.assign) {
                 if ('assignedUserId' in data) {
@@ -178,6 +196,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
                 scheduledDate = data?.scheduledDate
                     ? new Date(String(data.scheduledDate))
                     : undefined;
+                scheduledAt = event.createdAt;
             }
         }
 
@@ -198,6 +217,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
             error,
             errorCode,
             scheduledDate,
+            scheduledAt,
             canceledBy,
             canceledAt,
             cancelReason,
@@ -245,26 +265,143 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
     }));
 }
 
+function getOperationsWhere(input: GetOperationsInput) {
+    return and(
+        eq(operations.accountId, input.accountId),
+        eq(operations.isDeleted, false),
+        input.gardenId ? eq(operations.gardenId, input.gardenId) : undefined,
+        input.raisedBedId
+            ? eq(operations.raisedBedId, input.raisedBedId)
+            : undefined,
+        input.raisedBedFieldIds && input.raisedBedFieldIds.length > 0
+            ? inArray(operations.raisedBedFieldId, input.raisedBedFieldIds)
+            : undefined,
+    );
+}
+
+async function getOperationRows(input: GetOperationsInput) {
+    return storage().query.operations.findMany({
+        where: getOperationsWhere(input),
+        orderBy: desc(operations.timestamp),
+    });
+}
+
+const operationTimelineStatusTypes = [
+    knownEventTypes.operations.schedule,
+    knownEventTypes.operations.complete,
+    knownEventTypes.operations.verify,
+    knownEventTypes.operations.fail,
+    knownEventTypes.operations.cancel,
+];
+
+function getLatestOperationStatusTypeExpression() {
+    return sql<string | null>`(
+        select ${events.type}
+        from ${events}
+        where ${events.aggregateId} = CAST(${operations.id} as text)
+          and ${events.type} in (${sql.join(
+              operationTimelineStatusTypes.map((value) => sql`${value}`),
+              sql`, `,
+          )})
+        order by ${events.createdAt} desc, ${events.id} desc
+        limit 1
+    )`;
+}
+
+function getOperationScheduledDateExpression() {
+    return sql<Date | null>`(
+        select nullif((${events.data} ->> 'scheduledDate'), '')::timestamp
+        from ${events}
+        where ${events.aggregateId} = CAST(${operations.id} as text)
+          and ${events.type} = ${knownEventTypes.operations.schedule}
+        order by ${events.createdAt} desc, ${events.id} desc
+        limit 1
+    )`;
+}
+
+function getOperationStatusExpression() {
+    const latestStatusTypeExpression = getLatestOperationStatusTypeExpression();
+
+    return sql<OperationStatus>`(
+        case ${latestStatusTypeExpression}
+            when ${knownEventTypes.operations.schedule} then 'planned'
+            when ${knownEventTypes.operations.complete} then 'pendingVerification'
+            when ${knownEventTypes.operations.verify} then 'completed'
+            when ${knownEventTypes.operations.fail} then 'failed'
+            when ${knownEventTypes.operations.cancel} then 'canceled'
+            else 'new'
+        end
+    )`;
+}
+
+function getOperationTimelineSortExpression() {
+    const scheduledDateExpression = getOperationScheduledDateExpression();
+
+    return sql<Date>`coalesce(${scheduledDateExpression}, ${operations.createdAt})`;
+}
+
 export async function getOperations(
     accountId: string,
     gardenId?: number,
     raisedBedId?: number,
     raisedBedFieldIds?: number[],
 ) {
-    const query = await storage().query.operations.findMany({
-        where: and(
-            eq(operations.accountId, accountId),
-            eq(operations.isDeleted, false),
-            gardenId ? eq(operations.gardenId, gardenId) : undefined,
-            raisedBedId ? eq(operations.raisedBedId, raisedBedId) : undefined,
-            raisedBedFieldIds && raisedBedFieldIds.length > 0
-                ? inArray(operations.raisedBedFieldId, raisedBedFieldIds)
-                : undefined,
-        ),
-        orderBy: desc(operations.timestamp),
+    const query = await getOperationRows({
+        accountId,
+        gardenId,
+        raisedBedId,
+        raisedBedFieldIds,
     });
 
     return await fillOperationAggregates(query);
+}
+
+export async function getOperationsPage(
+    input: GetOperationsInput & {
+        cursor?: number;
+        limit?: number;
+        includeCompleted?: boolean;
+    },
+) {
+    const offset = input.cursor ?? 0;
+    const pageSize = input.limit ?? 20;
+    const statusExpression = getOperationStatusExpression();
+    const timelineSortExpression = getOperationTimelineSortExpression();
+    const includeCompletedWhere = input.includeCompleted
+        ? undefined
+        : sql`${statusExpression} != 'completed'`;
+
+    const [pageRows, totalResult] = await Promise.all([
+        storage()
+            .select({
+                id: operations.id,
+            })
+            .from(operations)
+            .where(and(getOperationsWhere(input), includeCompletedWhere))
+            .orderBy(asc(timelineSortExpression), asc(operations.id))
+            .offset(offset)
+            .limit(pageSize + 1),
+        storage()
+            .select({ count: count() })
+            .from(operations)
+            .where(and(getOperationsWhere(input), includeCompletedWhere)),
+    ]);
+
+    const pageIds = pageRows.slice(0, pageSize).map((row) => row.id);
+    const hydratedItems = await getOperationsByIds(pageIds);
+    const hydratedItemsById = new Map(
+        hydratedItems.map((item) => [item.id, item]),
+    );
+    const items = pageIds.flatMap((id) => {
+        const item = hydratedItemsById.get(id);
+        return item ? [item] : [];
+    });
+
+    return {
+        items,
+        nextCursor: pageRows.length > pageSize ? offset + pageSize : null,
+        total: totalResult[0]?.count ?? 0,
+    };
 }
 
 export async function getAllOperations(filter?: {


### PR DESCRIPTION
- 🧪 Add unit tests for queryBooleanSchema to ensure only "true"/"false"
 strings are and JavaScript truthiness is not.
 ✅ IntroduceBooleanSchema usage in gardensRoutes to validate the includeCompleted query parameter.
- ♻️ Replace adoc in-route listing logic with getOperationsPage:
 - fetch paginated, operations from the backend,
 - return items, nextCursor and total consistently - simplify route code and remove sorting/filtering/pagination.
- 🧩 Ex scheduledAt on operation DTOs and map scheduledDate ->At using scheduled when available to preserve exact scheduling timestamps.
- 🔧 Add scheduledAt to operation types in useGardenOperations hook.

This input validation, centralizes pagination logic, and keeps timestamps accurate and consistent.