### PR TITLE
Fix assigned/confirmed states in garden operation timeline serialization

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -129,6 +129,15 @@ function serializeGardenOperation(
     targetsByRaisedBedFieldId: Map<number, string>,
     targetsByRaisedBedId: Map<number, string>,
 ) {
+    const hasAssignedUser = (operation.assignedUserIds?.length ?? 0) > 0;
+    const isAssigned = operation.status === 'planned' && hasAssignedUser;
+    const isConfirmed = isAssigned && operation.isAccepted;
+    const timelineStatus = isConfirmed
+        ? 'confirmed'
+        : isAssigned
+          ? 'assigned'
+          : operation.status;
+
     const statusHistory = [
         {
             status: 'new',
@@ -140,6 +149,24 @@ function serializeGardenOperation(
                   changedAt:
                       operation.scheduledAt?.toISOString() ??
                       operation.scheduledDate.toISOString(),
+              }
+            : null,
+        isAssigned
+            ? {
+                  status: 'assigned',
+                  changedAt:
+                      operation.assignedAt?.toISOString() ??
+                      operation.scheduledAt?.toISOString() ??
+                      operation.createdAt.toISOString(),
+              }
+            : null,
+        isConfirmed
+            ? {
+                  status: 'confirmed',
+                  changedAt:
+                      operation.assignedAt?.toISOString() ??
+                      operation.scheduledAt?.toISOString() ??
+                      operation.createdAt.toISOString(),
               }
             : null,
         operation.completedAt
@@ -167,7 +194,7 @@ function serializeGardenOperation(
         entityId: operation.entityId,
         raisedBedId: operation.raisedBedId,
         raisedBedFieldId: operation.raisedBedFieldId,
-        status: operation.status,
+        status: timelineStatus,
         createdAt: operation.createdAt.toISOString(),
         scheduledDate: operation.scheduledDate?.toISOString() ?? null,
         scheduledAt: operation.scheduledAt?.toISOString() ?? null,


### PR DESCRIPTION
### Motivation
- The game UI (operation popover and history modal) continued to show "assignment" as the next step when an operation had already been assigned or accepted because the serialized timeline used the raw `operation.status` and omitted `assigned`/`confirmed` milestones.

### Description
- Compute `timelineStatus` from operation metadata so that a `planned` operation with assignees surfaces as `assigned` and becomes `confirmed` when accepted by checking `assignedUserIds` and `isAccepted` in `serializeGardenOperation`.
- Inject `assigned` and `confirmed` entries into the serialized `statusHistory` with sensible timestamp fallbacks (`assignedAt` → `scheduledAt` → `createdAt`).
- Return the computed `timelineStatus` (instead of `operation.status`) in the endpoint payload so the frontend receives the updated timeline state; changes are in `apps/api/app/api/[...route]/gardensRoutes.ts`.

### Testing
- Ran lint with `pnpm --filter api lint` which completed and applied fixes (succeeded). 
- Ran Biome check on the modified file with `pnpm --filter api exec biome check 'app/api/[...route]/gardensRoutes.ts'` which completed (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1668d83c832f85078e20f7106863)