### PR TITLE
[CMS] Add draft-mode preview for unpublished CMS pages on www

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,6 +8,7 @@ POSTHOG_PROXY_HOST=
 GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
 GREDICE_GARDEN_APP_URL=https://vrt.gredice.test
 AI_GATEWAY_MODEL=openai/gpt-5
+CMS_PAGES_PREVIEW_SECRET=local-preview-secret
 
 # Test-safe defaults for nonessential services
 CRON_SECRET=local-cron-secret

--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -32,51 +32,67 @@ const app = new Hono()
                 })),
         );
     })
-    .get('/pages/:slug{.+}', async (context) => {
-        const slug = context.req.param('slug');
-        const includeDraft = context.req.query('draft') === '1';
-        const previewSecret = context.req.header('x-preview-secret');
-        const expectedPreviewSecret = process.env.CMS_PAGES_PREVIEW_SECRET;
+    .get(
+        '/pages/:slug{.+}',
+        zValidator(
+            'query',
+            z.object({
+                draft: z.string().optional(),
+            }),
+        ),
+        async (context) => {
+            const slug = context.req.param('slug');
+            const includeDraft = context.req.valid('query').draft === '1';
+            const previewSecret = context.req.header('x-preview-secret');
+            const expectedPreviewSecret = process.env.CMS_PAGES_PREVIEW_SECRET;
 
-        const canAccessDraft =
-            includeDraft &&
-            Boolean(expectedPreviewSecret) &&
-            previewSecret === expectedPreviewSecret;
+            const canAccessDraft =
+                includeDraft &&
+                Boolean(expectedPreviewSecret) &&
+                previewSecret === expectedPreviewSecret;
 
-        const page = await getCmsPageBySlug(slug);
-        if (
-            !page ||
-            (!canAccessDraft &&
-                (page.state !== 'published' || !page.publishedAt))
-        ) {
-            return context.json({ error: 'Page not found' }, { status: 404 });
-        }
-
-        let content: unknown[] = [];
-        if (page.content) {
-            try {
-                const parsed = JSON.parse(page.content);
-                if (Array.isArray(parsed)) {
-                    content = parsed;
-                }
-            } catch {
-                content = [];
+            const page = await getCmsPageBySlug(slug);
+            if (
+                !page ||
+                (!canAccessDraft &&
+                    (page.state !== 'published' || !page.publishedAt))
+            ) {
+                return context.json(
+                    { error: 'Page not found' },
+                    { status: 404 },
+                );
             }
-        }
 
-        setCacheControl(context, cacheControlPresets.directories);
-        return context.json({
-            slug: page.slug,
-            title: page.title,
-            content,
-            state: page.state,
-            publishedAt: page.publishedAt,
-            metaTitle: page.metaTitle,
-            metaDescription: page.metaDescription,
-            metaImageUrl: page.metaImageUrl,
-            updatedAt: page.updatedAt,
-        });
-    })
+            let content: unknown[] = [];
+            if (page.content) {
+                try {
+                    const parsed = JSON.parse(page.content);
+                    if (Array.isArray(parsed)) {
+                        content = parsed;
+                    }
+                } catch {
+                    content = [];
+                }
+            }
+
+            if (canAccessDraft) {
+                context.header('Cache-Control', 'private, no-store');
+            } else {
+                setCacheControl(context, cacheControlPresets.directories);
+            }
+            return context.json({
+                slug: page.slug,
+                title: page.title,
+                content,
+                state: page.state,
+                publishedAt: page.publishedAt,
+                metaTitle: page.metaTitle,
+                metaDescription: page.metaDescription,
+                metaImageUrl: page.metaImageUrl,
+                updatedAt: page.updatedAt,
+            });
+        },
+    )
     .get(
         '/entities/:entityType',
         zValidator(

--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -34,8 +34,21 @@ const app = new Hono()
     })
     .get('/pages/:slug{.+}', async (context) => {
         const slug = context.req.param('slug');
+        const includeDraft = context.req.query('draft') === '1';
+        const previewSecret = context.req.header('x-preview-secret');
+        const expectedPreviewSecret = process.env.CMS_PAGES_PREVIEW_SECRET;
+
+        const canAccessDraft =
+            includeDraft &&
+            Boolean(expectedPreviewSecret) &&
+            previewSecret === expectedPreviewSecret;
+
         const page = await getCmsPageBySlug(slug);
-        if (!page || page.state !== 'published' || !page.publishedAt) {
+        if (
+            !page ||
+            (!canAccessDraft &&
+                (page.state !== 'published' || !page.publishedAt))
+        ) {
             return context.json({ error: 'Page not found' }, { status: 404 });
         }
 

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -9,6 +9,7 @@
                 "BLOB_READ_WRITE_TOKEN",
                 "CHECKLY_ACCOUNT_ID",
                 "CHECKLY_API_KEY",
+                "CMS_PAGES_PREVIEW_SECRET",
                 "CRON_SECRET",
                 "ENABLE_EXPERIMENTAL_COREPACK",
                 "FACEBOOK_CLIENT_ID",

--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -6,6 +6,7 @@ NEXT_PUBLIC_POSTHOG_HOST=
 NEXT_PUBLIC_POSTHOG_UI_HOST=
 POSTHOG_SERVER_HOST=
 POSTHOG_PROXY_HOST=
+CMS_PAGES_PREVIEW_SECRET=local-preview-secret
 
 # Optional integration-only values (real secrets required only for integration/visual test paths)
 FACEBOOK_CAPI_TOKEN=

--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import { clientPublic } from '@gredice/client';
 import { SectionsView } from '@signalco/cms-core/SectionsView';
+import { draftMode } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { sectionsComponentRegistry } from '../../components/shared/sectionsComponentRegistry';
 import {
@@ -20,8 +21,21 @@ export default async function CmsPublishedPageRoute({
         notFound();
     }
 
-    const response = await clientPublic().api.directories.pages[':slug{.+}'].$get({
+    const { isEnabled } = await draftMode();
+    const previewSecret = process.env.CMS_PAGES_PREVIEW_SECRET;
+
+    const response = await clientPublic().api.directories.pages[
+        ':slug{.+}'
+    ].$get({
         param: { slug: normalizedSlug },
+        query: isEnabled ? { draft: '1' } : undefined,
+        ...(isEnabled && previewSecret
+            ? {
+                  header: {
+                      'x-preview-secret': previewSecret,
+                  },
+              }
+            : {}),
     });
 
     if (response.status !== 200) {

--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -28,7 +28,7 @@ export default async function CmsPublishedPageRoute({
         ':slug{.+}'
     ].$get({
         param: { slug: normalizedSlug },
-        query: isEnabled ? { draft: '1' } : undefined,
+        query: isEnabled ? { draft: '1' } : {},
         ...(isEnabled && previewSecret
             ? {
                   header: {

--- a/apps/www/app/api/draft/disable/route.ts
+++ b/apps/www/app/api/draft/disable/route.ts
@@ -1,0 +1,9 @@
+import { draftMode } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export async function GET() {
+    const draft = await draftMode();
+    draft.disable();
+
+    redirect('/');
+}

--- a/apps/www/app/api/draft/route.ts
+++ b/apps/www/app/api/draft/route.ts
@@ -1,5 +1,4 @@
 import { draftMode } from 'next/headers';
-import { redirect } from 'next/navigation';
 
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
@@ -10,8 +9,13 @@ export async function GET(request: Request) {
         return new Response('Invalid token', { status: 401 });
     }
 
+    const redirectPath = slug.startsWith('/') ? slug : `/${slug}`;
+    if (redirectPath.startsWith('//')) {
+        return new Response('Invalid slug', { status: 400 });
+    }
+
     const draft = await draftMode();
     draft.enable();
 
-    redirect(slug.startsWith('/') ? slug : `/${slug}`);
+    return Response.redirect(new URL(redirectPath, request.url), 307);
 }

--- a/apps/www/app/api/draft/route.ts
+++ b/apps/www/app/api/draft/route.ts
@@ -1,0 +1,17 @@
+import { draftMode } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+    const secret = searchParams.get('secret');
+    const slug = searchParams.get('slug') ?? '/';
+
+    if (!secret || secret !== process.env.CMS_PAGES_PREVIEW_SECRET) {
+        return new Response('Invalid token', { status: 401 });
+    }
+
+    const draft = await draftMode();
+    draft.enable();
+
+    redirect(slug.startsWith('/') ? slug : `/${slug}`);
+}

--- a/apps/www/turbo.json
+++ b/apps/www/turbo.json
@@ -7,6 +7,7 @@
                 "BLOB_READ_WRITE_TOKEN",
                 "CHECKLY_ACCOUNT_ID",
                 "CHECKLY_API_KEY",
+                "CMS_PAGES_PREVIEW_SECRET",
                 "EDGE_CONFIG",
                 "ENABLE_EXPERIMENTAL_COREPACK",
                 "FACEBOOK_CAPI_API_VERSION",


### PR DESCRIPTION
### Motivation
- Allow editors to preview unpublished CMS pages on the production site using Next.js draft mode.
- Ensure unpublished content is only accessible when an explicit preview flow and a shared secret are used.
- Keep the public published behavior unchanged while enabling a secure preview path for drafts.

### Description
- Added draft preview endpoints in `apps/www`: `app/api/draft/route.ts` to enable draft mode when `secret` matches `CMS_PAGES_PREVIEW_SECRET` and redirect to the requested slug, and `app/api/draft/disable/route.ts` to disable draft mode.
- Updated `apps/www/app/[...slug]/page.tsx` to call `draftMode()` and, when enabled, request draft content from the API with `query: { draft: '1' }` and an `x-preview-secret` header.
- Updated `apps/api/app/api/[...route]/directoriesRoutes.ts` to allow serving draft pages only when `draft=1` and the `x-preview-secret` header matches `process.env.CMS_PAGES_PREVIEW_SECRET`, otherwise the endpoint continues to require `state === 'published' && publishedAt`.
- Added `CMS_PAGES_PREVIEW_SECRET` to `apps/www/.env.example`, `apps/api/.env.example`, and included the variable in `apps/www/turbo.json` and `apps/api/turbo.json` build env passthrough lists to support production builds.

### Testing
- Ran `pnpm --filter www lint` which completed successfully (biome fixed a few files). 
- Ran `pnpm --filter api lint` which completed successfully (biome fixed a couple files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf6b91614832f85ee67d1b3fba433)