### PR TITLE
Simplify raised bed cart info message

### DIFF
--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -207,8 +207,10 @@ export async function getCartInfo(
                   : 'biljke';
         const raisedBedsPlural =
             newRaisedBeds.length === 1 ? 'nove gredice' : 'novih gredica';
+        const raisedBedsLocation =
+            newRaisedBeds.length === 1 ? 'u ovoj gredici' : 'u novim gredicama';
         notes.push(
-            `${neededPlural} još ${missingItemsCount} ${plantPlural} u ovoj gredici za postavljanje ${raisedBedsPlural}.`,
+            `${neededPlural} još ${missingItemsCount} ${plantPlural} ${raisedBedsLocation} za postavljanje ${raisedBedsPlural}.`,
         );
         allowPurchase = false;
     }

--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -208,7 +208,7 @@ export async function getCartInfo(
         const raisedBedsPlural =
             newRaisedBeds.length === 1 ? 'nove gredice' : 'novih gredica';
         notes.push(
-            `${neededPlural} još ${missingItemsCount} ${plantPlural} u ovoj ili susjednoj gredici za postavljanje ${raisedBedsPlural}.`,
+            `${neededPlural} još ${missingItemsCount} ${plantPlural} u ovoj gredici za postavljanje ${raisedBedsPlural}.`,
         );
         allowPurchase = false;
     }


### PR DESCRIPTION
### Motivation
- Raised beds are no longer represented as two-part (current + neighboring), so user-facing cart text should reference only the current raised bed.

### Description
- Updated the missing-plants cart note in `apps/api/lib/checkout/cartInfo.ts` to remove the phrase "ili susjednoj gredici" and now read only "u ovoj gredici".

### Testing
- Ran `pnpm lint lib/checkout/cartInfo.ts` in `apps/api`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa14065084832f879c1a9f26092f12)