### PR TITLE
Keep desktop HUD panels visible in closeup view

### DIFF
--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -34,10 +34,18 @@ export function GameHud({
         <>
             <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
                 <AccountHud />
-                {!isCloseup && <GameModeHud />}
-                {!isCloseup && <AdventHud />}
-                {!isCloseup && <InventoryHud />}
-                {!isCloseup && <ShoppingCartHud />}
+                <div className={cx(isCloseup && 'hidden md:block')}>
+                    <GameModeHud />
+                </div>
+                <div className={cx(isCloseup && 'hidden md:block')}>
+                    <AdventHud />
+                </div>
+                <div className={cx(isCloseup && 'hidden md:block')}>
+                    <InventoryHud />
+                </div>
+                <div className={cx(isCloseup && 'hidden md:block')}>
+                    <ShoppingCartHud />
+                </div>
             </div>
             <div className="absolute top-2 right-2 flex items-end flex-col-reverse md:flex-row gap-1 md:gap-2">
                 <div className={cx(isCloseup && 'hidden md:block')}>


### PR DESCRIPTION
### Motivation
- Desktop HUD controls were being removed in closeup view, but they should remain visible on desktop while still hidden on small screens.

### Description
- Update `packages/game/src/GameHud.tsx` to wrap `GameModeHud`, `AdventHud`, `InventoryHud`, and `ShoppingCartHud` with `div` elements using `cx(isCloseup && 'hidden md:block')` so they are hidden on mobile closeup but remain visible on desktop.

### Testing
- Ran `pnpm --filter @gredice/game lint`, which completed successfully (biome auto-fixed one file and the lint command returned without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c7fab2b4832f89cf29b43923655a)