### PR TITLE
chore(garden): silence service worker lint warning

### DIFF
--- a/apps/garden/public/service-worker.js
+++ b/apps/garden/public/service-worker.js
@@ -14,7 +14,7 @@ self.addEventListener('push', (event) => {
     let payload;
     try {
         payload = event.data.json();
-    } catch (error) {
+    } catch (_error) {
         payload = { title: 'Gredice', body: event.data.text() };
     }
 


### PR DESCRIPTION
### Motivation
- Remove a Biome `noUnusedVariables` lint warning in the garden service worker by modernizing the catch binding without changing runtime behavior.

### Description
- Replace the unused `catch (error)` binding with an intentionally ignored `catch (_error)` in `apps/garden/public/service-worker.js` so the linter no longer flags an unused variable.

### Testing
- Ran the Biome checks with `pnpm --filter garden exec biome check components/providers/PushNotificationManager.tsx public/service-worker.js` and the warning was resolved.
- Attempted to run the storage node tests with `pnpm --filter @gredice/storage test -- --run tests/pushSubscriptionsRepo.node.spec.ts`, but the run was blocked in this environment because Docker is not available, so those tests could not complete.
- Could not perform an automated verification against the remote `main` branch in this environment because the repository remote information is not configured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8af2d6fc832fbe6c60230f24838a)