### PR TITLE
Validate CMS page content as SectionData JSON and update admin form

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -63,9 +63,15 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                 <textarea
                                     name="content"
                                     defaultValue={page?.content ?? ''}
+                                    placeholder='[{"component":"Feature1","header":"Naslov"}]'
                                     rows={10}
                                     className="block min-h-48 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                 />
+                                <Typography level="body3" secondary>
+                                    Unesi JSON niz SectionData blokova (npr.
+                                    komponenta Feature1, Heading1, Faq1 ili
+                                    Footer1).
+                                </Typography>
                             </label>
                         </Stack>
 

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -24,6 +24,13 @@ export type GetCmsPagesOptions = {
     includeDeleted?: boolean;
 };
 
+const supportedCmsPageSectionComponents = new Set([
+    'Heading1',
+    'Faq1',
+    'Feature1',
+    'Footer1',
+]);
+
 export function isCmsPageState(value: string): value is CmsPageState {
     return value === 'draft' || value === 'published';
 }
@@ -135,13 +142,57 @@ function pageInsertValues(input: CreateCmsPageInput): InsertCmsPage {
     return {
         slug: normalizeCmsPageSlug(input.slug),
         title,
-        content: optionalText(input.content),
+        content: normalizeCmsPageContent(input.content),
         state,
         publishedAt: state === 'published' ? new Date() : null,
         metaTitle: optionalText(input.metaTitle),
         metaDescription: optionalText(input.metaDescription),
         metaImageUrl: optionalText(input.metaImageUrl),
     };
+}
+
+function normalizeCmsPageContent(content: string | null | undefined) {
+    const normalized = optionalText(content);
+    if (!normalized) {
+        return null;
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(normalized);
+    } catch {
+        throw new Error(
+            'Page content must be a valid JSON array of SectionData blocks.',
+        );
+    }
+
+    if (!Array.isArray(parsed)) {
+        throw new Error(
+            'Page content must be a JSON array of SectionData blocks.',
+        );
+    }
+
+    parsed.forEach((section, index) => {
+        if (!section || typeof section !== 'object') {
+            throw new Error(
+                `Section at index ${index} must be an object with a component field.`,
+            );
+        }
+
+        if (!('component' in section) || typeof section.component !== 'string') {
+            throw new Error(
+                `Section at index ${index} must define a string component.`,
+            );
+        }
+
+        if (!supportedCmsPageSectionComponents.has(section.component)) {
+            throw new Error(
+                `Section at index ${index} has unsupported component: ${section.component}.`,
+            );
+        }
+    });
+
+    return JSON.stringify(parsed);
 }
 
 export async function getCmsPages(options: GetCmsPagesOptions = {}) {
@@ -214,7 +265,7 @@ export async function updateCmsPage(input: UpdateCmsPageInput) {
     }
 
     if (input.content !== undefined) {
-        updateData.content = optionalText(input.content);
+        updateData.content = normalizeCmsPageContent(input.content);
     }
 
     if (input.state !== undefined) {

--- a/packages/storage/tests/cmsPagesRepo.node.spec.ts
+++ b/packages/storage/tests/cmsPagesRepo.node.spec.ts
@@ -17,11 +17,17 @@ test('CMS pages normalize slugs and support CRUD lifecycle', async () => {
     createTestDb();
     const suffix = randomUUID();
     const rawSlug = ` /Vodiči/${suffix}/Česta pitanja/ `;
+    const originalContent = JSON.stringify([
+        { component: 'Feature1', header: 'Original section' },
+    ]);
+    const updatedContent = JSON.stringify([
+        { component: 'Heading1', header: 'Updated section' },
+    ]);
 
     const pageId = await createCmsPage({
         slug: rawSlug,
         title: 'Original title',
-        content: 'Original content',
+        content: originalContent,
         metaTitle: 'Original meta title',
         metaDescription: 'Original meta description',
     });
@@ -37,7 +43,7 @@ test('CMS pages normalize slugs and support CRUD lifecycle', async () => {
         id: pageId,
         slug: `Vodiči/${suffix}/Objavljena stranica`,
         title: 'Updated title',
-        content: 'Updated content',
+        content: updatedContent,
         state: 'published',
         metaImageUrl: 'https://www.gredice.com/assets/page.png',
     });
@@ -46,7 +52,7 @@ test('CMS pages normalize slugs and support CRUD lifecycle', async () => {
     const updated = await getCmsPageBySlug(updatedSlug);
     assert.equal(updated?.id, pageId);
     assert.equal(updated?.title, 'Updated title');
-    assert.equal(updated?.content, 'Updated content');
+    assert.equal(updated?.content, updatedContent);
     assert.equal(updated?.state, 'published');
     assert.ok(updated?.publishedAt instanceof Date);
 
@@ -115,5 +121,54 @@ test('CMS page slugs reject reserved static route conflicts', async () => {
                 title: 'Conflicting page',
             }),
         /reserved route/,
+    );
+});
+
+test('CMS page content stores valid SectionData JSON payload', async () => {
+    createTestDb();
+    const sectionData = [
+        {
+            component: 'Feature1',
+            header: 'Naslov',
+            description: 'Opis',
+        },
+        {
+            component: 'Faq1',
+            items: [{ question: 'Pitanje', answer: 'Odgovor' }],
+        },
+    ];
+
+    const pageId = await createCmsPage({
+        slug: `section-data-${randomUUID()}`,
+        title: 'Section data page',
+        content: JSON.stringify(sectionData),
+    });
+
+    const page = await getCmsPage(pageId);
+    assert.equal(page?.content, JSON.stringify(sectionData));
+});
+
+test('CMS page content rejects invalid SectionData JSON payload', async () => {
+    createTestDb();
+    const slug = `invalid-section-data-${randomUUID()}`;
+
+    await assert.rejects(
+        () =>
+            createCmsPage({
+                slug,
+                title: 'Invalid section data page',
+                content: '{"component":"Feature1"}',
+            }),
+        /JSON array of SectionData blocks/,
+    );
+
+    await assert.rejects(
+        () =>
+            createCmsPage({
+                slug: `${slug}-component`,
+                title: 'Invalid component page',
+                content: JSON.stringify([{ component: 'Unknown1' }]),
+            }),
+        /unsupported component/,
     );
 });


### PR DESCRIPTION
### Motivation
- Ensure CMS page `content` is stored as a validated JSON array of SectionData blocks to prevent arbitrary text and enforce supported components.
- Surface guidance in the admin form so editors know to provide SectionData JSON.

### Description
- Added a `supportedCmsPageSectionComponents` set and a `normalizeCmsPageContent` sanitizer/validator that parses `content`, enforces a JSON array, validates each section object has a string `component`, and ensures the component is supported; it returns a normalized JSON string or throws descriptive errors. 
- Replaced raw `content` passthrough with `normalizeCmsPageContent` in `pageInsertValues` and the update flow in `updateCmsPage` so both create and update paths validate content.
- Updated the admin form `CmsPageForm.tsx` `textarea` to include a placeholder and helper `Typography` text that instructs editors to enter a JSON array of SectionData blocks with example components.
- Extended `packages/storage/tests/cmsPagesRepo.node.spec.ts` to use JSON content in the CRUD lifecycle test and added tests that accept valid SectionData payloads and reject invalid payloads (non-array or unsupported components).

### Testing
- Ran the storage unit tests including `packages/storage/tests/cmsPagesRepo.node.spec.ts`, which exercise creation, update, deletion, slug rules, and the new content validation tests, and they passed.
- New tests specifically covering valid SectionData storage and rejection of invalid payloads were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7889e89c832f94876b5c7102b387)