### PR TITLE
Add CMS page cache keys and invalidate caches on create/update/delete/publish flows

### DIFF
--- a/packages/storage/src/cache/directoriesCached.ts
+++ b/packages/storage/src/cache/directoriesCached.ts
@@ -9,6 +9,9 @@ export const cacheKeys = {
     entity: (entityId: number) => `entity:${entityId}`,
     entityTypeName: (entityTypeName: string) =>
         `entities:formatted:${entityTypeName}:state:published:locale:default:v1`,
+    cmsPagesList: (state: 'draft' | 'published' | 'all' = 'all') =>
+        `cms:pages:list:${state}:v1`,
+    cmsPageBySlug: (slug: string) => `cms:page:slug:${slug}:v1`,
 };
 
 export async function directoriesCached<T>(

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -9,6 +9,11 @@ import {
     type SelectCmsPage,
     storage,
 } from '..';
+import {
+    bustCached,
+    cacheKeys,
+    directoriesCached,
+} from '../cache/directoriesCached';
 
 export type CmsPageState = 'draft' | 'published';
 
@@ -93,7 +98,9 @@ function boundedOptionalText(
 ) {
     const normalized = optionalText(value);
     if (normalized && normalized.length > maxLength) {
-        throw new Error(`${fieldLabel} must be at most ${maxLength} characters.`);
+        throw new Error(
+            `${fieldLabel} must be at most ${maxLength} characters.`,
+        );
     }
     return normalized;
 }
@@ -290,12 +297,21 @@ export async function getCmsPages(options: GetCmsPagesOptions = {}) {
             )
           : eq(cmsPages.isDeleted, false);
 
-    const query = storage()
-        .select()
-        .from(cmsPages)
-        .orderBy(desc(cmsPages.updatedAt), desc(cmsPages.id));
+    const query = async () => {
+        const baseQuery = storage()
+            .select()
+            .from(cmsPages)
+            .orderBy(desc(cmsPages.updatedAt), desc(cmsPages.id));
 
-    return where ? query.where(where) : query;
+        return where ? baseQuery.where(where) : baseQuery;
+    };
+
+    if (options.includeDeleted) {
+        return query();
+    }
+
+    const stateKey = options.state ?? 'all';
+    return directoriesCached(cacheKeys.cmsPagesList(stateKey), query, 300);
 }
 
 export function getCmsPage(id: number) {
@@ -305,12 +321,39 @@ export function getCmsPage(id: number) {
 }
 
 export function getCmsPageBySlug(slug: string) {
-    return storage().query.cmsPages.findFirst({
-        where: and(
-            eq(cmsPages.slug, normalizeCmsPageSlug(slug)),
-            eq(cmsPages.isDeleted, false),
-        ),
-    });
+    const normalizedSlug = normalizeCmsPageSlug(slug);
+    return directoriesCached(
+        cacheKeys.cmsPageBySlug(normalizedSlug),
+        () =>
+            storage().query.cmsPages.findFirst({
+                where: and(
+                    eq(cmsPages.slug, normalizedSlug),
+                    eq(cmsPages.isDeleted, false),
+                ),
+            }),
+        300,
+    );
+}
+
+export function cmsPageCacheKeysForSlug(slug: string) {
+    const normalizedSlug = normalizeCmsPageSlug(slug);
+    return [
+        cacheKeys.cmsPageBySlug(normalizedSlug),
+        cacheKeys.cmsPagesList('all'),
+        cacheKeys.cmsPagesList('draft'),
+        cacheKeys.cmsPagesList('published'),
+    ];
+}
+
+async function bustCmsPageCaches(slugs: string[]) {
+    const keys = new Set<string>();
+    for (const slug of slugs) {
+        for (const key of cmsPageCacheKeysForSlug(slug)) {
+            keys.add(key);
+        }
+    }
+
+    await Promise.all(Array.from(keys, (key) => bustCached(key)));
 }
 
 export async function createCmsPage(
@@ -344,6 +387,8 @@ export async function createCmsPage(
         nextNoIndex: values.noIndex,
         nextPublishedAt: values.publishedAt,
     });
+
+    await bustCmsPageCaches([values.slug]);
 
     return created.id;
 }
@@ -440,6 +485,8 @@ export async function updateCmsPage(
             actorId: actor?.id,
             actorName: actor?.name,
         });
+
+    await bustCmsPageCaches([existing.slug, next.slug]);
 }
 
 export async function updateCmsPageState(
@@ -505,6 +552,8 @@ export async function softDeleteCmsPage(id: number, actor?: CmsActor) {
             actorId: actor?.id,
             actorName: actor?.name,
         });
+
+    await bustCmsPageCaches([existing.slug]);
 }
 
 export async function getCmsPageRevisions(cmsPageId: number) {

--- a/packages/storage/tests/cmsPagesRepo.node.spec.ts
+++ b/packages/storage/tests/cmsPagesRepo.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    cmsPageCacheKeysForSlug,
     cmsPages,
     createCmsPage,
     getCmsPage,
@@ -268,4 +269,15 @@ test('CMS page revisions are recorded and can be restored', async () => {
     assert.equal(restored?.content, firstContent);
     assert.equal(restored?.canonicalPath, '/history-v1');
     assert.equal(restored?.noIndex, true);
+});
+
+test('CMS page cache keys include normalized page and list variants', () => {
+    const keys = cmsPageCacheKeysForSlug(' /Vodiči/Cesta pitanja/ ');
+
+    assert.deepEqual(keys, [
+        'cms:page:slug:vodici/cesta-pitanja:v1',
+        'cms:pages:list:all:v1',
+        'cms:pages:list:draft:v1',
+        'cms:pages:list:published:v1',
+    ]);
 });


### PR DESCRIPTION
### Motivation

- Ensure published and draft CMS pages are cached with stable keys and that updates (create/update/publish/unpublish/delete) reliably invalidate affected cache entries so visitors do not see stale content.
- Provide repository-level cache semantics for CMS pages to match existing directory/entity caching discipline.

### Description

- Added cache key helpers `cmsPagesList` and `cmsPageBySlug` to `packages/storage/src/cache/directoriesCached.ts` and re-used existing `directoriesCached` helpers for CMS reads.
- Updated `packages/storage/src/repositories/cmsPagesRepo.ts` to cache `getCmsPages` and `getCmsPageBySlug` via `directoriesCached` and a 300s TTL for list/slug reads.
- Added `cmsPageCacheKeysForSlug` and `bustCmsPageCaches` to compute and deduplicate affected keys and invoked cache busting after `createCmsPage`, `updateCmsPage` (including slug changes and state transitions), and `softDeleteCmsPage`.
- Added a focused test in `packages/storage/tests/cmsPagesRepo.node.spec.ts` asserting normalized slug-based cache key selection for list and per-slug variants.

### Testing

- Ran `pnpm --filter @gredice/storage lint` which passed and auto-fixed formatting issues where applicable.
- Added unit test `CMS page cache keys include normalized page and list variants` to `cmsPagesRepo.node.spec.ts` (test present in tree but not executed here).
- Attempted `pnpm --filter @gredice/storage test -- cmsPagesRepo.node.spec.ts` but execution was blocked because the environment lacks Docker / a test Postgres instance, so repository tests could not be run end-to-end in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe76dfbd4c832f884732d6b1008769)