### PR TITLE
Add refunds policy page and merchant return policy structured data

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -9,6 +9,7 @@ import { Chip } from '@signalco/ui-primitives/Chip';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { PageHeader } from '../../../components/shared/PageHeader';
@@ -167,6 +168,13 @@ export function PlantPageHeader({
                         }}
                         className="self-end group-hover:opacity-100 opacity-0 transition-opacity"
                     />
+                    <Typography level="body2" secondary>
+                        Nisi zadovoljan uslugom ili proizvodom? Pogledaj{' '}
+                        <Link className="underline" href={KnownPages.Refunds}>
+                            30-dnevnu politiku povrata novca
+                        </Link>
+                        .
+                    </Typography>
                 </Stack>
             </Stack>
         </PageHeader>

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -12,6 +12,7 @@ import { StructuredDataScript } from '../../../components/shared/seo/StructuredD
 import { getPlantsData } from '../../../lib/plants/getPlantsData';
 import { getRecipesData } from '../../../lib/recipes/getRecipesData';
 import { KnownPages } from '../../../src/KnownPages';
+import { merchantReturnPolicy } from '../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
 import { recipesFlag } from '../../flags';
 import { GrowthAttributeCards } from './GrowthAttributeCards';
@@ -118,6 +119,7 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                                           ? 'https://schema.org/OutOfStock'
                                           : 'https://schema.org/InStock',
                                   url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
+                                  hasMerchantReturnPolicy: merchantReturnPolicy,
                               }
                             : undefined,
                 }}

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -10,6 +10,7 @@ import { StructuredDataScript } from '../../../../../components/shared/seo/Struc
 import { getPlantSortsData } from '../../../../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../../../../lib/plants/getPlantsData';
 import { KnownPages } from '../../../../../src/KnownPages';
+import { merchantReturnPolicy } from '../../../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../../../src/pageAliases';
 import { GrowthAttributeCards } from '../../GrowthAttributeCards';
 import { getPlantInforationSections } from '../../getPlantInforationSections';
@@ -197,6 +198,7 @@ export default async function PlantSortPage(
                                           ? 'https://schema.org/OutOfStock'
                                           : 'https://schema.org/InStock',
                                   url: `https://www.gredice.com${KnownPages.PlantSort(alias, sortData.information.name)}`,
+                                  hasMerchantReturnPolicy: merchantReturnPolicy,
                               }
                             : undefined,
                 }}

--- a/apps/www/app/biljke/page.tsx
+++ b/apps/www/app/biljke/page.tsx
@@ -19,6 +19,7 @@ import { PageHeader } from '../../components/shared/PageHeader';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { KnownPages } from '../../src/KnownPages';
+import { merchantReturnPolicy } from '../../src/merchantReturnPolicy';
 import { PlantsCalendar } from './PlantsCalendar';
 import { PlantsGallery } from './PlantsGallery';
 import { PlantsSeedTimeFilterToggle } from './PlantsSeedTimeFilterToggle';
@@ -69,6 +70,8 @@ export default async function PlantsPage({
                                                   2,
                                               ),
                                               priceCurrency: 'EUR',
+                                              hasMerchantReturnPolicy:
+                                                  merchantReturnPolicy,
                                           }
                                         : undefined,
                             },

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -8,12 +8,14 @@ import { Container } from '@signalco/ui-primitives/Container';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { formatPrice } from '../../lib/formatPrice';
 import { getHqLocationsData } from '../../lib/getHqLocationsData';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { KnownPages } from '../../src/KnownPages';
 
 export const metadata: Metadata = {
     title: 'Cjenik',
@@ -52,7 +54,7 @@ export default async function PricingPage() {
                 <PageHeader
                     padded
                     header="💶 Cjenik"
-                    subHeader="Sve cijene na jednom mjestu: biljke, radnje i dostava"
+                    subHeader="Sve cijene na jednom mjestu: biljke, sorte, radnje i dostava"
                 />
 
                 <Card>
@@ -92,6 +94,16 @@ export default async function PricingPage() {
                                 </tbody>
                             </table>
                         </div>
+                        <Typography level="body2" secondary className="mt-3">
+                            Za biljke i sorte vrijedi{' '}
+                            <Link
+                                className="underline"
+                                href={KnownPages.Refunds}
+                            >
+                                30-dnevna politika povrata novca
+                            </Link>
+                            .
+                        </Typography>
                     </CardContent>
                 </Card>
 
@@ -133,6 +145,16 @@ export default async function PricingPage() {
                                 </tbody>
                             </table>
                         </div>
+                        <Typography level="body2" secondary className="mt-3">
+                            Za radnje vrijedi{' '}
+                            <Link
+                                className="underline"
+                                href={KnownPages.Refunds}
+                            >
+                                30-dnevna politika povrata novca
+                            </Link>
+                            .
+                        </Typography>
                     </CardContent>
                 </Card>
 

--- a/apps/www/app/povrati-i-povrat-novca/page.tsx
+++ b/apps/www/app/povrati-i-povrat-novca/page.tsx
@@ -1,0 +1,115 @@
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { PageHeader } from '../../components/shared/PageHeader';
+import { KnownPages } from '../../src/KnownPages';
+
+export const metadata: Metadata = {
+    title: 'Povrat novca',
+    description:
+        'Informacije o 30-dnevnoj politici povrata novca za biljke, sorte i radnje na tržištu Hrvatske.',
+};
+
+export default function RefundsPage() {
+    return (
+        <Stack spacing={3} className="py-8">
+            <PageHeader
+                header="Povrat novca"
+                subHeader="Ako nisi zadovoljan uslugom ili proizvodom, možeš zatražiti povrat novca u roku od 30 dana."
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Naša politika</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={1}>
+                        <Typography>
+                            Za biljke, sorte i radnje nudimo{' '}
+                            <strong>30 dana</strong> za zahtjev povrata novca od
+                            trenutka kupovine.
+                        </Typography>
+                        <Typography>
+                            Kako se radi o uslugama i digitalno vođenim
+                            procesima, klasičan fizički povrat robe nije
+                            primjenjiv. Umjesto povrata robe, odobravamo:
+                        </Typography>
+                        <ul className="list-disc pl-6">
+                            <li>
+                                <Typography>puni povrat novca, ili</Typography>
+                            </li>
+                            <li>
+                                <Typography>
+                                    kredit na korisničkom računu (store credit),
+                                    prema dogovoru sa podrškom.
+                                </Typography>
+                            </li>
+                        </ul>
+                    </Stack>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Kako zatražiti povrat</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={1}>
+                        <Typography>
+                            Javi se našoj podršci i opiši razlog nezadovoljstva.
+                            Nakon provjere zahtjeva predložit ćemo puni povrat
+                            novca ili kredit.
+                        </Typography>
+                        <Typography>
+                            Kontakt stranicu možeš otvoriti ovdje:{' '}
+                            <Link
+                                className="underline"
+                                href={KnownPages.Contact}
+                            >
+                                Kontakt
+                            </Link>
+                            .
+                        </Typography>
+                    </Stack>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Važno</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={1}>
+                        <Typography>
+                            Trenutno je ova politika dostupna samo za narudžbe
+                            na tržištu Hrvatske (HR).
+                        </Typography>
+                        <Typography>
+                            Za ovu vrstu ponude nema povratne dostave niti
+                            return feed procesa.
+                        </Typography>
+                        <Typography>
+                            Povrat je moguć isključivo kroz korisničku podršku i
+                            odobrenje povrata novca/kredita.
+                        </Typography>
+                    </Stack>
+                </CardContent>
+            </Card>
+
+            <Typography level="body2" secondary>
+                Cijene i povezane informacije možeš provjeriti na stranici{' '}
+                <Link className="underline" href={KnownPages.Pricing}>
+                    Cjenik
+                </Link>
+                .
+            </Typography>
+        </Stack>
+    );
+}

--- a/apps/www/app/povrati-i-povrat-novca/page.tsx
+++ b/apps/www/app/povrati-i-povrat-novca/page.tsx
@@ -1,13 +1,7 @@
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from '@signalco/ui-primitives/Card';
+import { StyledHtml } from '@gredice/ui/StyledHtml';
+import { Container } from '@signalco/ui-primitives/Container';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { KnownPages } from '../../src/KnownPages';
 
@@ -19,97 +13,59 @@ export const metadata: Metadata = {
 
 export default function RefundsPage() {
     return (
-        <Stack spacing={3} className="py-8">
-            <PageHeader
-                header="Povrat novca"
-                subHeader="Ako nisi zadovoljan uslugom ili proizvodom, možeš zatražiti povrat novca u roku od 30 dana."
-            />
-
-            <Card>
-                <CardHeader>
-                    <CardTitle>Naša politika</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={1}>
-                        <Typography>
-                            Za biljke, sorte i radnje nudimo{' '}
-                            <strong>30 dana</strong> za zahtjev povrata novca od
-                            trenutka kupovine.
-                        </Typography>
-                        <Typography>
-                            Kako se radi o uslugama i digitalno vođenim
-                            procesima, klasičan fizički povrat robe nije
-                            primjenjiv. Umjesto povrata robe, odobravamo:
-                        </Typography>
-                        <ul className="list-disc pl-6">
-                            <li>
-                                <Typography>puni povrat novca, ili</Typography>
-                            </li>
-                            <li>
-                                <Typography>
-                                    kredit na korisničkom računu (store credit),
-                                    prema dogovoru sa podrškom.
-                                </Typography>
-                            </li>
-                        </ul>
-                    </Stack>
-                </CardContent>
-            </Card>
-
-            <Card>
-                <CardHeader>
-                    <CardTitle>Kako zatražiti povrat</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={1}>
-                        <Typography>
-                            Javi se našoj podršci i opiši razlog nezadovoljstva.
-                            Nakon provjere zahtjeva predložit ćemo puni povrat
-                            novca ili kredit.
-                        </Typography>
-                        <Typography>
-                            Kontakt stranicu možeš otvoriti ovdje:{' '}
-                            <Link
-                                className="underline"
-                                href={KnownPages.Contact}
-                            >
-                                Kontakt
-                            </Link>
-                            .
-                        </Typography>
-                    </Stack>
-                </CardContent>
-            </Card>
-
-            <Card>
-                <CardHeader>
-                    <CardTitle>Važno</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={1}>
-                        <Typography>
-                            Trenutno je ova politika dostupna samo za narudžbe
-                            na tržištu Hrvatske (HR).
-                        </Typography>
-                        <Typography>
-                            Za ovu vrstu ponude nema povratne dostave niti
-                            return feed procesa.
-                        </Typography>
-                        <Typography>
-                            Povrat je moguć isključivo kroz korisničku podršku i
-                            odobrenje povrata novca/kredita.
-                        </Typography>
-                    </Stack>
-                </CardContent>
-            </Card>
-
-            <Typography level="body2" secondary>
-                Cijene i povezane informacije možeš provjeriti na stranici{' '}
-                <Link className="underline" href={KnownPages.Pricing}>
-                    Cjenik
-                </Link>
-                .
-            </Typography>
-        </Stack>
+        <Container maxWidth="md">
+            <Stack>
+                <PageHeader
+                    padded
+                    header="Povrat novca"
+                    subHeader="Ako nisi zadovoljan uslugom ili proizvodom, možeš zatražiti povrat novca u roku od 30 dana."
+                />
+                <StyledHtml>
+                    <h2>Naša politika</h2>
+                    <p>
+                        Reklamacije su moguće za biljke i radnje unutar{' '}
+                        <strong>30 dana</strong> od trenutka kupovine.
+                    </p>
+                    <p>
+                        Kako se radi o uslugama i digitalno vođenim procesima,
+                        klasičan fizički povrat robe nije primjenjiv. Umjesto
+                        povrata robe, odobravamo:
+                    </p>
+                    <ul>
+                        <li>puni povrat novca, ili</li>
+                        <li>
+                            kredit u obliku suncokreta na korisničkom računu,
+                            prema dogovoru sa podrškom.
+                        </li>
+                    </ul>
+                    <h2>Kako zatražiti povrat</h2>
+                    <p>
+                        Javi se našoj podršci i opiši razlog nezadovoljstva.
+                        Nakon provjere zahtjeva predložit ćemo puni povrat novca
+                        ili suncokreta.
+                    </p>
+                    <p>
+                        Kontakt stranicu možeš otvoriti ovdje:{' '}
+                        <a href={KnownPages.Contact}>Kontakt</a>.
+                    </p>
+                    <h2>Važno</h2>
+                    <p>
+                        Trenutno je ova politika dostupna samo za narudžbe na
+                        tržištu Hrvatske (HR).
+                    </p>
+                    <p>
+                        Povrat je moguć isključivo kroz korisničku podršku i
+                        odobrenje povrata novca/suncokreta.
+                    </p>
+                    <hr />
+                    <p>
+                        <small>
+                            Cijene i povezane informacije možeš provjeriti na
+                            stranici <a href={KnownPages.Pricing}>Cjenik</a>.
+                        </small>
+                    </p>
+                </StyledHtml>
+            </Stack>
+        </Container>
     );
 }

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -7,6 +7,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
@@ -14,6 +15,7 @@ import { PageHeader } from '../../../components/shared/PageHeader';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
 import { getOperationsData } from '../../../lib/plants/getOperationsData';
 import { KnownPages } from '../../../src/KnownPages';
+import { merchantReturnPolicy } from '../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
 import { OperationApplicationsList } from './OperationApplicationsList';
 import { OperationAttributesCards } from './OperationAttributesCards';
@@ -86,6 +88,7 @@ export default async function OperationPage(
                         priceCurrency: 'EUR',
                         availability: 'https://schema.org/InStock',
                         url: `https://www.gredice.com${KnownPages.Operation(operation.information.label)}`,
+                        hasMerchantReturnPolicy: merchantReturnPolicy,
                     },
                 }}
             />
@@ -121,6 +124,16 @@ export default async function OperationPage(
                                 }}
                                 className="self-end group-hover:opacity-100 opacity-0 transition-opacity"
                             />
+                            <Typography level="body2" secondary>
+                                Nisi zadovoljan uslugom? Dostupan je{' '}
+                                <Link
+                                    className="underline"
+                                    href={KnownPages.Refunds}
+                                >
+                                    povrat novca do 30 dana
+                                </Link>
+                                .
+                            </Typography>
                         </Stack>
                         <Typography level="h5" component="h2" gutterBottom>
                             Svojstva

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -23,6 +23,7 @@ import { NoDataPlaceholder } from '../../components/shared/placeholders/NoDataPl
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
 import { KnownPages } from '../../src/KnownPages';
+import { merchantReturnPolicy } from '../../src/merchantReturnPolicy';
 import { OperationCard } from './OperationCard';
 
 const stageIcons: Record<
@@ -114,6 +115,8 @@ export default async function OperationsPage({
                                         2,
                                     ),
                                     priceCurrency: 'EUR',
+                                    hasMerchantReturnPolicy:
+                                        merchantReturnPolicy,
                                 },
                             },
                         }),

--- a/apps/www/src/KnownPages.ts
+++ b/apps/www/src/KnownPages.ts
@@ -28,6 +28,7 @@ export const KnownPages = {
     FAQ: '/cesta-pitanja',
     Contact: '/kontakt',
     Pricing: '/cjenik',
+    Refunds: '/povrati-i-povrat-novca',
 
     LegalPrivacy: '/legalno/politika-privatnosti',
     LegalTerms: '/legalno/uvjeti-koristenja',

--- a/apps/www/src/merchantReturnPolicy.ts
+++ b/apps/www/src/merchantReturnPolicy.ts
@@ -5,5 +5,8 @@ export const merchantReturnPolicy = {
     merchantReturnDays: 30,
     returnMethod: 'https://schema.org/KeepProduct',
     returnFees: 'https://schema.org/FreeReturn',
-    refundType: 'https://schema.org/FullRefund',
+    refundType: [
+        'https://schema.org/FullRefund',
+        'https://schema.org/StoreCreditRefund',
+    ],
 } as const;

--- a/apps/www/src/merchantReturnPolicy.ts
+++ b/apps/www/src/merchantReturnPolicy.ts
@@ -1,0 +1,9 @@
+export const merchantReturnPolicy = {
+    '@type': 'MerchantReturnPolicy',
+    applicableCountry: 'HR',
+    returnPolicyCategory: 'https://schema.org/MerchantReturnFiniteReturnWindow',
+    merchantReturnDays: 30,
+    returnMethod: 'https://schema.org/KeepProduct',
+    returnFees: 'https://schema.org/FreeReturn',
+    refundType: 'https://schema.org/FullRefund',
+} as const;

--- a/packages/ui/src/StyledHtml/StyledHtml.tsx
+++ b/packages/ui/src/StyledHtml/StyledHtml.tsx
@@ -14,6 +14,7 @@ export function StyledHtml({
                 'prose prose-p:my-2 prose-sm prose-headings:font-normal prose-hr:my-6',
                 'text-primary prose-headings:text-primary',
                 'prose-a:text-primary',
+                'prose-hr:border-border',
                 className,
             )}
             {...rest}


### PR DESCRIPTION
### Motivation
- Expose and document a 30-day refund policy for plants, sorts and operations on the Croatian market and make it discoverable from pricing and product pages. 
- Surface the refund policy in JSON‑LD offers so search engines can consume merchant return information for listed products and services.

### Description
- Added a new public refunds page at `apps/www/app/povrati-i-povrat-novca/page.tsx` describing the 30‑day refund process, HR scope, support-driven refunds (full refund or store credit), and that there is no physical return shipping flow. 
- Introduced a reusable `merchantReturnPolicy` object at `apps/www/src/merchantReturnPolicy.ts` and attached it to `hasMerchantReturnPolicy` in Offer JSON‑LD on plants list/detail, plant sort detail and operations list/detail pages. 
- Added `KnownPages.Refunds` route and linked the refunds page from the pricing page and from plant/sort/operation info sections, and updated pricing copy to mention sorts and the refund policy. 

### Testing
- Ran `pnpm lint --filter www` which completed successfully; one pre‑existing TypeScript/biome warning remains in `PlantGrowthViewer.tsx` for an explicit `any` and was not introduced by this change. 
- Verified modified pages build locations and JSON‑LD injection points manually by inspecting the updated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb369ae16c832f832808834abd90e5)