### PR TITLE
fix(ui): center image in ImageViewer modal

### DIFF
--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -324,7 +324,7 @@ export function ImageViewer({
                             style={{ touchAction: 'none' }}
                         >
                             <div
-                                className="relative h-full w-full select-none transition-transform duration-200 ease-out will-change-transform"
+                                className="relative flex h-full w-full select-none items-center justify-center transition-transform duration-200 ease-out will-change-transform"
                                 style={{
                                     transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${position.y / zoomLevel}px)`,
                                     transformOrigin: 'center center',
@@ -334,7 +334,7 @@ export function ImageViewer({
                                 <img
                                     src={src}
                                     alt={alt}
-                                    className="object-contain select-none"
+                                    className="max-h-full max-w-full object-contain select-none"
                                     draggable={false}
                                 />
                             </div>


### PR DESCRIPTION
### Motivation
- The expanded `ImageViewer` opened images anchored to the top-left instead of centered in the viewport, causing the image to appear misaligned when first opened.

### Description
- Update `packages/ui/src/ImageViewer/ImageViewer.tsx` to center the transformed image wrapper by adding `flex items-center justify-center` and constrain the rendered image with `max-h-full max-w-full object-contain` so it stays centered and contained within the viewport.

### Testing
- Ran `pnpm --filter @gredice/ui lint` which completed successfully (Biome checks passed; environment emitted a Node engine version warning about `node >=24` vs current `v22.21.1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08b359f44832fa0592b465dc6e676)