### PR TITLE
Show compact inventory status on inventory overview cards

### DIFF
--- a/apps/app/app/admin/inventory/[inventoryId]/InventoryStatusProgress.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/InventoryStatusProgress.tsx
@@ -6,6 +6,7 @@ type InventoryStatusProgressProps = {
         lowCountThreshold: number | null;
     }[];
     defaultLowCountThreshold: number | null;
+    compact?: boolean;
 };
 
 function formatItemsCount(count: number) {
@@ -45,6 +46,7 @@ function getInventoryStatusCounts({
 export function InventoryStatusProgress({
     items,
     defaultLowCountThreshold,
+    compact = false,
 }: InventoryStatusProgressProps) {
     const counts = getInventoryStatusCounts({
         items,
@@ -76,9 +78,9 @@ export function InventoryStatusProgress({
     ];
 
     return (
-        <div className="space-y-3">
+        <div className={compact ? undefined : 'space-y-3'}>
             <div
-                className="flex h-3 overflow-hidden rounded-full bg-muted"
+                className={`flex overflow-hidden rounded-full bg-muted ${compact ? 'h-2' : 'h-3'}`}
                 aria-label={`Status zalihe: ${statuses
                     .map((status) => `${status.label} ${status.count}`)
                     .join(', ')}`}
@@ -101,39 +103,41 @@ export function InventoryStatusProgress({
                 })}
             </div>
 
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                {statuses.map((status) => {
-                    const percentage =
-                        totalItems > 0
-                            ? Math.round((status.count / totalItems) * 100)
-                            : 0;
+            {!compact && (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    {statuses.map((status) => {
+                        const percentage =
+                            totalItems > 0
+                                ? Math.round((status.count / totalItems) * 100)
+                                : 0;
 
-                    return (
-                        <div key={status.label} className="space-y-1">
-                            <div className="flex items-center gap-2">
-                                <span
-                                    className={`size-2 rounded-full ${status.dotClassName}`}
-                                    aria-hidden
-                                />
-                                <Typography level="body2" semiBold>
-                                    {status.label}
-                                </Typography>
-                            </div>
-                            <div className="flex items-baseline gap-2">
-                                <Typography level="body1" semiBold>
-                                    {status.count}
-                                </Typography>
+                        return (
+                            <div key={status.label} className="space-y-1">
+                                <div className="flex items-center gap-2">
+                                    <span
+                                        className={`size-2 rounded-full ${status.dotClassName}`}
+                                        aria-hidden
+                                    />
+                                    <Typography level="body2" semiBold>
+                                        {status.label}
+                                    </Typography>
+                                </div>
+                                <div className="flex items-baseline gap-2">
+                                    <Typography level="body1" semiBold>
+                                        {status.count}
+                                    </Typography>
+                                    <Typography level="body2" secondary>
+                                        {percentage}%
+                                    </Typography>
+                                </div>
                                 <Typography level="body2" secondary>
-                                    {percentage}%
+                                    {status.description}
                                 </Typography>
                             </div>
-                            <Typography level="body2" secondary>
-                                {status.description}
-                            </Typography>
-                        </div>
-                    );
-                })}
-            </div>
+                        );
+                    })}
+                </div>
+            )}
         </div>
     );
 }

--- a/apps/app/app/admin/inventory/page.tsx
+++ b/apps/app/app/admin/inventory/page.tsx
@@ -1,6 +1,6 @@
 import {
     getInventoryConfigs,
-    getInventoryItemsByConfig,
+    getInventoryStatusItemsByConfigIds,
 } from '@gredice/storage';
 import { Add, File } from '@signalco/ui-icons';
 import {
@@ -24,18 +24,19 @@ export default async function InventoryPage() {
     await auth(['admin']);
 
     const configs = await getInventoryConfigs();
-    const configItems = await Promise.all(
-        configs.map(async (config) => ({
-            configId: config.id,
-            items: await getInventoryItemsByConfig(config.id),
-        })),
+    const configIds = configs.map((config) => config.id);
+    const statusItems = await getInventoryStatusItemsByConfigIds(configIds);
+    const itemsByConfigId = new Map<number, typeof statusItems>(
+        configIds.map((configId) => [configId, []]),
     );
-    const itemsByConfigId = new Map(
-        configItems.map((configItem) => [
-            configItem.configId,
-            configItem.items,
-        ]),
-    );
+
+    for (const statusItem of statusItems) {
+        const configItems = itemsByConfigId.get(statusItem.inventoryConfigId);
+
+        if (configItems) {
+            configItems.push(statusItem);
+        }
+    }
 
     return (
         <Stack spacing={2}>

--- a/apps/app/app/admin/inventory/page.tsx
+++ b/apps/app/app/admin/inventory/page.tsx
@@ -1,4 +1,7 @@
-import { getInventoryConfigs } from '@gredice/storage';
+import {
+    getInventoryConfigs,
+    getInventoryItemsByConfig,
+} from '@gredice/storage';
 import { Add, File } from '@signalco/ui-icons';
 import {
     Card,
@@ -13,6 +16,7 @@ import Link from 'next/link';
 import { AdminPageHeader } from '../../../components/admin/navigation';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
+import { InventoryStatusProgress } from './[inventoryId]/InventoryStatusProgress';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,6 +24,18 @@ export default async function InventoryPage() {
     await auth(['admin']);
 
     const configs = await getInventoryConfigs();
+    const configItems = await Promise.all(
+        configs.map(async (config) => ({
+            configId: config.id,
+            items: await getInventoryItemsByConfig(config.id),
+        })),
+    );
+    const itemsByConfigId = new Map(
+        configItems.map((configItem) => [
+            configItem.configId,
+            configItem.items,
+        ]),
+    );
 
     return (
         <Stack spacing={2}>
@@ -61,24 +77,21 @@ export default async function InventoryPage() {
                                     <CardTitle>{config.label}</CardTitle>
                                 </CardHeader>
                                 <CardContent>
-                                    <Stack spacing={1}>
+                                    <Stack spacing={1.5}>
                                         <Typography level="body2" secondary>
-                                            Tip entiteta:{' '}
-                                            {config.entityTypeName}
+                                            Stanje zalihe
                                         </Typography>
-                                        <Typography level="body2" secondary>
-                                            Praćenje:{' '}
-                                            {config.defaultTrackingType ===
-                                            'pieces'
-                                                ? 'Komadi'
-                                                : 'Serijski broj'}
-                                        </Typography>
-                                        {config.fieldDefinitions.length > 0 && (
-                                            <Typography level="body2" secondary>
-                                                Dodatna polja:{' '}
-                                                {config.fieldDefinitions.length}
-                                            </Typography>
-                                        )}
+                                        <InventoryStatusProgress
+                                            items={
+                                                itemsByConfigId.get(
+                                                    config.id,
+                                                ) ?? []
+                                            }
+                                            defaultLowCountThreshold={
+                                                config.lowCountThreshold
+                                            }
+                                            compact
+                                        />
                                     </Stack>
                                 </CardContent>
                             </Card>

--- a/packages/storage/src/repositories/inventoryManagementRepo.ts
+++ b/packages/storage/src/repositories/inventoryManagementRepo.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import {
     type InsertInventoryConfig,
     type InsertInventoryItem,
@@ -149,6 +149,26 @@ export async function getInventoryItemsByConfig(inventoryConfigId: number) {
         with: {
             entity: true,
         },
+    });
+}
+
+export async function getInventoryStatusItemsByConfigIds(
+    inventoryConfigIds: number[],
+) {
+    if (inventoryConfigIds.length === 0) {
+        return [];
+    }
+
+    return storage().query.inventoryItems.findMany({
+        columns: {
+            inventoryConfigId: true,
+            quantity: true,
+            lowCountThreshold: true,
+        },
+        where: and(
+            inArray(inventoryItems.inventoryConfigId, inventoryConfigIds),
+            eq(inventoryItems.isDeleted, false),
+        ),
     });
 }
 


### PR DESCRIPTION
### Motivation
- Reduce clutter on the inventory overview by removing entity type, tracking type and custom field count and surface a quick status summary instead.
- Reuse the existing inventory status visualization from the inventory detail page to keep UI consistent while preserving the inventory config name.

### Description
- Added an optional `compact` prop to `InventoryStatusProgress` to render a smaller bar-only summary without the legend (`apps/app/app/admin/inventory/[inventoryId]/InventoryStatusProgress.tsx`).
- Loaded inventory items for each config on the inventory overview and passed them to the new compact progress view (`getInventoryItemsByConfig` + mapping in `apps/app/app/admin/inventory/page.tsx`).
- Replaced the previous metadata block (entity type, tracking type, custom field count) on each inventory card with the compact `InventoryStatusProgress` rendering the per-config status distribution (`apps/app/app/admin/inventory/page.tsx`).

### Testing
- Ran `pnpm --filter app lint` which completed successfully; Biome reported unrelated warnings in other files and auto-fixed formatting in touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fc32d00c832f8259587e521c6d54)