### PR TITLE
Add missing Turbo env vars for app build tasks

### DIFF
--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -7,6 +7,8 @@
                 "ACS_CONNECTION_STRING",
                 "AI_GATEWAY_API_KEY",
                 "BLOB_READ_WRITE_TOKEN",
+                "CHECKLY_ACCOUNT_ID",
+                "CHECKLY_API_KEY",
                 "CRON_SECRET",
                 "ENABLE_EXPERIMENTAL_COREPACK",
                 "FACEBOOK_CLIENT_ID",

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -11,7 +11,11 @@
                 "CDN_R2_ENDPOINT",
                 "CDN_R2_PUBLIC_URL",
                 "CDN_R2_SECRET_ACCESS_KEY",
+                "CHECKLY_ACCOUNT_ID",
+                "CHECKLY_API_KEY",
                 "ENABLE_EXPERIMENTAL_COREPACK",
+                "GREDICE_GOOGLE_MAPS_API_KEY",
+                "GREDICE_GOOGLE_MAPS_URL_SIGNING_SECRET",
                 "GREDICE_JWT_SIGN_SECRET",
                 "GREDICE_SILO_KV_REST_API_READ_ONLY_TOKEN",
                 "GREDICE_SILO_KV_REST_API_TOKEN",
@@ -42,6 +46,7 @@
                 "POSTGRES_USER",
                 "POSTHOG_SERVER_HOST",
                 "SIGNALCO_API_KEY",
+                "SLACK_BOT_TOKEN",
                 "VERCEL_OIDC_TOKEN"
             ]
         }

--- a/apps/farm/turbo.json
+++ b/apps/farm/turbo.json
@@ -5,7 +5,11 @@
         "build": {
             "env": [
                 "BLOB_READ_WRITE_TOKEN",
+                "CHECKLY_ACCOUNT_ID",
+                "CHECKLY_API_KEY",
                 "ENABLE_EXPERIMENTAL_COREPACK",
+                "GREDICE_GOOGLE_MAPS_API_KEY",
+                "GREDICE_GOOGLE_MAPS_URL_SIGNING_SECRET",
                 "GREDICE_JWT_SIGN_SECRET",
                 "HYPERTUNE_FRAMEWORK",
                 "HYPERTUNE_INCLUDE_INIT_DATA",
@@ -25,6 +29,7 @@
                 "POSTGRES_URL_NO_SSL",
                 "POSTGRES_USER",
                 "POSTHOG_SERVER_HOST",
+                "SLACK_BOT_TOKEN",
                 "VERCEL_OIDC_TOKEN"
             ]
         }

--- a/apps/garden/turbo.json
+++ b/apps/garden/turbo.json
@@ -5,9 +5,16 @@
         "build": {
             "env": [
                 "BLOB_READ_WRITE_TOKEN",
+                "CHECKLY_ACCOUNT_ID",
+                "CHECKLY_API_KEY",
+                "EDGE_CONFIG",
+                "EDGE_CONFIG_HYPERTUNE_ITEM_KEY",
                 "ENABLE_EXPERIMENTAL_COREPACK",
                 "FLAGS_SECRET",
+                "GREDICE_GOOGLE_MAPS_API_KEY",
+                "GREDICE_GOOGLE_MAPS_URL_SIGNING_SECRET",
                 "GREDICE_JWT_SIGN_SECRET",
+                "HYPERTUNE_ADMIN_TOKEN",
                 "HYPERTUNE_FRAMEWORK",
                 "HYPERTUNE_INCLUDE_INIT_DATA",
                 "HYPERTUNE_OUTPUT_DIRECTORY_PATH",

--- a/apps/www/turbo.json
+++ b/apps/www/turbo.json
@@ -5,13 +5,20 @@
         "build": {
             "env": [
                 "BLOB_READ_WRITE_TOKEN",
+                "CHECKLY_ACCOUNT_ID",
+                "CHECKLY_API_KEY",
+                "EDGE_CONFIG",
+                "EDGE_CONFIG_HYPERTUNE_ITEM_KEY",
                 "ENABLE_EXPERIMENTAL_COREPACK",
                 "FACEBOOK_CAPI_API_VERSION",
                 "FACEBOOK_CAPI_PIXEL_ID",
                 "FACEBOOK_CAPI_TOKEN",
                 "FLAGS_SECRET",
                 "GREDICE_API_HOST",
+                "GREDICE_GOOGLE_MAPS_API_KEY",
+                "GREDICE_GOOGLE_MAPS_URL_SIGNING_SECRET",
                 "GREDICE_JWT_SIGN_SECRET",
+                "HYPERTUNE_ADMIN_TOKEN",
                 "HYPERTUNE_FRAMEWORK",
                 "HYPERTUNE_INCLUDE_INIT_DATA",
                 "HYPERTUNE_OUTPUT_DIRECTORY_PATH",
@@ -31,7 +38,8 @@
                 "POSTGRES_URL_NO_SSL",
                 "POSTGRES_USER",
                 "POSTHOG_SERVER_HOST",
-                "VERCEL_OIDC_TOKEN"
+                "VERCEL_OIDC_TOKEN",
+                "VIZZLY_TOKEN"
             ]
         }
     }


### PR DESCRIPTION
## Summary
- Added the missing build-time environment variables to `turbo.json` files for `api`, `app`, `farm`, `garden`, and `www`.
- Covered the Checkly, Google Maps, Slack, Edge Config, Hypertune, and Vizzly variables reported by Vercel/Turborepo warnings.
- Kept the changes scoped to each app’s own build task configuration.

## Testing
- Biome formatting passed for the updated `turbo.json` files.
- Turbo dry-run validation confirmed the newly added env vars are resolved for the affected build tasks.