### PR TITLE
Fix inventory entity select empty option value

### DIFF
--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -17,6 +17,8 @@ import { redirect } from 'next/navigation';
 import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
 
+const noEntityValue = 'none';
+
 function parseQuantity(raw: string | null): number {
     if (!raw) return 1;
     const parsed = Number.parseInt(raw, 10);
@@ -168,7 +170,10 @@ export async function createInventoryItemAction(
     await auth(['admin']);
 
     const entityIdRaw = formData.get('entityId') as string;
-    const entityId = entityIdRaw ? parseInt(entityIdRaw, 10) : undefined;
+    const entityId =
+        entityIdRaw && entityIdRaw !== noEntityValue
+            ? parseInt(entityIdRaw, 10)
+            : undefined;
     const trackingType = (formData.get('trackingType') as string) || 'pieces';
     const serialNumber = (formData.get('serialNumber') as string) || null;
     const quantity = parseQuantity(formData.get('quantity') as string);
@@ -211,7 +216,10 @@ export async function updateInventoryItemAction(
     }
 
     const entityIdRaw = formData.get('entityId') as string;
-    const entityId = entityIdRaw ? parseInt(entityIdRaw, 10) : undefined;
+    const entityId =
+        entityIdRaw && entityIdRaw !== noEntityValue
+            ? parseInt(entityIdRaw, 10)
+            : undefined;
     const trackingType = (formData.get('trackingType') as string) || 'pieces';
     const serialNumber = (formData.get('serialNumber') as string) || null;
     const quantity = parseQuantity(formData.get('quantity') as string);

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -12,6 +12,7 @@ import { KnownPages } from '../../../../../../src/KnownPages';
 import { updateInventoryItemAction } from '../../../../../(actions)/inventoryActions';
 
 export const dynamic = 'force-dynamic';
+const noEntityValue = 'none';
 
 export default async function InventoryItemPage({
     params,
@@ -32,7 +33,7 @@ export default async function InventoryItemPage({
     const config = item.inventoryConfig;
     const entities = await getEntitiesRaw(config.entityTypeName, 'published');
     const entityItems = [
-        { value: '', label: '- Bez entiteta -' },
+        { value: noEntityValue, label: '- Bez entiteta -' },
         ...entities.map((entity) => {
             const nameAttr = entity.attributes.find(
                 (a) =>
@@ -82,7 +83,8 @@ export default async function InventoryItemPage({
                                     label="Entitet (opcionalno)"
                                     items={entityItems}
                                     defaultValue={
-                                        item.entityId?.toString() ?? ''
+                                        item.entityId?.toString() ??
+                                        noEntityValue
                                     }
                                 />
                                 <SelectItems

--- a/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
@@ -12,6 +12,7 @@ import { KnownPages } from '../../../../../../src/KnownPages';
 import { createInventoryItemAction } from '../../../../../(actions)/inventoryActions';
 
 export const dynamic = 'force-dynamic';
+const noEntityValue = 'none';
 
 export default async function CreateInventoryItemPage({
     params,
@@ -30,7 +31,7 @@ export default async function CreateInventoryItemPage({
 
     const entities = await getEntitiesRaw(config.entityTypeName, 'published');
     const entityItems = [
-        { value: '', label: '- Bez entiteta -' },
+        { value: noEntityValue, label: '- Bez entiteta -' },
         ...entities.map((entity) => {
             const nameAttr = entity.attributes.find(
                 (a) =>
@@ -78,7 +79,7 @@ export default async function CreateInventoryItemPage({
                                     name="entityId"
                                     label="Entitet (opcionalno)"
                                     items={entityItems}
-                                    defaultValue=""
+                                    defaultValue={noEntityValue}
                                     helperText="Odaberite entitet koji je predložak za ovu stavku"
                                 />
                                 <SelectItems


### PR DESCRIPTION
### Motivation
- Radix `Select` components reject empty-string option values, which caused a runtime error for the optional "no entity" option in the admin inventory item create/edit forms.

### Description
- Introduced a sentinel `noEntityValue = 'none'` and replaced the empty-string option for the "- Bez entiteta -" choice with this sentinel in the create and edit pages (`apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx` and `apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx`).
- Updated the create page `defaultValue` to use the sentinel and the edit page `defaultValue` to fall back to the sentinel when `item.entityId` is not set.
- Updated server actions (`apps/app/app/(actions)/inventoryActions.ts`) to treat the sentinel value as no selection by parsing `entityId` to `undefined` when `entityIdRaw === noEntityValue`.

### Testing
- Ran `pnpm --dir apps/app exec biome check "app/admin/inventory/[inventoryId]/items/create/page.tsx" "app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx" "app/(actions)/inventoryActions.ts"` and the check completed with no fixes or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca7489ef4832f9d9cc58a62ce7351)