### PR TITLE
Collapse admin sidebar to icon-only on tablet

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -90,9 +90,14 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                     <main className="relative h-full md:h-full min-h-[calc(100vh-3.5rem)] md:min-h-screen">
                         <div className="flex min-h-full flex-row gap-3 p-2 md:gap-4 md:p-4">
                             {/* Desktop Navigation */}
-                            <aside className="hidden md:block md:w-72 md:shrink-0">
-                                <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-3 shadow-sm">
-                                    <Nav />
+                            <aside className="hidden md:block md:w-20 md:shrink-0 lg:w-72">
+                                <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-2 shadow-sm lg:p-3">
+                                    <div className="lg:hidden">
+                                        <Nav compact />
+                                    </div>
+                                    <div className="hidden lg:block">
+                                        <Nav />
+                                    </div>
                                 </div>
                             </aside>
                             {/* Main Content */}

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -77,9 +77,11 @@ function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
 function SortableNavItem({
     entityType,
     onClick,
+    compact,
 }: {
     entityType: SelectEntityType;
     onClick?: () => void;
+    compact?: boolean;
 }) {
     const {
         attributes,
@@ -103,6 +105,7 @@ function SortableNavItem({
                 }
                 onClick={onClick}
                 isDragging={isDragging}
+                compact={compact}
             />
         </div>
     );
@@ -111,9 +114,11 @@ function SortableNavItem({
 function EntityTypeList({
     items: initialItems,
     onItemClick,
+    compact,
 }: {
     items: SelectEntityType[];
     onItemClick?: () => void;
+    compact?: boolean;
 }) {
     const [items, setItems] = useState(initialItems);
     const sensors = useSensors(useSensor(PointerSensor));
@@ -146,6 +151,7 @@ function EntityTypeList({
                             key={entityType.id}
                             entityType={entityType}
                             onClick={onItemClick}
+                            compact={compact}
                         />
                     ))}
                 </List>
@@ -154,7 +160,13 @@ function EntityTypeList({
     );
 }
 
-export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
+export function Nav({
+    onItemClick,
+    compact = false,
+}: {
+    onItemClick?: () => void;
+    compact?: boolean;
+} = {}) {
     const navContext = useContext(NavContext);
     const categorizedTypes = navContext?.categorizedTypes || [];
     const uncategorizedTypes = navContext?.uncategorizedTypes || [];
@@ -165,13 +177,14 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
     return (
         <Stack spacing={2}>
             <List>
-                <ProfileNavItem onItemClick={onItemClick} />
+                <ProfileNavItem onItemClick={onItemClick} compact={compact} />
                 <NavItem
                     href={adminPages.Dashboard.href}
                     label={adminPages.Dashboard.label}
                     icon={<Home className="size-5" />}
                     strictMatch
                     onClick={onItemClick}
+                    compact={compact}
                 />
                 {quickActions.map((quickAction) => (
                     <NavItem
@@ -180,6 +193,7 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                         label={quickAction.label}
                         icon={quickActionIcon(quickAction)}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                 ))}
             </List>
@@ -187,19 +201,20 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                 {/* Categories with their entity types */}
                 {categorizedTypes.map((category) => (
                     <Stack key={category.id} spacing={1}>
-                        <ListHeader header={category.label} />
+                        {!compact && <ListHeader header={category.label} />}
                         <EntityTypeList
                             items={category.entityTypes}
                             onItemClick={onItemClick}
+                            compact={compact}
                         />
                     </Stack>
                 ))}
 
-                <ListHeader header="Zapisi" />
+                {!compact && <ListHeader header="Zapisi" />}
                 {/* Shadow entity types */}
-                {shadowTypes.length > 0 && (
-                    <ListTreeItem label="Ostalo">
-                        {shadowTypes.map((entityType) => (
+                {shadowTypes.length > 0 &&
+                    (compact ? (
+                        shadowTypes.map((entityType) => (
                             <NavItem
                                 key={entityType.id}
                                 href={KnownPages.DirectoryEntityType(
@@ -213,27 +228,48 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                                     />
                                 }
                                 onClick={onItemClick}
+                                compact={compact}
                             />
-                        ))}
-                    </ListTreeItem>
-                )}
+                        ))
+                    ) : (
+                        <ListTreeItem label="Ostalo">
+                            {shadowTypes.map((entityType) => (
+                                <NavItem
+                                    key={entityType.id}
+                                    href={KnownPages.DirectoryEntityType(
+                                        entityType.name,
+                                    )}
+                                    label={entityType.label}
+                                    icon={
+                                        <EntityTypeIcon
+                                            icon={entityType.icon}
+                                            className="size-5"
+                                        />
+                                    }
+                                    onClick={onItemClick}
+                                />
+                            ))}
+                        </ListTreeItem>
+                    ))}
 
                 {/* Entity types without category come first */}
                 {uncategorizedTypes.length > 0 && (
                     <EntityTypeList
                         items={uncategorizedTypes}
                         onItemClick={onItemClick}
+                        compact={compact}
                     />
                 )}
             </Stack>
             <Stack spacing={1}>
-                <ListHeader header="Administracija" />
+                {!compact && <ListHeader header="Administracija" />}
                 <List>
                     <NavItem
                         href={adminPages.Accounts.href}
                         label={adminPages.Accounts.label}
                         icon={<Bank className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Achievements.href}
@@ -241,54 +277,63 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                         icon={<Success className="size-5" />}
                         onClick={onItemClick}
                         badge={pendingAchievementsCount}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.ShoppingCarts.href}
                         label={adminPages.ShoppingCarts.label}
                         icon={<ShoppingCart className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Invoices.href}
                         label={adminPages.Invoices.label}
                         icon={<File className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Transactions.href}
                         label={adminPages.Transactions.label}
                         icon={<Euro className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Sunflowers.href}
                         label={adminPages.Sunflowers.label}
                         icon={<Success className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Receipts.href}
                         label={adminPages.Receipts.label}
                         icon={<File className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Users.href}
                         label={adminPages.Users.label}
                         icon={<User className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Farms.href}
                         label={adminPages.Farms.label}
                         icon={<MapIcon className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Gardens.href}
                         label={adminPages.Gardens.label}
                         icon={<Fence className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.RaisedBeds.href}
@@ -300,116 +345,132 @@ export function Nav({ onItemClick }: { onItemClick?: () => void } = {}) {
                             />
                         }
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Operations.href}
                         label={adminPages.Operations.label}
                         icon={<Hammer className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                 </List>
             </Stack>
             <Stack spacing={1}>
-                <ListHeader header="Upravljanje" />
+                {!compact && <ListHeader header="Upravljanje" />}
                 <List>
                     <NavItem
                         href={adminPages.Inventory.href}
                         label={adminPages.Inventory.label}
                         icon={<Tally3 className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Occasions.href}
                         label={adminPages.Occasions.label}
                         icon={<Calendar className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Schedule.href}
                         label={adminPages.Schedule.label}
                         icon={<Calendar className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.SowingStatistics.href}
                         label={adminPages.SowingStatistics.label}
                         icon={<Tally3 className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.DeliverySlots.href}
                         label={adminPages.DeliverySlots.label}
                         icon={<Truck className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.DeliveryRequests.href}
                         label={adminPages.DeliveryRequests.label}
                         icon={<Truck className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                 </List>
             </Stack>
             <Stack spacing={1}>
-                <ListHeader header="Komunikacija" />
+                {!compact && <ListHeader header="Komunikacija" />}
                 <List>
                     <NavItem
                         href={adminPages.CommunicationInbox.href}
                         label={adminPages.CommunicationInbox.label}
                         icon={<Inbox className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.CommunicationEmails.href}
                         label={adminPages.CommunicationEmails.label}
                         icon={<Mail className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Notifications.href}
                         label={adminPages.Notifications.label}
                         icon={<Megaphone className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Feedback.href}
                         label={adminPages.Feedback.label}
                         icon={<SmileHappy className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                 </List>
             </Stack>
             <Stack spacing={1}>
-                <ListHeader header="Postavke" />
+                {!compact && <ListHeader header="Postavke" />}
                 <List>
                     <NavItem
                         href={adminPages.Settings.href}
                         label={adminPages.Settings.label}
                         icon={<Settings className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                 </List>
             </Stack>
             <Stack spacing={1}>
-                <ListHeader header="Sustavi" />
+                {!compact && <ListHeader header="Sustavi" />}
                 <List>
                     <NavItem
                         href={adminPages.Sensors.href}
                         label={adminPages.Sensors.label}
                         icon={<File className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.Cache.href}
                         label={adminPages.Cache.label}
                         icon={<File className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                     <NavItem
                         href={adminPages.AiAnalytics.href}
                         label={adminPages.AiAnalytics.label}
                         icon={<AI className="size-5" />}
                         onClick={onItemClick}
+                        compact={compact}
                     />
                 </List>
             </Stack>

--- a/apps/app/components/admin/navigation/NavItem.tsx
+++ b/apps/app/components/admin/navigation/NavItem.tsx
@@ -14,6 +14,7 @@ export function NavItem({
     onClick,
     isDragging = false,
     badge,
+    compact = false,
 }: {
     href: Route;
     label: string;
@@ -22,6 +23,7 @@ export function NavItem({
     onClick?: () => void;
     isDragging?: boolean;
     badge?: number;
+    compact?: boolean;
 }) {
     const pathname = usePathname();
 
@@ -37,7 +39,7 @@ export function NavItem({
     };
 
     return (
-        <Link href={href} onClick={handleClick}>
+        <Link href={href} onClick={handleClick} title={label}>
             <ListItem
                 nodeId={href}
                 selected={
@@ -46,10 +48,10 @@ export function NavItem({
                         : pathname === href || pathname.startsWith(`${href}/`)
                 }
                 onSelected={() => {}}
-                label={label}
+                label={compact ? '' : label}
                 startDecorator={icon}
                 endDecorator={
-                    badge != null && badge > 0 ? (
+                    !compact && badge != null && badge > 0 ? (
                         <span className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-medium min-w-5 h-5 px-1.5">
                             {badge}
                         </span>

--- a/apps/app/components/admin/navigation/ProfileNavItem.tsx
+++ b/apps/app/components/admin/navigation/ProfileNavItem.tsx
@@ -30,8 +30,10 @@ function resolveAccountId(currentUser: CurrentUser | null): string | null {
 
 export function ProfileNavItem({
     onItemClick,
+    compact = false,
 }: {
     onItemClick?: () => void;
+    compact?: boolean;
 } = {}) {
     const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
 
@@ -83,7 +85,7 @@ export function ProfileNavItem({
                             size="sm"
                         />
                     }
-                    label={userName}
+                    label={compact ? '' : userName}
                 />
             </DropdownMenuTrigger>
             <DropdownMenuContent>


### PR DESCRIPTION
### Motivation
- Improve admin UI on tablet by collapsing the left sidebar to an icon-only, compact rail so content gets more horizontal space while preserving full navigation on large screens.

### Description
- Render a compact navigation variant between `md` and `lg` by adjusting the aside in `apps/app/app/admin/layout.tsx` and showing `<Nav compact />` for tablet and the full `<Nav />` for `lg` and up.
- Add a `compact` prop to `Nav`, `NavItem`, and `ProfileNavItem` so entries can render icon-only (labels hidden), keep `title` for hover, and suppress numeric badges in compact mode (`apps/app/components/admin/navigation/Nav.tsx`, `NavItem.tsx`, `ProfileNavItem.tsx`).
- Hide section headers and simplify shadow-type rendering when `compact` is enabled so the compact rail remains usable and uncluttered (`Nav.tsx`).
- Propagate `compact` through sortable entity lists and nav items so drag/reorder and click handlers still work in compact mode (`Nav.tsx`).

### Testing
- Ran `pnpm lint --filter app` which completed successfully (an unrelated existing Biome warning remains in `app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx`).
- Ran `pnpm --filter app exec biome check --write` against the modified files (`app/admin/layout.tsx`, `components/admin/navigation/Nav.tsx`, `NavItem.tsx`, `ProfileNavItem.tsx`) and it passed with no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1e48418c832f8b2e8de9b353f407)