### PR TITLE
Add garden box entity registration and reusable base renderer

### DIFF
--- a/packages/game/src/entities/GardenBox.tsx
+++ b/packages/game/src/entities/GardenBox.tsx
@@ -1,0 +1,6 @@
+import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import { GardenBox as GardenBoxBase } from './helpers/GardenBox';
+
+export function GardenBox(props: EntityInstanceProps) {
+    return <GardenBoxBase {...props} bodyColor="#8B5A2B" trimColor="#5E3A1D" />;
+}

--- a/packages/game/src/entities/entityNameMap.ts
+++ b/packages/game/src/entities/entityNameMap.ts
@@ -13,6 +13,7 @@ import { Bucket } from './Bucket';
 import { Bush } from './Bush';
 import { Composter } from './Composter';
 import { Fence } from './Fence';
+import { GardenBox } from './GardenBox';
 import { GiftBoxBlueWhite } from './GiftBoxBlueWhite';
 import { GiftBoxGoldRed } from './GiftBoxGoldRed';
 import { GiftBoxGreenGold } from './GiftBoxGreenGold';
@@ -54,6 +55,7 @@ export const entityNameMap: Record<
     Raised_Bed: RaisedBed,
     Shade: Shade,
     Fence: Fence,
+    GardenBox: GardenBox,
     Stool: Stool,
     Bucket: Bucket,
     GiftBox_RedWhite: GiftBoxRedWhite,

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -1,0 +1,75 @@
+import { animated } from '@react-spring/three';
+import { useHoveredBlockStore } from '../../controls/useHoveredBlockStore';
+import { SnowOverlay } from '../../snow/SnowOverlay';
+import { snowPresets } from '../../snow/snowPresets';
+import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
+import { useStackHeight } from '../../utils/getStackHeight';
+import { useGameGLTF } from '../../utils/useGameGLTF';
+import { HoverOutline } from './HoverOutline';
+import { useAnimatedEntityRotation } from './useAnimatedEntityRotation';
+
+type GardenBoxProps = EntityInstanceProps & {
+    bodyColor: string;
+    trimColor: string;
+    bodyMetalness?: number;
+    bodyRoughness?: number;
+    trimMetalness?: number;
+    trimRoughness?: number;
+};
+
+export function GardenBox({
+    stack,
+    block,
+    rotation,
+    bodyColor,
+    trimColor,
+    bodyMetalness = 0.1,
+    bodyRoughness = 0.85,
+    trimMetalness = 0.2,
+    trimRoughness = 0.75,
+}: GardenBoxProps) {
+    const { nodes } = useGameGLTF();
+    const [animatedRotation] = useAnimatedEntityRotation(rotation);
+    const currentStackHeight = useStackHeight(stack, block);
+    const hovered =
+        useHoveredBlockStore((state) => state.hoveredBlock) === block;
+
+    return (
+        <animated.group
+            position={stack.position.clone().setY(currentStackHeight + 0.25)}
+            rotation={animatedRotation as unknown as [number, number, number]}
+        >
+            <mesh
+                castShadow
+                receiveShadow
+                geometry={nodes.GiftBox_Box.geometry}
+            >
+                <meshStandardMaterial
+                    color={bodyColor}
+                    metalness={bodyMetalness}
+                    roughness={bodyRoughness}
+                />
+                <HoverOutline hovered={hovered} variant="outlines" />
+            </mesh>
+            <mesh
+                castShadow
+                receiveShadow
+                geometry={nodes.GiftBox_Strip.geometry}
+            >
+                <meshStandardMaterial
+                    color={trimColor}
+                    metalness={trimMetalness}
+                    roughness={trimRoughness}
+                />
+            </mesh>
+            <SnowOverlay
+                geometry={nodes.GiftBox_Box.geometry}
+                {...snowPresets.giftBox}
+            />
+            <SnowOverlay
+                geometry={nodes.GiftBox_Strip.geometry}
+                {...snowPresets.giftBox}
+            />
+        </animated.group>
+    );
+}

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -46,6 +46,7 @@ const items: HudItem[] = [
         items: [
             { type: 'entity', name: 'Bucket' },
             { type: 'entity', name: 'Composter' },
+            { type: 'entity', name: 'GardenBox' },
         ],
     },
     {


### PR DESCRIPTION
## Summary
- Added a reusable `GardenBox` base renderer in `packages/game` using the existing model/material patterns.
- Registered `GardenBox` in the runtime entity map so it can be spawned and rendered in-game.
- Exposed the new entity in the garden item picker alongside the other utility entities.

## Testing
- `pnpm --filter @gredice/game exec biome check ...` passed for the touched files.
- `pnpm build --filter garden` passed.
- `pnpm --filter @gredice/game exec tsc --noEmit --project tsconfig.json` hit an existing worker lib issue unrelated to this change.