### PR TITLE
feat(app): enable enlarged preview for image attributes in admin UI

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -7,6 +7,7 @@ import {
     getInventoryItemsByConfig,
     updateInventoryItem,
 } from '@gredice/storage';
+import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Delete, ExternalLink } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
@@ -28,7 +29,6 @@ import {
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
 import { revalidatePath } from 'next/cache';
-import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
@@ -387,12 +387,11 @@ export default async function EntityDetailsPage(props: {
                                                 imageAttributeValue(value);
                                             if (imageUrl) {
                                                 return (
-                                                    <Image
+                                                    <ImageViewer
                                                         src={imageUrl}
                                                         alt={d.label}
-                                                        width={40}
-                                                        height={40}
-                                                        className="size-10 rounded-md object-cover"
+                                                        previewWidth={40}
+                                                        previewHeight={40}
                                                     />
                                                 );
                                             }

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -4,12 +4,12 @@ import type {
     getEntitiesRaw,
     SelectAttributeDefinition,
 } from '@gredice/storage';
+import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Duplicate } from '@signalco/ui-icons';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import Image from 'next/image';
 import Link from 'next/link';
 import { KnownPages } from '../../../src/KnownPages';
 import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
@@ -152,12 +152,11 @@ function EntityAttributeValueCell({
         const imageUrl = imageAttributeValue(value);
         if (imageUrl) {
             return (
-                <Image
+                <ImageViewer
                     src={imageUrl}
                     alt={definition.label}
-                    width={40}
-                    height={40}
-                    className="size-10 rounded-md object-cover"
+                    previewWidth={40}
+                    previewHeight={40}
                 />
             );
         }


### PR DESCRIPTION
### Motivation
- Provide a way to open image-type entity attributes in a larger view from both the entities table and entity details so users can inspect images without leaving the context.

### Description
- Replace inline `next/image` thumbnails with the shared `ImageViewer` component for image-type attributes in the admin entities table (`apps/app/components/admin/tables/EntitiesTable.tsx`).
- Replace inline `next/image` thumbnails with the shared `ImageViewer` component for image-type attributes on the entity details page (`apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx`).
- Preserve existing image JSON parsing logic (still reads `data.url`), and pass `previewWidth`/`previewHeight` of `40` to produce the original thumbnail size while enabling click-to-enlarge behavior.

### Testing
- Ran `pnpm --filter app lint` and it completed successfully; Biome reported one pre-existing unrelated warning in `app/admin/delivery/slots/ArchiveClosedSlotsButton.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f087dc41ac832f959bb55ad01692fd)