### PR TITLE
feat(debug): add collapsible DebugPanel and sectionsAdd collapse/expand controls DebugPanel and DebugPanelSectionusers can hide or panel contents. Introduce Icon and Up/Downicons and manage local collapsed state with use. Stop pointerevents on collapse to avoid interfering with panelhandle. Only render CardContent or children not.

### DIFF
--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -4,7 +4,6 @@ import { DebugPanel, DebugPanelSection } from '@gredice/ui/DebugControls';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Slider } from '@signalco/ui-primitives/Slider';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Typography } from '@signalco/ui-primitives/Typography';
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useWeatherNow } from '../hooks/useWeatherNow';
@@ -473,18 +472,14 @@ export function DebugHud() {
         >
             <div ref={panelWrapperRef} className="pointer-events-auto">
                 <DebugPanel
-                    title="Environment"
-                    description="Tune lighting and weather parameters for debugging."
+                    title="Env"
                     dragging={isDraggingPanel}
                     onDragHandlePointerDown={handlePanelPointerDown}
                 >
                     <Stack spacing={2}>
-                        <DebugPanelSection
-                            title="Time of day"
-                            description="Adjust the sun position across the day."
-                        >
+                        <DebugPanelSection title="Time">
                             <Slider
-                                label={`Time: ${formatTimeLabel(timeOfDay)}`}
+                                label={formatTimeLabel(timeOfDay)}
                                 min={0}
                                 max={1}
                                 step={0.01}
@@ -498,22 +493,16 @@ export function DebugHud() {
                                     }
                                 }}
                             />
-                            <Typography level="body3" secondary>
-                                Local time freeze is applied immediately.
-                            </Typography>
                         </DebugPanelSection>
-                        <DebugPanelSection
-                            title="Weather"
-                            description="Override live weather data when necessary."
-                        >
+                        <DebugPanelSection title="Weather">
                             <Checkbox
-                                label="Override live weather"
+                                label="Override"
                                 checked={overrideWeather}
                                 onCheckedChange={handleOverrideChange}
                             />
                             <Stack spacing={1} className="pt-1">
                                 <Slider
-                                    label={`Cloudiness: ${formatPercent(cloudy)}`}
+                                    label={`Cloud ${formatPercent(cloudy)}`}
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -529,7 +518,7 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Rain: ${formatPercent(rainy)}`}
+                                    label={`Rain ${formatPercent(rainy)}`}
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -545,7 +534,7 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Snow: ${formatPercent(snowy)}`}
+                                    label={`Snow ${formatPercent(snowy)}`}
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -561,7 +550,7 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Fog: ${formatPercent(foggy)}`}
+                                    label={`Fog ${formatPercent(foggy)}`}
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -577,7 +566,7 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Wind Speed: ${formatWindSpeed(windSpeed)}`}
+                                    label={`Wind ${formatWindSpeed(windSpeed)}`}
                                     min={0}
                                     max={3}
                                     step={1}
@@ -593,7 +582,7 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Wind Direction: ${formatWindDirection(windDirection)}`}
+                                    label={`Dir ${formatWindDirection(windDirection)}`}
                                     min={0}
                                     max={315}
                                     step={45}
@@ -609,7 +598,7 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Snow Accumulation: ${snowAccumulation} cm`}
+                                    label={`Accum ${snowAccumulation} cm`}
                                     min={0}
                                     max={50}
                                     step={1}

--- a/packages/ui/src/DebugControls/DebugPanel.tsx
+++ b/packages/ui/src/DebugControls/DebugPanel.tsx
@@ -1,3 +1,4 @@
+import { Down, Up } from '@signalco/ui-icons';
 import {
     Card,
     CardContent,
@@ -5,9 +6,11 @@ import {
     CardTitle,
 } from '@signalco/ui-primitives/Card';
 import { cx } from '@signalco/ui-primitives/cx';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { PointerEvent, PropsWithChildren } from 'react';
+import { useState } from 'react';
 
 interface DebugPanelProps extends PropsWithChildren {
     title: string;
@@ -25,6 +28,8 @@ export function DebugPanel({
     onDragHandlePointerDown,
     children,
 }: DebugPanelProps) {
+    const [collapsed, setCollapsed] = useState(false);
+
     return (
         <Card
             className={cx(
@@ -42,18 +47,37 @@ export function DebugPanel({
                 )}
                 onPointerDown={onDragHandlePointerDown}
             >
-                <CardTitle className="text-base font-semibold">
-                    {title}
-                </CardTitle>
+                <div className="flex items-start justify-between gap-2">
+                    <CardTitle className="text-base font-semibold">
+                        {title}
+                    </CardTitle>
+                    <IconButton
+                        type="button"
+                        size="sm"
+                        variant="plain"
+                        title={collapsed ? 'Expand' : 'Collapse'}
+                        className="size-7 shrink-0 rounded-full"
+                        onClick={() => setCollapsed((current) => !current)}
+                        onPointerDown={(event) => event.stopPropagation()}
+                    >
+                        {collapsed ? (
+                            <Down className="size-4" />
+                        ) : (
+                            <Up className="size-4" />
+                        )}
+                    </IconButton>
+                </div>
                 {description ? (
                     <Typography level="body3" secondary>
                         {description}
                     </Typography>
                 ) : null}
             </CardHeader>
-            <CardContent noHeader className="space-y-3">
-                {children}
-            </CardContent>
+            {collapsed ? null : (
+                <CardContent noHeader className="space-y-3">
+                    {children}
+                </CardContent>
+            )}
         </Card>
     );
 }
@@ -70,6 +94,8 @@ export function DebugPanelSection({
     className,
     children,
 }: DebugPanelSectionProps) {
+    const [collapsed, setCollapsed] = useState(false);
+
     return (
         <Stack
             spacing={1.5}
@@ -78,17 +104,33 @@ export function DebugPanelSection({
                 className,
             )}
         >
-            <div className="space-y-1">
-                <Typography level="body2" semiBold>
-                    {title}
-                </Typography>
-                {description ? (
-                    <Typography level="body3" secondary>
-                        {description}
+            <div className="flex items-start justify-between gap-2">
+                <div className="space-y-1">
+                    <Typography level="body2" semiBold>
+                        {title}
                     </Typography>
-                ) : null}
+                    {description ? (
+                        <Typography level="body3" secondary>
+                            {description}
+                        </Typography>
+                    ) : null}
+                </div>
+                <IconButton
+                    type="button"
+                    size="sm"
+                    variant="plain"
+                    title={collapsed ? 'Expand' : 'Collapse'}
+                    className="size-7 shrink-0 rounded-full"
+                    onClick={() => setCollapsed((current) => !current)}
+                >
+                    {collapsed ? (
+                        <Down className="size-4" />
+                    ) : (
+                        <Up className="size-4" />
+                    )}
+                </IconButton>
             </div>
-            {children}
+            {collapsed ? null : children}
         </Stack>
     );
 }


### PR DESCRIPTION
Also remove an unused Typography import from DebugHud to up ainter warning.