### PR TITLE
style(app): make scrollbars subtler in app UI

### DIFF
--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -1,1 +1,27 @@
 @import "@signalco/ui-themes-minimal-app/styles";
+
+:root {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, currentColor 20%, transparent)
+        transparent;
+}
+
+*::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background: color-mix(in srgb, currentColor 18%, transparent);
+    border: 2px solid transparent;
+    background-clip: content-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, currentColor 30%, transparent);
+}


### PR DESCRIPTION
### Motivation
- Reduce the visual prominence of scrollbars across the app so UI content is more prominent while keeping the scrollbar discoverable.

### Description
- Added lightweight app-level scrollbar styling in `apps/app/app/globals.css`, including `:root` `scrollbar-width` and `scrollbar-color`, WebKit rules for `::-webkit-scrollbar`, transparent track, rounded low-contrast thumb using `color-mix`, and a slightly stronger hover state.

### Testing
- Ran `pnpm lint` in `apps/app`, which completed successfully (exit 0) and reported one lint warning unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef692a4868832fb3cf25f7ba27430c)