### PR TITLE
feat(cms): add entity and attribute revision history

### DIFF
--- a/apps/app/app/(actions)/entityActions.ts
+++ b/apps/app/app/(actions)/entityActions.ts
@@ -117,7 +117,12 @@ export async function deleteEntityTypeFromEditPage(formData: FormData) {
 export async function createEntity(entityTypeName: string) {
     await auth(['admin']);
 
-    const entityId = await storageCreateEntity(entityTypeName);
+    const authData = await auth(['admin']);
+
+    const entityId = await storageCreateEntity(entityTypeName, {
+        id: authData.userId,
+        name: authData.user.userName,
+    });
     revalidatePath(KnownPages.Directories);
     revalidatePath(KnownPages.DirectoryEntityType(entityTypeName));
     revalidatePath(KnownPages.DirectoryEntity(entityTypeName, entityId));
@@ -127,7 +132,12 @@ export async function createEntity(entityTypeName: string) {
 export async function updateEntity(entity: UpdateEntity) {
     await auth(['admin']);
 
-    await storageUpdateEntity(entity);
+    const authData = await auth(['admin']);
+
+    await storageUpdateEntity(entity, {
+        id: authData.userId,
+        name: authData.user.userName,
+    });
     revalidatePath(KnownPages.Directories);
     revalidatePath(KnownPages.DirectoryEntityTypePath, 'page');
     revalidatePath(KnownPages.DirectoryEntityTypePath, 'layout');
@@ -158,20 +168,33 @@ export async function handleValueSave(
 
     const newAttributeValueValue =
         (newValue?.length ?? 0) <= 0 ? null : newValue;
-    await upsertAttributeValue({
-        id: !attributeValueId ? undefined : attributeValueId,
-        attributeDefinitionId: attributeDefinition.id,
-        entityTypeName: entityTypeName,
-        entityId: entityId,
-        value: newAttributeValueValue,
-    });
+    const authData = await auth(['admin']);
+
+    await upsertAttributeValue(
+        {
+            id: !attributeValueId ? undefined : attributeValueId,
+            attributeDefinitionId: attributeDefinition.id,
+            entityTypeName: entityTypeName,
+            entityId: entityId,
+            value: newAttributeValueValue,
+        },
+        {
+            id: authData.userId,
+            name: authData.user.userName,
+        },
+    );
     revalidatePath(KnownPages.DirectoryEntity(entityTypeName, entityId));
 }
 
 export async function handleValueDelete(attributeValue: SelectAttributeValue) {
     await auth(['admin']);
 
-    await deleteAttributeValue(attributeValue.id);
+    const authData = await auth(['admin']);
+
+    await deleteAttributeValue(attributeValue.id, {
+        id: authData.userId,
+        name: authData.user.userName,
+    });
     revalidatePath(
         `/admin/directories/${attributeValue.entityTypeName}/${attributeValue.entityId}`,
     );
@@ -230,7 +253,12 @@ export async function handleEntityDelete(
 ) {
     await auth(['admin']);
 
-    await deleteEntity(entityId);
+    const authData = await auth(['admin']);
+
+    await deleteEntity(entityId, {
+        id: authData.userId,
+        name: authData.user.userName,
+    });
     revalidatePath(KnownPages.Directories);
     redirect(KnownPages.DirectoryEntityType(entityTypeName));
 }

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -3,6 +3,7 @@ import {
     getAttributeDefinitionCategories,
     getAttributeDefinitions,
     getEntityRaw,
+    getEntityRevisions,
     getInventoryConfigByEntityTypeName,
     getInventoryItemsByConfig,
     updateInventoryItem,
@@ -62,13 +63,19 @@ export default async function EntityDetailsPage(props: {
 }) {
     const params = await props.params;
     const entityId = parseInt(params.entityId, 10);
-    const [attributeDefinitions, attributeCategories, entity, inventoryConfig] =
-        await Promise.all([
-            getAttributeDefinitions(params.entityType),
-            getAttributeDefinitionCategories(params.entityType),
-            getEntityRaw(entityId),
-            getInventoryConfigByEntityTypeName(params.entityType),
-        ]);
+    const [
+        attributeDefinitions,
+        attributeCategories,
+        entity,
+        inventoryConfig,
+        revisions,
+    ] = await Promise.all([
+        getAttributeDefinitions(params.entityType),
+        getAttributeDefinitionCategories(params.entityType),
+        getEntityRaw(entityId),
+        getInventoryConfigByEntityTypeName(params.entityType),
+        getEntityRevisions(entityId),
+    ]);
     if (!entity) {
         notFound();
     }
@@ -192,7 +199,10 @@ export default async function EntityDetailsPage(props: {
                 <EntityDetailsStickyHeader
                     tabs={
                         <TabsList>
-                            {attributeCategories.map((category) => (
+                            {[
+                                ...attributeCategories,
+                                { name: 'history', label: 'Historija' },
+                            ].map((category) => (
                                 <TabsTrigger
                                     key={category.name}
                                     value={category.name}
@@ -287,7 +297,10 @@ export default async function EntityDetailsPage(props: {
                             ))}
                         </FieldSet>
                     </Stack>
-                    {attributeCategories.map((category) => (
+                    {[
+                        ...attributeCategories,
+                        { name: 'history', label: 'Historija' },
+                    ].map((category) => (
                         <TabsContent value={category.name} key={category.name}>
                             <AttributeCategoryDetails
                                 entity={entity}
@@ -296,6 +309,22 @@ export default async function EntityDetailsPage(props: {
                             />
                         </TabsContent>
                     ))}
+
+                    <TabsContent value="history" key="history">
+                        <FieldSet>
+                            {revisions.length === 0 ? (
+                                <Field name="Historija" value="Nema promjena" />
+                            ) : (
+                                revisions.map((revision) => (
+                                    <Field
+                                        key={revision.id}
+                                        name={`${revision.action} • ${revision.actorName ?? 'Nepoznat korisnik'}`}
+                                        value={`${revision.createdAt.toISOString()} | ${revision.previousValue ?? revision.previousState ?? '-'} → ${revision.nextValue ?? revision.nextState ?? '-'}`}
+                                    />
+                                ))
+                            )}
+                        </FieldSet>
+                    </TabsContent>
                 </Stack>
             </Tabs>
         </EntityDetailsSaveProvider>

--- a/packages/storage/src/repositories/attributeValuesRepo.ts
+++ b/packages/storage/src/repositories/attributeValuesRepo.ts
@@ -107,6 +107,10 @@ export async function deleteAttributeValue(
     id: number,
     actor?: { id?: string; name?: string },
 ) {
+    const existingValue = await storage().query.attributeValues.findFirst({
+        where: eq(attributeValues.id, id),
+    });
+
     await Promise.all([
         storage()
             .update(attributeValues)

--- a/packages/storage/src/repositories/attributeValuesRepo.ts
+++ b/packages/storage/src/repositories/attributeValuesRepo.ts
@@ -6,10 +6,15 @@ import {
     bustCachedByPrefixes,
     cacheKeys,
 } from '../cache/directoriesCached';
-import { attributeValues, type InsertAttributeValue } from '../schema';
+import {
+    attributeValues,
+    entityRevisions,
+    type InsertAttributeValue,
+} from '../schema';
 
 export async function upsertAttributeValue(
     attributeValue: InsertAttributeValue,
+    actor?: { id?: string; name?: string },
 ) {
     let value = attributeValue.value;
 
@@ -22,6 +27,12 @@ export async function upsertAttributeValue(
             value = definition.defaultValue;
         }
     }
+
+    const existingValue = attributeValue.id
+        ? await storage().query.attributeValues.findFirst({
+              where: eq(attributeValues.id, attributeValue.id),
+          })
+        : undefined;
 
     await Promise.all([
         storage()
@@ -37,6 +48,24 @@ export async function upsertAttributeValue(
                     value,
                 },
             }),
+        attributeValue.entityId
+            ? storage()
+                  .insert(entityRevisions)
+                  .values({
+                      entityId: attributeValue.entityId,
+                      entityTypeName: attributeValue.entityTypeName,
+                      action: existingValue
+                          ? 'attribute.updated'
+                          : 'attribute.created',
+                      actorId: actor?.id,
+                      actorName: actor?.name,
+                      attributeValueId: attributeValue.id,
+                      attributeDefinitionId:
+                          attributeValue.attributeDefinitionId,
+                      previousValue: existingValue?.value ?? null,
+                      nextValue: value ?? null,
+                  })
+            : undefined,
         attributeValue.entityId
             ? bustCached(cacheKeys.entity(attributeValue.entityId))
             : undefined,
@@ -74,12 +103,28 @@ export async function upsertAttributeValue(
     ]);
 }
 
-export async function deleteAttributeValue(id: number) {
+export async function deleteAttributeValue(
+    id: number,
+    actor?: { id?: string; name?: string },
+) {
     await Promise.all([
         storage()
             .update(attributeValues)
             .set({ isDeleted: true })
             .where(eq(attributeValues.id, id)),
+        existingValue
+            ? storage().insert(entityRevisions).values({
+                  entityId: existingValue.entityId,
+                  entityTypeName: existingValue.entityTypeName,
+                  action: 'attribute.deleted',
+                  actorId: actor?.id,
+                  actorName: actor?.name,
+                  attributeValueId: existingValue.id,
+                  attributeDefinitionId: existingValue.attributeDefinitionId,
+                  previousValue: existingValue.value,
+                  nextValue: null,
+              })
+            : undefined,
         storage()
             .select()
             .from(attributeValues)

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -4,6 +4,7 @@ import {
     attributeDefinitions,
     attributeValues,
     entities,
+    entityRevisions,
     type SelectAttributeDefinition,
     type SelectAttributeValue,
     type SelectEntity,
@@ -709,33 +710,6 @@ export async function duplicateEntity(id: number) {
     }));
 
     await Promise.all([
-        storage().insert(entityRevisions).values({
-            entityId: id,
-            entityTypeName: entity.entityTypeName,
-            action: 'entity.deleted',
-            actorId: actor?.id,
-            actorName: actor?.name,
-            previousState: entity.state,
-            nextState: entity.state,
-        }),
-        previousEntity
-            ? storage()
-                  .insert(entityRevisions)
-                  .values({
-                      entityId: entity.id,
-                      entityTypeName:
-                          entity.entityTypeName ??
-                          previousEntity.entityTypeName,
-                      action:
-                          previousEntity.state !== updateData.state
-                              ? 'entity.state_changed'
-                              : 'entity.updated',
-                      actorId: actor?.id,
-                      actorName: actor?.name,
-                      previousState: previousEntity.state,
-                      nextState: updateData.state ?? previousEntity.state,
-                  })
-            : undefined,
         storage().insert(attributeValues).values(newAttributes),
         bustCached(cacheKeys.entityTypeName(entity.entityTypeName)),
         bustCached(cacheKeys.entity(newEntityId)),
@@ -762,15 +736,6 @@ export async function updateEntity(
     }
 
     await Promise.all([
-        storage().insert(entityRevisions).values({
-            entityId: id,
-            entityTypeName: entity.entityTypeName,
-            action: 'entity.deleted',
-            actorId: actor?.id,
-            actorName: actor?.name,
-            previousState: entity.state,
-            nextState: entity.state,
-        }),
         previousEntity
             ? storage()
                   .insert(entityRevisions)
@@ -842,24 +807,6 @@ export async function deleteEntity(
             previousState: entity.state,
             nextState: entity.state,
         }),
-        previousEntity
-            ? storage()
-                  .insert(entityRevisions)
-                  .values({
-                      entityId: entity.id,
-                      entityTypeName:
-                          entity.entityTypeName ??
-                          previousEntity.entityTypeName,
-                      action:
-                          previousEntity.state !== updateData.state
-                              ? 'entity.state_changed'
-                              : 'entity.updated',
-                      actorId: actor?.id,
-                      actorName: actor?.name,
-                      previousState: previousEntity.state,
-                      nextState: updateData.state ?? previousEntity.state,
-                  })
-            : undefined,
         storage()
             .update(entities)
             .set({ isDeleted: true })

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -670,7 +670,10 @@ export async function getEntityIncomingLinks(
         .sort((a, b) => a.entityTypeLabel.localeCompare(b.entityTypeLabel));
 }
 
-export async function createEntity(entityTypeName: string) {
+export async function createEntity(
+    entityTypeName: string,
+    actor?: { id?: string; name?: string },
+) {
     const [result] = await Promise.all([
         storage()
             .insert(entities)
@@ -679,7 +682,15 @@ export async function createEntity(entityTypeName: string) {
         bustCached(cacheKeys.entityTypeName(entityTypeName)),
         bustCachedByPrefixes(['dashboard:admin:']),
     ]);
-    return result[0].id;
+    const entityId = result[0].id;
+    await storage().insert(entityRevisions).values({
+        entityId,
+        entityTypeName,
+        action: 'entity.created',
+        actorId: actor?.id,
+        actorName: actor?.name,
+    });
+    return entityId;
 }
 
 export async function duplicateEntity(id: number) {
@@ -698,6 +709,33 @@ export async function duplicateEntity(id: number) {
     }));
 
     await Promise.all([
+        storage().insert(entityRevisions).values({
+            entityId: id,
+            entityTypeName: entity.entityTypeName,
+            action: 'entity.deleted',
+            actorId: actor?.id,
+            actorName: actor?.name,
+            previousState: entity.state,
+            nextState: entity.state,
+        }),
+        previousEntity
+            ? storage()
+                  .insert(entityRevisions)
+                  .values({
+                      entityId: entity.id,
+                      entityTypeName:
+                          entity.entityTypeName ??
+                          previousEntity.entityTypeName,
+                      action:
+                          previousEntity.state !== updateData.state
+                              ? 'entity.state_changed'
+                              : 'entity.updated',
+                      actorId: actor?.id,
+                      actorName: actor?.name,
+                      previousState: previousEntity.state,
+                      nextState: updateData.state ?? previousEntity.state,
+                  })
+            : undefined,
         storage().insert(attributeValues).values(newAttributes),
         bustCached(cacheKeys.entityTypeName(entity.entityTypeName)),
         bustCached(cacheKeys.entity(newEntityId)),
@@ -707,7 +745,14 @@ export async function duplicateEntity(id: number) {
     return newEntityId;
 }
 
-export async function updateEntity(entity: UpdateEntity) {
+export async function updateEntity(
+    entity: UpdateEntity,
+    actor?: { id?: string; name?: string },
+) {
+    const previousEntity = await storage().query.entities.findFirst({
+        where: eq(entities.id, entity.id),
+    });
+
     const updateData = {
         ...entity,
     };
@@ -717,6 +762,33 @@ export async function updateEntity(entity: UpdateEntity) {
     }
 
     await Promise.all([
+        storage().insert(entityRevisions).values({
+            entityId: id,
+            entityTypeName: entity.entityTypeName,
+            action: 'entity.deleted',
+            actorId: actor?.id,
+            actorName: actor?.name,
+            previousState: entity.state,
+            nextState: entity.state,
+        }),
+        previousEntity
+            ? storage()
+                  .insert(entityRevisions)
+                  .values({
+                      entityId: entity.id,
+                      entityTypeName:
+                          entity.entityTypeName ??
+                          previousEntity.entityTypeName,
+                      action:
+                          previousEntity.state !== updateData.state
+                              ? 'entity.state_changed'
+                              : 'entity.updated',
+                      actorId: actor?.id,
+                      actorName: actor?.name,
+                      previousState: previousEntity.state,
+                      nextState: updateData.state ?? previousEntity.state,
+                  })
+            : undefined,
         storage()
             .update(entities)
             .set(updateData)
@@ -751,13 +823,43 @@ export async function updateEntity(entity: UpdateEntity) {
     ]);
 }
 
-export async function deleteEntity(id: number) {
+export async function deleteEntity(
+    id: number,
+    actor?: { id?: string; name?: string },
+) {
     const entity = await getEntityRaw(id);
     if (!entity) {
         throw new Error(`Entity with id ${id} not found`);
     }
 
     await Promise.all([
+        storage().insert(entityRevisions).values({
+            entityId: id,
+            entityTypeName: entity.entityTypeName,
+            action: 'entity.deleted',
+            actorId: actor?.id,
+            actorName: actor?.name,
+            previousState: entity.state,
+            nextState: entity.state,
+        }),
+        previousEntity
+            ? storage()
+                  .insert(entityRevisions)
+                  .values({
+                      entityId: entity.id,
+                      entityTypeName:
+                          entity.entityTypeName ??
+                          previousEntity.entityTypeName,
+                      action:
+                          previousEntity.state !== updateData.state
+                              ? 'entity.state_changed'
+                              : 'entity.updated',
+                      actorId: actor?.id,
+                      actorName: actor?.name,
+                      previousState: previousEntity.state,
+                      nextState: updateData.state ?? previousEntity.state,
+                  })
+            : undefined,
         storage()
             .update(entities)
             .set({ isDeleted: true })
@@ -768,4 +870,14 @@ export async function deleteEntity(id: number) {
             : null,
         bustCachedByPrefixes(['dashboard:admin:']),
     ]);
+}
+
+export async function getEntityRevisions(entityId: number) {
+    return storage().query.entityRevisions.findMany({
+        where: eq(entityRevisions.entityId, entityId),
+        orderBy: (revisions, { desc }) => [
+            desc(revisions.createdAt),
+            desc(revisions.id),
+        ],
+    });
 }

--- a/packages/storage/src/schema/cmsSchema.ts
+++ b/packages/storage/src/schema/cmsSchema.ts
@@ -330,3 +330,32 @@ export type UpdateCmsPage = Partial<
 > &
     Pick<typeof cmsPages.$inferSelect, 'id'>;
 export type SelectCmsPage = typeof cmsPages.$inferSelect;
+
+export const entityRevisions = pgTable(
+    'entity_revisions',
+    {
+        id: serial('id').primaryKey(),
+        entityId: integer('entity_id')
+            .notNull()
+            .references(() => entities.id),
+        entityTypeName: text('entity_type').notNull(),
+        action: text('action').notNull(),
+        actorId: text('actor_id'),
+        actorName: text('actor_name'),
+        attributeValueId: integer('attribute_value_id'),
+        attributeDefinitionId: integer('attribute_definition_id'),
+        previousValue: text('previous_value'),
+        nextValue: text('next_value'),
+        previousState: text('previous_state'),
+        nextState: text('next_state'),
+        createdAt: timestamp('created_at').notNull().defaultNow(),
+    },
+    (table) => [
+        index('cms_er_entity_id_idx').on(table.entityId),
+        index('cms_er_entity_type_name_idx').on(table.entityTypeName),
+        index('cms_er_action_idx').on(table.action),
+    ],
+);
+
+export type InsertEntityRevision = typeof entityRevisions.$inferInsert;
+export type SelectEntityRevision = typeof entityRevisions.$inferSelect;


### PR DESCRIPTION
### Motivation
- Capture additive revision history for CMS entities and attribute values so editors can see what changed, who changed it, and when.
- Include actor metadata from admin auth in revision records to support auditing and eventual restore actions.
- Surface revision history in the entity detail UI without changing the current published entity API shape.

### Description
- Add an `entity_revisions` table and types to `packages/storage/src/schema/cmsSchema.ts` to store entity- and attribute-level revision events with actor, previous/next values, and state changes. 
- Write revision records from the storage layer by updating `packages/storage/src/repositories/attributeValuesRepo.ts` and `packages/storage/src/repositories/entitiesRepo.ts` to insert revisions on attribute create/update/delete and entity create/update/delete/state-change, and add `getEntityRevisions(entityId)` for reads. 
- Thread optional actor info into storage calls by extending storage APIs to accept an `actor?: { id?: string; name?: string }` parameter and update server actions in `apps/app/app/(actions)/entityActions.ts` to pass authenticated admin user info. 
- Add a read-only History tab to the CMS entity detail page at `apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx` that lists revision entries (action, actor, timestamp, previous→next value/state). 

### Testing
- Ran `pnpm --filter @gredice/storage lint` which executed `biome check --write` and completed successfully. 
- Ran `pnpm --filter app lint` which executed `biome check --write`, applied fixes, and completed successfully with warnings addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe0708cc8832fb9f5d721109348cb)