### PR TITLE
Update raised bed action text in game HUD

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -372,7 +372,7 @@ export function PlantPicker({
                                         <ShoppingCart className="shrink-0 size-5" />
                                     }
                                 >
-                                    Potvrdi sijanje
+                                    Dodaj u košaricu
                                 </Button>
                             </Row>
                         </Row>


### PR DESCRIPTION
### Motivation
- Replace `Potvrdi sijanje` with `Dodaj u košaricu` in the garden/game UI so the action reflects adding to the shopping cart.

### Description
- Updated the primary action label in `packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx` from `Potvrdi sijanje` to `Dodaj u košaricu`.

### Testing
- No automated tests were run because this is a text-only UI label change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7183e3c4832faeaf0f58a3a183d5)