### PR TITLE
Include draft entities in ref selector

### DIFF
--- a/apps/app/components/shared/attributes/actions/entitiesActions.ts
+++ b/apps/app/components/shared/attributes/actions/entitiesActions.ts
@@ -1,10 +1,26 @@
 'use server';
 
+import { getEntitiesRaw } from '@gredice/storage';
 import {
-    type EntityStandardized,
-    getEntitiesFormatted,
-} from '@gredice/storage';
+    entityAttributeValue,
+    entityDisplayName,
+} from '../../../../src/entities/entityAttributes';
 
 export async function getEntities(entityTypeName: string) {
-    return await getEntitiesFormatted<EntityStandardized>(entityTypeName);
+    const entities = await getEntitiesRaw(entityTypeName);
+    return entities.flatMap((entity) => {
+        const name = entityAttributeValue(entity, 'information', 'name');
+        if (!name) {
+            return [];
+        }
+
+        return [
+            {
+                id: entity.id,
+                name,
+                label: entityDisplayName(entity),
+                state: entity.state,
+            },
+        ];
+    });
 }

--- a/apps/app/components/shared/attributes/actions/entitiesActions.ts
+++ b/apps/app/components/shared/attributes/actions/entitiesActions.ts
@@ -1,26 +1,42 @@
 'use server';
 
-import { getEntitiesRaw } from '@gredice/storage';
+import { getEntitiesFormatted, getEntitiesRaw } from '@gredice/storage';
+import { unstable_cache } from 'next/cache';
+import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
 import {
     entityAttributeValue,
     entityDisplayName,
 } from '../../../../src/entities/entityAttributes';
 
 export async function getEntities(entityTypeName: string) {
-    const entities = await getEntitiesRaw(entityTypeName);
-    return entities.flatMap((entity) => {
-        const name = entityAttributeValue(entity, 'information', 'name');
-        if (!name) {
-            return [];
-        }
+    return getEntitiesFormatted<EntityStandardized>(entityTypeName);
+}
 
-        return [
-            {
-                id: entity.id,
-                name,
-                label: entityDisplayName(entity),
-                state: entity.state,
-            },
-        ];
-    });
+const getRefEntitiesCached = unstable_cache(
+    async (entityTypeName: string) => {
+        const entities = await getEntitiesRaw(entityTypeName);
+        return entities.flatMap((entity) => {
+            const name = entityAttributeValue(entity, 'information', 'name');
+            if (!name) {
+                return [];
+            }
+
+            return [
+                {
+                    id: entity.id,
+                    name,
+                    label: entityDisplayName(entity),
+                    state: entity.state,
+                },
+            ];
+        });
+    },
+    ['ref-entities'],
+    {
+        revalidate: 60 * 60,
+    },
+);
+
+export async function getRefEntities(entityTypeName: string) {
+    return getRefEntitiesCached(entityTypeName);
 }

--- a/apps/app/components/shared/attributes/actions/entitiesActions.ts
+++ b/apps/app/components/shared/attributes/actions/entitiesActions.ts
@@ -12,31 +12,33 @@ export async function getEntities(entityTypeName: string) {
     return getEntitiesFormatted<EntityStandardized>(entityTypeName);
 }
 
-const getRefEntitiesCached = unstable_cache(
-    async (entityTypeName: string) => {
-        const entities = await getEntitiesRaw(entityTypeName);
-        return entities.flatMap((entity) => {
-            const name = entityAttributeValue(entity, 'information', 'name');
-            if (!name) {
-                return [];
-            }
-
-            return [
-                {
-                    id: entity.id,
-                    name,
-                    label: entityDisplayName(entity),
-                    state: entity.state,
-                },
-            ];
-        });
-    },
-    ['ref-entities'],
-    {
-        revalidate: 60 * 60,
-    },
-);
-
 export async function getRefEntities(entityTypeName: string) {
-    return getRefEntitiesCached(entityTypeName);
+    return unstable_cache(
+        async () => {
+            const entities = await getEntitiesRaw(entityTypeName);
+            return entities.flatMap((entity) => {
+                const name = entityAttributeValue(
+                    entity,
+                    'information',
+                    'name',
+                );
+                if (!name) {
+                    return [];
+                }
+
+                return [
+                    {
+                        id: entity.id,
+                        name,
+                        label: entityDisplayName(entity),
+                        state: entity.state,
+                    },
+                ];
+            });
+        },
+        ['ref-entities', entityTypeName],
+        {
+            revalidate: 60 * 60,
+        },
+    )();
 }

--- a/apps/app/components/shared/attributes/typed/SelectEntity.tsx
+++ b/apps/app/components/shared/attributes/typed/SelectEntity.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { KnownPages } from '../../../../src/KnownPages';
 import type { AttributeInputProps } from '../AttributeInputProps';
-import { getEntities } from '../actions/entitiesActions';
+import { getRefEntities } from '../actions/entitiesActions';
 
 export function SelectEntity({
     value,
@@ -14,14 +14,14 @@ export function SelectEntity({
 }: AttributeInputProps) {
     const entityTypeName = attributeDefinition?.dataType.split(':')[1];
     const [entities, setEntities] =
-        useState<Awaited<ReturnType<typeof getEntities>>>();
+        useState<Awaited<ReturnType<typeof getRefEntities>>>();
 
     useEffect(() => {
         if (!entityTypeName) {
             return;
         }
 
-        getEntities(entityTypeName)
+        getRefEntities(entityTypeName)
             .then((response) => {
                 setEntities(response);
             })

--- a/apps/app/components/shared/attributes/typed/SelectEntity.tsx
+++ b/apps/app/components/shared/attributes/typed/SelectEntity.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from '@signalco/ui-icons';
+import { Chip } from '@signalco/ui-primitives/Chip';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
@@ -29,21 +30,15 @@ export function SelectEntity({
             });
     }, [entityTypeName]);
 
-    const selectableEntities = useMemo(
-        () =>
-            entities?.flatMap((entity) => {
-                const name = entity.information?.name;
-                return name ? [{ entity, name }] : [];
-            }) ?? [],
-        [entities],
-    );
-
     const items = [
         { value: '-', label: '-' },
-        ...selectableEntities.map(({ entity, name }) => ({
-            value: name,
-            label: entity.information?.label ?? name,
-        })),
+        ...(entities?.map((entity) => ({
+            value: entity.name,
+            label:
+                entity.state === 'draft'
+                    ? `${entity.label} (Draft)`
+                    : entity.label,
+        })) ?? []),
     ];
 
     const selectedEntity = useMemo(() => {
@@ -51,11 +46,8 @@ export function SelectEntity({
             return null;
         }
 
-        return (
-            selectableEntities.find(({ name }) => name === value)?.entity ??
-            null
-        );
-    }, [selectableEntities, value]);
+        return entities?.find((entity) => entity.name === value) ?? null;
+    }, [entities, value]);
 
     const handleOnChange = (newValue: string) => {
         onChange(newValue !== '-' ? newValue : null);
@@ -66,10 +58,15 @@ export function SelectEntity({
             <div className="flex-1">
                 <SelectItems
                     items={items}
-                    value={selectedEntity?.information?.name ?? '-'}
+                    value={selectedEntity?.name ?? '-'}
                     onValueChange={handleOnChange}
                 />
             </div>
+            {selectedEntity?.state === 'draft' ? (
+                <Chip color="neutral" className="w-fit">
+                    Draft
+                </Chip>
+            ) : null}
             {entityTypeName && selectedEntity && (
                 <Link
                     href={KnownPages.DirectoryEntity(


### PR DESCRIPTION
### Motivation

- Ref-attribute selectors currently only showed published entities, making it impossible to reference draft records from the editor; drafts should be selectable and clearly indicated.
- The selected reference should also display a visible badge when it points to a draft so editors can immediately see the state of the linked entity.

### Description

- Update server action `getEntities` to use `getEntitiesRaw` (no state filter) and normalize results to `{ id, name, label, state }` so both published and draft entities are returned (`apps/app/components/shared/attributes/actions/entitiesActions.ts`).
- Update the client ref selector to consume the normalized payload, show draft options with `(Draft)` appended in the dropdown, and set the SelectItems `value` to the normalized `name` field (`apps/app/components/shared/attributes/typed/SelectEntity.tsx`).
- Add a visible `Draft` `Chip` next to the selector when the currently selected ref entity is in `draft` state and import the `Chip` primitive for that purpose (`apps/app/components/shared/attributes/typed/SelectEntity.tsx`).

### Testing

- Ran targeted Biome type/linters with `pnpm --dir apps/app exec biome check components/shared/attributes/actions/entitiesActions.ts components/shared/attributes/typed/SelectEntity.tsx` which completed with no fixes required.
- Ran workspace lint `pnpm --dir apps/app lint` which executed `biome check --write` and completed; it emitted one unrelated warning about a suppression placeholder but did not block changes.
- The modified files were verified by the targeted checks after reverting unrelated auto-fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec81761fc4832f87aec78768ef1002)