### PR TITLE
GRE-222: Make Playwright configs use unique worktree-safe ports

### DIFF
--- a/apps/api/playwright.config.ts
+++ b/apps/api/playwright.config.ts
@@ -3,7 +3,7 @@ import {
     devices,
     type PlaywrightTestConfig,
 } from '@playwright/test';
-import { getAppByName, localAppUrl } from '../../scripts/app-registry.ts';
+import { getAppByName, getPlaywrightBaseUrl, shouldReusePlaywrightServer } from '../../scripts/app-registry.ts';
 
 const app = getAppByName('api');
 const reporter: PlaywrightTestConfig['reporter'] = [
@@ -21,7 +21,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter,
     use: {
-        baseURL: localAppUrl(app),
+        baseURL: getPlaywrightBaseUrl(app),
         trace: 'on-first-retry',
     },
     projects: [
@@ -32,8 +32,8 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: localAppUrl(app),
-        reuseExistingServer: !process.env.CI,
+        url: getPlaywrightBaseUrl(app),
+        reuseExistingServer: shouldReusePlaywrightServer(),
     },
 };
 

--- a/apps/api/playwright.config.ts
+++ b/apps/api/playwright.config.ts
@@ -3,7 +3,11 @@ import {
     devices,
     type PlaywrightTestConfig,
 } from '@playwright/test';
-import { getAppByName, getPlaywrightBaseUrl, shouldReusePlaywrightServer } from '../../scripts/app-registry.ts';
+import {
+    getAppByName,
+    getPlaywrightBaseUrl,
+    shouldReusePlaywrightServer,
+} from '../../scripts/app-registry.ts';
 
 const app = getAppByName('api');
 const reporter: PlaywrightTestConfig['reporter'] = [

--- a/apps/app/playwright.config.ts
+++ b/apps/app/playwright.config.ts
@@ -6,7 +6,8 @@ import {
 import {
     getAppByName,
     getComponentTestPort,
-    localAppUrl,
+    getPlaywrightBaseUrl,
+    shouldReusePlaywrightServer,
 } from '../../scripts/app-registry.ts';
 
 const app = getAppByName('app');
@@ -25,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter,
     use: {
-        baseURL: localAppUrl(app),
+        baseURL: getPlaywrightBaseUrl(app),
         trace: 'on-first-retry',
         ctPort: getComponentTestPort(app),
     },
@@ -37,8 +38,8 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: localAppUrl(app),
-        reuseExistingServer: !process.env.CI,
+        url: getPlaywrightBaseUrl(app),
+        reuseExistingServer: shouldReusePlaywrightServer(),
     },
 };
 

--- a/apps/farm/playwright.config.ts
+++ b/apps/farm/playwright.config.ts
@@ -6,7 +6,8 @@ import {
 import {
     getAppByName,
     getComponentTestPort,
-    localAppUrl,
+    getPlaywrightBaseUrl,
+    shouldReusePlaywrightServer,
 } from '../../scripts/app-registry.ts';
 
 const app = getAppByName('farm');
@@ -25,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter,
     use: {
-        baseURL: localAppUrl(app),
+        baseURL: getPlaywrightBaseUrl(app),
         trace: 'on-first-retry',
         ctPort: getComponentTestPort(app),
     },
@@ -37,8 +38,8 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: localAppUrl(app),
-        reuseExistingServer: !process.env.CI,
+        url: getPlaywrightBaseUrl(app),
+        reuseExistingServer: shouldReusePlaywrightServer(),
     },
 };
 

--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -8,7 +8,8 @@ import {
 import {
     getAppByName,
     getComponentTestPort,
-    localAppUrl,
+    getPlaywrightBaseUrl,
+    shouldReusePlaywrightServer,
 } from '../../scripts/app-registry.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -46,7 +47,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 1 : undefined,
     reporter,
     use: {
-        baseURL: localAppUrl(app),
+        baseURL: getPlaywrightBaseUrl(app),
         trace: 'on-first-retry',
         ctPort: getComponentTestPort(app),
         ctViteConfig: {
@@ -64,8 +65,8 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: localAppUrl(app),
-        reuseExistingServer: !process.env.CI,
+        url: getPlaywrightBaseUrl(app),
+        reuseExistingServer: shouldReusePlaywrightServer(),
     },
 };
 

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -6,7 +6,8 @@ import {
 import {
     getAppByName,
     getComponentTestPort,
-    localAppUrl,
+    getPlaywrightBaseUrl,
+    shouldReusePlaywrightServer,
 } from '../../scripts/app-registry.ts';
 
 const app = getAppByName('www');
@@ -25,7 +26,7 @@ export const config: PlaywrightTestConfig = {
     workers: process.env.CI ? 4 : undefined,
     reporter,
     use: {
-        baseURL: localAppUrl(app),
+        baseURL: getPlaywrightBaseUrl(app),
         trace: 'on-first-retry',
         ctPort: getComponentTestPort(app),
     },
@@ -48,8 +49,8 @@ export const config: PlaywrightTestConfig = {
     ],
     webServer: {
         command: 'pnpm start',
-        url: localAppUrl(app),
-        reuseExistingServer: !process.env.CI,
+        url: getPlaywrightBaseUrl(app),
+        reuseExistingServer: shouldReusePlaywrightServer(),
     },
 };
 

--- a/scripts/app-registry.ts
+++ b/scripts/app-registry.ts
@@ -147,6 +147,17 @@ export function getAppTestPort(app: AppRegistryEntry) {
     );
 }
 
+export function getAppStartPort(app: AppRegistryEntry) {
+    const appKey = app.name.toUpperCase();
+    return parsePortOverride(
+        process.env[`GREDICE_${appKey}_START_PORT`] ??
+            process.env.GREDICE_START_PORT ??
+            process.env[`GREDICE_${appKey}_TEST_PORT`] ??
+            process.env.GREDICE_TEST_PORT,
+        app.startPort,
+    );
+}
+
 export function getPlaywrightBaseUrl(app: AppRegistryEntry) {
     const appKey = app.name.toUpperCase();
     const override = process.env[`GREDICE_${appKey}_BASE_URL`] ?? process.env.GREDICE_TEST_BASE_URL;

--- a/scripts/app-registry.ts
+++ b/scripts/app-registry.ts
@@ -38,7 +38,7 @@ export const appRegistry: AppRegistryEntry[] = [
         devPort: 3001,
         startPort: 3001,
         testPort: 3001,
-        componentTestPort: 3100,
+        componentTestPort: 3101,
         vercelProjectName: 'garden',
         startsInDefaultDev: true,
     },
@@ -49,7 +49,7 @@ export const appRegistry: AppRegistryEntry[] = [
         devPort: 3002,
         startPort: 3002,
         testPort: 3002,
-        componentTestPort: 3100,
+        componentTestPort: 3102,
         vercelProjectName: 'farm',
         startsInDefaultDev: true,
     },
@@ -60,7 +60,7 @@ export const appRegistry: AppRegistryEntry[] = [
         devPort: 3003,
         startPort: 3003,
         testPort: 3003,
-        componentTestPort: 3100,
+        componentTestPort: 3103,
         vercelProjectName: 'app',
         startsInDefaultDev: true,
     },
@@ -126,10 +126,49 @@ export function localAppUrl(app: AppRegistryEntry, port = app.testPort) {
     return localAppHostnameUrl(app, '127.0.0.1', port);
 }
 
+function parsePortOverride(value: string | undefined, fallback: number) {
+    if (!value) {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 1 || parsed > 65_535) {
+        throw new Error(`Invalid port override: ${value}`);
+    }
+
+    return parsed;
+}
+
+export function getAppTestPort(app: AppRegistryEntry) {
+    const appKey = app.name.toUpperCase();
+    return parsePortOverride(
+        process.env[`GREDICE_${appKey}_TEST_PORT`] ?? process.env.GREDICE_TEST_PORT,
+        app.testPort,
+    );
+}
+
+export function getPlaywrightBaseUrl(app: AppRegistryEntry) {
+    const appKey = app.name.toUpperCase();
+    const override = process.env[`GREDICE_${appKey}_BASE_URL`] ?? process.env.GREDICE_TEST_BASE_URL;
+    if (override) {
+        return override;
+    }
+
+    return localAppUrl(app, getAppTestPort(app));
+}
+
 export function getComponentTestPort(app: AppRegistryEntry) {
     if (app.componentTestPort === null) {
         throw new Error(`${app.name} does not define a component test port.`);
     }
 
-    return app.componentTestPort;
+    const appKey = app.name.toUpperCase();
+    return parsePortOverride(
+        process.env[`GREDICE_${appKey}_CT_PORT`] ?? process.env.GREDICE_CT_PORT,
+        app.componentTestPort,
+    );
+}
+
+export function shouldReusePlaywrightServer() {
+    return process.env.CI ? false : process.env.GREDICE_PLAYWRIGHT_REUSE_SERVER === 'true';
 }

--- a/scripts/run-app-command.mjs
+++ b/scripts/run-app-command.mjs
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process';
 import os from 'node:os';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { getAppByPackagePath } from './app-registry.ts';
+import { getAppByPackagePath, getAppStartPort } from './app-registry.ts';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
@@ -57,7 +57,7 @@ function commandForApp() {
     if (commandName === 'start') {
         return {
             command: 'next',
-            args: ['start', '-p', String(app.startPort), ...forwardedArgs],
+            args: ['start', '-p', String(getAppStartPort(app)), ...forwardedArgs],
         };
     }
 


### PR DESCRIPTION
### Motivation
- Prevent Playwright port collisions when running tests in parallel, in Turbo, or across multiple worktrees by avoiding shared fixed component-test ports and fixed web-server ports.
- Allow local overrides so different worktrees or CI can select distinct ports or base URLs via environment variables.

### Description
- Assign unique default component-test ports in `scripts/app-registry.ts` so `www` keeps `3100` and `garden`, `farm`, and `app` use `3101`, `3102`, and `3103` respectively.
- Add `parsePortOverride`, `getAppTestPort`, and `getPlaywrightBaseUrl` helpers to `scripts/app-registry.ts` and make `getComponentTestPort` honor `GREDICE_CT_PORT` / `GREDICE_<APP>_CT_PORT` overrides.
- Add `shouldReusePlaywrightServer()` to opt into reusing existing servers via `GREDICE_PLAYWRIGHT_REUSE_SERVER=true`, defaulting to not reusing locally to avoid attaching to a server from another worktree.
- Update Playwright configs in `apps/{app,farm,garden,www,api}/playwright.config.ts` to use `getPlaywrightBaseUrl(...)` for `use.baseURL` and `webServer.url`, use `getComponentTestPort(...)` for `ctPort`, and use `shouldReusePlaywrightServer()` for `webServer.reuseExistingServer`.

### Testing
- Attempted to run a lint/type check with `pnpm exec biome check scripts/app-registry.ts apps/*/playwright.config.ts`, but it failed because the `biome` tool is not available in the execution environment (`Command "biome" not found`).
- No other automated tests were run in this environment; changes were committed locally and a PR was prepared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe3497b64832fa0ef6a7cac647777)