### PR TITLE
Extract TableFilter into shared `@gredice/ui` package and update app usage

### DIFF
--- a/apps/app/components/shared/filters/TableFilter.tsx
+++ b/apps/app/components/shared/filters/TableFilter.tsx
@@ -1,58 +1,26 @@
 'use client';
 
-import { Calendar, Close, Filter } from '@signalco/ui-icons';
-import { Button } from '@signalco/ui-primitives/Button';
-import { Chip } from '@signalco/ui-primitives/Chip';
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from '@signalco/ui-primitives/Menu';
-import { Row } from '@signalco/ui-primitives/Row';
+    type TableFilterProps as BaseTableFilterProps,
+    type FilterOption,
+    TIME_FILTER_OPTIONS,
+    TableFilter as UiTableFilter,
+} from '@gredice/ui/TableFilter';
 import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 
-export interface FilterOption {
-    key: string;
-    label: string;
-    icon?: React.ReactNode;
-    options: Array<{
-        value: string;
-        label: string;
-        icon?: React.ReactNode;
-    }>;
-}
+export type { FilterOption };
+export { TIME_FILTER_OPTIONS };
 
-export interface TableFilterProps {
-    filters: FilterOption[];
+export interface TableFilterProps
+    extends Omit<
+        BaseTableFilterProps,
+        'currentFilters' | 'onFilterChange' | 'onClearAll'
+    > {
     defaultValues?: Record<string, string>;
     onFiltersChange?: (filters: Record<string, string>) => void;
-    className?: string;
 }
-
-// Predefined time filter options for easy reuse
-export const TIME_FILTER_OPTIONS: FilterOption = {
-    key: 'from',
-    label: 'Vremenski period',
-    icon: <Calendar className="size-4" />,
-    options: [
-        { value: '', label: 'Sve vrijeme' },
-        { value: 'today', label: 'Danas' },
-        { value: 'yesterday', label: 'Jučer' },
-        { value: 'last-7-days', label: 'Zadnjih 7 dana' },
-        { value: 'last-14-days', label: 'Zadnjih 14 dana' },
-        { value: 'last-30-days', label: 'Zadnjih 30 dana' },
-        { value: 'last-90-days', label: 'Zadnjih 90 dana' },
-        { value: 'this-month', label: 'Ovaj mjesec' },
-        { value: 'last-month', label: 'Prošli mjesec' },
-        { value: 'this-year', label: 'Ova godina' },
-        { value: 'last-year', label: 'Prošla godina' },
-    ],
-};
 
 export function TableFilter({
     filters,
@@ -64,7 +32,6 @@ export function TableFilter({
     const searchParams = useSearchParams();
     const pathname = usePathname();
 
-    // Get current filter values from URL or defaults
     const currentFilters = useMemo(() => {
         const filtersObj: Record<string, string> = {};
         filters.forEach((filter) => {
@@ -77,16 +44,10 @@ export function TableFilter({
         return filtersObj;
     }, [searchParams, filters, defaultValues]);
 
-    // Get active filter count for display
-    const activeFilterCount =
-        Object.values(currentFilters).filter(Boolean).length;
-
-    // Update URL and notify parent component
     const updateFilters = useCallback(
         (key: string, value: string) => {
-            // Update URL
             const params = new URLSearchParams(searchParams.toString());
-            if (value && value !== 'all' && value !== '') {
+            if (value && value !== 'all') {
                 params.set(key, value);
             } else {
                 params.delete(key);
@@ -95,16 +56,11 @@ export function TableFilter({
             const query = params.toString();
             router.push(`${pathname}${query ? `?${query}` : ''}` as Route);
 
-            // Notify parent component with new filters
             const newFilters: Record<string, string> = {};
-            filters.forEach((filter) => {
+            filters.forEach((filter: FilterOption) => {
                 const filterValue =
                     key === filter.key ? value : searchParams.get(filter.key);
-                if (
-                    filterValue &&
-                    filterValue !== 'all' &&
-                    filterValue !== ''
-                ) {
+                if (filterValue && filterValue !== 'all') {
                     newFilters[filter.key] = filterValue;
                 }
             });
@@ -113,126 +69,18 @@ export function TableFilter({
         [searchParams, router, pathname, onFiltersChange, filters],
     );
 
-    // Clear all filters
     const clearAllFilters = useCallback(() => {
         router.push(pathname as Route);
         onFiltersChange?.({});
     }, [router, onFiltersChange, pathname]);
 
-    // Get label for filter option
-    const getOptionLabel = (filter: FilterOption, value: string) => {
-        const option = filter.options.find((opt) => opt.value === value);
-        return option?.label || value;
-    };
-
     return (
-        <div className={className}>
-            <Row spacing={2} className="items-center flex-wrap">
-                {/* Notion-style Filters Button */}
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="outlined"
-                            size="sm"
-                            startDecorator={
-                                <Filter className="size-4 shrink-0" />
-                            }
-                            className="relative rounded-full"
-                        >
-                            {activeFilterCount > 0 && (
-                                <Chip
-                                    size="sm"
-                                    color="info"
-                                    className="ml-2 px-1.5 py-0.5 text-xs min-w-fit"
-                                >
-                                    {activeFilterCount}
-                                </Chip>
-                            )}
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-64">
-                        <DropdownMenuLabel>Filtriraj po</DropdownMenuLabel>
-                        <DropdownMenuSeparator />
-
-                        {/* Filter Categories - Flat Structure */}
-                        {filters.map((filter) => (
-                            <div key={filter.key}>
-                                <DropdownMenuLabel className="text-xs text-muted-foreground px-3 py-1 flex items-center gap-2">
-                                    {filter.icon}
-                                    {filter.label}
-                                </DropdownMenuLabel>
-                                {filter.options.map((option) => (
-                                    <DropdownMenuItem
-                                        key={`${filter.key}-${option.value}`}
-                                        onClick={() =>
-                                            updateFilters(
-                                                filter.key,
-                                                option.value,
-                                            )
-                                        }
-                                        className="justify-between cursor-pointer pl-6"
-                                    >
-                                        <Row
-                                            spacing={2}
-                                            className="items-center"
-                                        >
-                                            {option.icon}
-                                            <span>{option.label}</span>
-                                        </Row>
-                                        {currentFilters[filter.key] ===
-                                            option.value && (
-                                            <div className="w-2 h-2 bg-primary rounded-full" />
-                                        )}
-                                    </DropdownMenuItem>
-                                ))}
-                                {/* Separator between filter groups, except for last */}
-                                {filters.indexOf(filter) <
-                                    filters.length - 1 && (
-                                    <DropdownMenuSeparator />
-                                )}
-                            </div>
-                        ))}
-
-                        {/* Clear All Option */}
-                        {activeFilterCount > 0 && (
-                            <>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                    onClick={clearAllFilters}
-                                    className="text-destructive cursor-pointer"
-                                >
-                                    <Close className="size-4 mr-2" />
-                                    Očisti sve filtere
-                                </DropdownMenuItem>
-                            </>
-                        )}
-                    </DropdownMenuContent>
-                </DropdownMenu>
-
-                {/* Active Filter Chips */}
-                {Object.entries(currentFilters).map(([key, value]) => {
-                    const filter = filters.find((f) => f.key === key);
-                    if (!filter) return null;
-
-                    return (
-                        <Chip
-                            key={key}
-                            color="neutral"
-                            size="sm"
-                            onClick={() => updateFilters(key, '')}
-                        >
-                            <Row spacing={1} className="items-center">
-                                {filter.icon}
-                                <span>
-                                    {filter.label}:{' '}
-                                    {getOptionLabel(filter, value)}
-                                </span>
-                                <Close className="size-3" />
-                            </Row>
-                        </Chip>
-                    );
-                })}
-            </Row>
-        </div>
+        <UiTableFilter
+            filters={filters}
+            currentFilters={currentFilters}
+            onFilterChange={updateFilters}
+            onClearAll={clearAllFilters}
+            className={className}
+        />
     );
 }

--- a/apps/app/components/shared/filters/index.ts
+++ b/apps/app/components/shared/filters/index.ts
@@ -1,2 +1,2 @@
-export { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
+export { getDateFromTimeFilter } from '@gredice/ui/TableFilter';
 export * from './TableFilter';

--- a/apps/storybook/stories/packages/ui/TableFilter.stories.tsx
+++ b/apps/storybook/stories/packages/ui/TableFilter.stories.tsx
@@ -1,0 +1,90 @@
+import {
+    type FilterOption,
+    TableFilter,
+    TIME_FILTER_OPTIONS,
+} from '@gredice/ui/TableFilter';
+import { Filter, User } from '@signalco/ui-icons';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useMemo, useState } from 'react';
+
+function ControlledTableFilter({ filters }: { filters: FilterOption[] }) {
+    const [currentFilters, setCurrentFilters] = useState<
+        Record<string, string>
+    >({});
+
+    const onFilterChange = (key: string, value: string) => {
+        setCurrentFilters((prev) => {
+            if (!value || value === 'all') {
+                const next = { ...prev };
+                delete next[key];
+                return next;
+            }
+            return { ...prev, [key]: value };
+        });
+    };
+
+    const onClearAll = () => setCurrentFilters({});
+
+    const activeFiltersText = useMemo(
+        () => JSON.stringify(currentFilters, null, 2),
+        [currentFilters],
+    );
+
+    return (
+        <div className="space-y-4">
+            <TableFilter
+                filters={filters}
+                currentFilters={currentFilters}
+                onFilterChange={onFilterChange}
+                onClearAll={onClearAll}
+            />
+            <pre className="rounded-md border p-3 text-xs">
+                {activeFiltersText}
+            </pre>
+        </div>
+    );
+}
+
+const meta = {
+    title: 'packages/ui/TableFilter',
+    component: ControlledTableFilter,
+} satisfies Meta<typeof ControlledTableFilter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TimeOnly: Story = {
+    args: {
+        filters: [TIME_FILTER_OPTIONS],
+    },
+};
+
+export const MultipleFilters: Story = {
+    args: {
+        filters: [
+            TIME_FILTER_OPTIONS,
+            {
+                key: 'status',
+                label: 'Status',
+                icon: <Filter className="size-4" />,
+                options: [
+                    { value: '', label: 'Svi statusi' },
+                    { value: 'pending', label: 'Na čekanju' },
+                    { value: 'approved', label: 'Odobreno' },
+                    { value: 'archived', label: 'Arhivirano' },
+                ],
+            },
+            {
+                key: 'assignee',
+                label: 'Dodijeljeno',
+                icon: <User className="size-4" />,
+                options: [
+                    { value: '', label: 'Svi korisnici' },
+                    { value: '1', label: 'Ana' },
+                    { value: '2', label: 'Marko' },
+                    { value: '3', label: 'Petra' },
+                ],
+            },
+        ],
+    },
+};

--- a/packages/ui/src/TableFilter/TableFilter.tsx
+++ b/packages/ui/src/TableFilter/TableFilter.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { Calendar, Close, Filter } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Chip } from '@signalco/ui-primitives/Chip';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@signalco/ui-primitives/Menu';
+import { Row } from '@signalco/ui-primitives/Row';
+import type { ReactNode } from 'react';
+import { useCallback, useMemo } from 'react';
+
+export interface FilterOption {
+    key: string;
+    label: string;
+    icon?: ReactNode;
+    options: Array<{
+        value: string;
+        label: string;
+        icon?: ReactNode;
+    }>;
+}
+
+export interface TableFilterProps {
+    filters: FilterOption[];
+    currentFilters: Record<string, string>;
+    onFilterChange: (key: string, value: string) => void;
+    onClearAll: () => void;
+    className?: string;
+}
+
+export const TIME_FILTER_OPTIONS: FilterOption = {
+    key: 'from',
+    label: 'Vremenski period',
+    icon: <Calendar className="size-4" />,
+    options: [
+        { value: '', label: 'Sve vrijeme' },
+        { value: 'today', label: 'Danas' },
+        { value: 'yesterday', label: 'Jučer' },
+        { value: 'last-7-days', label: 'Zadnjih 7 dana' },
+        { value: 'last-14-days', label: 'Zadnjih 14 dana' },
+        { value: 'last-30-days', label: 'Zadnjih 30 dana' },
+        { value: 'last-90-days', label: 'Zadnjih 90 dana' },
+        { value: 'this-month', label: 'Ovaj mjesec' },
+        { value: 'last-month', label: 'Prošli mjesec' },
+        { value: 'this-year', label: 'Ova godina' },
+        { value: 'last-year', label: 'Prošla godina' },
+    ],
+};
+
+export function TableFilter({
+    filters,
+    currentFilters,
+    onFilterChange,
+    onClearAll,
+    className,
+}: TableFilterProps) {
+    const activeFilterCount = useMemo(
+        () => Object.values(currentFilters).filter(Boolean).length,
+        [currentFilters],
+    );
+
+    const getOptionLabel = useCallback(
+        (filter: FilterOption, value: string) => {
+            const option = filter.options.find((opt) => opt.value === value);
+            return option?.label || value;
+        },
+        [],
+    );
+
+    return (
+        <div className={className}>
+            <Row spacing={2} className="items-center flex-wrap">
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant="outlined"
+                            size="sm"
+                            startDecorator={
+                                <Filter className="size-4 shrink-0" />
+                            }
+                            className="relative rounded-full"
+                        >
+                            {activeFilterCount > 0 && (
+                                <Chip
+                                    size="sm"
+                                    color="info"
+                                    className="ml-2 px-1.5 py-0.5 text-xs min-w-fit"
+                                >
+                                    {activeFilterCount}
+                                </Chip>
+                            )}
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-64">
+                        <DropdownMenuLabel>Filtriraj po</DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+
+                        {filters.map((filter, filterIndex) => (
+                            <div key={filter.key}>
+                                <DropdownMenuLabel className="text-xs text-muted-foreground px-3 py-1 flex items-center gap-2">
+                                    {filter.icon}
+                                    {filter.label}
+                                </DropdownMenuLabel>
+                                {filter.options.map((option) => (
+                                    <DropdownMenuItem
+                                        key={`${filter.key}-${option.value}`}
+                                        onClick={() =>
+                                            onFilterChange(
+                                                filter.key,
+                                                option.value,
+                                            )
+                                        }
+                                        className="justify-between cursor-pointer pl-6"
+                                    >
+                                        <Row
+                                            spacing={2}
+                                            className="items-center"
+                                        >
+                                            {option.icon}
+                                            <span>{option.label}</span>
+                                        </Row>
+                                        {currentFilters[filter.key] ===
+                                            option.value && (
+                                            <div className="w-2 h-2 bg-primary rounded-full" />
+                                        )}
+                                    </DropdownMenuItem>
+                                ))}
+                                {filterIndex < filters.length - 1 && (
+                                    <DropdownMenuSeparator />
+                                )}
+                            </div>
+                        ))}
+
+                        {activeFilterCount > 0 && (
+                            <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                    onClick={onClearAll}
+                                    className="text-destructive cursor-pointer"
+                                >
+                                    <Close className="size-4 mr-2" />
+                                    Očisti sve filtere
+                                </DropdownMenuItem>
+                            </>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+
+                {Object.entries(currentFilters).map(([key, value]) => {
+                    const filter = filters.find((f) => f.key === key);
+                    if (!filter) return null;
+
+                    return (
+                        <Chip
+                            key={key}
+                            color="neutral"
+                            size="sm"
+                            onClick={() => onFilterChange(key, '')}
+                        >
+                            <Row spacing={1} className="items-center">
+                                {filter.icon}
+                                <span>
+                                    {filter.label}:{' '}
+                                    {getOptionLabel(filter, value)}
+                                </span>
+                                <Close className="size-3" />
+                            </Row>
+                        </Chip>
+                    );
+                })}
+            </Row>
+        </div>
+    );
+}

--- a/packages/ui/src/TableFilter/index.ts
+++ b/packages/ui/src/TableFilter/index.ts
@@ -1,0 +1,2 @@
+export * from './TableFilter';
+export { getDateFromTimeFilter } from './timeFilters';

--- a/packages/ui/src/TableFilter/timeFilters.ts
+++ b/packages/ui/src/TableFilter/timeFilters.ts
@@ -1,0 +1,33 @@
+/**
+ * Utility functions for handling time filters.
+ * Can be used in both server and client components.
+ */
+export function getDateFromTimeFilter(filterValue: string): Date | undefined {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    switch (filterValue) {
+        case 'today':
+            return today;
+        case 'yesterday':
+            return new Date(today.getTime() - 24 * 60 * 60 * 1000);
+        case 'last-7-days':
+            return new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+        case 'last-14-days':
+            return new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000);
+        case 'last-30-days':
+            return new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
+        case 'last-90-days':
+            return new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
+        case 'this-month':
+            return new Date(now.getFullYear(), now.getMonth(), 1);
+        case 'last-month':
+            return new Date(now.getFullYear(), now.getMonth() - 1, 1);
+        case 'this-year':
+            return new Date(now.getFullYear(), 0, 1);
+        case 'last-year':
+            return new Date(now.getFullYear() - 1, 0, 1);
+        default:
+            return undefined;
+    }
+}


### PR DESCRIPTION
### Motivation
- Consolidate the `TableFilter` UI and related time utilities into a shared UI package for reuse across apps.
- Provide a single source of truth for filter UI/logic and time filter helpers to reduce duplication.
- Simplify the app-level filter component to delegate rendering and presentation to the shared component.

### Description
- Added a new shared package component `TableFilter` (`packages/ui/src/TableFilter/TableFilter.tsx`) and exported it via `packages/ui/src/TableFilter/index.ts`.
- Implemented time utilities in `packages/ui/src/TableFilter/timeFilters.ts` and exported `getDateFromTimeFilter`; re-exported the utility from the app-level filters index to preserve existing import paths.
- Replaced the previous app-local `TableFilter` implementation with a thin wrapper that computes URL-derived `currentFilters` and delegates rendering to `@gredice/ui/TableFilter` while mapping callbacks (`onFilterChange` / `onClearAll`).
- Added Storybook stories for the shared `TableFilter` at `apps/storybook/stories/packages/ui/TableFilter.stories.tsx` to demonstrate controlled usage and multiple filter configurations.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fadae894832fb2dd7f93fedf5bfd)