### PR TITLE
schedule: add day-level bulk approve and assign actions

### DIFF
--- a/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
@@ -1,13 +1,21 @@
 import { getAssignableFarmUsersByOperationIds } from '@gredice/storage';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
 import { RaisedBedOperationsScheduleSection } from './RaisedBedOperationsScheduleSection';
 import {
     getScheduleDayData,
     getScheduleOperationsData,
     getSchedulePlantSorts,
 } from './scheduleData';
-import { groupRaisedBedsForSchedule } from './scheduleShared';
+import {
+    groupRaisedBedsForSchedule,
+    isOperationCancelled,
+    isOperationCompleted,
+    isOperationPendingVerification,
+} from './scheduleShared';
 
 interface ScheduleDayOperationsSectionProps {
     isToday: boolean;
@@ -45,9 +53,47 @@ export async function ScheduleDayOperationsSection({
         affectedRaisedBedIds,
     );
 
+    const dayOperationsToApprove = scheduledOperations
+        .filter(
+            (operation) =>
+                !operation.isAccepted &&
+                !isOperationCompleted(operation.status) &&
+                !isOperationCancelled(operation.status) &&
+                !!operation.assignedUserId,
+        )
+        .map((operation) => ({
+            id: operation.id,
+            label: operation.entityId,
+        }));
+
+    const dayOperationsToAssign = scheduledOperations
+        .filter(
+            (operation) =>
+                !operation.assignedUserId &&
+                !isOperationCompleted(operation.status) &&
+                !isOperationPendingVerification(operation.status) &&
+                !isOperationCancelled(operation.status),
+        )
+        .map((operation) => ({
+            id: operation.id,
+            farmUsers: assignableFarmUsersByOperationId[operation.id] ?? [],
+        }));
+
     return (
         <Stack spacing={2}>
-            <Typography level="h6">Radnje</Typography>
+            <Row spacing={1} alignItems="center">
+                <Typography level="h6">Radnje</Typography>
+                <BulkApproveRaisedBedButton
+                    physicalId="dan"
+                    fields={[]}
+                    operations={dayOperationsToApprove}
+                />
+                <BulkAssignRaisedBedButton
+                    physicalId="dan"
+                    fields={[]}
+                    operations={dayOperationsToAssign}
+                />
+            </Row>
             {raisedBedGroups.map(({ key, physicalId, raisedBeds: beds }) => {
                 return (
                     <RaisedBedOperationsScheduleSection

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
@@ -1,9 +1,17 @@
 import { getAssignableFarmUsersByRaisedBedFieldIds } from '@gredice/storage';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
 import { RaisedBedPlantingScheduleSection } from './RaisedBedPlantingScheduleSection';
 import { getScheduleDayData, getSchedulePlantSorts } from './scheduleData';
-import { groupRaisedBedsForSchedule } from './scheduleShared';
+import {
+    groupRaisedBedsForSchedule,
+    isFieldApproved,
+    isFieldCompleted,
+    isFieldPendingVerification,
+} from './scheduleShared';
 
 interface ScheduleDayPlantingsSectionProps {
     isToday: boolean;
@@ -34,9 +42,47 @@ export async function ScheduleDayPlantingsSection({
         affectedRaisedBedIds,
     );
 
+    const dayFieldsToApprove = scheduledFields
+        .filter(
+            (field) =>
+                !isFieldApproved(field.plantStatus) &&
+                !isFieldPendingVerification(field.plantStatus) &&
+                !isFieldCompleted(field.plantStatus) &&
+                !!field.assignedUserId,
+        )
+        .map((field) => ({
+            raisedBedId: field.raisedBedId,
+            positionIndex: field.positionIndex,
+            label: `${field.positionIndex + 1}`,
+        }));
+
+    const dayFieldsToAssign = scheduledFields
+        .filter(
+            (field) =>
+                !field.assignedUserId &&
+                !isFieldCompleted(field.plantStatus) &&
+                !isFieldPendingVerification(field.plantStatus),
+        )
+        .map((field) => ({
+            id: field.id,
+            farmUsers: assignableFarmUsersByRaisedBedFieldId[field.id] ?? [],
+        }));
+
     return (
         <Stack spacing={2}>
-            <Typography level="h6">Sijanje</Typography>
+            <Row spacing={1} alignItems="center">
+                <Typography level="h6">Sijanje</Typography>
+                <BulkApproveRaisedBedButton
+                    physicalId="dan"
+                    fields={dayFieldsToApprove}
+                    operations={[]}
+                />
+                <BulkAssignRaisedBedButton
+                    physicalId="dan"
+                    fields={dayFieldsToAssign}
+                    operations={[]}
+                />
+            </Row>
             {raisedBedGroups.map(({ key, physicalId, raisedBeds: beds }) => {
                 return (
                     <RaisedBedPlantingScheduleSection


### PR DESCRIPTION
### Motivation
- Provide admins a way to approve all assigned tasks for a day and assign all unassigned tasks for a day from the schedule UI. 
- Surface day-scoped controls in the Schedule headers so bulk operations are discoverable and re-use existing bulk action components.

### Description
- Compute day-level targets in `ScheduleDayOperationsSection.tsx` by adding `dayOperationsToApprove` and `dayOperationsToAssign` filters and render `BulkApproveRaisedBedButton` and `BulkAssignRaisedBedButton` in the section header. 
- Compute day-level targets in `ScheduleDayPlantingsSection.tsx` by adding `dayFieldsToApprove` and `dayFieldsToAssign` filters and render the same bulk buttons in that section header. 
- Reuse existing components `BulkApproveRaisedBedButton` and `BulkAssignRaisedBedButton` and import helper predicates from `scheduleShared` (e.g. `isOperationCancelled`, `isFieldApproved`) to determine eligible tasks. 
- Files changed: `apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx` and `apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx`.

### Testing
- Ran the repo lint for the app package with `pnpm --filter app lint`, which completed successfully. 
- Lint output included unrelated pre-existing warnings about unused imports in other files but no failures for the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd10b1458832f9648f9c01b407cd2)