### PR TITLE
Fix Vercel env pull and bootstrap setup flow

### DIFF
--- a/scripts/link-vercel.mjs
+++ b/scripts/link-vercel.mjs
@@ -3,6 +3,7 @@
 // Links every app to its Vercel project in one go.
 
 import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { appRegistry } from './app-registry.ts';
@@ -66,6 +67,24 @@ async function hasVercelCli() {
     return result.code === 0;
 }
 
+function readLinkedProjectName(cwd) {
+    const projectJsonPath = resolve(cwd, '.vercel', 'project.json');
+    if (!existsSync(projectJsonPath)) {
+        return undefined;
+    }
+
+    try {
+        const link = JSON.parse(readFileSync(projectJsonPath, 'utf8'));
+        if (typeof link === 'object' && link !== null && typeof link.projectName === 'string') {
+            return link.projectName;
+        }
+    } catch {
+        return undefined;
+    }
+
+    return undefined;
+}
+
 function explainFailure(output, appName, projectName) {
     const combinedOutput = output.toLowerCase();
 
@@ -106,6 +125,13 @@ async function main() {
 
     for (const app of vercelApps) {
         const cwd = resolve(repoRoot, app.packagePath);
+
+        const linkedProjectName = readLinkedProjectName(cwd);
+        if (linkedProjectName === app.vercelProjectName) {
+            console.log(`\nSkipping ${app.name}; already linked to Vercel project ${app.vercelProjectName}.`);
+            continue;
+        }
+
         console.log(`\nLinking ${app.name} to Vercel project ${app.vercelProjectName}...`);
 
         const result = await run(

--- a/scripts/pull-envs.mjs
+++ b/scripts/pull-envs.mjs
@@ -3,6 +3,7 @@
 // Pulls Vercel environment variables for every app in one go.
 
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { appRegistry } from './app-registry.ts';
@@ -108,6 +109,11 @@ async function main() {
         const cwd = resolve(repoRoot, app.packagePath);
         console.log(`\nPulling environment variables for ${app.name} (${app.vercelProjectName})...`);
 
+        if (!existsSync(resolve(cwd, '.vercel', 'project.json'))) {
+            console.error(`${app.name}: Vercel project link is missing. Run \`pnpm vercel:link\` and retry.`);
+            process.exit(1);
+        }
+
         const result = await run(
             vercelCommand,
             [
@@ -118,8 +124,6 @@ async function main() {
                 '--environment=development',
                 '--scope',
                 vercelScope,
-                '--project',
-                app.vercelProjectName,
             ],
             {
                 cwd,

--- a/scripts/worktree-health.mjs
+++ b/scripts/worktree-health.mjs
@@ -16,6 +16,7 @@ const caddyCert = resolve(caddyDataDir, 'caddy', 'pki', 'authorities', 'local', 
 const checks = [];
 function addCheck(name, required, ok, detail, next) { checks.push({ name, required, ok, detail, next }); }
 function run(cmd, args, options = {}) { return spawnSync(cmd, args, { encoding: 'utf8', ...options }); }
+function hasFailedRequiredChecks() { return checks.some((c) => c.required && !c.ok); }
 
 function checkNode() {
   const major = Number(process.versions.node.split('.')[0]);
@@ -62,9 +63,9 @@ function checkEnvFiles() {
 }
 
 function checkPlaywright() {
-  const r = run('pnpm', ['exec', 'playwright', '--version']);
+  const r = run('pnpm', ['--filter', 'www', 'exec', 'playwright', '--version']);
   const ok = r.status === 0;
-  addCheck('Playwright browsers', true, ok, ok ? `Playwright available: ${(r.stdout || '').trim()}.` : 'Playwright runtime missing.', 'Run `pnpm exec playwright install`.');
+  addCheck('Playwright browsers', true, ok, ok ? `Playwright available: ${(r.stdout || '').trim()}.` : 'Playwright runtime missing.', 'Run `pnpm --filter www exec playwright install`.');
 }
 
 function checkHosts() {
@@ -179,10 +180,21 @@ function checkPorts() {
 async function maybeRunSetupActions() {
   if (mode !== 'setup') return;
   console.log('\nRunning setup actions...');
-  run('pnpm', ['install'], { stdio: 'inherit' });
-  run('pnpm', ['vercel:link'], { stdio: 'inherit' });
-  run('pnpm', ['env:pull'], { stdio: 'inherit' });
-  run('pnpm', ['exec', 'playwright', 'install'], { stdio: 'inherit' });
+  const actions = [
+    { label: 'Installing dependencies', cmd: 'pnpm', args: ['install'] },
+    { label: 'Linking Vercel projects', cmd: 'pnpm', args: ['vercel:link'] },
+    { label: 'Pulling Vercel environment variables', cmd: 'pnpm', args: ['env:pull'] },
+    { label: 'Installing Playwright browsers', cmd: 'pnpm', args: ['--filter', 'www', 'exec', 'playwright', 'install'] },
+  ];
+
+  for (const action of actions) {
+    console.log(`\n${action.label}...`);
+    const result = run(action.cmd, action.args, { stdio: 'inherit' });
+    if (result.status !== 0) {
+      console.error(`\nSetup action failed: ${action.label}.`);
+      process.exit(result.status ?? 1);
+    }
+  }
 }
 
 function printResults() {
@@ -204,17 +216,31 @@ function printResults() {
   console.log(`\n${mode} completed.`);
 }
 
-checkNode();
-checkPnpm();
-checkDependencies();
-checkDocker();
-checkVercelAuth();
-checkVercelLinks();
-checkEnvFiles();
-checkPlaywright();
-checkHosts();
-checkCertificate();
-checkBlenderVersion();
-await checkPorts();
-await maybeRunSetupActions();
+async function runChecks() {
+  checks.length = 0;
+  checkNode();
+  checkPnpm();
+  checkDependencies();
+  checkDocker();
+  checkVercelAuth();
+  checkVercelLinks();
+  checkEnvFiles();
+  checkPlaywright();
+  checkHosts();
+  checkCertificate();
+  checkBlenderVersion();
+  await checkPorts();
+}
+
+if (mode === 'setup') {
+  checks.length = 0;
+  checkNode();
+  checkPnpm();
+  if (hasFailedRequiredChecks()) {
+    printResults();
+  }
+  await maybeRunSetupActions();
+}
+
+await runChecks();
 printResults();


### PR DESCRIPTION
## Summary
- Remove the unsupported `--project` flag from `vercel env pull` and require an existing per-app `.vercel/project.json` link before pulling env vars.
- Make Vercel linking idempotent by skipping apps that are already linked to the expected project.
- Update bootstrap health checks to use the app-scoped Playwright binary and rerun checks after setup actions.

## Testing
- `node --check` on the edited scripts.
- `pnpm bootstrap` locally to verify Vercel linking, env pulling, and Playwright setup complete before the remaining machine-specific port warning.