### PR TITLE
Hide serial number inputs for non-serial inventory configs

### DIFF
--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -188,7 +188,10 @@ export async function createInventoryItemAction(
         inventoryConfigId,
         entityId,
         trackingType,
-        serialNumber: serialNumber || undefined,
+        serialNumber:
+            trackingType === 'serialNumber'
+                ? (serialNumber ?? undefined)
+                : undefined,
         quantity,
         notes: notes || undefined,
         additionalFields,
@@ -234,7 +237,10 @@ export async function updateInventoryItemAction(
         id: itemId,
         entityId,
         trackingType,
-        serialNumber: serialNumber || undefined,
+        serialNumber:
+            trackingType === 'serialNumber'
+                ? (serialNumber ?? undefined)
+                : undefined,
         quantity,
         notes: notes || undefined,
         additionalFields,

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -49,6 +49,28 @@ export default async function InventoryItemPage({
     ];
 
     const additionalFields = item.additionalFields ?? {};
+    const trackingTypeItems =
+        config.defaultTrackingType === 'serialNumber'
+            ? [
+                  {
+                      value: 'pieces',
+                      label: 'Komadi',
+                  },
+                  {
+                      value: 'serialNumber',
+                      label: 'Serijski broj',
+                  },
+              ]
+            : [
+                  {
+                      value: 'pieces',
+                      label: 'Komadi',
+                  },
+              ];
+    const trackingTypeDefault =
+        config.defaultTrackingType === 'serialNumber'
+            ? item.trackingType
+            : 'pieces';
 
     const updateItemBound = updateInventoryItemAction.bind(
         null,
@@ -90,23 +112,17 @@ export default async function InventoryItemPage({
                                 <SelectItems
                                     name="trackingType"
                                     label="Način praćenja"
-                                    items={[
-                                        {
-                                            value: 'pieces',
-                                            label: 'Komadi',
-                                        },
-                                        {
-                                            value: 'serialNumber',
-                                            label: 'Serijski broj',
-                                        },
-                                    ]}
-                                    defaultValue={item.trackingType}
+                                    items={trackingTypeItems}
+                                    defaultValue={trackingTypeDefault}
                                 />
-                                <Input
-                                    name="serialNumber"
-                                    label="Serijski broj (opcionalno)"
-                                    defaultValue={item.serialNumber ?? ''}
-                                />
+                                {config.defaultTrackingType ===
+                                    'serialNumber' && (
+                                    <Input
+                                        name="serialNumber"
+                                        label="Serijski broj (opcionalno)"
+                                        defaultValue={item.serialNumber ?? ''}
+                                    />
+                                )}
                                 <Input
                                     name="quantity"
                                     label="Količina"

--- a/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
@@ -47,6 +47,24 @@ export default async function CreateInventoryItemPage({
     ];
 
     const createItemBound = createInventoryItemAction.bind(null, id);
+    const trackingTypeItems =
+        config.defaultTrackingType === 'serialNumber'
+            ? [
+                  {
+                      value: 'pieces',
+                      label: 'Komadi',
+                  },
+                  {
+                      value: 'serialNumber',
+                      label: 'Serijski broj',
+                  },
+              ]
+            : [
+                  {
+                      value: 'pieces',
+                      label: 'Komadi',
+                  },
+              ];
 
     return (
         <Stack spacing={4}>
@@ -85,24 +103,18 @@ export default async function CreateInventoryItemPage({
                                 <SelectItems
                                     name="trackingType"
                                     label="Način praćenja"
-                                    items={[
-                                        {
-                                            value: 'pieces',
-                                            label: 'Komadi',
-                                        },
-                                        {
-                                            value: 'serialNumber',
-                                            label: 'Serijski broj',
-                                        },
-                                    ]}
+                                    items={trackingTypeItems}
                                     defaultValue={config.defaultTrackingType}
                                 />
-                                <Input
-                                    name="serialNumber"
-                                    label="Serijski broj (opcionalno)"
-                                    placeholder="npr. SN-12345"
-                                    helperText="Popunite ako pratite po serijskom broju"
-                                />
+                                {config.defaultTrackingType ===
+                                    'serialNumber' && (
+                                    <Input
+                                        name="serialNumber"
+                                        label="Serijski broj (opcionalno)"
+                                        placeholder="npr. SN-12345"
+                                        helperText="Popunite ako pratite po serijskom broju"
+                                    />
+                                )}
                                 <Input
                                     name="quantity"
                                     label="Količina"


### PR DESCRIPTION
### Motivation
- Prevent the UI from showing a `serialNumber` input when an inventory's entity type/config is not tracked by serial number so users won't enter irrelevant data. 
- Keep tracking options consistent with the inventory configuration so non-serial inventories only offer `pieces` and serial-enabled inventories offer both `pieces` and `serialNumber`.
- Enforce backend behavior so a `serialNumber` value cannot be persisted for items tracked by `pieces` even if a crafted request is sent.

### Description
- Conditionally render the `serialNumber` input on the inventory item **create** page so it is only shown when `config.defaultTrackingType === 'serialNumber'` in `apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx`.
- Apply the same conditional rendering and restrict the `trackingType` select options on the inventory item **edit** page in `apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx` and compute a sensible default when the config disallows serial tracking.
- Update server actions in `apps/app/app/(actions)/inventoryActions.ts` so `createInventoryItem` and `updateInventoryItem` only set `serialNumber` when `trackingType === 'serialNumber'` to enforce server-side correctness.

### Testing
- Ran code formatter/linter check with `cd apps/app && pnpm exec biome check --write 'app/(actions)/inventoryActions.ts' 'app/admin/inventory/[inventoryId]/items/create/page.tsx' 'app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx'` which first reported it "Fixed 1 file" and a subsequent run returned "No fixes applied", indicating lint/format is clean.
- No automated unit/integration tests were added or run for this change beyond the `biome` check; the lint/format check succeeded after the edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecafbc03a0832fa8512c2dca88ae6c)