### PR TITLE
www: capture separate midday and midnight visual snapshots

### DIFF
--- a/apps/www/tests/visual.spec.ts
+++ b/apps/www/tests/visual.spec.ts
@@ -20,16 +20,54 @@ function nameForUrl(url: string): string {
     return url.replace(/^\//, '').replace(/[^a-zA-Z0-9._-]+/g, '_');
 }
 
+const SNAPSHOT_SCENARIOS = [
+    {
+        name: 'midday',
+        fixedTimeIso: '2026-01-15T12:00:00+01:00',
+        colorScheme: 'light' as const,
+    },
+    {
+        name: 'midnight',
+        fixedTimeIso: '2026-01-15T00:00:00+01:00',
+        colorScheme: 'dark' as const,
+    },
+];
+
 test.describe('visual snapshots', () => {
     test.describe.configure({ timeout: 60_000 });
 
     for (const url of getRoutesToCheck()) {
-        test(`page ${url}`, async ({ page }, testInfo) => {
-            await page.goto(url, { waitUntil: 'domcontentloaded' });
-            await page.waitForLoadState('load');
+        for (const scenario of SNAPSHOT_SCENARIOS) {
+            test(`page ${url} (${scenario.name})`, async ({ page }) => {
+                const fixedTime = new Date(scenario.fixedTimeIso).getTime();
+                await page.emulateMedia({ colorScheme: scenario.colorScheme });
+                await page.addInitScript((timeMs) => {
+                    const NativeDate = Date;
+                    class MockDate extends NativeDate {
+                        constructor(
+                            ...args: ConstructorParameters<typeof Date>
+                        ) {
+                            if (args.length === 0) {
+                                super(timeMs);
+                                return;
+                            }
+                            super(...args);
+                        }
 
-            await page.addStyleTag({
-                content: `
+                        static now() {
+                            return timeMs;
+                        }
+                    }
+                    Object.defineProperty(MockDate, 'name', { value: 'Date' });
+                    // @ts-expect-error - Intentionally replacing Date for deterministic visual snapshots
+                    window.Date = MockDate;
+                }, fixedTime);
+
+                await page.goto(url, { waitUntil: 'domcontentloaded' });
+                await page.waitForLoadState('load');
+
+                await page.addStyleTag({
+                    content: `
                     *, *::before, *::after {
                         animation-duration: 0s !important;
                         animation-delay: 0s !important;
@@ -39,40 +77,45 @@ test.describe('visual snapshots', () => {
                     }
                     html { scroll-behavior: auto !important; }
                 `,
+                });
+
+                await page.evaluate(() => document.fonts?.ready);
+
+                // TODO: Evaluate and execute this only on needed pages that have lazy loaded images
+                // await page.evaluate(async () => {
+                //     const step = Math.max(window.innerHeight * 0.8, 400);
+                //     let prev = -1;
+                //     while (
+                //         document.documentElement.scrollHeight !== prev &&
+                //         window.scrollY + window.innerHeight <
+                //             document.documentElement.scrollHeight
+                //     ) {
+                //         prev = document.documentElement.scrollHeight;
+                //         window.scrollBy(0, step);
+                //         await new Promise((r) => requestAnimationFrame(() => r(null)));
+                //         await new Promise((r) => setTimeout(r, 100));
+                //     }
+                //     window.scrollTo(0, 0);
+                //     await new Promise((r) => setTimeout(r, 100));
+                // });
+
+                await page.waitForLoadState('networkidle').catch(() => {});
+
+                const screenshot = await page.screenshot({
+                    fullPage: true,
+                    animations: 'disabled',
+                    caret: 'hide',
+                });
+
+                await vizzlyScreenshot(
+                    `${nameForUrl(url)}-${scenario.name}`,
+                    screenshot,
+                    {
+                        properties: { url, timeOfDay: scenario.name },
+                        fullPage: true,
+                    },
+                );
             });
-
-            await page.evaluate(() => document.fonts?.ready);
-
-            // TODO: Evaluate and execute this only on needed pages that have lazy loaded images
-            // await page.evaluate(async () => {
-            //     const step = Math.max(window.innerHeight * 0.8, 400);
-            //     let prev = -1;
-            //     while (
-            //         document.documentElement.scrollHeight !== prev &&
-            //         window.scrollY + window.innerHeight <
-            //             document.documentElement.scrollHeight
-            //     ) {
-            //         prev = document.documentElement.scrollHeight;
-            //         window.scrollBy(0, step);
-            //         await new Promise((r) => requestAnimationFrame(() => r(null)));
-            //         await new Promise((r) => setTimeout(r, 100));
-            //     }
-            //     window.scrollTo(0, 0);
-            //     await new Promise((r) => setTimeout(r, 100));
-            // });
-
-            await page.waitForLoadState('networkidle').catch(() => {});
-
-            const screenshot = await page.screenshot({
-                fullPage: true,
-                animations: 'disabled',
-                caret: 'hide',
-            });
-
-            await vizzlyScreenshot(nameForUrl(url), screenshot, {
-                properties: { url },
-                fullPage: true,
-            });
-        });
+        }
     }
 });


### PR DESCRIPTION
### Motivation

- Ensure visual baselines cover both daytime (light) and nighttime (dark) variants so Vizzly retains separate image sets for pages that change by theme/time.

### Description

- Updated `apps/www/tests/visual.spec.ts` to run two snapshot scenarios per route: `midday` (light) and `midnight` (dark). 
- Frozen page time per scenario using `page.addInitScript` to override `Date`/`Date.now()` so theme resolution is deterministic for screenshots. 
- Set the Playwright media color scheme per scenario via `page.emulateMedia` and changed Vizzly snapshot naming to append the scenario (e.g. `home-midday`, `home-midnight`) and include `timeOfDay` metadata. 
- Preserved existing screenshot capture options (`fullPage`, animations disabled, caret hidden) and kept lazy-image scrolling TODO comment.

### Testing

- Ran formatter/check with `pnpm --filter www exec biome check --write tests/visual.spec.ts`, which fixed formatting issues and completed successfully. 
- Verified with `pnpm --filter www exec biome check tests/visual.spec.ts`, which reported no remaining issues but a local Node engine warning about the environment (non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c85962bc832f942c181501358cbc)