### PR TITLE
Fix inventory edit SelectItems empty-value runtime error

### DIFF
--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -18,6 +18,7 @@ import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
 
 const noEntityValue = 'none';
+const noAttributeValue = 'none';
 
 function parseQuantity(raw: string | null): number {
     if (!raw) return 1;
@@ -64,12 +65,22 @@ export async function createInventoryConfigAction(formData: FormData) {
     const label = formData.get('label') as string;
     const defaultTrackingType =
         (formData.get('defaultTrackingType') as string) || 'pieces';
+    const statusAttributeNameRaw = formData.get('statusAttributeName') as
+        | string
+        | null;
     const statusAttributeName =
-        (formData.get('statusAttributeName') as string) || null;
+        statusAttributeNameRaw && statusAttributeNameRaw !== noAttributeValue
+            ? statusAttributeNameRaw
+            : null;
     const emptyStatusValue =
         (formData.get('emptyStatusValue') as string) || null;
+    const amountAttributeNameRaw = formData.get('amountAttributeName') as
+        | string
+        | null;
     const amountAttributeName =
-        (formData.get('amountAttributeName') as string) || null;
+        amountAttributeNameRaw && amountAttributeNameRaw !== noAttributeValue
+            ? amountAttributeNameRaw
+            : null;
 
     const id = await createInventoryConfig({
         entityTypeName,
@@ -93,12 +104,22 @@ export async function updateInventoryConfigAction(
     const label = formData.get('label') as string;
     const defaultTrackingType =
         (formData.get('defaultTrackingType') as string) || 'pieces';
+    const statusAttributeNameRaw = formData.get('statusAttributeName') as
+        | string
+        | null;
     const statusAttributeName =
-        (formData.get('statusAttributeName') as string) || null;
+        statusAttributeNameRaw && statusAttributeNameRaw !== noAttributeValue
+            ? statusAttributeNameRaw
+            : null;
     const emptyStatusValue =
         (formData.get('emptyStatusValue') as string) || null;
+    const amountAttributeNameRaw = formData.get('amountAttributeName') as
+        | string
+        | null;
     const amountAttributeName =
-        (formData.get('amountAttributeName') as string) || null;
+        amountAttributeNameRaw && amountAttributeNameRaw !== noAttributeValue
+            ? amountAttributeNameRaw
+            : null;
 
     await updateInventoryConfig({
         id,

--- a/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
@@ -19,6 +19,7 @@ import { AddFieldDefinitionForm } from './AddFieldDefinitionForm';
 import { DeleteFieldDefinitionButton } from './DeleteFieldDefinitionButton';
 
 export const dynamic = 'force-dynamic';
+const noAttributeValue = 'none';
 
 export default async function EditInventoryConfigPage({
     params,
@@ -39,7 +40,7 @@ export default async function EditInventoryConfigPage({
         config.entityTypeName,
     );
     const attributeItems = [
-        { value: '', label: '- Nije odabrano -' },
+        { value: noAttributeValue, label: '- Nije odabrano -' },
         ...attributeDefinitions.map((attr) => ({
             value: attr.name,
             label: attr.label,
@@ -101,7 +102,8 @@ export default async function EditInventoryConfigPage({
                                     label="Atribut statusa (opcionalno)"
                                     items={attributeItems}
                                     defaultValue={
-                                        config.statusAttributeName ?? ''
+                                        config.statusAttributeName ??
+                                        noAttributeValue
                                     }
                                     helperText="Atribut entiteta koji definira status stavke"
                                 />
@@ -116,7 +118,8 @@ export default async function EditInventoryConfigPage({
                                     label="Atribut količine (opcionalno)"
                                     items={attributeItems}
                                     defaultValue={
-                                        config.amountAttributeName ?? ''
+                                        config.amountAttributeName ??
+                                        noAttributeValue
                                     }
                                     helperText="Atribut entiteta koji doprinosi izračunu ukupne količine"
                                 />


### PR DESCRIPTION
### Motivation
- The admin inventory edit form rendered a `<Select.Item />` with an empty-string value which causes Radix/Select runtime errors when the select is mounted with a placeholder option.
- The intent is to preserve the optional attribute semantics while avoiding empty-string values in `SelectItems` components.

### Description
- Introduced a non-empty sentinel `noAttributeValue = 'none'` and replaced the placeholder option value from `''` to the sentinel in `apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx`.
- Updated default select values on the edit page to use the sentinel when no attribute is configured instead of an empty string.
- Updated server actions in `apps/app/app/(actions)/inventoryActions.ts` to treat the sentinel as `null`/`undefined` by normalizing `statusAttributeName` and `amountAttributeName` on create and update flows.

### Testing
- Ran the workspace linter with `pnpm --dir apps/app lint 'app/(actions)/inventoryActions.ts' 'app/admin/inventory/[inventoryId]/edit/page.tsx'` which checked the modified files and reported no fixes applied (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecae4bf3fc832fa79f5272ddb6a5eb)