### PR TITLE
Fix shopping cart raised bed label to use physicalId

### DIFF
--- a/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
+++ b/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
@@ -1,6 +1,7 @@
 import {
     getEntitiesFormatted,
     getInventory,
+    getRaisedBed,
     getShoppingCart,
 } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
@@ -62,6 +63,29 @@ export default async function ShoppingCartDetailsPage({
     entitiesResults.forEach(({ entityTypeName, entities }) => {
         entitiesLookup[entityTypeName] = entities as EntityStandardized[];
     });
+
+    const raisedBedIds = [
+        ...new Set(
+            cart.items
+                .map((item) => item.raisedBedId)
+                .filter(
+                    (raisedBedId): raisedBedId is number =>
+                        typeof raisedBedId === 'number',
+                ),
+        ),
+    ];
+    const raisedBeds = await Promise.all(
+        raisedBedIds.map(async (raisedBedId) => ({
+            raisedBedId,
+            raisedBed: await getRaisedBed(raisedBedId),
+        })),
+    );
+    const raisedBedPhysicalIdLookup = new Map(
+        raisedBeds.map(({ raisedBedId, raisedBed }) => [
+            raisedBedId,
+            raisedBed?.physicalId,
+        ]),
+    );
 
     // Enhance cart items with entity names
     const enhancedItems = cart.items.map((item) => {
@@ -337,7 +361,10 @@ export default async function ShoppingCartDetailsPage({
                                                         item.raisedBedId,
                                                     )}
                                                 >
-                                                    Gr {item.raisedBedId}
+                                                    Gr{' '}
+                                                    {raisedBedPhysicalIdLookup.get(
+                                                        item.raisedBedId,
+                                                    ) ?? item.raisedBedId}
                                                 </Link>
                                             </>
                                         ) : (


### PR DESCRIPTION
### Motivation
- Shopping cart details rendered raised bed labels as the internal numeric `raisedBedId` instead of the human-friendly `physicalId`, causing confusion for admins. 
- The change ensures cart item rows show the correct physical identifier when available and falls back to the internal id when not.

### Description
- Imported `getRaisedBed` and collected unique `raisedBedId` values from `cart.items` in `apps/app/app/admin/shopping-carts/[cartId]/page.tsx`.
- Fetched each raised bed and built a `raisedBedId -> physicalId` lookup map to resolve and prefer `physicalId` in the UI. 
- Replaced the inline `Gr {item.raisedBedId}` render with `Gr {raisedBedPhysicalIdLookup.get(item.raisedBedId) ?? item.raisedBedId}` so it falls back to the numeric id when no physical ID exists. 
- Kept existing entity enhancement and currency/price logic unchanged.

### Testing
- Ran a repository search (`rg`) for the rendering pattern to locate other occurrences and verified this was the only shopping-cart occurrence needing the fix. 
- Ran workspace lint for the `app` scope with `pnpm lint --filter app`, which completed (reporting one unrelated warning). 
- Ran a targeted Biome check on the modified file with `pnpm --filter app exec biome check app/admin/shopping-carts/[cartId]/page.tsx`, which passed with no fixes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1e72e340832faf9bfd11e7865f28)