### PR TITLE
Update legal third-party list for PostHog and remove MailerLite

### DIFF
--- a/apps/www/app/legalno/trece-strane/page.tsx
+++ b/apps/www/app/legalno/trece-strane/page.tsx
@@ -12,8 +12,9 @@ export const metadata: Metadata = {
 
 const thirdPartyPlatforms = [
     {
-        name: 'Axiom',
-        description: 'platforma za upravljanje sistemskim zapisima.',
+        name: 'PostHog',
+        description:
+            'platforma za analitiku proizvoda i upravljanje sistemskim zapisima.',
     },
     {
         name: 'Azure',
@@ -49,10 +50,6 @@ const thirdPartyPlatforms = [
     {
         name: 'Hypertune',
         description: 'platforma za upravljanje značajkama sustava.',
-    },
-    {
-        name: 'MailerLite',
-        description: 'alat za slanje e-pošte i upravljanje pretplatnicima.',
     },
     { name: 'Stripe', description: 'platforma za online plaćanja i naplatu.' },
     {
@@ -106,7 +103,7 @@ export default function UvjetiKoristenjaPage() {
                     </p>
                 </StyledHtml>
                 <Typography level="body2" secondary className="mt-8">
-                    Zadnja izmjena: 28. Veljača 2025.
+                    Zadnja izmjena: 27. travnja 2026.
                 </Typography>
             </Stack>
         </Container>


### PR DESCRIPTION
### Motivation
- Keep the public legal "Third parties" page in sync with recent infrastructure changes: Axiom was replaced by PostHog for analytics/logging and MailerLite is no longer used, so the document must reflect current third-party services.

### Description
- Replaced the `Axiom` entry with `PostHog` and updated its description in `apps/www/app/legalno/trece-strane/page.tsx`.
- Removed the `MailerLite` entry from the third-party platforms list in the same file.
- Updated the page "last modified" date to `27. travnja 2026.`.

### Testing
- Ran the workspace-targeted lint for the `www` app with `pnpm --filter www lint`, which completed successfully; Biome reported one unrelated existing warning in `app/blokovi/biljke/[alias]/PlantGrowthViewer.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2f6048d0832f914f338d43b17df4)