### PR TITLE
[CMS] Add visual section builder for admin CMS pages

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -8,7 +8,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useActionState, useMemo, useState } from 'react';
+import { useActionState, useMemo, useRef, useState } from 'react';
 import type { CmsPageFormState } from './actions';
 
 type CmsPageFormProps = {
@@ -44,8 +44,6 @@ const cmsPageSectionItems = [
     { value: 'Faq1', label: 'Faq1' },
     { value: 'Footer1', label: 'Footer1' },
 ];
-
-let nextSectionId = 0;
 
 function parseSections(content?: string | null) {
     if (!content) {
@@ -83,10 +81,9 @@ function editableSection(
     };
 }
 
-function newSection(component: string): CmsPageEditableSection {
-    nextSectionId += 1;
+function newSection(component: string, id: number): CmsPageEditableSection {
     return {
-        id: `new-${component}-${nextSectionId}`,
+        id: `new-${component}-${id}`,
         data: { component },
     };
 }
@@ -129,20 +126,24 @@ function moveSection(
         return sections;
     }
 
-    const currentSection = sections[index];
-    const targetSection = sections[targetIndex];
-    if (!currentSection || !targetSection) {
+    const next = [...sections];
+    const movingSections = next.splice(index, 1);
+    if (movingSections.length !== 1) {
         return sections;
     }
 
-    const next = [...sections];
-    next[index] = targetSection;
-    next[targetIndex] = currentSection;
+    const [movingSection] = movingSections;
+    if (!movingSection) {
+        return sections;
+    }
+
+    next.splice(targetIndex, 0, movingSection);
     return next;
 }
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
+    const nextSectionId = useRef(0);
     const parsedSections = useMemo(
         () => parseSections(page?.content),
         [page?.content],
@@ -375,9 +376,13 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                             type="button"
                                             variant="outlined"
                                             onClick={() => {
+                                                nextSectionId.current += 1;
                                                 setSections((current) => [
                                                     ...current,
-                                                    newSection(item.value),
+                                                    newSection(
+                                                        item.value,
+                                                        nextSectionId.current,
+                                                    ),
                                                 ]);
                                             }}
                                         >

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -147,7 +147,7 @@ function moveSection(
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
-    const newSectionIdPrefix = useId();
+    const newSectionIdPrefix = `${useId()}-${page?.id ?? 'new'}`;
     const nextSectionId = useRef(0);
     const parsedSections = useMemo(
         () => parseSections(page?.content),
@@ -207,7 +207,7 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                 {sections.length === 0 ? (
                                     <Card className="p-4 text-sm text-muted-foreground">
                                         {preserveFallbackContent
-                                            ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju.'
+                                            ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija.'
                                             : 'Stranica još nema sekcija.'}
                                     </Card>
                                 ) : (

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -20,11 +20,14 @@ type CmsPageFormProps = {
     submitLabel: string;
 };
 
-type CmsPageSectionComponent = 'Heading1' | 'Faq1' | 'Feature1' | 'Footer1';
-
 type CmsPageSectionData = {
-    component: CmsPageSectionComponent;
+    component: string;
     [key: string]: unknown;
+};
+
+type CmsPageEditableSection = {
+    id: string;
+    data: CmsPageSectionData;
 };
 
 const cmsPageStateItems = [
@@ -35,51 +38,84 @@ const cmsPageStateItems = [
     },
 ];
 
-const cmsPageSectionItems: { value: CmsPageSectionComponent; label: string }[] = [
+const cmsPageSectionItems = [
     { value: 'Heading1', label: 'Heading1' },
     { value: 'Feature1', label: 'Feature1' },
     { value: 'Faq1', label: 'Faq1' },
     { value: 'Footer1', label: 'Footer1' },
 ];
 
-function parseSections(content?: string | null): CmsPageSectionData[] {
+function parseSections(content?: string | null) {
     if (!content) {
-        return [];
+        return { isStructured: true, sections: [] };
     }
 
     try {
         const parsed: unknown = JSON.parse(content);
         if (!Array.isArray(parsed)) {
-            return [];
+            return { isStructured: false, sections: [] };
         }
 
-        return parsed.filter(
-            (section): section is CmsPageSectionData =>
-                Boolean(section) &&
-                typeof section === 'object' &&
-                'component' in section &&
-                typeof section.component === 'string',
-        );
+        return {
+            isStructured: true,
+            sections: parsed.filter(
+                (section): section is CmsPageSectionData =>
+                    Boolean(section) &&
+                    typeof section === 'object' &&
+                    'component' in section &&
+                    typeof section.component === 'string',
+            ),
+        };
     } catch {
-        return [];
+        return { isStructured: false, sections: [] };
     }
 }
 
-function stringifySections(sections: CmsPageSectionData[]) {
-    return sections.length > 0 ? JSON.stringify(sections) : '';
+function editableSection(section: CmsPageSectionData): CmsPageEditableSection {
+    return {
+        id: crypto.randomUUID(),
+        data: section,
+    };
 }
 
-function sectionValue(section: CmsPageSectionData, key: string) {
-    const value = section[key];
+function newSection(component: string): CmsPageEditableSection {
+    return editableSection({ component });
+}
+
+function stringifySections(
+    sections: CmsPageEditableSection[],
+    fallbackContent?: string | null,
+    preserveFallback = false,
+) {
+    if (preserveFallback && sections.length === 0) {
+        return fallbackContent ?? '';
+    }
+
+    const data = sections.map((section) => section.data);
+    return data.length > 0 ? JSON.stringify(data) : '';
+}
+
+function sectionValue(section: CmsPageEditableSection, key: string) {
+    const value = section.data[key];
     return typeof value === 'string' ? value : '';
 }
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
-    const [sections, setSections] = useState<CmsPageSectionData[]>(() =>
-        parseSections(page?.content),
+    const parsedSections = useMemo(
+        () => parseSections(page?.content),
+        [page?.content],
     );
-    const serializedContent = useMemo(() => stringifySections(sections), [sections]);
+    const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
+        parsedSections.sections.map(editableSection),
+    );
+    const preserveFallbackContent =
+        !parsedSections.isStructured && Boolean(page?.content);
+    const serializedContent = useMemo(
+        () =>
+            stringifySections(sections, page?.content, preserveFallbackContent),
+        [page?.content, preserveFallbackContent, sections],
+    );
 
     return (
         <Card className="max-w-3xl">
@@ -112,7 +148,8 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                     Sadržaj stranice
                                 </Typography>
                                 <Typography level="body3" secondary>
-                                    Dodaj i uređuj sekcije bez ručnog uređivanja JSON-a.
+                                    Dodaj i uređuj sekcije bez ručnog uređivanja
+                                    JSON-a.
                                 </Typography>
                                 <input
                                     name="content"
@@ -122,39 +159,179 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                 />
                                 {sections.length === 0 ? (
                                     <Card className="p-4 text-sm text-muted-foreground">
-                                        Stranica još nema sekcija.
+                                        {preserveFallbackContent
+                                            ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju.'
+                                            : 'Stranica još nema sekcija.'}
                                     </Card>
                                 ) : (
                                     <Stack spacing={2}>
                                         {sections.map((section, index) => (
-                                            <Card key={`${section.component}-${index}`} className="p-4">
+                                            <Card
+                                                key={section.id}
+                                                className="p-4"
+                                            >
                                                 <Stack spacing={2}>
-                                                    <Row spacing={2} className="items-center justify-between">
-                                                        <Typography level="body1" semiBold>
-                                                            {index + 1}. {section.component}
+                                                    <Row
+                                                        spacing={2}
+                                                        className="items-center justify-between"
+                                                    >
+                                                        <Typography
+                                                            level="body1"
+                                                            semiBold
+                                                        >
+                                                            {index + 1}.{' '}
+                                                            {
+                                                                section.data
+                                                                    .component
+                                                            }
                                                         </Typography>
                                                         <Row spacing={1}>
-                                                            <Button type="button" variant="plain" disabled={index === 0} onClick={() => setSections((current) => {
-                                                                if (index === 0) return current;
-                                                                const next = [...current];
-                                                                [next[index - 1], next[index]] = [next[index], next[index - 1]];
-                                                                return next;
-                                                            })}>Gore</Button>
-                                                            <Button type="button" variant="plain" disabled={index === sections.length - 1} onClick={() => setSections((current) => {
-                                                                if (index >= current.length - 1) return current;
-                                                                const next = [...current];
-                                                                [next[index + 1], next[index]] = [next[index], next[index + 1]];
-                                                                return next;
-                                                            })}>Dolje</Button>
-                                                            <Button type="button" variant="plain" color="danger" onClick={() => setSections((current) => current.filter((_, currentIndex) => currentIndex !== index))}>Ukloni</Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                disabled={
+                                                                    index === 0
+                                                                }
+                                                                onClick={() =>
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) => {
+                                                                            if (
+                                                                                index ===
+                                                                                0
+                                                                            )
+                                                                                return current;
+                                                                            const next =
+                                                                                [
+                                                                                    ...current,
+                                                                                ];
+                                                                            [
+                                                                                next[
+                                                                                    index -
+                                                                                        1
+                                                                                ],
+                                                                                next[
+                                                                                    index
+                                                                                ],
+                                                                            ] =
+                                                                                [
+                                                                                    next[
+                                                                                        index
+                                                                                    ],
+                                                                                    next[
+                                                                                        index -
+                                                                                            1
+                                                                                    ],
+                                                                                ];
+                                                                            return next;
+                                                                        },
+                                                                    )
+                                                                }
+                                                            >
+                                                                Gore
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                disabled={
+                                                                    index ===
+                                                                    sections.length -
+                                                                        1
+                                                                }
+                                                                onClick={() =>
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) => {
+                                                                            if (
+                                                                                index >=
+                                                                                current.length -
+                                                                                    1
+                                                                            ) {
+                                                                                return current;
+                                                                            }
+
+                                                                            const next =
+                                                                                [
+                                                                                    ...current,
+                                                                                ];
+                                                                            [
+                                                                                next[
+                                                                                    index +
+                                                                                        1
+                                                                                ],
+                                                                                next[
+                                                                                    index
+                                                                                ],
+                                                                            ] =
+                                                                                [
+                                                                                    next[
+                                                                                        index
+                                                                                    ],
+                                                                                    next[
+                                                                                        index +
+                                                                                            1
+                                                                                    ],
+                                                                                ];
+                                                                            return next;
+                                                                        },
+                                                                    )
+                                                                }
+                                                            >
+                                                                Dolje
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                color="danger"
+                                                                onClick={() =>
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) =>
+                                                                            current.filter(
+                                                                                (
+                                                                                    currentSection,
+                                                                                ) =>
+                                                                                    currentSection.id !==
+                                                                                    section.id,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                Ukloni
+                                                            </Button>
                                                         </Row>
                                                     </Row>
                                                     <Input
                                                         label="Naslov"
-                                                        value={sectionValue(section, 'header')}
+                                                        value={sectionValue(
+                                                            section,
+                                                            'header',
+                                                        )}
                                                         onChange={(event) => {
-                                                            const value = event.target.value;
-                                                            setSections((current) => current.map((currentSection, currentIndex) => currentIndex === index ? { ...currentSection, header: value } : currentSection));
+                                                            const value =
+                                                                event.target
+                                                                    .value;
+                                                            setSections(
+                                                                (current) =>
+                                                                    current.map(
+                                                                        (
+                                                                            currentSection,
+                                                                        ) =>
+                                                                            currentSection.id ===
+                                                                            section.id
+                                                                                ? {
+                                                                                      ...currentSection,
+                                                                                      data: {
+                                                                                          ...currentSection.data,
+                                                                                          header: value,
+                                                                                      },
+                                                                                  }
+                                                                                : currentSection,
+                                                                    ),
+                                                            );
                                                         }}
                                                     />
                                                     <label className="space-y-1">
@@ -162,12 +339,37 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                             Opis
                                                         </span>
                                                         <textarea
-                                                            value={sectionValue(section, 'description')}
+                                                            value={sectionValue(
+                                                                section,
+                                                                'description',
+                                                            )}
                                                             rows={4}
                                                             className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                            onChange={(event) => {
-                                                                const value = event.target.value;
-                                                                setSections((current) => current.map((currentSection, currentIndex) => currentIndex === index ? { ...currentSection, description: value } : currentSection));
+                                                            onChange={(
+                                                                event,
+                                                            ) => {
+                                                                const value =
+                                                                    event.target
+                                                                        .value;
+                                                                setSections(
+                                                                    (current) =>
+                                                                        current.map(
+                                                                            (
+                                                                                currentSection,
+                                                                            ) =>
+                                                                                currentSection.id ===
+                                                                                section.id
+                                                                                    ? {
+                                                                                          ...currentSection,
+                                                                                          data: {
+                                                                                              ...currentSection.data,
+                                                                                              description:
+                                                                                                  value,
+                                                                                          },
+                                                                                      }
+                                                                                    : currentSection,
+                                                                        ),
+                                                                );
                                                             }}
                                                         />
                                                     </label>
@@ -185,7 +387,7 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                             onClick={() => {
                                                 setSections((current) => [
                                                     ...current,
-                                                    { component: item.value },
+                                                    newSection(item.value),
                                                 ]);
                                             }}
                                         >

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -147,12 +147,16 @@ function moveSection(
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
-    const newSectionIdPrefix = `${useId()}-${page?.id ?? 'new'}`;
-    const nextSectionId = useRef(0);
+    const reactId = useId();
+    const newSectionIdPrefix = useMemo(
+        () => `${reactId}-${page?.id ?? 'new'}`,
+        [page?.id, reactId],
+    );
     const parsedSections = useMemo(
         () => parseSections(page?.content),
         [page?.content],
     );
+    const nextSectionId = useRef(parsedSections.sections.length);
     const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
         editableSections(parsedSections.sections),
     );
@@ -381,15 +385,19 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                             type="button"
                                             variant="outlined"
                                             onClick={() => {
-                                                nextSectionId.current += 1;
-                                                setSections((current) => [
-                                                    ...current,
-                                                    newSection(
-                                                        item.value,
-                                                        newSectionIdPrefix,
-                                                        nextSectionId.current,
-                                                    ),
-                                                ]);
+                                                setSections((current) => {
+                                                    const sectionId =
+                                                        nextSectionId.current;
+                                                    nextSectionId.current += 1;
+                                                    return [
+                                                        ...current,
+                                                        newSection(
+                                                            item.value,
+                                                            newSectionIdPrefix,
+                                                            sectionId,
+                                                        ),
+                                                    ];
+                                                });
                                             }}
                                         >
                                             Dodaj {item.label}

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -4,10 +4,11 @@ import type { SelectCmsPage } from '@gredice/storage';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Input } from '@signalco/ui-primitives/Input';
+import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useActionState } from 'react';
+import { useActionState, useMemo, useState } from 'react';
 import type { CmsPageFormState } from './actions';
 
 type CmsPageFormProps = {
@@ -19,6 +20,13 @@ type CmsPageFormProps = {
     submitLabel: string;
 };
 
+type CmsPageSectionComponent = 'Heading1' | 'Faq1' | 'Feature1' | 'Footer1';
+
+type CmsPageSectionData = {
+    component: CmsPageSectionComponent;
+    [key: string]: unknown;
+};
+
 const cmsPageStateItems = [
     { value: 'draft', label: 'Draft' },
     {
@@ -27,8 +35,51 @@ const cmsPageStateItems = [
     },
 ];
 
+const cmsPageSectionItems: { value: CmsPageSectionComponent; label: string }[] = [
+    { value: 'Heading1', label: 'Heading1' },
+    { value: 'Feature1', label: 'Feature1' },
+    { value: 'Faq1', label: 'Faq1' },
+    { value: 'Footer1', label: 'Footer1' },
+];
+
+function parseSections(content?: string | null): CmsPageSectionData[] {
+    if (!content) {
+        return [];
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(content);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(
+            (section): section is CmsPageSectionData =>
+                Boolean(section) &&
+                typeof section === 'object' &&
+                'component' in section &&
+                typeof section.component === 'string',
+        );
+    } catch {
+        return [];
+    }
+}
+
+function stringifySections(sections: CmsPageSectionData[]) {
+    return sections.length > 0 ? JSON.stringify(sections) : '';
+}
+
+function sectionValue(section: CmsPageSectionData, key: string) {
+    const value = section[key];
+    return typeof value === 'string' ? value : '';
+}
+
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
+    const [sections, setSections] = useState<CmsPageSectionData[]>(() =>
+        parseSections(page?.content),
+    );
+    const serializedContent = useMemo(() => stringifySections(sections), [sections]);
 
     return (
         <Card className="max-w-3xl">
@@ -56,23 +107,93 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                 defaultValue={page?.state ?? 'draft'}
                                 items={cmsPageStateItems}
                             />
-                            <label className="space-y-1">
-                                <span className="block text-sm font-medium">
-                                    Sadržaj
-                                </span>
-                                <textarea
-                                    name="content"
-                                    defaultValue={page?.content ?? ''}
-                                    placeholder='[{"component":"Feature1","header":"Naslov"}]'
-                                    rows={10}
-                                    className="block min-h-48 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                />
-                                <Typography level="body3" secondary>
-                                    Unesi JSON niz SectionData blokova (npr.
-                                    komponenta Feature1, Heading1, Faq1 ili
-                                    Footer1).
+                            <Stack spacing={2}>
+                                <Typography level="h3" semiBold>
+                                    Sadržaj stranice
                                 </Typography>
-                            </label>
+                                <Typography level="body3" secondary>
+                                    Dodaj i uređuj sekcije bez ručnog uređivanja JSON-a.
+                                </Typography>
+                                <input
+                                    name="content"
+                                    type="hidden"
+                                    value={serializedContent}
+                                    readOnly
+                                />
+                                {sections.length === 0 ? (
+                                    <Card className="p-4 text-sm text-muted-foreground">
+                                        Stranica još nema sekcija.
+                                    </Card>
+                                ) : (
+                                    <Stack spacing={2}>
+                                        {sections.map((section, index) => (
+                                            <Card key={`${section.component}-${index}`} className="p-4">
+                                                <Stack spacing={2}>
+                                                    <Row spacing={2} className="items-center justify-between">
+                                                        <Typography level="body1" semiBold>
+                                                            {index + 1}. {section.component}
+                                                        </Typography>
+                                                        <Row spacing={1}>
+                                                            <Button type="button" variant="plain" disabled={index === 0} onClick={() => setSections((current) => {
+                                                                if (index === 0) return current;
+                                                                const next = [...current];
+                                                                [next[index - 1], next[index]] = [next[index], next[index - 1]];
+                                                                return next;
+                                                            })}>Gore</Button>
+                                                            <Button type="button" variant="plain" disabled={index === sections.length - 1} onClick={() => setSections((current) => {
+                                                                if (index >= current.length - 1) return current;
+                                                                const next = [...current];
+                                                                [next[index + 1], next[index]] = [next[index], next[index + 1]];
+                                                                return next;
+                                                            })}>Dolje</Button>
+                                                            <Button type="button" variant="plain" color="danger" onClick={() => setSections((current) => current.filter((_, currentIndex) => currentIndex !== index))}>Ukloni</Button>
+                                                        </Row>
+                                                    </Row>
+                                                    <Input
+                                                        label="Naslov"
+                                                        value={sectionValue(section, 'header')}
+                                                        onChange={(event) => {
+                                                            const value = event.target.value;
+                                                            setSections((current) => current.map((currentSection, currentIndex) => currentIndex === index ? { ...currentSection, header: value } : currentSection));
+                                                        }}
+                                                    />
+                                                    <label className="space-y-1">
+                                                        <span className="block text-sm font-medium">
+                                                            Opis
+                                                        </span>
+                                                        <textarea
+                                                            value={sectionValue(section, 'description')}
+                                                            rows={4}
+                                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                            onChange={(event) => {
+                                                                const value = event.target.value;
+                                                                setSections((current) => current.map((currentSection, currentIndex) => currentIndex === index ? { ...currentSection, description: value } : currentSection));
+                                                            }}
+                                                        />
+                                                    </label>
+                                                </Stack>
+                                            </Card>
+                                        ))}
+                                    </Stack>
+                                )}
+                                <Row spacing={2}>
+                                    {cmsPageSectionItems.map((item) => (
+                                        <Button
+                                            key={item.value}
+                                            type="button"
+                                            variant="outlined"
+                                            onClick={() => {
+                                                setSections((current) => [
+                                                    ...current,
+                                                    { component: item.value },
+                                                ]);
+                                            }}
+                                        >
+                                            Dodaj {item.label}
+                                        </Button>
+                                    ))}
+                                </Row>
+                            </Stack>
                         </Stack>
 
                         <Stack spacing={3}>

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -8,7 +8,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useActionState, useMemo, useRef, useState } from 'react';
+import { useActionState, useId, useMemo, useRef, useState } from 'react';
 import type { CmsPageFormState } from './actions';
 
 type CmsPageFormProps = {
@@ -81,9 +81,13 @@ function editableSection(
     };
 }
 
-function newSection(component: string, id: number): CmsPageEditableSection {
+function newSection(
+    component: string,
+    idPrefix: string,
+    id: number,
+): CmsPageEditableSection {
     return {
-        id: `new-${component}-${id}`,
+        id: `${idPrefix}-${id}`,
         data: { component },
     };
 }
@@ -143,6 +147,7 @@ function moveSection(
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
+    const newSectionIdPrefix = useId();
     const nextSectionId = useRef(0);
     const parsedSections = useMemo(
         () => parseSections(page?.content),
@@ -381,6 +386,7 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                     ...current,
                                                     newSection(
                                                         item.value,
+                                                        newSectionIdPrefix,
                                                         nextSectionId.current,
                                                     ),
                                                 ]);

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -45,6 +45,8 @@ const cmsPageSectionItems = [
     { value: 'Footer1', label: 'Footer1' },
 ];
 
+let nextSectionId = 0;
+
 function parseSections(content?: string | null) {
     if (!content) {
         return { isStructured: true, sections: [] };
@@ -82,8 +84,9 @@ function editableSection(
 }
 
 function newSection(component: string): CmsPageEditableSection {
+    nextSectionId += 1;
     return {
-        id: `new-${crypto.randomUUID()}`,
+        id: `new-${component}-${nextSectionId}`,
         data: { component },
     };
 }
@@ -122,18 +125,19 @@ function moveSection(
 ) {
     const index = sections.findIndex((section) => section.id === sectionId);
     const targetIndex = index + offset;
-    if (
-        index < 0 ||
-        targetIndex < 0 ||
-        targetIndex >= sections.length ||
-        !sections[index] ||
-        !sections[targetIndex]
-    ) {
+    if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
+        return sections;
+    }
+
+    const currentSection = sections[index];
+    const targetSection = sections[targetIndex];
+    if (!currentSection || !targetSection) {
         return sections;
     }
 
     const next = [...sections];
-    [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+    next[index] = targetSection;
+    next[targetIndex] = currentSection;
     return next;
 }
 

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -71,15 +71,30 @@ function parseSections(content?: string | null) {
     }
 }
 
-function editableSection(section: CmsPageSectionData): CmsPageEditableSection {
+function editableSection(
+    section: CmsPageSectionData,
+    occurrence: number,
+): CmsPageEditableSection {
     return {
-        id: crypto.randomUUID(),
+        id: `${section.component}-${occurrence}`,
         data: section,
     };
 }
 
 function newSection(component: string): CmsPageEditableSection {
-    return editableSection({ component });
+    return {
+        id: `new-${crypto.randomUUID()}`,
+        data: { component },
+    };
+}
+
+function editableSections(sections: CmsPageSectionData[]) {
+    const sectionCounts = new Map<string, number>();
+    return sections.map((section) => {
+        const occurrence = sectionCounts.get(section.component) ?? 0;
+        sectionCounts.set(section.component, occurrence + 1);
+        return editableSection(section, occurrence);
+    });
 }
 
 function stringifySections(
@@ -100,6 +115,28 @@ function sectionValue(section: CmsPageEditableSection, key: string) {
     return typeof value === 'string' ? value : '';
 }
 
+function moveSection(
+    sections: CmsPageEditableSection[],
+    sectionId: string,
+    offset: number,
+) {
+    const index = sections.findIndex((section) => section.id === sectionId);
+    const targetIndex = index + offset;
+    if (
+        index < 0 ||
+        targetIndex < 0 ||
+        targetIndex >= sections.length ||
+        !sections[index] ||
+        !sections[targetIndex]
+    ) {
+        return sections;
+    }
+
+    const next = [...sections];
+    [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+    return next;
+}
+
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     const [state, formAction, pending] = useActionState(action, null);
     const parsedSections = useMemo(
@@ -107,7 +144,7 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
         [page?.content],
     );
     const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
-        parsedSections.sections.map(editableSection),
+        editableSections(parsedSections.sections),
     );
     const preserveFallbackContent =
         !parsedSections.isStructured && Boolean(page?.content);
@@ -196,36 +233,12 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                                     setSections(
                                                                         (
                                                                             current,
-                                                                        ) => {
-                                                                            if (
-                                                                                index ===
-                                                                                0
-                                                                            )
-                                                                                return current;
-                                                                            const next =
-                                                                                [
-                                                                                    ...current,
-                                                                                ];
-                                                                            [
-                                                                                next[
-                                                                                    index -
-                                                                                        1
-                                                                                ],
-                                                                                next[
-                                                                                    index
-                                                                                ],
-                                                                            ] =
-                                                                                [
-                                                                                    next[
-                                                                                        index
-                                                                                    ],
-                                                                                    next[
-                                                                                        index -
-                                                                                            1
-                                                                                    ],
-                                                                                ];
-                                                                            return next;
-                                                                        },
+                                                                        ) =>
+                                                                            moveSection(
+                                                                                current,
+                                                                                section.id,
+                                                                                -1,
+                                                                            ),
                                                                     )
                                                                 }
                                                             >
@@ -243,39 +256,12 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                                     setSections(
                                                                         (
                                                                             current,
-                                                                        ) => {
-                                                                            if (
-                                                                                index >=
-                                                                                current.length -
-                                                                                    1
-                                                                            ) {
-                                                                                return current;
-                                                                            }
-
-                                                                            const next =
-                                                                                [
-                                                                                    ...current,
-                                                                                ];
-                                                                            [
-                                                                                next[
-                                                                                    index +
-                                                                                        1
-                                                                                ],
-                                                                                next[
-                                                                                    index
-                                                                                ],
-                                                                            ] =
-                                                                                [
-                                                                                    next[
-                                                                                        index
-                                                                                    ],
-                                                                                    next[
-                                                                                        index +
-                                                                                            1
-                                                                                    ],
-                                                                                ];
-                                                                            return next;
-                                                                        },
+                                                                        ) =>
+                                                                            moveSection(
+                                                                                current,
+                                                                                section.id,
+                                                                                1,
+                                                                            ),
                                                                     )
                                                                 }
                                                             >

--- a/apps/app/app/admin/cms/pages/[pageId]/page.tsx
+++ b/apps/app/app/admin/cms/pages/[pageId]/page.tsx
@@ -9,8 +9,8 @@ import { Breadcrumbs } from '@signalco/ui/Breadcrumbs';
 import { Delete, Edit, ExternalLink, Megaphone } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
+import { Divider } from '@signalco/ui-primitives/Divider';
 import { Row } from '@signalco/ui-primitives/Row';
-import { Separator } from '@signalco/ui-primitives/Separator';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
@@ -31,6 +31,15 @@ import { CmsPageStateChip } from '../CmsPageStateChip';
 
 export const dynamic = 'force-dynamic';
 
+function keyedCmsPageSection(
+    section: { component: string },
+    occurrence: number,
+) {
+    return {
+        key: `${JSON.stringify(section)}-${occurrence}`,
+        section,
+    };
+}
 
 function parseCmsPageSections(content: string | null) {
     if (!content) {
@@ -43,13 +52,21 @@ function parseCmsPageSections(content: string | null) {
             return [];
         }
 
-        return parsed.filter(
-            (section): section is { component: string } =>
-                Boolean(section) &&
-                typeof section === 'object' &&
-                'component' in section &&
-                typeof section.component === 'string',
-        );
+        const sectionCounts = new Map<string, number>();
+        return parsed
+            .filter(
+                (section): section is { component: string } =>
+                    Boolean(section) &&
+                    typeof section === 'object' &&
+                    'component' in section &&
+                    typeof section.component === 'string',
+            )
+            .map((section) => {
+                const sectionKey = JSON.stringify(section);
+                const occurrence = sectionCounts.get(sectionKey) ?? 0;
+                sectionCounts.set(sectionKey, occurrence + 1);
+                return keyedCmsPageSection(section, occurrence);
+            });
     } catch {
         return [];
     }
@@ -87,6 +104,7 @@ export default async function CmsPageDetailsPage({
         notFound();
     }
 
+    const pageSections = parseCmsPageSections(page.content);
     const publishAction = publishCmsPageAction.bind(null, id);
     const unpublishAction = unpublishCmsPageAction.bind(null, id);
     const deleteAction = deleteCmsPageAction.bind(null, id);
@@ -192,17 +210,17 @@ export default async function CmsPageDetailsPage({
                     <Typography level="h3" semiBold>
                         Sekcije stranice
                     </Typography>
-                    {parseCmsPageSections(page.content).length === 0 ? (
+                    {pageSections.length === 0 ? (
                         <Typography level="body2" secondary>
                             Nema konfiguriranih sekcija.
                         </Typography>
                     ) : (
-                        parseCmsPageSections(page.content).map((section, index) => (
-                            <Stack spacing={1} key={`${section.component}-${index}`}>
+                        pageSections.map(({ key, section }, index) => (
+                            <Stack spacing={1} key={key}>
                                 <Typography level="body2">
                                     {index + 1}. {section.component}
                                 </Typography>
-                                <Separator />
+                                <Divider />
                             </Stack>
                         ))
                     )}

--- a/apps/app/app/admin/cms/pages/[pageId]/page.tsx
+++ b/apps/app/app/admin/cms/pages/[pageId]/page.tsx
@@ -36,7 +36,7 @@ function keyedCmsPageSection(
     occurrence: number,
 ) {
     return {
-        key: `${JSON.stringify(section)}-${occurrence}`,
+        key: `${section.component}-${occurrence}`,
         section,
     };
 }
@@ -62,9 +62,8 @@ function parseCmsPageSections(content: string | null) {
                     typeof section.component === 'string',
             )
             .map((section) => {
-                const sectionKey = JSON.stringify(section);
-                const occurrence = sectionCounts.get(sectionKey) ?? 0;
-                sectionCounts.set(sectionKey, occurrence + 1);
+                const occurrence = sectionCounts.get(section.component) ?? 0;
+                sectionCounts.set(section.component, occurrence + 1);
                 return keyedCmsPageSection(section, occurrence);
             });
     } catch {

--- a/apps/app/app/admin/cms/pages/[pageId]/page.tsx
+++ b/apps/app/app/admin/cms/pages/[pageId]/page.tsx
@@ -10,6 +10,7 @@ import { Delete, Edit, ExternalLink, Megaphone } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
+import { Separator } from '@signalco/ui-primitives/Separator';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
@@ -29,6 +30,30 @@ import {
 import { CmsPageStateChip } from '../CmsPageStateChip';
 
 export const dynamic = 'force-dynamic';
+
+
+function parseCmsPageSections(content: string | null) {
+    if (!content) {
+        return [];
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(content);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(
+            (section): section is { component: string } =>
+                Boolean(section) &&
+                typeof section === 'object' &&
+                'component' in section &&
+                typeof section.component === 'string',
+        );
+    } catch {
+        return [];
+    }
+}
 
 function publishedAtValue(page: SelectCmsPage) {
     if (!page.publishedAt) {
@@ -162,13 +187,27 @@ export default async function CmsPageDetailsPage({
                     <Field name="Meta slika" value={page.metaImageUrl ?? '-'} />
                 </FieldSet>
             </Stack>
-            {page.content && (
-                <Card className="max-w-4xl">
-                    <div className="whitespace-pre-wrap p-6 text-sm leading-6">
-                        {page.content}
-                    </div>
-                </Card>
-            )}
+            <Card className="max-w-4xl p-6">
+                <Stack spacing={2}>
+                    <Typography level="h3" semiBold>
+                        Sekcije stranice
+                    </Typography>
+                    {parseCmsPageSections(page.content).length === 0 ? (
+                        <Typography level="body2" secondary>
+                            Nema konfiguriranih sekcija.
+                        </Typography>
+                    ) : (
+                        parseCmsPageSections(page.content).map((section, index) => (
+                            <Stack spacing={1} key={`${section.component}-${index}`}>
+                                <Typography level="body2">
+                                    {index + 1}. {section.component}
+                                </Typography>
+                                <Separator />
+                            </Stack>
+                        ))
+                    )}
+                </Stack>
+            </Card>
             <FieldSet>
                 {revisions.length === 0 ? (
                     <Field name="Historija" value="Nema promjena" />

--- a/packages/storage/tests/cmsPagesRepo.node.spec.ts
+++ b/packages/storage/tests/cmsPagesRepo.node.spec.ts
@@ -263,3 +263,26 @@ test('CMS page revisions are recorded and can be restored', async () => {
     assert.equal(restored?.title, 'V1 title');
     assert.equal(restored?.content, firstContent);
 });
+
+
+test('CMS page metadata is preserved when updating only content', async () => {
+    createTestDb();
+    const pageId = await createCmsPage({
+        slug: `meta-preserve-${randomUUID()}`,
+        title: 'Metadata preserve page',
+        content: JSON.stringify([{ component: 'Feature1', header: 'Initial' }]),
+        metaTitle: 'Meta title',
+        metaDescription: 'Meta description',
+        metaImageUrl: 'https://www.gredice.com/meta.png',
+    });
+
+    await updateCmsPage({
+        id: pageId,
+        content: JSON.stringify([{ component: 'Heading1', header: 'Updated' }]),
+    });
+
+    const page = await getCmsPage(pageId);
+    assert.equal(page?.metaTitle, 'Meta title');
+    assert.equal(page?.metaDescription, 'Meta description');
+    assert.equal(page?.metaImageUrl, 'https://www.gredice.com/meta.png');
+});


### PR DESCRIPTION
### Motivation
- Replace the raw JSON textarea in the admin CMS page form with a visual, structured editor so admins can compose pages from known section components without hand-editing JSON.
- Surface the page sections in the detail view to make page structure readable to admins without inspecting the raw `content` blob.
- Preserve existing storage and rendering contracts so the public site and validation logic are unchanged.

### Description
- Replaced the `content` textarea in `CmsPageForm` with a visual section builder that parses existing SectionData JSON into structured state and serializes it back into the hidden `content` form field on submit, supporting add, remove, and reorder for `Heading1`, `Feature1`, `Faq1`, and `Footer1` sections.
- Added light editing controls for section fields (`header`, `description`) and buttons to add supported component types in `apps/app/app/admin/cms/pages/CmsPageForm.tsx`.
- Replaced the raw JSON output on the CMS page detail view with a human-readable section list preview and separators in `apps/app/app/admin/cms/pages/[pageId]/page.tsx`.
- Added a focused storage test `CMS page metadata is preserved when updating only content` to `packages/storage/tests/cmsPagesRepo.node.spec.ts` to verify metadata is not lost when content is updated.

### Testing
- Added the unit test in `packages/storage/tests/cmsPagesRepo.node.spec.ts` (new test present in the branch).
- Attempted to run `pnpm -s test --filter @gredice/storage -- cmsPagesRepo.node.spec.ts`, but the run failed in this environment because Docker / the Postgres test database is unavailable and tests require a DB container or a configured `GREDICE_STORAGE_TEST_DB_ADMIN_URL`.
- No other automated tests were executed in this environment due to the same test DB constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe714203dc832fa43b4a41494e0386)