### PR TITLE
Batch delivery-ready emails behind a delayed cron job

### DIFF
--- a/apps/api/app/api/internal/cron/delivery-ready-emails/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-ready-emails/route.ts
@@ -19,41 +19,39 @@ export async function GET(request: NextRequest) {
     }
 
     const readyBefore = new Date(Date.now() - BATCH_DELAY_MINUTES * 60 * 1000);
-    const requestIds = await getPendingDeliveryReadyEmailRequestIds({
+    const pendingRequests = await getPendingDeliveryReadyEmailRequestIds({
         readyBefore,
         limit: MAX_REQUESTS_PER_RUN,
     });
-    const result = await sendBatchedDeliveryReadyEmails(requestIds);
+    const result = await sendBatchedDeliveryReadyEmails(pendingRequests);
 
-    for (const group of result.groupsSent) {
+    for (const group of result.processedGroups) {
         await markDeliveryReadyEmailsProcessed({
-            requestIds: group.requestIds,
+            readyEvents: group.readyEvents,
             recipients: group.recipients,
-            batchRequestIds: group.requestIds,
+            batchRequestIds: group.readyEvents.map((event) => event.requestId),
+            completed: group.completed,
+            skipped: group.skipped,
         });
     }
 
-    await markDeliveryReadyEmailsProcessed({
-        requestIds: result.skippedRequestIds,
-        recipients: [],
-        skipped: true,
-    });
-
     return Response.json({
         success: true,
-        candidates: requestIds.length,
+        candidates: pendingRequests.length,
         emailsSent: result.emailsSent,
         groupsSent: result.groupsSent.length,
-        requestsMarkedProcessed:
-            result.skippedRequestIds.length +
-            result.groupsSent.reduce(
-                (total, group) => total + group.requestIds.length,
-                0,
-            ),
+        requestsMarkedProcessed: result.processedGroups.reduce(
+            (total, group) => total + group.readyEvents.length,
+            0,
+        ),
         requestsMarkedSent: result.groupsSent.reduce(
             (total, group) => total + group.requestIds.length,
             0,
         ),
-        skipped: result.skippedRequestIds.length,
+        skipped: result.processedGroups.reduce(
+            (total, group) =>
+                group.skipped ? total + group.readyEvents.length : total,
+            0,
+        ),
     });
 }

--- a/apps/api/app/api/internal/cron/delivery-ready-emails/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-ready-emails/route.ts
@@ -1,0 +1,59 @@
+import {
+    getPendingDeliveryReadyEmailRequestIds,
+    markDeliveryReadyEmailsProcessed,
+} from '@gredice/storage';
+import type { NextRequest } from 'next/server';
+import { sendBatchedDeliveryReadyEmails } from '../../../../../lib/delivery/emailNotifications';
+
+export const dynamic = 'force-dynamic';
+
+const BATCH_DELAY_MINUTES = 10;
+const MAX_REQUESTS_PER_RUN = 200;
+
+export async function GET(request: NextRequest) {
+    const authHeader = request.headers.get('authorization');
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+        return new Response('Unauthorized', {
+            status: 401,
+        });
+    }
+
+    const readyBefore = new Date(Date.now() - BATCH_DELAY_MINUTES * 60 * 1000);
+    const requestIds = await getPendingDeliveryReadyEmailRequestIds({
+        readyBefore,
+        limit: MAX_REQUESTS_PER_RUN,
+    });
+    const result = await sendBatchedDeliveryReadyEmails(requestIds);
+
+    for (const group of result.groupsSent) {
+        await markDeliveryReadyEmailsProcessed({
+            requestIds: group.requestIds,
+            recipients: group.recipients,
+            batchRequestIds: group.requestIds,
+        });
+    }
+
+    await markDeliveryReadyEmailsProcessed({
+        requestIds: result.skippedRequestIds,
+        recipients: [],
+        skipped: true,
+    });
+
+    return Response.json({
+        success: true,
+        candidates: requestIds.length,
+        emailsSent: result.emailsSent,
+        groupsSent: result.groupsSent.length,
+        requestsMarkedProcessed:
+            result.skippedRequestIds.length +
+            result.groupsSent.reduce(
+                (total, group) => total + group.requestIds.length,
+                0,
+            ),
+        requestsMarkedSent: result.groupsSent.reduce(
+            (total, group) => total + group.requestIds.length,
+            0,
+        ),
+        skipped: result.skippedRequestIds.length,
+    });
+}

--- a/apps/api/lib/delivery/emailNotifications.ts
+++ b/apps/api/lib/delivery/emailNotifications.ts
@@ -198,12 +198,15 @@ export async function sendBatchedDeliveryReadyEmails(
                 }),
             ),
         );
-        const sentRecipients = group.recipients.filter(
-            (_, index) => sendResults[index]?.status === 'fulfilled',
-        );
-        const failedRecipients = group.recipients.filter(
-            (_, index) => sendResults[index]?.status === 'rejected',
-        );
+        const sentRecipients: string[] = [];
+        const failedRecipients: string[] = [];
+        for (const [index, recipient] of group.recipients.entries()) {
+            if (sendResults[index]?.status === 'fulfilled') {
+                sentRecipients.push(recipient);
+            } else {
+                failedRecipients.push(recipient);
+            }
+        }
 
         if (sentRecipients.length > 0) {
             emailsSent += sentRecipients.length;

--- a/apps/api/lib/delivery/emailNotifications.ts
+++ b/apps/api/lib/delivery/emailNotifications.ts
@@ -1,4 +1,7 @@
-import { buildDeliveryEmailDetails } from '@gredice/storage';
+import {
+    buildDeliveryEmailDetails,
+    type PendingDeliveryReadyEmailRequest,
+} from '@gredice/storage';
 import {
     sendDeliveryCancelled,
     sendDeliveryReady,
@@ -59,7 +62,10 @@ async function sendDeliveryEmails(
 
 interface DeliveryReadyEmailBatchGroup {
     key: string;
-    requestIds: string[];
+    readyEvents: {
+        requestId: string;
+        readyEventId: number;
+    }[];
     recipients: string[];
     readyItems: string[];
     deliveryWindow: string;
@@ -73,7 +79,15 @@ export interface DeliveryReadyEmailBatchResult {
         requestIds: string[];
         recipients: string[];
     }[];
-    skippedRequestIds: string[];
+    processedGroups: {
+        readyEvents: {
+            requestId: string;
+            readyEventId: number;
+        }[];
+        recipients: string[];
+        completed?: boolean;
+        skipped?: boolean;
+    }[];
 }
 
 function addUnique(values: string[], value: string) {
@@ -99,19 +113,48 @@ function getDeliveryReadyBatchKey(details: {
 }
 
 export async function sendBatchedDeliveryReadyEmails(
-    requestIds: string[],
+    requests: PendingDeliveryReadyEmailRequest[],
 ): Promise<DeliveryReadyEmailBatchResult> {
     const groups = new Map<string, DeliveryReadyEmailBatchGroup>();
-    const skippedRequestIds: string[] = [];
+    const processedGroups: DeliveryReadyEmailBatchResult['processedGroups'] =
+        [];
 
-    for (const requestId of requestIds) {
-        const details = await buildDeliveryEmailDetails(requestId);
+    for (const request of requests) {
+        const details = await buildDeliveryEmailDetails(request.requestId);
         if (!details || details.state !== 'ready') {
-            skippedRequestIds.push(requestId);
+            processedGroups.push({
+                readyEvents: [
+                    {
+                        requestId: request.requestId,
+                        readyEventId: request.readyEventId,
+                    },
+                ],
+                recipients: [],
+                completed: true,
+                skipped: true,
+            });
             continue;
         }
 
-        const recipients = details.recipients.toSorted();
+        const recipients = details.recipients
+            .filter(
+                (recipient) => !request.processedRecipients.includes(recipient),
+            )
+            .toSorted();
+        if (recipients.length === 0) {
+            processedGroups.push({
+                readyEvents: [
+                    {
+                        requestId: request.requestId,
+                        readyEventId: request.readyEventId,
+                    },
+                ],
+                recipients: [],
+                completed: true,
+            });
+            continue;
+        }
+
         const key = getDeliveryReadyBatchKey({
             accountId: details.accountId,
             deliveryWindow: details.deliveryWindow,
@@ -121,7 +164,7 @@ export async function sendBatchedDeliveryReadyEmails(
         });
         const group = groups.get(key) ?? {
             key,
-            requestIds: [],
+            readyEvents: [],
             recipients,
             readyItems: [],
             deliveryWindow: details.deliveryWindow,
@@ -129,7 +172,10 @@ export async function sendBatchedDeliveryReadyEmails(
             contactName: details.contactName,
         };
 
-        addUnique(group.requestIds, details.requestId);
+        group.readyEvents.push({
+            requestId: details.requestId,
+            readyEventId: request.readyEventId,
+        });
         if (details.readyItem) {
             addUnique(group.readyItems, details.readyItem);
         }
@@ -141,29 +187,43 @@ export async function sendBatchedDeliveryReadyEmails(
     const groupsSent: DeliveryReadyEmailBatchResult['groupsSent'] = [];
 
     for (const group of groups.values()) {
-        try {
-            await Promise.all(
-                group.recipients.map((recipient) =>
-                    sendDeliveryReady(recipient, {
-                        email: recipient,
-                        deliveryWindow: group.deliveryWindow,
-                        addressLine: group.addressLine,
-                        contactName: group.contactName,
-                        manageUrl: CUSTOMER_APP_URL,
-                        readyItems: group.readyItems,
-                    }),
-                ),
-            );
-            emailsSent += group.recipients.length;
+        const sendResults = await Promise.allSettled(
+            group.recipients.map((recipient) =>
+                sendDeliveryReady(recipient, {
+                    email: recipient,
+                    deliveryWindow: group.deliveryWindow,
+                    addressLine: group.addressLine,
+                    contactName: group.contactName,
+                    manageUrl: CUSTOMER_APP_URL,
+                    readyItems: group.readyItems,
+                }),
+            ),
+        );
+        const sentRecipients = group.recipients.filter(
+            (_recipient, index) => sendResults[index]?.status === 'fulfilled',
+        );
+        const failedRecipients = group.recipients.filter(
+            (_recipient, index) => sendResults[index]?.status === 'rejected',
+        );
+
+        if (sentRecipients.length > 0) {
+            emailsSent += sentRecipients.length;
             groupsSent.push({
-                requestIds: group.requestIds,
-                recipients: group.recipients,
+                requestIds: group.readyEvents.map((event) => event.requestId),
+                recipients: sentRecipients,
             });
-        } catch (error) {
+            processedGroups.push({
+                readyEvents: group.readyEvents,
+                recipients: sentRecipients,
+                completed: sentRecipients.length === group.recipients.length,
+            });
+        }
+
+        if (failedRecipients.length > 0) {
             console.error('Failed to send batched delivery ready email', {
-                requestIds: group.requestIds,
+                requestIds: group.readyEvents.map((event) => event.requestId),
                 key: group.key,
-                error,
+                failedRecipients,
             });
         }
     }
@@ -171,7 +231,7 @@ export async function sendBatchedDeliveryReadyEmails(
     return {
         emailsSent,
         groupsSent,
-        skippedRequestIds,
+        processedGroups,
     };
 }
 

--- a/apps/api/lib/delivery/emailNotifications.ts
+++ b/apps/api/lib/delivery/emailNotifications.ts
@@ -136,10 +136,9 @@ export async function sendBatchedDeliveryReadyEmails(
             continue;
         }
 
+        const processedRecipients = new Set(request.processedRecipients);
         const recipients = details.recipients
-            .filter(
-                (recipient) => !request.processedRecipients.includes(recipient),
-            )
+            .filter((recipient) => !processedRecipients.has(recipient))
             .toSorted();
         if (recipients.length === 0) {
             processedGroups.push({
@@ -200,10 +199,10 @@ export async function sendBatchedDeliveryReadyEmails(
             ),
         );
         const sentRecipients = group.recipients.filter(
-            (_recipient, index) => sendResults[index]?.status === 'fulfilled',
+            (_, index) => sendResults[index]?.status === 'fulfilled',
         );
         const failedRecipients = group.recipients.filter(
-            (_recipient, index) => sendResults[index]?.status === 'rejected',
+            (_, index) => sendResults[index]?.status === 'rejected',
         );
 
         if (sentRecipients.length > 0) {

--- a/apps/api/lib/delivery/emailNotifications.ts
+++ b/apps/api/lib/delivery/emailNotifications.ts
@@ -9,15 +9,9 @@ import {
 const CUSTOMER_APP_URL =
     process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
 
-const senders = {
-    scheduled: sendDeliveryScheduled,
-    ready: sendDeliveryReady,
-    cancelled: sendDeliveryCancelled,
-};
-
 async function sendDeliveryEmails(
     requestId: string,
-    type: keyof typeof senders,
+    type: 'scheduled' | 'ready' | 'cancelled',
 ) {
     try {
         const details = await buildDeliveryEmailDetails(requestId);
@@ -26,15 +20,30 @@ async function sendDeliveryEmails(
         }
 
         await Promise.all(
-            details.recipients.map((recipient) =>
-                senders[type](recipient, {
+            details.recipients.map((recipient) => {
+                const config = {
                     email: recipient,
                     deliveryWindow: details.deliveryWindow,
                     addressLine: details.addressLine,
                     contactName: details.contactName,
                     manageUrl: CUSTOMER_APP_URL,
-                }),
-            ),
+                };
+
+                if (type === 'scheduled') {
+                    return sendDeliveryScheduled(recipient, config);
+                }
+
+                if (type === 'ready') {
+                    return sendDeliveryReady(recipient, {
+                        ...config,
+                        readyItems: details.readyItem
+                            ? [details.readyItem]
+                            : undefined,
+                    });
+                }
+
+                return sendDeliveryCancelled(recipient, config);
+            }),
         );
 
         return true;
@@ -46,6 +55,124 @@ async function sendDeliveryEmails(
         });
         return false;
     }
+}
+
+interface DeliveryReadyEmailBatchGroup {
+    key: string;
+    requestIds: string[];
+    recipients: string[];
+    readyItems: string[];
+    deliveryWindow: string;
+    addressLine?: string;
+    contactName?: string;
+}
+
+export interface DeliveryReadyEmailBatchResult {
+    emailsSent: number;
+    groupsSent: {
+        requestIds: string[];
+        recipients: string[];
+    }[];
+    skippedRequestIds: string[];
+}
+
+function addUnique(values: string[], value: string) {
+    if (!values.includes(value)) {
+        values.push(value);
+    }
+}
+
+function getDeliveryReadyBatchKey(details: {
+    accountId: string;
+    deliveryWindow: string;
+    addressLine?: string;
+    contactName?: string;
+    recipients: string[];
+}) {
+    return [
+        details.accountId,
+        details.deliveryWindow,
+        details.addressLine ?? '',
+        details.contactName ?? '',
+        details.recipients.join(','),
+    ].join('|');
+}
+
+export async function sendBatchedDeliveryReadyEmails(
+    requestIds: string[],
+): Promise<DeliveryReadyEmailBatchResult> {
+    const groups = new Map<string, DeliveryReadyEmailBatchGroup>();
+    const skippedRequestIds: string[] = [];
+
+    for (const requestId of requestIds) {
+        const details = await buildDeliveryEmailDetails(requestId);
+        if (!details || details.state !== 'ready') {
+            skippedRequestIds.push(requestId);
+            continue;
+        }
+
+        const recipients = details.recipients.toSorted();
+        const key = getDeliveryReadyBatchKey({
+            accountId: details.accountId,
+            deliveryWindow: details.deliveryWindow,
+            addressLine: details.addressLine,
+            contactName: details.contactName,
+            recipients,
+        });
+        const group = groups.get(key) ?? {
+            key,
+            requestIds: [],
+            recipients,
+            readyItems: [],
+            deliveryWindow: details.deliveryWindow,
+            addressLine: details.addressLine,
+            contactName: details.contactName,
+        };
+
+        addUnique(group.requestIds, details.requestId);
+        if (details.readyItem) {
+            addUnique(group.readyItems, details.readyItem);
+        }
+
+        groups.set(key, group);
+    }
+
+    let emailsSent = 0;
+    const groupsSent: DeliveryReadyEmailBatchResult['groupsSent'] = [];
+
+    for (const group of groups.values()) {
+        try {
+            await Promise.all(
+                group.recipients.map((recipient) =>
+                    sendDeliveryReady(recipient, {
+                        email: recipient,
+                        deliveryWindow: group.deliveryWindow,
+                        addressLine: group.addressLine,
+                        contactName: group.contactName,
+                        manageUrl: CUSTOMER_APP_URL,
+                        readyItems: group.readyItems,
+                    }),
+                ),
+            );
+            emailsSent += group.recipients.length;
+            groupsSent.push({
+                requestIds: group.requestIds,
+                recipients: group.recipients,
+            });
+        } catch (error) {
+            console.error('Failed to send batched delivery ready email', {
+                requestIds: group.requestIds,
+                key: group.key,
+                error,
+            });
+        }
+    }
+
+    return {
+        emailsSent,
+        groupsSent,
+        skippedRequestIds,
+    };
 }
 
 export async function notifyDeliveryScheduled(requestId: string) {

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -18,6 +18,10 @@
             "schedule": "0 * 1,2 * *"
         },
         {
+            "path": "/api/internal/cron/delivery-ready-emails",
+            "schedule": "*/5 * * * *"
+        },
+        {
             "path": "/api/internal/cron/update-farm-weather",
             "schedule": "0 * * * *"
         },

--- a/apps/app/app/admin/delivery/requests/actions.ts
+++ b/apps/app/app/admin/delivery/requests/actions.ts
@@ -13,10 +13,7 @@ import {
     readyDeliveryRequest,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
-import {
-    notifyDeliveryCancelled,
-    notifyDeliveryReady,
-} from '../../../../../api/lib/delivery/emailNotifications';
+import { notifyDeliveryCancelled } from '../../../../../api/lib/delivery/emailNotifications';
 import { auth } from '../../../../lib/auth/auth';
 
 export async function updateDeliveryRequestStatusAction(
@@ -68,7 +65,6 @@ export async function updateDeliveryRequestStatusAction(
                 status,
                 note: notes,
             });
-            await notifyDeliveryReady(requestId);
         } else if (status === DeliveryRequestStates.FULFILLED) {
             await fulfillDeliveryRequest(requestId, notes);
             await notifyDeliveryRequestEvent(requestId, 'updated', {

--- a/packages/storage/src/helpers/deliveryEmail.ts
+++ b/packages/storage/src/helpers/deliveryEmail.ts
@@ -6,10 +6,12 @@ import { getDeliveryRequest } from '../repositories/deliveryRequestsRepo';
 export interface DeliveryEmailDetails {
     requestId: string;
     accountId: string;
+    state: string;
     deliveryWindow: string;
     recipients: string[];
     addressLine?: string;
     contactName?: string;
+    readyItem?: string;
 }
 
 export async function buildDeliveryEmailDetails(
@@ -55,13 +57,30 @@ export async function buildDeliveryEmailDetails(
               .filter(Boolean)
               .join(', ')
         : undefined;
+    const plantName = request.plantSort?.information?.name?.trim();
+    const operationName =
+        request.operationData?.information?.label?.trim() ||
+        request.operationData?.information?.name?.trim();
+    const fieldPosition =
+        request.raisedBedField?.positionIndex != null
+            ? `polje ${request.raisedBedField.positionIndex + 1}`
+            : undefined;
+    const locationParts = [request.raisedBed?.name?.trim(), fieldPosition]
+        .filter(Boolean)
+        .join(', ');
+    const readyItemBase = plantName || operationName || 'Dostavna stavka';
+    const readyItem = locationParts
+        ? `${readyItemBase} (${locationParts})`
+        : readyItemBase;
 
     return {
         requestId: request.id,
         accountId: request.accountId,
+        state: request.state,
         deliveryWindow,
         recipients: Array.from(recipients),
         addressLine,
         contactName: request.address?.contactName ?? undefined,
+        readyItem,
     };
 }

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -1106,7 +1106,10 @@ export async function getPendingDeliveryReadyEmailRequestIds({
                                     processedEvents.aggregateId,
                                     events.aggregateId,
                                 ),
-                                sql`${processedEvents.data}->>'readyEventId' = ${events.id}::text`,
+                                eq(
+                                    sql<number>`(${processedEvents.data}->>'readyEventId')::int`,
+                                    events.id,
+                                ),
                                 sql`(${processedEvents.data}->>'completed' = 'true' OR ${processedEvents.data}->>'skipped' = 'true')`,
                             ),
                         ),

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -1,6 +1,17 @@
 import { randomUUID } from 'node:crypto';
 import type { OperationData, PlantSortData } from '@gredice/directory-types';
-import { and, asc, desc, eq, gte, inArray, isNull, lte } from 'drizzle-orm';
+import {
+    and,
+    asc,
+    desc,
+    eq,
+    gte,
+    inArray,
+    isNull,
+    lte,
+    notExists,
+} from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import 'server-only';
 import { AUTO_CLOSE_WINDOW_MS } from '../helpers/timeSlotAutomation';
 import {
@@ -1049,6 +1060,80 @@ export async function readyDeliveryRequest(requestId: string): Promise<void> {
         knownEvents.delivery.requestReadyV1(requestId, {
             status: DeliveryRequestStates.READY,
         }),
+    );
+}
+
+export async function getPendingDeliveryReadyEmailRequestIds({
+    readyBefore,
+    limit = 200,
+}: {
+    readyBefore: Date;
+    limit?: number;
+}): Promise<string[]> {
+    const processedEvents = alias(
+        events,
+        'delivery_ready_email_processed_events',
+    );
+    const pendingReadyEvents = await storage()
+        .selectDistinct({
+            requestId: events.aggregateId,
+        })
+        .from(events)
+        .where(
+            and(
+                eq(events.type, knownEventTypes.delivery.requestReady),
+                lte(events.createdAt, readyBefore),
+                notExists(
+                    storage()
+                        .select({ id: processedEvents.id })
+                        .from(processedEvents)
+                        .where(
+                            and(
+                                eq(
+                                    processedEvents.type,
+                                    knownEventTypes.delivery
+                                        .requestReadyEmailProcessed,
+                                ),
+                                eq(
+                                    processedEvents.aggregateId,
+                                    events.aggregateId,
+                                ),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        .limit(limit);
+
+    return pendingReadyEvents.map((event) => event.requestId);
+}
+
+export async function markDeliveryReadyEmailsProcessed({
+    requestIds,
+    recipients,
+    batchRequestIds = requestIds,
+    skipped,
+}: {
+    requestIds: string[];
+    recipients: string[];
+    batchRequestIds?: string[];
+    skipped?: boolean;
+}): Promise<void> {
+    const uniqueRequestIds = Array.from(new Set(requestIds));
+    if (uniqueRequestIds.length === 0) {
+        return;
+    }
+
+    await Promise.all(
+        uniqueRequestIds.map((requestId) =>
+            createEvent(
+                knownEvents.delivery.requestReadyEmailProcessedV1(requestId, {
+                    sentTo: recipients,
+                    batchRequestIds,
+                    skipped,
+                }),
+            ),
+        ),
     );
 }
 

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -10,6 +10,7 @@ import {
     isNull,
     lte,
     notExists,
+    or,
     sql,
 } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
@@ -1082,7 +1083,7 @@ export async function getPendingDeliveryReadyEmailRequestIds({
         'delivery_ready_email_processed_events',
     );
     const pendingReadyEvents = await storage()
-        .select({
+        .selectDistinct({
             requestId: events.aggregateId,
             readyEventId: events.id,
         })
@@ -1107,10 +1108,19 @@ export async function getPendingDeliveryReadyEmailRequestIds({
                                     events.aggregateId,
                                 ),
                                 eq(
-                                    sql<number>`(${processedEvents.data}->>'readyEventId')::int`,
-                                    events.id,
+                                    sql<string>`${processedEvents.data}->>'readyEventId'`,
+                                    sql<string>`${events.id}::text`,
                                 ),
-                                sql`(${processedEvents.data}->>'completed' = 'true' OR ${processedEvents.data}->>'skipped' = 'true')`,
+                                or(
+                                    eq(
+                                        sql<string>`${processedEvents.data}->>'completed'`,
+                                        'true',
+                                    ),
+                                    eq(
+                                        sql<string>`${processedEvents.data}->>'skipped'`,
+                                        'true',
+                                    ),
+                                ),
                             ),
                         ),
                 ),

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -10,6 +10,7 @@ import {
     isNull,
     lte,
     notExists,
+    sql,
 } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import 'server-only';
@@ -120,6 +121,12 @@ interface DeliveryRequestStateProjection {
     deliveryNotes?: string;
     accountId?: string;
     surveySent: boolean;
+}
+
+export interface PendingDeliveryReadyEmailRequest {
+    requestId: string;
+    readyEventId: number;
+    processedRecipients: string[];
 }
 
 function reconstructDeliveryRequestState(
@@ -1069,14 +1076,15 @@ export async function getPendingDeliveryReadyEmailRequestIds({
 }: {
     readyBefore: Date;
     limit?: number;
-}): Promise<string[]> {
+}): Promise<PendingDeliveryReadyEmailRequest[]> {
     const processedEvents = alias(
         events,
         'delivery_ready_email_processed_events',
     );
     const pendingReadyEvents = await storage()
-        .selectDistinct({
+        .select({
             requestId: events.aggregateId,
+            readyEventId: events.id,
         })
         .from(events)
         .where(
@@ -1098,38 +1106,106 @@ export async function getPendingDeliveryReadyEmailRequestIds({
                                     processedEvents.aggregateId,
                                     events.aggregateId,
                                 ),
+                                sql`${processedEvents.data}->>'readyEventId' = ${events.id}::text`,
+                                sql`(${processedEvents.data}->>'completed' = 'true' OR ${processedEvents.data}->>'skipped' = 'true')`,
                             ),
                         ),
                 ),
             ),
         )
+        .orderBy(asc(events.createdAt))
         .limit(limit);
 
-    return pendingReadyEvents.map((event) => event.requestId);
+    if (pendingReadyEvents.length === 0) {
+        return [];
+    }
+
+    const requestIds = Array.from(
+        new Set(pendingReadyEvents.map((event) => event.requestId)),
+    );
+    const readyEventIds = new Set(
+        pendingReadyEvents.map((event) => event.readyEventId),
+    );
+    const processedReadyEvents = await storage()
+        .select({
+            data: events.data,
+        })
+        .from(events)
+        .where(
+            and(
+                eq(
+                    events.type,
+                    knownEventTypes.delivery.requestReadyEmailProcessed,
+                ),
+                inArray(events.aggregateId, requestIds),
+            ),
+        );
+    const processedRecipients = new Map<number, Set<string>>();
+
+    for (const event of processedReadyEvents) {
+        if (!event.data || typeof event.data !== 'object') {
+            continue;
+        }
+
+        const data = event.data as {
+            readyEventId?: unknown;
+            sentTo?: unknown;
+        };
+        if (
+            typeof data.readyEventId !== 'number' ||
+            !readyEventIds.has(data.readyEventId) ||
+            !Array.isArray(data.sentTo)
+        ) {
+            continue;
+        }
+
+        const recipients =
+            processedRecipients.get(data.readyEventId) ?? new Set<string>();
+        for (const recipient of data.sentTo) {
+            if (typeof recipient === 'string') {
+                recipients.add(recipient);
+            }
+        }
+        processedRecipients.set(data.readyEventId, recipients);
+    }
+
+    return pendingReadyEvents.map((event) => ({
+        requestId: event.requestId,
+        readyEventId: event.readyEventId,
+        processedRecipients: Array.from(
+            processedRecipients.get(event.readyEventId) ?? [],
+        ),
+    }));
 }
 
 export async function markDeliveryReadyEmailsProcessed({
-    requestIds,
+    readyEvents,
     recipients,
-    batchRequestIds = requestIds,
+    batchRequestIds = readyEvents.map((event) => event.requestId),
+    completed,
     skipped,
 }: {
-    requestIds: string[];
+    readyEvents: {
+        requestId: string;
+        readyEventId: number;
+    }[];
     recipients: string[];
     batchRequestIds?: string[];
+    completed?: boolean;
     skipped?: boolean;
 }): Promise<void> {
-    const uniqueRequestIds = Array.from(new Set(requestIds));
-    if (uniqueRequestIds.length === 0) {
+    if (readyEvents.length === 0) {
         return;
     }
 
     await Promise.all(
-        uniqueRequestIds.map((requestId) =>
+        readyEvents.map(({ requestId, readyEventId }) =>
             createEvent(
                 knownEvents.delivery.requestReadyEmailProcessedV1(requestId, {
+                    readyEventId,
                     sentTo: recipients,
                     batchRequestIds,
+                    completed,
                     skipped,
                 }),
             ),

--- a/packages/storage/src/repositories/events/knownEventTypes.ts
+++ b/packages/storage/src/repositories/events/knownEventTypes.ts
@@ -62,6 +62,7 @@ export const knownEventTypes = {
         requestConfirmed: 'delivery.request.confirmed',
         requestPreparing: 'delivery.request.preparing',
         requestReady: 'delivery.request.ready',
+        requestReadyEmailProcessed: 'delivery.request.ready.email_processed',
         requestCancelled: 'delivery.request.cancelled',
         requestFulfilled: 'delivery.request.fulfilled',
         requestSurveySent: 'delivery.request.survey_sent',

--- a/packages/storage/src/repositories/events/knownEvents.ts
+++ b/packages/storage/src/repositories/events/knownEvents.ts
@@ -7,6 +7,7 @@ import type {
     DeliveryRequestCancelledPayload,
     DeliveryRequestCreatePayload,
     DeliveryRequestFulfilledPayload,
+    DeliveryRequestReadyEmailProcessedPayload,
     DeliveryRequestSlotChangedPayload,
     DeliveryRequestStatusPayload,
     DeliveryRequestSurveySentPayload,
@@ -377,6 +378,15 @@ export const knownEvents = {
             data: DeliveryRequestStatusPayload,
         ) => ({
             type: knownEventTypes.delivery.requestReady,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        requestReadyEmailProcessedV1: (
+            aggregateId: string,
+            data: DeliveryRequestReadyEmailProcessedPayload,
+        ) => ({
+            type: knownEventTypes.delivery.requestReadyEmailProcessed,
             version: 1,
             aggregateId,
             data,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -314,6 +314,13 @@ export type DeliveryRequestFulfilledPayload = {
 export type DeliveryRequestSurveySentPayload = {
     sentTo: string[];
 };
+
+export type DeliveryRequestReadyEmailProcessedPayload = {
+    sentTo: string[];
+    batchRequestIds: string[];
+    skipped?: boolean;
+};
+
 export type DeliveryRequestEventsPayload =
     | DeliveryRequestCreatePayload
     | DeliveryRequestSlotChangedPayload
@@ -321,7 +328,8 @@ export type DeliveryRequestEventsPayload =
     | DeliveryRequestCancelledPayload
     | DeliveryRequestStatusPayload
     | DeliveryRequestFulfilledPayload
-    | DeliveryRequestSurveySentPayload;
+    | DeliveryRequestSurveySentPayload
+    | DeliveryRequestReadyEmailProcessedPayload;
 
 export type DeliveryRequestEventsAnyPayload = Partial<
     DeliveryRequestCreatePayload &
@@ -330,7 +338,8 @@ export type DeliveryRequestEventsAnyPayload = Partial<
         DeliveryRequestCancelledPayload &
         DeliveryRequestStatusPayload &
         DeliveryRequestFulfilledPayload &
-        DeliveryRequestSurveySentPayload
+        DeliveryRequestSurveySentPayload &
+        DeliveryRequestReadyEmailProcessedPayload
 >;
 
 // ============================================================================

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -316,8 +316,10 @@ export type DeliveryRequestSurveySentPayload = {
 };
 
 export type DeliveryRequestReadyEmailProcessedPayload = {
+    readyEventId: number;
     sentTo: string[];
     batchRequestIds: string[];
+    completed?: boolean;
     skipped?: boolean;
 };
 

--- a/packages/transactional/emails/Notifications/delivery-ready.tsx
+++ b/packages/transactional/emails/Notifications/delivery-ready.tsx
@@ -14,6 +14,7 @@ export interface DeliveryReadyEmailTemplateProps {
     addressLine?: string;
     contactName?: string;
     manageUrl?: string;
+    readyItems?: string[];
     appName?: string;
     appDomain?: string;
 }
@@ -24,10 +25,24 @@ export default function DeliveryReadyEmailTemplate({
     addressLine,
     contactName,
     manageUrl = 'https://vrt.gredice.com/?pregled=dostava',
+    readyItems = [],
     appName = 'Gredice',
     appDomain = 'gredice.com',
 }: DeliveryReadyEmailTemplateProps) {
-    const previewText = `${appName} - dostava je spremna`;
+    const distinctReadyItems = Array.from(
+        new Set(readyItems.map((item) => item.trim()).filter(Boolean)),
+    );
+    const readyItemsCount = distinctReadyItems.length;
+    const readyItemsPreviewText =
+        readyItemsCount === 1
+            ? '1 stavka je spremna'
+            : readyItemsCount < 5
+              ? `${readyItemsCount} stavke su spremne`
+              : `${readyItemsCount} stavki je spremno`;
+    const previewText =
+        readyItemsCount > 0
+            ? `${appName} - ${readyItemsPreviewText}`
+            : `${appName} - dostava je spremna`;
     const greeting = contactName ? `Bok ${contactName}!` : 'Bok!';
 
     return (
@@ -45,6 +60,21 @@ export default function DeliveryReadyEmailTemplate({
                         Podsjećamo te da je tvoja dostava spremna za uručenje u
                         dogovorenom terminu.
                     </Paragraph>
+                    {readyItemsCount > 0 ? (
+                        <Section className="my-4 rounded-2xl bg-[#f7f7f7] p-4">
+                            <Paragraph className="m-0 text-[16px] font-semibold">
+                                Spremno za dostavu:
+                            </Paragraph>
+                            {distinctReadyItems.map((item) => (
+                                <Paragraph
+                                    key={item}
+                                    className="m-0 py-1 text-[15px]"
+                                >
+                                    • {item}
+                                </Paragraph>
+                            ))}
+                        </Section>
+                    ) : null}
                     <Paragraph>
                         <strong>📅 Termin:</strong> {deliveryWindow}
                     </Paragraph>


### PR DESCRIPTION
## Summary
- Removed immediate customer email sends from the admin "mark ready" flow.
- Added a cron-driven batch sender that waits 10 minutes, groups ready deliveries, and sends one summary email per recipient set.
- Extended the delivery-ready template to include the list of ready items in the email body and preview text.
- Added event tracking so each ready request is only processed once, including skipped requests that no longer qualify when the batch runs.

## Testing
- `pnpm lint --filter api --filter app --filter @gredice/storage --filter @gredice/transactional` passed after formatting.
- `pnpm --filter api exec tsc --noEmit` passed.
- `pnpm --filter @gredice/transactional exec tsc --noEmit` passed.
- Full `app` and `@gredice/storage` type checks still report existing unrelated errors outside this change.