### PR TITLE
Update admin page titles to reflect the current route

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -6,6 +6,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { NotificationsTableCard } from '../../../../components/notifications/NotificationsTableCard';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -39,6 +40,7 @@ export default async function AccountPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={`Račun ${accountId}`} />
             <Stack spacing={2}>
                 <Stack spacing={2}>
                     <Breadcrumbs

--- a/apps/app/app/admin/communication/emails/[emailId]/page.tsx
+++ b/apps/app/app/admin/communication/emails/[emailId]/page.tsx
@@ -14,6 +14,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../../components/admin/navigation/AdminPageTitle';
 import { NoDataPlaceholder } from '../../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../src/KnownPages';
@@ -94,6 +95,7 @@ export default async function EmailDetailPage({
 
     return (
         <Stack spacing={3}>
+            <AdminPageTitle title={email.subject || `Email #${email.id}`} />
             <Breadcrumbs
                 items={[
                     {

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -22,6 +22,7 @@ import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../../components/admin/navigation/AdminPageTitle';
 import { BarcodeValue } from '../../../../../components/shared/attributes/BarcodeValue';
 import { formatAttributeValueWithUnit } from '../../../../../components/shared/attributes/formatAttributeValueWithUnit';
 import { Field } from '../../../../../components/shared/fields/Field';
@@ -75,6 +76,7 @@ export default async function EntityDetailsPage(props: {
     const entityInventoryItem = inventoryItems.find(
         (item) => item.entityId === entityId,
     );
+    const entityTitle = entityDisplayName(entity);
 
     const entityDeleteBound = handleEntityDelete.bind(
         null,
@@ -156,6 +158,7 @@ export default async function EntityDetailsPage(props: {
 
     return (
         <EntityDetailsSaveProvider>
+            <AdminPageTitle title={entityTitle} />
             <Tabs defaultValue={attributeCategories.at(0)?.name}>
                 <EntityDetailsStickyHeader
                     breadcrumbs={
@@ -176,7 +179,7 @@ export default async function EntityDetailsPage(props: {
                                             ),
                                         },
                                         {
-                                            label: entityDisplayName(entity),
+                                            label: entityTitle,
                                         },
                                     ]}
                                 />

--- a/apps/app/app/admin/farms/[farmId]/page.tsx
+++ b/apps/app/app/admin/farms/[farmId]/page.tsx
@@ -12,6 +12,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { FormFields } from '../../../../components/shared/fields/FormFields';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
@@ -37,6 +38,7 @@ export default async function FarmPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={farm.name} />
             <Stack spacing={2}>
                 <Row spacing={2} justifyContent="space-between">
                     <Breadcrumbs

--- a/apps/app/app/admin/gardens/[gardenId]/page.tsx
+++ b/apps/app/app/admin/gardens/[gardenId]/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
 import { auth } from '../../../../lib/auth/auth';
@@ -51,6 +52,7 @@ export default async function GardenPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={garden.name} />
             <Stack spacing={2}>
                 <Breadcrumbs
                     items={[

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -14,6 +14,7 @@ import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../../../components/admin/navigation/AdminPageTitle';
 import { auth } from '../../../../../../lib/auth/auth';
 import {
     getInventoryFieldType,
@@ -63,6 +64,14 @@ export default async function InventoryItemPage({
             };
         }),
     ];
+    const itemEntityLabel = item.entityId
+        ? entityItems.find(
+              (entityItem) => entityItem.value === item.entityId?.toString(),
+          )?.label
+        : null;
+    const itemTitle = itemEntityLabel
+        ? `${itemEntityLabel} - stavka #${id}`
+        : `Stavka #${id}`;
 
     const additionalFields = item.additionalFields ?? {};
     const trackingTypeItems =
@@ -113,6 +122,7 @@ export default async function InventoryItemPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={itemTitle} />
             <Breadcrumbs
                 items={[
                     {

--- a/apps/app/app/admin/inventory/[inventoryId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/page.tsx
@@ -13,6 +13,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
@@ -65,6 +66,7 @@ export default async function InventoryConfigPage({
 
     return (
         <Stack spacing={2}>
+            <AdminPageTitle title={config.label} />
             <Breadcrumbs
                 items={[
                     {

--- a/apps/app/app/admin/invoices/[invoiceId]/page.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/page.tsx
@@ -15,6 +15,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
@@ -79,6 +80,7 @@ export default async function InvoicePage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={`Ponuda ${invoice.invoiceNumber}`} />
             <Breadcrumbs
                 items={[
                     {

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -22,6 +22,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
 import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
@@ -76,9 +77,14 @@ export default async function OperationDetailsPage({
         raisedBed && operation.raisedBedFieldId
             ? raisedBed.fields.find((f) => f.id === operation.raisedBedFieldId)
             : undefined;
+    const operationTitle =
+        operationDetails?.information?.label ||
+        operationDetails?.information?.name ||
+        `Radnja ${operation.id}`;
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={operationTitle} />
             <Stack spacing={2}>
                 <Breadcrumbs
                     items={[

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -11,6 +11,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { NotificationsTableCard } from '../../../../components/notifications/NotificationsTableCard';
 import { RaisedBedEventsTable } from '../../../../components/raised-beds/RaisedBedEventsTable';
 import { RaisedBedFieldsTable } from '../../../../components/raised-beds/RaisedBedFieldsTable';
@@ -36,9 +37,12 @@ export default async function RaisedBedPage({
     if (!raisedBed) {
         notFound();
     }
+    const raisedBedTitle =
+        raisedBed.name || `Gredica ${raisedBed.physicalId ?? raisedBed.id}`;
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={raisedBedTitle} />
             <Stack spacing={2}>
                 <Stack spacing={2}>
                     <Breadcrumbs

--- a/apps/app/app/admin/receipts/[receiptId]/page.tsx
+++ b/apps/app/app/admin/receipts/[receiptId]/page.tsx
@@ -14,6 +14,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
 import { ServerActionButton } from '../../../../components/shared/ServerActionButton';
@@ -74,6 +75,9 @@ export default async function ReceiptPage({
 
     return (
         <Stack spacing={2}>
+            <AdminPageTitle
+                title={`Fiskalni račun ${receipt.receiptNumber || `#${receipt.id}`}`}
+            />
             <h1 className="sr-only">Fiskalni račun #{receipt.id}</h1>
             <Row
                 spacing={2}

--- a/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
+++ b/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
@@ -14,6 +14,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
@@ -170,6 +171,7 @@ export default async function ShoppingCartDetailsPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={`Košarica ${cartIdNumber}`} />
             <Stack spacing={2}>
                 <Breadcrumbs
                     items={[

--- a/apps/app/app/admin/transactions/[transactionId]/page.tsx
+++ b/apps/app/app/admin/transactions/[transactionId]/page.tsx
@@ -12,6 +12,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
 import { KnownPages } from '../../../../src/KnownPages';
@@ -36,6 +37,7 @@ export default async function TransactionDetailsPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={`Transakcija ${transaction.id}`} />
             <Stack spacing={2}>
                 <Breadcrumbs
                     items={[

--- a/apps/app/app/admin/users/[userId]/page.tsx
+++ b/apps/app/app/admin/users/[userId]/page.tsx
@@ -16,6 +16,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
@@ -51,9 +52,11 @@ export default async function UserPage({
         displayName,
     } = user;
     const publicProfileUrl = KnownPages.GrediceUser(userIdToPublicId(id));
+    const userTitle = displayName ?? userName;
 
     return (
         <Stack spacing={4}>
+            <AdminPageTitle title={userTitle} />
             <Stack spacing={2}>
                 <Row spacing={2} justifyContent="space-between">
                     <Breadcrumbs

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -2,20 +2,27 @@ import { PostHogPageView, PostHogProvider } from '@posthog/next';
 import { Analytics } from '@vercel/analytics/react';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
-import Head from 'next/head';
 import type { ReactNode } from 'react';
 import { ImpersonationBanner } from '../components/ImpersonationBanner';
 import { ClientAppProvider } from '../components/providers/ClientAppProvider';
+import { adminAppTitle } from '../src/adminDocumentTitle';
 
 export function generateMetadata(): Metadata {
     return {
-        title: 'Gredice Admin',
+        title: {
+            default: adminAppTitle,
+            template: `%s | ${adminAppTitle}`,
+        },
         description: 'Gredice admin - upravljanje gredicama',
+        appleWebApp: {
+            title: adminAppTitle,
+        },
     };
 }
 
 export const viewport: Viewport = {
     initialScale: 1,
+    themeColor: '#111111',
     width: 'device-width',
 };
 
@@ -43,14 +50,6 @@ export default function RootLayout({
 
     return (
         <html lang="hr" translate="no" suppressHydrationWarning={true}>
-            <Head>
-                <meta
-                    name="apple-mobile-web-app-title"
-                    content="Gredice Admin"
-                />
-                <meta name="theme-color" content="#111111" />
-                <title>Gredice Admin</title>
-            </Head>
             <body className="antialiased min-h-screen flex bg-background text-foreground">
                 {postHogApiKey ? (
                     <PostHogProvider

--- a/apps/app/components/admin/navigation/AdminPageTitle.tsx
+++ b/apps/app/components/admin/navigation/AdminPageTitle.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useContext, useEffect } from 'react';
+import { AdminTitleContext } from './AdminTitleContext';
+
+export function AdminPageTitle({
+    title,
+}: {
+    title: string | null | undefined;
+}) {
+    const setTitle = useContext(AdminTitleContext);
+
+    useEffect(() => {
+        if (!setTitle) {
+            return;
+        }
+
+        setTitle(title?.trim() || null);
+        return () => setTitle(null);
+    }, [setTitle, title]);
+
+    return null;
+}

--- a/apps/app/components/admin/navigation/AdminTitleContext.ts
+++ b/apps/app/components/admin/navigation/AdminTitleContext.ts
@@ -1,0 +1,7 @@
+'use client';
+
+import { createContext } from 'react';
+
+export const AdminTitleContext = createContext<
+    ((title: string | null) => void) | undefined
+>(undefined);

--- a/apps/app/components/admin/navigation/AdminTitleProvider.tsx
+++ b/apps/app/components/admin/navigation/AdminTitleProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import {
+    type ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import { formatAdminDocumentTitle } from '../../../src/adminDocumentTitle';
+import { AdminTitleContext } from './AdminTitleContext';
+import { resolveAdminRouteTitle } from './adminRouteTitle';
+import { NavContext } from './NavContext';
+
+export function AdminTitleProvider({ children }: { children: ReactNode }) {
+    const pathname = usePathname();
+    const navContext = useContext(NavContext);
+    const [titleOverride, setTitleOverride] = useState<{
+        pathname: string;
+        title: string | null;
+    } | null>(null);
+
+    const routeTitle = useMemo(
+        () => resolveAdminRouteTitle(pathname, navContext),
+        [pathname, navContext],
+    );
+    const scopedTitleOverride =
+        titleOverride?.pathname === pathname ? titleOverride.title : null;
+    const title = scopedTitleOverride ?? routeTitle;
+
+    const setCurrentPageTitle = useCallback(
+        (nextTitle: string | null) => {
+            setTitleOverride({ pathname, title: nextTitle });
+        },
+        [pathname],
+    );
+
+    useEffect(() => {
+        document.title = formatAdminDocumentTitle(title);
+    }, [title]);
+
+    return (
+        <AdminTitleContext.Provider value={setCurrentPageTitle}>
+            {children}
+        </AdminTitleContext.Provider>
+    );
+}

--- a/apps/app/components/admin/navigation/adminRouteTitle.ts
+++ b/apps/app/components/admin/navigation/adminRouteTitle.ts
@@ -1,0 +1,198 @@
+import { adminBreadcrumbPages } from './adminPages';
+import type { NavContextType } from './NavContext';
+
+const idRouteTitles = [
+    { pattern: /^\/admin\/accounts\/([^/]+)$/, prefix: 'Račun' },
+    {
+        pattern: /^\/admin\/communication\/emails\/([^/]+)$/,
+        prefix: 'Email',
+    },
+    { pattern: /^\/admin\/farms\/([^/]+)$/, prefix: 'Farma' },
+    { pattern: /^\/admin\/gardens\/([^/]+)$/, prefix: 'Vrt' },
+    { pattern: /^\/admin\/inventory\/([^/]+)$/, prefix: 'Zaliha' },
+    { pattern: /^\/admin\/invoices\/([^/]+)$/, prefix: 'Ponuda' },
+    { pattern: /^\/admin\/operations\/([^/]+)$/, prefix: 'Radnja' },
+    { pattern: /^\/admin\/raised-beds\/([^/]+)$/, prefix: 'Gredica' },
+    { pattern: /^\/admin\/receipts\/([^/]+)$/, prefix: 'Fiskalni račun' },
+    { pattern: /^\/admin\/shopping-carts\/([^/]+)$/, prefix: 'Košarica' },
+    { pattern: /^\/admin\/transactions\/([^/]+)$/, prefix: 'Transakcija' },
+    { pattern: /^\/admin\/users\/([^/]+)$/, prefix: 'Korisnik' },
+];
+
+function decodePathSegment(segment: string) {
+    try {
+        return decodeURIComponent(segment);
+    } catch {
+        return segment;
+    }
+}
+
+function getEntityTypeLabel(
+    navContext: NavContextType | undefined,
+    entityTypeName: string,
+) {
+    const decodedEntityTypeName = decodePathSegment(entityTypeName);
+    const categorizedTypes =
+        navContext?.categorizedTypes.flatMap(
+            (category) => category.entityTypes,
+        ) ?? [];
+    const entityTypes = [
+        ...categorizedTypes,
+        ...(navContext?.uncategorizedTypes ?? []),
+        ...(navContext?.shadowTypes ?? []),
+    ];
+
+    return (
+        entityTypes.find(
+            (entityType) => entityType.name === decodedEntityTypeName,
+        )?.label ?? decodedEntityTypeName
+    );
+}
+
+function resolveDirectoryTitle(
+    pathname: string,
+    navContext: NavContextType | undefined,
+) {
+    if (pathname === '/admin/directories/entity-types/create') {
+        return 'Novi direktorij';
+    }
+
+    if (pathname === '/admin/directories/categories/create') {
+        return 'Nova kategorija';
+    }
+
+    if (/^\/admin\/directories\/categories\/[^/]+\/edit$/.test(pathname)) {
+        return 'Uredi kategoriju';
+    }
+
+    const directoryMatch = pathname.match(
+        /^\/admin\/directories\/([^/]+)(?:\/(.+))?$/,
+    );
+    if (!directoryMatch) {
+        return null;
+    }
+
+    const entityTypeName = directoryMatch[1];
+    if (!entityTypeName) {
+        return null;
+    }
+
+    const entityTypeLabel = getEntityTypeLabel(navContext, entityTypeName);
+    const suffix = directoryMatch[2];
+
+    if (!suffix) {
+        return entityTypeLabel;
+    }
+
+    if (suffix === 'edit') {
+        return `Uredi ${entityTypeLabel}`;
+    }
+
+    if (suffix === 'attribute-definitions') {
+        return `Atributi - ${entityTypeLabel}`;
+    }
+
+    if (suffix === 'attribute-definitions/categories') {
+        return `Kategorije atributa - ${entityTypeLabel}`;
+    }
+
+    if (/^attribute-definitions\/categories\/[^/]+$/.test(suffix)) {
+        return `Kategorija atributa - ${entityTypeLabel}`;
+    }
+
+    if (/^attribute-definitions\/[^/]+$/.test(suffix)) {
+        return `Atribut - ${entityTypeLabel}`;
+    }
+
+    if (/^[^/]+$/.test(suffix)) {
+        return `${entityTypeLabel} ${decodePathSegment(suffix)}`;
+    }
+
+    return null;
+}
+
+function resolveInventoryTitle(pathname: string) {
+    if (pathname === '/admin/inventory/create') {
+        return 'Nova zaliha';
+    }
+
+    const inventoryEditMatch = pathname.match(
+        /^\/admin\/inventory\/([^/]+)\/edit$/,
+    );
+    if (inventoryEditMatch?.[1]) {
+        return `Uredi zalihu ${decodePathSegment(inventoryEditMatch[1])}`;
+    }
+
+    const inventoryItemCreateMatch = pathname.match(
+        /^\/admin\/inventory\/([^/]+)\/items\/create$/,
+    );
+    if (inventoryItemCreateMatch?.[1]) {
+        return `Nova stavka zalihe ${decodePathSegment(
+            inventoryItemCreateMatch[1],
+        )}`;
+    }
+
+    const inventoryItemMatch = pathname.match(
+        /^\/admin\/inventory\/([^/]+)\/items\/([^/]+)$/,
+    );
+    if (inventoryItemMatch?.[2]) {
+        return `Stavka zalihe ${decodePathSegment(inventoryItemMatch[2])}`;
+    }
+
+    return null;
+}
+
+function resolveInvoiceTitle(pathname: string) {
+    if (pathname === '/admin/invoices/create') {
+        return 'Nova ponuda';
+    }
+
+    const invoiceEditMatch = pathname.match(
+        /^\/admin\/invoices\/([^/]+)\/edit$/,
+    );
+    if (invoiceEditMatch?.[1]) {
+        return `Uredi ponudu ${decodePathSegment(invoiceEditMatch[1])}`;
+    }
+
+    return null;
+}
+
+export function resolveAdminRouteTitle(
+    pathname: string,
+    navContext: NavContextType | undefined,
+) {
+    const exactPage = adminBreadcrumbPages.find(
+        (page) => page.href === pathname,
+    );
+    if (exactPage) {
+        return exactPage.label;
+    }
+
+    if (pathname === '/admin/logout') {
+        return 'Odjava';
+    }
+
+    const directoryTitle = resolveDirectoryTitle(pathname, navContext);
+    if (directoryTitle) {
+        return directoryTitle;
+    }
+
+    const inventoryTitle = resolveInventoryTitle(pathname);
+    if (inventoryTitle) {
+        return inventoryTitle;
+    }
+
+    const invoiceTitle = resolveInvoiceTitle(pathname);
+    if (invoiceTitle) {
+        return invoiceTitle;
+    }
+
+    for (const routeTitle of idRouteTitles) {
+        const match = pathname.match(routeTitle.pattern);
+        if (match?.[1]) {
+            return `${routeTitle.prefix} ${decodePathSegment(match[1])}`;
+        }
+    }
+
+    return null;
+}

--- a/apps/app/components/admin/navigation/index.ts
+++ b/apps/app/components/admin/navigation/index.ts
@@ -1,5 +1,7 @@
 export { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 export { AdminPageCardHeader } from './AdminPageCardHeader';
+export { AdminPageTitle } from './AdminPageTitle';
+export { AdminTitleProvider } from './AdminTitleProvider';
 export { DesktopNav } from './DesktopNav';
 export { DesktopNavProvider } from './DesktopNavProvider';
 export { DesktopNavToggle } from './DesktopNavToggle';

--- a/apps/app/components/admin/providers/AdminClientProvider.tsx
+++ b/apps/app/components/admin/providers/AdminClientProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AdminTitleProvider } from '../navigation/AdminTitleProvider';
 import { NavContext, type NavContextType } from '../navigation/NavContext';
 
 export function AdminClientProvider({
@@ -27,7 +28,7 @@ export function AdminClientProvider({
                 quickActions,
             }}
         >
-            {children}
+            <AdminTitleProvider>{children}</AdminTitleProvider>
         </NavContext.Provider>
     );
 }

--- a/apps/app/src/adminDocumentTitle.ts
+++ b/apps/app/src/adminDocumentTitle.ts
@@ -1,0 +1,15 @@
+export const adminAppTitle = 'Gredice Admin';
+
+export function formatAdminDocumentTitle(title: string | null | undefined) {
+    const normalizedTitle = title?.trim();
+
+    if (!normalizedTitle || normalizedTitle === adminAppTitle) {
+        return adminAppTitle;
+    }
+
+    if (normalizedTitle.endsWith(` | ${adminAppTitle}`)) {
+        return normalizedTitle;
+    }
+
+    return `${normalizedTitle} | ${adminAppTitle}`;
+}


### PR DESCRIPTION
## Summary
- Added a shared admin title layer so the document title resolves to `"<page> | Gredice Admin"` instead of staying static.
- Wired route-aware titles into the admin shell and added a fallback resolver for common admin paths.
- Set exact titles on detail pages that already fetch a meaningful label, name, subject, or number, including entity details, farms, gardens, inventory items, invoices, receipts, carts, transactions, users, accounts, and emails.

## Testing
- `pnpm --filter app lint` passed; Biome also formatted the touched files.
- `pnpm --filter app build` passed.
- Local browser smoke check against the app dev server passed with no error overlay and the expected page content rendered.