### PR TITLE
Export BlurText as a named symbol for Storybook

### DIFF
--- a/packages/ui/src/BlurText/BlurText.tsx
+++ b/packages/ui/src/BlurText/BlurText.tsx
@@ -30,7 +30,7 @@ const buildKeyframes = (
     });
     return keyframes;
 };
-const BlurText: React.FC<BlurTextProps> = ({
+function BlurText({
     text = '',
     delay = 200,
     className = '',
@@ -43,22 +43,23 @@ const BlurText: React.FC<BlurTextProps> = ({
     easing = (t: number) => t,
     onAnimationComplete,
     stepDuration = 0.35,
-}) => {
+}: BlurTextProps) {
     const elements = animateBy === 'words' ? text.split(' ') : text.split('');
     const [inView, setInView] = useState(false);
     const ref = useRef<HTMLParagraphElement>(null);
     useEffect(() => {
-        if (!ref.current) return;
+        const element = ref.current;
+        if (!element) return;
         const observer = new IntersectionObserver(
             ([entry]) => {
                 if (entry.isIntersecting) {
                     setInView(true);
-                    observer.unobserve(ref.current as Element);
+                    observer.unobserve(element);
                 }
             },
             { threshold, rootMargin },
         );
-        observer.observe(ref.current);
+        observer.observe(element);
         return () => observer.disconnect();
     }, [threshold, rootMargin]);
     const defaultFrom = useMemo(
@@ -125,5 +126,7 @@ const BlurText: React.FC<BlurTextProps> = ({
             })}
         </p>
     );
-};
+}
+
+export { BlurText, type BlurTextProps };
 export default BlurText;


### PR DESCRIPTION
## Summary
- Added a named `BlurText` export alongside the default export so `@gredice/ui/BlurText` matches the import style used by Storybook.
- Tightened the `IntersectionObserver` effect by avoiding a nullable ref read and removing the type assertion.

## Testing
- `pnpm lint --filter @gredice/ui`
- `pnpm --filter storybook build`