### PR TITLE
[CMS] Add entity-to-SectionData transformer with validation

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,8 @@
     "license": "MIT",
     "exports": {
         ".": "./src/index.ts",
-        "./entityCompleteness": "./src/helpers/entityCompleteness.ts"
+        "./entityCompleteness": "./src/helpers/entityCompleteness.ts",
+        "./entityPageSections": "./src/helpers/entityPageSections.ts"
     },
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",

--- a/packages/storage/src/helpers/entityPageSections.ts
+++ b/packages/storage/src/helpers/entityPageSections.ts
@@ -1,0 +1,97 @@
+export type EntitySectionData = {
+    component: string;
+    data: Record<string, unknown>;
+};
+
+export type EntitySectionTransformInput = {
+    id: number | string;
+    entityType?: {
+        name?: string;
+        label?: string;
+    };
+    [key: string]: unknown;
+};
+
+type SectionTemplate = {
+    component: string;
+    requiredFields: string[];
+    buildData: (entity: EntitySectionTransformInput) => Record<string, unknown>;
+};
+
+const sectionTemplatesByEntityType: Record<string, SectionTemplate[]> = {
+    operation: [
+        {
+            component: 'header',
+            requiredFields: ['information.label'],
+            buildData: (entity) => ({
+                title: getValue(entity, 'information.label'),
+                subtitle: getValue(entity, 'information.shortDescription'),
+                image: getValue(entity, 'image.cover.url'),
+            }),
+        },
+        {
+            component: 'richtext',
+            requiredFields: ['information.description'],
+            buildData: (entity) => ({
+                content: getValue(entity, 'information.description'),
+            }),
+        },
+    ],
+};
+
+export function transformEntityToSectionData(
+    entity: EntitySectionTransformInput,
+): EntitySectionData[] {
+    const entityTypeName = entity.entityType?.name;
+    if (!entityTypeName) {
+        throw new Error('Entity is missing entityType.name required for transformation.');
+    }
+
+    const templates = sectionTemplatesByEntityType[entityTypeName];
+    if (!templates) {
+        throw new Error(`Unsupported entity type for page transformation: ${entityTypeName}.`);
+    }
+
+    return templates.map((template) => {
+        const missingField = template.requiredFields.find(
+            (field) => !hasValidValue(getValue(entity, field)),
+        );
+        if (missingField) {
+            throw new Error(
+                `Entity ${entityTypeName}#${entity.id} is missing required field: ${missingField}.`,
+            );
+        }
+
+        return {
+            component: template.component,
+            data: template.buildData(entity),
+        };
+    });
+}
+
+function getValue(entity: EntitySectionTransformInput, path: string): unknown {
+    return path.split('.').reduce<unknown>((current, key) => {
+        if (!current || typeof current !== 'object') {
+            return undefined;
+        }
+
+        return readObjectProperty(current, key);
+    }, entity);
+}
+
+function readObjectProperty(value: object, key: string): unknown {
+    const property = Object.entries(value).find(([entryKey]) => entryKey === key);
+    return property?.[1];
+}
+
+function hasValidValue(value: unknown): boolean {
+    if (value === null || typeof value === 'undefined') {
+        return false;
+    }
+
+    if (typeof value === 'string') {
+        return value.trim().length > 0;
+    }
+
+    return true;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -5,6 +5,7 @@ export * from './cache/redisCache';
 export * from './cache/scheduleCache';
 export * from './helpers/deliveryEmail';
 export * from './helpers/entityCompleteness';
+export * from './helpers/entityPageSections';
 export * from './helpers/timeSlotAutomation';
 export * from './helpers/timezoneUtils';
 export * from './repositories/accountDeletionRepo';

--- a/packages/storage/tests/entityPageSections.node.spec.ts
+++ b/packages/storage/tests/entityPageSections.node.spec.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    transformEntityToSectionData,
+    type EntitySectionTransformInput,
+} from '@gredice/storage/entityPageSections';
+
+test('transformEntityToSectionData maps supported entity type to deterministic sections', () => {
+    const entity: EntitySectionTransformInput = {
+        id: 42,
+        entityType: {
+            name: 'operation',
+            label: 'Operation',
+        },
+        information: {
+            label: 'Mulching',
+            shortDescription: 'Protects soil moisture.',
+            description: 'Apply mulch around plants to reduce water loss.',
+        },
+        image: {
+            cover: {
+                url: 'https://cdn.gredice.com/operation/mulching.jpg',
+            },
+        },
+    };
+
+    assert.deepStrictEqual(transformEntityToSectionData(entity), [
+        {
+            component: 'header',
+            data: {
+                title: 'Mulching',
+                subtitle: 'Protects soil moisture.',
+                image: 'https://cdn.gredice.com/operation/mulching.jpg',
+            },
+        },
+        {
+            component: 'richtext',
+            data: {
+                content: 'Apply mulch around plants to reduce water loss.',
+            },
+        },
+    ]);
+});
+
+test('transformEntityToSectionData throws validation error when required field is missing', () => {
+    const invalidEntity: EntitySectionTransformInput = {
+        id: 108,
+        entityType: {
+            name: 'operation',
+        },
+        information: {
+            label: '',
+            description: 'Still has description but no label.',
+        },
+    };
+
+    assert.throws(
+        () => transformEntityToSectionData(invalidEntity),
+        /missing required field: information.label/,
+    );
+});
+
+test('transformEntityToSectionData fails for unsupported entity type', () => {
+    const entity: EntitySectionTransformInput = {
+        id: 7,
+        entityType: {
+            name: 'plant',
+        },
+        information: {
+            label: 'Tomato',
+        },
+    };
+
+    assert.throws(
+        () => transformEntityToSectionData(entity),
+        /Unsupported entity type for page transformation: plant/,
+    );
+});


### PR DESCRIPTION
### Motivation
- Provide an explicit, reusable contract to convert CMS-backed entities into `SectionData[]` so entity-backed content can be rendered by the page system. 
- Ensure mappings are deterministic and explicit per entity type instead of inferring layouts from arbitrary attributes. 
- Surface clear validation errors for missing required data or unsupported entity types to avoid malformed pages. 

### Description
- Added `packages/storage/src/helpers/entityPageSections.ts` which implements `transformEntityToSectionData` and types `EntitySectionData` / `EntitySectionTransformInput`. 
- Implemented a per-entity-type template mapping registry with a first mapping for `operation` producing `header` and `richtext` sections and runtime validation of required fields. 
- Exported the helper from `@gredice/storage` by updating `packages/storage/src/index.ts` and adding a subpath export `./entityPageSections` in `packages/storage/package.json`. 
- Added unit tests at `packages/storage/tests/entityPageSections.node.spec.ts` covering successful mapping, missing required attribute validation, and unsupported entity type failure. 

### Testing
- Ran targeted node tests with `pnpm --filter @gredice/storage exec tsx --test tests/entityPageSections.node.spec.ts` and all tests passed (3/3). 
- Attempted the package test runner `pnpm --filter @gredice/storage test -- entityPageSections.node.spec.ts`, which failed in this environment due to missing Docker and Node engine constraints (DB-backed test runner requires Docker). 
- No changes were made to existing entity formatting APIs; the work is isolated to a new helper and unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe344714c832f8151efd08efd38dd)