### PR TITLE
Redesign admin sidebar with mobile-friendly shadcn-style drawer

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -85,20 +85,22 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                 pendingAchievementsCount={pendingAchievementsCount}
                 quickActions={quickActions}
             >
-                <div className="grow bg-secondary">
+                <div className="grow bg-secondary/40">
                     <MobileHeader />
                     <main className="relative h-full md:h-full min-h-[calc(100vh-3.5rem)] md:min-h-screen">
-                        <div className="flex flex-row min-h-full">
+                        <div className="flex min-h-full flex-row gap-3 p-2 md:gap-4 md:p-4">
                             {/* Desktop Navigation */}
-                            <div className="hidden md:block p-4 min-w-64">
-                                <Nav />
-                            </div>
+                            <aside className="hidden md:block md:w-72 md:shrink-0">
+                                <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-3 shadow-sm">
+                                    <Nav />
+                                </div>
+                            </aside>
                             {/* Main Content */}
-                            <div className="min-h-full grow md:pt-2">
-                                <div className="p-2 md:p-4 bg-background rounded-t-xl md:border-l md:border-t md:rounded-tr-none min-h-full">
+                            <div className="min-h-full grow">
+                                <div className="min-h-full rounded-2xl border bg-background p-2 md:p-4">
                                     <AuthProtectedSection auth={authAdmin}>
                                         <Suspense>
-                                            <div className="mb-3 hidden md:block">
+                                            <div className="mb-4 hidden md:block">
                                                 <AdminPageBreadcrumbs />
                                             </div>
                                             {children}

--- a/apps/app/components/admin/navigation/MobileHeader.tsx
+++ b/apps/app/components/admin/navigation/MobileHeader.tsx
@@ -4,7 +4,7 @@ import { MobileNav } from './MobileNav';
 
 export function MobileHeader() {
     return (
-        <div className="md:hidden sticky top-0 z-50 w-full">
+        <div className="sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur md:hidden">
             <div className="flex h-14 items-center px-4">
                 <Row spacing={3} className="w-full items-center">
                     <MobileNav />

--- a/apps/app/components/admin/navigation/MobileNav.tsx
+++ b/apps/app/components/admin/navigation/MobileNav.tsx
@@ -4,10 +4,18 @@ import { Close, Menu } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Nav } from './Nav';
 
 export function MobileNav() {
     const [isOpen, setIsOpen] = useState(false);
+    const [portalElement, setPortalElement] = useState<HTMLElement | null>(
+        null,
+    );
+
+    useEffect(() => {
+        setPortalElement(document.body);
+    }, []);
 
     useEffect(() => {
         if (isOpen) {
@@ -21,6 +29,77 @@ export function MobileNav() {
         };
     }, [isOpen]);
 
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setIsOpen(false);
+            }
+        };
+
+        window.addEventListener('keydown', handleEscape);
+
+        return () => {
+            window.removeEventListener('keydown', handleEscape);
+        };
+    }, [isOpen]);
+
+    const drawer = (
+        <>
+            <div
+                className={`fixed inset-0 z-50 bg-black/40 backdrop-blur-[1px] transition-opacity duration-200 md:hidden ${
+                    isOpen
+                        ? 'pointer-events-auto opacity-100'
+                        : 'pointer-events-none opacity-0'
+                }`}
+                onClick={() => setIsOpen(false)}
+                aria-hidden="true"
+            />
+
+            <aside
+                className={`fixed inset-y-0 left-0 z-[60] flex w-[88vw] max-w-[22rem] flex-col border-r bg-background shadow-xl transition-transform duration-300 ease-out md:hidden ${
+                    isOpen ? 'translate-x-0' : '-translate-x-full'
+                }`}
+                aria-label="Administracijski izbornik"
+            >
+                <div className="border-b px-4 py-3">
+                    <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0">
+                            <Typography
+                                level="h4"
+                                semiBold
+                                className="truncate"
+                            >
+                                Administracija
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                className="text-muted-foreground"
+                            >
+                                Navigacija i upravljanje
+                            </Typography>
+                        </div>
+                        <IconButton
+                            variant="plain"
+                            title="Zatvori"
+                            onClick={() => setIsOpen(false)}
+                            className="rounded-md border"
+                        >
+                            <Close className="size-4" />
+                        </IconButton>
+                    </div>
+                </div>
+
+                <div className="flex-1 overflow-y-auto px-3 py-4">
+                    <Nav onItemClick={() => setIsOpen(false)} />
+                </div>
+            </aside>
+        </>
+    );
+
     return (
         <>
             <IconButton
@@ -32,32 +111,7 @@ export function MobileNav() {
                 <Menu className="size-4" />
             </IconButton>
 
-            {/* Sidebar */}
-            <div
-                className={`fixed top-0 left-0 h-full w-80 max-w-[80vw] bg-background border-r z-50 md:hidden transform transition-transform duration-300 ease-in-out ${
-                    isOpen ? 'translate-x-0' : '-translate-x-full'
-                }`}
-            >
-                <div className="flex flex-col h-full">
-                    {/* Header */}
-                    <div className="flex items-center justify-between p-4 border-b">
-                        <Typography level="h4" semiBold>
-                            Administracija
-                        </Typography>
-                        <IconButton
-                            variant="plain"
-                            title="Zatvori"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            <Close className="size-4" />
-                        </IconButton>
-                    </div>
-                    {/* Navigation */}
-                    <div className="flex-1 overflow-y-auto p-4">
-                        <Nav onItemClick={() => setIsOpen(false)} />
-                    </div>
-                </div>
-            </div>
+            {portalElement ? createPortal(drawer, portalElement) : null}
         </>
     );
 }


### PR DESCRIPTION
### Motivation
- Improve mobile usability by replacing the old slide-in sidebar with a polished off-canvas drawer that follows shadcn-style visual patterns. 
- Make the desktop admin shell visually consistent and easier to scan with a sticky, rounded, bordered sidebar container and refreshed content surface spacing. 

### Description
- Reworked `MobileNav` into an off-canvas drawer with a dimmed backdrop, smooth transitions, and Escape-to-close handling while preserving existing `Nav` content and interactions. 
- Added a translucent sticky mobile header in `MobileHeader` to match the new drawer visual treatment. 
- Updated `app/admin/layout.tsx` to render a sticky, scrollable desktop sidebar container with rounded corners, border, and refined spacing, and adjusted the main content surface styling. 
- Kept all navigation items and drag/reorder logic intact by reusing the existing `Nav` component and only changing surrounding layout and affordances. 

### Testing
- Ran automated formatting/type checks with `pnpm --dir apps/app exec biome check --write app/admin/layout.tsx components/admin/navigation/MobileHeader.tsx components/admin/navigation/MobileNav.tsx` which completed and fixed issues. 
- No UI screenshots or visual tests were produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a91c49c832f881dc72cbe192dca)