### PR TITLE
Add Storybook autodocs and fix fullscreen preview height

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -4,12 +4,22 @@ import '../styles.css';
 
 const preview: Preview = {
     decorators: [
-        (Story) => (
-            <div className="min-h-screen bg-background p-6 text-foreground">
-                <Story />
-                <Analytics />
-            </div>
-        ),
+        (Story, context) => {
+            const isFullscreen = context.parameters.layout === 'fullscreen';
+
+            return (
+                <div
+                    className={
+                        isFullscreen
+                            ? 'bg-background text-foreground'
+                            : 'bg-background p-6 text-foreground'
+                    }
+                >
+                    <Story />
+                    <Analytics />
+                </div>
+            );
+        },
     ],
     parameters: {
         a11y: {

--- a/apps/storybook/stories/apps/app/FactCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/FactCard.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'apps/app/Admin/FactCard',
     component: FactCard,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'FactCard presents an admin metric with its current value and optional comparison against a previous value.',
+            },
+        },
+    },
     args: {
         beforeValue: 108,
         header: 'Active subscriptions',

--- a/apps/storybook/stories/apps/app/NoDataPlaceholder.stories.tsx
+++ b/apps/storybook/stories/apps/app/NoDataPlaceholder.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'apps/app/Shared/NoDataPlaceholder',
     component: NoDataPlaceholder,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'NoDataPlaceholder provides a compact empty state message for admin and app views when a list or query has no results.',
+            },
+        },
+    },
     args: {
         children: 'No records match the current filters.',
     },

--- a/apps/storybook/stories/apps/farm/HomeButton.stories.tsx
+++ b/apps/storybook/stories/apps/farm/HomeButton.stories.tsx
@@ -15,6 +15,12 @@ const meta = {
         useRouter.mockImplementation(getRouter);
     },
     parameters: {
+        docs: {
+            description: {
+                component:
+                    'HomeButton links farm users back to the primary farm home route using the app router navigation primitives.',
+            },
+        },
         nextjs: {
             appDirectory: true,
         },

--- a/apps/storybook/stories/apps/garden/Logotype.stories.tsx
+++ b/apps/storybook/stories/apps/garden/Logotype.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'apps/garden/Brand/Logotype',
     component: Logotype,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'The garden Logotype renders the Vrt Gredice brand mark with configurable sizing and color for garden-facing surfaces.',
+            },
+        },
+    },
     args: {
         className: 'h-12 w-auto',
         color: '#2E6F40',

--- a/apps/storybook/stories/apps/www/AttributeCard.stories.tsx
+++ b/apps/storybook/stories/apps/www/AttributeCard.stories.tsx
@@ -1,11 +1,19 @@
 import { AttributeCard } from '@apps/www/components/attributes/DetailCard';
-import { Leaf, Sprout, Droplet } from '@signalco/ui-icons';
+import { Droplet, Leaf, Sprout } from '@signalco/ui-icons';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
     title: 'apps/www/Attributes/AttributeCard',
     component: AttributeCard,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'AttributeCard displays a labeled plant or product attribute with an icon, value, optional description, and optional navigation.',
+            },
+        },
+    },
     args: {
         icon: <Leaf className="size-5 text-primary" />,
         header: 'Tip biljke',

--- a/apps/storybook/stories/apps/www/ExpandableText.stories.tsx
+++ b/apps/storybook/stories/apps/www/ExpandableText.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'apps/www/Shared/ExpandableText',
     component: ExpandableText,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ExpandableText clamps longer editorial content to a fixed height and lets readers expand or collapse it in place.',
+            },
+        },
+    },
     args: {
         children: null,
         collapseButtonText: 'Show less',

--- a/apps/storybook/stories/apps/www/ItemCard.stories.tsx
+++ b/apps/storybook/stories/apps/www/ItemCard.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'apps/www/Shared/ItemCard',
     component: ItemCard,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ItemCard is a linked visual tile for public listing grids, pairing media content with a short item label.',
+            },
+        },
+    },
     args: {
         label: 'Rajčica',
         href: '/biljke/rajcica',
@@ -36,15 +44,20 @@ export const WithLongLabel: Story = {
 export const Grid: Story = {
     render: () => (
         <div className="grid grid-cols-3 gap-4 w-96">
-            {['Rajčica 🍅', 'Paprika 🫑', 'Krastavac 🥒', 'Tikvica 🥒', 'Patlidžan 🍆', 'Mrkva 🥕'].map(
-                (label) => (
-                    <ItemCard key={label} label={label} href={`/biljke/${label}`}>
-                        <div className="flex size-full items-center justify-center bg-green-50 text-3xl">
-                            {label.split(' ')[1]}
-                        </div>
-                    </ItemCard>
-                ),
-            )}
+            {[
+                'Rajčica 🍅',
+                'Paprika 🫑',
+                'Krastavac 🥒',
+                'Tikvica 🥒',
+                'Patlidžan 🍆',
+                'Mrkva 🥕',
+            ].map((label) => (
+                <ItemCard key={label} label={label} href={`/biljke/${label}`}>
+                    <div className="flex size-full items-center justify-center bg-green-50 text-3xl">
+                        {label.split(' ')[1]}
+                    </div>
+                </ItemCard>
+            ))}
         </div>
     ),
 };

--- a/apps/storybook/stories/apps/www/ListCollapsable.stories.tsx
+++ b/apps/storybook/stories/apps/www/ListCollapsable.stories.tsx
@@ -1,5 +1,5 @@
 import { ListCollapsable } from '@apps/www/components/shared/ListCollapsable';
-import { Leaf, Sprout, Droplet } from '@signalco/ui-icons';
+import { Droplet, Leaf, Sprout } from '@signalco/ui-icons';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import {
     createNavigation,
@@ -8,15 +8,38 @@ import {
 } from '@storybook/nextjs-vite/navigation.mock';
 
 const items = [
-    { value: 'povrce', label: 'Povrće', icon: <Leaf className="size-4" />, href: '/biljke/povrce' as const },
-    { value: 'voca', label: 'Voće', icon: <Sprout className="size-4" />, href: '/biljke/voca' as const },
-    { value: 'zacini', label: 'Začini', icon: <Droplet className="size-4" />, href: '/biljke/zacini' as const },
+    {
+        value: 'povrce',
+        label: 'Povrće',
+        icon: <Leaf className="size-4" />,
+        href: '/biljke/povrce' as const,
+    },
+    {
+        value: 'voca',
+        label: 'Voće',
+        icon: <Sprout className="size-4" />,
+        href: '/biljke/voca' as const,
+    },
+    {
+        value: 'zacini',
+        label: 'Začini',
+        icon: <Droplet className="size-4" />,
+        href: '/biljke/zacini' as const,
+    },
 ];
 
 const meta = {
     title: 'apps/www/Shared/ListCollapsable',
     component: ListCollapsable,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ListCollapsable renders a compact selectable link list for public taxonomy navigation and category filters.',
+            },
+        },
+    },
     beforeEach: () => {
         createNavigation({});
         useRouter.mockImplementation(getRouter);

--- a/apps/storybook/stories/apps/www/Logotype.stories.tsx
+++ b/apps/storybook/stories/apps/www/Logotype.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'apps/www/Brand/Logotype',
     component: Logotype,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'The public website Logotype renders the Gredice brand mark for headers, footers, and marketing surfaces.',
+            },
+        },
+    },
     args: {
         className: 'h-12 w-auto',
     },

--- a/apps/storybook/stories/apps/www/PageHeader.stories.tsx
+++ b/apps/storybook/stories/apps/www/PageHeader.stories.tsx
@@ -19,6 +19,12 @@ const meta = {
         ),
     },
     parameters: {
+        docs: {
+            description: {
+                component:
+                    'PageHeader composes public page titles, alternate labels, supporting copy, optional visuals, and adjacent content.',
+            },
+        },
         layout: 'fullscreen',
     },
     render: (args) => (

--- a/apps/storybook/stories/apps/www/SocialCard.stories.tsx
+++ b/apps/storybook/stories/apps/www/SocialCard.stories.tsx
@@ -31,6 +31,14 @@ const meta = {
     title: 'apps/www/Social/SocialCard',
     component: SocialCard,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'SocialCard promotes an external social channel with brand-specific icon styling, call-to-action copy, and link affordance.',
+            },
+        },
+    },
     args: {
         href: 'https://www.instagram.com/gredice',
         ctaText: 'Pratite nas na Instagramu',

--- a/apps/storybook/stories/packages/ui/ArchiveIcon.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ArchiveIcon.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Icons/ArchiveIcon',
     component: ArchiveIcon,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ArchiveIcon renders the archive glyph used for actions and empty states that refer to stored, hidden, or archived records.',
+            },
+        },
+    },
     args: {
         className: 'size-8 text-primary',
     },

--- a/apps/storybook/stories/packages/ui/AvatarSelectionMenu.stories.tsx
+++ b/apps/storybook/stories/packages/ui/AvatarSelectionMenu.stories.tsx
@@ -6,13 +6,24 @@ const meta = {
     title: 'packages/ui/Inputs/AvatarSelectionMenu',
     component: AvatarSelectionMenu,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'AvatarSelectionMenu opens an avatar picker from a custom trigger and reports the selected avatar through its change handler.',
+            },
+        },
+    },
     args: {
         displayName: 'Ana Kovač',
         title: 'Odaberi avatar',
         emptyLabel: 'Prazno',
         onChange: () => {},
         children: (
-            <button type="button" className="rounded-full ring-2 ring-primary ring-offset-2 cursor-pointer">
+            <button
+                type="button"
+                className="rounded-full ring-2 ring-primary ring-offset-2 cursor-pointer"
+            >
                 <Avatar size="lg">AK</Avatar>
             </button>
         ),

--- a/apps/storybook/stories/packages/ui/BlurText.stories.tsx
+++ b/apps/storybook/stories/packages/ui/BlurText.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Animation/BlurText',
     component: BlurText,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'BlurText reveals text with a staggered blur animation, either by words or by individual letters.',
+            },
+        },
+    },
     args: {
         text: 'Uzgajajte zdravo povrće',
         className: 'text-3xl font-semibold text-primary',

--- a/apps/storybook/stories/packages/ui/CountingNumber.stories.tsx
+++ b/apps/storybook/stories/packages/ui/CountingNumber.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Data Display/CountingNumber',
     component: CountingNumber,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'CountingNumber animates numeric values between a starting point and a target value, including optional decimal formatting.',
+            },
+        },
+    },
     args: {
         className: 'font-mono text-4xl font-semibold text-primary',
         fromNumber: 1200,

--- a/apps/storybook/stories/packages/ui/DailySchedule.stories.tsx
+++ b/apps/storybook/stories/packages/ui/DailySchedule.stories.tsx
@@ -6,6 +6,14 @@ const meta = {
     title: 'packages/ui/Data Display/DailySchedule',
     component: DailySchedule,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'DailySchedule lays out a sequence of calendar days and delegates each day row to a render function for domain-specific content.',
+            },
+        },
+    },
     args: {
         days: 5,
         startDate: new Date('2025-06-09'),
@@ -22,7 +30,9 @@ const meta = {
                         {date.getDate()}
                     </Typography>
                 </div>
-                <Typography level="body2">Zadatak {index + 1}: Zalijevanje</Typography>
+                <Typography level="body2">
+                    Zadatak {index + 1}: Zalijevanje
+                </Typography>
             </div>
         ),
     },

--- a/apps/storybook/stories/packages/ui/ErrorFallback.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ErrorFallback.stories.tsx
@@ -6,6 +6,12 @@ const meta = {
     component: ErrorFallback,
     tags: ['autodocs'],
     parameters: {
+        docs: {
+            description: {
+                component:
+                    'ErrorFallback displays a recoverable error state with optional retry handling and correlation details for support workflows.',
+            },
+        },
         layout: 'fullscreen',
     },
     args: {

--- a/apps/storybook/stories/packages/ui/FilterInput.stories.tsx
+++ b/apps/storybook/stories/packages/ui/FilterInput.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Inputs/FilterInput',
     component: FilterInput,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'FilterInput binds a search field to URL query state and can update either on submit or immediately as the user types.',
+            },
+        },
+    },
     args: {
         searchParamName: 'q',
         fieldName: 'search',

--- a/apps/storybook/stories/packages/ui/GridIcons.stories.tsx
+++ b/apps/storybook/stories/packages/ui/GridIcons.stories.tsx
@@ -1,8 +1,8 @@
 import {
-    Grid16Icon,
     Grid1Icon,
     Grid4Icon,
     Grid9Icon,
+    Grid16Icon,
     PlantGridIcon,
 } from '@gredice/ui/GridIcons';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
@@ -34,6 +34,14 @@ const meta = {
     title: 'packages/ui/Icons/GridIcons',
     component: Grid16Icon,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'GridIcons provide reusable glyphs for raised-bed grids, plant grid density, and garden layout selection controls.',
+            },
+        },
+    },
     render: () => <GridIconsShowcase />,
 } satisfies Meta<typeof Grid16Icon>;
 
@@ -46,14 +54,15 @@ export const AllIcons: Story = {};
 export const LargeSize: Story = {
     render: () => (
         <div className="flex flex-wrap gap-6">
-            {[Grid1Icon, Grid4Icon, Grid9Icon, Grid16Icon, PlantGridIcon].map(
-                (Icon, i) => (
-                    <Icon
-                        key={i}
-                        className="size-16 text-primary"
-                    />
-                ),
-            )}
+            {[
+                { Icon: Grid1Icon, label: 'Grid1Icon' },
+                { Icon: Grid4Icon, label: 'Grid4Icon' },
+                { Icon: Grid9Icon, label: 'Grid9Icon' },
+                { Icon: Grid16Icon, label: 'Grid16Icon' },
+                { Icon: PlantGridIcon, label: 'PlantGridIcon' },
+            ].map(({ Icon, label }) => (
+                <Icon key={label} className="size-16 text-primary" />
+            ))}
         </div>
     ),
 };

--- a/apps/storybook/stories/packages/ui/Icons.stories.tsx
+++ b/apps/storybook/stories/packages/ui/Icons.stories.tsx
@@ -104,7 +104,14 @@ function IconsShowcasePage() {
 const meta = {
     title: 'packages/ui/Icons/Showcase',
     component: IconsShowcasePage,
+    tags: ['autodocs'],
     parameters: {
+        docs: {
+            description: {
+                component:
+                    'The icon showcase indexes exported UI package icons and provides a searchable preview for choosing the right glyph.',
+            },
+        },
         layout: 'padded',
     },
     render: () => <IconsShowcase />,

--- a/apps/storybook/stories/packages/ui/ImageGallery.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ImageGallery.stories.tsx
@@ -20,6 +20,14 @@ const meta = {
     title: 'packages/ui/Media/ImageGallery',
     component: ImageGallery,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ImageGallery presents one or more images with configurable preview sizing and carousel or stacked preview layouts.',
+            },
+        },
+    },
     args: {
         images: sampleImages,
         previewWidth: 300,

--- a/apps/storybook/stories/packages/ui/ImageViewer.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ImageViewer.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Media/ImageViewer',
     component: ImageViewer,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ImageViewer renders an image preview that can open a larger viewer while preserving alt text and preview dimensions.',
+            },
+        },
+    },
     args: {
         src: 'https://cdn.gredice.com/sunflower-sad-500x500.png',
         alt: 'Sunflower',

--- a/apps/storybook/stories/packages/ui/LocalDateTime.stories.tsx
+++ b/apps/storybook/stories/packages/ui/LocalDateTime.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Data Display/LocalDateTime',
     component: LocalDateTime,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'LocalDateTime formats Date, string, or empty values for the selected locale with independent date and time display controls.',
+            },
+        },
+    },
     args: {
         children: new Date('2025-06-15T10:30:00'),
         date: true,

--- a/apps/storybook/stories/packages/ui/Markdown.stories.tsx
+++ b/apps/storybook/stories/packages/ui/Markdown.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Typography/Markdown',
     component: Markdown,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Markdown renders trusted Markdown content with the Gredice typography styles used for editorial and help content.',
+            },
+        },
+    },
     args: {
         children: [
             '## Harvest Notes',

--- a/apps/storybook/stories/packages/ui/RaisedBedIcon.stories.tsx
+++ b/apps/storybook/stories/packages/ui/RaisedBedIcon.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Icons/RaisedBedIcon',
     component: RaisedBedIcon,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'RaisedBedIcon visualizes a raised garden bed and can include a physical bed identifier when one is available.',
+            },
+        },
+    },
     args: {
         className: 'text-primary',
         physicalId: 'A12',

--- a/apps/storybook/stories/packages/ui/SeedTimeInformationBadge.stories.tsx
+++ b/apps/storybook/stories/packages/ui/SeedTimeInformationBadge.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Plants/SeedTimeInformationBadge',
     component: SeedTimeInformationBadge,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'SeedTimeInformationBadge summarizes plant sowing timing in a compact badge that can scale across dense and spacious layouts.',
+            },
+        },
+    },
     args: {
         size: 'md',
     },

--- a/apps/storybook/stories/packages/ui/SegmentedCircularProgress.stories.tsx
+++ b/apps/storybook/stories/packages/ui/SegmentedCircularProgress.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Data Display/SegmentedCircularProgress',
     component: SegmentedCircularProgress,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'SegmentedCircularProgress shows multiple progress segments around a shared circular track with optional centered content.',
+            },
+        },
+    },
     args: {
         segments: [
             {

--- a/apps/storybook/stories/packages/ui/StyledHtml.stories.tsx
+++ b/apps/storybook/stories/packages/ui/StyledHtml.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Typography/StyledHtml',
     component: StyledHtml,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'StyledHtml applies Gredice prose styling to trusted HTML content such as plant guides, articles, and CMS-rendered sections.',
+            },
+        },
+    },
     args: {
         children: (
             <div>

--- a/apps/storybook/stories/packages/ui/UserAvatar.stories.tsx
+++ b/apps/storybook/stories/packages/ui/UserAvatar.stories.tsx
@@ -5,6 +5,14 @@ const meta = {
     title: 'packages/ui/Data Display/UserAvatar',
     component: UserAvatar,
     tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'UserAvatar displays either a user image or generated initials with configurable sizing and optional entry animation.',
+            },
+        },
+    },
     args: {
         displayName: 'Ana Kovač',
     },


### PR DESCRIPTION
## Summary
- Removed the global `min-h-screen` wrapper from Storybook previews so component stories no longer inherit artificial vertical height.
- Preserved fullscreen story behavior while keeping the default canvas content-sized and padded.
- Added `autodocs` component descriptions across Storybook stories for app and shared UI components.
- Fixed the `GridIcons` story lint issue by replacing the array index key with a stable label key.

## Testing
- `pnpm --filter storybook lint`
- `pnpm --filter storybook build`
- Verified the Storybook docs route responds locally on `http://localhost:3004`