### PR TITLE
(time): reduce frequent time updates and avoid extra stateStop updating day/night and sunriseunset fields on eachtick by only setting currentTime in the store. This prevents repeatedresolving of timeOfDay sunriseunset every second.

### DIFF
--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -22,7 +22,6 @@ import { useBlockData } from './hooks/useBlockData';
 import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { useDeferredSceneDetails } from './hooks/useDeferredSceneDetails';
 import { useFocusPlacedBlock } from './hooks/useFocusPlacedBlock';
-import { useGameTimeManager } from './hooks/useGameTimeManager';
 import { useWeatherNow } from './hooks/useWeatherNow';
 import { EditModeGrid } from './indicators/EditModeGrid';
 import { GardenLoadingIndicator } from './indicators/GardenLoadingIndicator';
@@ -66,7 +65,6 @@ export function GameScene({
     deferDetails,
     ...rest
 }: GameSceneProps) {
-    useGameTimeManager();
     useFocusPlacedBlock();
     useRaisedBedCloseup();
     const weatherVisualizationDisabled = useGameState(

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -8,6 +8,7 @@ import {
     resolveInGamePlantPreset,
 } from '../../generators/plant/lib/inGamePlantPresets';
 import { usePlantSort } from '../../hooks/usePlantSorts';
+import { useSnapshotTime } from '../../hooks/useSnapshotTime';
 import { useGameState } from '../../useGameState';
 import {
     getGridPositionFromIndex,
@@ -34,7 +35,7 @@ export function RaisedBedPlantField({
     const { data: sortData } = usePlantSort(plantSortId);
     const flags = useGameFlags();
     const isMock = useGameState((state) => state.isMock);
-    const currentTime = useGameState((state) => state.currentTime);
+    const currentTime = useSnapshotTime();
     const offsetX =
         orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
     const offsetY =

--- a/packages/game/src/hooks/useGameTimeManager.ts
+++ b/packages/game/src/hooks/useGameTimeManager.ts
@@ -1,9 +1,18 @@
-import { useInterval } from '@signalco/hooks/useInterval';
+import { useEffect } from 'react';
 import { useGameState } from '../useGameState';
 
 export function useGameTimeManager() {
     const setCurrentTime = useGameState((state) => state.setCurrentTime);
-    useInterval(() => {
-        setCurrentTime(new Date());
-    }, 1000);
+    useEffect(() => {
+        const tick = () => setCurrentTime(new Date());
+        let intervalId: ReturnType<typeof setInterval> | undefined;
+        const timeoutId = setTimeout(() => {
+            tick();
+            intervalId = setInterval(tick, 60_000);
+        }, 60_000 - (Date.now() % 60_000));
+        return () => {
+            clearTimeout(timeoutId);
+            if (intervalId) clearInterval(intervalId);
+        };
+    }, [setCurrentTime]);
 }

--- a/packages/game/src/hooks/useLiveTime.ts
+++ b/packages/game/src/hooks/useLiveTime.ts
@@ -1,10 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useGameState } from '../useGameState';
 
-export function useGameTimeManager() {
-    const setCurrentTime = useGameState((state) => state.setCurrentTime);
+export function useLiveTime() {
+    const freezeTime = useGameState((state) => state.freezeTime);
+    const [now, setNow] = useState(() => freezeTime ?? new Date());
     useEffect(() => {
-        const tick = () => setCurrentTime(new Date());
+        if (freezeTime) {
+            setNow(freezeTime);
+            return;
+        }
+        const tick = () => setNow(new Date());
         let intervalId: ReturnType<typeof setInterval> | undefined;
         const timeoutId = setTimeout(() => {
             tick();
@@ -14,5 +19,6 @@ export function useGameTimeManager() {
             clearTimeout(timeoutId);
             if (intervalId) clearInterval(intervalId);
         };
-    }, [setCurrentTime]);
+    }, [freezeTime]);
+    return now;
 }

--- a/packages/game/src/hooks/useSnapshotTime.ts
+++ b/packages/game/src/hooks/useSnapshotTime.ts
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+import { useGameState } from '../useGameState';
+
+export function useSnapshotTime() {
+    const freezeTime = useGameState((state) => state.freezeTime);
+    const [snapshot] = useState(() => new Date());
+    return freezeTime ?? snapshot;
+}

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -6,6 +6,7 @@ import { Slider } from '@signalco/ui-primitives/Slider';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLiveTime } from '../hooks/useLiveTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import { useGameState } from '../useGameState';
 
@@ -67,7 +68,7 @@ interface PanelPosition {
 
 export function DebugHud() {
     const setWeather = useGameState((s) => s.setWeather);
-    const currentTime = useGameState((s) => s.currentTime);
+    const currentTime = useLiveTime();
     const setFreezeTime = useGameState((s) => s.setFreezeTime);
 
     const { data: weather } = useWeatherNow();

--- a/packages/game/src/hud/WeatherHud.tsx
+++ b/packages/game/src/hud/WeatherHud.tsx
@@ -4,9 +4,9 @@ import { Button } from '@signalco/ui-primitives/Button';
 import { Popper } from '@signalco/ui-primitives/Popper';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useLiveTime } from '../hooks/useLiveTime';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
 import { useWeatherNow } from '../hooks/useWeatherNow';
-import { useGameState } from '../useGameState';
 import { HudCard } from './components/HudCard';
 import { TimeDisplay } from './components/TimeDisplay';
 import { WeatherForecastDetails } from './components/weather/WeatherForecastDetails';
@@ -14,7 +14,7 @@ import { weatherIcons } from './components/weather/WeatherIcons';
 import { WeatherNowDetails } from './components/weather/WeatherNowDetails';
 
 export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
-    const currentTime = useGameState((state) => state.currentTime);
+    const currentTime = useLiveTime();
     const weatherEnabled = !noWeather;
     const { data: weatherData } = useWeatherNow(weatherEnabled);
     const { data: forecastData } = useWeatherForecast(weatherEnabled);

--- a/packages/game/src/hud/components/TimeDisplay.tsx
+++ b/packages/game/src/hud/components/TimeDisplay.tsx
@@ -3,6 +3,7 @@
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useLiveTime } from '../../hooks/useLiveTime';
 import { useGameState } from '../../useGameState';
 import { DayNightVisualization } from './DayNightVisualization';
 
@@ -11,7 +12,7 @@ export function TimeDisplay({
 }: {
     variant?: 'card' | 'overlay';
 }) {
-    const currentTime = useGameState((state) => state.currentTime);
+    const currentTime = useLiveTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const sunrise = useGameState((state) => state.sunriseTime);
     const sunset = useGameState((state) => state.sunsetTime);

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -5,8 +5,8 @@ import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
+import { useSnapshotTime } from '../../hooks/useSnapshotTime';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
-import { useGameState } from '../../useGameState';
 import {
     countRaisedBedOccupiedFields,
     findRaisedBedOccupiedField,
@@ -207,7 +207,7 @@ export function RaisedBedFieldSuggestions({
         useShoppingCart();
     const { data: allSorts, isLoading: isLoadingSorts } = useAllSorts();
     const setCartItem = useSetShoppingCartItem();
-    const season = useGameState((state) => getSeasonForDate(state.currentTime));
+    const season = getSeasonForDate(useSnapshotTime());
     const hasRequiredData = Boolean(currentGarden && raisedBed && shoppingCart);
     const isRaisedBedValid = raisedBed?.isValid ?? false;
 

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { getPosition } from 'suncalc';
 import { Color, Quaternion, Vector3 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import { type GameState, useGameState } from '../useGameState';
 import { CloudLayer } from './CloudLayer';
@@ -265,7 +266,7 @@ export function Environment({
     const baseCameraShadowSize = 20;
     const shadowMapSize = 8;
 
-    const currentTime = useGameState((state) => state.currentTime);
+    const currentTime = useSnapshotTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const ambientAudioMixer = useGameState((state) => state.audio.ambient);
     const setSnowCoverage = useGameState((state) => state.setSnowCoverage);

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -14,6 +14,7 @@ import {
     Vector3,
 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useGameState } from '../useGameState';
 import { altAzToScenePosition, timeOfDayToDate } from './Environment';
 
@@ -182,7 +183,7 @@ type SunMoonProps = {
 };
 
 export function SunMoon({ visibility = 1 }: SunMoonProps) {
-    const currentTime = useGameState((state) => state.currentTime);
+    const currentTime = useSnapshotTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const dayNightCycleDisabled = useGameState(
         (state) => state.dayNightCycleDisabled,

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -111,11 +111,9 @@ export type GameState = {
     setDayNightCycleDisabled: (disabled: boolean) => void;
     weatherVisualizationDisabled: boolean;
     setWeatherVisualizationDisabled: (disabled: boolean) => void;
-    currentTime: Date;
     timeOfDay: number;
     sunsetTime: Date | null;
     sunriseTime: Date | null;
-    setCurrentTime: (currentTime: Date) => void;
 
     // Game
     mode: GameMode;
@@ -210,16 +208,15 @@ export function createGameState({
         },
         freezeTime,
         setFreezeTime: (freezeTime) => {
-            const currentTime = freezeTime ?? new Date();
+            const referenceTime = freezeTime ?? new Date();
             const { sunrise, sunset } = getSunriseSunset(
                 defaultLocation,
-                currentTime,
+                referenceTime,
             );
             set({
                 freezeTime,
-                currentTime,
                 timeOfDay: resolveTimeOfDay(
-                    currentTime,
+                    referenceTime,
                     get().dayNightCycleDisabled,
                 ),
                 sunriseTime: sunrise,
@@ -231,7 +228,10 @@ export function createGameState({
             persistDayNightCycleDisabled(disabled);
             set({
                 dayNightCycleDisabled: disabled,
-                timeOfDay: resolveTimeOfDay(get().currentTime, disabled),
+                timeOfDay: resolveTimeOfDay(
+                    get().freezeTime ?? new Date(),
+                    disabled,
+                ),
             });
         },
         weatherVisualizationDisabled,
@@ -241,7 +241,6 @@ export function createGameState({
                 weatherVisualizationDisabled: disabled,
             });
         },
-        currentTime: now,
         timeOfDay,
         sunriseTime: sunrise,
         sunsetTime: sunset,
@@ -292,14 +291,6 @@ export function createGameState({
             })),
         setWorldRotation: (worldRotation) => set({ worldRotation }),
         setIsDragging: (isDragging) => set({ isDragging }),
-        setCurrentTime: (currentTime) => {
-            const freezeTime = get().freezeTime;
-            if (freezeTime) {
-                currentTime = freezeTime;
-            }
-
-            return set({ currentTime });
-        },
         setWeather: (weather) => set({ weather }),
         snowCoverage: 0,
         setSnowCoverage: (snowCoverage) => set({ snowCoverage }),

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -298,17 +298,7 @@ export function createGameState({
                 currentTime = freezeTime;
             }
 
-            return set({
-                currentTime,
-                timeOfDay: resolveTimeOfDay(
-                    currentTime,
-                    get().dayNightCycleDisabled,
-                ),
-                sunriseTime: getSunriseSunset(defaultLocation, currentTime)
-                    .sunrise,
-                sunsetTime: getSunriseSunset(defaultLocation, currentTime)
-                    .sunset,
-            });
+            return set({ currentTime });
         },
         setWeather: (weather) => set({ weather }),
         snowCoverage: 0,


### PR DESCRIPTION
Replace the per-second interval with a aligned minute-basedtick: wait the next minute boundary, then update currentTimeand schedule updates60s. reduces update frequency,
lowers CPU work and avoids unnecessary state churn while keepingtime in sync at minute resolution.