### PR TITLE
Disable L-system plant animations in visual snapshots

### DIFF
--- a/apps/www/generate/blocks-snapshots.specgen.tsx
+++ b/apps/www/generate/blocks-snapshots.specgen.tsx
@@ -4,7 +4,14 @@ import { EntityViewer } from '@gredice/game';
 import { test } from '@playwright/experimental-ct-react';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 
-test.use({ deviceScaleFactor: 2, viewport: { width: 320 / 2, height: 320 } });
+test.use({
+    deviceScaleFactor: 2,
+    viewport: { width: 320 / 2, height: 320 },
+});
+
+test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+});
 
 type SnapshotView = 'normal' | 'far' | 'closeup';
 
@@ -94,6 +101,7 @@ test.describe('block screenshots', async () => {
                     await component.screenshot({
                         omitBackground: true,
                         path: `./public/assets/blocks/${entity.information.name}.png`,
+                        animations: 'disabled',
                     });
                 }
             });

--- a/apps/www/tests/visual.spec.ts
+++ b/apps/www/tests/visual.spec.ts
@@ -40,18 +40,45 @@ test.describe('visual snapshots', () => {
         for (const scenario of SNAPSHOT_SCENARIOS) {
             test(`page ${url} (${scenario.name})`, async ({ page }) => {
                 const fixedTime = new Date(scenario.fixedTimeIso).getTime();
-                await page.emulateMedia({ colorScheme: scenario.colorScheme });
+                await page.emulateMedia({
+                    colorScheme: scenario.colorScheme,
+                    reducedMotion: 'reduce',
+                });
                 await page.addInitScript((timeMs) => {
                     const NativeDate = Date;
+                    type MockDateConstructorArgs =
+                        | []
+                        | [value: string | number]
+                        | [
+                              year: number,
+                              monthIndex: number,
+                              date?: number,
+                              hours?: number,
+                              minutes?: number,
+                              seconds?: number,
+                              ms?: number,
+                          ];
                     class MockDate extends NativeDate {
-                        constructor(
-                            ...args: ConstructorParameters<typeof Date>
-                        ) {
+                        constructor(...args: MockDateConstructorArgs) {
                             if (args.length === 0) {
                                 super(timeMs);
                                 return;
                             }
-                            super(...args);
+
+                            if (args.length === 1) {
+                                super(args[0]);
+                                return;
+                            }
+
+                            super(
+                                args[0],
+                                args[1],
+                                args[2],
+                                args[3],
+                                args[4],
+                                args[5],
+                                args[6],
+                            );
                         }
 
                         static now() {

--- a/packages/game/src/generators/plant/hooks/usePlantSway.ts
+++ b/packages/game/src/generators/plant/hooks/usePlantSway.ts
@@ -1,13 +1,59 @@
 'use client';
 
 import { useFrame } from '@react-three/fiber';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useGameState } from '../../../useGameState';
 import { SeededRNG } from '../lib/rng';
 
 interface PlantSwayOptions {
     amplitude: number;
     speed: number;
+}
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function getPrefersReducedMotion() {
+    if (
+        typeof window === 'undefined' ||
+        typeof window.matchMedia !== 'function'
+    ) {
+        return false;
+    }
+
+    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function usePrefersReducedMotion() {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+        getPrefersReducedMotion,
+    );
+
+    useEffect(() => {
+        if (
+            typeof window === 'undefined' ||
+            typeof window.matchMedia !== 'function'
+        ) {
+            return;
+        }
+
+        const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
+        const handleChange = () => {
+            setPrefersReducedMotion(mediaQueryList.matches);
+        };
+
+        handleChange();
+        mediaQueryList.addEventListener('change', handleChange);
+
+        return () => {
+            mediaQueryList.removeEventListener('change', handleChange);
+        };
+    }, []);
+
+    return prefersReducedMotion;
+}
+
+function defaultWindDirection(): [number, number] {
+    return [1, 0];
 }
 
 export const plantSwayVertexShader = /* glsl */ `
@@ -63,19 +109,31 @@ export const plantSwayVertexShader = /* glsl */ `
 
 export function usePlantSway(seed: string, options: PlantSwayOptions) {
     const weather = useGameState((state) => state.weather);
+    const prefersReducedMotion = usePrefersReducedMotion();
     const uniforms = useMemo(() => {
         const rng = new SeededRNG(seed);
         return {
             uTime: { value: 0 },
-            uSwayAmplitude: { value: options.amplitude },
-            uSwaySpeed: { value: options.speed },
+            uSwayAmplitude: {
+                value: prefersReducedMotion ? 0 : options.amplitude,
+            },
+            uSwaySpeed: { value: prefersReducedMotion ? 0 : options.speed },
             uSwayPhase: { value: rng.nextRange(0, Math.PI * 2) },
             uWindStrength: { value: 0 },
-            uWindDirection: { value: [1, 0] as [number, number] },
+            uWindDirection: { value: defaultWindDirection() },
         };
-    }, [options.amplitude, options.speed, seed]);
+    }, [options.amplitude, options.speed, prefersReducedMotion, seed]);
 
     useFrame(({ clock }) => {
+        if (prefersReducedMotion) {
+            uniforms.uTime.value = 0;
+            uniforms.uSwayAmplitude.value = 0;
+            uniforms.uSwaySpeed.value = 0;
+            uniforms.uWindStrength.value = 0;
+            uniforms.uWindDirection.value = defaultWindDirection();
+            return;
+        }
+
         uniforms.uTime.value = clock.getElapsedTime();
         const windStrength = Math.max(
             0,


### PR DESCRIPTION
## Summary
- Freeze L-system plant sway when `prefers-reduced-motion` is enabled so WebGL plant renders stay deterministic.
- Enable reduced motion in the Vizzly visual snapshot suite and block snapshot generation.
- Disable animations on the base block screenshot path as an extra guard.

## Testing
- Biome check passed on the edited files.
- Playwright visual test listing succeeded.
- `git diff --check` passed.
- Full `tsc` still reports existing repo-wide type issues unrelated to this change.