### PR TITLE
Queue seasonal free watering operations when sowing is completed

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -15,6 +15,7 @@ import {
     getRaisedBedFieldsWithEvents,
     knownEvents,
     moveRaisedBedFieldPlantHistory,
+    queueSeasonalSowingOfferOperations,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import type { EntityStandardized } from '../../lib/@types/EntityStandardized';
@@ -65,6 +66,13 @@ async function applyRaisedBedFieldPlantUpdate({
                 ),
             ),
         );
+
+        if (status === 'sowed' && raisedBed.accountId) {
+            await queueSeasonalSowingOfferOperations({
+                accountId: raisedBed.accountId,
+                raisedBedId: raisedBed.id,
+            });
+        }
     }
 
     const sortIdToUse = plantSortId ?? existingField?.plantSortId;

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -69,12 +69,13 @@ async function applyRaisedBedFieldPlantUpdate({
 
         if (
             status === 'sowed' &&
-            existingField?.plantStatus !== 'sowed' &&
+            existingField &&
+            existingField.plantStatus !== 'sowed' &&
             raisedBed.accountId
         ) {
             await queueSeasonalSowingOfferOperations({
                 accountId: raisedBed.accountId,
-                gardenId: raisedBed.gardenId,
+                gardenId: raisedBed.gardenId ?? undefined,
                 raisedBedId: raisedBed.id,
             });
         }

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -73,9 +73,10 @@ async function applyRaisedBedFieldPlantUpdate({
             existingField.plantStatus !== 'sowed' &&
             raisedBed.accountId
         ) {
+            const gardenId = raisedBed.gardenId;
             await queueSeasonalSowingOfferOperations({
                 accountId: raisedBed.accountId,
-                gardenId: raisedBed.gardenId ?? undefined,
+                ...(gardenId ? { gardenId } : {}),
                 raisedBedId: raisedBed.id,
             });
         }

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -67,9 +67,14 @@ async function applyRaisedBedFieldPlantUpdate({
             ),
         );
 
-        if (status === 'sowed' && raisedBed.accountId) {
+        if (
+            status === 'sowed' &&
+            existingField?.plantStatus !== 'sowed' &&
+            raisedBed.accountId
+        ) {
             await queueSeasonalSowingOfferOperations({
                 accountId: raisedBed.accountId,
+                gardenId: raisedBed.gardenId,
                 raisedBedId: raisedBed.id,
             });
         }

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -171,6 +171,7 @@ export async function completeFarmPlanting(
     if (nextStatus === 'sowed' && raisedBed.accountId) {
         await queueSeasonalSowingOfferOperations({
             accountId: raisedBed.accountId,
+            gardenId: raisedBed.gardenId,
             raisedBedId,
         });
     }

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -169,9 +169,10 @@ export async function completeFarmPlanting(
     );
 
     if (nextStatus === 'sowed' && raisedBed.accountId) {
+        const gardenId = raisedBed.gardenId;
         await queueSeasonalSowingOfferOperations({
             accountId: raisedBed.accountId,
-            gardenId: raisedBed.gardenId ?? undefined,
+            ...(gardenId ? { gardenId } : {}),
             raisedBedId,
         });
     }

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -8,6 +8,7 @@ import {
     getOperationById,
     getRaisedBed,
     knownEvents,
+    queueSeasonalSowingOfferOperations,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { auth } from '../../lib/auth/auth';
@@ -155,15 +156,24 @@ export async function completeFarmPlanting(
         throw new Error('Sijanje mora biti potvrđeno prije završetka.');
     }
 
+    const nextStatus = role === 'admin' ? 'sowed' : 'pendingVerification';
+
     await createEvent(
         knownEvents.raisedBedFields.plantUpdateV1(
             `${raisedBedId}|${positionIndex}`,
             buildRaisedBedFieldPlantUpdatePayload(
-                role === 'admin' ? 'sowed' : 'pendingVerification',
+                nextStatus,
                 field.assignedUserIds,
             ),
         ),
     );
+
+    if (nextStatus === 'sowed' && raisedBed.accountId) {
+        await queueSeasonalSowingOfferOperations({
+            accountId: raisedBed.accountId,
+            raisedBedId,
+        });
+    }
 
     revalidateSchedule();
 

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -171,7 +171,7 @@ export async function completeFarmPlanting(
     if (nextStatus === 'sowed' && raisedBed.accountId) {
         await queueSeasonalSowingOfferOperations({
             accountId: raisedBed.accountId,
-            gardenId: raisedBed.gardenId,
+            gardenId: raisedBed.gardenId ?? undefined,
             raisedBedId,
         });
     }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -33,6 +33,7 @@ export * from './repositories/occasionsRepo';
 export * from './repositories/operationsRepo';
 export * from './repositories/pickupLocationsRepo';
 export * from './repositories/refreshTokensRepo';
+export * from './repositories/seasonalOffersRepo';
 export * from './repositories/settingsRepo';
 export * from './repositories/shoppingCartRepo';
 export * from './repositories/timeSlotsRepo';

--- a/packages/storage/src/repositories/seasonalOffersRepo.ts
+++ b/packages/storage/src/repositories/seasonalOffersRepo.ts
@@ -72,7 +72,7 @@ export async function queueSeasonalSowingOfferOperations({
     referenceDate = new Date(),
 }: {
     accountId: string;
-    gardenId?: number | null;
+    gardenId?: number;
     raisedBedId: number;
     referenceDate?: Date;
 }) {
@@ -83,7 +83,7 @@ export async function queueSeasonalSowingOfferOperations({
 
     const existingOperations = await getOperations(
         accountId,
-        gardenId ?? undefined,
+        gardenId,
         raisedBedId,
     );
 

--- a/packages/storage/src/repositories/seasonalOffersRepo.ts
+++ b/packages/storage/src/repositories/seasonalOffersRepo.ts
@@ -1,0 +1,120 @@
+import { knownEvents } from './events/knownEvents';
+import { createEvent } from './eventsRepo';
+import { createOperation, getOperations } from './operationsRepo';
+
+const FREE_WATERING_OPERATION_ID = 274;
+
+type SeasonalSowingOffer = {
+    freeWaterings: number;
+    dayInterval: number;
+};
+
+function getSeasonalSowingOffer(date: Date): SeasonalSowingOffer | null {
+    const month = date.getUTCMonth() + 1;
+
+    if (month >= 3 && month <= 5) {
+        return {
+            freeWaterings: 3,
+            dayInterval: 2,
+        };
+    }
+
+    if (month >= 6 && month <= 8) {
+        return {
+            freeWaterings: 5,
+            dayInterval: 1,
+        };
+    }
+
+    if (month >= 9 && month <= 11) {
+        return {
+            freeWaterings: 3,
+            dayInterval: 2,
+        };
+    }
+
+    return null;
+}
+
+function addDays(date: Date, days: number) {
+    const nextDate = new Date(date);
+    nextDate.setUTCDate(nextDate.getUTCDate() + days);
+    return nextDate;
+}
+
+function getLatestScheduledFreeWateringDate(
+    operations: Awaited<ReturnType<typeof getOperations>>,
+    now: Date,
+) {
+    const scheduledDates = operations.flatMap((operation) => {
+        if (
+            operation.entityId !== FREE_WATERING_OPERATION_ID ||
+            operation.status === 'canceled' ||
+            operation.status === 'failed' ||
+            !operation.scheduledDate ||
+            operation.scheduledDate < now
+        ) {
+            return [];
+        }
+
+        return [operation.scheduledDate];
+    });
+
+    return scheduledDates.sort(
+        (left, right) => right.getTime() - left.getTime(),
+    )[0];
+}
+
+export async function queueSeasonalSowingOfferOperations({
+    accountId,
+    raisedBedId,
+    referenceDate = new Date(),
+}: {
+    accountId: string;
+    raisedBedId: number;
+    referenceDate?: Date;
+}) {
+    const offer = getSeasonalSowingOffer(referenceDate);
+    if (!offer) {
+        return [];
+    }
+
+    const existingOperations = await getOperations({
+        accountId,
+        raisedBedId,
+    });
+
+    const latestScheduledDate = getLatestScheduledFreeWateringDate(
+        existingOperations,
+        referenceDate,
+    );
+
+    const firstScheduleDate = latestScheduledDate
+        ? addDays(latestScheduledDate, offer.dayInterval)
+        : new Date(referenceDate);
+
+    const createdOperationIds: number[] = [];
+    for (let index = 0; index < offer.freeWaterings; index += 1) {
+        const scheduledDate = addDays(
+            firstScheduleDate,
+            index * offer.dayInterval,
+        );
+
+        const operationId = await createOperation({
+            accountId,
+            entityId: FREE_WATERING_OPERATION_ID,
+            entityTypeName: 'operation',
+            raisedBedId,
+        });
+
+        await createEvent(
+            knownEvents.operations.scheduledV1(operationId.toString(), {
+                scheduledDate: scheduledDate.toISOString(),
+            }),
+        );
+
+        createdOperationIds.push(operationId);
+    }
+
+    return createdOperationIds;
+}

--- a/packages/storage/src/repositories/seasonalOffersRepo.ts
+++ b/packages/storage/src/repositories/seasonalOffersRepo.ts
@@ -67,10 +67,12 @@ function getLatestScheduledFreeWateringDate(
 
 export async function queueSeasonalSowingOfferOperations({
     accountId,
+    gardenId,
     raisedBedId,
     referenceDate = new Date(),
 }: {
     accountId: string;
+    gardenId?: number | null;
     raisedBedId: number;
     referenceDate?: Date;
 }) {
@@ -79,10 +81,11 @@ export async function queueSeasonalSowingOfferOperations({
         return [];
     }
 
-    const existingOperations = await getOperations({
+    const existingOperations = await getOperations(
         accountId,
+        gardenId ?? undefined,
         raisedBedId,
-    });
+    );
 
     const latestScheduledDate = getLatestScheduledFreeWateringDate(
         existingOperations,
@@ -104,6 +107,7 @@ export async function queueSeasonalSowingOfferOperations({
             accountId,
             entityId: FREE_WATERING_OPERATION_ID,
             entityTypeName: 'operation',
+            gardenId,
             raisedBedId,
         });
 

--- a/packages/storage/src/repositories/seasonalOffersRepo.ts
+++ b/packages/storage/src/repositories/seasonalOffersRepo.ts
@@ -2,7 +2,7 @@ import { knownEvents } from './events/knownEvents';
 import { createEvent } from './eventsRepo';
 import { createOperation, getOperations } from './operationsRepo';
 
-const FREE_WATERING_OPERATION_ID = 274;
+export const FREE_WATERING_OPERATION_ID = 274;
 
 type SeasonalSowingOffer = {
     freeWaterings: number;

--- a/packages/storage/tests/seasonalOffersRepo.node.spec.ts
+++ b/packages/storage/tests/seasonalOffersRepo.node.spec.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createAccount,
+    createEvent,
+    createOperation,
+    getOperations,
+    knownEvents,
+    queueSeasonalSowingOfferOperations,
+} from '@gredice/storage';
+import {
+    createTestBlock,
+    createTestGarden,
+    createTestRaisedBed,
+    ensureFarmId,
+} from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+const FREE_WATERING_OPERATION_ID = 274;
+
+async function createSeasonalOfferTestContext() {
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'seasonal-offer-block');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    return {
+        accountId,
+        gardenId,
+        raisedBedId,
+    };
+}
+
+async function getScheduledFreeWateringDates(
+    accountId: string,
+    gardenId: number,
+    raisedBedId: number,
+) {
+    const operations = await getOperations(accountId, gardenId, raisedBedId);
+
+    return operations
+        .filter(
+            (operation) =>
+                operation.entityId === FREE_WATERING_OPERATION_ID &&
+                operation.scheduledDate,
+        )
+        .map((operation) => operation.scheduledDate?.toISOString())
+        .sort();
+}
+
+test('queueSeasonalSowingOfferOperations queues spring free waterings every two days', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createSeasonalOfferTestContext();
+
+    const createdOperationIds = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-03-10T08:00:00.000Z'),
+    });
+
+    assert.strictEqual(createdOperationIds.length, 3);
+    assert.deepStrictEqual(
+        await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
+        [
+            '2026-03-10T08:00:00.000Z',
+            '2026-03-12T08:00:00.000Z',
+            '2026-03-14T08:00:00.000Z',
+        ],
+    );
+});
+
+test('queueSeasonalSowingOfferOperations queues summer free waterings daily', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createSeasonalOfferTestContext();
+
+    const createdOperationIds = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-06-01T08:00:00.000Z'),
+    });
+
+    assert.strictEqual(createdOperationIds.length, 5);
+    assert.deepStrictEqual(
+        await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
+        [
+            '2026-06-01T08:00:00.000Z',
+            '2026-06-02T08:00:00.000Z',
+            '2026-06-03T08:00:00.000Z',
+            '2026-06-04T08:00:00.000Z',
+            '2026-06-05T08:00:00.000Z',
+        ],
+    );
+});
+
+test('queueSeasonalSowingOfferOperations queues autumn free waterings every two days', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createSeasonalOfferTestContext();
+
+    const createdOperationIds = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-09-10T08:00:00.000Z'),
+    });
+
+    assert.strictEqual(createdOperationIds.length, 3);
+    assert.deepStrictEqual(
+        await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
+        [
+            '2026-09-10T08:00:00.000Z',
+            '2026-09-12T08:00:00.000Z',
+            '2026-09-14T08:00:00.000Z',
+        ],
+    );
+});
+
+test('queueSeasonalSowingOfferOperations skips dates without a seasonal offer', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createSeasonalOfferTestContext();
+
+    const createdOperationIds = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-01-10T08:00:00.000Z'),
+    });
+
+    assert.deepStrictEqual(createdOperationIds, []);
+    assert.deepStrictEqual(
+        await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
+        [],
+    );
+});
+
+test('queueSeasonalSowingOfferOperations extends after active scheduled free waterings', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createSeasonalOfferTestContext();
+    const existingOperationId = await createOperation({
+        accountId,
+        entityId: FREE_WATERING_OPERATION_ID,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    await createEvent(
+        knownEvents.operations.scheduledV1(existingOperationId.toString(), {
+            scheduledDate: '2026-06-20T08:00:00.000Z',
+        }),
+    );
+
+    const createdOperationIds = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-06-15T08:00:00.000Z'),
+    });
+
+    assert.strictEqual(createdOperationIds.length, 5);
+    assert.deepStrictEqual(
+        await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
+        [
+            '2026-06-20T08:00:00.000Z',
+            '2026-06-21T08:00:00.000Z',
+            '2026-06-22T08:00:00.000Z',
+            '2026-06-23T08:00:00.000Z',
+            '2026-06-24T08:00:00.000Z',
+            '2026-06-25T08:00:00.000Z',
+        ],
+    );
+});

--- a/packages/storage/tests/seasonalOffersRepo.node.spec.ts
+++ b/packages/storage/tests/seasonalOffersRepo.node.spec.ts
@@ -4,6 +4,7 @@ import {
     createAccount,
     createEvent,
     createOperation,
+    FREE_WATERING_OPERATION_ID,
     getOperations,
     knownEvents,
     queueSeasonalSowingOfferOperations,
@@ -15,8 +16,6 @@ import {
     ensureFarmId,
 } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
-
-const FREE_WATERING_OPERATION_ID = 274;
 
 async function createSeasonalOfferTestContext() {
     const accountId = await createAccount();


### PR DESCRIPTION
### Motivation
- Implement automatic queuing of promotional free watering operations when a plant is marked as sown based on the seasonal offers described in the operation content.
- Ensure newly queued free-watering operations extend any active free-watering period instead of overlapping existing scheduled free waterings.

### Description
- Added `queueSeasonalSowingOfferOperations` in `packages/storage/src/repositories/seasonalOffersRepo.ts` that enqueues operation `274` according to season: spring (Mar–May) 3 waterings every 2 days, summer (Jun–Aug) 5 daily, autumn (Sep–Nov) 3 every 2 days.
- When queuing, the helper looks up existing operations via `getOperations` and appends new scheduled dates after the latest active free-watering date found for the same raised bed.
- Wired the helper into sowing completion flows by importing and calling `queueSeasonalSowingOfferOperations` when a raised-bed field status becomes `sowed` in `apps/app/app/(actions)/raisedBedFieldsActions.ts` and `apps/farm/app/schedule/actions.ts`.
- Exported the new repository from `packages/storage/src/index.ts` for cross-package usage.

### Testing
- Ran linter: `pnpm lint --filter app --filter farm --filter @gredice/storage`, which completed successfully (with one unrelated non-blocking warning in `apps/app`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef30512ed0832fb223c32fc0b351b4)