### PR TITLE
feat(tests): Playwright CI workers to4Increase number of Playwright test workers in from1.

### DIFF
--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -16,7 +16,7 @@ export const config: PlaywrightTestConfig = {
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
+    workers: process.env.CI ? 4 : undefined,
     reporter,
     use: {
         baseURL: 'http://127.0.0.1:3000',


### PR DESCRIPTION
speeds up test on by allowing more to run inparallel still keeping a single default for local runs.
Adjusting workers overall pipeline runtime and improves feedback for changes.