### PR TITLE
Tighten app theme contrast and neutralize selection colors

### DIFF
--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -1,28 +1,29 @@
 @import "@signalco/ui-themes-minimal-app/styles";
 
 :root {
-    --background: 0 0% 7%;
+    color-scheme: dark;
+    --background: 0 0% 5%;
     --foreground: 0 0% 100%;
-    --muted: 0 0% 10%;
+    --muted: 0 0% 14%;
     --muted-foreground: 0 0% 72%;
-    --popover: 0 0% 7%;
+    --popover: 0 0% 8%;
     --popover-foreground: 0 0% 100%;
-    --card: 0 0% 10%;
-    --card-transparent: 0 0% 7%;
+    --card: 0 0% 13%;
+    --card-transparent: 0 0% 5%;
     --card-foreground: 0 0% 100%;
-    --border: 0 0% 18%;
-    --input: 0 0% 18%;
+    --border: 0 0% 22%;
+    --input: 0 0% 22%;
     --primary: 0 0% 100%;
-    --primary-foreground: 0 0% 7%;
-    --secondary: 0 0% 16%;
+    --primary-foreground: 0 0% 5%;
+    --secondary: 0 0% 15%;
     --secondary-foreground: 0 0% 92%;
-    --tertiary: 45 65% 52%;
-    --tertiary-foreground: 0 0% 7%;
-    --accent: 45 65% 52%;
-    --accent-foreground: 0 0% 7%;
-    --ring: 45 65% 52%;
-    --bg-selection: #d4af37;
-    --text-selection: #111;
+    --tertiary: 0 0% 18%;
+    --tertiary-foreground: 0 0% 66%;
+    --accent: 0 0% 20%;
+    --accent-foreground: 0 0% 100%;
+    --ring: 0 0% 72%;
+    --bg-selection: #fff;
+    --text-selection: #000;
     scrollbar-width: thin;
     scrollbar-color: color-mix(in srgb, currentColor 20%, transparent)
         transparent;


### PR DESCRIPTION
## Summary
- Darkened the app background and lifted card/surface contrast so dashboard panels separate more clearly.
- Replaced the gold/yellow selection styling with a neutral white selection state.
- Adjusted tertiary, accent, and ring tokens so text and controls stay readable after the branding update.
- Enabled `color-scheme: dark` for more consistent native control styling.

## Testing
- `pnpm --dir apps/app lint` passed after installing workspace dependencies.
- Verified the updated theme tokens in a local browser session; the app renders without a Next.js error overlay and the new selection/surface colors are applied.