### PR TITLE
Adjust sun placement and size to improve mobile visibility

### DIFF
--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -42,6 +42,8 @@ const SKY_SCREEN_FRACTION = 1.05;
 // game camera zoom so on-screen size matches the plane size at default zoom.
 const REFERENCE_ZOOM = 100;
 const SIZE_MULTIPLIER = 1.5;
+const SUN_SIZE_MULTIPLIER = 0.8;
+const SUN_SCREEN_OFFSET_MULTIPLIER = 0.8;
 
 const MOON_NIGHT_COLOR = new Color('#c8d8f2');
 const MOON_DAY_COLOR = new Color('#f4f2ec');
@@ -212,7 +214,7 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         const skyRadius = halfHeight * SKY_SCREEN_FRACTION;
         const screenScale =
             (REFERENCE_ZOOM / orthographic.zoom) * SIZE_MULTIPLIER;
-        sunMesh.current.scale.setScalar(screenScale);
+        sunMesh.current.scale.setScalar(screenScale * SUN_SIZE_MULTIPLIER);
         moonMesh.current.scale.setScalar(screenScale);
 
         const date = timeOfDayToDate(currentTime, timeOfDay);
@@ -234,8 +236,14 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
             sunMesh.current.position
                 .copy(camera.position)
                 .addScaledVector(forwardRef.current, FORWARD_DISTANCE)
-                .addScaledVector(rightRef.current, sx * skyRadius)
-                .addScaledVector(viewUpRef.current, sy * skyRadius);
+                .addScaledVector(
+                    rightRef.current,
+                    sx * skyRadius * SUN_SCREEN_OFFSET_MULTIPLIER,
+                )
+                .addScaledVector(
+                    viewUpRef.current,
+                    sy * skyRadius * SUN_SCREEN_OFFSET_MULTIPLIER,
+                );
             sunMesh.current.lookAt(camera.position);
 
             const sunRgb = sunColorScale(timeOfDay).rgb();


### PR DESCRIPTION
### Motivation
- The sun disc was not reliably visible on smaller/mobile viewports, so it should be moved closer to the screen center and reduced in size by 20% (x0.8) to improve visibility.

### Description
- Introduced `SUN_SIZE_MULTIPLIER = 0.8` and applied it to the sun mesh scale so the sun is rendered at 80% of its previous size in `packages/game/src/scene/SunMoon.tsx`.
- Introduced `SUN_SCREEN_OFFSET_MULTIPLIER = 0.8` and applied it to both horizontal and vertical screen-space offsets so the sun is positioned closer to the origin of the view.
- Kept moon sizing and positioning logic unchanged and left existing horizon/opacity math intact.

### Testing
- Ran `pnpm --filter @gredice/game lint` which completed (note: environment engine warning about Node version is unrelated to the change).
- Ran `pnpm --filter @gredice/game exec biome check src/scene/SunMoon.tsx` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb21d94b68832f8a7f2725939e88f6)