### PR TITLE
feat(scripts): add vercel link helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "clean": "turbo clean",
         "dev": "node ./scripts/dev-with-proxy.mjs",
         "env:pull": "node ./scripts/pull-envs.mjs",
+        "vercel:link": "node ./scripts/link-vercel.mjs",
         "lint": "turbo lint",
         "lint:migrate": "turbo lint:migrate",
         "lint:ci-filters": "node ./scripts/check-ci-filters.mjs",

--- a/scripts/link-vercel.mjs
+++ b/scripts/link-vercel.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+// Links every app to its Vercel project in one go.
+
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const vercelCommand = 'vercel';
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const appNames = ['www', 'garden', 'farm', 'app', 'api'];
+
+function getSpawnOptions(command, args) {
+    if (process.platform !== 'win32') {
+        return { command, args };
+    }
+
+    return {
+        command: process.env.ComSpec ?? 'cmd.exe',
+        args: ['/d', '/s', '/c', [command, ...args].join(' ')],
+    };
+}
+
+function run(command, args, options) {
+    return new Promise((resolvePromise, rejectPromise) => {
+        const spawnOptions = getSpawnOptions(command, args);
+        const child = spawn(spawnOptions.command, spawnOptions.args, {
+            ...options,
+            stdio: options?.stdio ?? 'inherit',
+        });
+
+        child.on('error', (error) => {
+            rejectPromise(error);
+        });
+
+        child.on('close', (code) => {
+            resolvePromise(code ?? 1);
+        });
+    });
+}
+
+async function hasVercelCli() {
+    const command = process.platform === 'win32' ? 'where.exe' : 'which';
+    const code = await run(command, [vercelCommand], {
+        env: process.env,
+        stdio: 'ignore',
+    });
+
+    return code === 0;
+}
+
+async function main() {
+    if (!(await hasVercelCli())) {
+        console.error(
+            'Vercel CLI was not found. Install it and make sure `vercel` is on PATH (for example, `pnpm add -Dw vercel` or `npm i -g vercel`).',
+        );
+        process.exit(1);
+    }
+
+    for (const appName of appNames) {
+        const cwd = resolve(repoRoot, 'apps', appName);
+        console.log(`\nLinking ${appName} to Vercel...`);
+
+        const code = await run(vercelCommand, ['link'], {
+            cwd,
+            env: process.env,
+        });
+
+        if (code !== 0) {
+            console.error(`Vercel link failed for ${appName}.`);
+            process.exit(code ?? 1);
+        }
+    }
+
+    console.log('\nFinished linking all apps to Vercel.');
+}
+
+main().catch((error) => {
+    if (error?.code === 'ENOENT') {
+        console.error(
+            'A required command was not found. Make sure Vercel CLI is installed and available as `vercel` on PATH.',
+        );
+    } else if (error?.message) {
+        console.error(error.message);
+    } else if (error) {
+        console.error(error);
+    }
+
+    process.exit(1);
+});


### PR DESCRIPTION
- Implement platform helper and promise wrapper to run Vercel CLI reliably Windows POSIX.
- AddVercelCli check to surface a clear error the Vercel is not installed or on PATH.
- Add scriptscel.mjs to iterate names (www, garden, farm-app, api) run `vercel link` in each app directory, exiting on with an explanatory message.
- Improve error handling in main() and top-level catch to print useful diagnostics for ENOENT other errors- Expose the script via package as an npm `vercel:link` for easy execution from the root.