### PR TITLE
Enable system color-scheme switching in app (next-themes + prefers-color-scheme)

### DIFF
--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -1,32 +1,16 @@
 @import "@signalco/ui-themes-minimal-app/styles";
 
 :root {
-    color-scheme: dark;
-    --background: 0 0% 5%;
-    --foreground: 0 0% 100%;
-    --muted: 0 0% 14%;
-    --muted-foreground: 0 0% 72%;
-    --popover: 0 0% 8%;
-    --popover-foreground: 0 0% 100%;
-    --card: 0 0% 13%;
-    --card-transparent: 0 0% 5%;
-    --card-foreground: 0 0% 100%;
-    --border: 0 0% 22%;
-    --input: 0 0% 22%;
-    --primary: 0 0% 100%;
-    --primary-foreground: 0 0% 5%;
-    --secondary: 0 0% 15%;
-    --secondary-foreground: 0 0% 92%;
-    --tertiary: 0 0% 18%;
-    --tertiary-foreground: 0 0% 66%;
-    --accent: 0 0% 20%;
-    --accent-foreground: 0 0% 100%;
-    --ring: 0 0% 72%;
-    --bg-selection: #fff;
-    --text-selection: #000;
+    color-scheme: light;
     scrollbar-width: thin;
     scrollbar-color: color-mix(in srgb, currentColor 20%, transparent)
         transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        color-scheme: dark;
+    }
 }
 
 *::-webkit-scrollbar {

--- a/apps/app/components/providers/ClientAppProvider.tsx
+++ b/apps/app/components/providers/ClientAppProvider.tsx
@@ -9,7 +9,9 @@ export const queryClient = new QueryClient();
 export function ClientAppProvider({ children }: PropsWithChildren) {
     return (
         <QueryClientProvider client={queryClient}>
-            <ThemeProvider attribute="class">{children}</ThemeProvider>
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+                {children}
+            </ThemeProvider>
         </QueryClientProvider>
     );
 }


### PR DESCRIPTION
### Motivation
- The app was forcing a dark color scheme in CSS which prevented following the browser/OS preference.  
- The goal is to let the app automatically switch between light and dark based on the user's system preference.

### Description
- Configure `next-themes` in `apps/app/components/providers/ClientAppProvider.tsx` with `defaultTheme="system"` and `enableSystem` so the client follows system/browser preferences.  
- Replace the hardcoded dark token overrides in `apps/app/app/globals.css` with a default `color-scheme: light;` and a `@media (prefers-color-scheme: dark)` rule that sets `color-scheme: dark;`.  
- Remove the explicit dark-mode variable block so the theme is driven by the system preference while preserving custom scrollbar styling.  
- Changes affect `apps/app/components/providers/ClientAppProvider.tsx` and `apps/app/app/globals.css`.

### Testing
- Ran the workspace lint for the app with `pnpm --dir apps/app lint`, which completed successfully and auto-fixed one file; lint reported 4 remaining warnings.  
- No unit or integration tests were changed or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91366fd50832f9a30e92810a634ec)