### PR TITLE
Enable browser-to-terminal logging across Next.js apps

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
     reactStrictMode: true,
+    logging: {
+        browserToTerminal: true,
+    },
     experimental: {
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,
+    logging: {
+        browserToTerminal: true,
+    },
     experimental: {
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,

--- a/apps/farm/next.config.ts
+++ b/apps/farm/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,
+    logging: {
+        browserToTerminal: true,
+    },
     experimental: {
         turbopackFileSystemCacheForDev: true,
         typedEnv: true,

--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -26,6 +26,9 @@ const nextConfig: NextConfig = {
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,
+    logging: {
+        browserToTerminal: true,
+    },
     async headers() {
         return [
             {

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -26,6 +26,9 @@ const nextConfig: NextConfig = {
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,
+    logging: {
+        browserToTerminal: true,
+    },
     async headers() {
         return [
             {


### PR DESCRIPTION
### Motivation
- Forward browser-side errors into the terminal during development so client errors are visible without opening the browser console.

### Description
- Add `logging: { browserToTerminal: true }` to each app's `next.config.ts` in `apps/api`, `apps/app`, `apps/farm`, `apps/garden`, and `apps/www`.

### Testing
- Ran `pnpm lint --filter app --filter farm --filter garden --filter www --filter api`, which completed successfully (existing unrelated lint warnings remain in `app` and `www`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b67bacc0832fa9b63e4b2c2825a7)