### PR TITLE
[CMS] Render published CMS pages in www

### DIFF
--- a/apps/www/app/[...slug]/cmsPageRouteUtils.node.spec.ts
+++ b/apps/www/app/[...slug]/cmsPageRouteUtils.node.spec.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    hasReservedFirstSegment,
+    normalizeCmsRouteSlug,
+    parseCmsSectionData,
+} from './cmsPageRouteUtils';
+
+test('normalizeCmsRouteSlug builds nested slug segments', () => {
+    assert.equal(normalizeCmsRouteSlug([' cms ', 'about-us ']), 'cms/about-us');
+});
+
+test('parseCmsSectionData returns section-like objects only', () => {
+    const sections = parseCmsSectionData([
+        { component: 'Feature1', header: 'Title' },
+        { component: 5 },
+        null,
+        'section',
+    ]);
+
+    assert.deepEqual(sections, [{ component: 'Feature1', header: 'Title' }]);
+});
+
+test('parseCmsSectionData returns empty array for invalid payloads', () => {
+    assert.deepEqual(parseCmsSectionData({ component: 'Feature1' }), []);
+});
+
+test('hasReservedFirstSegment flags static route conflicts', () => {
+    assert.equal(hasReservedFirstSegment('legalno/politika-privatnosti'), true);
+    assert.equal(hasReservedFirstSegment('cms/about-us'), false);
+});

--- a/apps/www/app/[...slug]/cmsPageRouteUtils.ts
+++ b/apps/www/app/[...slug]/cmsPageRouteUtils.ts
@@ -1,0 +1,59 @@
+import type { SectionData } from '@signalco/cms-core/SectionData';
+
+export function normalizeCmsRouteSlug(segments: string[]) {
+    return segments
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+        .join('/');
+}
+
+function isSectionData(section: unknown): section is SectionData {
+    if (!section || typeof section !== 'object') {
+        return false;
+    }
+
+    if (!('component' in section)) {
+        return false;
+    }
+
+    return typeof section.component === 'string';
+}
+
+export function parseCmsSectionData(value: unknown): SectionData[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.filter(isSectionData);
+}
+
+const reservedFirstSegments = new Set([
+    'biljke',
+    'blokovi',
+    'cesta-pitanja',
+    'checkout',
+    'cjenik',
+    'development',
+    'dostava',
+    'kontakt',
+    'legalno',
+    'o-nama',
+    'podignuta-gredica',
+    'pozdrav',
+    'preporuke',
+    'racun',
+    'radnje',
+    'recepti',
+    'sjetva',
+    'suncokreti',
+    'vrtovi',
+]);
+
+export function hasReservedFirstSegment(slug: string) {
+    const firstSegment = slug.split('/')[0]?.toLowerCase();
+    if (!firstSegment) {
+        return false;
+    }
+
+    return reservedFirstSegments.has(firstSegment);
+}

--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -35,7 +35,7 @@ export default async function CmsPublishedPageRoute({
     return (
         <main>
             <SectionsView
-                data={parseCmsSectionData(response.data.content)}
+                sectionsData={parseCmsSectionData(response.data.content)}
                 componentsRegistry={sectionsComponentRegistry}
             />
         </main>

--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -1,4 +1,4 @@
-import { directoriesClient } from '@gredice/client';
+import { clientPublic } from '@gredice/client';
 import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { notFound } from 'next/navigation';
 import { sectionsComponentRegistry } from '../../components/shared/sectionsComponentRegistry';
@@ -20,22 +20,20 @@ export default async function CmsPublishedPageRoute({
         notFound();
     }
 
-    const response = await directoriesClient().GET('/pages/{slug}', {
-        params: {
-            path: {
-                slug: normalizedSlug,
-            },
-        },
+    const response = await clientPublic().api.directories.pages[':slug{.+}'].$get({
+        param: { slug: normalizedSlug },
     });
 
-    if (response.error || !response.data) {
+    if (response.status !== 200) {
         notFound();
     }
+
+    const page = await response.json();
 
     return (
         <main>
             <SectionsView
-                sectionsData={parseCmsSectionData(response.data.content)}
+                sectionsData={parseCmsSectionData(page.content)}
                 componentsRegistry={sectionsComponentRegistry}
             />
         </main>

--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -1,0 +1,43 @@
+import { directoriesClient } from '@gredice/client';
+import { SectionsView } from '@signalco/cms-core/SectionsView';
+import { notFound } from 'next/navigation';
+import { sectionsComponentRegistry } from '../../components/shared/sectionsComponentRegistry';
+import {
+    hasReservedFirstSegment,
+    normalizeCmsRouteSlug,
+    parseCmsSectionData,
+} from './cmsPageRouteUtils';
+
+export default async function CmsPublishedPageRoute({
+    params,
+}: {
+    params: Promise<{ slug: string[] }>;
+}) {
+    const { slug } = await params;
+    const normalizedSlug = normalizeCmsRouteSlug(slug);
+
+    if (!normalizedSlug || hasReservedFirstSegment(normalizedSlug)) {
+        notFound();
+    }
+
+    const response = await directoriesClient().GET('/pages/{slug}', {
+        params: {
+            path: {
+                slug: normalizedSlug,
+            },
+        },
+    });
+
+    if (response.error || !response.data) {
+        notFound();
+    }
+
+    return (
+        <main>
+            <SectionsView
+                data={parseCmsSectionData(response.data.content)}
+                componentsRegistry={sectionsComponentRegistry}
+            />
+        </main>
+    );
+}


### PR DESCRIPTION
### Motivation
- Allow published CMS-managed pages to be served by the public `www` app so content updates can publish without code deploys. 
- Reuse the existing component rendering pipeline (`SectionsView` + `sectionsComponentRegistry`) for consistency with hardcoded pages. 
- Preserve existing static route precedence and return 404 for missing, draft, or deleted pages.

### Description
- Added a catch-all App Router page at `apps/www/app/[...slug]/page.tsx` that normalizes incoming slug segments, guards reserved/static-first segments, fetches the published page via the directories API, and renders its sections with `SectionsView` and `sectionsComponentRegistry`.
- Introduced route helpers in `apps/www/app/[...slug]/cmsPageRouteUtils.ts` for `normalizeCmsRouteSlug`, `parseCmsSectionData`, and `hasReservedFirstSegment` to centralize slug and payload validation.
- Added focused unit tests in `apps/www/app/[...slug]/cmsPageRouteUtils.node.spec.ts` covering slug normalization, section payload filtering, and reserved-segment conflict detection.
- The route returns `notFound()` for empty slugs, reserved-first segments, API errors, or when the API response is missing or unpublished.

### Testing
- Ran `pnpm --filter www lint` which completed successfully and auto-fixed 4 files. 
- Ran Node's test runner with `node --test` and `node --experimental-strip-types --test` against `cmsPageRouteUtils.node.spec.ts`, but the environment did not discover `.ts` tests (reported `0` tests). 
- Attempted to run the spec with `pnpm exec tsx --test`, which failed because the `tsx` binary was not available in the environment. 
- No Playwright or end-to-end visual tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb5da6f4c832fb420ed7a98706a76)