### PR TITLE
GRE-238: Publish readiness validation for entities and CMS pages

### DIFF
--- a/apps/app/app/admin/cms/pages/[pageId]/page.tsx
+++ b/apps/app/app/admin/cms/pages/[pageId]/page.tsx
@@ -38,12 +38,15 @@ function publishedAtValue(page: SelectCmsPage) {
 
 export default async function CmsPageDetailsPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ pageId: string }>;
+    searchParams: Promise<{ publishError?: string }>;
 }) {
     await auth(['admin']);
 
     const { pageId } = await params;
+    const resolvedSearchParams = await searchParams;
     const id = Number.parseInt(pageId, 10);
     if (Number.isNaN(id)) {
         notFound();
@@ -129,6 +132,11 @@ export default async function CmsPageDetailsPage({
                 heading={page.title}
             />
             <Stack spacing={2}>
+                {resolvedSearchParams.publishError && (
+                    <Card className="border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                        {resolvedSearchParams.publishError}
+                    </Card>
+                )}
                 <Typography level="h2" className="text-2xl" semiBold>
                     {page.title}
                 </Typography>

--- a/apps/app/app/admin/cms/pages/actions.ts
+++ b/apps/app/app/admin/cms/pages/actions.ts
@@ -108,7 +108,12 @@ export async function updateCmsPageAction(
 export async function publishCmsPageAction(pageId: number) {
     await auth(['admin']);
 
-    await updateCmsPageState(pageId, 'published');
+    try {
+        await updateCmsPageState(pageId, 'published');
+    } catch (error) {
+        const message = encodeURIComponent(cmsPageErrorMessage(error));
+        redirect(`${KnownPages.CmsPage(pageId)}?publishError=${message}`);
+    }
     revalidateCmsPagePaths(pageId);
 }
 

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx
@@ -38,17 +38,29 @@ export function EntityActions({
     deleteAction: () => Promise<void>;
 }) {
     const [state, setState] = useState(entity.state);
+    const [publishError, setPublishError] = useState<string | null>(null);
     const [isDeleting, setIsDeleting] = useState(false);
     const { trackSave } = useEntityDetailsSave();
 
     async function changeState(newState: string) {
+        const previousState = state;
         setState(newState);
-        await trackSave(() =>
-            updateEntity({
-                id: entity.id,
-                state: newState,
-            }),
-        );
+        setPublishError(null);
+        try {
+            await trackSave(() =>
+                updateEntity({
+                    id: entity.id,
+                    state: newState,
+                }),
+            );
+        } catch (error) {
+            setState(previousState);
+            setPublishError(
+                error instanceof Error
+                    ? error.message
+                    : 'Promjena statusa nije uspjela.',
+            );
+        }
     }
 
     function handleDelete(event: Event) {
@@ -68,6 +80,9 @@ export function EntityActions({
 
     return (
         <Row spacing={1} className="items-center">
+            {publishError && (
+                <span className="text-sm text-red-600">{publishError}</span>
+            )}
             <Link
                 href={KnownPages.DirectoryEntityPreview(entityType, entity.id)}
                 target="_blank"

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -185,7 +185,10 @@ function normalizeCmsPageContent(content: string | null | undefined) {
             );
         }
 
-        if (!('component' in section) || typeof section.component !== 'string') {
+        if (
+            !('component' in section) ||
+            typeof section.component !== 'string'
+        ) {
             throw new Error(
                 `Section at index ${index} must define a string component.`,
             );
@@ -217,9 +220,9 @@ function normalizeCmsPageContentForUpdate(
 
 function assertCmsPagePublishReadiness(input: {
     slug: string;
-    content: string | null;
-    metaTitle: string | null;
-    metaDescription: string | null;
+    content?: string | null;
+    metaTitle?: string | null;
+    metaDescription?: string | null;
 }) {
     const issues: string[] = [];
 
@@ -241,7 +244,9 @@ function assertCmsPagePublishReadiness(input: {
     }
 
     if (issues.length > 0) {
-        throw new Error(`Page is not ready for publishing. ${issues.join(' ')}`);
+        throw new Error(
+            `Page is not ready for publishing. ${issues.join(' ')}`,
+        );
     }
 }
 
@@ -321,6 +326,18 @@ export async function updateCmsPage(input: UpdateCmsPageInput) {
         );
     }
 
+    if (input.metaTitle !== undefined) {
+        updateData.metaTitle = optionalText(input.metaTitle);
+    }
+
+    if (input.metaDescription !== undefined) {
+        updateData.metaDescription = optionalText(input.metaDescription);
+    }
+
+    if (input.metaImageUrl !== undefined) {
+        updateData.metaImageUrl = optionalText(input.metaImageUrl);
+    }
+
     if (input.state !== undefined) {
         updateData.state = input.state;
         if (input.state === 'published' && existing.state !== 'published') {
@@ -333,18 +350,6 @@ export async function updateCmsPage(input: UpdateCmsPageInput) {
             });
             updateData.publishedAt = new Date();
         }
-    }
-
-    if (input.metaTitle !== undefined) {
-        updateData.metaTitle = optionalText(input.metaTitle);
-    }
-
-    if (input.metaDescription !== undefined) {
-        updateData.metaDescription = optionalText(input.metaDescription);
-    }
-
-    if (input.metaImageUrl !== undefined) {
-        updateData.metaImageUrl = optionalText(input.metaImageUrl);
     }
 
     if (Object.keys(updateData).length === 0) {

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -139,7 +139,7 @@ function pageInsertValues(input: CreateCmsPageInput): InsertCmsPage {
     const state = input.state ?? 'draft';
     const title = requiredText(input.title, 'Page title');
 
-    return {
+    const values: InsertCmsPage = {
         slug: normalizeCmsPageSlug(input.slug),
         title,
         content: normalizeCmsPageContent(input.content),
@@ -149,6 +149,12 @@ function pageInsertValues(input: CreateCmsPageInput): InsertCmsPage {
         metaDescription: optionalText(input.metaDescription),
         metaImageUrl: optionalText(input.metaImageUrl),
     };
+
+    if (state === 'published') {
+        assertCmsPagePublishReadiness(values);
+    }
+
+    return values;
 }
 
 function normalizeCmsPageContent(content: string | null | undefined) {
@@ -207,6 +213,36 @@ function normalizeCmsPageContentForUpdate(
     }
 
     return normalizeCmsPageContent(content);
+}
+
+function assertCmsPagePublishReadiness(input: {
+    slug: string;
+    content: string | null;
+    metaTitle: string | null;
+    metaDescription: string | null;
+}) {
+    const issues: string[] = [];
+
+    const slugError = getCmsPageSlugValidationError(input.slug);
+    if (slugError) {
+        issues.push(slugError);
+    }
+
+    if (!input.content) {
+        issues.push('Page content is required before publishing.');
+    }
+
+    if (!input.metaTitle) {
+        issues.push('Meta title is required before publishing.');
+    }
+
+    if (!input.metaDescription) {
+        issues.push('Meta description is required before publishing.');
+    }
+
+    if (issues.length > 0) {
+        throw new Error(`Page is not ready for publishing. ${issues.join(' ')}`);
+    }
 }
 
 export async function getCmsPages(options: GetCmsPagesOptions = {}) {
@@ -288,6 +324,13 @@ export async function updateCmsPage(input: UpdateCmsPageInput) {
     if (input.state !== undefined) {
         updateData.state = input.state;
         if (input.state === 'published' && existing.state !== 'published') {
+            assertCmsPagePublishReadiness({
+                slug: updateData.slug ?? existing.slug,
+                content: updateData.content ?? existing.content,
+                metaTitle: updateData.metaTitle ?? existing.metaTitle,
+                metaDescription:
+                    updateData.metaDescription ?? existing.metaDescription,
+            });
             updateData.publishedAt = new Date();
         }
     }

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -18,6 +18,7 @@ import {
     cacheKeys,
     directoriesCached,
 } from '../cache/directoriesCached';
+import { getEntityCompleteness } from '../helpers/entityCompleteness';
 
 const entityCacheTtl = 60 * 60; // 1 hour
 
@@ -732,6 +733,39 @@ export async function updateEntity(
     };
 
     if (updateData.state === 'published') {
+        const entityForValidation = await storage().query.entities.findFirst({
+            where: and(eq(entities.id, entity.id), eq(entities.isDeleted, false)),
+            with: {
+                attributes: {
+                    where: eq(attributeValues.isDeleted, false),
+                },
+                entityType: {
+                    with: {
+                        attributeDefinitions: {
+                            where: eq(attributeDefinitions.isDeleted, false),
+                        },
+                    },
+                },
+            },
+        });
+
+        if (!entityForValidation) {
+            throw new Error(`Entity with id ${entity.id} not found.`);
+        }
+
+        const completeness = getEntityCompleteness(
+            entityForValidation,
+            entityForValidation.entityType.attributeDefinitions,
+        );
+        if (!completeness.isComplete) {
+            const missingFields = completeness.missingRequiredDefinitions
+                .map((definition) => definition.label)
+                .join(', ');
+            throw new Error(
+                `Entity is not ready for publishing. Fill required fields: ${missingFields}.`,
+            );
+        }
+
         updateData.publishedAt = new Date();
     }
 

--- a/packages/storage/tests/cmsPagesRepo.node.spec.ts
+++ b/packages/storage/tests/cmsPagesRepo.node.spec.ts
@@ -126,6 +126,31 @@ test('CMS page slugs reject reserved static route conflicts', async () => {
     );
 });
 
+test('CMS page publish readiness uses metadata from the same update', async () => {
+    createTestDb();
+    const content = JSON.stringify([
+        { component: 'Feature1', header: 'Ready section' },
+    ]);
+    const pageId = await createCmsPage({
+        slug: `publish-with-meta-${randomUUID()}`,
+        title: 'Publish with meta',
+        content,
+    });
+
+    await updateCmsPage({
+        id: pageId,
+        state: 'published',
+        metaTitle: 'Publishable meta title',
+        metaDescription: 'Publishable meta description',
+    });
+
+    const page = await getCmsPage(pageId);
+    assert.equal(page?.state, 'published');
+    assert.equal(page?.metaTitle, 'Publishable meta title');
+    assert.equal(page?.metaDescription, 'Publishable meta description');
+    assert.ok(page?.publishedAt instanceof Date);
+});
+
 test('CMS page content stores valid SectionData JSON payload', async () => {
     createTestDb();
     const sectionData = [


### PR DESCRIPTION
### Motivation
- Prevent incomplete or malformed content from being published by enforcing server-side readiness checks for entities and CMS pages when transitioning to `published`.
- Reuse existing completeness helpers so publish validation stays consistent with filtering and editing behavior.

### Description
- Added entity publish validation in `packages/storage/src/repositories/entitiesRepo.ts` that loads the entity with its `attributeDefinitions` and uses `getEntityCompleteness` to block `state: 'published'` when required attributes are missing and surface a clear error listing missing fields.
- Added CMS page publish readiness checks in `packages/storage/src/repositories/cmsPagesRepo.ts` via `assertCmsPagePublishReadiness`, validating slug (reusing `getCmsPageSlugValidationError`), `content`, `metaTitle`, and `metaDescription` on create and on draft→published transitions.
- Surface publish validation errors in the admin UI by catching errors from `updateCmsPageState` in `apps/app/app/admin/cms/pages/actions.ts` and redirecting back with `publishError`, and by rendering the message on the page in `apps/app/app/admin/cms/pages/[pageId]/page.tsx`.
- Make entity publish failures observable in the entity details UI by rolling back optimistic state changes and showing an inline error in `apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx` when `updateEntity` throws.

### Testing
- Ran storage package tests targeting completeness and CMS page repo with `pnpm -C /workspace/gredice test --filter @gredice/storage -- entityCompleteness.node.spec.ts cmsPagesRepo.node.spec.ts`, but the run failed due to environment constraints: `docker: command not found` (test DB container cannot be started), so automated tests could not complete.
- Local unit test attempts were blocked by Docker absence; runtime validation (manual smoke) not included in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe39b9ea1c832f98f0079dc4a62bd4)