### PR TITLE
Deduplicate delivery-ready email recipients by normalizing addresses

### DIFF
--- a/packages/storage/src/helpers/deliveryEmail.ts
+++ b/packages/storage/src/helpers/deliveryEmail.ts
@@ -29,7 +29,7 @@ export async function buildDeliveryEmailDetails(
     const recipients = new Set<string>();
     const accountUsers = await getAccountUsers(request.accountId);
     for (const accountUser of accountUsers) {
-        const email = accountUser.user?.userName?.trim();
+        const email = accountUser.user?.userName?.trim().toLowerCase();
         if (email) {
             recipients.add(email);
         }


### PR DESCRIPTION
### Motivation
- Prevent the same mailbox from receiving multiple delivery-ready emails when account users have identical emails that differ only by casing by normalizing addresses before deduplication.

### Description
- Normalize account user email addresses with `trim().toLowerCase()` in `buildDeliveryEmailDetails` (`packages/storage/src/helpers/deliveryEmail.ts`) before adding them to the `Set` of recipients.

### Testing
- Ran `pnpm lint --filter @gredice/storage` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78b156188832f95143827534025c6)