### PR TITLE
Responsive sun sizing and positioning for mobile/tablet viewports

### DIFF
--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -68,23 +68,23 @@ function getSunViewportTuning(
     if (viewportWidth <= MOBILE_MAX_WIDTH) {
         return {
             sizeMultiplier: 0.6,
-            horizontalOffsetMultiplier: isPortrait ? 0.45 : 0.6,
-            verticalOffsetMultiplier: isPortrait ? 0.85 : 0.6,
+            horizontalOffsetMultiplier: isPortrait ? 0.7 : 1,
+            verticalOffsetMultiplier: isPortrait ? 1 : 0.8,
         };
     }
 
     if (viewportWidth <= TABLET_MAX_WIDTH) {
         return {
             sizeMultiplier: 0.9,
-            horizontalOffsetMultiplier: isPortrait ? 0.7 : 0.9,
+            horizontalOffsetMultiplier: isPortrait ? 1 : 0.9,
             verticalOffsetMultiplier: isPortrait ? 1 : 0.9,
         };
     }
 
     return {
         sizeMultiplier: 1,
-        horizontalOffsetMultiplier: isPortrait ? 0.9 : 1,
-        verticalOffsetMultiplier: isPortrait ? 1.05 : 1,
+        horizontalOffsetMultiplier: isPortrait ? 0.9 : 1.6,
+        verticalOffsetMultiplier: isPortrait ? 1.1 : 1,
     };
 }
 

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFrame } from '@react-three/fiber';
+import { useFrame, useThree } from '@react-three/fiber';
 import chroma from 'chroma-js';
 import { useMemo, useRef } from 'react';
 import { getMoonIllumination, getMoonPosition, getPosition } from 'suncalc';
@@ -45,10 +45,15 @@ const SIZE_MULTIPLIER = 1.5;
 const SUN_SIZE_MULTIPLIER = 0.8;
 const SUN_SCREEN_OFFSET_MULTIPLIER = 0.8;
 
+// Renderer `size` is reported in CSS pixels. These breakpoints map the sun
+// tuning to our mobile/tablet/desktop layout ranges so responsive adjustments
+// stay aligned with the rest of the UI.
 const MOBILE_MAX_WIDTH = 767;
 const TABLET_MAX_WIDTH = 1023;
 
 type SunViewportTuning = {
+    // Multiplies the default billboard scale and camera-space offsets for the
+    // sun so smaller viewports keep it fully visible without affecting the moon.
     sizeMultiplier: number;
     horizontalOffsetMultiplier: number;
     verticalOffsetMultiplier: number;
@@ -183,6 +188,9 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         (state) => state.dayNightCycleDisabled,
     );
     const { data: garden } = useCurrentGarden();
+    const { width: viewportWidth, height: viewportHeight } = useThree(
+        (state) => state.size,
+    );
 
     const location = useMemo(
         () => ({
@@ -230,11 +238,16 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         [],
     );
 
+    const sunViewportTuning = useMemo(
+        () => getSunViewportTuning(viewportWidth, viewportHeight),
+        [viewportHeight, viewportWidth],
+    );
+
     const forwardRef = useRef(new Vector3());
     const rightRef = useRef(new Vector3());
     const viewUpRef = useRef(new Vector3());
 
-    useFrame(({ camera, size }) => {
+    useFrame(({ camera }) => {
         if (!sunMesh.current || !moonMesh.current) return;
 
         const orthographic = camera as OrthographicCamera;
@@ -252,9 +265,10 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         const skyRadius = halfHeight * SKY_SCREEN_FRACTION;
         const screenScale =
             (REFERENCE_ZOOM / orthographic.zoom) * SIZE_MULTIPLIER;
-        const sunTuning = getSunViewportTuning(size.width, size.height);
         sunMesh.current.scale.setScalar(
-            screenScale * SUN_SIZE_MULTIPLIER * sunTuning.sizeMultiplier,
+            screenScale *
+                SUN_SIZE_MULTIPLIER *
+                sunViewportTuning.sizeMultiplier,
         );
         moonMesh.current.scale.setScalar(screenScale);
 
@@ -282,14 +296,14 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
                     sx *
                         skyRadius *
                         SUN_SCREEN_OFFSET_MULTIPLIER *
-                        sunTuning.horizontalOffsetMultiplier,
+                        sunViewportTuning.horizontalOffsetMultiplier,
                 )
                 .addScaledVector(
                     viewUpRef.current,
                     sy *
                         skyRadius *
                         SUN_SCREEN_OFFSET_MULTIPLIER *
-                        sunTuning.verticalOffsetMultiplier,
+                        sunViewportTuning.verticalOffsetMultiplier,
                 );
             sunMesh.current.lookAt(camera.position);
 

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -45,6 +45,44 @@ const SIZE_MULTIPLIER = 1.5;
 const SUN_SIZE_MULTIPLIER = 0.8;
 const SUN_SCREEN_OFFSET_MULTIPLIER = 0.8;
 
+const MOBILE_MAX_WIDTH = 767;
+const TABLET_MAX_WIDTH = 1023;
+
+type SunViewportTuning = {
+    sizeMultiplier: number;
+    horizontalOffsetMultiplier: number;
+    verticalOffsetMultiplier: number;
+};
+
+function getSunViewportTuning(
+    viewportWidth: number,
+    viewportHeight: number,
+): SunViewportTuning {
+    const isPortrait = viewportHeight > viewportWidth;
+
+    if (viewportWidth <= MOBILE_MAX_WIDTH) {
+        return {
+            sizeMultiplier: 0.6,
+            horizontalOffsetMultiplier: isPortrait ? 0.45 : 0.6,
+            verticalOffsetMultiplier: isPortrait ? 0.85 : 0.6,
+        };
+    }
+
+    if (viewportWidth <= TABLET_MAX_WIDTH) {
+        return {
+            sizeMultiplier: 0.9,
+            horizontalOffsetMultiplier: isPortrait ? 0.7 : 0.9,
+            verticalOffsetMultiplier: isPortrait ? 1 : 0.9,
+        };
+    }
+
+    return {
+        sizeMultiplier: 1,
+        horizontalOffsetMultiplier: isPortrait ? 0.9 : 1,
+        verticalOffsetMultiplier: isPortrait ? 1.05 : 1,
+    };
+}
+
 const MOON_NIGHT_COLOR = new Color('#c8d8f2');
 const MOON_DAY_COLOR = new Color('#f4f2ec');
 
@@ -196,7 +234,7 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
     const rightRef = useRef(new Vector3());
     const viewUpRef = useRef(new Vector3());
 
-    useFrame(({ camera }) => {
+    useFrame(({ camera, size }) => {
         if (!sunMesh.current || !moonMesh.current) return;
 
         const orthographic = camera as OrthographicCamera;
@@ -214,7 +252,10 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         const skyRadius = halfHeight * SKY_SCREEN_FRACTION;
         const screenScale =
             (REFERENCE_ZOOM / orthographic.zoom) * SIZE_MULTIPLIER;
-        sunMesh.current.scale.setScalar(screenScale * SUN_SIZE_MULTIPLIER);
+        const sunTuning = getSunViewportTuning(size.width, size.height);
+        sunMesh.current.scale.setScalar(
+            screenScale * SUN_SIZE_MULTIPLIER * sunTuning.sizeMultiplier,
+        );
         moonMesh.current.scale.setScalar(screenScale);
 
         const date = timeOfDayToDate(currentTime, timeOfDay);
@@ -238,11 +279,17 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
                 .addScaledVector(forwardRef.current, FORWARD_DISTANCE)
                 .addScaledVector(
                     rightRef.current,
-                    sx * skyRadius * SUN_SCREEN_OFFSET_MULTIPLIER,
+                    sx *
+                        skyRadius *
+                        SUN_SCREEN_OFFSET_MULTIPLIER *
+                        sunTuning.horizontalOffsetMultiplier,
                 )
                 .addScaledVector(
                     viewUpRef.current,
-                    sy * skyRadius * SUN_SCREEN_OFFSET_MULTIPLIER,
+                    sy *
+                        skyRadius *
+                        SUN_SCREEN_OFFSET_MULTIPLIER *
+                        sunTuning.verticalOffsetMultiplier,
                 );
             sunMesh.current.lookAt(camera.position);
 


### PR DESCRIPTION
### Motivation
- Ensure the sun disc stays appropriately sized and positioned across viewport sizes and orientations so it doesn't appear too large or offscreen on mobile and tablet devices.

### Description
- Add viewport breakpoints `MOBILE_MAX_WIDTH` and `TABLET_MAX_WIDTH`, a `SunViewportTuning` type, and `getSunViewportTuning(viewportWidth, viewportHeight)` to compute `sizeMultiplier`, `horizontalOffsetMultiplier`, and `verticalOffsetMultiplier` per device class and orientation.
- Read the renderer `size` inside `useFrame` and apply the tuning to the sun by scaling `sunMesh.current.scale` and adjusting the right and up offset multipliers when computing the sun position.
- Keep moon rendering and material/uniform logic unchanged while only changing sun sizing and placement behavior.

### Testing
- Run `yarn test` which executed the unit test suite and reported all tests passing.
- Run a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb21d94b68832f8a7f2725939e88f6)