### PR TITLE
[CMS] Validate and edit SectionData content for CMS pages

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -63,9 +63,15 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                 <textarea
                                     name="content"
                                     defaultValue={page?.content ?? ''}
+                                    placeholder='[{"component":"Feature1","header":"Naslov"}]'
                                     rows={10}
                                     className="block min-h-48 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                 />
+                                <Typography level="body3" secondary>
+                                    Unesi JSON niz SectionData blokova (npr.
+                                    komponenta Feature1, Heading1, Faq1 ili
+                                    Footer1).
+                                </Typography>
                             </label>
                         </Stack>
 

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -24,6 +24,13 @@ export type GetCmsPagesOptions = {
     includeDeleted?: boolean;
 };
 
+const supportedCmsPageSectionComponents = new Set([
+    'Heading1',
+    'Faq1',
+    'Feature1',
+    'Footer1',
+]);
+
 export function isCmsPageState(value: string): value is CmsPageState {
     return value === 'draft' || value === 'published';
 }
@@ -135,13 +142,57 @@ function pageInsertValues(input: CreateCmsPageInput): InsertCmsPage {
     return {
         slug: normalizeCmsPageSlug(input.slug),
         title,
-        content: optionalText(input.content),
+        content: normalizeCmsPageContent(input.content),
         state,
         publishedAt: state === 'published' ? new Date() : null,
         metaTitle: optionalText(input.metaTitle),
         metaDescription: optionalText(input.metaDescription),
         metaImageUrl: optionalText(input.metaImageUrl),
     };
+}
+
+function normalizeCmsPageContent(content: string | null | undefined) {
+    const normalized = optionalText(content);
+    if (!normalized) {
+        return null;
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(normalized);
+    } catch {
+        throw new Error(
+            'Page content must be a valid JSON array of SectionData blocks.',
+        );
+    }
+
+    if (!Array.isArray(parsed)) {
+        throw new Error(
+            'Page content must be a JSON array of SectionData blocks.',
+        );
+    }
+
+    parsed.forEach((section, index) => {
+        if (!section || typeof section !== 'object') {
+            throw new Error(
+                `Section at index ${index} must be an object with a component field.`,
+            );
+        }
+
+        if (!('component' in section) || typeof section.component !== 'string') {
+            throw new Error(
+                `Section at index ${index} must define a string component.`,
+            );
+        }
+
+        if (!supportedCmsPageSectionComponents.has(section.component)) {
+            throw new Error(
+                `Section at index ${index} has unsupported component: ${section.component}.`,
+            );
+        }
+    });
+
+    return JSON.stringify(parsed);
 }
 
 export async function getCmsPages(options: GetCmsPagesOptions = {}) {
@@ -214,7 +265,7 @@ export async function updateCmsPage(input: UpdateCmsPageInput) {
     }
 
     if (input.content !== undefined) {
-        updateData.content = optionalText(input.content);
+        updateData.content = normalizeCmsPageContent(input.content);
     }
 
     if (input.state !== undefined) {

--- a/packages/storage/tests/cmsPagesRepo.node.spec.ts
+++ b/packages/storage/tests/cmsPagesRepo.node.spec.ts
@@ -117,3 +117,52 @@ test('CMS page slugs reject reserved static route conflicts', async () => {
         /reserved route/,
     );
 });
+
+test('CMS page content stores valid SectionData JSON payload', async () => {
+    createTestDb();
+    const sectionData = [
+        {
+            component: 'Feature1',
+            header: 'Naslov',
+            description: 'Opis',
+        },
+        {
+            component: 'Faq1',
+            items: [{ question: 'Pitanje', answer: 'Odgovor' }],
+        },
+    ];
+
+    const pageId = await createCmsPage({
+        slug: `section-data-${randomUUID()}`,
+        title: 'Section data page',
+        content: JSON.stringify(sectionData),
+    });
+
+    const page = await getCmsPage(pageId);
+    assert.equal(page?.content, JSON.stringify(sectionData));
+});
+
+test('CMS page content rejects invalid SectionData JSON payload', async () => {
+    createTestDb();
+    const slug = `invalid-section-data-${randomUUID()}`;
+
+    await assert.rejects(
+        () =>
+            createCmsPage({
+                slug,
+                title: 'Invalid section data page',
+                content: '{"component":"Feature1"}',
+            }),
+        /JSON array of SectionData blocks/,
+    );
+
+    await assert.rejects(
+        () =>
+            createCmsPage({
+                slug: `${slug}-component`,
+                title: 'Invalid component page',
+                content: JSON.stringify([{ component: 'Unknown1' }]),
+            }),
+        /unsupported component/,
+    );
+});


### PR DESCRIPTION
### Motivation
- Enable storing editable `SectionData[]` content on CMS pages while preventing invalid payloads from being persisted.
- Enforce server-side validation that only supported marketing section components are accepted so rendering and publishing remain safe and deterministic.

### Description
- Added a `supportedCmsPageSectionComponents` set and a `normalizeCmsPageContent` helper in `packages/storage/src/repositories/cmsPagesRepo.ts` that parses, validates, and normalizes JSON content for `SectionData[]` payloads.
- Wired `normalizeCmsPageContent` into page creation and update flows by replacing raw `optionalText` usage for `content` in `pageInsertValues` and `updateCmsPage` so invalid content is rejected before persistence.
- Added tests in `packages/storage/tests/cmsPagesRepo.node.spec.ts` that assert valid `SectionData[]` payloads are saved and that invalid payloads (non-array JSON and unsupported component names) are rejected.
- Improved the admin editor UX in `apps/app/app/admin/cms/pages/CmsPageForm.tsx` by adding a JSON placeholder and helper text describing the expected `SectionData[]` input.

### Testing
- Added automated tests in `packages/storage/tests/cmsPagesRepo.node.spec.ts` covering valid `SectionData[]` persistence and rejection of invalid payloads.
- Attempted to run `pnpm --filter @gredice/storage test` in this environment but the run failed due to missing Docker (`docker: command not found`), so the storage test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7889e89c832f94876b5c7102b387)