### PR TITLE
Trim README and move operational guidance into workspace docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,232 +10,55 @@
 
 ## Overview
 
-Gredice is a Turborepo monorepo that powers the entire Gredice platform. It includes multiple applications (`www`, `garden`, `farm`, `app`, `storybook`, and `api`) plus shared packages and assets that bring the experience together. Clone the repo to explore the user-facing products, APIs, and infrastructure that help modular gardens thrive.
+Gredice is a Turborepo monorepo for the Gredice platform. It includes the public website, customer garden experience, farm back office, internal operations tools, API routes, Storybook, status page, shared packages, and product assets.
 
-## Table of Contents
+## Repository Map
 
-- [Development](#development)
-  - [Prerequisites](#prerequisites)
-  - [Quick start](#quick-start)
-  - [Environment variables](#environment-variables)
-  - [API reference](#api-reference)
-- [Database migrations](#database-migrations)
-- [Assets workflow](#assets-workflow)
-  - [Regenerating game assets](#regenerating-game-assets)
-  - [Sprite atlas workflow](#sprite-atlas-workflow)
-  - [Adding a new entity model](#adding-a-new-entity-model)
-- [Contributing](#contributing)
-- [License](#license)
+- `apps/www`: public marketing and commerce site.
+- `apps/garden`: customer garden experience and game-facing UI.
+- `apps/farm`: farm back-office application.
+- `apps/app`: internal operations and admin application.
+- `apps/api`: API routes and API documentation.
+- `apps/storybook`: public component documentation.
+- `apps/status`: public status page.
+- `packages/*`: shared libraries for UI, client APIs, storage, game behavior, notifications, integrations, and other platform code.
+- `assets`: source brand and game assets.
 
-## Development
+## Getting Started
 
-### Prerequisites
-
-- [Node.js](https://nodejs.org/en/)
-- [pnpm](https://pnpm.io/)
-- [Docker](https://www.docker.com/) (used for the local reverse proxy)
-- [Vercel CLI](https://vercel.com/download)
-
-### Quick start
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/gredice/gredice.git
-   cd gredice
-   ```
-
-2. Install the dependencies:
-
-   ```bash
-   pnpm install
-   ```
-
-3. Pull environment variables for all applications:
-
-   ```bash
-   pnpm env:pull
-   ```
-
-4. Start the development server from the project root:
-
-   ```bash
-   pnpm dev
-   ```
-
-### Local domains
-
-Running `pnpm dev` automatically starts a Dockerized Caddy reverse proxy so that each app is available on the same subdomains we use in production:
-
-- <https://www.gredice.test> → marketing site (`apps/www`)
-- <https://vrt.gredice.test> → customer garden (`apps/garden`)
-- <https://farma.gredice.test> → farm back office (`apps/farm`)
-- <https://app.gredice.test> → internal operations (`apps/app`)
-- <https://storybook.gredice.test> → public component documentation (`apps/storybook`)
-- <https://api.gredice.test> → API routes (`apps/api`)
-- <https://status.gredice.test> → public status page (`apps/status`, not started by default)
-
-Add the following entry to your hosts file (e.g. `/etc/hosts` on macOS/Linux or `C:\Windows\System32\drivers\etc\hosts` on Windows) so the domains resolve to your machine:
-
-```text
-127.0.0.1 www.gredice.test vrt.gredice.test farma.gredice.test app.gredice.test storybook.gredice.test api.gredice.test status.gredice.test
-```
-
-Make sure Docker Desktop (or the Docker daemon) is running before you start the dev server. To bypass the proxy—for example, if Docker is unavailable—run `SKIP_DEV_PROXY=1 pnpm dev`. If the proxy ever lingers after an interrupted session, you can stop it manually with `docker stop gredice-dev-caddy`.
-
-The `status` app is excluded from the default `pnpm dev` stack. Start it explicitly with `pnpm --filter=status dev` when working on the status page.
-
-### Development HTTPS certificates
-
-The development proxy terminates HTTPS locally so the applications behave the same way they do in production. When you run `pnpm dev`, the script stores Caddy's internal certificate authority in `~/.gredice/dev-caddy` (or the path specified by `GREDICE_DEV_CADDY_DATA_DIR`) and attempts to trust it automatically for your operating system. You may be prompted for your password if the trust store requires elevated access.
-
-If the automatic step fails, you can trust the authority manually from the path above:
-
-- **macOS**: open Keychain Access, import `root.crt` from the Caddy data directory, and mark it as trusted for SSL.
-- **Windows**: run `certmgr.msc`, open the *Trusted Root Certification Authorities* store (either user or local machine), and import `root.crt`.
-- **Linux**: install it into your user trust store with `trust anchor ~/.gredice/dev-caddy/caddy/pki/authorities/local/root.crt`, or use your distribution's certificate tooling.
-
-After the certificate is trusted, browsers will stop warning about the `*.gredice.test` HTTPS domains.
-
-### Environment variables
-
-Use the Vercel CLI to pull environment variables for every app at once:
+Use [Node.js](https://nodejs.org/en/) `>=24`, [pnpm](https://pnpm.io/) `10.33.2`, [Docker](https://www.docker.com/), and the [Vercel CLI](https://vercel.com/download).
 
 ```bash
-pnpm env:pull
-```
-
-This runs `vercel env pull .env` in `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, `apps/storybook`, `apps/api`, and `apps/status`.
-
-If you are running the command for the first time on the development machine, make sure you are logged in to the Vercel CLI and that the project is linked:
-
-```bash
+pnpm install
 vercel login
-vercel link
+pnpm vercel:link
+pnpm env:pull
+pnpm dev
 ```
 
-After logging in and linking, rerun `pnpm env:pull` to update all local environment files.
+The default dev command starts the main apps through local HTTPS domains such as `https://www.gredice.test`, `https://vrt.gredice.test`, and `https://api.gredice.test`. The `status` app is not part of the default dev stack; start it with `pnpm --filter=status dev` when working on the status page.
 
-### API reference
+For local domains, certificates, environment files, generated assets, and detailed commands, see [WORKSPACE.md](./WORKSPACE.md).
 
-See the [API Reference](https://api.gredice.com) for the official documentation. You can use the API to interact with the Gredice platform, manage gardens and farms, and integrate Gredice capabilities into your own applications.
+## Documentation
 
-## Database migrations
+- [AGENTS.md](./AGENTS.md): entry point for AI collaborators.
+- [WORKSPACE.md](./WORKSPACE.md): repo layout, setup, commands, package boundaries, and local development servers.
+- [FRONTEND.md](./FRONTEND.md): Next.js, React, TypeScript, shared UI, Storybook, and app structure rules.
+- [DESIGN.md](./DESIGN.md): visual and interaction design standards.
+- [PRODUCT_SENSE.md](./PRODUCT_SENSE.md): product expectations, user roles, language, and domain behavior.
+- [QUALITY_SCORE.md](./QUALITY_SCORE.md): quality rubric, validation commands, type standards, and review expectations.
+- [RELIABILITY.md](./RELIABILITY.md): data integrity, migrations, background work, observability, and failure handling.
+- [SECURITY.md](./SECURITY.md): auth, secrets, data exposure, validation, payments, and unsafe rendering.
+- [SEO.md](./SEO.md): metadata, structured data, sitemap, canonical URL, and public page rules.
 
-Use the workspace scripts to manage migrations during development:
+## API Reference
 
-1. Generate new migrations after making schema changes:
-
-   ```bash
-   pnpm db-generate
-   ```
-
-2. Apply migrations to your local database (requires the connection string in your environment):
-
-   ```bash
-   pnpm db-push
-   ```
-
-These commands leverage the monorepo's Turbo tasks to execute the appropriate migration scripts in the relevant packages (typically `packages/storage`).
-
-- Run `pnpm db-generate` whenever you adjust the database schema to create new migration files.
-- Run `pnpm db-push` to apply all pending migrations to your database once the environment variables are configured.
-
-## Assets workflow
-
-Coordinate with teammates before editing the shared game asset files. Only one person should export changes at a time to avoid conflicting updates.
-
-### Regenerating game assets
-
-After updating the `GameAssets.blend` file in the `assets/` directory, regenerate both the GLB file and TypeScript types by running this command from the project root:
-
-```bash
-pnpm generate:game-assets
-```
-
-This command does the following:
-
-1. Exports `GameAssets.blend` to `apps/garden/public/assets/models/GameAssets.glb` using Blender
-2. Generates TypeScript types in `packages/game/src/models/GameAssets.tsx` using gltfjsx
-3. Applies linting and formatting fixes to ensure the generated code is error-free
-
-**Prerequisites**: This command requires [Blender](https://www.blender.org/download/) to be installed at the default location for your platform:
-
-- **macOS**: `/Applications/Blender.app`
-- **Windows**: `C:\Program Files\Blender Foundation\Blender 4.5\blender.exe`
-- **Linux/other**: Update the path in `assets/export.sh`
-
-The command automatically detects your platform and uses the appropriate export script (`export.ps1` on Windows, `export.sh` on Unix-like systems).
-
-### Manual steps (alternative)
-
-If you need to run the steps separately:
-
-1. **Export the GLB file** - Run from the `assets/` directory:
-
-   **Unix-like systems (macOS, Linux):**
-
-   ```bash
-   ./export.sh
-   ```
-
-   **Windows:**
-
-   ```powershell
-   .\export.ps1
-   ```
-
-2. **Generate TypeScript types** - Run from the project root:
-
-   ```bash
-   pnpm generate:models-types
-   ```
-
-### Sprite atlas workflow
-
-The garden client supports texture atlases for billboard-style sprites such as ground decorations. The current decoration atlas pipeline lives in `packages/cdn/scripts/` and is designed so atlas pages stay stable as the input set grows.
-
-The current ground-cover source sheets live in `apps/garden/data/sriptes/` and are processed in two stages:
-
-1. `extract-decoration-sprites.ts` cuts individual transparent sprite images out of the source sheets.
-2. `create-decoration-atlas.ts` packs those images into one or more atlas pages and writes PNG/WebP textures plus a manifest.
-
-Use this command from the repository root:
-
-```bash
-pnpm --filter @gredice/cdn run regenerate-cdn:decoration-atlas
-```
-
-The atlas generator writes:
-
-- `apps/garden/public/assets/sprites/decorations/<name>.atlas.png`
-- `apps/garden/public/assets/sprites/decorations/<name>.atlas.webp`
-- `apps/garden/public/assets/sprites/decorations/<name>.atlas.json`
-- Additional pages as `.../<name>.atlas.1.png`, `.../<name>.atlas.1.webp`, etc. when the category grows beyond a single page
-
-The atlas manifest is the source of truth for runtime loading. It contains:
-
-- Stable sprite metadata keyed by sprite name
-- Page metadata for multi-page atlases
-- Grid layout metadata so page slots remain deterministic
-
-Atlas slot assignment is intentionally stable. Existing sprites keep their previous page and cell when you regenerate, so adding or removing a few input files does not force the entire category to shift around. For categories where stability matters, lock the page grid with explicit `--columns` and `--rows` values in the corresponding package script. When a page fills up, new sprites spill onto a new atlas page instead of shrinking or repacking the old page.
-
-When adding new input sprites to an existing category:
-
-1. Put the extracted source images under the category input directory.
-2. Keep sprite names stable, because the manifest uses the relative input path as the sprite id.
-3. Regenerate the atlas JSON/PNG.
-
-### Adding a new entity model
-
-We use [https://gltf.pmnd.rs/](https://gltf.pmnd.rs/) to convert GLTF assets into Three.js compatible components before integrating them into the project.
-
-When adding new models to `GameAssets.blend`, run `pnpm generate:game-assets` to update the GLB export and TypeScript types.
+See the [API Reference](https://api.gredice.com) for the official API documentation.
 
 ## Contributing
 
-We welcome community contributions—check out the repository activity below and jump into issues or discussions that interest you.
+We welcome community contributions. Explore repository activity, issues, and discussions to find a useful place to start.
 
 ![Alt](https://repobeats.axiom.co/api/embed/ba847f4d1fae06c8250692c08295602bca8de554.svg "Repobeats analytics image")
 

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -42,6 +42,9 @@ Run commands from the repo root unless an app/package script explicitly requires
 # Install dependencies
 pnpm install
 
+# Link every app to its Vercel project
+pnpm vercel:link
+
 # Pull Vercel environment variables for all apps
 pnpm env:pull
 
@@ -88,13 +91,69 @@ Type checking is integrated into Next.js builds and package scripts. To validate
 - `api`: <https://api.gredice.test>
 - `status`: <https://status.gredice.test> with `pnpm --filter=status dev`
 
-Hosts file entry:
+The dev script verifies the hosts entries for the `*.gredice.test` domains and attempts to add missing entries automatically. If it cannot modify the hosts file, add this entry manually and rerun the command:
 
 ```text
 127.0.0.1 www.gredice.test vrt.gredice.test farma.gredice.test app.gredice.test storybook.gredice.test api.gredice.test status.gredice.test
 ```
 
 Docker must be running for the proxy. Use `SKIP_DEV_PROXY=1 pnpm dev` only when the local proxy is not needed.
+
+### Development HTTPS certificates
+
+The local Caddy proxy terminates HTTPS. Its internal certificate authority is stored in `~/.gredice/dev-caddy` unless `GREDICE_DEV_CADDY_DATA_DIR` points somewhere else. The dev script attempts to trust the certificate authority automatically for the current OS.
+
+If automatic trust fails, import `root.crt` manually from the Caddy data directory:
+
+- macOS: import `root.crt` into Keychain Access and mark it as trusted for SSL.
+- Windows: open `certmgr.msc`, then import `root.crt` into Trusted Root Certification Authorities.
+- Linux: run `trust anchor ~/.gredice/dev-caddy/caddy/pki/authorities/local/root.crt`, or use the distribution's certificate tooling.
+
+After the certificate is trusted, browsers should accept the local `*.gredice.test` HTTPS domains.
+
+## Environment setup
+
+Use the Vercel CLI for local environment files. If the apps are not linked on the current machine, log in and run the repo script before pulling env vars:
+
+```bash
+vercel login
+pnpm vercel:link
+pnpm env:pull
+```
+
+`pnpm env:pull` runs `vercel env pull .env` in `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, `apps/storybook`, `apps/api`, and `apps/status`.
+
+## Asset generation
+
+Coordinate with teammates before editing shared game asset files. Only one person should export shared asset changes at a time.
+
+### Game assets
+
+After changing `assets/GameAssets.blend`, regenerate the exported GLB and model types from the repo root:
+
+```bash
+pnpm generate:game-assets
+```
+
+This runs the platform export script from `assets`, writes `apps/garden/public/assets/models/GameAssets.glb`, then runs `pnpm generate:models-types` to update `packages/game/src/models/GameAssets.tsx` through `gltfjsx` and the local post-processing script.
+
+Blender must be installed where the export scripts expect it:
+
+- macOS: `/Applications/Blender.app`
+- Windows: `C:\Program Files\Blender Foundation\Blender 4.5\blender.exe`
+- Linux/other Unix-like systems: update `assets/export.sh` for the local Blender path before running the generator.
+
+If the steps need to run separately, run `./export.sh` from `assets` on Unix-like systems or `.\export.ps1` from `assets` on Windows, then run `pnpm generate:models-types` from the repo root.
+
+### Decoration sprite atlas
+
+The decoration atlas pipeline lives in `packages/cdn/scripts` and currently processes source sheets from `apps/garden/data/sriptes`. Regenerate the ground-cover atlas with:
+
+```bash
+pnpm --filter @gredice/cdn run regenerate-cdn:decoration-atlas
+```
+
+The script extracts source sprites, packs them into stable atlas pages, and writes PNG, WebP, and JSON manifest files under `apps/garden/public/assets/sprites/decorations`. The manifest is the runtime source of truth. Keep sprite names stable, because the manifest uses relative input paths as sprite IDs.
 
 ## Generated files
 


### PR DESCRIPTION
## Summary
- Reduced `README.md` to a human-facing project overview, repo map, quick start, docs index, API reference, and contribution/license info.
- Moved repo-operational details into `WORKSPACE.md`, including Vercel linking/env setup, local HTTPS proxy/hosts/cert guidance, and asset generation workflows.
- Removed the stale README migration instructions that conflicted with the current `RELIABILITY.md` policy on `pnpm db-push`.

## Testing
- `git diff --check` passed.
- Fact-checked the updated commands and paths against the current workspace scripts, Caddy config, and package metadata.