### PR TITLE
Add inventory quick-actions card to entity details

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -1,12 +1,25 @@
 import {
+    createInventoryItem,
     getAttributeDefinitionCategories,
     getAttributeDefinitions,
     getEntityRaw,
+    getInventoryConfigByEntityTypeName,
+    getInventoryItemsByConfig,
+    updateInventoryItem,
 } from '@gredice/storage';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
-import { Delete } from '@signalco/ui-icons';
+import { Delete, ExternalLink } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
+import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import {
     Tabs,
@@ -14,7 +27,9 @@ import {
     TabsList,
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
+import { revalidatePath } from 'next/cache';
 import Image from 'next/image';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
@@ -51,21 +66,73 @@ export default async function EntityDetailsPage(props: {
     params: Promise<{ entityType: string; entityId: string }>;
 }) {
     const params = await props.params;
-    const [attributeDefinitions, attributeCategories, entity] =
+    const [attributeDefinitions, attributeCategories, entity, inventoryConfig] =
         await Promise.all([
             getAttributeDefinitions(params.entityType),
             getAttributeDefinitionCategories(params.entityType),
             getEntityRaw(parseInt(params.entityId, 10)),
+            getInventoryConfigByEntityTypeName(params.entityType),
         ]);
     if (!entity) {
         notFound();
     }
 
+    const inventoryItems = inventoryConfig
+        ? await getInventoryItemsByConfig(inventoryConfig.id)
+        : [];
+    const entityId = parseInt(params.entityId, 10);
+    const entityInventoryItem = inventoryItems.find(
+        (item) => item.entityId === entityId,
+    );
+
     const entityDeleteBound = handleEntityDelete.bind(
         null,
         params.entityType,
-        parseInt(params.entityId, 10),
+        entityId,
     );
+
+    async function upsertInventoryAction(formData: FormData) {
+        'use server';
+        await auth(['admin']);
+
+        if (!inventoryConfig) {
+            return;
+        }
+
+        const trackingType =
+            (formData.get('trackingType') as string) ||
+            inventoryConfig.defaultTrackingType;
+        const quantityRaw = formData.get('quantity');
+        const quantityParsed = Number.parseInt(
+            typeof quantityRaw === 'string' ? quantityRaw : '0',
+            10,
+        );
+        const quantity = Number.isFinite(quantityParsed)
+            ? Math.max(0, quantityParsed)
+            : 0;
+        const notes = (formData.get('notes') as string) || undefined;
+
+        if (entityInventoryItem) {
+            await updateInventoryItem({
+                id: entityInventoryItem.id,
+                entityId,
+                trackingType,
+                quantity,
+                notes,
+            });
+        } else {
+            await createInventoryItem({
+                inventoryConfigId: inventoryConfig.id,
+                entityId,
+                trackingType,
+                quantity,
+                notes,
+            });
+        }
+
+        revalidatePath(KnownPages.DirectoryEntity(params.entityType, entityId));
+        revalidatePath(KnownPages.InventoryConfig(inventoryConfig.id));
+    }
 
     // Remove useFormState, use a plain form with server action
     async function importAction(formData: FormData) {
@@ -139,7 +206,8 @@ export default async function EntityDetailsPage(props: {
                                                         aria-hidden
                                                     />
                                                     <span className="sr-only">
-                                                        Nedostaju obavezni atributi
+                                                        Nedostaju obavezni
+                                                        atributi
                                                     </span>
                                                 </>
                                             )}
@@ -179,6 +247,109 @@ export default async function EntityDetailsPage(props: {
                         }
                     />
                     <Stack spacing={2}>
+                        {inventoryConfig && (
+                            <Card>
+                                <CardHeader>
+                                    <Row
+                                        justifyContent="space-between"
+                                        className="items-center"
+                                    >
+                                        <CardTitle>
+                                            Zaliha za ovaj entitet
+                                        </CardTitle>
+                                        <Link
+                                            href={KnownPages.InventoryConfig(
+                                                inventoryConfig.id,
+                                            )}
+                                        >
+                                            <IconButton
+                                                variant="plain"
+                                                title="Otvori stranicu zalihe"
+                                            >
+                                                <ExternalLink className="size-4" />
+                                            </IconButton>
+                                        </Link>
+                                    </Row>
+                                </CardHeader>
+                                <CardContent>
+                                    <Stack spacing={2}>
+                                        <Row spacing={4} className="flex-wrap">
+                                            <Field
+                                                name="Stanje"
+                                                value={
+                                                    entityInventoryItem
+                                                        ? entityInventoryItem.trackingType ===
+                                                          'serialNumber'
+                                                            ? 'Serijski broj'
+                                                            : 'Komadi'
+                                                        : 'Nema u zalihi'
+                                                }
+                                            />
+                                            <Field
+                                                name="Količina"
+                                                value={
+                                                    entityInventoryItem?.quantity ??
+                                                    0
+                                                }
+                                            />
+                                        </Row>
+
+                                        <form action={upsertInventoryAction}>
+                                            <Row
+                                                spacing={2}
+                                                className="items-end flex-wrap"
+                                            >
+                                                <SelectItems
+                                                    name="trackingType"
+                                                    label="Stanje"
+                                                    items={[
+                                                        {
+                                                            value: 'pieces',
+                                                            label: 'Komadi',
+                                                        },
+                                                        {
+                                                            value: 'serialNumber',
+                                                            label: 'Serijski broj',
+                                                        },
+                                                    ]}
+                                                    defaultValue={
+                                                        entityInventoryItem?.trackingType ??
+                                                        inventoryConfig.defaultTrackingType
+                                                    }
+                                                />
+                                                <Input
+                                                    name="quantity"
+                                                    label="Količina"
+                                                    type="number"
+                                                    min={0}
+                                                    defaultValue={String(
+                                                        entityInventoryItem?.quantity ??
+                                                            0,
+                                                    )}
+                                                />
+                                                <Input
+                                                    name="notes"
+                                                    label="Bilješka"
+                                                    defaultValue={
+                                                        entityInventoryItem?.notes ??
+                                                        ''
+                                                    }
+                                                />
+                                                <Button
+                                                    type="submit"
+                                                    variant="solid"
+                                                    className="w-fit"
+                                                >
+                                                    {entityInventoryItem
+                                                        ? 'Ažuriraj zalihu'
+                                                        : 'Dodaj u zalihu'}
+                                                </Button>
+                                            </Row>
+                                        </form>
+                                    </Stack>
+                                </CardContent>
+                            </Card>
+                        )}
                         <FieldSet>
                             <Field
                                 name="Datum kreiranja"


### PR DESCRIPTION
### Motivation
- Provide a quick inventory overview and inline actions on the entity details page when an inventory configuration exists for that entity type. 

### Description
- Load inventory configuration for the entity type via `getInventoryConfigByEntityTypeName` and the items via `getInventoryItemsByConfig`, then resolve the current entity's inventory item.  
- Add a server action `upsertInventoryAction` to create or update an inventory item using `createInventoryItem` / `updateInventoryItem` and revalidate the entity and inventory routes with `revalidatePath`.  
- Render a new inventory `Card` at the top of the details content showing current tracking type and quantity, a compact inline form (`SelectItems`, `Input`, `Button`) to change tracking/quantity/notes, and a small external-link icon that navigates to the inventory configuration page.  
- Add required imports and minor UI wiring (wrap icon button with `Link`, use `Field` displays, etc.).

### Testing
- Ran `pnpm --filter app exec biome check --write 'app/admin/directories/[entityType]/[entityId]/page.tsx'` which completed successfully for the modified file.  
- Ran `pnpm --filter app lint` which completed and preserved an existing unrelated warning elsewhere in the repo.  
- Ran `pnpm --filter app exec tsc --noEmit` which failed due to pre-existing, repo-wide TypeScript errors unrelated to this change (no compilation errors introduced by this patch were observed during implementation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecaf36bae8832f8ec227585155e95a)