### PR TITLE
Add account referral system (backend events + frontend UI)

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -12,6 +12,7 @@ import {
     getAccountInvitationByToken,
     getAccountInvitations,
     getAccountInvitationsByEmail,
+    getAccounts,
     getAccountUsers,
     getEvents,
     getRaisedBeds,
@@ -194,6 +195,25 @@ async function hasActiveRaisedBed(accountId: string) {
         if (raisedBeds.length > 0) return true;
     }
     return false;
+}
+
+async function findAccountIdByReferralCode(code: string) {
+    const accounts = await getAccounts();
+    for (const account of accounts) {
+        const events = await getEvents(
+            REFERRAL_EVENT_TYPE,
+            [account.id],
+            0,
+            1000,
+        );
+        for (let i = events.length - 1; i >= 0; i--) {
+            const data = events[i]?.data as Record<string, unknown> | null;
+            if (data?.action === 'code_set' && data.code === code) {
+                return account.id;
+            }
+        }
+    }
+    return null;
 }
 
 const app = new Hono<{ Variables: AuthVariables }>()
@@ -390,13 +410,24 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
 
+            const referredAccountId = await findAccountIdByReferralCode(code);
+            if (!referredAccountId) {
+                return context.json({ error: 'Referral kod ne postoji' }, 404);
+            }
+            if (referredAccountId === accountId) {
+                return context.json(
+                    { error: 'Ne možete koristiti vlastiti referral kod' },
+                    400,
+                );
+            }
+
             await createEvent({
                 type: REFERRAL_EVENT_TYPE,
                 version: 1,
                 aggregateId: accountId,
-                data: { action: 'used_code', code },
+                data: { action: 'used_code', code, referredAccountId },
             });
-            return context.json({ ok: true });
+            return context.json({ ok: true, referredAccountId });
         },
     )
 

--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -3,14 +3,18 @@ import {
     acceptAccountInvitation,
     cancelAccountInvitation,
     createAccountInvitation,
+    createEvent,
     deleteAccountWithDependencies,
     earnSunflowers,
     getAccount,
     getAccountAchievements,
+    getAccountGardens,
     getAccountInvitationByToken,
     getAccountInvitations,
     getAccountInvitationsByEmail,
     getAccountUsers,
+    getEvents,
+    getRaisedBeds,
     getSunflowers,
     getSunflowersHistory,
     getUser,
@@ -172,6 +176,26 @@ async function getDailyRewardState(accountId: string) {
     };
 }
 
+const REFERRAL_REWARD = 10000;
+const REFERRAL_EVENT_TYPE = 'account.referral.v1';
+
+function normalizeReferralCode(code: string) {
+    return code
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '')
+        .slice(0, 32);
+}
+
+async function hasActiveRaisedBed(accountId: string) {
+    const gardens = await getAccountGardens(accountId);
+    for (const garden of gardens) {
+        const raisedBeds = await getRaisedBeds(garden.id, { status: 'active' });
+        if (raisedBeds.length > 0) return true;
+    }
+    return false;
+}
+
 const app = new Hono<{ Variables: AuthVariables }>()
     .get(
         '/current',
@@ -252,6 +276,130 @@ const app = new Hono<{ Variables: AuthVariables }>()
             });
         },
     )
+    .get(
+        '/current/referrals',
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const events = await getEvents(
+                REFERRAL_EVENT_TYPE,
+                [accountId],
+                0,
+                1000,
+            );
+
+            let myCode = '';
+            let usedReferralCode: string | null = null;
+            const referredAccounts: Array<{
+                accountId: string;
+                rewarded: boolean;
+            }> = [];
+
+            for (const event of events) {
+                const data = event.data as Record<string, unknown> | null;
+                if (
+                    data?.action === 'code_set' &&
+                    typeof data.code === 'string'
+                ) {
+                    myCode = data.code;
+                }
+                if (
+                    data?.action === 'used_code' &&
+                    typeof data.code === 'string'
+                ) {
+                    usedReferralCode = data.code;
+                }
+                if (
+                    data?.action === 'referred_account' &&
+                    typeof data.referredAccountId === 'string'
+                ) {
+                    referredAccounts.push({
+                        accountId: data.referredAccountId,
+                        rewarded: data.rewarded === true,
+                    });
+                }
+            }
+
+            if (!myCode) {
+                myCode = normalizeReferralCode(accountId.slice(0, 12));
+            }
+
+            return context.json({
+                myCode,
+                usedReferralCode,
+                referredAccounts,
+                rewardAmount: REFERRAL_REWARD,
+                referralLink: `https://www.gredice.com/preporuke?ref=${encodeURIComponent(myCode)}`,
+            });
+        },
+    )
+    .post(
+        '/current/referrals/code',
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const body = await context.req.json<{ code?: string }>();
+            const code = normalizeReferralCode(body.code ?? '');
+            if (!code) return context.json({ error: 'Neispravan kod' }, 400);
+            if (await hasActiveRaisedBed(accountId)) {
+                return context.json(
+                    { error: 'Kod se ne može mijenjati nakon aktivne gredice' },
+                    400,
+                );
+            }
+            await createEvent({
+                type: REFERRAL_EVENT_TYPE,
+                version: 1,
+                aggregateId: accountId,
+                data: { action: 'code_set', code },
+            });
+            return context.json({ code });
+        },
+    )
+    .post(
+        '/current/referrals/use',
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const body = await context.req.json<{ code?: string }>();
+            const code = normalizeReferralCode(body.code ?? '');
+            if (!code) return context.json({ error: 'Neispravan kod' }, 400);
+            if (await hasActiveRaisedBed(accountId)) {
+                return context.json(
+                    { error: 'Kod se ne može unijeti nakon aktivne gredice' },
+                    400,
+                );
+            }
+
+            const myEvents = await getEvents(
+                REFERRAL_EVENT_TYPE,
+                [accountId],
+                0,
+                1000,
+            );
+            if (
+                myEvents.some(
+                    (e) =>
+                        (e.data as Record<string, unknown> | null)?.action ===
+                        'used_code',
+                )
+            ) {
+                return context.json(
+                    { error: 'Referral kod je već iskorišten' },
+                    400,
+                );
+            }
+
+            await createEvent({
+                type: REFERRAL_EVENT_TYPE,
+                version: 1,
+                aggregateId: accountId,
+                data: { action: 'used_code', code },
+            });
+            return context.json({ ok: true });
+        },
+    )
+
     .get(
         '/current/sunflowers',
         describeRoute({

--- a/apps/www/app/preporuke/page.tsx
+++ b/apps/www/app/preporuke/page.tsx
@@ -1,0 +1,27 @@
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+
+export default function ReferralsLandingPage() {
+    return (
+        <main className="container py-10">
+            <Stack spacing={3}>
+                <Typography level="h2">💮 Gredice referral program</Typography>
+                <Typography>
+                    Podijeli svoj referral kod i zaradi{' '}
+                    <strong>10.000 suncokreta</strong> kada novi račun ispuni
+                    uvjet aktivne gredice.
+                </Typography>
+                <Typography>
+                    Pravila: kod je vezan uz račun (ne korisnika), kod se može
+                    mijenjati dok račun nema aktivnu gredicu, nakon prve aktivne
+                    gredice kod se zaključava.
+                </Typography>
+                <Typography>
+                    Nagrađivanje se obrađuje kada novi račun ima barem jednu
+                    aktivnu gredicu. Broj dijeljenja referral koda nije
+                    ograničen.
+                </Typography>
+            </Stack>
+        </main>
+    );
+}

--- a/packages/game/src/hooks/useReferrals.ts
+++ b/packages/game/src/hooks/useReferrals.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { clientAuthenticated } from '../api/clientAuthenticated';
+
+export function useReferrals() {
+    return useQuery({
+        queryKey: ['accounts', 'current', 'referrals'],
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.accounts.current.referrals.$get();
+            if (!response.ok) throw new Error('Failed to fetch referrals');
+            return await response.json();
+        },
+    });
+}

--- a/packages/game/src/hooks/useReferrals.ts
+++ b/packages/game/src/hooks/useReferrals.ts
@@ -1,5 +1,5 @@
+import { clientAuthenticated } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
-import { clientAuthenticated } from '../api/clientAuthenticated';
 
 export function useReferrals() {
     return useQuery({

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -15,6 +15,7 @@ import { GameTab } from './components/GameTab';
 import { GardenTab } from './components/GardenTab';
 import { GeneralTab } from './components/GeneralTab';
 import { NotificationsTab } from './components/NotificationsTab';
+import { ReferralsTab } from './components/ReferralsTab';
 import { SecurityTab } from './components/SecurityTab';
 import { SoundTab } from './components/SoundTab';
 import { SunflowersTab } from './components/SunflowersTab';
@@ -52,6 +53,12 @@ const navGroups = [
                 icon: '🔔',
                 label: 'Obavijesti',
                 value: 'obavijesti',
+            },
+            {
+                nodeId: 'profile-referrals',
+                icon: '💮',
+                label: 'Preporuke',
+                value: 'preporuke',
             },
         ],
     },
@@ -179,6 +186,7 @@ export function OverviewModal() {
                     {settingsMode === 'suncokreti' && <SunflowersTab />}
                     {settingsMode === 'postignuca' && <AchievementsTab />}
                     {settingsMode === 'korisnici' && <AccountUsersTab />}
+                    {settingsMode === 'preporuke' && <ReferralsTab />}
                 </div>
             </div>
         </Modal>

--- a/packages/game/src/modals/components/GeneralTab.tsx
+++ b/packages/game/src/modals/components/GeneralTab.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { ReferralsManagementCard } from './ReferralsManagementCard';
 import { TimeZoneSettingsCard } from './TimeZoneSettingsCard';
 import { UserBirthdayCard } from './UserBirthdayCard';
 import { UserProfileCard } from './UserProfileCard';
@@ -14,6 +15,7 @@ export function GeneralTab() {
                 <UserProfileCard />
                 <UserBirthdayCard />
                 <TimeZoneSettingsCard />
+                <ReferralsManagementCard />
             </Stack>
         </Stack>
     );

--- a/packages/game/src/modals/components/ReferralsManagementCard.tsx
+++ b/packages/game/src/modals/components/ReferralsManagementCard.tsx
@@ -1,3 +1,4 @@
+import { clientAuthenticated } from '@gredice/client';
 import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
@@ -9,7 +10,6 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
-import { clientAuthenticated } from '../../api/clientAuthenticated';
 import { useReferrals } from '../../hooks/useReferrals';
 
 export function ReferralsManagementCard() {

--- a/packages/game/src/modals/components/ReferralsManagementCard.tsx
+++ b/packages/game/src/modals/components/ReferralsManagementCard.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardActions,
+    CardContent,
+    CardHeader,
+} from '@signalco/ui-primitives/Card';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useState } from 'react';
+import { clientAuthenticated } from '../../api/clientAuthenticated';
+import { useReferrals } from '../../hooks/useReferrals';
+
+export function ReferralsManagementCard() {
+    const { data, refetch } = useReferrals();
+    const [code, setCode] = useState('');
+
+    return (
+        <Card>
+            <CardHeader title="💮 Referral račun" />
+            <CardContent>
+                <Stack spacing={1}>
+                    <Typography level="body2">
+                        Vaš kod: {data?.myCode}
+                    </Typography>
+                    <Typography level="body3">
+                        Link: {data?.referralLink}
+                    </Typography>
+                    <Input
+                        value={code}
+                        onChange={(e) => setCode(e.target.value)}
+                        placeholder="Promijeni kod računa"
+                    />
+                </Stack>
+            </CardContent>
+            <CardActions>
+                <Button
+                    size="sm"
+                    onClick={async () => {
+                        await clientAuthenticated().api.accounts.current.referrals.code.$post(
+                            { json: { code } },
+                        );
+                        await refetch();
+                    }}
+                >
+                    Spremi kod
+                </Button>
+            </CardActions>
+        </Card>
+    );
+}

--- a/packages/game/src/modals/components/ReferralsTab.tsx
+++ b/packages/game/src/modals/components/ReferralsTab.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { useState } from 'react';
+import { clientAuthenticated } from '../../api/clientAuthenticated';
+import { useReferrals } from '../../hooks/useReferrals';
+
+export function ReferralsTab() {
+    const { data, refetch } = useReferrals();
+    const [myCode, setMyCode] = useState('');
+    const [useCode, setUseCode] = useState('');
+
+    return (
+        <Stack spacing={2}>
+            <div className="text-sm">
+                💮 Referral reward: {data?.rewardAmount ?? 10000} sunflowers
+            </div>
+            <div>
+                <div className="text-xs">Account referral code</div>
+                <div className="font-bold">{data?.myCode}</div>
+                <div className="text-xs">
+                    Referral link:{' '}
+                    {typeof window !== 'undefined'
+                        ? `${window.location.origin}?ref=${data?.myCode ?? ''}`
+                        : ''}
+                </div>
+                <Input
+                    value={myCode}
+                    onChange={(e) => setMyCode(e.target.value)}
+                    placeholder="Change my code"
+                />
+                <Button
+                    onClick={async () => {
+                        await clientAuthenticated().api.accounts.current.referrals.code.$post(
+                            { json: { code: myCode } },
+                        );
+                        await refetch();
+                    }}
+                >
+                    Save code
+                </Button>
+            </div>
+            <div>
+                <div className="text-xs">Use account referral code</div>
+                <Input
+                    value={useCode}
+                    onChange={(e) => setUseCode(e.target.value)}
+                    placeholder="Enter code"
+                />
+                <Button
+                    onClick={async () => {
+                        await clientAuthenticated().api.accounts.current.referrals.use.$post(
+                            { json: { code: useCode } },
+                        );
+                        await refetch();
+                    }}
+                >
+                    Apply code
+                </Button>
+            </div>
+            <div>
+                <div className="text-xs">Referred accounts</div>
+                <ul>
+                    {data?.referredAccounts?.map((u) => (
+                        <li key={u.accountId}>
+                            {u.accountId} {u.rewarded ? '✅' : '⏳'}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </Stack>
+    );
+}

--- a/packages/game/src/modals/components/ReferralsTab.tsx
+++ b/packages/game/src/modals/components/ReferralsTab.tsx
@@ -1,8 +1,8 @@
+import { clientAuthenticated } from '@gredice/client';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { useState } from 'react';
-import { clientAuthenticated } from '../../api/clientAuthenticated';
 import { useReferrals } from '../../hooks/useReferrals';
 
 export function ReferralsTab() {
@@ -21,7 +21,7 @@ export function ReferralsTab() {
                 <div className="text-xs">
                     Referral link:{' '}
                     {typeof window !== 'undefined'
-                        ? `${window.location.origin}?ref=${data?.myCode ?? ''}`
+                        ? `${window.location.origin}/preporuke?ref=${data?.myCode ?? ''}`
                         : ''}
                 </div>
                 <Input

--- a/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
+++ b/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
@@ -99,6 +99,14 @@ function sunflowerReasonToDescription(reason: string) {
             label: 'Povrat sredstava za radnju',
         };
     }
+
+    if (reason.startsWith('referral')) {
+        return {
+            icon: <span className="text-4xl text-center size-10">💮</span>,
+            label: 'Referral nagrada',
+        };
+    }
+
     if (reason.startsWith('birthday')) {
         return {
             icon: <span className="text-4xl text-center size-10">🎂</span>,


### PR DESCRIPTION
### Motivation

- Introduce a referral program so accounts can set a referral code, apply another account's code, and track referred accounts and rewards.
- Prevent changing/using referral codes after an account has an active raised bed and record referral actions as events for later processing.
- Expose referral management and visibility in the web UI so users can view, change and apply referral codes.

### Description

- Backend: added referral constants and helpers (`REFERRAL_REWARD`, `REFERRAL_EVENT_TYPE`, `normalizeReferralCode`, `hasActiveRaisedBed`) and new event-based endpoints `GET /current/referrals`, `POST /current/referrals/code`, and `POST /current/referrals/use` which use `getEvents` and `createEvent` and check gardens/raised beds via `getAccountGardens` and `getRaisedBeds`.
- Frontend: added a referrals landing page at `apps/www/app/preporuke/page.tsx`, a React hook `useReferrals`, a management card `ReferralsManagementCard`, a full `ReferralsTab`, and wired the tab/card into `OverviewModal` and `GeneralTab` so users can view, change, and apply codes from the profile modal.
- UI/UX: added referral reason mapping to sunflower history rendering so referral rewards are shown with a `💮` icon and labeled as "Referral nagrada".

### Testing

- Performed TypeScript type-check and build verification locally with the workspace build which completed successfully; no new unit tests were added for this change.
- Manual verification of basic flows in development: fetching referral data, saving an account code, and applying a code returned expected responses during local testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb55c6e3d0832fba7a3ba27bdeb755)