### PR TITLE
Add Linear project badge link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
   Tools for growing thriving gardens through collaborative planning, simulation, and automation.
 </p>
 
+<p align="center">
+  <a href="https://linear.app/gredice">
+    <img src="https://img.shields.io/badge/Linear-Gredice-5E6AD2?logo=linear&logoColor=white" alt="Linear project">
+  </a>
+</p>
+
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add a centered Linear badge in the README header
- Link the badge to the Gredice Linear project

## Testing
- Not run (not requested)