### PR TITLE
Prioritize shopping cart items in raised-bed operation lists

### DIFF
--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -2,13 +2,16 @@ import type { OperationData } from '@gredice/client';
 import { Alert } from '@signalco/ui/Alert';
 import { NoDataPlaceholder } from '@signalco/ui/NoDataPlaceholder';
 import { Close, Search } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { List } from '@signalco/ui-primitives/List';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { memo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useOperations } from '../../../hooks/useOperations';
 import { usePlantSort } from '../../../hooks/usePlantSorts';
+import { useShoppingCart } from '../../../hooks/useShoppingCart';
+import { useShoppingCartOpenParam } from '../../../useUrlState';
 import { OperationListItemSkeleton } from '../OperationListItemSkeleton';
 import { OperationsListItem } from './OperationsListItem';
 
@@ -21,6 +24,7 @@ const OperationsListContent = memo(function OperationsListContent({
     gardenId,
     raisedBedId,
     positionIndex,
+    shoppingCartOperationIds,
 }: {
     operations: OperationData[] | undefined;
     isLoading: boolean;
@@ -28,6 +32,7 @@ const OperationsListContent = memo(function OperationsListContent({
     gardenId: number;
     raisedBedId?: number;
     positionIndex?: number;
+    shoppingCartOperationIds: Set<number>;
 }) {
     return (
         <List variant="outlined" className="bg-card max-h-96 overflow-y-auto">
@@ -45,6 +50,7 @@ const OperationsListContent = memo(function OperationsListContent({
                 ))}
             {operations?.map((operation) => (
                 <MemoizedOperationsListItem
+                    inShoppingCart={shoppingCartOperationIds.has(operation.id)}
                     key={operation.id}
                     operation={operation}
                     gardenId={gardenId}
@@ -76,9 +82,21 @@ export function OperationsList({
     } = useOperations();
     const { data: plantSort, isLoading: isPlantSortLoading } =
         usePlantSort(plantSortId);
+    const { data: cart } = useShoppingCart();
+    const [, setShoppingCartOpen] = useShoppingCartOpenParam();
     const isLoading =
         isLoadingOperations || (Boolean(plantSortId) && isPlantSortLoading);
     const [search, setSearch] = useState('');
+
+    const shoppingCartOperationIds = useMemo(
+        () =>
+            new Set(
+                (cart?.items ?? [])
+                    .filter((item) => item.entityTypeName === 'operation')
+                    .map((item) => Number(item.entityId)),
+            ),
+        [cart?.items],
+    );
 
     const filteredOperations = operations
         ?.filter(filterFunc)
@@ -99,6 +117,16 @@ export function OperationsList({
                       .includes(search.toLowerCase())
                 : true,
         );
+
+    const cartOperations =
+        filteredOperations?.filter((op) =>
+            shoppingCartOperationIds.has(op.id),
+        ) ?? [];
+    const remainingOperations =
+        filteredOperations?.filter(
+            (op) => !shoppingCartOperationIds.has(op.id),
+        ) ?? [];
+    const sortedOperations = [...cartOperations, ...remainingOperations];
 
     return (
         <Stack spacing={1}>
@@ -126,13 +154,32 @@ export function OperationsList({
             {isError && (
                 <Alert color="danger">Greška prilikom učitavanja radnji</Alert>
             )}
+            {cartOperations.length > 0 && (
+                <Row
+                    justifyContent="space-between"
+                    alignItems="center"
+                    className="px-1"
+                >
+                    <Alert color="warning" className="py-1">
+                        Radnje u košarici (nisu kupljene) su na vrhu popisa.
+                    </Alert>
+                    <Button
+                        size="sm"
+                        variant="link"
+                        onClick={() => setShoppingCartOpen(true)}
+                    >
+                        Otvori košaricu
+                    </Button>
+                </Row>
+            )}
             <OperationsListContent
-                operations={filteredOperations}
+                operations={sortedOperations}
                 isLoading={isLoading}
                 search={search}
                 gardenId={gardenId}
                 raisedBedId={raisedBedId}
                 positionIndex={positionIndex}
+                shoppingCartOperationIds={shoppingCartOperationIds}
             />
         </Stack>
     );

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -10,12 +10,42 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { memo, useMemo, useState } from 'react';
 import { useOperations } from '../../../hooks/useOperations';
 import { usePlantSort } from '../../../hooks/usePlantSorts';
-import { useShoppingCart } from '../../../hooks/useShoppingCart';
+import {
+    type ShoppingCartItemData,
+    useShoppingCart,
+} from '../../../hooks/useShoppingCart';
 import { useShoppingCartOpenParam } from '../../../useUrlState';
 import { OperationListItemSkeleton } from '../OperationListItemSkeleton';
 import { OperationsListItem } from './OperationsListItem';
 
 const MemoizedOperationsListItem = memo(OperationsListItem);
+
+function isOperationInCurrentContext(
+    {
+        entityTypeName,
+        status,
+        gardenId: itemGardenId,
+        raisedBedId: itemRaisedBedId,
+        positionIndex: itemPositionIndex,
+    }: ShoppingCartItemData,
+    {
+        gardenId,
+        raisedBedId,
+        positionIndex,
+    }: {
+        gardenId: number;
+        raisedBedId?: number;
+        positionIndex?: number;
+    },
+) {
+    return (
+        entityTypeName === 'operation' &&
+        status === 'new' &&
+        itemGardenId === gardenId &&
+        (itemRaisedBedId ?? undefined) === raisedBedId &&
+        (itemPositionIndex ?? undefined) === positionIndex
+    );
+}
 
 const OperationsListContent = memo(function OperationsListContent({
     operations,
@@ -92,10 +122,16 @@ export function OperationsList({
         () =>
             new Set(
                 (cart?.items ?? [])
-                    .filter((item) => item.entityTypeName === 'operation')
+                    .filter((item) =>
+                        isOperationInCurrentContext(item, {
+                            gardenId,
+                            raisedBedId,
+                            positionIndex,
+                        }),
+                    )
                     .map((item) => Number(item.entityId)),
             ),
-        [cart?.items],
+        [cart?.items, gardenId, raisedBedId, positionIndex],
     );
 
     const filteredOperations = operations

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -22,11 +22,13 @@ export function OperationsListItem({
     gardenId,
     raisedBedId,
     positionIndex,
+    inShoppingCart,
 }: {
     gardenId: number;
     raisedBedId?: number;
     positionIndex?: number;
     operation: OperationData;
+    inShoppingCart?: boolean;
 }) {
     const setShoppingCartItem = useSetShoppingCartItem();
     const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
@@ -84,6 +86,11 @@ export function OperationsListItem({
                     <Typography level="body1" semiBold noWrap>
                         {operation.information.label}
                     </Typography>
+                    {inShoppingCart && (
+                        <Typography level="body3" className="text-amber-600">
+                            U košarici (nije kupljeno)
+                        </Typography>
+                    )}
                     <Typography level="body1" semiBold>
                         {price}
                     </Typography>


### PR DESCRIPTION
### Motivation
- Surface operations that the user has added to the shopping cart (but not yet purchased) at the top of field operation lists so pending actions are easier to find. 
- Allow players to quickly open the shopping cart from the operation selection UI and clearly mark in-cart operations as not purchased. 

### Description
- Read the current shopping cart via `useShoppingCart()` and compute `shoppingCartOperationIds` to detect operation items in the cart. 
- Group operations so in-cart items appear first (`cartOperations` + `remainingOperations`) and pass an `inShoppingCart` flag into list rows. 
- Show a contextual warning row and a cart CTA (`Otvori košaricu`) that opens the cart using `useShoppingCartOpenParam()` when there are in-cart operations. 
- Add an explicit per-item indicator `U košarici (nije kupljeno)` inside `OperationsListItem` to mark pending cart items. 
- Modified files: `packages/game/src/hud/raisedBed/shared/OperationsList.tsx` and `packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx`.

### Testing
- Ran workspace lint for the game package: `pnpm --filter @gredice/game lint`, which passed and Biome auto-formatted one file.
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f718cf97dc832f8b33e85193b30d7d)