### PR TITLE
Remove user count badge from admin users page

### DIFF
--- a/apps/app/app/admin/users/page.tsx
+++ b/apps/app/app/admin/users/page.tsx
@@ -1,8 +1,6 @@
 import { getUsers } from '@gredice/storage';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
-import { Chip } from '@signalco/ui-primitives/Chip';
-import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Table } from '@signalco/ui-primitives/Table';
 import Link from 'next/link';
@@ -52,10 +50,6 @@ export default async function UsersPage({
 
     return (
         <Stack spacing={2}>
-            <Row spacing={1}>
-                <Chip color="primary">{filteredUsers.length}</Chip>
-            </Row>
-
             <UsersFilters />
 
             <Card>


### PR DESCRIPTION
### Motivation
- Remove the users-count badge from the admin Users page because the numeric chip provides little value and adds visual clutter.

### Description
- Deleted the top `Row` / `Chip` block and removed the now-unused `Chip` and `Row` imports in `apps/app/app/admin/users/page.tsx`.
- The page now renders `UsersFilters` followed directly by the users `Table` without the count badge.

### Testing
- Ran `pnpm --filter app lint` which completed successfully and reported only pre-existing unrelated warnings in other files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb717a00832f97c3696d82cba4ca)