### PR TITLE
fix(app): use configured category icons in Zapisi nav

### DIFF
--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -237,7 +237,12 @@ export function Nav({
                         <NavGroup
                             key={category.id}
                             label={category.label}
-                            icon={<File className="size-5" />}
+                            icon={
+                                <EntityTypeIcon
+                                    icon={category.icon}
+                                    className="size-5"
+                                />
+                            }
                             forceOpen={category.entityTypes.some((entityType) =>
                                 isSelectedPath(
                                     pathname,


### PR DESCRIPTION
### Motivation
- The "Zapisi" navigation groups always rendered the default `File` icon instead of the icon configured per category, preventing assigned icons from settings from appearing in the nav.

### Description
- Replace the hardcoded `File` icon with `<EntityTypeIcon icon={category.icon} className="size-5" />` in `apps/app/components/admin/navigation/Nav.tsx` so category groups render their configured icons while preserving `EntityTypeIcon`'s fallback behavior.

### Testing
- Ran `pnpm --filter app lint` which completed successfully; `biome` reported 4 existing unused-import warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a58af6c8832f9bf278aa750550f9)