### PR TITLE
Add completion and publish-state filters to CMS entity tables

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/EntitiesFilters.tsx
+++ b/apps/app/app/admin/directories/[entityType]/EntitiesFilters.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Check, Edit, Megaphone, Warning } from '@signalco/ui-icons';
+import {
+    type FilterOption,
+    TableFilter,
+} from '../../../../components/shared/filters';
+
+const COMPLETION_FILTER_OPTIONS: FilterOption = {
+    key: 'completion',
+    label: 'Ispunjenost',
+    icon: <Check className="size-4" />,
+    options: [
+        { value: '', label: 'Svi zapisi' },
+        {
+            value: 'complete',
+            label: 'Ispunjeni',
+            icon: <Check className="size-4" />,
+        },
+        {
+            value: 'incomplete',
+            label: 'Nepotpuni',
+            icon: <Warning className="size-4" />,
+        },
+    ],
+};
+
+const PUBLISH_STATE_FILTER_OPTIONS: FilterOption = {
+    key: 'state',
+    label: 'Status objave',
+    icon: <Megaphone className="size-4" />,
+    options: [
+        { value: '', label: 'Svi statusi' },
+        {
+            value: 'draft',
+            label: 'Draft',
+            icon: <Edit className="size-4" />,
+        },
+        {
+            value: 'published',
+            label: 'Objavljeno',
+            icon: <Megaphone className="size-4" />,
+        },
+    ],
+};
+
+export function EntitiesFilters() {
+    return (
+        <TableFilter
+            filters={[COMPLETION_FILTER_OPTIONS, PUBLISH_STATE_FILTER_OPTIONS]}
+            defaultValues={{
+                completion: '',
+                state: '',
+            }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -7,6 +7,7 @@ import {
     getInventoryItemsByConfig,
     updateInventoryItem,
 } from '@gredice/storage';
+import { getEntityCompleteness } from '@gredice/storage/entityCompleteness';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -142,20 +143,11 @@ export default async function EntityDetailsPage(props: {
     }
 
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
-    const populatedAttributeDefinitionIds = new Set(
-        entity.attributes
-            .filter((attribute) => (attribute.value?.length ?? 0) > 0)
-            .map((attribute) => attribute.attributeDefinitionId),
-    );
+    const completeness = getEntityCompleteness(entity, attributeDefinitions);
     const categoriesWithMissingRequiredAttributes = new Set(
-        attributeDefinitions
-            .filter(
-                (definition) =>
-                    definition.required &&
-                    !definition.defaultValue &&
-                    !populatedAttributeDefinitionIds.has(definition.id),
-            )
-            .map((definition) => definition.category),
+        completeness.missingRequiredDefinitions.map(
+            (definition) => definition.category,
+        ),
     );
 
     return (

--- a/apps/app/app/admin/directories/[entityType]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/page.tsx
@@ -25,16 +25,24 @@ import {
     createEntity,
     duplicateEntity,
 } from '../../../(actions)/entityActions';
+import { EntitiesFilters } from './EntitiesFilters';
 
 export const dynamic = 'force-dynamic';
 
 export default async function EntitiesPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ entityType: string }>;
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
     await auth(['admin']);
     const { entityType: entityTypeName } = await params;
+    const urlParams = await searchParams;
+    const completionFilter =
+        typeof urlParams.completion === 'string' ? urlParams.completion : '';
+    const stateFilter =
+        typeof urlParams.state === 'string' ? urlParams.state : '';
     const entityType = await getEntityTypeByName(entityTypeName);
     const createEntityBound = createEntity.bind(null, entityTypeName);
     const duplicateEntityBound = duplicateEntity.bind(null, entityTypeName);
@@ -93,6 +101,7 @@ export default async function EntitiesPage({
                 <h1 className="sr-only">
                     {entityType?.label ?? entityTypeName}
                 </h1>
+                <EntitiesFilters />
                 <Card>
                     <CardOverflow>
                         <EntitiesTable
@@ -103,6 +112,8 @@ export default async function EntitiesPage({
                             inventoryLowCountThreshold={
                                 inventoryConfig?.lowCountThreshold
                             }
+                            completionFilter={completionFilter}
+                            stateFilter={stateFilter}
                             onDuplicate={duplicateEntityBound}
                         />
                     </CardOverflow>

--- a/apps/app/components/admin/directories/EntityAttributeProgress.tsx
+++ b/apps/app/components/admin/directories/EntityAttributeProgress.tsx
@@ -4,6 +4,7 @@ import type {
     getEntitiesRaw,
     SelectAttributeDefinition,
 } from '@gredice/storage';
+import { getEntityCompleteness } from '@gredice/storage/entityCompleteness';
 import { Check } from '@signalco/ui-icons';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -21,32 +22,12 @@ export function EntityAttributeProgress({
     entity: Awaited<ReturnType<typeof getEntitiesRaw>>[number];
     definitions: SelectAttributeDefinition[];
 }) {
-    const numberOfRequiredAttributes = definitions.filter(
-        (d) => d.required,
-    ).length;
-    const notPopulatedRequiredAttributes = definitions.filter(
-        (d) =>
-            d.required &&
-            !d.defaultValue &&
-            !entity.attributes.some(
-                (a) =>
-                    a.attributeDefinitionId === d.id &&
-                    (a.value?.length ?? 0) > 0,
-            ),
-    );
-    const progress =
-        numberOfRequiredAttributes > 0
-            ? ((numberOfRequiredAttributes -
-                  notPopulatedRequiredAttributes.length) /
-                  numberOfRequiredAttributes) *
-              100
-            : 100;
-    const isComplete = progress >= 99.99;
+    const completeness = getEntityCompleteness(entity, definitions);
 
     return (
         <Tooltip delayDuration={250}>
             <TooltipTrigger asChild>
-                {isComplete ? (
+                {completeness.isComplete ? (
                     <span className="flex size-5 items-center justify-center">
                         <Check className="size-5 text-green-500" aria-hidden />
                         <span className="sr-only">
@@ -58,37 +39,42 @@ export function EntityAttributeProgress({
                         <div className="h-1 bg-primary/10 rounded-full overflow-hidden grow">
                             <div
                                 className="h-full bg-red-400"
-                                style={{ width: `${progress}%` }}
+                                style={{
+                                    width: `${completeness.progress}%`,
+                                }}
                             />
                         </div>
                         <Typography
                             level="body2"
                             className="hidden group-hover:inline"
                         >
-                            {progress.toFixed(0)}%
+                            {completeness.progress.toFixed(0)}%
                         </Typography>
                     </Row>
                 )}
             </TooltipTrigger>
             <TooltipContent className="min-w-60">
-                {isComplete && 'Svi obavezni atributi su ispunjeni'}
-                {!isComplete && (
+                {completeness.isComplete &&
+                    'Svi obavezni atributi su ispunjeni'}
+                {!completeness.isComplete && (
                     <Stack spacing={1}>
                         <Typography semiBold>
-                            Manjak obaveznih atributa ({progress.toFixed(0)}%):
+                            {`Manjak obaveznih atributa (${completeness.progress.toFixed(0)}%):`}
                         </Typography>
                         <Stack>
-                            {notPopulatedRequiredAttributes
+                            {completeness.missingRequiredDefinitions
                                 .slice(0, 5)
                                 .map((a) => (
                                     <Typography key={a.id}>
                                         {a.label}
                                     </Typography>
                                 ))}
-                            {notPopulatedRequiredAttributes.length > 5 && (
+                            {completeness.missingRequiredDefinitions.length >
+                                5 && (
                                 <Typography secondary>
                                     i{' '}
-                                    {notPopulatedRequiredAttributes.length - 5}{' '}
+                                    {completeness.missingRequiredDefinitions
+                                        .length - 5}{' '}
                                     drugih...
                                 </Typography>
                             )}

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -4,6 +4,10 @@ import type {
     getEntitiesRaw,
     SelectAttributeDefinition,
 } from '@gredice/storage';
+import {
+    filterEntitiesByCompletionAndState,
+    getEntityCompleteness,
+} from '@gredice/storage/entityCompleteness';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Duplicate } from '@signalco/ui-icons';
@@ -53,6 +57,8 @@ type EntitiesTableProps = {
     attributeDefinitions: SelectAttributeDefinition[];
     inventoryItems: InventoryItem[];
     inventoryLowCountThreshold?: number | null;
+    completionFilter?: string;
+    stateFilter?: string;
     onDuplicate: (entityId: number) => Promise<void>;
 };
 
@@ -62,12 +68,22 @@ export function EntitiesTable({
     attributeDefinitions,
     inventoryItems,
     inventoryLowCountThreshold = null,
+    completionFilter = '',
+    stateFilter = '',
     onDuplicate,
 }: EntitiesTableProps) {
     const { filter } = useFilter();
     const [sort, setSort] = useState<SortState>(defaultSort);
     const normalized = filter.toLowerCase();
-    const filteredEntities = entities.filter((entity) =>
+    const statusFilteredEntities = filterEntitiesByCompletionAndState(
+        entities,
+        attributeDefinitions,
+        {
+            completion: completionFilter,
+            state: stateFilter,
+        },
+    );
+    const filteredEntities = statusFilteredEntities.filter((entity) =>
         entityDisplayName(entity).toLowerCase().includes(normalized),
     );
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
@@ -355,7 +371,7 @@ function entitySortValue(
     }
 
     if (key === 'progress') {
-        return entityAttributeProgress(entity, definitions);
+        return getEntityCompleteness(entity, definitions).progress;
     }
 
     if (key === 'updatedAt') {
@@ -410,32 +426,6 @@ function attributeSortValue(
     }
 
     return value;
-}
-
-function entityAttributeProgress(
-    entity: Entities[number],
-    definitions: SelectAttributeDefinition[],
-) {
-    const requiredDefinitions = definitions.filter((d) => d.required);
-    if (!requiredDefinitions.length) {
-        return 100;
-    }
-
-    const missingRequiredDefinitions = requiredDefinitions.filter(
-        (d) =>
-            !d.defaultValue &&
-            !entity.attributes.some(
-                (a) =>
-                    a.attributeDefinitionId === d.id &&
-                    (a.value?.length ?? 0) > 0,
-            ),
-    );
-
-    return (
-        ((requiredDefinitions.length - missingRequiredDefinitions.length) /
-            requiredDefinitions.length) *
-        100
-    );
 }
 
 function entityDisplayName(entity: Entities[number]) {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,7 +6,8 @@
     "type": "module",
     "license": "MIT",
     "exports": {
-        ".": "./src/index.ts"
+        ".": "./src/index.ts",
+        "./entityCompleteness": "./src/helpers/entityCompleteness.ts"
     },
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",

--- a/packages/storage/src/helpers/entityCompleteness.ts
+++ b/packages/storage/src/helpers/entityCompleteness.ts
@@ -1,0 +1,100 @@
+export type EntityCompletenessAttributeDefinition = {
+    id: number;
+    category: string;
+    label: string;
+    required: boolean;
+    defaultValue: string | null;
+};
+
+export type EntityCompletenessAttribute = {
+    attributeDefinitionId: number;
+    value: string | null;
+};
+
+export type EntityCompletenessEntity = {
+    attributes: EntityCompletenessAttribute[];
+    state?: string;
+};
+
+export type EntityCompletenessFilter = 'complete' | 'incomplete' | '';
+export type EntityPublishStateFilter = 'draft' | 'published' | '';
+
+export type EntityCompleteness = {
+    requiredCount: number;
+    completedRequiredCount: number;
+    missingRequiredDefinitions: EntityCompletenessAttributeDefinition[];
+    progress: number;
+    isComplete: boolean;
+};
+
+export function getEntityCompleteness(
+    entity: EntityCompletenessEntity,
+    definitions: EntityCompletenessAttributeDefinition[],
+): EntityCompleteness {
+    const requiredDefinitions = definitions.filter(
+        (definition) => definition.required,
+    );
+
+    if (!requiredDefinitions.length) {
+        return {
+            requiredCount: 0,
+            completedRequiredCount: 0,
+            missingRequiredDefinitions: [],
+            progress: 100,
+            isComplete: true,
+        };
+    }
+
+    const missingRequiredDefinitions = requiredDefinitions.filter(
+        (definition) =>
+            !definition.defaultValue &&
+            !entity.attributes.some(
+                (attribute) =>
+                    attribute.attributeDefinitionId === definition.id &&
+                    (attribute.value?.length ?? 0) > 0,
+            ),
+    );
+    const completedRequiredCount =
+        requiredDefinitions.length - missingRequiredDefinitions.length;
+    const progress =
+        (completedRequiredCount / requiredDefinitions.length) * 100;
+
+    return {
+        requiredCount: requiredDefinitions.length,
+        completedRequiredCount,
+        missingRequiredDefinitions,
+        progress,
+        isComplete: progress >= 99.99,
+    };
+}
+
+export function filterEntitiesByCompletionAndState<
+    TEntity extends EntityCompletenessEntity,
+>(
+    entities: TEntity[],
+    definitions: EntityCompletenessAttributeDefinition[],
+    filters: {
+        completion?: string;
+        state?: string;
+    },
+) {
+    return entities.filter((entity) => {
+        if (
+            filters.state &&
+            (filters.state === 'draft' || filters.state === 'published') &&
+            entity.state !== filters.state
+        ) {
+            return false;
+        }
+
+        if (filters.completion === 'complete') {
+            return getEntityCompleteness(entity, definitions).isComplete;
+        }
+
+        if (filters.completion === 'incomplete') {
+            return !getEntityCompleteness(entity, definitions).isComplete;
+        }
+
+        return true;
+    });
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -2,6 +2,7 @@ export * from './@types/EntityStandardized';
 export * from './cache/directoriesCached';
 export * from './cache/grediceCached';
 export * from './helpers/deliveryEmail';
+export * from './helpers/entityCompleteness';
 export * from './helpers/timeSlotAutomation';
 export * from './helpers/timezoneUtils';
 export * from './repositories/accountDeletionRepo';

--- a/packages/storage/tests/entityCompleteness.node.spec.ts
+++ b/packages/storage/tests/entityCompleteness.node.spec.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    type EntityCompletenessAttributeDefinition,
+    type EntityCompletenessEntity,
+    filterEntitiesByCompletionAndState,
+    getEntityCompleteness,
+} from '@gredice/storage/entityCompleteness';
+
+const requiredLabelDefinition: EntityCompletenessAttributeDefinition = {
+    id: 1,
+    category: 'information',
+    label: 'Naziv',
+    required: true,
+    defaultValue: null,
+};
+
+const requiredDefaultDefinition: EntityCompletenessAttributeDefinition = {
+    id: 2,
+    category: 'information',
+    label: 'Vrsta',
+    required: true,
+    defaultValue: 'standard',
+};
+
+const optionalDefinition: EntityCompletenessAttributeDefinition = {
+    id: 3,
+    category: 'metadata',
+    label: 'Napomena',
+    required: false,
+    defaultValue: null,
+};
+
+test('getEntityCompleteness treats entities without required definitions as complete', () => {
+    const entity: EntityCompletenessEntity = {
+        attributes: [],
+    };
+
+    assert.deepStrictEqual(
+        getEntityCompleteness(entity, [optionalDefinition]),
+        {
+            requiredCount: 0,
+            completedRequiredCount: 0,
+            missingRequiredDefinitions: [],
+            progress: 100,
+            isComplete: true,
+        },
+    );
+});
+
+test('getEntityCompleteness reports missing required definitions and preserves default value behavior', () => {
+    const entity: EntityCompletenessEntity = {
+        attributes: [
+            {
+                attributeDefinitionId: requiredLabelDefinition.id,
+                value: '',
+            },
+        ],
+    };
+
+    const completeness = getEntityCompleteness(entity, [
+        requiredLabelDefinition,
+        requiredDefaultDefinition,
+        optionalDefinition,
+    ]);
+
+    assert.strictEqual(completeness.requiredCount, 2);
+    assert.strictEqual(completeness.completedRequiredCount, 1);
+    assert.strictEqual(completeness.progress, 50);
+    assert.strictEqual(completeness.isComplete, false);
+    assert.deepStrictEqual(completeness.missingRequiredDefinitions, [
+        requiredLabelDefinition,
+    ]);
+});
+
+test('filterEntitiesByCompletionAndState combines completion and publish state filters', () => {
+    const completeDraft: EntityCompletenessEntity = {
+        state: 'draft',
+        attributes: [
+            {
+                attributeDefinitionId: requiredLabelDefinition.id,
+                value: 'Mrkva',
+            },
+        ],
+    };
+    const incompleteDraft: EntityCompletenessEntity = {
+        state: 'draft',
+        attributes: [],
+    };
+    const incompletePublished: EntityCompletenessEntity = {
+        state: 'published',
+        attributes: [],
+    };
+    const entities = [completeDraft, incompleteDraft, incompletePublished];
+    const definitions = [requiredLabelDefinition];
+
+    assert.deepStrictEqual(
+        filterEntitiesByCompletionAndState(entities, definitions, {
+            completion: 'incomplete',
+            state: 'draft',
+        }),
+        [incompleteDraft],
+    );
+    assert.deepStrictEqual(
+        filterEntitiesByCompletionAndState(entities, definitions, {
+            completion: 'complete',
+            state: '',
+        }),
+        [completeDraft],
+    );
+    assert.deepStrictEqual(
+        filterEntitiesByCompletionAndState(entities, definitions, {
+            completion: '',
+            state: 'published',
+        }),
+        [incompletePublished],
+    );
+});


### PR DESCRIPTION
## Summary
- Added a shared entity-completeness helper in `@gredice/storage` and reused it for progress display, table sorting, and entity detail validation markers.
- Added URL-backed CMS entity table filters for completion and publish state, so editors can combine incomplete/complete with draft/published views without breaking search or sorting.
- Added focused unit coverage for completeness calculation and combined filter behavior.

## Testing
- `pnpm --filter @gredice/storage lint`
- `pnpm --filter @gredice/storage exec node --import tsx --test tests/entityCompleteness.node.spec.ts`
- `pnpm --filter app lint`
- `pnpm --filter app build`
- `git diff --check`

Closes #2523
