### PR TITLE
Split AGENTS guidance into focused repo docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,102 +1,44 @@
 # Welcome, AI collaborator
 
-This repository is the **Gredice** monorepo. It hosts several Next.js applications, supporting packages, and shared assets that power the Gredice platform.
+This repository is the **Gredice** monorepo. It hosts multiple Next.js applications, shared packages, and assets for the Gredice platform.
 
-## Quick start checklist
+## First steps
 
-- Use **Node.js** and **pnpm**.
+- Use Node.js `>=24` and pnpm `10.33.2`.
 - Install dependencies from the repo root with `pnpm install`.
-- Before editing code, look for additional `AGENTS.md` files inside the path you plan to touch—nested instructions override this file.
-- Keep the worktree clean: run the relevant lint/tests locally and commit only intentional changes (never commit `node_modules` or build artifacts).
-- Use linting commands to check and format edited files.
+- Before editing code, look for additional `AGENTS.md` files inside the path you plan to touch. Nested instructions override this file.
+- Keep the worktree clean. Commit only intentional source changes and never commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless explicitly requested.
+- Use targeted Turbo commands from the repo root whenever possible.
 
-## Repository layout
+## Read the relevant guides
 
-- `apps/`
-  - `api/`: Next.js app exposing API routes and OpenAPI generation.
-  - `app/`, `garden/`, `farm/`, `www/`: Product-facing Next.js front-ends (each with its own scripts, linting, and Playwright setup).
-  - `storybook/`: Public Storybook app for package-grouped component documentation.
-- `packages/`: Shared libraries (client SDK, storage, UI kit, transactional email helpers, payment integration, etc.). Use pnpm workspaces to depend on these via `workspace:*` versions.
-- `assets/`: Source files for 3D game assets.
-- `turbo.json`, `pnpm-workspace.yaml`, and app-level `package.json` files coordinate Turborepo tasks, workspace scopes, and scripts.
+- [WORKSPACE.md](./WORKSPACE.md): repo layout, local setup, commands, package boundaries, and development servers.
+- [FRONTEND.md](./FRONTEND.md): Next.js, React, TypeScript, shared UI, Storybook, and app structure rules.
+- [DESIGN.md](./DESIGN.md): visual design standards for product, marketing, admin, farm, garden, and Storybook work.
+- [PRODUCT_SENSE.md](./PRODUCT_SENSE.md): Gredice product expectations, user roles, language, and domain behavior.
+- [QUALITY_SCORE.md](./QUALITY_SCORE.md): quality rubric, validation commands, type standards, and review expectations.
+- [RELIABILITY.md](./RELIABILITY.md): data integrity, migrations, background work, observability, and failure handling.
+- [SECURITY.md](./SECURITY.md): auth, secrets, data exposure, validation, payments, and unsafe rendering.
+- [SEO.md](./SEO.md): metadata, structured data, sitemap, canonical URL, and public page rules.
 
-## Conventions and standards
+## Non-negotiables
 
-- Don't create new components or utilities without checking for existing ones in `@gredice/ui` or other shared packages.
-- If a UI component is not present in `@gredice/ui`, consider contributing it there if it has potential for reuse across applications.
-- Do not create multiple components in same file, split them into separate files.
-- When adding a new reusable UI component (especially in `@gredice/ui`), add/update its Storybook story under `apps/storybook/stories` in the same change.
+- Reuse existing packages and UI before adding new utilities or components.
+- Use `workspace:*` for internal package dependencies.
+- Do not duplicate shared TypeScript types. Prefer inferred types, use `unknown` instead of `any`, and avoid `as` assertions.
+- Schema changes live in `packages/storage`; run `pnpm db-generate` after editing schema.
+- Do not run `pnpm db-push`. Database migrations are applied manually during deployment.
+- For shared PRs, leave new migration files out of version control unless explicitly requested.
+- Follow existing Biome, TypeScript, React, Next.js, Tailwind, and package conventions.
 
-## TypeScript types
-
-- Don't create types that duplicate existing ones. Reuse types from shared packages whenever possible.
-- Don't create types that can be inferred by TypeScript.
-- When types are unknown, use `unknown` instead of `any` to ensure type safety.
-- Avoid using `as` type assertions.
-
-## Database & storage tooling
-
-- Schema changes live under `packages/storage`. Use `pnpm db-generate` after modifying the schema to create migrations.
-- NEVER apply migrations with `pnpm db-push`, the DB migrations will be applied manually during deployment.
-- For shared PRs, leave new migration files out of version control unless explicitly requested. Coordinate with maintainers before merging so the migrations can be added manually without ordering conflicts.
-
-## Package dependencies
-
-- Use `workspace:*` versions for internal package dependencies in `package.json` files.
-- Common shared packages (not all listed):
-  - `@gredice/storage`: Database schema and migrations using Drizzle ORM
-  - `@gredice/email`: Email sending utilities
-  - `@gredice/ui`: Shared UI components with Tailwind CSS
-  - `@gredice/client`: API client SDK
-  - `@gredice/transactional`: Email templates and components
-  - `@gredice/stripe`: Payment integration utilities
-  - `@gredice/game`: Game-related components and models
-
-## Collaboration tips
-
-- When introducing new scripts or workspace packages, update the relevant `package.json` and workspace manifests.
-- Follow the repo's existing TypeScript, React, and Biome conventions.
-
-## Common commands reference
+## Quick commands
 
 ```bash
-# Install dependencies for entire monorepo
 pnpm install
-
-# Lint entire workspace
-pnpm lint
-
-# Lint specific package
-pnpm lint --filter @gredice/storage
-
-# Lint and apply fixes to specific app/package (from app/package directory)
-pnpm lint --filter @gredice/storage -- --write
-
-# Run tests for all packages
-pnpm test
-
-# Run tests for specific app
+pnpm dev
+pnpm lint --filter garden
 pnpm test --filter garden
-
-# Build all apps
-pnpm build
-
-# Build specific app
 pnpm build --filter garden
 ```
 
-## Using commands
-
-- To check types for packages, build the app that consumes them, as type checking is integrated into the Next.js build process.
-- Prefer targeted Turborepo commands (`pnpm <COMMAND> --filter ...`) to speed up workflows during development and CI validation.
-
-## Development servers
-
-- **Development servers**: Use `pnpm dev` to start all apps, then you can access them at:
-  - `www`: <https://www.gredice.test>
-  - `garden`: <https://vrt.gredice.test>
-  - `farm`: <https://farma.gredice.test>
-  - `app`: <https://app.gredice.test>
-  - `storybook`: <https://storybook.gredice.test>
-  - `api`: <https://api.gredice.test>
-  - `status`: <https://status.gredice.test> (start explicitly with `pnpm --filter=status dev`)
+For full command guidance, see [WORKSPACE.md](./WORKSPACE.md).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,42 @@
+# Design Guide
+
+Use this guide for visual and interaction design decisions.
+
+## Product surfaces
+
+- `www`: polished public marketing and commerce pages. The product, offer, plant, operation, or place should be visible and inspectable early.
+- `garden`: immersive customer experience. Favor tactile interaction, clear garden state, readable HUDs, and smooth responsive behavior.
+- `farm`: operational interface. Favor dense, calm layouts for repeated farm work.
+- `app`: internal admin interface. Favor scannable tables, filters, forms, status indicators, and predictable navigation.
+- `storybook`: documentation surface. Favor isolated examples, states, variants, and clear component names.
+
+## Visual standards
+
+- Follow the app's existing Tailwind, typography, spacing, and component patterns before introducing new visual language.
+- Reuse `@gredice/ui` and `@signalco/ui` primitives first.
+- Avoid decorative layouts that reduce task clarity in admin and farm tools.
+- Use cards for repeated items, modals, and genuinely framed tools. Do not nest cards inside cards.
+- Keep repeated operational views compact and aligned. Avoid oversized hero-style typography inside panels, tables, cards, and sidebars.
+- Avoid one-note palettes. Use the existing app palette and status colors rather than building an entire view from one hue family.
+- Make loading, empty, error, disabled, and success states part of the design, not afterthoughts.
+
+## Interaction standards
+
+- Use icons for common tool actions when an established icon exists.
+- Use segmented controls for modes, toggles or checkboxes for binary settings, sliders or numeric inputs for numbers, menus for option sets, and tabs for sibling views.
+- Text in controls must fit at mobile and desktop widths.
+- Layout dimensions should be stable for boards, grids, toolbars, counters, and tiles so hover states and dynamic labels do not shift the interface.
+- Do not expose instructions about how the UI works as permanent page copy when the control can be made self-evident.
+
+## Responsive behavior
+
+- Verify dense app views at mobile, tablet, and desktop breakpoints when touched.
+- Public pages must keep the first viewport meaningful on mobile and desktop.
+- Game and canvas views must avoid blank, clipped, or unclickable primary content.
+- Avoid viewport-width font scaling. Use responsive layout constraints instead.
+
+## Storybook expectations
+
+- New reusable UI components need stories under `apps/storybook/stories`.
+- Stories should cover the meaningful states: default, loading, empty, disabled, error, long content, and any important variants.
+- Keep stories close to real product usage rather than synthetic decoration.

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -1,0 +1,61 @@
+# Frontend Guide
+
+Use this guide for React, Next.js, TypeScript, UI components, and frontend app structure.
+
+## App ownership
+
+- `apps/www`: public site and commerce flows. Treat SEO, accessibility, performance, and polish as core behavior.
+- `apps/garden`: customer garden/game experience. Treat canvas/3D/game state, asset loading, touch input, and responsive layout as core behavior.
+- `apps/farm`: farm operations. Optimize for dense, repeatable workflows and clear task status.
+- `apps/app`: internal admin and operations. Optimize for data density, scanning, bulk actions, and reliable form workflows.
+- `apps/status`: public status page. Keep it simple, fast, and resilient.
+- `apps/storybook`: documentation surface for shared UI and reusable app components.
+
+## Component rules
+
+- Check `@gredice/ui`, `@gredice/game`, and existing app components before creating a new component.
+- If a component is reusable across apps, add it to `packages/ui` or the appropriate shared package.
+- Do not create multiple components in the same file. Split each component into its own file.
+- Keep app-specific components inside their owning app unless reuse is real.
+- When adding or changing a reusable UI component, add or update a Storybook story under `apps/storybook/stories` in the same change.
+- Prefer established `@signalco/*` and `@gredice/*` primitives already used in the app before introducing a new dependency.
+
+## Next.js and React
+
+- Follow the App Router patterns already present in each app.
+- Keep server-only code on the server. Use `server-only` where the package/app already uses it.
+- Add client components only when interactivity, browser APIs, or client state require them.
+- Prefer Server Components for data loading and page composition.
+- Use Server Actions where the app already uses them for mutations, and revalidate the affected routes with `revalidatePath` or the established cache pattern.
+- Keep client state scoped. Use React Query or existing state helpers where the local app already does.
+- Preserve existing route, layout, error boundary, and loading conventions.
+
+## TypeScript
+
+- Reuse types from `@gredice/*`, generated OpenAPI types, Drizzle schema types, and existing domain modules.
+- Do not create types that duplicate existing ones.
+- Do not create types that TypeScript can infer.
+- Use `unknown` instead of `any`.
+- Avoid `as` assertions. If narrowing is needed, prefer validation, discriminated unions, or local type guards.
+- Keep exported component props minimal and stable.
+
+## Forms and data entry
+
+- Validate user input at the boundary, not only in the UI.
+- Preserve existing form action result shapes and error display patterns.
+- Keep optimistic UI conservative for inventory, payment, delivery, account, and schedule workflows.
+- After mutations, revalidate every page or query that can show stale data.
+
+## Assets and media
+
+- Use `next/image` where the app already expects optimized images.
+- Use existing image and gallery components from `@gredice/ui` when possible.
+- For game assets and generated model types, use the existing generation scripts instead of hand-editing generated model output.
+- Avoid adding large assets unless the workflow explicitly needs them.
+
+## Accessibility
+
+- Interactive elements must be keyboard reachable and have clear labels.
+- Prefer semantic buttons, links, headings, tables, and form labels.
+- Keep focus management correct in dialogs, menus, drawers, and async forms.
+- Public `www` changes should satisfy the existing Playwright accessibility tests.

--- a/PRODUCT_SENSE.md
+++ b/PRODUCT_SENSE.md
@@ -1,0 +1,39 @@
+# Product Sense Guide
+
+Use this guide when choosing behavior, copy, defaults, and workflow shape.
+
+## Product model
+
+Gredice helps people plan, buy, operate, and understand modular gardens. The platform combines public education and commerce, customer garden management, farm operations, internal administration, notifications, payments, delivery, and game-like garden visualization.
+
+## Users
+
+- Public visitors compare offers, plants, raised beds, blocks, recipes, delivery terms, and company information.
+- Customers use the garden experience to understand what is planted, what happens next, and what they purchased.
+- Farm operators need clear daily work, schedules, raised-bed context, delivery status, and account/user details.
+- Internal admins need reliable directory, inventory, invoice, transaction, communication, and support workflows.
+- Developers and collaborators use Storybook and shared packages to keep UI behavior consistent.
+
+## Decision principles
+
+- Preserve domain meaning. Gardens, raised beds, fields, plants, sorts, operations, carts, deliveries, invoices, and accounts are business concepts, not generic records.
+- Optimize for the user doing the work, not for implementation convenience.
+- Keep money, inventory, delivery, fiscalization, and scheduled operation behavior explicit and auditable.
+- Prefer clear state transitions over hidden side effects.
+- When a workflow crosses apps or packages, maintain a single source of truth and reuse the shared package contract.
+- Match the language and tone already used by the app and route. Public-facing Croatian copy should stay consistent with nearby pages.
+
+## Feature shaping
+
+- Before adding a new UI, identify which app owns the workflow and whether a shared component already exists.
+- For public pages, make the primary offer or content clear without requiring the user to decode platform internals.
+- For operational tools, make the next action, current status, and data provenance easy to scan.
+- For garden/game features, preserve the user's mental model of a real raised bed and the timing of real garden work.
+- For notifications and emails, make triggers, recipients, timing, and opt-out/settings behavior explicit.
+
+## Copy and content
+
+- Do not invent facts about plants, delivery, pricing, legal terms, fiscalization, or availability.
+- Keep copy close to existing terminology in the app.
+- Avoid vague success messages. Confirm the object and state that changed.
+- Error messages should explain the problem and the next recoverable action without exposing secrets or internals.

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -1,0 +1,68 @@
+# Quality Score Guide
+
+Use this guide to decide whether a change is ready.
+
+## Readiness score
+
+Score the change from 0 to 5 before handing it off:
+
+- `0`: Does not run, has unresolved syntax/type errors, or leaves known broken behavior.
+- `1`: Runs only on the narrow happy path and has obvious missing validation or UI states.
+- `2`: Implements the request but leaves meaningful edge cases, stale data, or test gaps.
+- `3`: Solid targeted implementation with relevant lint/test/build checks passing.
+- `4`: Handles edge cases, failure states, accessibility, and cross-app/package impact.
+- `5`: Production-ready for critical paths: verified behavior, migrations handled, observability considered, and no unexplained risk.
+
+Aim for `3` on small low-risk changes and `4` or higher on shared, public, payment, inventory, delivery, auth, or database work.
+
+## Validation commands
+
+Use targeted commands first.
+
+```bash
+pnpm lint --filter <workspace>
+pnpm test --filter <workspace>
+pnpm build --filter <workspace>
+```
+
+Examples:
+
+```bash
+pnpm lint --filter @gredice/storage
+pnpm test --filter @gredice/storage
+pnpm build --filter www
+pnpm test --filter www
+```
+
+For docs-only changes, at minimum check formatting-sensitive diffs with:
+
+```bash
+git diff --check
+```
+
+## Testing expectations
+
+- Unit-test pure domain logic, parsing, validation, and repository behavior.
+- Use Playwright for app flows, accessibility, and user-visible regressions.
+- For `apps/www`, preserve sitemap-driven tests and visual test workflows when public pages change.
+- For storage changes, run the relevant storage tests. Remember that storage tests manage their own test database scripts.
+- For API route changes, test validation, auth, success, and failure responses.
+- For shared UI, add or update Storybook stories and test the consuming app when behavior changes.
+
+## Review checklist
+
+- The change is scoped to the requested behavior.
+- Existing user changes are preserved.
+- Types come from existing shared contracts where possible.
+- No avoidable `any`, non-null assertion, or `as` assertion was introduced.
+- Loading, empty, error, disabled, and success states are handled where relevant.
+- Mutations invalidate or revalidate the right data.
+- Public pages preserve metadata, structured data, accessibility, and responsive layout.
+- Secrets and private data are not logged, rendered, or sent to the client.
+- New dependencies are justified and added to the right workspace.
+
+## Documentation expectations
+
+- Update docs when behavior, setup, scripts, architecture, or contributor expectations change.
+- Keep docs concrete to this repo. Prefer exact package names, app paths, and commands over generic guidance.
+- Remove stale instructions when replacing them.

--- a/RELIABILITY.md
+++ b/RELIABILITY.md
@@ -1,0 +1,56 @@
+# Reliability Guide
+
+Use this guide for database, storage, background jobs, payments, notifications, generated assets, and failure handling.
+
+## Data ownership
+
+- Database schema and repository code live in `packages/storage`.
+- API route behavior lives mainly in `apps/api`.
+- Shared API client behavior lives in `packages/client`.
+- Payments live in `packages/stripe` and API checkout/Stripe processing code.
+- Notifications live in `packages/notifications`, `packages/slack`, `packages/email`, and `packages/transactional`.
+- Game and visual garden state live in `packages/game`, `apps/garden`, and generated assets.
+
+## Database changes
+
+- Edit schema under `packages/storage`.
+- Run `pnpm db-generate` after modifying schema.
+- Do not run `pnpm db-push`.
+- For shared PRs, leave new migration files out of version control unless explicitly requested.
+- Coordinate with maintainers before merging schema work so migrations can be ordered manually.
+- Repository changes should preserve existing event/history semantics and avoid silent data loss.
+
+## Consistency and idempotency
+
+- Payment, checkout, delivery, inventory, notification, and cron code must be safe to retry.
+- Prefer idempotent updates keyed by durable IDs from Stripe, carts, operations, notifications, or events.
+- Validate external metadata before trusting it.
+- Log enough context to diagnose failures without logging secrets or unnecessary personal data.
+- Keep partial failure behavior explicit: skipped, retryable, failed, or completed.
+
+## Background and cron work
+
+- Cron routes live in app route handlers and Vercel config where applicable.
+- Protect cron/internal routes with the established auth or secret pattern for that route.
+- Make cron work bounded and observable.
+- Handle empty work as a successful no-op.
+- Avoid making cron jobs depend on fragile client-side state.
+
+## External services
+
+- Stripe webhooks must verify signatures before processing events.
+- Email and Slack sending should tolerate missing optional configuration by using existing skipped-result patterns when available.
+- Vercel Blob, S3/R2, PostHog, OpenTelemetry, Redis, and external APIs should be called through existing helper packages or app-local wrappers.
+- Network failures should not corrupt local state.
+
+## Generated assets and models
+
+- Use existing scripts for generated game assets and model types.
+- Do not hand-edit generated model output unless the script output itself is broken and the fix is explicitly temporary.
+- Keep generated files deterministic when possible.
+
+## Observability
+
+- Preserve existing PostHog, Vercel Analytics, and OpenTelemetry instrumentation patterns.
+- Add event names and properties that match `apps/api/posthog-setup-report.md` or nearby analytics code.
+- Use logs for operational diagnostics, not user-facing control flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Guide
+
+Use this guide for auth, secrets, validation, payments, private data, and unsafe rendering.
+
+## Auth and authorization
+
+- Use the existing Signalco auth helpers and app-local `auth` wrappers.
+- Enforce authorization on the server for pages, route handlers, and Server Actions.
+- Do not rely on hidden UI, disabled buttons, or client checks for access control.
+- Admin workflows must require the appropriate role before reading or mutating data.
+- Preserve impersonation and session handling patterns where they already exist.
+
+## Secrets and environment variables
+
+- Never hardcode secrets, tokens, connection strings, webhook secrets, or private keys.
+- Only expose variables with `NEXT_PUBLIC_` when the value is safe for the browser.
+- Do not log secrets, auth headers, cookies, full webhook payloads, or payment credentials.
+- Use `pnpm env:pull` to populate local env files instead of inventing placeholder production values.
+
+## Input validation
+
+- Validate request bodies, query params, route params, webhook metadata, and Server Action input at the server boundary.
+- Use existing Zod, Valibot, Hono validator, or local validation patterns.
+- Treat external service metadata as untrusted.
+- Prefer allowlists for enum-like values, entity types, statuses, and sort/filter keys.
+
+## Data exposure
+
+- Send the client only the data needed for the rendered view or interaction.
+- Avoid exposing internal IDs when a route already uses public aliases or slugs.
+- Be careful with account, user, address, delivery, invoice, transaction, and email data.
+- Do not add broad `select *` style payloads to API or client helpers.
+
+## Payments and webhooks
+
+- Verify Stripe webhook signatures before processing.
+- Keep payment amounts, currency, line items, customer IDs, and cart/account relationships consistent.
+- Treat checkout processing as retryable and idempotent.
+- Do not trust Stripe product metadata without validating required fields and reconciling with local cart/account data.
+
+## Rendering and XSS
+
+- Avoid `dangerouslySetInnerHTML`.
+- If HTML or JSON-LD injection is required, keep it limited to trusted generated content and include a clear Biome ignore comment that explains why it is safe.
+- Sanitize or structurally validate user-authored content before rendering.
+- Do not render raw error objects or stack traces to users.
+
+## Dependencies
+
+- Prefer existing dependencies.
+- Add new dependencies only to the workspace that uses them.
+- Avoid packages that duplicate platform or existing helper behavior.

--- a/SEO.md
+++ b/SEO.md
@@ -1,0 +1,55 @@
+# SEO Guide
+
+Use this guide for public pages, metadata, structured data, canonical URLs, and sitemap behavior.
+
+## Scope
+
+SEO work primarily applies to:
+
+- `apps/www`: public marketing, commerce, plant, block, recipe, legal, FAQ, contact, and content pages.
+- `apps/status`: public status page metadata.
+
+SEO usually does not apply to authenticated `garden`, `farm`, `app`, or API routes except for basic metadata and share previews where those apps already define them.
+
+## Metadata
+
+- Use Next.js `metadata` or `generateMetadata` in route files.
+- Keep `metadataBase` aligned with the production domain already used by the app.
+- Each indexable public page should have a specific title and description.
+- Dynamic pages should derive metadata from the same data source used to render the page.
+- Missing dynamic content should return the established not-found behavior instead of generic metadata.
+- Keep Open Graph and Twitter metadata consistent with page intent.
+
+## Canonical URLs and routing
+
+- Preserve canonical path handling in `apps/www/proxy.ts`.
+- Do not create duplicate public routes for the same content without a canonical strategy.
+- Use stable slugs and aliases already present in directory/API data.
+- Redirect outdated paths rather than rendering duplicate content when the app already has redirect/proxy conventions.
+
+## Structured data
+
+- Use structured data only when it accurately represents rendered page content.
+- Existing product, operation, plant, sort, merchant return policy, and list pages should keep their schema.org data accurate.
+- Inject JSON-LD through the existing structured data component pattern.
+- Do not invent price, availability, review, or legal data for schema.
+
+## Sitemaps and tests
+
+- `apps/www` runs `next-sitemap` in `postbuild`.
+- Sitemap-driven test cases are populated by `apps/www/tests/populate-test-cases.ts`.
+- Public route changes may require checking:
+
+```bash
+pnpm build --filter www
+pnpm test --filter www
+```
+
+- If a page should not be indexed, make that explicit through the app's metadata or sitemap config.
+
+## Content quality
+
+- Public copy should be useful, concrete, and consistent with nearby Croatian content.
+- Headings should describe the page content, not internal implementation concepts.
+- Images should represent the actual plant, block, product, recipe, operation, or Gredice concept when available.
+- Avoid thin public pages that only wrap a component without meaningful metadata or content.

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -1,0 +1,103 @@
+# Workspace Guide
+
+Use this guide for repo layout, setup, commands, package boundaries, and local development servers.
+
+## Repository layout
+
+- `apps/api`: Next.js app exposing API routes, OpenAPI documentation, Stripe cron routes, internal cron routes, and API Playwright tests.
+- `apps/www`: public marketing and commerce site. It owns SEO-heavy public pages, sitemap generation, accessibility tests, and visual tests.
+- `apps/garden`: customer garden experience and game-facing UI.
+- `apps/farm`: farm back-office application.
+- `apps/app`: internal operations/admin application.
+- `apps/storybook`: public Storybook documentation for shared and app-adjacent UI.
+- `apps/status`: public status page. It is not started by the default root dev command.
+- `packages/*`: shared libraries such as `@gredice/ui`, `@gredice/client`, `@gredice/storage`, `@gredice/email`, `@gredice/transactional`, `@gredice/stripe`, `@gredice/game`, and integration helpers.
+- `assets`: source files for brand and 3D/game assets.
+- `scripts`: repo automation for development proxy, environment pull, Vercel linking, and generated assets.
+
+## Tooling
+
+- Runtime: Node.js `>=24`.
+- Package manager: pnpm `10.33.2`.
+- Task runner: Turborepo.
+- Formatting and linting: Biome per app/package.
+- Framework: Next.js 16 with React 19 and TypeScript 6.
+- Styling: Tailwind CSS 3 where applicable.
+- Browser tests: Playwright.
+- Node tests: Node's built-in test runner through `node --test` with `tsx` where needed.
+
+## Package boundaries
+
+- Use `workspace:*` versions for internal dependencies.
+- Add shared code to an existing package when the behavior is reused by more than one app.
+- Keep app-only behavior inside the app that owns the workflow.
+- Check existing exports before adding a new package export.
+- If you add a new workspace package or script, update the relevant `package.json`, `pnpm-workspace.yaml`, and Turbo task only when needed.
+
+## Commands
+
+Run commands from the repo root unless an app/package script explicitly requires its own directory.
+
+```bash
+# Install dependencies
+pnpm install
+
+# Pull Vercel environment variables for all apps
+pnpm env:pull
+
+# Start the default development stack with the local HTTPS proxy
+pnpm dev
+
+# Lint the full workspace
+pnpm lint
+
+# Lint one workspace
+pnpm lint --filter @gredice/storage
+pnpm lint --filter garden
+
+# Run tests
+pnpm test
+pnpm test --filter garden
+
+# Build
+pnpm build
+pnpm build --filter garden
+
+# Generate Drizzle migrations after storage schema changes
+pnpm db-generate
+
+# Regenerate OpenAPI-derived or generated package outputs
+pnpm regenerate
+```
+
+Many package lint scripts run `biome check --write`, so linting may modify files. Review the diff after linting.
+
+## Type checking
+
+Type checking is integrated into Next.js builds and package scripts. To validate app or package types, build the consuming app or run the targeted package test/build command that exercises the change.
+
+## Development servers
+
+`pnpm dev` starts the default app stack and a Dockerized Caddy HTTPS proxy.
+
+- `www`: <https://www.gredice.test>
+- `garden`: <https://vrt.gredice.test>
+- `farm`: <https://farma.gredice.test>
+- `app`: <https://app.gredice.test>
+- `storybook`: <https://storybook.gredice.test>
+- `api`: <https://api.gredice.test>
+- `status`: <https://status.gredice.test> with `pnpm --filter=status dev`
+
+Hosts file entry:
+
+```text
+127.0.0.1 www.gredice.test vrt.gredice.test farma.gredice.test app.gredice.test storybook.gredice.test api.gredice.test status.gredice.test
+```
+
+Docker must be running for the proxy. Use `SKIP_DEV_PROXY=1 pnpm dev` only when the local proxy is not needed.
+
+## Generated files
+
+- Do not commit build output, caches, `.next`, coverage, Storybook static output, or `node_modules`.
+- Generated TypeScript and assets may be committed only when the source change requires it and the generated file is an established tracked artifact.
+- For database migrations, follow [RELIABILITY.md](./RELIABILITY.md).


### PR DESCRIPTION
## Summary
- Replaced the root `AGENTS.md` with a compact index and repo-wide rules.
- Added focused guidance docs for workspace setup, frontend, design, product sense, quality, reliability, security, and SEO.
- Aligned the new docs with the actual monorepo structure, scripts, app roles, and validation patterns.

## Testing
- Not run (not requested)