### PR TITLE
Make status/amount inventory attributes custom fields and add quick-create actions

### DIFF
--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -65,30 +65,11 @@ export async function createInventoryConfigAction(formData: FormData) {
     const label = formData.get('label') as string;
     const defaultTrackingType =
         (formData.get('defaultTrackingType') as string) || 'pieces';
-    const statusAttributeNameRaw = formData.get('statusAttributeName') as
-        | string
-        | null;
-    const statusAttributeName =
-        statusAttributeNameRaw && statusAttributeNameRaw !== noAttributeValue
-            ? statusAttributeNameRaw
-            : null;
-    const emptyStatusValue =
-        (formData.get('emptyStatusValue') as string) || null;
-    const amountAttributeNameRaw = formData.get('amountAttributeName') as
-        | string
-        | null;
-    const amountAttributeName =
-        amountAttributeNameRaw && amountAttributeNameRaw !== noAttributeValue
-            ? amountAttributeNameRaw
-            : null;
 
     const id = await createInventoryConfig({
         entityTypeName,
         label,
         defaultTrackingType,
-        statusAttributeName: statusAttributeName || undefined,
-        emptyStatusValue: emptyStatusValue || undefined,
-        amountAttributeName: amountAttributeName || undefined,
     });
 
     revalidatePath(KnownPages.Inventory);

--- a/apps/app/app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx
@@ -9,8 +9,12 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 
 export function AddFieldDefinitionForm({
     onSubmit,
+    hasStatusField,
+    hasAmountField,
 }: {
     onSubmit: (formData: FormData) => Promise<void>;
+    hasStatusField: boolean;
+    hasAmountField: boolean;
 }) {
     return (
         <Card className="max-w-2xl">
@@ -18,6 +22,57 @@ export function AddFieldDefinitionForm({
                 <Typography level="body1" semiBold>
                     Dodaj novo polje
                 </Typography>
+                <Stack spacing={1}>
+                    <Typography level="body2" secondary>
+                        Brze akcije za najčešća polja:
+                    </Typography>
+                    <Stack direction="row" spacing={1}>
+                        <form action={onSubmit}>
+                            <input type="hidden" name="name" value="status" />
+                            <input type="hidden" name="label" value="Status" />
+                            <input type="hidden" name="dataType" value="text" />
+                            <input
+                                type="hidden"
+                                name="required"
+                                value="false"
+                            />
+                            <Button
+                                type="submit"
+                                variant="outlined"
+                                disabled={hasStatusField}
+                                className="w-fit"
+                            >
+                                Dodaj status atribut
+                            </Button>
+                        </form>
+                        <form action={onSubmit}>
+                            <input type="hidden" name="name" value="amount" />
+                            <input
+                                type="hidden"
+                                name="label"
+                                value="Količina"
+                            />
+                            <input
+                                type="hidden"
+                                name="dataType"
+                                value="number"
+                            />
+                            <input
+                                type="hidden"
+                                name="required"
+                                value="false"
+                            />
+                            <Button
+                                type="submit"
+                                variant="outlined"
+                                disabled={hasAmountField}
+                                className="w-fit"
+                            >
+                                Dodaj amount atribut
+                            </Button>
+                        </form>
+                    </Stack>
+                </Stack>
                 <form action={onSubmit}>
                     <Stack spacing={3}>
                         <Input

--- a/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { getAttributeDefinitions, getInventoryConfig } from '@gredice/storage';
+import { getInventoryConfig } from '@gredice/storage';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
@@ -36,16 +36,41 @@ export default async function EditInventoryConfigPage({
         notFound();
     }
 
-    const attributeDefinitions = await getAttributeDefinitions(
-        config.entityTypeName,
-    );
     const attributeItems = [
         { value: noAttributeValue, label: '- Nije odabrano -' },
-        ...attributeDefinitions.map((attr) => ({
-            value: attr.name,
-            label: attr.label,
+        ...config.fieldDefinitions.map((field) => ({
+            value: field.name,
+            label: field.label,
         })),
     ];
+    if (
+        config.statusAttributeName &&
+        !attributeItems.some(
+            (item) => item.value === config.statusAttributeName,
+        )
+    ) {
+        attributeItems.push({
+            value: config.statusAttributeName,
+            label: `${config.statusAttributeName} (postojeće)`,
+        });
+    }
+    if (
+        config.amountAttributeName &&
+        !attributeItems.some(
+            (item) => item.value === config.amountAttributeName,
+        )
+    ) {
+        attributeItems.push({
+            value: config.amountAttributeName,
+            label: `${config.amountAttributeName} (postojeće)`,
+        });
+    }
+    const hasStatusField = config.fieldDefinitions.some(
+        (field) => field.name === 'status',
+    );
+    const hasAmountField = config.fieldDefinitions.some(
+        (field) => field.name === 'amount',
+    );
 
     const updateConfigBound = updateInventoryConfigAction.bind(null, id);
     const deleteConfigBound = deleteInventoryConfigAction.bind(null, id);
@@ -105,7 +130,7 @@ export default async function EditInventoryConfigPage({
                                         config.statusAttributeName ??
                                         noAttributeValue
                                     }
-                                    helperText="Atribut entiteta koji definira status stavke"
+                                    helperText="Polje stavke zalihe koje definira status stavke"
                                 />
                                 <Input
                                     name="emptyStatusValue"
@@ -121,7 +146,7 @@ export default async function EditInventoryConfigPage({
                                         config.amountAttributeName ??
                                         noAttributeValue
                                     }
-                                    helperText="Atribut entiteta koji doprinosi izračunu ukupne količine"
+                                    helperText="Polje stavke zalihe koje doprinosi izračunu ukupne količine"
                                 />
                             </Stack>
                             <Button
@@ -177,7 +202,11 @@ export default async function EditInventoryConfigPage({
                     </Card>
                 )}
 
-                <AddFieldDefinitionForm onSubmit={createFieldBound} />
+                <AddFieldDefinitionForm
+                    onSubmit={createFieldBound}
+                    hasStatusField={hasStatusField}
+                    hasAmountField={hasAmountField}
+                />
             </Stack>
 
             <Stack spacing={2}>

--- a/apps/app/app/admin/inventory/create/page.tsx
+++ b/apps/app/app/admin/inventory/create/page.tsx
@@ -69,24 +69,6 @@ export default async function CreateInventoryPage() {
                                     ]}
                                     defaultValue="pieces"
                                 />
-                                <Input
-                                    name="statusAttributeName"
-                                    label="Atribut statusa (opcionalno)"
-                                    placeholder="npr. openState"
-                                    helperText="Naziv atributa entiteta koji definira status stavke"
-                                />
-                                <Input
-                                    name="emptyStatusValue"
-                                    label="Vrijednost praznog statusa (opcionalno)"
-                                    placeholder="npr. empty"
-                                    helperText="Vrijednost atributa koja označava praznu stavku i automatski smanjuje zalihu"
-                                />
-                                <Input
-                                    name="amountAttributeName"
-                                    label="Atribut količine (opcionalno)"
-                                    placeholder="npr. packSize"
-                                    helperText="Naziv atributa entiteta koji definira količinu stavke"
-                                />
                             </Stack>
                             <Button
                                 variant="solid"


### PR DESCRIPTION
### Motivation
- Inventory `status` and `amount` are not entity-type attributes but per-inventory custom item fields, so they should be managed as inventory field definitions rather than asked during initial config creation. 
- Creating those fields should be easy for admins, so provide quick actions to create common `status`/`amount` fields. 
- Keep backward compatibility for configs that already reference an attribute name not present in field definitions by showing the existing name in the selector. 

### Description
- Removed `statusAttributeName`, `emptyStatusValue` and `amountAttributeName` inputs from the inventory creation UI so `createInventoryConfigAction` no longer reads/persists these at creation time. 
- Switched the inventory edit UI to populate the `statusAttributeName` and `amountAttributeName` selectors from `config.fieldDefinitions` (custom inventory fields) and added fallbacks that append existing configured names if they are not present among definitions. 
- Added `hasStatusField` and `hasAmountField` flags and quick-action buttons to `AddFieldDefinitionForm` to create common `status` (text) and `amount` (number) fields with the buttons disabled when those fields already exist. 
- Adjusted helper text to clarify these attributes refer to inventory item fields and updated the server action `createInventoryConfigAction` to ignore status/amount on initial creation. 

### Testing
- Ran `pnpm --filter app lint` which completed (fixed 2 files and reported one unrelated existing warning). 
- Ran `pnpm --filter app exec biome check --write 'app/(actions)/inventoryActions.ts' 'app/admin/inventory/create/page.tsx' 'app/admin/inventory/[inventoryId]/edit/page.tsx' 'app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx'` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb231a050832fa0a1184870fe44ea)