### PR TITLE
Add `firstFlowers` and `firstFruitSet` plant lifecycle statuses

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -104,6 +104,12 @@ async function applyRaisedBedFieldPlantUpdate({
             } else if (status === 'died') {
                 header = `😢 Biljka ${sortData.information?.name} nije uspjela!`;
                 content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** nije uspjela. Veselimo se novim biljkama koje će rasti na ovom mestu.`;
+            } else if (status === 'firstFlowers') {
+                header = `🌸 Biljka ${sortData.information?.name} je procvjetala!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je razvila prve cvjetove.`;
+            } else if (status === 'firstFruitSet') {
+                header = `🍅 Biljka ${sortData.information?.name} ima prve plodove!`;
+                content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je razvila prve plodove.`;
             } else if (status === 'ready') {
                 header = `🌿 Biljka ${sortData.information?.name} je spremna za berbu!`;
                 content = `U gredici **${raisedBed.name}** na poziciji **${positionIndex + 1}** biljka **${sortData.information?.name}** je spremna za berbu.`;

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector.tsx
@@ -34,6 +34,8 @@ export function RaisedBedFieldPlantStatusSelector({
                 },
                 { value: 'sowed', label: 'Sijano', icon: '🫘' },
                 { value: 'sprouted', label: 'Proklijalo', icon: '🌱' },
+                { value: 'firstFlowers', label: 'Prvi cvjetovi', icon: '🌸' },
+                { value: 'firstFruitSet', label: 'Prvi plodovi', icon: '🍅' },
                 { value: 'notSprouted', label: 'Nije proklijalo', icon: '❌' },
                 { value: 'died', label: 'Uginulo', icon: '💀' },
                 { value: 'ready', label: 'Spremno', icon: '🥕' },

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -31,6 +31,8 @@ const fieldStatusMetadata: Record<string, { label: string; icon: string }> = {
     pendingVerification: { label: 'Čeka verifikaciju', icon: '🔍' },
     sowed: { label: 'Sijano', icon: '🫘' },
     sprouted: { label: 'Proklijalo', icon: '🌱' },
+    firstFlowers: { label: 'Prvi cvjetovi', icon: '🌸' },
+    firstFruitSet: { label: 'Prvi plodovi', icon: '🍅' },
     notSprouted: { label: 'Nije proklijalo', icon: '❌' },
     died: { label: 'Uginulo', icon: '💀' },
     ready: { label: 'Spremno', icon: '🥕' },

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -212,6 +212,12 @@ export function RaisedBedFieldLifecycleTab({
         case 'sprouted':
             icon = <span className="mr-0.5">{'🌱'}</span>;
             break;
+        case 'firstFlowers':
+            icon = <span className="mr-0.5">{'🌸'}</span>;
+            break;
+        case 'firstFruitSet':
+            icon = <span className="mr-0.5">{'🍅'}</span>;
+            break;
         case 'ready':
             icon = <span className="mr-0.5">{'🌿'}</span>;
             break;

--- a/packages/game/src/hud/raisedBed/featuredOperations.ts
+++ b/packages/game/src/hud/raisedBed/featuredOperations.ts
@@ -15,6 +15,8 @@ export type PlantFieldStatus =
     | 'pendingVerification'
     | 'sowed'
     | 'sprouted'
+    | 'firstFlowers'
+    | 'firstFruitSet'
     | 'notSprouted'
     | 'ready'
     | 'harvested'
@@ -129,6 +131,8 @@ export const PLANT_STATUS_STAGE_SEQUENCE: Record<
     pendingVerification: ['sowing', 'watering'],
     sowed: ['sowing', 'watering'],
     sprouted: ['maintenance', 'growth', 'watering'],
+    firstFlowers: ['flowering', 'maintenance', 'watering'],
+    firstFruitSet: ['growth', 'watering', 'harvest'],
     notSprouted: ['sowing', 'maintenance'],
     ready: ['harvest', 'storage'],
     harvested: ['storage'],

--- a/packages/js/src/plants/plantFieldStatusLabel.ts
+++ b/packages/js/src/plants/plantFieldStatusLabel.ts
@@ -34,6 +34,19 @@ export function plantFieldStatusLabel(status: string | undefined) {
                 description:
                     'Sjeme je uspješno proklijalo i biljka je krenula rasti.',
             };
+        case 'firstFlowers':
+            return {
+                shortLabel: 'Prvi cvjetovi',
+                label: 'Biljka je razvila prve cvjetove',
+                description:
+                    'Biljka je ušla u fazu cvjetanja i pojavili su se prvi cvjetovi.',
+            };
+        case 'firstFruitSet':
+            return {
+                shortLabel: 'Prvi plodovi',
+                label: 'Biljka je razvila prve plodove',
+                description: 'Nakon cvjetanja formirani su prvi plodovi.',
+            };
         case 'ready':
             return {
                 shortLabel: 'Spremna za berbu',

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1563,11 +1563,9 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                     plantDeadDate = event.createdAt;
                     stoppedDate = event.createdAt;
                 } else if (plantStatus === 'firstFlowers') {
-                    plantGrowthDate =
-                        plantGrowthDate ?? plantCycleEvent.createdAt;
+                    plantGrowthDate = plantGrowthDate ?? event.createdAt;
                 } else if (plantStatus === 'firstFruitSet') {
-                    plantGrowthDate =
-                        plantGrowthDate ?? plantCycleEvent.createdAt;
+                    plantGrowthDate = plantGrowthDate ?? event.createdAt;
                 } else if (plantStatus === 'ready') {
                     plantReadyDate = event.createdAt;
                 } else if (plantStatus === 'harvested') {

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -778,6 +778,10 @@ function summarizePlantCycle(
             } else if (plantStatus === 'died') {
                 plantDeadDate = plantCycleEvent.createdAt;
                 stoppedDate = plantCycleEvent.createdAt;
+            } else if (plantStatus === 'firstFlowers') {
+                plantGrowthDate = plantGrowthDate ?? plantCycleEvent.createdAt;
+            } else if (plantStatus === 'firstFruitSet') {
+                plantGrowthDate = plantGrowthDate ?? plantCycleEvent.createdAt;
             } else if (plantStatus === 'ready') {
                 plantReadyDate = plantCycleEvent.createdAt;
             } else if (plantStatus === 'harvested') {
@@ -1558,6 +1562,12 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 } else if (plantStatus === 'died') {
                     plantDeadDate = event.createdAt;
                     stoppedDate = event.createdAt;
+                } else if (plantStatus === 'firstFlowers') {
+                    plantGrowthDate =
+                        plantGrowthDate ?? plantCycleEvent.createdAt;
+                } else if (plantStatus === 'firstFruitSet') {
+                    plantGrowthDate =
+                        plantGrowthDate ?? plantCycleEvent.createdAt;
                 } else if (plantStatus === 'ready') {
                     plantReadyDate = event.createdAt;
                 } else if (plantStatus === 'harvested') {


### PR DESCRIPTION
### Motivation
- Introduce two intermediate plant lifecycle states after `sprouted` so some plants can record first flowers and initial fruit set. 
- Make these states manageable from the admin UI so gardeners/farmers can mark them in `apps/app`.
- Ensure the garden/game frontends and storage projection understand the new statuses so UI, notifications and historical event replay remain consistent.

### Description
- Added two new statuses `firstFlowers` and `firstFruitSet` to the admin status selector in `apps/app` at `RaisedBedFieldPlantStatusSelector.tsx` so they can be set from the UI. 
- Extended `apps/app/components/raised-beds/RaisedBedFieldsTable.tsx` to include label/icon metadata for the new statuses so they render in tables and removed-field views. 
- Added notification messages for both statuses in `apps/app/(actions)/raisedBedFieldsActions.ts` so account notifications are created when a field is updated to these states. 
- Updated shared label descriptions in `packages/js/src/plants/plantFieldStatusLabel.ts`, game lifecycle typing and stage sequence in `packages/game/src/hud/raisedBed/featuredOperations.ts`, and lifecycle UI icons in `packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx` so the garden/game experience displays the new states. 
- Updated storage projection logic in `packages/storage/src/repositories/gardensRepo.ts` to recognize `firstFlowers` and `firstFruitSet` during event replay and populate growth-related timestamps consistently.

### Testing
- Ran targeted linting: `pnpm -s lint --filter app --filter garden --filter @gredice/js --filter @gredice/game --filter @gredice/storage`, which completed successfully with only pre-existing warning-level unused-import notices unrelated to this change. 
- No database schema or migration files were added as this change extends in-memory/event projection and UI handling only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78ace8cf4832f8bb84b9f4b42df92)