### PR TITLE
feat(api): add published CMS pages endpoints to directories surface

### DIFF
--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -1,7 +1,7 @@
 import {
+    type EntityStandardized,
     getCmsPageBySlug,
     getCmsPages,
-    type EntityStandardized,
     getEntitiesFormatted,
     getEntityFormatted,
 } from '@gredice/storage';
@@ -18,16 +18,18 @@ const app = new Hono()
         const pages = await getCmsPages({ state: 'published' });
         setCacheControl(context, cacheControlPresets.directories);
         return context.json(
-            pages.map((page) => ({
-                slug: page.slug,
-                title: page.title,
-                state: page.state,
-                publishedAt: page.publishedAt,
-                metaTitle: page.metaTitle,
-                metaDescription: page.metaDescription,
-                metaImageUrl: page.metaImageUrl,
-                updatedAt: page.updatedAt,
-            })),
+            pages
+                .filter((page) => page.publishedAt)
+                .map((page) => ({
+                    slug: page.slug,
+                    title: page.title,
+                    state: page.state,
+                    publishedAt: page.publishedAt,
+                    metaTitle: page.metaTitle,
+                    metaDescription: page.metaDescription,
+                    metaImageUrl: page.metaImageUrl,
+                    updatedAt: page.updatedAt,
+                })),
         );
     })
     .get('/pages/:slug{.+}', async (context) => {

--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -1,4 +1,6 @@
 import {
+    getCmsPageBySlug,
+    getCmsPages,
     type EntityStandardized,
     getEntitiesFormatted,
     getEntityFormatted,
@@ -12,6 +14,54 @@ import {
 } from '../../../lib/http/cacheControl';
 
 const app = new Hono()
+    .get('/pages', async (context) => {
+        const pages = await getCmsPages({ state: 'published' });
+        setCacheControl(context, cacheControlPresets.directories);
+        return context.json(
+            pages.map((page) => ({
+                slug: page.slug,
+                title: page.title,
+                state: page.state,
+                publishedAt: page.publishedAt,
+                metaTitle: page.metaTitle,
+                metaDescription: page.metaDescription,
+                metaImageUrl: page.metaImageUrl,
+                updatedAt: page.updatedAt,
+            })),
+        );
+    })
+    .get('/pages/:slug{.+}', async (context) => {
+        const slug = context.req.param('slug');
+        const page = await getCmsPageBySlug(slug);
+        if (!page || page.state !== 'published' || !page.publishedAt) {
+            return context.json({ error: 'Page not found' }, { status: 404 });
+        }
+
+        let content: unknown[] = [];
+        if (page.content) {
+            try {
+                const parsed = JSON.parse(page.content);
+                if (Array.isArray(parsed)) {
+                    content = parsed;
+                }
+            } catch {
+                content = [];
+            }
+        }
+
+        setCacheControl(context, cacheControlPresets.directories);
+        return context.json({
+            slug: page.slug,
+            title: page.title,
+            content,
+            state: page.state,
+            publishedAt: page.publishedAt,
+            metaTitle: page.metaTitle,
+            metaDescription: page.metaDescription,
+            metaImageUrl: page.metaImageUrl,
+            updatedAt: page.updatedAt,
+        });
+    })
     .get(
         '/entities/:entityType',
         zValidator(

--- a/apps/api/lib/docs/openApiDocs.ts
+++ b/apps/api/lib/docs/openApiDocs.ts
@@ -452,7 +452,10 @@ export async function openApiDocs(
         },
     };
 
-    baseDoc.paths['/pages'] = {
+    const paths = baseDoc.paths ?? {};
+    baseDoc.paths = paths;
+
+    paths['/pages'] = {
         get: {
             summary: '/pages',
             description: 'Get published CMS pages.',
@@ -474,7 +477,7 @@ export async function openApiDocs(
         },
     };
 
-    baseDoc.paths['/pages/{slug}'] = {
+    paths['/pages/{slug}'] = {
         get: {
             summary: '/pages/{slug}',
             description: 'Get a published CMS page by slug/path.',
@@ -522,10 +525,10 @@ export async function openApiDocs(
                 slug: { type: 'string' },
                 title: { type: 'string' },
                 state: { type: 'string', enum: ['published'] },
-                publishedAt: { type: 'string', format: 'date-time', nullable: true },
-                metaTitle: { type: 'string', nullable: true },
-                metaDescription: { type: 'string', nullable: true },
-                metaImageUrl: { type: 'string', nullable: true },
+                publishedAt: { type: ['string', 'null'], format: 'date-time' },
+                metaTitle: { type: ['string', 'null'] },
+                metaDescription: { type: ['string', 'null'] },
+                metaImageUrl: { type: ['string', 'null'] },
                 updatedAt: { type: 'string', format: 'date-time' },
             },
         };
@@ -538,7 +541,9 @@ export async function openApiDocs(
                     properties: {
                         content: {
                             type: 'array',
-                            items: { $ref: '#/components/schemas/section-data' },
+                            items: {
+                                $ref: '#/components/schemas/section-data',
+                            },
                         },
                     },
                 },

--- a/apps/api/lib/docs/openApiDocs.ts
+++ b/apps/api/lib/docs/openApiDocs.ts
@@ -452,6 +452,100 @@ export async function openApiDocs(
         },
     };
 
+    baseDoc.paths['/pages'] = {
+        get: {
+            summary: '/pages',
+            description: 'Get published CMS pages.',
+            responses: {
+                200: {
+                    description: 'Successful response',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'array',
+                                items: {
+                                    $ref: '#/components/schemas/page-summary',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    baseDoc.paths['/pages/{slug}'] = {
+        get: {
+            summary: '/pages/{slug}',
+            description: 'Get a published CMS page by slug/path.',
+            parameters: [
+                {
+                    name: 'slug',
+                    in: 'path',
+                    required: true,
+                    schema: { type: 'string' },
+                },
+            ],
+            responses: {
+                200: {
+                    description: 'Successful response',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                $ref: '#/components/schemas/page-detail',
+                            },
+                        },
+                    },
+                },
+                404: {
+                    description: 'Page not found',
+                },
+            },
+        },
+    };
+
+    if (baseDoc.components?.schemas) {
+        baseDoc.components.schemas['section-data'] = {
+            type: 'object',
+            additionalProperties: true,
+            required: ['component'],
+            properties: {
+                component: {
+                    type: 'string',
+                },
+            },
+        };
+        baseDoc.components.schemas['page-summary'] = {
+            type: 'object',
+            required: ['slug', 'title', 'state', 'updatedAt'],
+            properties: {
+                slug: { type: 'string' },
+                title: { type: 'string' },
+                state: { type: 'string', enum: ['published'] },
+                publishedAt: { type: 'string', format: 'date-time', nullable: true },
+                metaTitle: { type: 'string', nullable: true },
+                metaDescription: { type: 'string', nullable: true },
+                metaImageUrl: { type: 'string', nullable: true },
+                updatedAt: { type: 'string', format: 'date-time' },
+            },
+        };
+        baseDoc.components.schemas['page-detail'] = {
+            allOf: [
+                { $ref: '#/components/schemas/page-summary' },
+                {
+                    type: 'object',
+                    required: ['content'],
+                    properties: {
+                        content: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/section-data' },
+                        },
+                    },
+                },
+            ],
+        };
+    }
+
     const entityTypes = await getEntityTypes();
     const typeDocs = await Promise.all(
         entityTypes.map((entityType) => openApiEntitiesDoc(entityType)),


### PR DESCRIPTION
### Motivation
- Provide a public API surface for retrieving published CMS pages (list and detail) so frontend apps can fetch published content without exposing drafts, per GRE-229.
- Reuse existing directories cache pattern and cache-control behavior to keep public page responses consistent with other directory content.

### Description
- Added two new Hono routes in `apps/api/app/api/[...route]/directoriesRoutes.ts`: `GET /api/directories/pages` for published page summaries and `GET /api/directories/pages/:slug{.+}` for published page details, returning `404` for missing/draft/deleted pages and parsing stored JSON `content` into an array for the detail response.
- Extended OpenAPI generation in `apps/api/lib/docs/openApiDocs.ts` to include `/pages` and `/pages/{slug}` paths and new reusable schemas: `section-data`, `page-summary`, and `page-detail` (which includes `content` as an array of `section-data`).
- Responses from the new endpoints use the existing directories cache-control preset via `setCacheControl(context, cacheControlPresets.directories)`.

### Testing
- Ran node test suite for the API with `pnpm --filter api test:node`, and the suite completed successfully with all tests passing.
- Attempted a targeted docs test run (`pnpm --filter api test -- openApiDocs.node.spec.ts`) but it failed in the local environment due to missing runtime environment (e.g. `POSTGRES_URL`) and Playwright production-server requirements; this is an environment limitation and not a regression in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda137561c832f9d117f8fc32870fe)