### PR TITLE
Add `select` inventory custom attribute type with option lists

### DIFF
--- a/apps/app/app/(actions)/inventoryActions.ts
+++ b/apps/app/app/(actions)/inventoryActions.ts
@@ -17,6 +17,12 @@ import {
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { auth } from '../../lib/auth/auth';
+import {
+    encodeSelectFieldDataType,
+    getInventoryFieldType,
+    getInventorySelectOptions,
+    parseSelectOptionsInput,
+} from '../../lib/inventoryFieldTypes';
 import { KnownPages } from '../../src/KnownPages';
 
 const noEntityValue = 'none';
@@ -67,11 +73,23 @@ async function collectAdditionalFields(
 
         // Skip fields that don't match any configured field definition
         if (!def) continue;
-        if (def.dataType === 'number') {
+        const fieldType = getInventoryFieldType(def.dataType);
+        if (fieldType === 'number') {
             const num = Number(rawValue);
             entries[fieldName] = Number.isFinite(num) ? num : rawValue;
-        } else if (def.dataType === 'boolean') {
+        } else if (fieldType === 'boolean') {
             entries[fieldName] = rawValue === 'true';
+        } else if (fieldType === 'select') {
+            const options = getInventorySelectOptions(def.dataType);
+            const isKnownOption = options.some(
+                (option) => option.value === rawValue,
+            );
+            if (!isKnownOption) {
+                throw new Error(
+                    `Unknown value for select field "${fieldName}".`,
+                );
+            }
+            entries[fieldName] = rawValue;
         } else {
             entries[fieldName] = rawValue;
         }
@@ -153,8 +171,22 @@ export async function createInventoryItemFieldDefinitionAction(
 
     const name = formData.get('name') as string;
     const label = formData.get('label') as string;
-    const dataType = (formData.get('dataType') as string) || 'text';
+    const rawDataType = (formData.get('dataType') as string) || 'text';
     const required = formData.get('required') === 'true';
+    const parsedSelectOptions = parseSelectOptionsInput(
+        formData.get('selectOptions'),
+    );
+
+    const dataType =
+        rawDataType === 'select'
+            ? encodeSelectFieldDataType(parsedSelectOptions)
+            : rawDataType;
+
+    if (rawDataType === 'select' && parsedSelectOptions.length === 0) {
+        throw new Error(
+            'Select polje mora sadržavati barem jednu opciju (value|label).',
+        );
+    }
 
     await createInventoryItemFieldDefinition({
         inventoryConfigId,
@@ -368,6 +400,21 @@ export async function quickAdjustInventoryItemAction(
     const eventNotes = (formData.get('notes') as string) || null;
     const statusFieldName = existingItem.inventoryConfig.statusAttributeName;
     const nextStateRaw = (formData.get('state') as string) || '';
+    const statusFieldDefinition = statusFieldName
+        ? existingItem.inventoryConfig.fieldDefinitions.find(
+              (field) => field.name === statusFieldName,
+          )
+        : undefined;
+    const statusFieldOptions = statusFieldDefinition
+        ? getInventorySelectOptions(statusFieldDefinition.dataType)
+        : [];
+    if (
+        nextStateRaw.length > 0 &&
+        statusFieldOptions.length > 0 &&
+        !statusFieldOptions.some((option) => option.value === nextStateRaw)
+    ) {
+        throw new Error('Unknown status value.');
+    }
     const nextState = nextStateRaw.length > 0 ? nextStateRaw : null;
     const previousState = getItemStateFromAdditionalFields(
         existingItem.additionalFields,

--- a/apps/app/app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx
@@ -6,6 +6,7 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useMemo, useState } from 'react';
 
 export function AddFieldDefinitionForm({
     onSubmit,
@@ -16,6 +17,13 @@ export function AddFieldDefinitionForm({
     hasStatusField: boolean;
     hasAmountField: boolean;
 }) {
+    const [selectedDataType, setSelectedDataType] = useState('text');
+    const showSelectOptions = selectedDataType === 'select';
+    const statusSelectOptions = useMemo(
+        () => ['new|Novo', 'opened|Otvoreno', 'used|Korišteno'].join('\n'),
+        [],
+    );
+
     return (
         <Card className="max-w-2xl">
             <Stack spacing={4} className="p-6">
@@ -30,7 +38,16 @@ export function AddFieldDefinitionForm({
                         <form action={onSubmit}>
                             <input type="hidden" name="name" value="status" />
                             <input type="hidden" name="label" value="Status" />
-                            <input type="hidden" name="dataType" value="text" />
+                            <input
+                                type="hidden"
+                                name="dataType"
+                                value="select"
+                            />
+                            <input
+                                type="hidden"
+                                name="selectOptions"
+                                value={statusSelectOptions}
+                            />
                             <input
                                 type="hidden"
                                 name="required"
@@ -95,9 +112,30 @@ export function AddFieldDefinitionForm({
                                 { value: 'number', label: 'Broj' },
                                 { value: 'date', label: 'Datum' },
                                 { value: 'boolean', label: 'Da/Ne' },
+                                { value: 'select', label: 'Odabir (select)' },
                             ]}
                             defaultValue="text"
+                            onValueChange={setSelectedDataType}
                         />
+                        {showSelectOptions && (
+                            <label className="flex flex-col gap-1">
+                                <Typography level="body2" semiBold>
+                                    Select opcije
+                                </Typography>
+                                <textarea
+                                    name="selectOptions"
+                                    required
+                                    rows={4}
+                                    placeholder={'new|Novo\nopened|Otvoreno'}
+                                    className="min-h-24 rounded-md border bg-background px-3 py-2 text-sm"
+                                />
+                                <Typography level="body3" secondary>
+                                    Jedna opcija po retku u formatu{' '}
+                                    <code>value|label</code>. Ako ne navedete
+                                    label, koristi se value.
+                                </Typography>
+                            </label>
+                        )}
                         <SelectItems
                             name="required"
                             label="Obavezno"

--- a/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
@@ -9,6 +9,10 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../lib/auth/auth';
+import {
+    getInventoryFieldType,
+    getInventorySelectOptions,
+} from '../../../../../lib/inventoryFieldTypes';
 import { KnownPages } from '../../../../../src/KnownPages';
 import {
     createInventoryItemFieldDefinitionAction,
@@ -176,31 +180,51 @@ export default async function EditInventoryConfigPage({
                 {config.fieldDefinitions.length > 0 && (
                     <Card className="max-w-2xl">
                         <Stack spacing={0}>
-                            {config.fieldDefinitions.map((field, index) => (
-                                <div
-                                    key={field.id}
-                                    className={`flex items-center justify-between p-4 ${index < config.fieldDefinitions.length - 1 ? 'border-b' : ''}`}
-                                >
-                                    <Stack spacing={0}>
-                                        <Typography level="body1" semiBold>
-                                            {field.label}
-                                        </Typography>
-                                        <Typography level="body2" secondary>
-                                            {field.name} · {field.dataType}
-                                            {field.required
-                                                ? ' · Obavezno'
-                                                : ''}
-                                        </Typography>
-                                    </Stack>
-                                    <DeleteFieldDefinitionButton
-                                        inventoryConfigId={id}
-                                        fieldId={field.id}
-                                        onDelete={
-                                            deleteInventoryItemFieldDefinitionAction
-                                        }
-                                    />
-                                </div>
-                            ))}
+                            {config.fieldDefinitions.map((field, index) => {
+                                const fieldType = getInventoryFieldType(
+                                    field.dataType,
+                                );
+                                const selectOptions =
+                                    fieldType === 'select'
+                                        ? getInventorySelectOptions(
+                                              field.dataType,
+                                          )
+                                        : [];
+
+                                return (
+                                    <div
+                                        key={field.id}
+                                        className={`flex items-center justify-between p-4 ${index < config.fieldDefinitions.length - 1 ? 'border-b' : ''}`}
+                                    >
+                                        <Stack spacing={0}>
+                                            <Typography level="body1" semiBold>
+                                                {field.label}
+                                            </Typography>
+                                            <Typography level="body2" secondary>
+                                                {field.name} · {fieldType}
+                                                {field.required
+                                                    ? ' · Obavezno'
+                                                    : ''}
+                                                {selectOptions.length > 0
+                                                    ? ` · ${selectOptions
+                                                          .map(
+                                                              (option) =>
+                                                                  `${option.value}:${option.label}`,
+                                                          )
+                                                          .join(', ')}`
+                                                    : ''}
+                                            </Typography>
+                                        </Stack>
+                                        <DeleteFieldDefinitionButton
+                                            inventoryConfigId={id}
+                                            fieldId={field.id}
+                                            onDelete={
+                                                deleteInventoryItemFieldDefinitionAction
+                                            }
+                                        />
+                                    </div>
+                                );
+                            })}
                         </Stack>
                     </Card>
                 )}

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -15,6 +15,10 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../../lib/auth/auth';
+import {
+    getInventoryFieldType,
+    getInventorySelectOptions,
+} from '../../../../../../lib/inventoryFieldTypes';
 import { KnownPages } from '../../../../../../src/KnownPages';
 import {
     quickAdjustInventoryItemAction,
@@ -95,6 +99,14 @@ export default async function InventoryItemPage({
         id,
     );
     const statusAttributeName = config.statusAttributeName;
+    const statusFieldDefinition = statusAttributeName
+        ? config.fieldDefinitions.find(
+              (field) => field.name === statusAttributeName,
+          )
+        : undefined;
+    const statusOptions = statusFieldDefinition
+        ? getInventorySelectOptions(statusFieldDefinition.dataType)
+        : [];
     const currentState = statusAttributeName
         ? ((additionalFields[statusAttributeName] as string) ?? '')
         : '';
@@ -170,10 +182,12 @@ export default async function InventoryItemPage({
                                                     additionalFields[
                                                         field.name
                                                     ];
+                                                const fieldType =
+                                                    getInventoryFieldType(
+                                                        field.dataType,
+                                                    );
 
-                                                if (
-                                                    field.dataType === 'boolean'
-                                                ) {
+                                                if (fieldType === 'boolean') {
                                                     return (
                                                         <SelectItems
                                                             key={field.id}
@@ -205,16 +219,46 @@ export default async function InventoryItemPage({
                                                     );
                                                 }
 
+                                                if (fieldType === 'select') {
+                                                    const options =
+                                                        getInventorySelectOptions(
+                                                            field.dataType,
+                                                        );
+                                                    const selectedValue =
+                                                        typeof fieldValue ===
+                                                        'string'
+                                                            ? fieldValue
+                                                            : options[0]?.value;
+                                                    if (!selectedValue) {
+                                                        return null;
+                                                    }
+
+                                                    return (
+                                                        <SelectItems
+                                                            key={field.id}
+                                                            name={`field_${field.name}`}
+                                                            label={field.label}
+                                                            items={options}
+                                                            defaultValue={
+                                                                selectedValue
+                                                            }
+                                                            required={
+                                                                field.required
+                                                            }
+                                                        />
+                                                    );
+                                                }
+
                                                 return (
                                                     <Input
                                                         key={field.id}
                                                         name={`field_${field.name}`}
                                                         label={field.label}
                                                         type={
-                                                            field.dataType ===
+                                                            fieldType ===
                                                             'number'
                                                                 ? 'number'
-                                                                : field.dataType ===
+                                                                : fieldType ===
                                                                     'date'
                                                                   ? 'date'
                                                                   : 'text'
@@ -259,13 +303,24 @@ export default async function InventoryItemPage({
                                 min={0}
                                 defaultValue={item.quantity.toString()}
                             />
-                            {statusAttributeName && (
-                                <Input
-                                    name="state"
-                                    label="Novo stanje (opcionalno)"
-                                    defaultValue={currentState}
-                                />
-                            )}
+                            {statusAttributeName &&
+                                (statusOptions.length > 0 ? (
+                                    <SelectItems
+                                        name="state"
+                                        label="Novo stanje (opcionalno)"
+                                        items={statusOptions}
+                                        defaultValue={
+                                            currentState ||
+                                            statusOptions[0].value
+                                        }
+                                    />
+                                ) : (
+                                    <Input
+                                        name="state"
+                                        label="Novo stanje (opcionalno)"
+                                        defaultValue={currentState}
+                                    />
+                                ))}
                             <Input
                                 name="notes"
                                 label="Napomena događaja (opcionalno)"

--- a/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
@@ -9,6 +9,10 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../../lib/auth/auth';
+import {
+    getInventoryFieldType,
+    getInventorySelectOptions,
+} from '../../../../../../lib/inventoryFieldTypes';
 import { KnownPages } from '../../../../../../src/KnownPages';
 import { createInventoryItemAction } from '../../../../../(actions)/inventoryActions';
 
@@ -136,42 +140,83 @@ export default async function CreateInventoryItemPage({
                                         <Typography level="body1" semiBold>
                                             Dodatna polja
                                         </Typography>
-                                        {config.fieldDefinitions.map((field) =>
-                                            field.dataType === 'boolean' ? (
-                                                <SelectItems
-                                                    key={field.id}
-                                                    name={`field_${field.name}`}
-                                                    label={field.label}
-                                                    items={[
-                                                        {
-                                                            value: 'true',
-                                                            label: 'Da',
-                                                        },
-                                                        {
-                                                            value: 'false',
-                                                            label: 'Ne',
-                                                        },
-                                                    ]}
-                                                    defaultValue="false"
-                                                    required={field.required}
-                                                />
-                                            ) : (
-                                                <Input
-                                                    key={field.id}
-                                                    name={`field_${field.name}`}
-                                                    label={field.label}
-                                                    type={
-                                                        field.dataType ===
-                                                        'number'
-                                                            ? 'number'
-                                                            : field.dataType ===
-                                                                'date'
-                                                              ? 'date'
-                                                              : 'text'
+                                        {config.fieldDefinitions.map(
+                                            (field) => {
+                                                const fieldType =
+                                                    getInventoryFieldType(
+                                                        field.dataType,
+                                                    );
+                                                if (fieldType === 'boolean') {
+                                                    return (
+                                                        <SelectItems
+                                                            key={field.id}
+                                                            name={`field_${field.name}`}
+                                                            label={field.label}
+                                                            items={[
+                                                                {
+                                                                    value: 'true',
+                                                                    label: 'Da',
+                                                                },
+                                                                {
+                                                                    value: 'false',
+                                                                    label: 'Ne',
+                                                                },
+                                                            ]}
+                                                            defaultValue="false"
+                                                            required={
+                                                                field.required
+                                                            }
+                                                        />
+                                                    );
+                                                }
+
+                                                if (fieldType === 'select') {
+                                                    const options =
+                                                        getInventorySelectOptions(
+                                                            field.dataType,
+                                                        );
+                                                    const defaultValue =
+                                                        options[0]?.value;
+                                                    if (!defaultValue) {
+                                                        return null;
                                                     }
-                                                    required={field.required}
-                                                />
-                                            ),
+
+                                                    return (
+                                                        <SelectItems
+                                                            key={field.id}
+                                                            name={`field_${field.name}`}
+                                                            label={field.label}
+                                                            items={options}
+                                                            defaultValue={
+                                                                defaultValue
+                                                            }
+                                                            required={
+                                                                field.required
+                                                            }
+                                                        />
+                                                    );
+                                                }
+
+                                                return (
+                                                    <Input
+                                                        key={field.id}
+                                                        name={`field_${field.name}`}
+                                                        label={field.label}
+                                                        type={
+                                                            fieldType ===
+                                                            'number'
+                                                                ? 'number'
+                                                                : fieldType ===
+                                                                    'date'
+                                                                  ? 'date'
+                                                                  : 'text'
+                                                        }
+                                                        required={
+                                                            field.required
+                                                        }
+                                                    />
+                                                );
+                                            },
                                         )}
                                     </Stack>
                                 )}

--- a/apps/app/app/admin/inventory/[inventoryId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/page.tsx
@@ -24,6 +24,7 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { Field } from '../../../../components/shared/fields/Field';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../lib/auth/auth';
+import { getInventoryFieldType } from '../../../../lib/inventoryFieldTypes';
 import { KnownPages } from '../../../../src/KnownPages';
 import { DeleteInventoryItemButton } from './DeleteInventoryItemButton';
 
@@ -177,7 +178,9 @@ export default async function InventoryConfigPage({
                                         <Table.Cell>{field.name}</Table.Cell>
                                         <Table.Cell>{field.label}</Table.Cell>
                                         <Table.Cell>
-                                            {field.dataType}
+                                            {getInventoryFieldType(
+                                                field.dataType,
+                                            )}
                                         </Table.Cell>
                                         <Table.Cell>
                                             {field.required ? 'Da' : 'Ne'}

--- a/apps/app/lib/inventoryFieldTypes.ts
+++ b/apps/app/lib/inventoryFieldTypes.ts
@@ -1,0 +1,128 @@
+export type InventoryCustomFieldType =
+    | 'text'
+    | 'number'
+    | 'date'
+    | 'boolean'
+    | 'select';
+
+export type InventorySelectOption = {
+    value: string;
+    label: string;
+};
+
+const selectPrefix = 'select|';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function normalizeOption(option: unknown): InventorySelectOption | null {
+    if (!isRecord(option)) {
+        return null;
+    }
+
+    const value = option.value;
+    const label = option.label;
+    if (typeof value !== 'string' || typeof label !== 'string') {
+        return null;
+    }
+
+    const normalizedValue = value.trim();
+    const normalizedLabel = label.trim();
+    if (!normalizedValue || !normalizedLabel) {
+        return null;
+    }
+
+    return {
+        value: normalizedValue,
+        label: normalizedLabel,
+    };
+}
+
+function parseOptions(rawOptions: string): InventorySelectOption[] {
+    if (!rawOptions) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(rawOptions) as unknown;
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed
+            .map(normalizeOption)
+            .filter(
+                (option): option is InventorySelectOption => option !== null,
+            );
+    } catch {
+        return [];
+    }
+}
+
+export function getInventoryFieldType(
+    dataType: string,
+): InventoryCustomFieldType {
+    if (dataType === 'text' || dataType === 'number' || dataType === 'date') {
+        return dataType;
+    }
+    if (dataType === 'boolean') {
+        return 'boolean';
+    }
+    if (dataType.startsWith(selectPrefix)) {
+        return 'select';
+    }
+    return 'text';
+}
+
+export function getInventorySelectOptions(
+    dataType: string,
+): InventorySelectOption[] {
+    if (!dataType.startsWith(selectPrefix)) {
+        return [];
+    }
+    return parseOptions(dataType.slice(selectPrefix.length));
+}
+
+export function encodeSelectFieldDataType(
+    options: InventorySelectOption[],
+): string {
+    return `${selectPrefix}${JSON.stringify(options)}`;
+}
+
+export function parseSelectOptionsInput(
+    rawValue: FormDataEntryValue | null,
+): InventorySelectOption[] {
+    if (typeof rawValue !== 'string') {
+        return [];
+    }
+
+    const lines = rawValue
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+
+    const options = lines
+        .map((line) => {
+            const [rawOptionValue, ...labelParts] = line
+                .split('|')
+                .map((part) => part.trim());
+            const rawOptionLabel =
+                labelParts.length > 0 ? labelParts.join('|') : rawOptionValue;
+
+            if (!rawOptionValue || !rawOptionLabel) {
+                return null;
+            }
+
+            return {
+                value: rawOptionValue,
+                label: rawOptionLabel,
+            } satisfies InventorySelectOption;
+        })
+        .filter((option): option is InventorySelectOption => option !== null);
+
+    const uniqueOptionsMap = new Map(
+        options.map((option) => [option.value, option] as const),
+    );
+    return Array.from(uniqueOptionsMap.values());
+}


### PR DESCRIPTION
### Motivation

- Introduce a new inventory custom attribute type that lets admins define a choice list so attributes like status can be constrained to a set of string values with labels.

### Description

- Added a reusable helper `apps/app/lib/inventoryFieldTypes.ts` that encodes/decodes `select` field definitions using a `select|<json>` dataType prefix and provides parsing/normalization helpers for `{ value, label }` options.
- Store and validate select definitions in server actions by parsing `selectOptions` from forms and encoding them via `encodeSelectFieldDataType`, and require at least one option when creating a `select` field (`apps/app/app/(actions)/inventoryActions.ts`).
- Render `select` fields in the UI: updated the add-field form to accept option lists, auto-create a status `select` with default options, and render dropdowns for `select` custom attributes in item create/edit/quick-adjust pages (`apps/app/app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx`, `.../items/create/page.tsx`, `.../items/[itemId]/page.tsx`).
- Improve admin listings and edit view to show normalized field types and include option summaries for `select` fields (`apps/app/app/admin/inventory/[inventoryId]/page.tsx`, `.../edit/page.tsx`).

### Testing

- Ran targeted static checks with `pnpm --dir apps/app exec biome check 'app/(actions)/inventoryActions.ts' 'app/admin/inventory/[inventoryId]/edit/AddFieldDefinitionForm.tsx' 'app/admin/inventory/[inventoryId]/edit/page.tsx' 'app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx' 'app/admin/inventory/[inventoryId]/items/create/page.tsx' 'app/admin/inventory/[inventoryId]/page.tsx' 'lib/inventoryFieldTypes.ts'` which completed without errors.
- Built the `app` package with `pnpm build --filter app`, which succeeded (build passed), noting a workspace Node engine warning because the repo requests `node >=24` while the environment ran `v22.21.1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc0505908832f81e84ec8a98a2801)