### PR TITLE
Simplify inventory column in entities table

### DIFF
--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -62,12 +62,7 @@ export function EntitiesTable({
                     {displayDefinitions.map((d) => (
                         <Table.Head key={d.id}>{d.label}</Table.Head>
                     ))}
-                    {hasInventory && (
-                        <>
-                            <Table.Head>Stanje zalihe</Table.Head>
-                            <Table.Head>Količina</Table.Head>
-                        </>
-                    )}
+                    {hasInventory && <Table.Head>Stanje zalihe</Table.Head>}
                     <Table.Head>Ispunjenost</Table.Head>
                     <Table.Head>Zadnja izmjena</Table.Head>
                     <Table.Head></Table.Head>
@@ -80,7 +75,7 @@ export function EntitiesTable({
                             colSpan={
                                 4 +
                                 displayDefinitions.length +
-                                (hasInventory ? 2 : 0)
+                                (hasInventory ? 1 : 0)
                             }
                         >
                             <NoDataPlaceholder />
@@ -123,24 +118,11 @@ export function EntitiesTable({
                                 </Table.Cell>
                             ))}
                             {hasInventory && (
-                                <>
-                                    <Table.Cell>
-                                        <Typography secondary>
-                                            {inventoryItem?.trackingType ===
-                                            'serialNumber'
-                                                ? 'Serijski broj'
-                                                : inventoryItem?.trackingType ===
-                                                    'pieces'
-                                                  ? 'Komadi'
-                                                  : '-'}
-                                        </Typography>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Typography secondary>
-                                            {inventoryItem?.quantity ?? 0}
-                                        </Typography>
-                                    </Table.Cell>
-                                </>
+                                <Table.Cell>
+                                    <Typography secondary>
+                                        {inventoryItem?.quantity ?? 0}
+                                    </Typography>
+                                </Table.Cell>
                             )}
                             <Table.Cell>
                                 <div className="w-24">


### PR DESCRIPTION
### Motivation
- When inventory is enabled for an entity type we only care about the numeric count, so the tracking-type column should be removed and the table should show a single inventory quantity column.

### Description
- Updated `apps/app/components/admin/tables/EntitiesTable.tsx` to render a single `Stanje zalihe` column that displays `inventoryItem?.quantity ?? 0` and adjusted the empty-state `colSpan` from 2 to 1 to match the removed column.

### Testing
- Ran `pnpm lint --filter app`, which completed successfully (biome auto-fixed one file and reported one unrelated warning in a different file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08b022f1c832f8fc338dcabd4d659)