### PR TITLE
Fix admin directory breadcrumbs and labels

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -8,7 +8,6 @@ import {
     updateInventoryItem,
 } from '@gredice/storage';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import {
@@ -21,8 +20,10 @@ import { revalidatePath } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
-import { AdminPageHeader } from '../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../components/admin/navigation';
 import { AdminPageTitle } from '../../../../../components/admin/navigation/AdminPageTitle';
 import { BarcodeValue } from '../../../../../components/shared/attributes/BarcodeValue';
 import { formatAttributeValueWithUnit } from '../../../../../components/shared/attributes/formatAttributeValueWithUnit';
@@ -164,18 +165,10 @@ export default async function EntityDetailsPage(props: {
                 breadcrumbs={
                     <Row spacing={2} className="min-w-0">
                         <div className="min-w-0">
-                            <Breadcrumbs
+                            <AdminDirectoryBreadcrumbs
+                                entityTypeName={params.entityType}
+                                entityTypeLabel={entity.entityType.label}
                                 items={[
-                                    {
-                                        label: <AdminBreadcrumbLevelSelector />,
-                                        href: KnownPages.Directories,
-                                    },
-                                    {
-                                        label: entity.entityType.label,
-                                        href: KnownPages.DirectoryEntityType(
-                                            params.entityType,
-                                        ),
-                                    },
                                     {
                                         label: entityDisplayName(entity),
                                     },

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/[id]/page.tsx
@@ -1,11 +1,12 @@
 import { getAttributeDefinition, getEntityTypeByName } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Delete } from '@signalco/ui-icons';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
-import { AdminPageHeader } from '../../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../../components/admin/navigation';
 import { ServerActionIconButton } from '../../../../../../components/shared/ServerActionIconButton';
 import { KnownPages } from '../../../../../../src/KnownPages';
 import { deleteAttributeDefinition } from '../../../../../(actions)/definitionActions';
@@ -52,18 +53,10 @@ export default async function AttributeDefinitionPage({
         <Stack spacing={2}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
+                    <AdminDirectoryBreadcrumbs
+                        entityTypeName={entityTypeName}
+                        entityTypeLabel={entityType.label}
                         items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            {
-                                label: entityType.label,
-                                href: KnownPages.DirectoryEntityType(
-                                    entityTypeName,
-                                ),
-                            },
                             {
                                 label: 'Atributi',
                                 href: KnownPages.DirectoryEntityTypeAttributeDefinitions(

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/[id]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/[id]/page.tsx
@@ -2,12 +2,13 @@ import {
     getAttributeDefinitionCategories,
     getEntityTypeByName,
 } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
-import { AdminPageHeader } from '../../../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../../../components/admin/navigation';
 import { KnownPages } from '../../../../../../../src/KnownPages';
 import { FormInput } from './Form';
 
@@ -35,18 +36,10 @@ export default async function AttributeDefinitionCategoryDetailsPage({
         <Stack spacing={2}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
+                    <AdminDirectoryBreadcrumbs
+                        entityTypeName={entityTypeName}
+                        entityTypeLabel={entityType.label}
                         items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            {
-                                label: entityType.label,
-                                href: KnownPages.DirectoryEntityType(
-                                    entityTypeName,
-                                ),
-                            },
                             {
                                 label: 'Atributi',
                                 href: KnownPages.DirectoryEntityTypeAttributeDefinitions(

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/categories/page.tsx
@@ -1,10 +1,11 @@
 import { getEntityTypeByName } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { notFound } from 'next/navigation';
-import { AdminPageHeader } from '../../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../../components/admin/navigation';
 import { KnownPages } from '../../../../../../src/KnownPages';
 
 export default async function EntityTypeAttributeDefinitionCategoriesPage({
@@ -20,18 +21,10 @@ export default async function EntityTypeAttributeDefinitionCategoriesPage({
         <Stack spacing={2}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
+                    <AdminDirectoryBreadcrumbs
+                        entityTypeName={entityTypeName}
+                        entityTypeLabel={entityType.label}
                         items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            {
-                                label: entityType.label,
-                                href: KnownPages.DirectoryEntityType(
-                                    entityTypeName,
-                                ),
-                            },
                             {
                                 label: 'Atributi',
                                 href: KnownPages.DirectoryEntityTypeAttributeDefinitions(

--- a/apps/app/app/admin/directories/[entityType]/attribute-definitions/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/attribute-definitions/page.tsx
@@ -1,11 +1,11 @@
 import { getEntityTypeByName } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
 import { AttributeDefinitionsList } from '../../../../../components/admin/directories';
-import { AdminPageHeader } from '../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
-import { KnownPages } from '../../../../../src/KnownPages';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../components/admin/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,20 +24,10 @@ export default async function AttributesPage({
         <Stack spacing={2}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            {
-                                label: entityType.label,
-                                href: KnownPages.DirectoryEntityType(
-                                    entityTypeName,
-                                ),
-                            },
-                            { label: 'Atributi' },
-                        ]}
+                    <AdminDirectoryBreadcrumbs
+                        entityTypeName={entityTypeName}
+                        entityTypeLabel={entityType.label}
+                        items={[{ label: 'Atributi' }]}
                     />
                 }
                 heading="Atributi"

--- a/apps/app/app/admin/directories/[entityType]/edit/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/edit/page.tsx
@@ -2,13 +2,13 @@ import {
     getEntityTypeByNameWithCategory,
     getEntityTypeCategories,
 } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { notFound } from 'next/navigation';
-import { AdminPageHeader } from '../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../components/admin/navigation';
 import { auth } from '../../../../../lib/auth/auth';
-import { KnownPages } from '../../../../../src/KnownPages';
 import { EntityTypeEditForm } from './EntityTypeEditForm';
 
 export const dynamic = 'force-dynamic';
@@ -30,20 +30,10 @@ export default async function EditEntityTypePage({
         <Stack spacing={4}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            {
-                                label: entityType.label,
-                                href: KnownPages.DirectoryEntityType(
-                                    entityTypeName,
-                                ),
-                            },
-                            { label: 'Uredi' },
-                        ]}
+                    <AdminDirectoryBreadcrumbs
+                        entityTypeName={entityTypeName}
+                        entityTypeLabel={entityType.label}
+                        items={[{ label: 'Uredi' }]}
                     />
                 }
                 heading={`Uredi ${entityType.label}`}

--- a/apps/app/app/admin/directories/[entityType]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/page.tsx
@@ -5,15 +5,16 @@ import {
     getInventoryConfigByEntityTypeName,
     getInventoryItemsByConfig,
 } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Add } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import Link from 'next/link';
 import { EntityTypeMenu } from '../../../../components/admin/directories';
-import { AdminPageHeader } from '../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../components/admin/navigation';
 import { FilterProvider } from '../../../../components/admin/providers';
 import { SearchInput } from '../../../../components/admin/SearchInput';
 import { EntitiesTable } from '../../../../components/admin/tables';
@@ -53,16 +54,9 @@ export default async function EntitiesPage({
             <Stack spacing={2}>
                 <AdminPageHeader
                     breadcrumbs={
-                        <Breadcrumbs
-                            items={[
-                                {
-                                    label: <AdminBreadcrumbLevelSelector />,
-                                    href: KnownPages.Directories,
-                                },
-                                {
-                                    label: entityType?.label ?? entityTypeName,
-                                },
-                            ]}
+                        <AdminDirectoryBreadcrumbs
+                            entityTypeName={entityTypeName}
+                            entityTypeLabel={entityType?.label}
                         />
                     }
                     actions={

--- a/apps/app/app/admin/directories/categories/[categoryId]/edit/EditEntityTypeCategoryPage.tsx
+++ b/apps/app/app/admin/directories/categories/[categoryId]/edit/EditEntityTypeCategoryPage.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { SelectEntityTypeCategory } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { ModalConfirm } from '@signalco/ui/ModalConfirm';
 import { Delete } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
@@ -10,9 +9,10 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
-import { AdminPageHeader } from '../../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
-import { KnownPages } from '../../../../../../src/KnownPages';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../../components/admin/navigation';
 import {
     removeEntityTypeCategoryById,
     updateEntityTypeCategoryFromForm,
@@ -40,16 +40,9 @@ export function EditEntityTypeCategoryPage({
         <Stack spacing={4}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
+                    <AdminDirectoryBreadcrumbs
                         items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            {
-                                label: 'Kategorije',
-                                href: KnownPages.Directories,
-                            },
+                            { label: 'Kategorije' },
                             { label: category.label },
                         ]}
                     />

--- a/apps/app/app/admin/directories/categories/create/page.tsx
+++ b/apps/app/app/admin/directories/categories/create/page.tsx
@@ -1,12 +1,12 @@
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { AdminPageHeader } from '../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../components/admin/navigation';
 import { auth } from '../../../../../lib/auth/auth';
-import { KnownPages } from '../../../../../src/KnownPages';
 import { createEntityTypeCategoryFromForm } from '../../../../(actions)/entityTypeCategoryActions';
 import { EntityTypeCategoryFormFields } from '../EntityTypeCategoryFormFields';
 
@@ -19,14 +19,8 @@ export default async function CreateEntityTypeCategoryPage() {
         <Stack spacing={4}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            { label: 'Nova kategorija' },
-                        ]}
+                    <AdminDirectoryBreadcrumbs
+                        items={[{ label: 'Nova kategorija' }]}
                     />
                 }
                 heading="Nova kategorija tipova zapisa"

--- a/apps/app/app/admin/directories/entity-types/create/page.tsx
+++ b/apps/app/app/admin/directories/entity-types/create/page.tsx
@@ -1,5 +1,4 @@
 import { getEntityTypeCategories } from '@gredice/storage';
-import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Input } from '@signalco/ui-primitives/Input';
@@ -7,10 +6,11 @@ import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { availableIcons } from '../../../../../components/admin/directories/EntityTypeIcon';
-import { AdminPageHeader } from '../../../../../components/admin/navigation';
-import { AdminBreadcrumbLevelSelector } from '../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import {
+    AdminDirectoryBreadcrumbs,
+    AdminPageHeader,
+} from '../../../../../components/admin/navigation';
 import { auth } from '../../../../../lib/auth/auth';
-import { KnownPages } from '../../../../../src/KnownPages';
 import { submitCreateForm } from '../../../../(actions)/entityFormActions';
 
 export const dynamic = 'force-dynamic';
@@ -39,14 +39,8 @@ export default async function CreateEntityTypePage() {
         <Stack spacing={4}>
             <AdminPageHeader
                 breadcrumbs={
-                    <Breadcrumbs
-                        items={[
-                            {
-                                label: <AdminBreadcrumbLevelSelector />,
-                                href: KnownPages.Directories,
-                            },
-                            { label: 'Novi tip zapisa' },
-                        ]}
+                    <AdminDirectoryBreadcrumbs
+                        items={[{ label: 'Novi tip zapisa' }]}
                     />
                 }
                 heading="Novi tip zapisa"

--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -3,7 +3,6 @@
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import {
     AI,
-    ArrowDown,
     Bank,
     Calendar,
     Euro,
@@ -23,7 +22,6 @@ import {
     Truck,
     User,
 } from '@signalco/ui-icons';
-import { Button } from '@signalco/ui-primitives/Button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -34,6 +32,7 @@ import {
 } from '@signalco/ui-primitives/Menu';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { AdminBreadcrumbSelectorTrigger } from './AdminBreadcrumbSelectorTrigger';
 import { adminBreadcrumbPages, adminPages } from './adminPages';
 
 export function resolveCurrentTopLevel(pathname: string) {
@@ -171,13 +170,9 @@ export function AdminBreadcrumbLevelSelector() {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button
-                    variant="plain"
-                    className="h-auto p-0 font-medium"
-                    endDecorator={<ArrowDown className="size-3" />}
-                >
+                <AdminBreadcrumbSelectorTrigger>
                     {currentTopLevel.label}
-                </Button>
+                </AdminBreadcrumbSelectorTrigger>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
                 {breadcrumbSections.map((section, index) => (

--- a/apps/app/components/admin/navigation/AdminBreadcrumbSelectorTrigger.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbSelectorTrigger.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { ArrowDown } from '@signalco/ui-icons';
+import { type ButtonHTMLAttributes, forwardRef, type ReactNode } from 'react';
+import { adminBreadcrumbSelectorTriggerClassName } from './adminBreadcrumbStyles';
+
+export const AdminBreadcrumbSelectorTrigger = forwardRef<
+    HTMLButtonElement,
+    ButtonHTMLAttributes<HTMLButtonElement> & {
+        children: ReactNode;
+    }
+>(function AdminBreadcrumbSelectorTrigger(
+    { children, className, type, ...props },
+    ref,
+) {
+    return (
+        <button
+            ref={ref}
+            type={type ?? 'button'}
+            className={[adminBreadcrumbSelectorTriggerClassName, className]
+                .filter(Boolean)
+                .join(' ')}
+            {...props}
+        >
+            <span className="min-w-0 truncate">{children}</span>
+            <ArrowDown className="size-3 shrink-0" aria-hidden />
+        </button>
+    );
+});

--- a/apps/app/components/admin/navigation/AdminDirectoryBreadcrumbs.tsx
+++ b/apps/app/components/admin/navigation/AdminDirectoryBreadcrumbs.tsx
@@ -1,0 +1,42 @@
+import { type BreadcrumbItem, Breadcrumbs } from '@signalco/ui/Breadcrumbs';
+import { AdminBreadcrumbLevelSelector } from './AdminBreadcrumbLevelSelector';
+import { AdminDirectoryCategoryBreadcrumbSelector } from './AdminDirectoryCategoryBreadcrumbSelector';
+import { AdminDirectoryEntityTypeBreadcrumbSelector } from './AdminDirectoryEntityTypeBreadcrumbSelector';
+
+export function AdminDirectoryBreadcrumbs({
+    entityTypeName,
+    entityTypeLabel,
+    items = [],
+}: {
+    entityTypeName?: string;
+    entityTypeLabel?: string;
+    items?: BreadcrumbItem[];
+}) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        {
+            label: <AdminBreadcrumbLevelSelector />,
+        },
+    ];
+
+    if (entityTypeName) {
+        breadcrumbs.push(
+            {
+                label: (
+                    <AdminDirectoryCategoryBreadcrumbSelector
+                        entityTypeName={entityTypeName}
+                    />
+                ),
+            },
+            {
+                label: (
+                    <AdminDirectoryEntityTypeBreadcrumbSelector
+                        entityTypeName={entityTypeName}
+                        fallbackLabel={entityTypeLabel}
+                    />
+                ),
+            },
+        );
+    }
+
+    return <Breadcrumbs items={[...breadcrumbs, ...items]} />;
+}

--- a/apps/app/components/admin/navigation/AdminDirectoryCategoryBreadcrumbSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminDirectoryCategoryBreadcrumbSelector.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@signalco/ui-primitives/Menu';
+import { useContext } from 'react';
+import { KnownPages } from '../../../src/KnownPages';
+import { EntityTypeIcon } from '../directories/EntityTypeIcon';
+import { AdminBreadcrumbSelectorTrigger } from './AdminBreadcrumbSelectorTrigger';
+import {
+    findDirectoryBreadcrumbGroup,
+    getDirectoryBreadcrumbGroups,
+} from './directoryBreadcrumbGroups';
+import { NavContext } from './NavContext';
+
+export function AdminDirectoryCategoryBreadcrumbSelector({
+    entityTypeName,
+}: {
+    entityTypeName: string;
+}) {
+    const navContext = useContext(NavContext);
+    const groups = getDirectoryBreadcrumbGroups(navContext);
+    const currentGroup = findDirectoryBreadcrumbGroup(groups, entityTypeName);
+
+    if (!currentGroup) {
+        return null;
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <AdminBreadcrumbSelectorTrigger>
+                    {currentGroup.label}
+                </AdminBreadcrumbSelectorTrigger>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                {groups.map((group) => {
+                    const firstEntityType = group.entityTypes[0];
+                    if (!firstEntityType) {
+                        return null;
+                    }
+
+                    return (
+                        <DropdownMenuItem
+                            key={group.key}
+                            href={KnownPages.DirectoryEntityType(
+                                firstEntityType.name,
+                            )}
+                        >
+                            <div className="flex items-center gap-2">
+                                <EntityTypeIcon
+                                    icon={group.icon}
+                                    className="size-4"
+                                />
+                                <span>{group.label}</span>
+                            </div>
+                        </DropdownMenuItem>
+                    );
+                })}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/apps/app/components/admin/navigation/AdminDirectoryEntityTypeBreadcrumbSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminDirectoryEntityTypeBreadcrumbSelector.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@signalco/ui-primitives/Menu';
+import { useContext } from 'react';
+import { KnownPages } from '../../../src/KnownPages';
+import { EntityTypeIcon } from '../directories/EntityTypeIcon';
+import { AdminBreadcrumbSelectorTrigger } from './AdminBreadcrumbSelectorTrigger';
+import {
+    findDirectoryBreadcrumbEntityType,
+    findDirectoryBreadcrumbGroup,
+    getDirectoryBreadcrumbGroups,
+} from './directoryBreadcrumbGroups';
+import { NavContext } from './NavContext';
+
+export function AdminDirectoryEntityTypeBreadcrumbSelector({
+    entityTypeName,
+    fallbackLabel,
+}: {
+    entityTypeName: string;
+    fallbackLabel?: string;
+}) {
+    const navContext = useContext(NavContext);
+    const groups = getDirectoryBreadcrumbGroups(navContext);
+    const currentGroup = findDirectoryBreadcrumbGroup(groups, entityTypeName);
+    const currentEntityType = findDirectoryBreadcrumbEntityType(
+        groups,
+        entityTypeName,
+    );
+
+    if (!currentEntityType) {
+        return fallbackLabel ?? entityTypeName;
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <AdminBreadcrumbSelectorTrigger>
+                    {currentEntityType.label}
+                </AdminBreadcrumbSelectorTrigger>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                {(currentGroup?.entityTypes ?? [currentEntityType]).map(
+                    (entityType) => (
+                        <DropdownMenuItem
+                            key={entityType.id}
+                            href={KnownPages.DirectoryEntityType(
+                                entityType.name,
+                            )}
+                        >
+                            <div className="flex items-center gap-2">
+                                <EntityTypeIcon
+                                    icon={entityType.icon}
+                                    className="size-4"
+                                />
+                                <span>{entityType.label}</span>
+                            </div>
+                        </DropdownMenuItem>
+                    ),
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/apps/app/components/admin/navigation/AdminPageCardHeader.tsx
+++ b/apps/app/components/admin/navigation/AdminPageCardHeader.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from 'next/navigation';
 import { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 import { useAdminPageHeaderContext } from './AdminPageHeaderContext';
+import { adminBreadcrumbClassName } from './adminBreadcrumbStyles';
 import { DesktopNavToggle } from './DesktopNavToggle';
 import { MobileNav } from './MobileNav';
 
@@ -26,7 +27,9 @@ export function AdminPageCardHeader() {
                         ref={setSlotElement}
                     >
                         {!activeHeaderId && (
-                            <div className="min-w-0 overflow-hidden">
+                            <div
+                                className={`min-w-0 overflow-hidden ${adminBreadcrumbClassName}`}
+                            >
                                 <AdminPageBreadcrumbs />
                             </div>
                         )}

--- a/apps/app/components/admin/navigation/AdminPageHeader.tsx
+++ b/apps/app/components/admin/navigation/AdminPageHeader.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useEffect, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 import { useAdminPageHeaderContext } from './AdminPageHeaderContext';
+import { adminBreadcrumbClassName } from './adminBreadcrumbStyles';
 
 export type AdminPageHeaderProps = {
     breadcrumbs?: ReactNode;
@@ -36,7 +37,9 @@ export function AdminPageHeader({
     return createPortal(
         <>
             {heading && <h1 className="sr-only">{heading}</h1>}
-            <div className="min-w-0 overflow-hidden">
+            <div
+                className={`min-w-0 overflow-hidden ${adminBreadcrumbClassName}`}
+            >
                 {breadcrumbs ?? <AdminPageBreadcrumbs />}
             </div>
             {actions && (

--- a/apps/app/components/admin/navigation/MobileHeader.tsx
+++ b/apps/app/components/admin/navigation/MobileHeader.tsx
@@ -1,5 +1,6 @@
 import { Row } from '@signalco/ui-primitives/Row';
 import { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
+import { adminBreadcrumbClassName } from './adminBreadcrumbStyles';
 import { MobileNav } from './MobileNav';
 
 export function MobileHeader() {
@@ -8,7 +9,9 @@ export function MobileHeader() {
             <div className="flex h-14 items-center px-4">
                 <Row spacing={3} className="w-full items-center">
                     <MobileNav />
-                    <div className="min-w-0 flex-1 overflow-hidden">
+                    <div
+                        className={`min-w-0 flex-1 overflow-hidden ${adminBreadcrumbClassName}`}
+                    >
                         <AdminPageBreadcrumbs />
                     </div>
                 </Row>

--- a/apps/app/components/admin/navigation/adminBreadcrumbStyles.ts
+++ b/apps/app/components/admin/navigation/adminBreadcrumbStyles.ts
@@ -1,0 +1,5 @@
+export const adminBreadcrumbClassName =
+    'text-muted-foreground text-sm font-medium';
+
+export const adminBreadcrumbSelectorTriggerClassName =
+    'inline-flex max-w-full items-center gap-1 rounded-sm text-inherit [font:inherit] outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';

--- a/apps/app/components/admin/navigation/adminPages.ts
+++ b/apps/app/components/admin/navigation/adminPages.ts
@@ -2,7 +2,7 @@ import { KnownPages } from '../../../src/KnownPages';
 
 export const adminPages = {
     Dashboard: { href: KnownPages.Dashboard, label: 'Početna' },
-    Directories: { href: KnownPages.Directories, label: 'Direktoriji' },
+    Directories: { href: KnownPages.Directories, label: 'Zapisi' },
     Accounts: { href: KnownPages.Accounts, label: 'Korisnički računi' },
     Achievements: { href: KnownPages.Achievements, label: 'Postignuća' },
     ShoppingCarts: { href: KnownPages.ShoppingCarts, label: 'Košarice' },

--- a/apps/app/components/admin/navigation/adminRouteTitle.ts
+++ b/apps/app/components/admin/navigation/adminRouteTitle.ts
@@ -52,7 +52,7 @@ function resolveDirectoryTitle(
     navContext: NavContextType | undefined,
 ) {
     if (pathname === '/admin/directories/entity-types/create') {
-        return 'Novi direktorij';
+        return 'Novi tip zapisa';
     }
 
     if (pathname === '/admin/directories/categories/create') {

--- a/apps/app/components/admin/navigation/directoryBreadcrumbGroups.ts
+++ b/apps/app/components/admin/navigation/directoryBreadcrumbGroups.ts
@@ -1,0 +1,61 @@
+import type { NavContextType } from './NavContext';
+
+type DirectoryEntityType =
+    NavContextType['categorizedTypes'][number]['entityTypes'][number];
+
+export type DirectoryBreadcrumbGroup = {
+    key: string;
+    label: string;
+    icon?: string | null;
+    entityTypes: DirectoryEntityType[];
+};
+
+export function getDirectoryBreadcrumbGroups(
+    navContext: NavContextType | undefined,
+) {
+    const groups: DirectoryBreadcrumbGroup[] =
+        navContext?.categorizedTypes.map((category) => ({
+            key: `category-${category.id}`,
+            label: category.label,
+            icon: category.icon,
+            entityTypes: category.entityTypes,
+        })) ?? [];
+
+    if (navContext?.uncategorizedTypes.length) {
+        groups.push({
+            key: 'uncategorized',
+            label: 'Nekategorizirano',
+            entityTypes: navContext.uncategorizedTypes,
+        });
+    }
+
+    if (navContext?.shadowTypes.length) {
+        groups.push({
+            key: 'shadow',
+            label: 'Ostalo',
+            entityTypes: navContext.shadowTypes,
+        });
+    }
+
+    return groups;
+}
+
+export function findDirectoryBreadcrumbGroup(
+    groups: DirectoryBreadcrumbGroup[],
+    entityTypeName: string,
+) {
+    return groups.find((group) =>
+        group.entityTypes.some(
+            (entityType) => entityType.name === entityTypeName,
+        ),
+    );
+}
+
+export function findDirectoryBreadcrumbEntityType(
+    groups: DirectoryBreadcrumbGroup[],
+    entityTypeName: string,
+) {
+    return groups
+        .flatMap((group) => group.entityTypes)
+        .find((entityType) => entityType.name === entityTypeName);
+}

--- a/apps/app/components/admin/navigation/index.ts
+++ b/apps/app/components/admin/navigation/index.ts
@@ -1,3 +1,4 @@
+export { AdminDirectoryBreadcrumbs } from './AdminDirectoryBreadcrumbs';
 export { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 export { AdminPageCardHeader } from './AdminPageCardHeader';
 export { AdminPageHeader } from './AdminPageHeader';


### PR DESCRIPTION
## Summary
- Added a shared directory breadcrumb composition so admin directory pages now show `Zapisi`, category, entity type, and the page-specific crumb in a consistent order.
- Fixed the breadcrumb dropdown styling so all breadcrumb items use the same size and color.
- Restored category selection in the directory breadcrumb flow and added entity-type selection for the second level.
- Renamed the top-level breadcrumb label from `Direktoriji` to `Zapisi`.

## Testing
- `pnpm lint --filter app` passed.
- `pnpm build --filter app` passed.
- `pnpm --filter app exec tsc --noEmit` was not clean due to unrelated existing type errors elsewhere in the repo.