### PR TITLE
fix(www): show plant sorts on plant detail pages by matching plant id

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantSortsList.tsx
+++ b/apps/www/app/biljke/[alias]/PlantSortsList.tsx
@@ -10,16 +10,15 @@ import { KnownPages } from '../../../src/KnownPages';
 
 async function PlantSortsListContent({
     basePlantName,
+    basePlantId,
 }: {
     basePlantName: string;
+    basePlantId: number;
 }) {
     const allSorts = await getPlantSortsData();
     const sorts = (
-        allSorts?.filter(
-            (sort) =>
-                sort.information.plant.information?.name?.toLowerCase() ===
-                basePlantName.toLowerCase(),
-        ) ?? []
+        allSorts?.filter((sort) => sort.information.plant.id === basePlantId) ??
+        []
     ).sort((a, b) => a.information.name.localeCompare(b.information.name));
     if (!sorts.length) {
         return (
@@ -87,14 +86,23 @@ async function PlantSortsListContent({
     );
 }
 
-export function PlantSortsList({ basePlantName }: { basePlantName: string }) {
+export function PlantSortsList({
+    basePlantName,
+    basePlantId,
+}: {
+    basePlantName: string;
+    basePlantId: number;
+}) {
     return (
         <Suspense
             fallback={
                 <Typography level="body2">Učitavanje sorti...</Typography>
             }
         >
-            <PlantSortsListContent basePlantName={basePlantName} />
+            <PlantSortsListContent
+                basePlantName={basePlantName}
+                basePlantId={basePlantId}
+            />
         </Suspense>
     );
 }

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -150,7 +150,10 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                 {(plant.information.tip?.length ?? 0) > 0 && (
                     <PlantTips plant={plant} />
                 )}
-                <PlantSortsList basePlantName={plant.information.name} />
+                <PlantSortsList
+                    basePlantName={plant.information.name}
+                    basePlantId={plant.id}
+                />
                 {recipes.length > 0 && (
                     <Stack spacing={2}>
                         <Typography level="h2">


### PR DESCRIPTION
### Motivation
- Plant detail pages showed the "no sorts available" placeholder because sorts were filtered by comparing plant names, which can differ in formatting or content and cause valid sorts to be omitted. 
- Use a stable identifier to reliably associate sorts with their parent plant.

### Description
- Change filtering in `PlantSortsList` to match sorts by `sort.information.plant.id` instead of comparing `information.plant.information.name` to the page name. 
- Add a required `basePlantId` prop to `PlantSortsList` and its internal `PlantSortsListContent` component. 
- Pass `plant.id` from the plant detail page (`apps/www/app/biljke/[alias]/page.tsx`) into `PlantSortsList` so the component can filter by ID.

### Testing
- Ran `pnpm lint --filter www` and the command completed successfully (Biome reported unrelated warnings but no failures). 
- Verified the changes by ensuring the `PlantSortsList` now receives `basePlantId` and the internal filter uses `sort.information.plant.id` (files changed: `apps/www/app/biljke/[alias]/PlantSortsList.tsx`, `apps/www/app/biljke/[alias]/page.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f074da5ea4832fa20e6f14421eeaa3)