### PR TITLE
Add inventory link and columns to entity type listing

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/page.tsx
@@ -2,12 +2,15 @@ import {
     getAttributeDefinitions,
     getEntitiesRaw,
     getEntityTypeByName,
+    getInventoryConfigByEntityTypeName,
+    getInventoryItemsByConfig,
 } from '@gredice/storage';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Add } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import Link from 'next/link';
 import { EntityTypeMenu } from '../../../../components/admin/directories';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { FilterProvider } from '../../../../components/admin/providers';
@@ -33,10 +36,16 @@ export default async function EntitiesPage({
     const entityType = await getEntityTypeByName(entityTypeName);
     const createEntityBound = createEntity.bind(null, entityTypeName);
     const duplicateEntityBound = duplicateEntity.bind(null, entityTypeName);
-    const [entities, attributeDefinitions] = await Promise.all([
-        getEntitiesRaw(entityTypeName),
-        getAttributeDefinitions(entityTypeName),
-    ]);
+    const [entities, attributeDefinitions, inventoryConfig] = await Promise.all(
+        [
+            getEntitiesRaw(entityTypeName),
+            getAttributeDefinitions(entityTypeName),
+            getInventoryConfigByEntityTypeName(entityTypeName),
+        ],
+    );
+    const inventoryItems = inventoryConfig
+        ? await getInventoryItemsByConfig(inventoryConfig.id)
+        : [];
 
     return (
         <FilterProvider>
@@ -59,6 +68,20 @@ export default async function EntitiesPage({
                         ]}
                     />
                     <Row spacing={1}>
+                        {inventoryConfig && (
+                            <Link
+                                href={KnownPages.InventoryConfig(
+                                    inventoryConfig.id,
+                                )}
+                            >
+                                <Row
+                                    spacing={1}
+                                    className="text-sm font-medium px-3 py-2 rounded-md border hover:bg-accent transition-colors"
+                                >
+                                    <span>Zaliha</span>
+                                </Row>
+                            </Link>
+                        )}
                         <SearchInput />
                         <ServerActionIconButton
                             variant="plain"
@@ -78,6 +101,7 @@ export default async function EntitiesPage({
                             entityTypeName={entityTypeName}
                             entities={entities}
                             attributeDefinitions={attributeDefinitions}
+                            inventoryItems={inventoryItems}
                             onDuplicate={duplicateEntityBound}
                         />
                     </CardOverflow>

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -23,6 +23,11 @@ type EntitiesTableProps = {
     entityTypeName: string;
     entities: Entities;
     attributeDefinitions: SelectAttributeDefinition[];
+    inventoryItems: Array<{
+        entityId: number | null;
+        trackingType: 'pieces' | 'serialNumber';
+        quantity: number;
+    }>;
     onDuplicate: (entityId: number) => Promise<void>;
 };
 
@@ -30,6 +35,7 @@ export function EntitiesTable({
     entityTypeName,
     entities,
     attributeDefinitions,
+    inventoryItems,
     onDuplicate,
 }: EntitiesTableProps) {
     const { filter } = useFilter();
@@ -38,6 +44,15 @@ export function EntitiesTable({
         entityDisplayName(entity).toLowerCase().includes(normalized),
     );
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
+    const inventoryByEntityId = new Map(
+        inventoryItems
+            .filter(
+                (item): item is typeof item & { entityId: number } =>
+                    item.entityId !== null,
+            )
+            .map((item) => [item.entityId, item]),
+    );
+    const hasInventory = inventoryByEntityId.size > 0;
 
     return (
         <Table>
@@ -47,6 +62,12 @@ export function EntitiesTable({
                     {displayDefinitions.map((d) => (
                         <Table.Head key={d.id}>{d.label}</Table.Head>
                     ))}
+                    {hasInventory && (
+                        <>
+                            <Table.Head>Stanje zalihe</Table.Head>
+                            <Table.Head>Količina</Table.Head>
+                        </>
+                    )}
                     <Table.Head>Ispunjenost</Table.Head>
                     <Table.Head>Zadnja izmjena</Table.Head>
                     <Table.Head></Table.Head>
@@ -55,67 +76,100 @@ export function EntitiesTable({
             <Table.Body>
                 {!filteredEntities.length && (
                     <Table.Row>
-                        <Table.Cell colSpan={4 + displayDefinitions.length}>
+                        <Table.Cell
+                            colSpan={
+                                4 +
+                                displayDefinitions.length +
+                                (hasInventory ? 2 : 0)
+                            }
+                        >
                             <NoDataPlaceholder />
                         </Table.Cell>
                     </Table.Row>
                 )}
-                {filteredEntities.map((entity) => (
-                    <Table.Row key={entity.id} className="group">
-                        <Table.Cell>
-                            <Link
-                                href={KnownPages.DirectoryEntity(
-                                    entityTypeName,
-                                    entity.id,
-                                )}
-                            >
-                                <div className="flex items-center gap-2">
-                                    {entity.state === 'draft' ? (
-                                        <Chip color="neutral" className="w-fit">
-                                            Draft
-                                        </Chip>
-                                    ) : null}
-                                    <Typography>
-                                        {entityDisplayName(entity)}
-                                    </Typography>
-                                </div>
-                            </Link>
-                        </Table.Cell>
-                        {displayDefinitions.map((d) => (
-                            <Table.Cell key={d.id}>
-                                <EntityAttributeValueCell
-                                    entity={entity}
-                                    definition={d}
-                                />
+                {filteredEntities.map((entity) => {
+                    const inventoryItem = inventoryByEntityId.get(entity.id);
+
+                    return (
+                        <Table.Row key={entity.id} className="group">
+                            <Table.Cell>
+                                <Link
+                                    href={KnownPages.DirectoryEntity(
+                                        entityTypeName,
+                                        entity.id,
+                                    )}
+                                >
+                                    <div className="flex items-center gap-2">
+                                        {entity.state === 'draft' ? (
+                                            <Chip
+                                                color="neutral"
+                                                className="w-fit"
+                                            >
+                                                Draft
+                                            </Chip>
+                                        ) : null}
+                                        <Typography>
+                                            {entityDisplayName(entity)}
+                                        </Typography>
+                                    </div>
+                                </Link>
                             </Table.Cell>
-                        ))}
-                        <Table.Cell>
-                            <div className="w-24">
-                                <EntityAttributeProgress
-                                    entity={entity}
-                                    definitions={attributeDefinitions}
-                                />
-                            </div>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <Typography secondary>
-                                <LocalDateTime time={false}>
-                                    {entity.updatedAt}
-                                </LocalDateTime>
-                            </Typography>
-                        </Table.Cell>
-                        <Table.Cell>
-                            <ServerActionIconButton
-                                variant="plain"
-                                title="Dupliciraj zapis"
-                                className="group-hover:opacity-100 opacity-0 transition-opacity"
-                                onClick={onDuplicate.bind(null, entity.id)}
-                            >
-                                <Duplicate className="size-5" />
-                            </ServerActionIconButton>
-                        </Table.Cell>
-                    </Table.Row>
-                ))}
+                            {displayDefinitions.map((d) => (
+                                <Table.Cell key={d.id}>
+                                    <EntityAttributeValueCell
+                                        entity={entity}
+                                        definition={d}
+                                    />
+                                </Table.Cell>
+                            ))}
+                            {hasInventory && (
+                                <>
+                                    <Table.Cell>
+                                        <Typography secondary>
+                                            {inventoryItem?.trackingType ===
+                                            'serialNumber'
+                                                ? 'Serijski broj'
+                                                : inventoryItem?.trackingType ===
+                                                    'pieces'
+                                                  ? 'Komadi'
+                                                  : '-'}
+                                        </Typography>
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <Typography secondary>
+                                            {inventoryItem?.quantity ?? 0}
+                                        </Typography>
+                                    </Table.Cell>
+                                </>
+                            )}
+                            <Table.Cell>
+                                <div className="w-24">
+                                    <EntityAttributeProgress
+                                        entity={entity}
+                                        definitions={attributeDefinitions}
+                                    />
+                                </div>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <Typography secondary>
+                                    <LocalDateTime time={false}>
+                                        {entity.updatedAt}
+                                    </LocalDateTime>
+                                </Typography>
+                            </Table.Cell>
+                            <Table.Cell>
+                                <ServerActionIconButton
+                                    variant="plain"
+                                    title="Dupliciraj zapis"
+                                    className="group-hover:opacity-100 opacity-0 transition-opacity"
+                                    onClick={onDuplicate.bind(null, entity.id)}
+                                >
+                                    <Duplicate className="size-5" />
+                                </ServerActionIconButton>
+                            </Table.Cell>
+                        </Table.Row>
+                    );
+                })}
             </Table.Body>
         </Table>
     );


### PR DESCRIPTION
### Motivation
- When an entity type has inventory configured, admins need a quick link to the inventory and visibility into each entity's current inventory state from the entity-type listing page.
- Surface inventory state (tracking type and quantity) inline in the entities table to avoid extra navigation for common checks.

### Description
- Load inventory data on the entity-type listing page by calling `getInventoryConfigByEntityTypeName` and `getInventoryItemsByConfig` and expose a top-level `Zaliha` link to `KnownPages.InventoryConfig(...)` when a config exists in `apps/app/app/admin/directories/[entityType]/page.tsx`.
- Pass `inventoryItems` into `EntitiesTable` as a new prop and add a lightweight type for item shape in `apps/app/components/admin/tables/EntitiesTable.tsx`.
- In `EntitiesTable` map inventory items by `entityId`, add conditional header columns `Stanje zalihe` and `Količina`, and render per-row inventory state and quantity with fallbacks (`-` and `0`).
- Adjust the empty-state `colSpan` to account for the two optional inventory columns and use a type guard to filter out `null` `entityId`s.

### Testing
- Ran linting with `pnpm --dir apps/app lint`, which completed successfully (Biome checked files and auto-fixed two files; one unrelated warning remained).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08752cedc832f97f8bcd142c50e53)