### PR TITLE
[Worktree] Add local app env examples and smoke-test defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The default dev command starts the main apps through local HTTPS domains such as
 
 For local domains, certificates, environment files, generated assets, and detailed commands, see [WORKSPACE.md](./WORKSPACE.md).
 
+For fresh worktrees, copy each app's `.env.example` into `.env` before smoke testing. Real external secrets are only needed for explicit integration flows (for example payments, analytics, OAuth, and visual tests).
+
 ## Documentation
 
 - [AGENTS.md](./AGENTS.md): entry point for AI collaborators.

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -137,6 +137,14 @@ pnpm env:pull
 
 `pnpm env:pull` runs `vercel env pull .env` in `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, `apps/storybook`, `apps/api`, and `apps/status`.
 
+### Local and test environment examples
+
+Each app now includes a checked-in `.env.example` (or `.env.test.example` where needed) with safe local defaults for smoke tests. Copy the file to `.env` in each app when starting from a fresh worktree.
+
+- Local smoke tests should run with placeholders for analytics, email, payment, and similar nonessential integrations.
+- Integration or visual tests that validate those providers still require real secrets pulled from Vercel (`pnpm env:pull`) or another secure secret source.
+- Never commit real secrets; keep examples sanitized and use them as shape documentation only.
+
 ## Asset generation
 
 Coordinate with teammates before editing shared game asset files. Only one person should export shared asset changes at a time.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,23 @@
+# Local smoke/default values (safe placeholders)
+NEXT_PUBLIC_VERCEL_ENV=development
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+NEXT_PUBLIC_POSTHOG_UI_HOST=
+POSTHOG_SERVER_HOST=
+POSTHOG_PROXY_HOST=
+GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
+GREDICE_GARDEN_APP_URL=https://vrt.gredice.test
+AI_GATEWAY_MODEL=openai/gpt-5
+
+# Test-safe defaults for nonessential services
+CRON_SECRET=local-cron-secret
+STRIPE_WEBHOOK_SECRET=whsec_local_placeholder
+
+# Optional integration-only values (real secrets required when testing those integrations)
+POSTGRES_URL=
+AI_GATEWAY_API_KEY=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+FACEBOOK_CLIENT_ID=
+FACEBOOK_CLIENT_SECRET=
+COOKIE_DOMAIN=

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,0 +1,11 @@
+# Local smoke/default values (safe placeholders)
+NEXT_PUBLIC_VERCEL_ENV=development
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+NEXT_PUBLIC_POSTHOG_UI_HOST=
+POSTHOG_SERVER_HOST=
+POSTHOG_PROXY_HOST=
+GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
+
+# Optional integration values
+COOKIE_DOMAIN=

--- a/apps/farm/.env.example
+++ b/apps/farm/.env.example
@@ -1,0 +1,11 @@
+# Local smoke/default values (safe placeholders)
+NEXT_PUBLIC_VERCEL_ENV=development
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+NEXT_PUBLIC_POSTHOG_UI_HOST=
+POSTHOG_SERVER_HOST=
+POSTHOG_PROXY_HOST=
+GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
+
+# Optional integration values
+COOKIE_DOMAIN=

--- a/apps/garden/.env.example
+++ b/apps/garden/.env.example
@@ -1,0 +1,10 @@
+# Local smoke/default values (safe placeholders)
+NEXT_PUBLIC_VERCEL_ENV=development
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+NEXT_PUBLIC_POSTHOG_UI_HOST=
+POSTHOG_SERVER_HOST=
+POSTHOG_PROXY_HOST=
+
+# Optional integration values (set real values only when validating production-like integrations)
+COOKIE_DOMAIN=

--- a/apps/storybook/.env.example
+++ b/apps/storybook/.env.example
@@ -1,0 +1,5 @@
+# Local smoke/default values (safe placeholders)
+NEXT_PUBLIC_VERCEL_ENV=development
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+NEXT_PUBLIC_POSTHOG_UI_HOST=

--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -1,0 +1,14 @@
+# Local smoke/default values (safe placeholders)
+NEXT_PUBLIC_VERCEL_ENV=development
+GREDICE_API_HOST=https://api.gredice.test
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+NEXT_PUBLIC_POSTHOG_UI_HOST=
+POSTHOG_SERVER_HOST=
+POSTHOG_PROXY_HOST=
+
+# Optional integration-only values (real secrets required only for integration/visual test paths)
+FACEBOOK_CAPI_TOKEN=
+FACEBOOK_CAPI_PIXEL_ID=
+FACEBOOK_CAPI_API_VERSION=v23.0
+SITE_URL=https://www.gredice.test


### PR DESCRIPTION
### Motivation

- Allow fresh worktrees to start and run app smoke tests without relying on Vercel-pulled secrets or external integrations.
- Provide safe, documented placeholders for nonessential services so builds and local tests fail less often in developer environments.
- Clarify which variables are required for integration/visual tests versus local smoke testing.

### Description

- Add checked-in `.env.example` files for `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, `apps/api`, and `apps/storybook` containing safe local defaults and placeholders.
- Populate `apps/api/.env.example` with test-safe defaults (for example `CRON_SECRET` and `STRIPE_WEBHOOK_SECRET`) and mark integration-only variables such as `POSTGRES_URL` and `AI_GATEWAY_API_KEY` as optional.
- Update `README.md` and `WORKSPACE.md` to document copying each app's `.env.example` into `.env` for fresh worktrees and to explain when `pnpm env:pull` (real secrets) is required.
- Do not add any real secrets or production credentials in examples.

### Testing

- No automated test suites were executed as part of this change because it only adds example and documentation files.
- Standard CI test suites will run on the branch and should validate there are no regressions when this PR is processed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd09d5e84832f8bf0791b6ea3586a)