### PR TITLE
Add inventory item events (audit trail) and quick-adjust UI

### DIFF
--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -10,7 +10,6 @@ import {
     deleteInventoryItemEvent,
     deleteInventoryItemFieldDefinition,
     getInventoryItem,
-    getInventoryItemEvents,
     getInventoryItemFieldDefinitions,
     updateInventoryConfig,
     updateInventoryItem,
@@ -32,10 +31,11 @@ function parseQuantity(raw: string | null): number {
 }
 
 function parseQuickActionQuantity(raw: string | null): number | null {
-    if (!raw || raw.trim().length === 0) return null;
-    const parsed = Number.parseInt(raw, 10);
-    if (!Number.isFinite(parsed) || parsed < 0) {
-        return null;
+    const normalized = raw?.trim();
+    if (!normalized) return null;
+    const parsed = Number(normalized);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new Error('Quantity must be a non-negative integer.');
     }
     return parsed;
 }
@@ -215,13 +215,21 @@ export async function createInventoryItemAction(
         notes: notes || undefined,
         additionalFields,
     });
+    const createdItem = await getInventoryItem(createdItemId);
+    if (!createdItem) {
+        throw new Error('Created item not found.');
+    }
+    const newState = getItemStateFromAdditionalFields(
+        createdItem.additionalFields,
+        createdItem.inventoryConfig.statusAttributeName,
+    );
     await createInventoryItemEvent({
         inventoryItemId: createdItemId,
         action: 'created',
         previousQuantity: null,
         newQuantity: quantity,
         previousState: null,
-        newState: null,
+        newState,
         notes: notes || null,
     });
 
@@ -260,6 +268,12 @@ export async function updateInventoryItemAction(
         inventoryConfigId,
         formData,
     );
+    const nextAdditionalFields = additionalFields
+        ? {
+              ...(existingItem.additionalFields ?? {}),
+              ...additionalFields,
+          }
+        : existingItem.additionalFields;
 
     await updateInventoryItem({
         id: itemId,
@@ -268,7 +282,7 @@ export async function updateInventoryItemAction(
         serialNumber: serialNumber || undefined,
         quantity,
         notes: notes || undefined,
-        additionalFields,
+        additionalFields: nextAdditionalFields,
     });
 
     const oldState = getItemStateFromAdditionalFields(
@@ -276,7 +290,7 @@ export async function updateInventoryItemAction(
         existingItem.inventoryConfig.statusAttributeName,
     );
     const nextState = getItemStateFromAdditionalFields(
-        additionalFields,
+        nextAdditionalFields,
         existingItem.inventoryConfig.statusAttributeName,
     );
     await createInventoryItemEvent({
@@ -357,13 +371,21 @@ export async function quickAdjustInventoryItemAction(
         id: number;
         quantity?: number;
         additionalFields?: Record<string, unknown> | null;
-        notes?: string;
     } = { id: itemId };
 
-    if (nextQuantity !== null) {
+    const quantityChanged =
+        nextQuantity !== null && nextQuantity !== existingItem.quantity;
+    const stateChanged = statusFieldName ? nextState !== previousState : false;
+    const hasEventNotes = notes !== null;
+
+    if (!quantityChanged && !stateChanged && !hasEventNotes) {
+        throw new Error('No inventory item changes were provided.');
+    }
+
+    if (quantityChanged) {
         updates.quantity = nextQuantity;
     }
-    if (statusFieldName) {
+    if (statusFieldName && stateChanged) {
         const previousAdditionalFields =
             (existingItem.additionalFields as Record<string, unknown> | null) ??
             {};
@@ -372,11 +394,11 @@ export async function quickAdjustInventoryItemAction(
             [statusFieldName]: nextState,
         };
     }
-    if (notes) {
-        updates.notes = notes;
+
+    if (quantityChanged || stateChanged) {
+        await updateInventoryItem(updates);
     }
 
-    await updateInventoryItem(updates);
     await createInventoryItemEvent({
         inventoryItemId: itemId,
         action: 'quick-adjustment',
@@ -405,13 +427,12 @@ export async function deleteInventoryItemEventAction(
         );
     }
 
-    const events = await getInventoryItemEvents(itemId);
-    if (!events.some((event) => event.id === eventId)) {
+    const eventDeleted = await deleteInventoryItemEvent(eventId, itemId);
+    if (!eventDeleted) {
         throw new Error(
             'Event does not belong to the specified inventory item.',
         );
     }
 
-    await deleteInventoryItemEvent(eventId, itemId);
     revalidatePath(KnownPages.InventoryItem(inventoryConfigId, itemId));
 }

--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -35,7 +35,7 @@ function parseQuickActionQuantity(raw: string | null): number | null {
     if (!normalized) return null;
     const parsed = Number(normalized);
     if (!Number.isInteger(parsed) || parsed < 0) {
-        throw new Error('Quantity must be a non-negative integer.');
+        throw new Error('Please enter a valid quantity (0 or greater).');
     }
     return parsed;
 }
@@ -379,7 +379,9 @@ export async function quickAdjustInventoryItemAction(
     const hasEventNotes = notes !== null;
 
     if (!quantityChanged && !stateChanged && !hasEventNotes) {
-        throw new Error('No inventory item changes were provided.');
+        throw new Error(
+            'Please provide at least one change: update quantity, change status, or add notes.',
+        );
     }
 
     if (quantityChanged) {

--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -358,7 +358,7 @@ export async function quickAdjustInventoryItemAction(
     const nextQuantity = parseQuickActionQuantity(
         formData.get('quantity') as string,
     );
-    const notes = (formData.get('notes') as string) || null;
+    const eventNotes = (formData.get('notes') as string) || null;
     const statusFieldName = existingItem.inventoryConfig.statusAttributeName;
     const nextStateRaw = (formData.get('state') as string) || '';
     const nextState = nextStateRaw.length > 0 ? nextStateRaw : null;
@@ -376,7 +376,7 @@ export async function quickAdjustInventoryItemAction(
     const quantityChanged =
         nextQuantity !== null && nextQuantity !== existingItem.quantity;
     const stateChanged = statusFieldName ? nextState !== previousState : false;
-    const hasEventNotes = notes !== null;
+    const hasEventNotes = eventNotes !== null;
 
     if (!quantityChanged && !stateChanged && !hasEventNotes) {
         throw new Error(
@@ -408,7 +408,7 @@ export async function quickAdjustInventoryItemAction(
         newQuantity: nextQuantity ?? existingItem.quantity,
         previousState,
         newState: statusFieldName ? nextState : previousState,
-        notes,
+        notes: eventNotes,
     });
 
     revalidatePath(KnownPages.InventoryConfig(inventoryConfigId));

--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -33,11 +33,10 @@ function parseQuantity(raw: string | null): number {
 function parseQuickActionQuantity(raw: string | null): number | null {
     const normalized = raw?.trim();
     if (!normalized) return null;
-    const parsed = Number(normalized);
-    if (!Number.isInteger(parsed) || parsed < 0) {
+    if (!/^\d+$/.test(normalized)) {
         throw new Error('Please enter a valid quantity (0 or greater).');
     }
-    return parsed;
+    return Number.parseInt(normalized, 10);
 }
 
 function getItemStateFromAdditionalFields(

--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -3,11 +3,14 @@
 import {
     createInventoryConfig,
     createInventoryItem,
+    createInventoryItemEvent,
     createInventoryItemFieldDefinition,
     deleteInventoryConfig,
     deleteInventoryItem,
+    deleteInventoryItemEvent,
     deleteInventoryItemFieldDefinition,
     getInventoryItem,
+    getInventoryItemEvents,
     getInventoryItemFieldDefinitions,
     updateInventoryConfig,
     updateInventoryItem,
@@ -26,6 +29,25 @@ function parseQuantity(raw: string | null): number {
         return 1;
     }
     return parsed;
+}
+
+function parseQuickActionQuantity(raw: string | null): number | null {
+    if (!raw || raw.trim().length === 0) return null;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        return null;
+    }
+    return parsed;
+}
+
+function getItemStateFromAdditionalFields(
+    additionalFields: Record<string, unknown> | null | undefined,
+    statusAttributeName: string | null | undefined,
+): string | null {
+    if (!statusAttributeName) return null;
+    const state = additionalFields?.[statusAttributeName];
+    if (typeof state !== 'string' || state.length === 0) return null;
+    return state;
 }
 
 async function collectAdditionalFields(
@@ -184,7 +206,7 @@ export async function createInventoryItemAction(
         formData,
     );
 
-    await createInventoryItem({
+    const createdItemId = await createInventoryItem({
         inventoryConfigId,
         entityId,
         trackingType,
@@ -192,6 +214,15 @@ export async function createInventoryItemAction(
         quantity,
         notes: notes || undefined,
         additionalFields,
+    });
+    await createInventoryItemEvent({
+        inventoryItemId: createdItemId,
+        action: 'created',
+        previousQuantity: null,
+        newQuantity: quantity,
+        previousState: null,
+        newState: null,
+        notes: notes || null,
     });
 
     revalidatePath(KnownPages.InventoryConfig(inventoryConfigId));
@@ -240,6 +271,24 @@ export async function updateInventoryItemAction(
         additionalFields,
     });
 
+    const oldState = getItemStateFromAdditionalFields(
+        existingItem.additionalFields,
+        existingItem.inventoryConfig.statusAttributeName,
+    );
+    const nextState = getItemStateFromAdditionalFields(
+        additionalFields,
+        existingItem.inventoryConfig.statusAttributeName,
+    );
+    await createInventoryItemEvent({
+        inventoryItemId: itemId,
+        action: 'updated',
+        previousQuantity: existingItem.quantity,
+        newQuantity: quantity,
+        previousState: oldState,
+        newState: nextState,
+        notes: notes || null,
+    });
+
     revalidatePath(KnownPages.InventoryConfig(inventoryConfigId));
     redirect(KnownPages.InventoryConfig(inventoryConfigId));
 }
@@ -250,6 +299,119 @@ export async function deleteInventoryItemAction(
 ) {
     await auth(['admin']);
 
+    const item = await getInventoryItem(itemId);
+    if (!item || item.inventoryConfigId !== inventoryConfigId) {
+        throw new Error(
+            'Item does not belong to the specified inventory configuration.',
+        );
+    }
+
+    const previousState = getItemStateFromAdditionalFields(
+        item.additionalFields,
+        item.inventoryConfig.statusAttributeName,
+    );
+
     await deleteInventoryItem(itemId, inventoryConfigId);
+    await createInventoryItemEvent({
+        inventoryItemId: itemId,
+        action: 'deleted',
+        previousQuantity: item.quantity,
+        newQuantity: null,
+        previousState,
+        newState: null,
+        notes: item.notes ?? null,
+    });
     revalidatePath(KnownPages.InventoryConfig(inventoryConfigId));
+}
+
+export async function quickAdjustInventoryItemAction(
+    inventoryConfigId: number,
+    itemId: number,
+    formData: FormData,
+) {
+    await auth(['admin']);
+
+    const existingItem = await getInventoryItem(itemId);
+    if (!existingItem) {
+        throw new Error('Item not found.');
+    }
+    if (existingItem.inventoryConfigId !== inventoryConfigId) {
+        throw new Error(
+            'Item does not belong to the specified inventory configuration.',
+        );
+    }
+
+    const nextQuantity = parseQuickActionQuantity(
+        formData.get('quantity') as string,
+    );
+    const notes = (formData.get('notes') as string) || null;
+    const statusFieldName = existingItem.inventoryConfig.statusAttributeName;
+    const nextStateRaw = (formData.get('state') as string) || '';
+    const nextState = nextStateRaw.length > 0 ? nextStateRaw : null;
+    const previousState = getItemStateFromAdditionalFields(
+        existingItem.additionalFields,
+        statusFieldName,
+    );
+
+    const updates: {
+        id: number;
+        quantity?: number;
+        additionalFields?: Record<string, unknown> | null;
+        notes?: string;
+    } = { id: itemId };
+
+    if (nextQuantity !== null) {
+        updates.quantity = nextQuantity;
+    }
+    if (statusFieldName) {
+        const previousAdditionalFields =
+            (existingItem.additionalFields as Record<string, unknown> | null) ??
+            {};
+        updates.additionalFields = {
+            ...previousAdditionalFields,
+            [statusFieldName]: nextState,
+        };
+    }
+    if (notes) {
+        updates.notes = notes;
+    }
+
+    await updateInventoryItem(updates);
+    await createInventoryItemEvent({
+        inventoryItemId: itemId,
+        action: 'quick-adjustment',
+        previousQuantity: existingItem.quantity,
+        newQuantity: nextQuantity ?? existingItem.quantity,
+        previousState,
+        newState: statusFieldName ? nextState : previousState,
+        notes,
+    });
+
+    revalidatePath(KnownPages.InventoryConfig(inventoryConfigId));
+    revalidatePath(KnownPages.InventoryItem(inventoryConfigId, itemId));
+}
+
+export async function deleteInventoryItemEventAction(
+    inventoryConfigId: number,
+    itemId: number,
+    eventId: number,
+) {
+    await auth(['admin']);
+
+    const existingItem = await getInventoryItem(itemId);
+    if (!existingItem || existingItem.inventoryConfigId !== inventoryConfigId) {
+        throw new Error(
+            'Item does not belong to the specified inventory configuration.',
+        );
+    }
+
+    const events = await getInventoryItemEvents(itemId);
+    if (!events.some((event) => event.id === eventId)) {
+        throw new Error(
+            'Event does not belong to the specified inventory item.',
+        );
+    }
+
+    await deleteInventoryItemEvent(eventId, itemId);
+    revalidatePath(KnownPages.InventoryItem(inventoryConfigId, itemId));
 }

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/DeleteInventoryItemEventButton.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/DeleteInventoryItemEventButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Delete } from '@signalco/ui-icons';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { useTransition } from 'react';
+import { deleteInventoryItemEventAction } from '../../../../../(actions)/inventoryActions';
+
+export function DeleteInventoryItemEventButton({
+    inventoryConfigId,
+    itemId,
+    eventId,
+}: {
+    inventoryConfigId: number;
+    itemId: number;
+    eventId: number;
+}) {
+    const [isPending, startTransition] = useTransition();
+
+    const handleDelete = () => {
+        if (!confirm('Da li ste sigurni da želite obrisati ovaj događaj?')) {
+            return;
+        }
+
+        startTransition(async () => {
+            await deleteInventoryItemEventAction(
+                inventoryConfigId,
+                itemId,
+                eventId,
+            );
+        });
+    };
+
+    return (
+        <IconButton
+            title="Obriši događaj"
+            variant="plain"
+            color="danger"
+            size="sm"
+            onClick={handleDelete}
+            loading={isPending}
+        >
+            <Delete className="size-4" />
+        </IconButton>
+    );
+}

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -1,15 +1,25 @@
-import { getEntitiesRaw, getInventoryItem } from '@gredice/storage';
+import {
+    getEntitiesRaw,
+    getInventoryItem,
+    getInventoryItemEvents,
+} from '@gredice/storage';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Input } from '@signalco/ui-primitives/Input';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { auth } from '../../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../../src/KnownPages';
-import { updateInventoryItemAction } from '../../../../../(actions)/inventoryActions';
+import {
+    quickAdjustInventoryItemAction,
+    updateInventoryItemAction,
+} from '../../../../../(actions)/inventoryActions';
+import { DeleteInventoryItemEventButton } from './DeleteInventoryItemEventButton';
 
 export const dynamic = 'force-dynamic';
 const noEntityValue = 'none';
@@ -29,6 +39,7 @@ export default async function InventoryItemPage({
     if (!item || item.inventoryConfigId !== inventoryConfigId) {
         notFound();
     }
+    const events = await getInventoryItemEvents(id);
 
     const config = item.inventoryConfig;
     const entities = await getEntitiesRaw(config.entityTypeName, 'published');
@@ -55,6 +66,15 @@ export default async function InventoryItemPage({
         inventoryConfigId,
         id,
     );
+    const quickAdjustItemBound = quickAdjustInventoryItemAction.bind(
+        null,
+        inventoryConfigId,
+        id,
+    );
+    const statusAttributeName = config.statusAttributeName;
+    const currentState = statusAttributeName
+        ? ((additionalFields[statusAttributeName] as string) ?? '')
+        : '';
 
     return (
         <Stack spacing={4}>
@@ -204,6 +224,98 @@ export default async function InventoryItemPage({
                         </Stack>
                     </form>
                 </Stack>
+            </Card>
+
+            <Card className="max-w-2xl">
+                <Stack spacing={4} className="p-6">
+                    <Typography level="h3" semiBold>
+                        Brza promjena stanja/količine
+                    </Typography>
+                    <form action={quickAdjustItemBound}>
+                        <Stack spacing={3}>
+                            <Input
+                                name="quantity"
+                                label="Nova količina (opcionalno)"
+                                type="number"
+                                min={0}
+                                defaultValue={item.quantity.toString()}
+                            />
+                            {statusAttributeName && (
+                                <Input
+                                    name="state"
+                                    label="Novo stanje (opcionalno)"
+                                    defaultValue={currentState}
+                                />
+                            )}
+                            <Input
+                                name="notes"
+                                label="Napomena događaja (opcionalno)"
+                            />
+                            <Button
+                                variant="solid"
+                                type="submit"
+                                className="w-fit"
+                            >
+                                Dodaj događaj
+                            </Button>
+                        </Stack>
+                    </form>
+                </Stack>
+            </Card>
+
+            <Card>
+                <Stack spacing={2} className="p-6 pb-0">
+                    <Typography level="h3" semiBold>
+                        Povijest promjena
+                    </Typography>
+                </Stack>
+                <Table>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.Head>Vrijeme</Table.Head>
+                            <Table.Head>Akcija</Table.Head>
+                            <Table.Head>Količina</Table.Head>
+                            <Table.Head>Stanje</Table.Head>
+                            <Table.Head>Napomena</Table.Head>
+                            <Table.Head />
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {events.length === 0 && (
+                            <Table.Row>
+                                <Table.Cell colSpan={6}>
+                                    Nema događaja za ovu stavku.
+                                </Table.Cell>
+                            </Table.Row>
+                        )}
+                        {events.map((event) => (
+                            <Table.Row key={event.id}>
+                                <Table.Cell>
+                                    <LocalDateTime time>
+                                        {event.createdAt}
+                                    </LocalDateTime>
+                                </Table.Cell>
+                                <Table.Cell>{event.action}</Table.Cell>
+                                <Table.Cell>
+                                    {event.previousQuantity ?? '-'} →{' '}
+                                    {event.newQuantity ?? '-'}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {event.previousState ?? '-'} →{' '}
+                                    {event.newState ?? '-'}
+                                </Table.Cell>
+                                <Table.Cell>{event.notes ?? '-'}</Table.Cell>
+                                <Table.Cell>
+                                    <DeleteInventoryItemEventButton
+                                        inventoryConfigId={inventoryConfigId}
+                                        itemId={id}
+                                        eventId={event.id}
+                                    />
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table>
             </Card>
         </Stack>
     );

--- a/packages/storage/src/repositories/inventoryManagementRepo.ts
+++ b/packages/storage/src/repositories/inventoryManagementRepo.ts
@@ -3,8 +3,10 @@ import { and, eq } from 'drizzle-orm';
 import {
     type InsertInventoryConfig,
     type InsertInventoryItem,
+    type InsertInventoryItemEvent,
     type InsertInventoryItemFieldDefinition,
     inventoryConfigs,
+    inventoryItemEvents,
     inventoryItemFieldDefinitions,
     inventoryItems,
     type UpdateInventoryConfig,
@@ -205,6 +207,41 @@ export async function deleteInventoryItem(
             and(
                 eq(inventoryItems.id, id),
                 eq(inventoryItems.inventoryConfigId, inventoryConfigId),
+            ),
+        );
+}
+
+export async function getInventoryItemEvents(inventoryItemId: number) {
+    return storage().query.inventoryItemEvents.findMany({
+        where: and(
+            eq(inventoryItemEvents.inventoryItemId, inventoryItemId),
+            eq(inventoryItemEvents.isDeleted, false),
+        ),
+        orderBy: (table, { desc }) => [desc(table.createdAt), desc(table.id)],
+    });
+}
+
+export async function createInventoryItemEvent(
+    data: Omit<InsertInventoryItemEvent, 'id' | 'createdAt' | 'isDeleted'>,
+) {
+    const [created] = await storage()
+        .insert(inventoryItemEvents)
+        .values(data)
+        .returning({ id: inventoryItemEvents.id });
+    return created.id;
+}
+
+export async function deleteInventoryItemEvent(
+    id: number,
+    inventoryItemId: number,
+) {
+    await storage()
+        .update(inventoryItemEvents)
+        .set({ isDeleted: true })
+        .where(
+            and(
+                eq(inventoryItemEvents.id, id),
+                eq(inventoryItemEvents.inventoryItemId, inventoryItemId),
             ),
         );
 }

--- a/packages/storage/src/repositories/inventoryManagementRepo.ts
+++ b/packages/storage/src/repositories/inventoryManagementRepo.ts
@@ -235,15 +235,18 @@ export async function deleteInventoryItemEvent(
     id: number,
     inventoryItemId: number,
 ) {
-    await storage()
+    const [deleted] = await storage()
         .update(inventoryItemEvents)
         .set({ isDeleted: true })
         .where(
             and(
                 eq(inventoryItemEvents.id, id),
                 eq(inventoryItemEvents.inventoryItemId, inventoryItemId),
+                eq(inventoryItemEvents.isDeleted, false),
             ),
-        );
+        )
+        .returning({ id: inventoryItemEvents.id });
+    return Boolean(deleted);
 }
 
 // ==================== Summary ====================

--- a/packages/storage/src/schema/inventoryManagementSchema.ts
+++ b/packages/storage/src/schema/inventoryManagementSchema.ts
@@ -139,18 +139,24 @@ export const inventoryItems = pgTable(
     ],
 );
 
-export const inventoryItemRelations = relations(inventoryItems, ({ one }) => ({
-    inventoryConfig: one(inventoryConfigs, {
-        fields: [inventoryItems.inventoryConfigId],
-        references: [inventoryConfigs.id],
-        relationName: 'inventoryConfigItems',
+export const inventoryItemRelations = relations(
+    inventoryItems,
+    ({ one, many }) => ({
+        inventoryConfig: one(inventoryConfigs, {
+            fields: [inventoryItems.inventoryConfigId],
+            references: [inventoryConfigs.id],
+            relationName: 'inventoryConfigItems',
+        }),
+        entity: one(entities, {
+            fields: [inventoryItems.entityId],
+            references: [entities.id],
+            relationName: 'entity',
+        }),
+        events: many(inventoryItemEvents, {
+            relationName: 'inventoryItemEvents',
+        }),
     }),
-    entity: one(entities, {
-        fields: [inventoryItems.entityId],
-        references: [entities.id],
-        relationName: 'entity',
-    }),
-}));
+);
 
 export type InsertInventoryItem = typeof inventoryItems.$inferInsert;
 export type UpdateInventoryItem = Partial<
@@ -161,3 +167,41 @@ export type UpdateInventoryItem = Partial<
 > &
     Pick<typeof inventoryItems.$inferSelect, 'id'>;
 export type SelectInventoryItem = typeof inventoryItems.$inferSelect;
+
+export const inventoryItemEvents = pgTable(
+    'inventory_item_events',
+    {
+        id: serial('id').primaryKey(),
+        inventoryItemId: integer('inventory_item_id')
+            .notNull()
+            .references(() => inventoryItems.id),
+        action: text('action').notNull(),
+        previousQuantity: integer('previous_quantity'),
+        newQuantity: integer('new_quantity'),
+        previousState: text('previous_state'),
+        newState: text('new_state'),
+        notes: text('notes'),
+        createdAt: timestamp('created_at').notNull().defaultNow(),
+        isDeleted: boolean('is_deleted').notNull().default(false),
+    },
+    (table) => [
+        index('inv_item_events_inventory_item_id_idx').on(
+            table.inventoryItemId,
+        ),
+        index('inv_item_events_is_deleted_idx').on(table.isDeleted),
+    ],
+);
+
+export const inventoryItemEventRelations = relations(
+    inventoryItemEvents,
+    ({ one }) => ({
+        inventoryItem: one(inventoryItems, {
+            fields: [inventoryItemEvents.inventoryItemId],
+            references: [inventoryItems.id],
+            relationName: 'inventoryItemEvents',
+        }),
+    }),
+);
+
+export type InsertInventoryItemEvent = typeof inventoryItemEvents.$inferInsert;
+export type SelectInventoryItemEvent = typeof inventoryItemEvents.$inferSelect;


### PR DESCRIPTION
### Motivation
- Provide an audit trail for inventory items so changes (quantity/state/notes) are visible over time. 
- Allow quick non-destructive adjustments (change quantity/state/create event) without editing the full item record. 
- Enable safe cleanup of erroneous events via per-event soft-delete.

### Description
- Add a new DB schema `inventory_item_events` and relations to `inventory_items` to record `action`, `previousQuantity`, `newQuantity`, `previousState`, `newState`, `notes`, timestamps and soft-delete flags (`packages/storage/src/schema/inventoryManagementSchema.ts`).
- Extend storage repository with `getInventoryItemEvents`, `createInventoryItemEvent`, and `deleteInventoryItemEvent` to read/write/soft-delete event rows (`packages/storage/src/repositories/inventoryManagementRepo.ts`).
- Log events from server actions for item lifecycle changes by creating events when items are `created`, `updated`, `deleted`, and when a `quick-adjustment` is made; add `quickAdjustInventoryItemAction` and `deleteInventoryItemEventAction` server actions (`apps/app/app/(actions)/inventoryActions.ts`).
- Add UI for quick adjustments and event history on the item details page: a quick-adjust form (quantity/state/notes), a history `Table` listing events, and a per-event `DeleteInventoryItemEventButton` component to remove events (`apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx` and `DeleteInventoryItemEventButton.tsx`).

### Testing
- Ran BIOME formatting/lint checks on storage and app sources: `pnpm --filter @gredice/storage exec biome check --write 'src/repositories/inventoryManagementRepo.ts' 'src/schema/inventoryManagementSchema.ts'` and `pnpm --filter app exec biome check --write 'app/(actions)/inventoryActions.ts' 'app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx' 'app/admin/inventory/[inventoryId]/items/[itemId]/DeleteInventoryItemEventButton.tsx'`, both completed with no remaining fixes.
- Ran package lint: `pnpm --filter @gredice/storage lint` completed successfully.
- Ran workspace app lint: `pnpm --filter app lint` completed and reported a pre-existing unrelated warning in another file but did not fail.
- All automated checks above passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecaf7fa0d8832f8b800b60065a8b43)