### PR TITLE
Make entity table header buttons full-width and enable label truncation

### DIFF
--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -118,11 +118,13 @@ export function EntitiesTable({
             >
                 <button
                     type="button"
-                    className="flex items-center gap-1 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
+                    className="flex w-full min-w-0 items-center gap-1 text-left font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
                     onClick={() => handleSort(key)}
                     aria-label={`Sortiraj ${label.toLowerCase()}`}
                 >
-                    <span>{label}</span>
+                    <span className="block min-w-0 flex-1 truncate">
+                        {label}
+                    </span>
                     {isSorted && (
                         <>
                             <span aria-hidden>


### PR DESCRIPTION
### Motivation
- Prevent header labels from overflowing and improve responsive layout alignment by allowing header buttons to take full width and truncate long labels.

### Description
- Add `w-full min-w-0` to the header button and wrap the label in a `span` with `block min-w-0 flex-1 truncate` so column headers truncate cleanly without breaking layout while preserving sort indicators and ARIA attributes.

### Testing
- Ran unit tests and linting (`yarn test` and `yarn lint`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f786ccdc832f8c4a79d479661468)