### PR TITLE
Move admin page breadcrumbs and actions into the shared header

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -2,9 +2,9 @@ import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { ModalConfirm } from '@signalco/ui/ModalConfirm';
 import { Delete } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { NotificationsTableCard } from '../../../../components/notifications/NotificationsTableCard';
 import { Field } from '../../../../components/shared/fields/Field';
@@ -39,8 +39,8 @@ export default async function AccountPage({
 
     return (
         <Stack spacing={4}>
-            <Stack spacing={2}>
-                <Stack spacing={2}>
+            <AdminPageHeader
+                breadcrumbs={
                     <Breadcrumbs
                         items={[
                             {
@@ -50,26 +50,31 @@ export default async function AccountPage({
                             { label: accountId },
                         ]}
                     />
-                    <Row justifyContent="space-between">
-                        <Typography level="h1" semiBold>
-                            Račun
-                        </Typography>
-                        <ModalConfirm
-                            title="Potvrda brisanja računa"
-                            header="Jeste li sigurni da želite izbrisati račun?"
-                            expectedConfirm="Da"
-                            onConfirm={actionBound}
-                            trigger={
-                                <Button
-                                    startDecorator={
-                                        <Delete className="size-5 shrink-0" />
-                                    }
-                                >
-                                    Brisanje računa
-                                </Button>
-                            }
-                        />
-                    </Row>
+                }
+                actions={
+                    <ModalConfirm
+                        title="Potvrda brisanja računa"
+                        header="Jeste li sigurni da želite izbrisati račun?"
+                        expectedConfirm="Da"
+                        onConfirm={actionBound}
+                        trigger={
+                            <Button
+                                startDecorator={
+                                    <Delete className="size-5 shrink-0" />
+                                }
+                            >
+                                Brisanje računa
+                            </Button>
+                        }
+                    />
+                }
+                heading="Račun"
+            />
+            <Stack spacing={2}>
+                <Stack spacing={2}>
+                    <Typography level="h1" semiBold>
+                        Račun
+                    </Typography>
                 </Stack>
                 <Stack spacing={2}>
                     <FieldSet>

--- a/apps/app/app/admin/communication/emails/[emailId]/page.tsx
+++ b/apps/app/app/admin/communication/emails/[emailId]/page.tsx
@@ -13,6 +13,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { NoDataPlaceholder } from '../../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../../lib/auth/auth';
@@ -94,22 +95,24 @@ export default async function EmailDetailPage({
 
     return (
         <Stack spacing={3}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.CommunicationEmails,
-                    },
-                    { label: `Email #${email.id}` },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.CommunicationEmails,
+                            },
+                            { label: `Email #${email.id}` },
+                        ]}
+                    />
+                }
+                actions={<EmailStatusBadge status={email.status} />}
+                heading={email.subject}
             />
 
             <Stack spacing={2}>
-                <Row
-                    spacing={2}
-                    alignItems="center"
-                    justifyContent="space-between"
-                >
+                <Row spacing={2} alignItems="center">
                     <Stack spacing={0.5} className="min-w-0">
                         <Typography level="h1" className="text-2xl" semiBold>
                             {email.subject}
@@ -123,7 +126,6 @@ export default async function EmailDetailPage({
                             </Typography>
                         )}
                     </Stack>
-                    <EmailStatusBadge status={email.status} />
                 </Row>
 
                 <Row spacing={2} className="flex-wrap" alignItems="stretch">

--- a/apps/app/app/admin/delivery/slots/page.tsx
+++ b/apps/app/app/admin/delivery/slots/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@signalco/ui-primitives/Button';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { auth } from '../../../../lib/auth/auth';
 import { ArchiveClosedSlotsButton } from './ArchiveClosedSlotsButton';
 import { BulkGenerateModal } from './BulkGenerateModal';
@@ -38,35 +39,39 @@ export default async function AdminTimeSlotsPage({
 
     return (
         <Stack spacing={4}>
-            <Row justifyContent="space-between">
-                <Row spacing={2}>
-                    <ArchiveClosedSlotsButton
-                        slotIds={archivableClosedSlotIds}
-                    />
-                    <CreateTimeSlotModal
-                        trigger={
-                            <Button
-                                variant="solid"
-                                startDecorator={<Add className="size-4" />}
-                            >
-                                Kreiraj slot
-                            </Button>
-                        }
-                        locations={pickupLocations}
-                    />
-                    <BulkGenerateModal
-                        trigger={
-                            <Button
-                                variant="outlined"
-                                startDecorator={<Calendar className="size-4" />}
-                            >
-                                Generiraj u bloku
-                            </Button>
-                        }
-                        locations={pickupLocations}
-                    />
-                </Row>
-            </Row>
+            <AdminPageHeader
+                actions={
+                    <Row spacing={2}>
+                        <ArchiveClosedSlotsButton
+                            slotIds={archivableClosedSlotIds}
+                        />
+                        <CreateTimeSlotModal
+                            trigger={
+                                <Button
+                                    variant="solid"
+                                    startDecorator={<Add className="size-4" />}
+                                >
+                                    Kreiraj slot
+                                </Button>
+                            }
+                            locations={pickupLocations}
+                        />
+                        <BulkGenerateModal
+                            trigger={
+                                <Button
+                                    variant="outlined"
+                                    startDecorator={
+                                        <Calendar className="size-4" />
+                                    }
+                                >
+                                    Generiraj u bloku
+                                </Button>
+                            }
+                            locations={pickupLocations}
+                        />
+                    </Row>
+                }
+            />
 
             <TimeSlotsFilters />
 

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsStickyHeader.tsx
@@ -4,15 +4,11 @@ import { cx } from '@signalco/ui-primitives/cx';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 export type EntityDetailsStickyHeaderProps = {
-    breadcrumbs: ReactNode;
     tabs: ReactNode;
-    actions: ReactNode;
 };
 
 export function EntityDetailsStickyHeader({
-    breadcrumbs,
     tabs,
-    actions,
 }: EntityDetailsStickyHeaderProps) {
     const sentinelRef = useRef<HTMLDivElement | null>(null);
     const [isStuck, setIsStuck] = useState(false);
@@ -50,13 +46,7 @@ export function EntityDetailsStickyHeader({
                         'rounded-2xl border bg-background/90 px-3 py-2 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80',
                 )}
             >
-                <div className="flex flex-row items-center justify-between gap-2">
-                    <div className="min-w-0 flex-1">{breadcrumbs}</div>
-                    <div className="flex min-w-0 shrink-0 items-center gap-2">
-                        <div className="min-w-0 overflow-x-auto">{tabs}</div>
-                        <div className="shrink-0">{actions}</div>
-                    </div>
-                </div>
+                <div className="min-w-0 overflow-x-auto">{tabs}</div>
             </div>
         </>
     );

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -21,6 +21,7 @@ import { revalidatePath } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { BarcodeValue } from '../../../../../components/shared/attributes/BarcodeValue';
 import { formatAttributeValueWithUnit } from '../../../../../components/shared/attributes/formatAttributeValueWithUnit';
@@ -156,39 +157,51 @@ export default async function EntityDetailsPage(props: {
 
     return (
         <EntityDetailsSaveProvider>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Row spacing={2} className="min-w-0">
+                        <div className="min-w-0">
+                            <Breadcrumbs
+                                items={[
+                                    {
+                                        label: <AdminBreadcrumbLevelSelector />,
+                                        href: KnownPages.Directories,
+                                    },
+                                    {
+                                        label: entity.entityType.label,
+                                        href: KnownPages.DirectoryEntityType(
+                                            params.entityType,
+                                        ),
+                                    },
+                                    {
+                                        label: entityDisplayName(entity),
+                                    },
+                                ]}
+                            />
+                        </div>
+                        <div className="w-20 shrink-0">
+                            <EntityAttributeProgress
+                                entity={entity}
+                                definitions={attributeDefinitions}
+                            />
+                        </div>
+                    </Row>
+                }
+                actions={
+                    <Row className="items-center" spacing={1}>
+                        <EntityDetailsSaveIndicator />
+                        <EntityLinksPanel entityId={entityId} />
+                        <EntityActions
+                            entity={entity}
+                            importAction={importAction}
+                            deleteAction={entityDeleteBound}
+                        />
+                    </Row>
+                }
+                heading={entityDisplayName(entity)}
+            />
             <Tabs defaultValue={attributeCategories.at(0)?.name}>
                 <EntityDetailsStickyHeader
-                    breadcrumbs={
-                        <Row spacing={2} className="min-w-0">
-                            <div className="min-w-0">
-                                <Breadcrumbs
-                                    items={[
-                                        {
-                                            label: (
-                                                <AdminBreadcrumbLevelSelector />
-                                            ),
-                                            href: KnownPages.Directories,
-                                        },
-                                        {
-                                            label: entity.entityType.label,
-                                            href: KnownPages.DirectoryEntityType(
-                                                params.entityType,
-                                            ),
-                                        },
-                                        {
-                                            label: entityDisplayName(entity),
-                                        },
-                                    ]}
-                                />
-                            </div>
-                            <div className="w-20 shrink-0">
-                                <EntityAttributeProgress
-                                    entity={entity}
-                                    definitions={attributeDefinitions}
-                                />
-                            </div>
-                        </Row>
-                    }
                     tabs={
                         <TabsList>
                             {attributeCategories.map((category) => (
@@ -215,17 +228,6 @@ export default async function EntityDetailsPage(props: {
                                 </TabsTrigger>
                             ))}
                         </TabsList>
-                    }
-                    actions={
-                        <Row className="items-center" spacing={1}>
-                            <EntityDetailsSaveIndicator />
-                            <EntityLinksPanel entityId={entityId} />
-                            <EntityActions
-                                entity={entity}
-                                importAction={importAction}
-                                deleteAction={entityDeleteBound}
-                            />
-                        </Row>
                     }
                 />
                 <Stack spacing={2}>

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Delete } from '@signalco/ui-icons';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { ServerActionIconButton } from '../../../../../../components/shared/ServerActionIconButton';
 import { KnownPages } from '../../../../../../src/KnownPages';
@@ -49,36 +50,41 @@ export default async function AttributeDefinitionPage({
 
     return (
         <Stack spacing={2}>
-            <Row spacing={1} justifyContent="space-between">
-                <Breadcrumbs
-                    items={[
-                        {
-                            label: <AdminBreadcrumbLevelSelector />,
-                            href: KnownPages.Directories,
-                        },
-                        {
-                            label: entityType.label,
-                            href: KnownPages.DirectoryEntityType(
-                                entityTypeName,
-                            ),
-                        },
-                        {
-                            label: 'Atributi',
-                            href: KnownPages.DirectoryEntityTypeAttributeDefinitions(
-                                entityTypeName,
-                            ),
-                        },
-                        { label: label },
-                    ]}
-                />
-                <ServerActionIconButton
-                    title="Obriši"
-                    onClick={deleteAttributeDefinitionBound}
-                    variant="plain"
-                >
-                    <Delete className="size-5" />
-                </ServerActionIconButton>
-            </Row>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            {
+                                label: entityType.label,
+                                href: KnownPages.DirectoryEntityType(
+                                    entityTypeName,
+                                ),
+                            },
+                            {
+                                label: 'Atributi',
+                                href: KnownPages.DirectoryEntityTypeAttributeDefinitions(
+                                    entityTypeName,
+                                ),
+                            },
+                            { label: label },
+                        ]}
+                    />
+                }
+                actions={
+                    <ServerActionIconButton
+                        title="Obriši"
+                        onClick={deleteAttributeDefinitionBound}
+                        variant="plain"
+                    >
+                        <Delete className="size-5" />
+                    </ServerActionIconButton>
+                }
+                heading={label}
+            />
             <form>
                 <Stack spacing={3}>
                     <FormInput

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/[id]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { KnownPages } from '../../../../../../../src/KnownPages';
 import { FormInput } from './Form';
@@ -32,25 +33,32 @@ export default async function AttributeDefinitionCategoryDetailsPage({
 
     return (
         <Stack spacing={2}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    {
-                        label: entityType.label,
-                        href: KnownPages.DirectoryEntityType(entityTypeName),
-                    },
-                    {
-                        label: 'Atributi',
-                        href: KnownPages.DirectoryEntityTypeAttributeDefinitions(
-                            entityTypeName,
-                        ),
-                    },
-                    { label: 'Kategorije' },
-                    { label: label },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            {
+                                label: entityType.label,
+                                href: KnownPages.DirectoryEntityType(
+                                    entityTypeName,
+                                ),
+                            },
+                            {
+                                label: 'Atributi',
+                                href: KnownPages.DirectoryEntityTypeAttributeDefinitions(
+                                    entityTypeName,
+                                ),
+                            },
+                            { label: 'Kategorije' },
+                            { label: label },
+                        ]}
+                    />
+                }
+                heading={label}
             />
             <form>
                 <Row spacing={2}>

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/page.tsx
@@ -3,6 +3,7 @@ import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { KnownPages } from '../../../../../../src/KnownPages';
 
@@ -17,24 +18,31 @@ export default async function EntityTypeAttributeDefinitionCategoriesPage({
 
     return (
         <Stack spacing={2}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    {
-                        label: entityType.label,
-                        href: KnownPages.DirectoryEntityType(entityTypeName),
-                    },
-                    {
-                        label: 'Atributi',
-                        href: KnownPages.DirectoryEntityTypeAttributeDefinitions(
-                            entityTypeName,
-                        ),
-                    },
-                    { label: 'Kategorije' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            {
+                                label: entityType.label,
+                                href: KnownPages.DirectoryEntityType(
+                                    entityTypeName,
+                                ),
+                            },
+                            {
+                                label: 'Atributi',
+                                href: KnownPages.DirectoryEntityTypeAttributeDefinitions(
+                                    entityTypeName,
+                                ),
+                            },
+                            { label: 'Kategorije' },
+                        ]}
+                    />
+                }
+                heading="Kategorije"
             />
             <Stack spacing={2} className="py-8" alignItems="center">
                 <Typography level="body2" center>

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/page.tsx
@@ -3,6 +3,7 @@ import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
 import { AttributeDefinitionsList } from '../../../../../components/admin/directories';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { KnownPages } from '../../../../../src/KnownPages';
 
@@ -21,18 +22,25 @@ export default async function AttributesPage({
 
     return (
         <Stack spacing={2}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    {
-                        label: entityType.label,
-                        href: KnownPages.DirectoryEntityType(entityTypeName),
-                    },
-                    { label: 'Atributi' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            {
+                                label: entityType.label,
+                                href: KnownPages.DirectoryEntityType(
+                                    entityTypeName,
+                                ),
+                            },
+                            { label: 'Atributi' },
+                        ]}
+                    />
+                }
+                heading="Atributi"
             />
             <AttributeDefinitionsList entityTypeName={entityTypeName} />
         </Stack>

--- a/apps/app/app/admin/directories/[entityType]/edit/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/edit/page.tsx
@@ -5,6 +5,7 @@ import {
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../src/KnownPages';
@@ -27,18 +28,25 @@ export default async function EditEntityTypePage({
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    {
-                        label: entityType.label,
-                        href: KnownPages.DirectoryEntityType(entityTypeName),
-                    },
-                    { label: 'Uredi' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            {
+                                label: entityType.label,
+                                href: KnownPages.DirectoryEntityType(
+                                    entityTypeName,
+                                ),
+                            },
+                            { label: 'Uredi' },
+                        ]}
+                    />
+                }
+                heading={`Uredi ${entityType.label}`}
             />
             <EntityTypeEditForm
                 entityType={entityType}

--- a/apps/app/app/admin/directories/[entityType]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/page.tsx
@@ -12,6 +12,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import Link from 'next/link';
 import { EntityTypeMenu } from '../../../../components/admin/directories';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { FilterProvider } from '../../../../components/admin/providers';
 import { SearchInput } from '../../../../components/admin/SearchInput';
@@ -50,51 +51,54 @@ export default async function EntitiesPage({
     return (
         <FilterProvider>
             <Stack spacing={2}>
+                <AdminPageHeader
+                    breadcrumbs={
+                        <Breadcrumbs
+                            items={[
+                                {
+                                    label: <AdminBreadcrumbLevelSelector />,
+                                    href: KnownPages.Directories,
+                                },
+                                {
+                                    label: entityType?.label ?? entityTypeName,
+                                },
+                            ]}
+                        />
+                    }
+                    actions={
+                        <Row spacing={1}>
+                            {inventoryConfig && (
+                                <Link
+                                    href={KnownPages.InventoryConfig(
+                                        inventoryConfig.id,
+                                    )}
+                                >
+                                    <Row
+                                        spacing={1}
+                                        className="text-sm font-medium px-3 py-2 rounded-md border hover:bg-accent transition-colors"
+                                    >
+                                        <span>Zaliha</span>
+                                    </Row>
+                                </Link>
+                            )}
+                            <SearchInput />
+                            <ServerActionIconButton
+                                variant="plain"
+                                title="Dodaj zapis"
+                                onClick={createEntityBound}
+                            >
+                                <Add className="size-5" />
+                            </ServerActionIconButton>
+                            {entityType && (
+                                <EntityTypeMenu entityType={entityType} />
+                            )}
+                        </Row>
+                    }
+                    heading={entityType?.label ?? entityTypeName}
+                />
                 <h1 className="sr-only">
                     {entityType?.label ?? entityTypeName}
                 </h1>
-                <Row
-                    spacing={1}
-                    justifyContent="space-between"
-                    className="flex-wrap gap-2"
-                >
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            { label: entityType?.label ?? entityTypeName },
-                        ]}
-                    />
-                    <Row spacing={1}>
-                        {inventoryConfig && (
-                            <Link
-                                href={KnownPages.InventoryConfig(
-                                    inventoryConfig.id,
-                                )}
-                            >
-                                <Row
-                                    spacing={1}
-                                    className="text-sm font-medium px-3 py-2 rounded-md border hover:bg-accent transition-colors"
-                                >
-                                    <span>Zaliha</span>
-                                </Row>
-                            </Link>
-                        )}
-                        <SearchInput />
-                        <ServerActionIconButton
-                            variant="plain"
-                            title="Dodaj zapis"
-                            onClick={createEntityBound}
-                        >
-                            <Add className="size-5" />
-                        </ServerActionIconButton>
-                        {entityType && (
-                            <EntityTypeMenu entityType={entityType} />
-                        )}
-                    </Row>
-                </Row>
                 <Card>
                     <CardOverflow>
                         <EntitiesTable

--- a/apps/app/app/admin/directories/categories/[categoryId]/edit/EditEntityTypeCategoryPage.tsx
+++ b/apps/app/app/admin/directories/categories/[categoryId]/edit/EditEntityTypeCategoryPage.tsx
@@ -10,6 +10,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
+import { AdminPageHeader } from '../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { KnownPages } from '../../../../../../src/KnownPages';
 import {
@@ -37,18 +38,36 @@ export function EditEntityTypeCategoryPage({
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    { label: 'Kategorije', href: KnownPages.Directories },
-                    { label: category.label },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            {
+                                label: 'Kategorije',
+                                href: KnownPages.Directories,
+                            },
+                            { label: category.label },
+                        ]}
+                    />
+                }
+                actions={
+                    <Button
+                        variant="plain"
+                        color="danger"
+                        onClick={() => setShowDeleteConfirm(true)}
+                    >
+                        <Delete className="size-4" />
+                        Obriši kategoriju
+                    </Button>
+                }
+                heading={`Uredi kategoriju: ${category.label}`}
             />
 
-            <Row spacing={4} justifyContent="space-between" alignItems="start">
+            <Row spacing={4} alignItems="start">
                 <Stack spacing={2}>
                     <Typography level="h2" className="text-2xl" semiBold>
                         Uredi kategoriju: {category.label}
@@ -70,15 +89,6 @@ export function EditEntityTypeCategoryPage({
                         <strong>{category.label}</strong>?
                     </Typography>
                 </ModalConfirm>
-
-                <Button
-                    variant="plain"
-                    color="danger"
-                    onClick={() => setShowDeleteConfirm(true)}
-                >
-                    <Delete className="size-4" />
-                    Obriši kategoriju
-                </Button>
             </Row>
 
             <Card className="max-w-2xl">

--- a/apps/app/app/admin/directories/categories/create/page.tsx
+++ b/apps/app/app/admin/directories/categories/create/page.tsx
@@ -3,6 +3,7 @@ import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../src/KnownPages';
@@ -16,14 +17,19 @@ export default async function CreateEntityTypeCategoryPage() {
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    { label: 'Nova kategorija' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            { label: 'Nova kategorija' },
+                        ]}
+                    />
+                }
+                heading="Nova kategorija tipova zapisa"
             />
 
             <Stack spacing={2}>

--- a/apps/app/app/admin/directories/entity-types/create/page.tsx
+++ b/apps/app/app/admin/directories/entity-types/create/page.tsx
@@ -7,6 +7,7 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { availableIcons } from '../../../../../components/admin/directories/EntityTypeIcon';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../src/KnownPages';
@@ -36,14 +37,19 @@ export default async function CreateEntityTypePage() {
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Directories,
-                    },
-                    { label: 'Novi tip zapisa' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Directories,
+                            },
+                            { label: 'Novi tip zapisa' },
+                        ]}
+                    />
+                }
+                heading="Novi tip zapisa"
             />
 
             <Stack spacing={2}>

--- a/apps/app/app/admin/farms/[farmId]/page.tsx
+++ b/apps/app/app/admin/farms/[farmId]/page.tsx
@@ -8,9 +8,9 @@ import {
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { FormFields } from '../../../../components/shared/fields/FormFields';
 import { auth } from '../../../../lib/auth/auth';
@@ -37,8 +37,8 @@ export default async function FarmPage({
 
     return (
         <Stack spacing={4}>
-            <Stack spacing={2}>
-                <Row spacing={2} justifyContent="space-between">
+            <AdminPageHeader
+                breadcrumbs={
                     <Breadcrumbs
                         items={[
                             {
@@ -48,6 +48,8 @@ export default async function FarmPage({
                             { label: farm.name },
                         ]}
                     />
+                }
+                actions={
                     <Button
                         href={`https://vrt.gredice.com/farme/${farm.id}`}
                         target="_blank"
@@ -58,7 +60,10 @@ export default async function FarmPage({
                     >
                         Stranica farme
                     </Button>
-                </Row>
+                }
+                heading={farm.name}
+            />
+            <Stack spacing={2}>
                 <FormFields
                     fields={[
                         { name: 'ID farme', value: farm.id, mono: true },

--- a/apps/app/app/admin/gardens/[gardenId]/page.tsx
+++ b/apps/app/app/admin/gardens/[gardenId]/page.tsx
@@ -5,6 +5,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -51,16 +52,21 @@ export default async function GardenPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Gardens,
+                            },
+                            { label: garden?.name },
+                        ]}
+                    />
+                }
+                heading={garden.name}
+            />
             <Stack spacing={2}>
-                <Breadcrumbs
-                    items={[
-                        {
-                            label: <AdminBreadcrumbLevelSelector />,
-                            href: KnownPages.Gardens,
-                        },
-                        { label: garden?.name },
-                    ]}
-                />
                 <Stack spacing={2}>
                     <FieldSet>
                         <Field name="ID vrta" value={garden?.id} mono />

--- a/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/edit/page.tsx
@@ -7,6 +7,7 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../lib/auth/auth';
 import {
@@ -86,17 +87,22 @@ export default async function EditInventoryConfigPage({
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                    },
-                    {
-                        label: config.label,
-                        href: KnownPages.InventoryConfig(id),
-                    },
-                    { label: 'Uredi' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                            },
+                            {
+                                label: config.label,
+                                href: KnownPages.InventoryConfig(id),
+                            },
+                            { label: 'Uredi' },
+                        ]}
+                    />
+                }
+                heading="Uredi zalihu"
             />
 
             <Typography level="h2" className="text-2xl" semiBold>

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -13,6 +13,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../../lib/auth/auth';
 import {
@@ -113,17 +114,24 @@ export default async function InventoryItemPage({
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                    },
-                    {
-                        label: config.label,
-                        href: KnownPages.InventoryConfig(inventoryConfigId),
-                    },
-                    { label: `Stavka #${id}` },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                            },
+                            {
+                                label: config.label,
+                                href: KnownPages.InventoryConfig(
+                                    inventoryConfigId,
+                                ),
+                            },
+                            { label: `Stavka #${id}` },
+                        ]}
+                    />
+                }
+                heading={`Uredi stavku #${id}`}
             />
 
             <Typography level="h2" className="text-2xl" semiBold>

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -67,7 +67,7 @@ export default async function InventoryItemPage({
     ];
     const itemEntityLabel = item.entityId
         ? entityItems.find(
-              (entityItem) => entityItem.value === item.entityId?.toString(),
+              (entityItem) => entityItem.value === item.entityId.toString(),
           )?.label
         : null;
     const itemTitle = itemEntityLabel

--- a/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/[itemId]/page.tsx
@@ -65,13 +65,13 @@ export default async function InventoryItemPage({
             };
         }),
     ];
-    const itemEntityLabel = item.entityId
+    const entityLabel = item.entityId
         ? entityItems.find(
               (entityItem) => entityItem.value === item.entityId.toString(),
           )?.label
         : null;
-    const itemTitle = itemEntityLabel
-        ? `${itemEntityLabel} - stavka #${id}`
+    const itemTitle = entityLabel
+        ? `${entityLabel} - stavka #${id}`
         : `Stavka #${id}`;
 
     const additionalFields = item.additionalFields ?? {};

--- a/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/items/create/page.tsx
@@ -7,6 +7,7 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../../lib/auth/auth';
 import {
@@ -73,17 +74,22 @@ export default async function CreateInventoryItemPage({
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                    },
-                    {
-                        label: config.label,
-                        href: KnownPages.InventoryConfig(id),
-                    },
-                    { label: 'Dodaj stavku' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                            },
+                            {
+                                label: config.label,
+                                href: KnownPages.InventoryConfig(id),
+                            },
+                            { label: 'Dodaj stavku' },
+                        ]}
+                    />
+                }
+                heading="Dodaj stavku zalihe"
             />
 
             <Stack spacing={2}>

--- a/apps/app/app/admin/inventory/[inventoryId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/page.tsx
@@ -12,6 +12,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { auth } from '../../../../lib/auth/auth';
@@ -65,40 +66,45 @@ export default async function InventoryConfigPage({
 
     return (
         <Stack spacing={2}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                    },
-                    { label: config.label },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                            },
+                            { label: config.label },
+                        ]}
+                    />
+                }
+                actions={
+                    <Row spacing={1}>
+                        <Link href={KnownPages.InventoryItemCreate(id)}>
+                            <Row
+                                spacing={1}
+                                className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                            >
+                                <Add className="size-4" />
+                                <span>Dodaj stavku</span>
+                            </Row>
+                        </Link>
+                        <Link href={KnownPages.InventoryConfigEdit(id)}>
+                            <Row
+                                spacing={1}
+                                className="text-sm font-medium px-3 py-2 rounded-md border hover:bg-accent transition-colors"
+                            >
+                                <Edit className="size-4" />
+                                <span>Uredi</span>
+                            </Row>
+                        </Link>
+                    </Row>
+                }
+                heading={config.label}
             />
 
-            <Row spacing={1} justifyContent="space-between">
-                <Typography level="h1" className="text-2xl" semiBold>
-                    {config.label}
-                </Typography>
-                <Row spacing={1}>
-                    <Link href={KnownPages.InventoryItemCreate(id)}>
-                        <Row
-                            spacing={1}
-                            className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                        >
-                            <Add className="size-4" />
-                            <span>Dodaj stavku</span>
-                        </Row>
-                    </Link>
-                    <Link href={KnownPages.InventoryConfigEdit(id)}>
-                        <Row
-                            spacing={1}
-                            className="text-sm font-medium px-3 py-2 rounded-md border hover:bg-accent transition-colors"
-                        >
-                            <Edit className="size-4" />
-                            <span>Uredi</span>
-                        </Row>
-                    </Link>
-                </Row>
-            </Row>
+            <Typography level="h1" className="text-2xl" semiBold>
+                {config.label}
+            </Typography>
 
             <Card>
                 <CardContent noHeader>

--- a/apps/app/app/admin/inventory/create/page.tsx
+++ b/apps/app/app/admin/inventory/create/page.tsx
@@ -6,6 +6,7 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../lib/auth/auth';
 import { createInventoryConfigAction } from '../../../(actions)/inventoryActions';
@@ -23,13 +24,18 @@ export default async function CreateInventoryPage() {
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                    },
-                    { label: 'Nova zaliha' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                            },
+                            { label: 'Nova zaliha' },
+                        ]}
+                    />
+                }
+                heading="Nova zaliha"
             />
 
             <Stack spacing={2}>

--- a/apps/app/app/admin/inventory/page.tsx
+++ b/apps/app/app/admin/inventory/page.tsx
@@ -10,6 +10,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
+import { AdminPageHeader } from '../../../components/admin/navigation';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
 
@@ -22,17 +23,19 @@ export default async function InventoryPage() {
 
     return (
         <Stack spacing={2}>
-            <Row spacing={1} justifyContent="space-between">
-                <Link href={KnownPages.InventoryCreate}>
-                    <Row
-                        spacing={1}
-                        className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                    >
-                        <Add className="size-4" />
-                        <span>Nova zaliha</span>
-                    </Row>
-                </Link>
-            </Row>
+            <AdminPageHeader
+                actions={
+                    <Link href={KnownPages.InventoryCreate}>
+                        <Row
+                            spacing={1}
+                            className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                        >
+                            <Add className="size-4" />
+                            <span>Nova zaliha</span>
+                        </Row>
+                    </Link>
+                }
+            />
 
             {configs.length === 0 ? (
                 <Card>

--- a/apps/app/app/admin/invoices/[invoiceId]/edit/page.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/edit/page.tsx
@@ -2,6 +2,7 @@ import { getInvoice } from '@gredice/storage';
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound, redirect } from 'next/navigation';
+import { AdminPageHeader } from '../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../src/KnownPages';
@@ -32,18 +33,23 @@ export default async function EditInvoicePage({
 
     return (
         <Stack spacing={2}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Invoices,
-                    },
-                    {
-                        label: `${invoice.invoiceNumber}`,
-                        href: KnownPages.Invoice(invoice.id),
-                    },
-                    { label: 'Uredi' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Invoices,
+                            },
+                            {
+                                label: `${invoice.invoiceNumber}`,
+                                href: KnownPages.Invoice(invoice.id),
+                            },
+                            { label: 'Uredi' },
+                        ]}
+                    />
+                }
+                heading={`Uredi ponudu ${invoice.invoiceNumber}`}
             />
             <InvoiceForm mode="edit" invoice={invoice} />
         </Stack>

--- a/apps/app/app/admin/invoices/[invoiceId]/page.tsx
+++ b/apps/app/app/admin/invoices/[invoiceId]/page.tsx
@@ -14,6 +14,7 @@ import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../lib/auth/auth';
@@ -79,22 +80,25 @@ export default async function InvoicePage({
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Invoices,
-                    },
-                    { label: `${invoice.invoiceNumber}` },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Invoices,
+                            },
+                            { label: `${invoice.invoiceNumber}` },
+                        ]}
+                    />
+                }
+                actions={<InvoiceActions invoice={invoice} />}
+                heading={`Ponuda ${invoice.invoiceNumber}`}
             />
             <Stack spacing={2}>
-                <Row spacing={2} justifyContent="space-between">
-                    <Typography level="h1">
-                        Ponuda {invoice.invoiceNumber}
-                    </Typography>
-                    <InvoiceActions invoice={invoice} />
-                </Row>
+                <Typography level="h1">
+                    Ponuda {invoice.invoiceNumber}
+                </Typography>
 
                 <Row spacing={2} alignItems="stretch">
                     <Stack spacing={2} className="flex-1">

--- a/apps/app/app/admin/invoices/create/page.tsx
+++ b/apps/app/app/admin/invoices/create/page.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
@@ -10,14 +11,19 @@ export default async function CreateInvoicePage() {
 
     return (
         <Stack spacing={2}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Invoices,
-                    },
-                    { label: 'Kreiraj novu ponudu' },
-                ]}
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Invoices,
+                            },
+                            { label: 'Kreiraj novu ponudu' },
+                        ]}
+                    />
+                }
+                heading="Kreiraj novu ponudu"
             />
             <InvoiceForm mode="create" />
         </Stack>

--- a/apps/app/app/admin/invoices/page.tsx
+++ b/apps/app/app/admin/invoices/page.tsx
@@ -1,8 +1,8 @@
 import { Add } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { AdminPageHeader } from '../../../components/admin/navigation';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
 import { InvoicesTable } from './InvoicesTable';
@@ -14,15 +14,17 @@ export default async function InvoicesPage() {
 
     return (
         <Stack spacing={2}>
-            <Row spacing={1} justifyContent="space-between">
-                <Button
-                    variant="solid"
-                    startDecorator={<Add className="size-5 shrink-0" />}
-                    href={KnownPages.CreateInvoice}
-                >
-                    Nova ponuda
-                </Button>
-            </Row>
+            <AdminPageHeader
+                actions={
+                    <Button
+                        variant="solid"
+                        startDecorator={<Add className="size-5 shrink-0" />}
+                        href={KnownPages.CreateInvoice}
+                    >
+                        Nova ponuda
+                    </Button>
+                }
+            />
             <Card>
                 <CardOverflow>
                     <InvoicesTable />

--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -11,6 +11,7 @@ import { redirect } from 'next/navigation';
 import { type PropsWithChildren, Suspense } from 'react';
 import {
     AdminPageCardHeader,
+    AdminPageHeaderProvider,
     DesktopNav,
     DesktopNavProvider,
     LoginDialog,
@@ -96,8 +97,10 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                                     <div className="min-h-full border bg-background p-3 md:rounded-2xl md:p-4">
                                         <AuthProtectedSection auth={authAdmin}>
                                             <Suspense>
-                                                <AdminPageCardHeader />
-                                                {children}
+                                                <AdminPageHeaderProvider>
+                                                    <AdminPageCardHeader />
+                                                    {children}
+                                                </AdminPageHeaderProvider>
                                             </Suspense>
                                         </AuthProtectedSection>
                                     </div>

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -21,6 +21,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -79,16 +80,21 @@ export default async function OperationDetailsPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Operations,
+                            },
+                            { label: operationId },
+                        ]}
+                    />
+                }
+                heading="Detalji radnje"
+            />
             <Stack spacing={2}>
-                <Breadcrumbs
-                    items={[
-                        {
-                            label: <AdminBreadcrumbLevelSelector />,
-                            href: KnownPages.Operations,
-                        },
-                        { label: operationId },
-                    ]}
-                />
                 <Typography level="h1" className="text-2xl" semiBold>
                     Detalji radnje
                 </Typography>

--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -4,8 +4,8 @@ import {
     getUniqueAssignableFarmUsersByGardenIds,
 } from '@gredice/storage';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import { AdminPageHeader } from '../../../components/admin/navigation';
 import { OperationsTable } from '../../../components/operations/OperationsTable';
 import { auth } from '../../../lib/auth/auth';
 import { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
@@ -41,13 +41,15 @@ export default async function OperationsPage({
 
     return (
         <Stack spacing={2}>
-            <Row justifyContent="space-between">
-                <BulkOperationCreateModal
-                    gardens={gardens}
-                    raisedBeds={raisedBeds}
-                    assignableUsers={assignableUsers}
-                />
-            </Row>
+            <AdminPageHeader
+                actions={
+                    <BulkOperationCreateModal
+                        gardens={gardens}
+                        raisedBeds={raisedBeds}
+                        assignableUsers={assignableUsers}
+                    />
+                }
+            />
             <OperationsFilters />
             <Card>
                 <CardOverflow>

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -10,6 +10,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { NotificationsTableCard } from '../../../../components/notifications/NotificationsTableCard';
 import { RaisedBedEventsTable } from '../../../../components/raised-beds/RaisedBedEventsTable';
@@ -39,8 +40,8 @@ export default async function RaisedBedPage({
 
     return (
         <Stack spacing={4}>
-            <Stack spacing={2}>
-                <Stack spacing={2}>
+            <AdminPageHeader
+                breadcrumbs={
                     <Breadcrumbs
                         items={[
                             {
@@ -65,14 +66,17 @@ export default async function RaisedBedPage({
                             { label: raisedBed?.id },
                         ]}
                     />
-                    <div className="flex items-start justify-between gap-2">
-                        <Typography level="h1" semiBold>
-                            Gredica
-                        </Typography>
-                        <RaisedBedActionsMenu
-                            targetRaisedBedId={raisedBed.id}
-                        />
-                    </div>
+                }
+                actions={
+                    <RaisedBedActionsMenu targetRaisedBedId={raisedBed.id} />
+                }
+                heading="Gredica"
+            />
+            <Stack spacing={2}>
+                <Stack spacing={2}>
+                    <Typography level="h1" semiBold>
+                        Gredica
+                    </Typography>
                 </Stack>
                 <Stack spacing={2}>
                     <FieldSet>

--- a/apps/app/app/admin/receipts/[receiptId]/page.tsx
+++ b/apps/app/app/admin/receipts/[receiptId]/page.tsx
@@ -13,6 +13,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -75,27 +76,26 @@ export default async function ReceiptPage({
     return (
         <Stack spacing={2}>
             <h1 className="sr-only">Fiskalni račun #{receipt.id}</h1>
-            <Row
-                spacing={2}
-                justifyContent="space-between"
-                className="flex-wrap gap-2"
-            >
-                <Row spacing={2} className="flex-wrap">
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Receipts,
-                            },
-                            { label: `Fiskalni račun #${receipt.id}` },
-                        ]}
-                    />
-                    <Chip color={getCisStatusColor(receipt.cisStatus)}>
-                        {getCisStatusLabel(receipt.cisStatus)}
-                    </Chip>
-                </Row>
-                <ReceiptActions receipt={receipt} />
-            </Row>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Row spacing={2} className="flex-wrap">
+                        <Breadcrumbs
+                            items={[
+                                {
+                                    label: <AdminBreadcrumbLevelSelector />,
+                                    href: KnownPages.Receipts,
+                                },
+                                { label: `Fiskalni račun #${receipt.id}` },
+                            ]}
+                        />
+                        <Chip color={getCisStatusColor(receipt.cisStatus)}>
+                            {getCisStatusLabel(receipt.cisStatus)}
+                        </Chip>
+                    </Row>
+                }
+                actions={<ReceiptActions receipt={receipt} />}
+                heading={`Fiskalni račun #${receipt.id}`}
+            />
 
             <Stack spacing={2}>
                 <FieldSet>

--- a/apps/app/app/admin/settings/page.tsx
+++ b/apps/app/app/admin/settings/page.tsx
@@ -9,7 +9,6 @@ import {
     SettingsKeys,
     type SlackConfig,
 } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Add, Edit } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import {
@@ -24,7 +23,6 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { EntityTypeIcon } from '../../../components/admin/directories/EntityTypeIcon';
-import { AdminBreadcrumbLevelSelector } from '../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../lib/auth/auth';
 import {
     buildDashboardQuickActionOptions,
@@ -100,15 +98,6 @@ export default async function SettingsPage() {
 
     return (
         <Stack spacing={4}>
-            <Breadcrumbs
-                items={[
-                    {
-                        label: <AdminBreadcrumbLevelSelector />,
-                        href: KnownPages.Settings,
-                    },
-                ]}
-            />
-
             <div className="grid gap-8 lg:grid-cols-[240px_1fr]">
                 <nav className="lg:sticky self-start">
                     <Card>

--- a/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
+++ b/apps/app/app/admin/shopping-carts/[cartId]/page.tsx
@@ -13,6 +13,7 @@ import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -170,16 +171,21 @@ export default async function ShoppingCartDetailsPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.ShoppingCarts,
+                            },
+                            { label: `Košarica ${cartIdNumber}` },
+                        ]}
+                    />
+                }
+                heading="Detalji košarice"
+            />
             <Stack spacing={2}>
-                <Breadcrumbs
-                    items={[
-                        {
-                            label: <AdminBreadcrumbLevelSelector />,
-                            href: KnownPages.ShoppingCarts,
-                        },
-                        { label: `Košarica ${cartIdNumber}` },
-                    ]}
-                />
                 <Typography level="h1" className="text-2xl" semiBold>
                     Detalji košarice
                 </Typography>

--- a/apps/app/app/admin/transactions/[transactionId]/page.tsx
+++ b/apps/app/app/admin/transactions/[transactionId]/page.tsx
@@ -11,6 +11,7 @@ import { Chip } from '@signalco/ui-primitives/Chip';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -36,16 +37,21 @@ export default async function TransactionDetailsPage({
 
     return (
         <Stack spacing={4}>
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.Transactions,
+                            },
+                            { label: transactionId },
+                        ]}
+                    />
+                }
+                heading="Detalji transakcije"
+            />
             <Stack spacing={2}>
-                <Breadcrumbs
-                    items={[
-                        {
-                            label: <AdminBreadcrumbLevelSelector />,
-                            href: KnownPages.Transactions,
-                        },
-                        { label: transactionId },
-                    ]}
-                />
                 <Typography level="h1" className="text-2xl" semiBold>
                     Detalji transakcije
                 </Typography>

--- a/apps/app/app/admin/users/[userId]/page.tsx
+++ b/apps/app/app/admin/users/[userId]/page.tsx
@@ -15,6 +15,7 @@ import { Table } from '@signalco/ui-primitives/Table';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { Field } from '../../../../components/shared/fields/Field';
 import { FieldSet } from '../../../../components/shared/fields/FieldSet';
@@ -54,8 +55,8 @@ export default async function UserPage({
 
     return (
         <Stack spacing={4}>
-            <Stack spacing={2}>
-                <Row spacing={2} justifyContent="space-between">
+            <AdminPageHeader
+                breadcrumbs={
                     <Breadcrumbs
                         items={[
                             {
@@ -65,8 +66,11 @@ export default async function UserPage({
                             { label: user.userName },
                         ]}
                     />
-                    <ButtonImpersonateUser userId={user.id} />
-                </Row>
+                }
+                actions={<ButtonImpersonateUser userId={user.id} />}
+                heading={user.userName}
+            />
+            <Stack spacing={2}>
                 <Stack spacing={2}>
                     <FieldSet>
                         <Field name="ID korisnika" value={id} mono />

--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -57,43 +57,6 @@ export function resolveCurrentTopLevel(pathname: string) {
     }, undefined);
 }
 
-export function shouldUseInlineBreadcrumbs(pathname: string) {
-    return inlineBreadcrumbPathPatterns.some((pattern) =>
-        pattern.test(pathname),
-    );
-}
-
-const inlineBreadcrumbPathPatterns = [
-    /^\/admin\/settings$/,
-    /^\/admin\/accounts\/[^/]+$/,
-    /^\/admin\/communication\/emails\/\d+$/,
-    /^\/admin\/directories\/entity-types\/create$/,
-    /^\/admin\/directories\/categories\/create$/,
-    /^\/admin\/directories\/categories\/\d+\/edit$/,
-    /^\/admin\/directories\/[^/]+\/edit$/,
-    /^\/admin\/directories\/[^/]+\/attribute-definitions$/,
-    /^\/admin\/directories\/[^/]+\/attribute-definitions\/categories$/,
-    /^\/admin\/directories\/[^/]+\/attribute-definitions\/\d+$/,
-    /^\/admin\/directories\/[^/]+\/attribute-definitions\/categories\/\d+$/,
-    /^\/admin\/directories\/[^/]+\/\d+$/,
-    /^\/admin\/farms\/\d+$/,
-    /^\/admin\/gardens\/\d+$/,
-    /^\/admin\/inventory\/create$/,
-    /^\/admin\/inventory\/\d+$/,
-    /^\/admin\/inventory\/\d+\/edit$/,
-    /^\/admin\/inventory\/\d+\/items\/create$/,
-    /^\/admin\/inventory\/\d+\/items\/\d+$/,
-    /^\/admin\/invoices\/create$/,
-    /^\/admin\/invoices\/\d+$/,
-    /^\/admin\/invoices\/\d+\/edit$/,
-    /^\/admin\/operations\/\d+$/,
-    /^\/admin\/raised-beds\/\d+$/,
-    /^\/admin\/receipts\/\d+$/,
-    /^\/admin\/shopping-carts\/\d+$/,
-    /^\/admin\/transactions\/\d+$/,
-    /^\/admin\/users\/[^/]+$/,
-];
-
 const breadcrumbSections: {
     title: string;
     pages: {

--- a/apps/app/components/admin/navigation/AdminPageBreadcrumbs.tsx
+++ b/apps/app/components/admin/navigation/AdminPageBreadcrumbs.tsx
@@ -6,17 +6,13 @@ import { KnownPages } from '../../../src/KnownPages';
 import {
     AdminBreadcrumbLevelSelector,
     resolveCurrentTopLevel,
-    shouldUseInlineBreadcrumbs,
 } from './AdminBreadcrumbLevelSelector';
 import { adminBreadcrumbPages } from './adminPages';
 
 export function AdminPageBreadcrumbs() {
     const pathname = usePathname();
 
-    if (
-        !pathname.startsWith('/admin') ||
-        shouldUseInlineBreadcrumbs(pathname)
-    ) {
+    if (!pathname.startsWith('/admin')) {
         return null;
     }
 

--- a/apps/app/components/admin/navigation/AdminPageCardHeader.tsx
+++ b/apps/app/components/admin/navigation/AdminPageCardHeader.tsx
@@ -1,28 +1,35 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { shouldUseInlineBreadcrumbs } from './AdminBreadcrumbLevelSelector';
 import { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
+import { useAdminPageHeaderContext } from './AdminPageHeaderContext';
 import { DesktopNavToggle } from './DesktopNavToggle';
 import { MobileNav } from './MobileNav';
 
 export function AdminPageCardHeader() {
     const pathname = usePathname();
-    const showBreadcrumbs =
-        pathname.startsWith('/admin') && !shouldUseInlineBreadcrumbs(pathname);
+    const { activeHeaderId, setSlotElement } = useAdminPageHeaderContext();
+    const showHeaderContent = pathname.startsWith('/admin');
 
     return (
         <div className="mb-4 flex min-h-9 items-center gap-2">
             <MobileNav />
             <DesktopNavToggle />
-            {showBreadcrumbs && (
+            {showHeaderContent && (
                 <>
                     <div
                         className="h-4 w-px shrink-0 bg-border"
                         aria-hidden="true"
                     />
-                    <div className="min-w-0 flex-1 overflow-hidden">
-                        <AdminPageBreadcrumbs />
+                    <div
+                        className="flex min-w-0 flex-1 items-center justify-between gap-2 overflow-hidden"
+                        ref={setSlotElement}
+                    >
+                        {!activeHeaderId && (
+                            <div className="min-w-0 overflow-hidden">
+                                <AdminPageBreadcrumbs />
+                            </div>
+                        )}
                     </div>
                 </>
             )}

--- a/apps/app/components/admin/navigation/AdminPageHeader.tsx
+++ b/apps/app/components/admin/navigation/AdminPageHeader.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { type ReactNode, useEffect, useId } from 'react';
+import { createPortal } from 'react-dom';
+import { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
+import { useAdminPageHeaderContext } from './AdminPageHeaderContext';
+
+export type AdminPageHeaderProps = {
+    breadcrumbs?: ReactNode;
+    actions?: ReactNode;
+    heading?: ReactNode;
+};
+
+export function AdminPageHeader({
+    breadcrumbs,
+    actions,
+    heading,
+}: AdminPageHeaderProps) {
+    const id = useId();
+    const { setActiveHeaderId, slotElement } = useAdminPageHeaderContext();
+
+    useEffect(() => {
+        setActiveHeaderId(id);
+
+        return () => {
+            setActiveHeaderId((currentHeaderId) =>
+                currentHeaderId === id ? null : currentHeaderId,
+            );
+        };
+    }, [id, setActiveHeaderId]);
+
+    if (!slotElement) {
+        return null;
+    }
+
+    return createPortal(
+        <>
+            {heading && <h1 className="sr-only">{heading}</h1>}
+            <div className="min-w-0 overflow-hidden">
+                {breadcrumbs ?? <AdminPageBreadcrumbs />}
+            </div>
+            {actions && (
+                <div className="flex min-w-0 items-center gap-2 overflow-x-auto">
+                    {actions}
+                </div>
+            )}
+        </>,
+        slotElement,
+    );
+}

--- a/apps/app/components/admin/navigation/AdminPageHeaderContext.ts
+++ b/apps/app/components/admin/navigation/AdminPageHeaderContext.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import {
+    createContext,
+    type Dispatch,
+    type SetStateAction,
+    useContext,
+} from 'react';
+
+type AdminPageHeaderContextValue = {
+    activeHeaderId: string | null;
+    setActiveHeaderId: Dispatch<SetStateAction<string | null>>;
+    slotElement: HTMLDivElement | null;
+    setSlotElement: Dispatch<SetStateAction<HTMLDivElement | null>>;
+};
+
+export const AdminPageHeaderContext =
+    createContext<AdminPageHeaderContextValue | null>(null);
+
+export function useAdminPageHeaderContext() {
+    const context = useContext(AdminPageHeaderContext);
+    if (!context) {
+        throw new Error(
+            'useAdminPageHeaderContext must be used within AdminPageHeaderProvider',
+        );
+    }
+
+    return context;
+}

--- a/apps/app/components/admin/navigation/AdminPageHeaderProvider.tsx
+++ b/apps/app/components/admin/navigation/AdminPageHeaderProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { type PropsWithChildren, useState } from 'react';
+import { AdminPageHeaderContext } from './AdminPageHeaderContext';
+
+export function AdminPageHeaderProvider({ children }: PropsWithChildren) {
+    const [activeHeaderId, setActiveHeaderId] = useState<string | null>(null);
+    const [slotElement, setSlotElement] = useState<HTMLDivElement | null>(null);
+
+    return (
+        <AdminPageHeaderContext.Provider
+            value={{
+                activeHeaderId,
+                setActiveHeaderId,
+                slotElement,
+                setSlotElement,
+            }}
+        >
+            {children}
+        </AdminPageHeaderContext.Provider>
+    );
+}

--- a/apps/app/components/admin/navigation/adminRouteTitle.ts
+++ b/apps/app/components/admin/navigation/adminRouteTitle.ts
@@ -1,23 +1,20 @@
 import { adminBreadcrumbPages } from './adminPages';
 import type { NavContextType } from './NavContext';
 
-const idRouteTitles = [
-    { pattern: /^\/admin\/accounts\/([^/]+)$/, prefix: 'Račun' },
-    {
-        pattern: /^\/admin\/communication\/emails\/([^/]+)$/,
-        prefix: 'Email',
-    },
-    { pattern: /^\/admin\/farms\/([^/]+)$/, prefix: 'Farma' },
-    { pattern: /^\/admin\/gardens\/([^/]+)$/, prefix: 'Vrt' },
-    { pattern: /^\/admin\/inventory\/([^/]+)$/, prefix: 'Zaliha' },
-    { pattern: /^\/admin\/invoices\/([^/]+)$/, prefix: 'Ponuda' },
-    { pattern: /^\/admin\/operations\/([^/]+)$/, prefix: 'Radnja' },
-    { pattern: /^\/admin\/raised-beds\/([^/]+)$/, prefix: 'Gredica' },
-    { pattern: /^\/admin\/receipts\/([^/]+)$/, prefix: 'Fiskalni račun' },
-    { pattern: /^\/admin\/shopping-carts\/([^/]+)$/, prefix: 'Košarica' },
-    { pattern: /^\/admin\/transactions\/([^/]+)$/, prefix: 'Transakcija' },
-    { pattern: /^\/admin\/users\/([^/]+)$/, prefix: 'Korisnik' },
-];
+const idRouteTitlePrefixes = new Map([
+    ['/admin/accounts', 'Račun'],
+    ['/admin/communication/emails', 'Email'],
+    ['/admin/farms', 'Farma'],
+    ['/admin/gardens', 'Vrt'],
+    ['/admin/inventory', 'Zaliha'],
+    ['/admin/invoices', 'Ponuda'],
+    ['/admin/operations', 'Radnja'],
+    ['/admin/raised-beds', 'Gredica'],
+    ['/admin/receipts', 'Fiskalni račun'],
+    ['/admin/shopping-carts', 'Košarica'],
+    ['/admin/transactions', 'Transakcija'],
+    ['/admin/users', 'Korisnik'],
+]);
 
 function decodePathSegment(segment: string) {
     try {
@@ -187,10 +184,13 @@ export function resolveAdminRouteTitle(
         return invoiceTitle;
     }
 
-    for (const routeTitle of idRouteTitles) {
-        const match = pathname.match(routeTitle.pattern);
-        if (match?.[1]) {
-            return `${routeTitle.prefix} ${decodePathSegment(match[1])}`;
+    const idSeparatorIndex = pathname.lastIndexOf('/');
+    if (idSeparatorIndex > 0) {
+        const routePrefix = pathname.slice(0, idSeparatorIndex);
+        const routeId = pathname.slice(idSeparatorIndex + 1);
+        const titlePrefix = idRouteTitlePrefixes.get(routePrefix);
+        if (titlePrefix && routeId) {
+            return `${titlePrefix} ${decodePathSegment(routeId)}`;
         }
     }
 

--- a/apps/app/components/admin/navigation/adminRouteTitle.ts
+++ b/apps/app/components/admin/navigation/adminRouteTitle.ts
@@ -20,6 +20,7 @@ function decodePathSegment(segment: string) {
     try {
         return decodeURIComponent(segment);
     } catch {
+        // Keep malformed path segments readable instead of failing title updates.
         return segment;
     }
 }
@@ -102,6 +103,7 @@ function resolveDirectoryTitle(
     }
 
     if (/^[^/]+$/.test(suffix)) {
+        // Directory entity detail routes use a single entity id after the entity type.
         return `${entityTypeLabel} ${decodePathSegment(suffix)}`;
     }
 

--- a/apps/app/components/admin/navigation/index.ts
+++ b/apps/app/components/admin/navigation/index.ts
@@ -1,5 +1,7 @@
 export { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 export { AdminPageCardHeader } from './AdminPageCardHeader';
+export { AdminPageHeader } from './AdminPageHeader';
+export { AdminPageHeaderProvider } from './AdminPageHeaderProvider';
 export { DesktopNav } from './DesktopNav';
 export { DesktopNavProvider } from './DesktopNavProvider';
 export { DesktopNavToggle } from './DesktopNavToggle';


### PR DESCRIPTION
## Summary
- Added a shared admin page header slot so page-specific breadcrumbs, headings, and first-line actions render next to the nav toggle
- Removed the old inline breadcrumb exclusion behavior and updated admin routes to use the shared header pattern
- Moved the affected detail/create/edit pages, plus directory entity views, inventory, invoices, operations, receipts, users, and delivery slots, into the shared header flow

## Testing
- `pnpm --filter app lint` passed; remaining warnings are unrelated pre-existing unused imports elsewhere in the app
- `pnpm --filter app build` passed
- Local TypeScript no-emit check was attempted, but it surfaces pre-existing unrelated repo errors outside this change