### PR TITLE
fix(game): enable scrolling in overview modal on mobile

### DIFF
--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -130,10 +130,10 @@ export function OverviewModal() {
         <Modal
             open={Boolean(settingsMode)}
             onOpenChange={handleOpenChange}
-            className="md:min-w-full lg:min-w-[80%] xl:min-w-[60%] md:min-h-[70%] md:max-h-full md:border-tertiary md:border-b-4"
+            className="max-h-[90dvh] overflow-hidden md:min-w-full lg:min-w-[80%] xl:min-w-[60%] md:min-h-[70%] md:max-h-full md:border-tertiary md:border-b-4"
             title="Profil"
         >
-            <div className="grid grid-rows-[auto_1fr] gap-4 md:gap-0 md:grid-rows-1 md:grid-cols-[minmax(230px,auto)_1fr]">
+            <div className="grid max-h-[calc(90dvh-5rem)] grid-rows-[auto_1fr] gap-4 overflow-y-auto pr-1 md:max-h-none md:gap-0 md:grid-rows-1 md:grid-cols-[minmax(230px,auto)_1fr] md:overflow-hidden md:pr-0">
                 <Stack spacing={2} className="md:border-r md:pl-2">
                     <ProfileInfo />
                     <SelectItems
@@ -175,7 +175,7 @@ export function OverviewModal() {
                         ))}
                     </List>
                 </Stack>
-                <div className="md:pl-6">
+                <div className="overflow-y-auto md:pl-6">
                     {settingsMode === 'generalno' && <GeneralTab />}
                     {settingsMode === 'vrt' && <GardenTab />}
                     {settingsMode === 'igra' && <GameTab />}


### PR DESCRIPTION
### Motivation
- On small screens the Overview modal content could overflow the viewport and users couldn't scroll through tabs, causing accidental modal closure or inaccessible content.

### Description
- Constrain the modal height and enable vertical scrolling on mobile by updating `packages/game/src/modals/OverviewModal.tsx` (added `max-h-[90dvh]`, `overflow-hidden` on the `Modal` and `overflow-y-auto` / `max-h-[calc(90dvh-5rem)]` on the internal grid and content wrapper) so overview tabs remain scrollable without changing desktop behavior.

### Testing
- Ran `pnpm lint --filter garden`, which completed successfully (Biome fixed one file automatically).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd1d6ef34832f998510e86a3e66a9)