### PR TITLE
✨ feat: improve/night controls, weather togg, and UI tabs SunMoon: read dayCycle from state and use it to force moon tint when cycling is disabled. Clean up suncalc import formatting small for consistent style.

### DIFF
--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -120,7 +120,7 @@ export function GameScene({
                     {!noControls && <Controls />}
                 </ParticleSystemProvider>
             </Scene>
-            {!hideHud && <GameHud flags={flags} noWeather={weatherDisabled} />}
+            {!hideHud && <GameHud flags={flags} noWeather={noWeather} />}
         </div>
     );
 }

--- a/packages/game/src/hud/WeatherHud.tsx
+++ b/packages/game/src/hud/WeatherHud.tsx
@@ -14,11 +14,8 @@ import { weatherIcons } from './components/weather/WeatherIcons';
 import { WeatherNowDetails } from './components/weather/WeatherNowDetails';
 
 export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
-    const weatherVisualizationDisabled = useGameState(
-        (state) => state.weatherVisualizationDisabled,
-    );
     const currentTime = useGameState((state) => state.currentTime);
-    const weatherEnabled = !noWeather && !weatherVisualizationDisabled;
+    const weatherEnabled = !noWeather;
     const { data: weatherData } = useWeatherNow(weatherEnabled);
     const { data: forecastData } = useWeatherForecast(weatherEnabled);
     if (!weatherEnabled) return null;

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -11,6 +11,7 @@ import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { AccountUsersTab } from './components/AccountUsersTab';
 import { AchievementsTab } from './components/AchievementsTab';
 import { DeliveryTab } from './components/DeliveryTab';
+import { GameTab } from './components/GameTab';
 import { GardenTab } from './components/GardenTab';
 import { GeneralTab } from './components/GeneralTab';
 import { NotificationsTab } from './components/NotificationsTab';
@@ -74,6 +75,12 @@ const navGroups = [
     {
         label: 'Postavke',
         items: [
+            {
+                nodeId: 'settings-game',
+                icon: '🎮',
+                label: 'Igra',
+                value: 'igra',
+            },
             {
                 nodeId: 'profile-security',
                 icon: '🔒',
@@ -164,6 +171,7 @@ export function OverviewModal() {
                 <div className="md:pl-6">
                     {settingsMode === 'generalno' && <GeneralTab />}
                     {settingsMode === 'vrt' && <GardenTab />}
+                    {settingsMode === 'igra' && <GameTab />}
                     {settingsMode === 'sigurnost' && <SecurityTab />}
                     {settingsMode === 'dostava' && <DeliveryTab />}
                     {settingsMode === 'zvuk' && <SoundTab />}

--- a/packages/game/src/modals/components/GameTab.tsx
+++ b/packages/game/src/modals/components/GameTab.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { EnvironmentSettingsCard } from './EnvironmentSettingsCard';
+
+export function GameTab() {
+    return (
+        <Stack spacing={4}>
+            <Typography level="h4" className="hidden md:block">
+                🎮 Igra
+            </Typography>
+            <Stack spacing={1}>
+                <EnvironmentSettingsCard />
+            </Stack>
+        </Stack>
+    );
+}

--- a/packages/game/src/modals/components/GeneralTab.tsx
+++ b/packages/game/src/modals/components/GeneralTab.tsx
@@ -1,6 +1,5 @@
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { EnvironmentSettingsCard } from './EnvironmentSettingsCard';
 import { TimeZoneSettingsCard } from './TimeZoneSettingsCard';
 import { UserBirthdayCard } from './UserBirthdayCard';
 import { UserProfileCard } from './UserProfileCard';
@@ -12,7 +11,6 @@ export function GeneralTab() {
                 ⚙️ Profil
             </Typography>
             <Stack spacing={1}>
-                <EnvironmentSettingsCard />
                 <UserProfileCard />
                 <UserBirthdayCard />
                 <TimeZoneSettingsCard />

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -3,11 +3,7 @@
 import { useFrame } from '@react-three/fiber';
 import chroma from 'chroma-js';
 import { useMemo, useRef } from 'react';
-import {
-    getMoonIllumination,
-    getMoonPosition,
-    getPosition,
-} from 'suncalc';
+import { getMoonIllumination, getMoonPosition, getPosition } from 'suncalc';
 import {
     AdditiveBlending,
     Color,
@@ -143,6 +139,9 @@ type SunMoonProps = {
 export function SunMoon({ visibility = 1 }: SunMoonProps) {
     const currentTime = useGameState((state) => state.currentTime);
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const dayNightCycleDisabled = useGameState(
+        (state) => state.dayNightCycleDisabled,
+    );
     const { data: garden } = useCurrentGarden();
 
     const location = useMemo(
@@ -211,7 +210,8 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
 
         const halfHeight = orthographic.top / orthographic.zoom;
         const skyRadius = halfHeight * SKY_SCREEN_FRACTION;
-        const screenScale = (REFERENCE_ZOOM / orthographic.zoom) * SIZE_MULTIPLIER;
+        const screenScale =
+            (REFERENCE_ZOOM / orthographic.zoom) * SIZE_MULTIPLIER;
         sunMesh.current.scale.setScalar(screenScale);
         moonMesh.current.scale.setScalar(screenScale);
 
@@ -258,8 +258,7 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         );
         // Fade the moon down while the sun is well above the horizon so it
         // reads as a pale daytime moon rather than a competing sun.
-        const moonDayFade =
-            1 - 0.85 * smoothstep(-0.05, 0.3, sun.altitude);
+        const moonDayFade = 1 - 0.85 * smoothstep(-0.05, 0.3, sun.altitude);
         const moonOpacity = moonHorizonOpacity * moonDayFade * visibility;
         if (moonOpacity > 0.001) {
             const moonDir = altAzToScenePosition(
@@ -281,7 +280,9 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
             moonMaterial.uniforms.uOpacity.value = moonOpacity;
             // Warm the tint toward white as the sun rises so the daytime moon
             // doesn't read as a cool blue spot against a bright sky.
-            const dayBlend = smoothstep(-0.05, 0.3, sun.altitude);
+            const dayBlend = dayNightCycleDisabled
+                ? 1
+                : smoothstep(-0.05, 0.3, sun.altitude);
             (moonMaterial.uniforms.uColor.value as Color)
                 .copy(MOON_NIGHT_COLOR)
                 .lerp(MOON_DAY_COLOR, dayBlend);


### PR DESCRIPTION
This ensures moon stays correct when the day/night cycle turned off.

- WeatherHud: dependency weatherDisabled when computing weatherEnabled rely on the explicit no prop Prevents flag from inadvertently blocking data for consumers.
- Scene: forward the incoming no prop to GameHud ( weatherDisabled variable). Fix a where HUD weather visibility be out of scene.
- General & Game: relocate EnvironmentSettingsCard of GeneralTab into a new GameTab and GameTab import Overview. Split settings into a dedicated Game tab for better organization and to avoid duplicate UI elements.
- SunMoon: read dayCycle from state and use it to force moon tint when cycling is disabled.
- Minor wrap long lines and normalize in files for code style.