### PR TITLE
Add `dev:all` command and document full-app startup validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pnpm doctor
 pnpm dev
 ```
 
-The default dev command starts the main apps through local HTTPS domains such as `https://www.gredice.test`, `https://vrt.gredice.test`, and `https://api.gredice.test`. The `status` app is not part of the default dev stack; start it with `pnpm --filter=status dev` when working on the status page.
+The default dev command starts the main apps through local HTTPS domains such as `https://www.gredice.test`, `https://vrt.gredice.test`, and `https://api.gredice.test`. The `status` app is intentionally excluded so normal startup stays fast. Use `pnpm dev:all` when you need to validate every app (including `status`) can start in a fresh worktree, and use `pnpm --filter=status dev` for status-only development.
 
 `pnpm bootstrap` prepares a fresh worktree as far as local permissions and credentials allow.
 `pnpm doctor` runs the same checks in read-only mode and exits non-zero when required dependencies are missing.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "generate:models-types": "turbo generate:models-types",
         "generate:game-assets": "node ./scripts/generate-game-assets.mjs",
         "doctor": "node ./scripts/worktree-health.mjs doctor",
-        "bootstrap": "node ./scripts/worktree-health.mjs setup"
+        "bootstrap": "node ./scripts/worktree-health.mjs setup",
+        "dev:all": "node ./scripts/dev-with-proxy.mjs --all-apps"
     },
     "devDependencies": {
         "rimraf": "6.1.3",

--- a/scripts/dev-with-proxy.mjs
+++ b/scripts/dev-with-proxy.mjs
@@ -14,10 +14,12 @@ const worktreeSlug = worktreeId.toLowerCase().replace(/[^a-z0-9]+/g, '-').replac
 const containerName = `gredice-dev-caddy-${worktreeSlug}`;
 const dockerImage = process.env.GREDICE_DEV_CADDY_IMAGE ?? 'gredice-caddy-dev';
 const shouldSkipProxy = parseEnvFlag(process.env.SKIP_DEV_PROXY ?? '');
-const extraTurboArgs = process.argv.slice(2);
-const excludedDefaultDevApps = appRegistry.filter(
-    (app) => !app.startsInDefaultDev,
-);
+const rawCliArgs = process.argv.slice(2);
+const includeAllApps = rawCliArgs.includes('--all-apps');
+const extraTurboArgs = rawCliArgs.filter((arg) => arg !== '--all-apps');
+const excludedDefaultDevApps = includeAllApps
+    ? []
+    : appRegistry.filter((app) => !app.startsInDefaultDev);
 const signalNumbers = os.constants?.signals ?? {};
 const defaultDataDir = (() => {
     const homeDir = os.homedir?.();


### PR DESCRIPTION
### Motivation
- Provide an explicit command to start every app (including `status`) for fresh-worktree validation so the full stack can be smoke-tested.
- Keep the existing `pnpm dev` behavior fast by keeping `status` opt-in for normal development.
- Make the all-app startup path worktree-safe and proxied using the same dev entrypoint as the default flow.

### Description
- Added a root `dev:all` script in `package.json` that runs `node ./scripts/dev-with-proxy.mjs --all-apps` to opt into starting all apps.
- Updated `scripts/dev-with-proxy.mjs` to parse a `--all-apps` flag (`rawCliArgs`, `includeAllApps`) and only apply the default app exclusions when the flag is not present.
- Clarified the Getting Started guidance in `README.md` to document when to use `pnpm dev`, `pnpm dev:all`, and `pnpm --filter=status dev`.
- Modified files: `package.json`, `scripts/dev-with-proxy.mjs`, and `README.md`.

### Testing
- Ran `pnpm run lint:ci-filters` which completed successfully.
- The lint run emitted a Node engine warning in this environment because the container Node is `v22.22.2` while the repo specifies `>=24`, but the script still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb171acc4832f9bdafc43e57a35de)