### PR TITLE
Fix page header search input focus loss while typing

### DIFF
--- a/apps/www/components/shared/PageFilterInput.tsx
+++ b/apps/www/components/shared/PageFilterInput.tsx
@@ -63,6 +63,7 @@ export function PageFilterInput({
                             localSearch ? 'visible' : 'invisible',
                         )}
                         title="Očisti pretragu"
+                        type="button"
                         onClick={() => updateSearch('')}
                         size="sm"
                         variant="plain"

--- a/apps/www/components/shared/PageFilterInput.tsx
+++ b/apps/www/components/shared/PageFilterInput.tsx
@@ -6,6 +6,7 @@ import { cx } from '@signalco/ui-primitives/cx';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
 import type { HTMLAttributes } from 'react';
+import { useEffect, useState } from 'react';
 
 export type PageFilterInputProps = HTMLAttributes<HTMLFormElement> & {
     searchParamName: string;
@@ -18,22 +19,48 @@ export function PageFilterInput({
     ...rest
 }: PageFilterInputProps) {
     const [search, setSearch] = useSearchParam(searchParamName);
-    const updateSearch = (value: string) => setSearch(value);
+    const [localSearch, setLocalSearch] = useState(search ?? '');
+
+    useEffect(() => {
+        setLocalSearch(search ?? '');
+    }, [search]);
+
+    const updateSearch = (value: string) => {
+        setLocalSearch(value);
+        setSearch(value);
+    };
+
+    const handleSubmit = (formData: FormData) => {
+        const nextSearch = formData.get(fieldName);
+        if (typeof nextSearch === 'string') {
+            setSearch(nextSearch);
+        }
+    };
 
     return (
-        <form onSubmit={(event) => event.preventDefault()} {...rest}>
+        <form action={handleSubmit} {...rest}>
             <Input
                 name={fieldName}
-                value={search ?? ''}
-                onChange={(event) => updateSearch(event.target.value)}
+                value={localSearch}
+                onChange={(event) => setLocalSearch(event.target.value)}
                 placeholder="Pretraži..."
-                startDecorator={<Search className="size-5 shrink-0 ml-3" />}
+                startDecorator={
+                    <IconButton
+                        className="hover:bg-neutral-300 ml-1 rounded-full aspect-square"
+                        title="Pretraga"
+                        type="submit"
+                        size="sm"
+                        variant="plain"
+                    >
+                        <Search className="size-5" />
+                    </IconButton>
+                }
                 // Clear search
                 endDecorator={
                     <IconButton
                         className={cx(
                             'hover:bg-neutral-300 mr-1 rounded-full aspect-square',
-                            search ? 'visible' : 'invisible',
+                            localSearch ? 'visible' : 'invisible',
                         )}
                         title="Očisti pretragu"
                         onClick={() => updateSearch('')}


### PR DESCRIPTION
### Motivation
- Typing into the page header search was causing focus loss because each keystroke updated the URL search param and retriggered navigation. 
- The goal is to keep typing smooth and only update the query string when the user explicitly submits or clears the search.

### Description
- Introduced local input state with `useState` and `useEffect` in `PageFilterInput` to decouple typing from immediate URL updates. 
- Changed the form to use a submit handler (`action={handleSubmit}`) and made the start/search icon an actual submit button (`type="submit"`) so the query param updates on explicit submit. 
- Kept the clear button instantaneous by clearing both the local state and the search param via the existing `setSearch` call. 
- Modified `apps/www/components/shared/PageFilterInput.tsx` to implement the above behavior.

### Testing
- Ran linting with `pnpm lint --filter www` which completed successfully (Biome reported one unrelated `any` warning in another file). 
- Verified build/lint step passed locally in the workspace after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef30aea098832f8042df55e030dfdd)