### PR TITLE
Fix directory inventory link to open the inventory item page

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityInventoryCard.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityInventoryCard.tsx
@@ -17,6 +17,7 @@ type EntityInventoryCardProps = {
     inventoryConfigId: number;
     inventoryLowCountThreshold: number | null;
     entityInventoryItem?: {
+        id: number;
         quantity: number;
         lowCountThreshold: number | null;
         notes?: string | null;
@@ -30,15 +31,23 @@ export function EntityInventoryCard({
     entityInventoryItem,
     upsertInventoryAction,
 }: EntityInventoryCardProps) {
+    const inventoryHref = entityInventoryItem
+        ? KnownPages.InventoryItem(inventoryConfigId, entityInventoryItem.id)
+        : KnownPages.InventoryConfig(inventoryConfigId);
+
     return (
         <Card>
             <CardHeader>
                 <Row justifyContent="space-between" className="items-center">
                     <CardTitle>Zaliha</CardTitle>
-                    <Link href={KnownPages.InventoryConfig(inventoryConfigId)}>
+                    <Link href={inventoryHref}>
                         <IconButton
                             variant="plain"
-                            title="Otvori stranicu zalihe"
+                            title={
+                                entityInventoryItem
+                                    ? 'Otvori stavku zalihe'
+                                    : 'Otvori stranicu zalihe'
+                            }
                         >
                             <ExternalLink className="size-4" />
                         </IconButton>


### PR DESCRIPTION
## Summary
- Update the directory entity inventory card to link to the inventory item page when the entity already has inventory data.
- Keep the existing inventory config link as a fallback when no item exists yet.
- Adjust the link title to match the destination.

## Testing
- Ran targeted Biome formatting/lint on the edited file.
- Ran `pnpm build --filter app` successfully.
- `pnpm --dir apps/app exec tsc --noEmit` still reports existing unrelated TypeScript errors elsewhere in the app.