### PR TITLE
Highlight overdue schedule tasks in red

### DIFF
--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -29,6 +29,7 @@ import {
     isOperationCancelled,
     isOperationCompleted,
     isOperationPendingVerification,
+    isTaskDateBeforeToday,
 } from './scheduleShared';
 import type { Operation, RaisedBed } from './types';
 import { VerifyOperationModal } from './VerifyOperationModal';
@@ -263,6 +264,9 @@ export function RaisedBedOperationsScheduleSection({
                     const operationTextInactive =
                         isOperationCancelled(operation.status) ||
                         isOperationCompleted(operation.status);
+                    const operationDateOverdue =
+                        isTaskDateBeforeToday(operation.scheduledDate) &&
+                        !operationLocked;
 
                     const operationStatusText = isOperationCancelled(
                         operation.status,
@@ -299,7 +303,14 @@ export function RaisedBedOperationsScheduleSection({
 
                     return (
                         <div key={operation.id}>
-                            <Row spacing={1} className="hover:bg-muted rounded">
+                            <Row
+                                spacing={1}
+                                className={
+                                    operationDateOverdue
+                                        ? 'bg-red-50 hover:bg-red-100 rounded ring-1 ring-red-200'
+                                        : 'hover:bg-muted rounded'
+                                }
+                            >
                                 <Row spacing={1} className="grow">
                                     {isOperationCompleted(operation.status) ? (
                                         <Checkbox
@@ -395,7 +406,11 @@ export function RaisedBedOperationsScheduleSection({
                                         )}
                                     <Typography
                                         level="body2"
-                                        className="select-none"
+                                        className={
+                                            operationDateOverdue
+                                                ? 'select-none text-red-600 font-medium'
+                                                : 'select-none'
+                                        }
                                     >
                                         {operation.scheduledDate ? (
                                             <LocalDateTime time={false}>

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -29,6 +29,7 @@ import {
     isFieldApproved,
     isFieldCompleted,
     isFieldPendingVerification,
+    isTaskDateBeforeToday,
     PLANTING_TASK_DURATION_MINUTES,
 } from './scheduleShared';
 import type { RaisedBed, RaisedBedField } from './types';
@@ -249,10 +250,20 @@ export function RaisedBedPlantingScheduleSection({
                             : 'text-muted-foreground';
                     const fieldLocked =
                         fieldCompleted || fieldPendingVerification;
+                    const fieldDateOverdue =
+                        isTaskDateBeforeToday(field.plantScheduledDate) &&
+                        !fieldLocked;
 
                     return (
                         <div key={field.id}>
-                            <Row spacing={1} className="hover:bg-muted rounded">
+                            <Row
+                                spacing={1}
+                                className={
+                                    fieldDateOverdue
+                                        ? 'bg-red-50 hover:bg-red-100 rounded ring-1 ring-red-200'
+                                        : 'hover:bg-muted rounded'
+                                }
+                            >
                                 <Row spacing={1} className="grow">
                                     {fieldCompleted ? (
                                         <Checkbox
@@ -296,7 +307,11 @@ export function RaisedBedPlantingScheduleSection({
                                     </Typography>
                                     <Typography
                                         level="body2"
-                                        className="select-none"
+                                        className={
+                                            fieldDateOverdue
+                                                ? 'select-none text-red-600 font-medium'
+                                                : 'select-none'
+                                        }
                                     >
                                         {field.plantScheduledDate ? (
                                             <LocalDateTime time={false}>

--- a/apps/app/app/admin/schedule/scheduleShared.ts
+++ b/apps/app/app/admin/schedule/scheduleShared.ts
@@ -122,6 +122,20 @@ export function formatMinutes(minutes: number, hideUnit = false) {
     return hideUnit ? `${rounded}` : `${rounded} min`;
 }
 
+export function isTaskDateBeforeToday(date: Date | undefined) {
+    if (!date) {
+        return false;
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const taskDate = new Date(date);
+    taskDate.setHours(0, 0, 0, 0);
+
+    return Number.isFinite(taskDate.getTime()) && taskDate < today;
+}
+
 export function getOperationDurationMinutes(
     operationData: EntityStandardized | undefined,
 ) {


### PR DESCRIPTION
## Summary
- Add a shared overdue-date helper for schedule tasks.
- Highlight past-due operations and plantings in the admin schedule with red row and date styling.
- Keep completed, cancelled, and verification-locked items out of the overdue highlight.

## Testing
- Biome formatting/check passed for the touched schedule files.
- `git diff --check` passed.