### PR TITLE
[CI] Cancel obsolete GitHub Actions workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
       - main
   workflow_dispatch:
 
+# Keep only the latest CI run per workflow + PR/branch, cancel obsolete in-progress runs.
+# For PR events we scope by PR number, and for branch events we scope by ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: "Detect changes"


### PR DESCRIPTION
### Motivation
- Reduce wasted GitHub Actions capacity by ensuring only the latest run for a given PR or branch remains active.
- Ensure new commits on a PR cancel older runs and merged PRs do not leave obsolete runs consuming CI time.

### Description
- Added a workflow-level `concurrency` block to `.github/workflows/ci.yml` with `cancel-in-progress: true` to automatically cancel obsolete runs.
- Scoped the concurrency group as `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` so grouping is per-workflow and per-PR or branch to avoid cross-branch/PR cancellations.
- Included inline comments documenting the intent and behavior for future workflow edits.

### Testing
- Inspected workflows with `rg` and file snippets with `sed -n` to verify locations and context, which completed successfully.
- Verified the change with `git diff -- .github/workflows/ci.yml`, committed with `git commit`, and confirmed file contents with `nl -ba .github/workflows/ci.yml | sed -n '1,40p'`, all of which succeeded.
- No full CI run was executed in this change; the modification is a configuration update intended to affect future GitHub Actions behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe94e03d28832f97b7d38ed181b9ca)