### PR TITLE
Replace operation progress status labels with icons

### DIFF
--- a/packages/game/src/controls/components/SegmentedProgress.tsx
+++ b/packages/game/src/controls/components/SegmentedProgress.tsx
@@ -1,6 +1,6 @@
 import { Check, Close } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
-import { Fragment, type HTMLAttributes } from 'react';
+import { Fragment, type HTMLAttributes, type ReactNode } from 'react';
 import { Progress } from './Progress';
 
 export type SegmentedProgressProps = {
@@ -10,6 +10,7 @@ export type SegmentedProgressProps = {
         highlighted?: boolean;
         failed?: boolean;
         label?: string;
+        icon?: ReactNode;
         title?: string;
         onClick?: () => void;
     }[];
@@ -77,9 +78,9 @@ export function SegmentedProgress({
                                     />
                                 )}
                             </div>
-                            {segment.label && (
+                            {(segment.label || segment.icon) && (
                                 <div className="select-none text-xs text-center absolute left-1/2 top-full transform -translate-x-1/2 pt-1">
-                                    {segment.label}
+                                    {segment.icon ?? segment.label}
                                 </div>
                             )}
                         </CircleComponent>

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -209,38 +209,65 @@ function buildSegments(operation: GardenOperationItem) {
         const title = tooltipParts.join(' — ');
 
         if (reached) {
+            const StatusIcon = config.icon;
             return {
                 value: 100,
                 label: config.label,
+                icon: (
+                    <StatusIcon
+                        className={cx('size-3.5 shrink-0', config.colorClass)}
+                    />
+                ),
                 title,
             };
         }
 
         if (isTerminalFailure) {
+            const StatusIcon = config.icon;
             return {
                 value: 0,
                 failed: true,
                 label: config.label,
+                icon: (
+                    <StatusIcon
+                        className={cx('size-3.5 shrink-0', config.colorClass)}
+                    />
+                ),
                 title: `${config.label} — preskočeno`,
             };
         }
 
         const isNextPending = idx === firstPendingIdx;
+        const StatusIcon = config.icon;
         return {
             value: isNextPending ? 50 : 0,
             indeterminate: isNextPending,
             highlighted: isNextPending,
             label: config.label,
+            icon: (
+                <StatusIcon
+                    className={cx('size-3.5 shrink-0', config.colorClass)}
+                />
+            ),
             title,
         };
     });
 
     if (isTerminalFailure) {
         const terminalConfig = statusConfig[operation.status];
+        const StatusIcon = terminalConfig.icon;
         segments.push({
             value: 0,
             failed: true,
             label: terminalConfig.label,
+            icon: (
+                <StatusIcon
+                    className={cx(
+                        'size-3.5 shrink-0',
+                        terminalConfig.colorClass,
+                    )}
+                />
+            ),
             title: `${terminalConfig.label} — ${
                 formatDateTime(
                     operation.canceledAt ?? operation.completedAt ?? null,


### PR DESCRIPTION
### Motivation

- Status labels in the operations popover and history modal do not fit reliably on small/mobile screens, so the status legend under the segmented progress should use icons to improve layout.
- The operations HUD and history modal share the same progress UI path, so the change targets the shared `SegmentedProgress`/`OperationProgress` flow.

### Description

- Extended `SegmentedProgress` segment type with an optional `icon` (`ReactNode`) and updated the renderer to show `icon` first with a fallback to the existing `label` to preserve compatibility.
- Updated `buildSegments` in `GardenOperationsHud` to attach status-specific icon components (using the existing `statusConfig.icon` and `statusConfig.colorClass`) for reached, pending, skipped, and terminal failure states so the legend displays icons.
- Kept existing label text available as a fallback and did not alter `StatusBadge` behavior or other status text usages.
- Changes made in `packages/game/src/controls/components/SegmentedProgress.tsx` and `packages/game/src/hud/GardenOperationsHud.tsx`.

### Testing

- Ran `pnpm lint --filter @gredice/game` and the lint check completed successfully (the tool applied one automatic fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef153c5928832f9e5269ec45ffb5b6)