### PR TITLE
Allow scheduling tasks for today in admin schedule

### DIFF
--- a/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
@@ -46,19 +46,14 @@ export function BulkRescheduleRaisedBedButton({
     const disabled = totalItems === 0 || isSubmitting;
 
     const today = new Date();
-    const tomorrow = new Date(
+    const threeMonthsFromToday = new Date(
         today.getFullYear(),
-        today.getMonth(),
-        today.getDate() + 1,
-    );
-    const threeMonthsFromTomorrow = new Date(
-        tomorrow.getFullYear(),
-        tomorrow.getMonth() + 3,
-        tomorrow.getDate(),
+        today.getMonth() + 3,
+        today.getDate(),
     );
 
-    const min = formatLocalDate(tomorrow);
-    const max = formatLocalDate(threeMonthsFromTomorrow);
+    const min = formatLocalDate(today);
+    const max = formatLocalDate(threeMonthsFromToday);
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -5,6 +5,7 @@ import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Calendar, Close } from '@signalco/ui-icons';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Chip } from '@signalco/ui-primitives/Chip';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -379,7 +380,13 @@ export function RaisedBedOperationsScheduleSection({
                                                 {operation.scheduledDate}
                                             </LocalDateTime>
                                         ) : (
-                                            <span>Danas</span>
+                                            <Chip
+                                                size="sm"
+                                                color="warning"
+                                                className="w-fit"
+                                            >
+                                                Nije planirano
+                                            </Chip>
                                         )}
                                     </Typography>
                                 </Row>

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -6,6 +6,7 @@ import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Calendar, Close } from '@signalco/ui-icons';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Chip } from '@signalco/ui-primitives/Chip';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -302,7 +303,13 @@ export function RaisedBedPlantingScheduleSection({
                                                 {field.plantScheduledDate}
                                             </LocalDateTime>
                                         ) : (
-                                            <span>Danas</span>
+                                            <Chip
+                                                size="sm"
+                                                color="warning"
+                                                className="w-fit"
+                                            >
+                                                Nije planirano
+                                            </Chip>
                                         )}
                                     </Typography>
                                 </Row>

--- a/apps/app/app/admin/schedule/RescheduleModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleModal.tsx
@@ -52,22 +52,17 @@ export function RescheduleModal({
     }
 
     const today = new Date();
-    const tomorrow = new Date(
+    const threeMonthsFromToday = new Date(
         today.getFullYear(),
-        today.getMonth(),
-        today.getDate() + 1,
-    );
-    const threeMonthsFromTomorrow = new Date(
-        tomorrow.getFullYear(),
-        tomorrow.getMonth() + 3,
-        tomorrow.getDate(),
+        today.getMonth() + 3,
+        today.getDate(),
     );
 
     const currentScheduledDate = scheduledDate
         ? formatLocalDate(scheduledDate)
-        : formatLocalDate(tomorrow);
-    const min = formatLocalDate(tomorrow);
-    const max = formatLocalDate(threeMonthsFromTomorrow);
+        : formatLocalDate(today);
+    const min = formatLocalDate(today);
+    const max = formatLocalDate(threeMonthsFromToday);
 
     return (
         <Modal

--- a/apps/app/app/admin/schedule/RescheduleModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleModal.tsx
@@ -58,15 +58,11 @@ export function RescheduleModal({
         today.getDate(),
     );
 
-    const todayMidnight = new Date(
-        today.getFullYear(),
-        today.getMonth(),
-        today.getDate(),
-    );
-    const effectiveDate =
-        scheduledDate && scheduledDate >= todayMidnight ? scheduledDate : today;
-    const currentScheduledDate = formatLocalDate(effectiveDate);
     const min = formatLocalDate(today);
+    const currentScheduledDate =
+        scheduledDate && formatLocalDate(scheduledDate) >= min
+            ? formatLocalDate(scheduledDate)
+            : min;
     const max = formatLocalDate(threeMonthsFromToday);
 
     return (

--- a/apps/app/app/admin/schedule/RescheduleModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleModal.tsx
@@ -58,9 +58,14 @@ export function RescheduleModal({
         today.getDate(),
     );
 
-    const currentScheduledDate = scheduledDate
-        ? formatLocalDate(scheduledDate)
-        : formatLocalDate(today);
+    const todayMidnight = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate(),
+    );
+    const effectiveDate =
+        scheduledDate && scheduledDate >= todayMidnight ? scheduledDate : today;
+    const currentScheduledDate = formatLocalDate(effectiveDate);
     const min = formatLocalDate(today);
     const max = formatLocalDate(threeMonthsFromToday);
 

--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -12,7 +12,9 @@ import { ScheduleDayPlantingsSkeleton } from './ScheduleDayPlantingsSkeleton';
 export const dynamic = 'force-dynamic';
 
 function parseDateParam(dateParam?: string | string[]): Date | undefined {
-    const normalizedDateParam = Array.isArray(dateParam) ? dateParam[0] : dateParam;
+    const normalizedDateParam = Array.isArray(dateParam)
+        ? dateParam[0]
+        : dateParam;
     if (!normalizedDateParam) {
         return undefined;
     }


### PR DESCRIPTION
### Motivation
- Users need to be able to schedule or reschedule planting and operation tasks for the current day instead of being forced to start from tomorrow. 
- Unscheduled tasks displayed as `Danas` are ambiguous with tasks actually scheduled for today and should be visually distinct. 

### Description
- Updated `RescheduleModal` to allow selecting `today` as the minimum/default date and extended the max bound to three months from today by computing `threeMonthsFromToday` and using `today` for `min` and default value instead of `tomorrow` (file: `apps/app/app/admin/schedule/RescheduleModal.tsx`).
- Updated `BulkRescheduleRaisedBedButton` to use `today` as the minimum/default date and compute `threeMonthsFromToday` for the max bound (file: `apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx`).
- Replaced the inline `Danas` fallback with a yellow warning `Chip` labeled `Nije planirano` in both planting and operation schedule rows, and imported `Chip` where needed (files: `apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx`, `apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx`).

### Testing
- Ran `pnpm lint --filter app`, which completed successfully with lint fixes applied and one non-failing suppression warning reported. All lint tasks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef20fb1ab8832f9953ae5290b53a29)