### PR TITLE
Rename CMS admin navigation to Stranice

### DIFF
--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -80,6 +80,11 @@ const breadcrumbSections: {
                 ...adminPages.Directories,
                 icon: <File className="size-4" />,
             },
+        ],
+    },
+    {
+        title: 'Stranice',
+        pages: [
             {
                 ...adminPages.CmsPages,
                 icon: <File className="size-4" />,

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -206,7 +206,6 @@ export function Nav({
         pathname,
         adminPages.SowingStatistics.href,
     );
-    const cmsPagesActive = isSelectedPath(pathname, adminPages.CmsPages.href);
 
     return (
         <div className={navClassName}>
@@ -231,22 +230,16 @@ export function Nav({
                     />
                 ))}
             </div>
-            <NavSection label="Zapisi" compact={compact}>
-                <NavGroup
-                    label="CMS"
+            <NavSection label="Stranice" compact={compact}>
+                <NavItem
+                    href={adminPages.CmsPages.href}
+                    label={adminPages.CmsPages.label}
                     icon={<File className="size-5" />}
-                    forceOpen={cmsPagesActive}
+                    onClick={onItemClick}
                     compact={compact}
-                >
-                    <NavItem
-                        href={adminPages.CmsPages.href}
-                        label={adminPages.CmsPages.label}
-                        icon={<File className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                </NavGroup>
+                />
+            </NavSection>
+            <NavSection label="Zapisi" compact={compact}>
                 {hasDirectoryRecords && (
                     <>
                         {/* Categories with their entity types */}


### PR DESCRIPTION
### Motivation
- The admin sidebar should show the pages feature as its own top-level section named **Stranice** ("Pages") instead of being grouped under the generic "CMS" group inside the "Zapisi" section to match API naming and upcoming feature expansion.

### Description
- Replaced the former "CMS" `NavGroup` inside `Nav.tsx` with a dedicated `NavSection` labeled `Stranice` and moved the pages `NavItem` into that section. 
- Removed the now-unused `cmsPagesActive` selection variable and simplified the navigation rendering accordingly in `apps/app/components/admin/navigation/Nav.tsx`.
- Updated `AdminBreadcrumbLevelSelector.tsx` to place `CmsPages` under a new breadcrumb section `Stranice` instead of `Zapisi`.

### Testing
- Ran targeted Biome checks with `pnpm exec biome check components/admin/navigation/Nav.tsx components/admin/navigation/AdminBreadcrumbLevelSelector.tsx` (run in `apps/app`) and the checks completed with no fixes required.  
- Ran repository lint with `pnpm lint --filter app`, which completed successfully but reported pre-existing unrelated warnings in other files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdeed01714832f9611ddd2e94865f8)