### PR TITLE
Add harvest removal disclaimers and display them across UI

### DIFF
--- a/apps/www/app/biljke/[alias]/HarvestAttributeCards.tsx
+++ b/apps/www/app/biljke/[alias]/HarvestAttributeCards.tsx
@@ -1,5 +1,8 @@
 import type { PlantData } from '@gredice/client';
-import { calculatePlantsPerField } from '@gredice/js/plants';
+import {
+    calculatePlantsPerField,
+    getHarvestPlantRemovalDisclaimer,
+} from '@gredice/js/plants';
 import { ShoppingCart, Store } from '@signalco/ui-icons';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
@@ -10,6 +13,10 @@ export function HarvestAttributeCards({
 }: {
     attributes: PlantData['attributes'] | undefined;
 }) {
+    const harvestPlantRemovalDescription = getHarvestPlantRemovalDisclaimer(
+        attributes?.cleanHarvest,
+    );
+
     const formatDayRange = (
         min?: number | null,
         max?: number | null,
@@ -93,35 +100,40 @@ export function HarvestAttributeCards({
     const yieldDetails = getYieldDetails();
 
     return (
-        <div className="grid grid-cols-2 gap-2">
-            <AttributeCard
-                icon={<Store />}
-                header="Vrijeme berbe"
-                value={formatDayRange(
-                    attributes?.harvestWindowMin,
-                    attributes?.harvestWindowMax,
-                )}
-            />
-            <AttributeCard
-                icon={<ShoppingCart />}
-                header="Očekivani prinos"
-                value={
-                    yieldDetails ? (
-                        <Stack spacing={0.5}>
-                            <Typography semiBold>
-                                {yieldDetails.expectedPerFieldKg
-                                    ? `~${yieldDetails.expectedPerFieldKg} kg po polju`
-                                    : '-'}
-                            </Typography>
-                            {yieldDetails.perFieldRange && (
-                                <Typography level="body3">
-                                    {yieldDetails.perFieldRange}
+        <Stack spacing={1}>
+            <div className="grid grid-cols-2 gap-2">
+                <AttributeCard
+                    icon={<Store />}
+                    header="Vrijeme berbe"
+                    value={formatDayRange(
+                        attributes?.harvestWindowMin,
+                        attributes?.harvestWindowMax,
+                    )}
+                />
+                <AttributeCard
+                    icon={<ShoppingCart />}
+                    header="Očekivani prinos"
+                    value={
+                        yieldDetails ? (
+                            <Stack spacing={0.5}>
+                                <Typography semiBold>
+                                    {yieldDetails.expectedPerFieldKg
+                                        ? `~${yieldDetails.expectedPerFieldKg} kg po polju`
+                                        : '-'}
                                 </Typography>
-                            )}
-                        </Stack>
-                    ) : undefined
-                }
-            />
-        </div>
+                                {yieldDetails.perFieldRange && (
+                                    <Typography level="body3">
+                                        {yieldDetails.perFieldRange}
+                                    </Typography>
+                                )}
+                            </Stack>
+                        ) : undefined
+                    }
+                />
+            </div>
+            <Typography level="body2">
+                {harvestPlantRemovalDescription}
+            </Typography>
+        </Stack>
     );
 }

--- a/apps/www/app/biljke/[alias]/HarvestAttributeCards.tsx
+++ b/apps/www/app/biljke/[alias]/HarvestAttributeCards.tsx
@@ -131,9 +131,11 @@ export function HarvestAttributeCards({
                     }
                 />
             </div>
-            <Typography level="body2">
-                {harvestPlantRemovalDescription}
-            </Typography>
+            {harvestPlantRemovalDescription && (
+                <Typography level="body2">
+                    {harvestPlantRemovalDescription}
+                </Typography>
+            )}
         </Stack>
     );
 }

--- a/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
+++ b/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
@@ -1,3 +1,4 @@
+import { getHarvestBehaviorOverviewDisclaimer } from '@gredice/js/plants';
 import { BlockImage } from '@gredice/ui/BlockImage';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { NavigatingButton } from '@signalco/ui/NavigatingButton';
@@ -75,29 +76,56 @@ export async function OperationApplicationsList({
                 ?.map((op) => op.information?.name)
                 .includes(operation.information.name),
         );
+        const isHarvestOperation =
+            operation.attributes.stage.information?.name === 'harvest';
+        const plantsRemovedAfterHarvest = isHarvestOperation
+            ? (plantsWithOperation?.filter(
+                  (plant) => plant.attributes?.cleanHarvest === true,
+              ) ?? [])
+            : [];
         if (plantsWithOperation && (plantsWithOperation?.length ?? 0) > 0) {
             return (
-                <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
-                    {plantsWithOperation.map((plant) => (
-                        <Card
-                            key={plant.id}
-                            href={KnownPages.Plant(plant.information.name)}
-                            className="border-tertiary border-b-4"
-                        >
-                            <CardContent noHeader>
-                                <Row spacing={2}>
-                                    <PlantOrSortImage
-                                        plant={plant}
-                                        width={42}
-                                        height={42}
-                                    />
-                                    <Typography>
-                                        {plant.information.name ?? 'Nepoznato'}
-                                    </Typography>
-                                </Row>
-                            </CardContent>
-                        </Card>
-                    ))}
+                <div className="py-4 space-y-3">
+                    {isHarvestOperation && (
+                        <Typography level="body2">
+                            {getHarvestBehaviorOverviewDisclaimer()}
+                        </Typography>
+                    )}
+                    {plantsRemovedAfterHarvest.length > 0 && (
+                        <Typography level="body2" semiBold>
+                            Automatsko uklanjanje nakon berbe:{' '}
+                            {plantsRemovedAfterHarvest
+                                .map(
+                                    (plant) =>
+                                        plant.information.name ?? 'Nepoznato',
+                                )
+                                .join(', ')}
+                            .
+                        </Typography>
+                    )}
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
+                        {plantsWithOperation.map((plant) => (
+                            <Card
+                                key={plant.id}
+                                href={KnownPages.Plant(plant.information.name)}
+                                className="border-tertiary border-b-4"
+                            >
+                                <CardContent noHeader>
+                                    <Row spacing={2}>
+                                        <PlantOrSortImage
+                                            plant={plant}
+                                            width={42}
+                                            height={42}
+                                        />
+                                        <Typography>
+                                            {plant.information.name ??
+                                                'Nepoznato'}
+                                        </Typography>
+                                    </Row>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
                 </div>
             );
         }

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -1,3 +1,4 @@
+import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
 import { decodeRouteParam } from '@gredice/js/uri';
 import { Markdown } from '@gredice/ui/Markdown';
 import { OperationImage } from '@gredice/ui/OperationImage';
@@ -64,6 +65,11 @@ export default async function OperationPage(
     if (!operation) {
         notFound();
     }
+    const isHarvestOperation =
+        operation.attributes.stage.information?.name === 'harvest';
+    const harvestPlantRemovalDescription = isHarvestOperation
+        ? getHarvestOperationRemovalDisclaimer(operation.actions?.removePlant)
+        : null;
 
     return (
         <div className="operation-page py-8">
@@ -134,6 +140,11 @@ export default async function OperationPage(
                                 </Link>
                                 .
                             </Typography>
+                            {harvestPlantRemovalDescription && (
+                                <Typography level="body2" secondary>
+                                    {harvestPlantRemovalDescription}
+                                </Typography>
+                            )}
                         </Stack>
                         <Typography level="h5" component="h2" gutterBottom>
                             Svojstva

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -1,5 +1,6 @@
 import type { OperationData } from '@gredice/client';
 import { formatPrice } from '@gredice/js/currency';
+import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Calendar } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
@@ -51,6 +52,14 @@ export function OperationScheduleModal({
     const operationDefaultDate = formatLocalDate(tomorrow);
     const min = formatLocalDate(tomorrow);
     const max = formatLocalDate(threeMonthsFromTomorrow);
+    const isHarvestOperation =
+        operation.attributes.stage.information?.name === 'harvest';
+    const harvestPlantRemovalDescription = isHarvestOperation
+        ? getHarvestOperationRemovalDisclaimer(
+              operation.actions?.removePlant,
+              true,
+          )
+        : null;
 
     return (
         <Modal
@@ -82,6 +91,14 @@ export function OperationScheduleModal({
                                     <Typography level="body2">
                                         {operation.information.shortDescription}
                                     </Typography>
+                                    {harvestPlantRemovalDescription && (
+                                        <Typography
+                                            level="body2"
+                                            className="text-muted-foreground"
+                                        >
+                                            {harvestPlantRemovalDescription}
+                                        </Typography>
+                                    )}
                                     <Typography level="body2" semiBold>
                                         {formatPrice(
                                             operation.prices?.perOperation,

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -1,5 +1,6 @@
 import type { OperationData } from '@gredice/client';
 import { formatPrice } from '@gredice/js/currency';
+import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Calendar } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
@@ -32,6 +33,14 @@ export function OperationsListItem({
     const { data: inventory } = useInventory();
 
     const price = formatPrice(operation.prices?.perOperation);
+    const isHarvestOperation =
+        operation.attributes.stage.information?.name === 'harvest';
+    const harvestPlantRemovalDescription = isHarvestOperation
+        ? getHarvestOperationRemovalDisclaimer(
+              operation.actions?.removePlant,
+              true,
+          )
+        : null;
 
     const availableFromInventory = inventory?.items?.find(
         (item) =>
@@ -85,6 +94,11 @@ export function OperationsListItem({
                         className="line-clamp-2 break-words"
                     >
                         {operation.information.shortDescription}
+                    </Typography>
+                )}
+                {harvestPlantRemovalDescription && (
+                    <Typography level="body2" className="text-muted-foreground">
+                        {harvestPlantRemovalDescription}
                     </Typography>
                 )}
             </Stack>

--- a/packages/js/src/plants/harvestDisclaimer.ts
+++ b/packages/js/src/plants/harvestDisclaimer.ts
@@ -1,0 +1,38 @@
+const HARVEST_DISCLAIMER_TEXT = {
+    autoRemove: 'Nakon ove berbe biljka se uklanja u istoj radnji.',
+    autoRemoveWithExample:
+        'Nakon ove berbe biljka se uklanja u istoj radnji (npr. mrkva).',
+    requiresSeparateRemoval:
+        'Nakon ove berbe biljka ostaje u polju pa je uklanjanje biljke zasebna radnja.',
+    requiresSeparateRemovalWithExample:
+        'Nakon ove berbe biljka ostaje u polju, pa je uklanjanje biljke zasebna radnja (npr. rajčica).',
+    behaviorOverview:
+        'Kod berbe neke biljke ostaju u polju i uklanjaju se zasebnom radnjom, dok se neke uklanjaju odmah nakon berbe.',
+};
+
+export function getHarvestOperationRemovalDisclaimer(
+    removePlant: boolean | undefined,
+    includeExamples = false,
+) {
+    if (removePlant) {
+        return includeExamples
+            ? HARVEST_DISCLAIMER_TEXT.autoRemoveWithExample
+            : HARVEST_DISCLAIMER_TEXT.autoRemove;
+    }
+
+    return includeExamples
+        ? HARVEST_DISCLAIMER_TEXT.requiresSeparateRemovalWithExample
+        : HARVEST_DISCLAIMER_TEXT.requiresSeparateRemoval;
+}
+
+export function getHarvestPlantRemovalDisclaimer(
+    cleanHarvest: boolean | undefined,
+) {
+    return cleanHarvest
+        ? 'Nakon berbe biljka se automatski uklanja iz polja.'
+        : 'Nakon berbe biljka može ostati u polju i tada je uklanjanje zasebna radnja.';
+}
+
+export function getHarvestBehaviorOverviewDisclaimer() {
+    return HARVEST_DISCLAIMER_TEXT.behaviorOverview;
+}

--- a/packages/js/src/plants/index.ts
+++ b/packages/js/src/plants/index.ts
@@ -1,3 +1,4 @@
 export * from './fieldCalculations';
+export * from './harvestDisclaimer';
 export * from './isPlantRecommended';
 export * from './plantFieldStatusLabel';


### PR DESCRIPTION
### Motivation

- Clarify to users whether plants are removed automatically after harvest or require a separate removal operation. 
- Provide reusable utilities for harvest-related disclaimers to keep messaging consistent across web and game UIs.

### Description

- Add `packages/js/src/plants/harvestDisclaimer.ts` implementing `getHarvestOperationRemovalDisclaimer`, `getHarvestPlantRemovalDisclaimer`, and `getHarvestBehaviorOverviewDisclaimer` and export them from `packages/js/src/plants/index.ts`.
- Show plant-level harvest removal text on the plant detail UI by updating `HarvestAttributeCards.tsx` and adjusting layout to include the disclaimer text.
- Surface harvest behavior and a list of plants that are auto-removed in the operations applications list by updating `OperationApplicationsList.tsx` and using `getHarvestBehaviorOverviewDisclaimer` and the new helpers.
- Display operation-level removal disclaimers on the operation page and in scheduling and HUD components by updating `page.tsx`, `OperationScheduleModal.tsx`, and `OperationsListItem.tsx`, passing `includeExamples` where appropriate.

### Testing

- Ran the TypeScript build/type-check for the workspace via `pnpm -w build` and confirmed it completed successfully. 
- Ran the repository test suite via `pnpm -w test` and all existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef15ea4294832f8180f9e68d80b5ec)