### PR TITLE
Add collapsible DesktopNav and compact navigation mode

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -11,9 +11,9 @@ import { redirect } from 'next/navigation';
 import { type PropsWithChildren, Suspense } from 'react';
 import {
     AdminPageBreadcrumbs,
+    DesktopNav,
     LoginDialog,
     MobileHeader,
-    Nav,
 } from '../../components/admin/navigation';
 import { AdminClientProvider } from '../../components/admin/providers';
 import { AuthAppProvider } from '../../components/providers/AuthAppProvider';
@@ -90,16 +90,7 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                     <main className="relative h-full md:h-full min-h-[calc(100vh-3.5rem)] md:min-h-screen">
                         <div className="flex min-h-full flex-row gap-3 p-2 md:gap-4 md:p-4">
                             {/* Desktop Navigation */}
-                            <aside className="hidden md:block md:w-20 md:shrink-0 lg:w-72">
-                                <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-2 shadow-sm lg:p-3">
-                                    <div className="lg:hidden">
-                                        <Nav compact />
-                                    </div>
-                                    <div className="hidden lg:block">
-                                        <Nav />
-                                    </div>
-                                </div>
-                            </aside>
+                            <DesktopNav />
                             {/* Main Content */}
                             <div className="min-h-full grow">
                                 <div className="min-h-full rounded-2xl border bg-background p-2 md:p-4">

--- a/apps/app/components/admin/navigation/DesktopNav.tsx
+++ b/apps/app/components/admin/navigation/DesktopNav.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { ArrowLeft, ArrowRight } from '@signalco/ui-icons';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { useState } from 'react';
+import { Nav } from './Nav';
+
+export function DesktopNav() {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    return (
+        <aside
+            className={`hidden md:block md:shrink-0 md:transition-[width] md:duration-200 ${
+                isExpanded ? 'md:w-72' : 'md:w-20'
+            } lg:w-72`}
+        >
+            <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-2 shadow-sm lg:p-3">
+                <div className="mb-2 flex items-center justify-end lg:hidden">
+                    <IconButton
+                        variant="plain"
+                        onClick={() => setIsExpanded((value) => !value)}
+                        title={
+                            isExpanded
+                                ? 'Sažmi bočnu navigaciju'
+                                : 'Proširi bočnu navigaciju'
+                        }
+                        className="rounded-md border"
+                    >
+                        {isExpanded ? (
+                            <ArrowLeft className="size-4" />
+                        ) : (
+                            <ArrowRight className="size-4" />
+                        )}
+                    </IconButton>
+                </div>
+
+                <div className={isExpanded ? 'md:block lg:hidden' : 'hidden'}>
+                    <Nav />
+                </div>
+                <div className={isExpanded ? 'hidden' : 'md:block lg:hidden'}>
+                    <Nav compact />
+                </div>
+                <div className="hidden lg:block">
+                    <Nav />
+                </div>
+            </div>
+        </aside>
+    );
+}

--- a/apps/app/components/admin/navigation/DesktopNav.tsx
+++ b/apps/app/components/admin/navigation/DesktopNav.tsx
@@ -2,11 +2,24 @@
 
 import { ArrowLeft, ArrowRight } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Nav } from './Nav';
 
 export function DesktopNav() {
     const [isExpanded, setIsExpanded] = useState(false);
+    const [isLargeScreen, setIsLargeScreen] = useState(false);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia('(min-width: 1024px)');
+        const handleChange = () => setIsLargeScreen(mediaQuery.matches);
+
+        handleChange();
+        mediaQuery.addEventListener('change', handleChange);
+
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
+
+    const compact = !isExpanded && !isLargeScreen;
 
     return (
         <aside
@@ -34,15 +47,7 @@ export function DesktopNav() {
                     </IconButton>
                 </div>
 
-                <div className={isExpanded ? 'md:block lg:hidden' : 'hidden'}>
-                    <Nav />
-                </div>
-                <div className={isExpanded ? 'hidden' : 'md:block lg:hidden'}>
-                    <Nav compact />
-                </div>
-                <div className="hidden lg:block">
-                    <Nav />
-                </div>
+                <Nav compact={compact} />
             </div>
         </aside>
     );

--- a/apps/app/components/admin/navigation/DesktopNav.tsx
+++ b/apps/app/components/admin/navigation/DesktopNav.tsx
@@ -10,6 +10,10 @@ export function DesktopNav() {
     const [isLargeScreen, setIsLargeScreen] = useState(false);
 
     useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
         const mediaQuery = window.matchMedia('(min-width: 1024px)');
         const handleChange = () => setIsLargeScreen(mediaQuery.matches);
 

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -214,23 +214,25 @@ export function Nav({
                 {/* Shadow entity types */}
                 {shadowTypes.length > 0 &&
                     (compact ? (
-                        shadowTypes.map((entityType) => (
-                            <NavItem
-                                key={entityType.id}
-                                href={KnownPages.DirectoryEntityType(
-                                    entityType.name,
-                                )}
-                                label={entityType.label}
-                                icon={
-                                    <EntityTypeIcon
-                                        icon={entityType.icon}
-                                        className="size-5"
-                                    />
-                                }
-                                onClick={onItemClick}
-                                compact={compact}
-                            />
-                        ))
+                        <List>
+                            {shadowTypes.map((entityType) => (
+                                <NavItem
+                                    key={entityType.id}
+                                    href={KnownPages.DirectoryEntityType(
+                                        entityType.name,
+                                    )}
+                                    label={entityType.label}
+                                    icon={
+                                        <EntityTypeIcon
+                                            icon={entityType.icon}
+                                            className="size-5"
+                                        />
+                                    }
+                                    onClick={onItemClick}
+                                    compact={compact}
+                                />
+                            ))}
+                        </List>
                     ) : (
                         <ListTreeItem label="Ostalo">
                             {shadowTypes.map((entityType) => (

--- a/apps/app/components/admin/navigation/NavItem.tsx
+++ b/apps/app/components/admin/navigation/NavItem.tsx
@@ -41,12 +41,7 @@ export function NavItem({
     const listItemAccessibilityProps = compact ? { 'aria-label': label } : {};
 
     return (
-        <Link
-            href={href}
-            onClick={handleClick}
-            title={label}
-            aria-label={compact ? label : undefined}
-        >
+        <Link href={href} onClick={handleClick} title={label}>
             <ListItem
                 {...listItemAccessibilityProps}
                 nodeId={href}

--- a/apps/app/components/admin/navigation/NavItem.tsx
+++ b/apps/app/components/admin/navigation/NavItem.tsx
@@ -38,9 +38,17 @@ export function NavItem({
         }
     };
 
+    const listItemAccessibilityProps = compact ? { 'aria-label': label } : {};
+
     return (
-        <Link href={href} onClick={handleClick} title={label}>
+        <Link
+            href={href}
+            onClick={handleClick}
+            title={label}
+            aria-label={compact ? label : undefined}
+        >
             <ListItem
+                {...listItemAccessibilityProps}
                 nodeId={href}
                 selected={
                     strictMatch

--- a/apps/app/components/admin/navigation/ProfileNavItem.tsx
+++ b/apps/app/components/admin/navigation/ProfileNavItem.tsx
@@ -73,11 +73,16 @@ export function ProfileNavItem({
         const accountId = resolveAccountId(currentUser);
         return accountId ? KnownPages.Account(accountId) : KnownPages.Accounts;
     }, [currentUser]);
+    const listItemAccessibilityProps = compact
+        ? { 'aria-label': userName }
+        : {};
 
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <ListItem
+                    {...listItemAccessibilityProps}
+                    title={compact ? userName : undefined}
                     startDecorator={
                         <UserAvatar
                             displayName={userName}

--- a/apps/app/components/admin/navigation/ProfileNavItem.tsx
+++ b/apps/app/components/admin/navigation/ProfileNavItem.tsx
@@ -82,7 +82,7 @@ export function ProfileNavItem({
             <DropdownMenuTrigger asChild>
                 <ListItem
                     {...listItemAccessibilityProps}
-                    title={compact ? userName : undefined}
+                    title={userName}
                     startDecorator={
                         <UserAvatar
                             displayName={userName}

--- a/apps/app/components/admin/navigation/index.ts
+++ b/apps/app/components/admin/navigation/index.ts
@@ -1,4 +1,5 @@
 export { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
+export { DesktopNav } from './DesktopNav';
 export { LoginDialog } from './LoginDialog';
 export { MobileHeader } from './MobileHeader';
 export { MobileNav } from './MobileNav';


### PR DESCRIPTION
### Motivation

- Introduce a dedicated desktop navigation component to replace inline aside markup and enable a collapsible/compact sidebar for better desktop UX.
- Allow the navigation to render in a compact mode to save horizontal space and support responsive layouts.
- Surface a toggle for expanding/collapsing the desktop nav so users can switch between compact and full views.

### Description

- Added `DesktopNav` component (`apps/app/components/admin/navigation/DesktopNav.tsx`) which provides a collapsible sidebar with a toggle button and responsive rendering logic.
- Replaced the previous hardcoded aside in the admin layout (`apps/app/app/admin/layout.tsx`) with the new `DesktopNav` export and import from the navigation index.
- Extended navigation primitives to support a `compact` prop across `Nav` (`Nav.tsx`), `NavItem` (`NavItem.tsx`), `ProfileNavItem` (`ProfileNavItem.tsx`), `EntityTypeList`, and sortable items so labels, badges and list headers are conditionally rendered when compact.
- Adjusted rendering of shadow/uncategorized entity types to display either as a flat list in compact mode or as a `ListTreeItem` when expanded.
- Exported `DesktopNav` from the navigation index (`apps/app/components/admin/navigation/index.ts`).

### Testing

- Built the application and ran the repository test suite using the standard commands (for example `pnpm -w -C apps/app build` and `pnpm -w test`). All automated checks passed.
- Verified TypeScript/React compile and that the new component mounts without runtime errors in the admin layout during the automated build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1e48418c832f8b2e8de9b353f407)