### PR TITLE
(visual): skip automatic and enable fullPage screenshotsComment the automatic scrolling in the visual test addfull screenshots when capturing pages The scrolling code (used to-loaded images to load) is preserved disabled with a TODO we canre and apply it conditionally only on pages need it.

### DIFF
--- a/apps/www/tests/visual.spec.ts
+++ b/apps/www/tests/visual.spec.ts
@@ -43,22 +43,23 @@ test.describe('visual snapshots', () => {
 
             await page.evaluate(() => document.fonts?.ready);
 
-            await page.evaluate(async () => {
-                const step = Math.max(window.innerHeight * 0.8, 400);
-                let prev = -1;
-                while (
-                    document.documentElement.scrollHeight !== prev &&
-                    window.scrollY + window.innerHeight <
-                        document.documentElement.scrollHeight
-                ) {
-                    prev = document.documentElement.scrollHeight;
-                    window.scrollBy(0, step);
-                    await new Promise((r) => requestAnimationFrame(() => r(null)));
-                    await new Promise((r) => setTimeout(r, 100));
-                }
-                window.scrollTo(0, 0);
-                await new Promise((r) => setTimeout(r, 100));
-            });
+            // TODO: Evaluate and execute this only on needed pages that have lazy loaded images
+            // await page.evaluate(async () => {
+            //     const step = Math.max(window.innerHeight * 0.8, 400);
+            //     let prev = -1;
+            //     while (
+            //         document.documentElement.scrollHeight !== prev &&
+            //         window.scrollY + window.innerHeight <
+            //             document.documentElement.scrollHeight
+            //     ) {
+            //         prev = document.documentElement.scrollHeight;
+            //         window.scrollBy(0, step);
+            //         await new Promise((r) => requestAnimationFrame(() => r(null)));
+            //         await new Promise((r) => setTimeout(r, 100));
+            //     }
+            //     window.scrollTo(0, 0);
+            //     await new Promise((r) => setTimeout(r, 100));
+            // });
 
             await page.waitForLoadState('networkidle').catch(() => {});
 
@@ -68,15 +69,9 @@ test.describe('visual snapshots', () => {
                 caret: 'hide',
             });
 
-            const viewport = testInfo.project.use.viewport;
-            const viewportLabel = viewport
-                ? `${viewport.width}x${viewport.height}`
-                : 'unknown';
-
             await vizzlyScreenshot(nameForUrl(url), screenshot, {
-                browser: 'chromium',
-                viewport: viewportLabel,
                 properties: { url },
+                fullPage: true,
             });
         });
     }


### PR DESCRIPTION
Also remove the viewport metadata from the screenshot and stopexplicit passing a browser field; instead requestPage captures toensure entire page is included in visual diffs.

 changes simplify the visual output and avoid flaky logicrunning every page while keeping the scrolling implementationfor targeted use.