### PR TITLE
Hide garden edit toggle in raised-bed closeup view

### DIFF
--- a/packages/game/src/hud/GameModeHud.tsx
+++ b/packages/game/src/hud/GameModeHud.tsx
@@ -11,6 +11,7 @@ export function GameModeHud() {
     const [isEditMode, setIsEditMode] = useGameModeParam();
     const { track } = useGameAnalytics();
     const mode = useGameState((state) => state.mode);
+    const view = useGameState((state) => state.view);
     const setMode = useGameState((state) => state.setMode);
 
     // Sync URL param to game state
@@ -20,6 +21,10 @@ export function GameModeHud() {
             setMode(gameMode);
         }
     }, [isEditMode, mode, setMode]);
+
+    if (view === 'closeup') {
+        return null;
+    }
 
     const handleToggleMode = () => {
         const newEditMode = !isEditMode;


### PR DESCRIPTION
### Motivation
- Users reported the app crashes when clicking the garden edit action from a raised-bed closeup view, so the edit entrypoint must be disabled in that context.
- Prevent entering global garden edit mode while focused on a raised-bed closeup to avoid inconsistent state and the crash.

### Description
- Update `packages/game/src/hud/GameModeHud.tsx` to read the current `view` from `useGameState` and return `null` when `view === 'closeup'`, removing the `Uredi vrt` toggle in closeup context.
- Preserve the existing URL sync and edit-mode toggle behavior for non-closeup views and keep analytics tracking intact.

### Testing
- Ran `pnpm --filter @gredice/game lint` which executed `biome check --write` and completed successfully with no fixes applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b1a3b574832fa69e4807917b261a)