### PR TITLE
Enable the development hub in production

### DIFF
--- a/apps/www/app/development/page.tsx
+++ b/apps/www/app/development/page.tsx
@@ -4,7 +4,6 @@ import { Container } from '@signalco/ui-primitives/Container';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 
 export const metadata: Metadata = {
     title: 'Development Hub',
@@ -35,12 +34,11 @@ type EnvironmentHosts = {
     www: string;
 };
 
-function getEnvironmentHosts(): EnvironmentHosts | null {
-    if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production') {
-        return null;
-    }
-
-    const domain = 'gredice.test';
+function getEnvironmentHosts(): EnvironmentHosts {
+    const domain =
+        process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+            ? 'gredice.com'
+            : 'gredice.test';
 
     return {
         app: `https://app.${domain}`,
@@ -165,11 +163,6 @@ function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
 
 export default function DevelopmentPage() {
     const hosts = getEnvironmentHosts();
-
-    if (!hosts) {
-        notFound();
-    }
-
     const developmentSections = getDevelopmentSections(hosts);
 
     return (


### PR DESCRIPTION
## Summary
- Remove the production 404 guard from `/development`
- Resolve environment links to `gredice.com` in production and keep `gredice.test` in non-production
- Keep the development hub available as a normal page in production builds

## Testing
- Biome check passed for `apps/www/app/development/page.tsx`
- Production `www` build passed with `NEXT_PUBLIC_VERCEL_ENV=production`