### PR TITLE
fix(app): use ellipsis (...) icon for Ostali category

### DIFF
--- a/apps/app/app/admin/settings/page.tsx
+++ b/apps/app/app/admin/settings/page.tsx
@@ -172,7 +172,11 @@ export default async function SettingsPage() {
                                                         >
                                                             <EntityTypeIcon
                                                                 icon={
-                                                                    category.icon
+                                                                    category.icon ??
+                                                                    (category.label ===
+                                                                    'Ostali'
+                                                                        ? 'MoreHorizontal'
+                                                                        : undefined)
                                                                 }
                                                                 className="size-4"
                                                             />


### PR DESCRIPTION
### Motivation
- Entity category cards were falling back to the generic `File` icon when no icon was defined, but the special category labeled `Ostali` should show an ellipsis (`...`) icon instead.

### Description
- Updated `apps/app/app/admin/settings/page.tsx` to pass `category.icon ?? (category.label === 'Ostali' ? 'MoreHorizontal' : undefined)` into `EntityTypeIcon`, so `Ostali` uses the `MoreHorizontal` icon while all other categories keep the existing fallback behavior.

### Testing
- Ran `pnpm --filter app lint` and it completed successfully; existing unrelated warnings about unused imports were present but unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92dad1614832fab6606e68fb54405)