### PR TITLE
Add contributing and code of conduct docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Code of Conduct
+
+Gredice is a shared workspace for people building the Gredice platform, including applications, packages, documentation, and assets. We expect contributors and maintainers to keep collaboration professional, respectful, and focused on useful outcomes.
+
+## Our standards
+
+Examples of behavior that helps the project:
+
+- Treat contributors, maintainers, users, and community members with respect.
+- Give and receive technical feedback with clarity, patience, and evidence.
+- Assume good intent while still addressing concrete problems directly.
+- Keep discussions focused on the work, the users affected by it, and the quality bar for the platform.
+- Respect different levels of experience, language fluency, and domain familiarity.
+- Credit work appropriately and avoid misrepresenting ownership or authorship.
+
+Examples of unacceptable behavior:
+
+- Harassment, intimidation, stalking, or sustained disruption.
+- Insults, personal attacks, derogatory comments, or demeaning language.
+- Discrimination based on age, body size, disability, ethnicity, gender identity or expression, level of experience, nationality, personal appearance, race, religion, sexual identity or orientation, socioeconomic status, or similar personal characteristics.
+- Sexualized language, imagery, attention, or advances in project spaces.
+- Publishing private information without explicit permission.
+- Deliberately derailing issues, pull requests, reviews, discussions, meetings, or other project channels.
+- Retaliation against people who report or help address conduct concerns.
+
+## Scope
+
+This code of conduct applies in all Gredice project spaces, including issues, pull requests, discussions, code review, documentation, community channels, meetings, and events. It also applies when someone represents the project in public or private project-related communication.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to the project maintainers through a private channel already available to you. If you do not have a private channel, open a minimal public issue asking for maintainer contact, without sharing sensitive details publicly.
+
+Reports should include enough context for maintainers to understand and respond to the concern when it is safe to provide it:
+
+- What happened and where it happened.
+- When it happened.
+- Who was involved.
+- Any relevant links, screenshots, or logs.
+- Whether there is an immediate safety or access concern.
+
+Maintainers will handle reports as privately as practical. Information will be shared only with people who need it to investigate, respond, or meet legal or operational obligations.
+
+## Enforcement
+
+Maintainers may take any action they judge necessary to protect contributors and the project, including:
+
+- Clarifying expectations or asking for behavior to change.
+- Editing, hiding, or removing comments, issues, pull requests, or other content.
+- Temporarily or permanently limiting participation in project spaces.
+- Blocking accounts or escalating to platform administrators where needed.
+
+Participants asked to stop unacceptable behavior are expected to comply immediately. Maintainers should apply this code of conduct consistently and in proportion to the behavior, context, and impact.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to Gredice
+
+Thank you for contributing to Gredice. This repository is a Turborepo monorepo for multiple Next.js applications, shared packages, documentation, and assets. Contributions are easiest to review when they are scoped, grounded in the existing packages, and validated with targeted commands.
+
+Please also follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Before you start
+
+- Read [WORKSPACE.md](./WORKSPACE.md) for repo layout, local setup, commands, package boundaries, and development servers.
+- Read the guide that matches your change: [FRONTEND.md](./FRONTEND.md), [DESIGN.md](./DESIGN.md), [PRODUCT_SENSE.md](./PRODUCT_SENSE.md), [QUALITY_SCORE.md](./QUALITY_SCORE.md), [RELIABILITY.md](./RELIABILITY.md), [SECURITY.md](./SECURITY.md), or [SEO.md](./SEO.md).
+- Search existing issues and pull requests before opening duplicate work.
+- Discuss larger product, schema, architecture, payment, inventory, delivery, or auth changes before investing heavily in implementation.
+- Keep changes focused. Separate unrelated fixes, refactors, generated output, and feature work into different pull requests.
+
+## Local setup
+
+Use Node.js `>=24`, pnpm `10.33.2`, Docker, and the Vercel CLI.
+
+```bash
+pnpm install
+vercel login
+pnpm vercel:link
+pnpm env:pull
+pnpm dev
+```
+
+The default dev command starts the main apps through local HTTPS domains:
+
+- `apps/www`: <https://www.gredice.test>
+- `apps/garden`: <https://vrt.gredice.test>
+- `apps/farm`: <https://farma.gredice.test>
+- `apps/app`: <https://app.gredice.test>
+- `apps/storybook`: <https://storybook.gredice.test>
+- `apps/api`: <https://api.gredice.test>
+
+The `status` app is not part of the default dev stack. Start it separately when needed:
+
+```bash
+pnpm --filter=status dev
+```
+
+## Development guidelines
+
+- Reuse existing packages and UI before adding new utilities, components, dependencies, or packages.
+- Use `workspace:*` for internal package dependencies.
+- Keep app-only behavior inside the owning app. Move shared behavior into an existing package only when reuse is real.
+- Do not duplicate shared TypeScript types. Prefer inferred types, use `unknown` instead of `any`, and avoid `as` assertions.
+- Validate data at server boundaries and avoid exposing secrets or private data to the client.
+- Preserve existing auth, authorization, cache invalidation, analytics, observability, and failure-handling patterns.
+- Do not commit `node_modules`, `.next`, build output, coverage, Storybook static output, or other generated artifacts unless the generated file is an established tracked artifact required by the source change.
+
+## Database and generated assets
+
+Database schema changes live in `packages/storage`.
+
+```bash
+pnpm db-generate
+```
+
+Run `pnpm db-generate` after editing schema. Do not run `pnpm db-push`. For shared pull requests, leave new migration files out of version control unless maintainers explicitly request them.
+
+For game assets, use the existing generation scripts instead of hand-editing generated model output:
+
+```bash
+pnpm generate:game-assets
+pnpm generate:models-types
+```
+
+Coordinate with maintainers before changing shared game asset sources.
+
+## Validation
+
+Run targeted commands from the repo root. Choose the smallest check that covers the change, then broaden when the change touches shared behavior or critical flows.
+
+```bash
+pnpm lint --filter <workspace>
+pnpm test --filter <workspace>
+pnpm build --filter <workspace>
+```
+
+Examples:
+
+```bash
+pnpm lint --filter garden
+pnpm test --filter garden
+pnpm build --filter www
+pnpm test --filter @gredice/storage
+```
+
+For docs-only changes, run:
+
+```bash
+git diff --check
+```
+
+Note that some lint scripts run `biome check --write` and may modify files. Review the diff after linting.
+
+## Issues
+
+Use GitHub Issue Type as the primary kind:
+
+- `Feature` for larger product capabilities or umbrella work.
+- `Task` for concrete implementation slices.
+- `Bug` for broken or incorrect behavior.
+
+Use labels for routing and context, including existing area, package, feature, asset, documentation, test, enhancement, epic, and AI-origin labels. Do not create near-duplicate labels.
+
+Use the existing square-bracket scope convention when a clear scope exists, such as `[CMS] Pages - define Page structure` or `[Field] Ability to see diary and history if field had plants before`.
+
+For product and feature issues, prefer these sections:
+
+- `User story`
+- `Current-system notes`
+- `Scope`
+- `Acceptance criteria`
+
+For internal tooling or reliability issues, prefer:
+
+- `Goal`
+- `Context`
+- `Scope`
+- `Acceptance criteria`
+- `Blocked by`, when sequencing matters
+
+Umbrella issues should link implementation issues with a checklist, include a suggested implementation order, call out dependencies with issue references, and use the `epic` label.
+
+## Pull requests
+
+Before opening a pull request:
+
+- Confirm the change is scoped to the requested behavior.
+- Include relevant tests, stories, or docs updates for user-facing and shared behavior.
+- Run the targeted validation commands and include the results in the pull request description.
+- Call out skipped checks and why they were skipped.
+- Mention schema changes, generated assets, environment requirements, migrations, or deployment coordination explicitly.
+- Keep pull request descriptions concrete enough for reviewers to understand the user impact and the technical shape of the change.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ For local domains, certificates, environment files, generated assets, and detail
 ## Documentation
 
 - [AGENTS.md](./AGENTS.md): entry point for AI collaborators.
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md): expectations for respectful project participation and reporting concerns.
+- [CONTRIBUTING.md](./CONTRIBUTING.md): setup, development, validation, issue, and pull request guidance.
 - [WORKSPACE.md](./WORKSPACE.md): repo layout, setup, commands, package boundaries, and local development servers.
 - [FRONTEND.md](./FRONTEND.md): Next.js, React, TypeScript, shared UI, Storybook, and app structure rules.
 - [DESIGN.md](./DESIGN.md): visual and interaction design standards.
@@ -58,7 +60,7 @@ See the [API Reference](https://api.gredice.com) for the official API documentat
 
 ## Contributing
 
-We welcome community contributions. Explore repository activity, issues, and discussions to find a useful place to start.
+We welcome community contributions. See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, development, validation, issue, and pull request guidance, and follow the [Code of Conduct](./CODE_OF_CONDUCT.md) in project spaces.
 
 ![Alt](https://repobeats.axiom.co/api/embed/ba847f4d1fae06c8250692c08295602bca8de554.svg "Repobeats analytics image")
 


### PR DESCRIPTION
## Summary
- Added a root-level `CODE_OF_CONDUCT.md` covering expected behavior, scope, reporting, and enforcement.
- Added a root-level `CONTRIBUTING.md` with repo-specific setup, validation, database, generated asset, issue, and pull request guidance.
- Updated `README.md` to link both documents from the docs and contributing sections.

## Testing
- `git diff --check` passed.
- Docs review completed against the existing repo guidance and commands.