### PR TITLE
Validate and normalize CMS page content as SectionData JSON and add editor hint

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -63,9 +63,15 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                 <textarea
                                     name="content"
                                     defaultValue={page?.content ?? ''}
+                                    placeholder='[{"component":"Feature1","header":"Naslov"}]'
                                     rows={10}
                                     className="block min-h-48 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                 />
+                                <Typography level="body3" secondary>
+                                    Unesi JSON niz SectionData blokova (npr.
+                                    komponenta Feature1, Heading1, Faq1 ili
+                                    Footer1).
+                                </Typography>
                             </label>
                         </Stack>
 

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -24,6 +24,13 @@ export type GetCmsPagesOptions = {
     includeDeleted?: boolean;
 };
 
+const supportedCmsPageSectionComponents = new Set([
+    'Heading1',
+    'Faq1',
+    'Feature1',
+    'Footer1',
+]);
+
 export function isCmsPageState(value: string): value is CmsPageState {
     return value === 'draft' || value === 'published';
 }
@@ -135,13 +142,71 @@ function pageInsertValues(input: CreateCmsPageInput): InsertCmsPage {
     return {
         slug: normalizeCmsPageSlug(input.slug),
         title,
-        content: optionalText(input.content),
+        content: normalizeCmsPageContent(input.content),
         state,
         publishedAt: state === 'published' ? new Date() : null,
         metaTitle: optionalText(input.metaTitle),
         metaDescription: optionalText(input.metaDescription),
         metaImageUrl: optionalText(input.metaImageUrl),
     };
+}
+
+function normalizeCmsPageContent(content: string | null | undefined) {
+    const normalized = optionalText(content);
+    if (!normalized) {
+        return null;
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(normalized);
+    } catch {
+        throw new Error(
+            'Page content must be a valid JSON array of SectionData blocks.',
+        );
+    }
+
+    if (!Array.isArray(parsed)) {
+        throw new Error(
+            'Page content must be a JSON array of SectionData blocks.',
+        );
+    }
+
+    parsed.forEach((section, index) => {
+        if (!section || typeof section !== 'object') {
+            throw new Error(
+                `Section at index ${index} must be an object with a component field.`,
+            );
+        }
+
+        if (!('component' in section) || typeof section.component !== 'string') {
+            throw new Error(
+                `Section at index ${index} must define a string component.`,
+            );
+        }
+
+        if (!supportedCmsPageSectionComponents.has(section.component)) {
+            throw new Error(
+                `Section at index ${index} has unsupported component: ${section.component}.`,
+            );
+        }
+    });
+
+    return JSON.stringify(parsed);
+}
+
+function normalizeCmsPageContentForUpdate(
+    content: string | null | undefined,
+    existingContent: string | null | undefined,
+) {
+    const normalized = optionalText(content);
+    const normalizedExisting = optionalText(existingContent);
+
+    if (normalized === normalizedExisting) {
+        return normalizedExisting;
+    }
+
+    return normalizeCmsPageContent(content);
 }
 
 export async function getCmsPages(options: GetCmsPagesOptions = {}) {
@@ -214,7 +279,10 @@ export async function updateCmsPage(input: UpdateCmsPageInput) {
     }
 
     if (input.content !== undefined) {
-        updateData.content = optionalText(input.content);
+        updateData.content = normalizeCmsPageContentForUpdate(
+            input.content,
+            existing.content,
+        );
     }
 
     if (input.state !== undefined) {

--- a/packages/storage/tests/cmsPagesRepo.node.spec.ts
+++ b/packages/storage/tests/cmsPagesRepo.node.spec.ts
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    cmsPages,
     createCmsPage,
     getCmsPage,
     getCmsPageBySlug,
     getCmsPages,
     normalizeCmsPageSlug,
     softDeleteCmsPage,
+    storage,
     updateCmsPage,
     updateCmsPageState,
 } from '@gredice/storage';
@@ -17,11 +19,17 @@ test('CMS pages normalize slugs and support CRUD lifecycle', async () => {
     createTestDb();
     const suffix = randomUUID();
     const rawSlug = ` /Vodiči/${suffix}/Česta pitanja/ `;
+    const originalContent = JSON.stringify([
+        { component: 'Feature1', header: 'Original section' },
+    ]);
+    const updatedContent = JSON.stringify([
+        { component: 'Heading1', header: 'Updated section' },
+    ]);
 
     const pageId = await createCmsPage({
         slug: rawSlug,
         title: 'Original title',
-        content: 'Original content',
+        content: originalContent,
         metaTitle: 'Original meta title',
         metaDescription: 'Original meta description',
     });
@@ -37,7 +45,7 @@ test('CMS pages normalize slugs and support CRUD lifecycle', async () => {
         id: pageId,
         slug: `Vodiči/${suffix}/Objavljena stranica`,
         title: 'Updated title',
-        content: 'Updated content',
+        content: updatedContent,
         state: 'published',
         metaImageUrl: 'https://www.gredice.com/assets/page.png',
     });
@@ -46,7 +54,7 @@ test('CMS pages normalize slugs and support CRUD lifecycle', async () => {
     const updated = await getCmsPageBySlug(updatedSlug);
     assert.equal(updated?.id, pageId);
     assert.equal(updated?.title, 'Updated title');
-    assert.equal(updated?.content, 'Updated content');
+    assert.equal(updated?.content, updatedContent);
     assert.equal(updated?.state, 'published');
     assert.ok(updated?.publishedAt instanceof Date);
 
@@ -116,4 +124,80 @@ test('CMS page slugs reject reserved static route conflicts', async () => {
             }),
         /reserved route/,
     );
+});
+
+test('CMS page content stores valid SectionData JSON payload', async () => {
+    createTestDb();
+    const sectionData = [
+        {
+            component: 'Feature1',
+            header: 'Naslov',
+            description: 'Opis',
+        },
+        {
+            component: 'Faq1',
+            items: [{ question: 'Pitanje', answer: 'Odgovor' }],
+        },
+    ];
+
+    const pageId = await createCmsPage({
+        slug: `section-data-${randomUUID()}`,
+        title: 'Section data page',
+        content: JSON.stringify(sectionData),
+    });
+
+    const page = await getCmsPage(pageId);
+    assert.equal(page?.content, JSON.stringify(sectionData));
+});
+
+test('CMS page content rejects invalid SectionData JSON payload', async () => {
+    createTestDb();
+    const slug = `invalid-section-data-${randomUUID()}`;
+
+    await assert.rejects(
+        () =>
+            createCmsPage({
+                slug,
+                title: 'Invalid section data page',
+                content: '{"component":"Feature1"}',
+            }),
+        /JSON array of SectionData blocks/,
+    );
+
+    await assert.rejects(
+        () =>
+            createCmsPage({
+                slug: `${slug}-component`,
+                title: 'Invalid component page',
+                content: JSON.stringify([{ component: 'Unknown1' }]),
+            }),
+        /unsupported component/,
+    );
+});
+
+test('CMS page update allows legacy plaintext content when unchanged', async () => {
+    createTestDb();
+    const slug = `legacy-plaintext-${randomUUID()}`;
+    const legacyContent = 'Legacy plain text content';
+
+    const [created] = await storage()
+        .insert(cmsPages)
+        .values({
+            slug,
+            title: 'Legacy page',
+            content: legacyContent,
+            state: 'draft',
+        })
+        .returning({ id: cmsPages.id });
+
+    assert.ok(created);
+    await updateCmsPage({
+        id: created.id,
+        title: 'Legacy page updated',
+        content: legacyContent,
+    });
+
+    const updated = await getCmsPage(created.id);
+    assert.equal(updated?.title, 'Legacy page updated');
+    assert.equal(updated?.content, legacyContent);
 });


### PR DESCRIPTION
### Motivation
- Ensure CMS page `content` is a structured JSON array of SectionData blocks and prevent storing arbitrary/plaintext payloads by validating allowed components. 
- Preserve backward compatibility for legacy plaintext content when unchanged during updates. 
- Make the admin page editor clearer by adding a JSON example placeholder and helper text for the `content` field. 

### Description
- Added a `supportedCmsPageSectionComponents` set and implemented `normalizeCmsPageContent` to parse, validate, and normalize `content` into a JSON string and to reject invalid payloads or unsupported components. 
- Added `normalizeCmsPageContentForUpdate` to allow legacy plaintext content to remain unchanged when an update does not modify it. 
- Hooked normalization into `pageInsertValues` and `updateCmsPage` so `createCmsPage` and `updateCmsPage` enforce the new content rules. 
- Updated the admin form `CmsPageForm.tsx` to include a `placeholder` JSON example and an explanatory `Typography` helper for the `content` textarea. 
- Extended `cmsPagesRepo` tests in `cmsPagesRepo.node.spec.ts` to cover valid SectionData storage, rejection of invalid payloads and unsupported components, and the legacy plaintext update path, and adjusted imports to use `cmsPages` and `storage` where needed. 

### Testing
- Ran the `packages/storage` node test suite, specifically `cmsPagesRepo.node.spec.ts`, which includes tests for slug normalization, CRUD lifecycle, content acceptance, content rejection, and legacy plaintext update, and all tests passed. 
- The new content-related unit tests verify successful creation with valid SectionData, rejection for non-array or invalid component payloads, and acceptance of unchanged legacy plaintext during updates, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7889e89c832f94876b5c7102b387)