### PR TITLE
Add variant inheritance resolution for CMS entities

### DIFF
--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -22,6 +22,17 @@ import { getEntityCompleteness } from '../helpers/entityCompleteness';
 
 const entityCacheTtl = 60 * 60; // 1 hour
 
+type EntityAttribute = SelectAttributeValue & {
+    attributeDefinition: SelectAttributeDefinition;
+};
+
+type EntityWithAttributesAndDefinitions = SelectEntity & {
+    attributes: EntityAttribute[];
+    entityType: SelectEntityType & {
+        attributeDefinitions: SelectAttributeDefinition[];
+    };
+};
+
 function tryParseAttributeJson(
     value: string,
     attributeDefinition: SelectAttributeDefinition,
@@ -64,18 +75,10 @@ function parseEntityRefId(value: string | null | undefined) {
     return Number.parseInt(trimmedValue, 10);
 }
 
-
 async function buildEffectiveEntity(
-    entity: SelectEntity & {
-        attributes: (SelectAttributeValue & {
-            attributeDefinition: SelectAttributeDefinition;
-        })[];
-        entityType: SelectEntityType & {
-            attributeDefinitions: SelectAttributeDefinition[];
-        };
-    },
+    entity: EntityWithAttributesAndDefinitions,
     visited = new Set<number>(),
-) {
+): Promise<EntityWithAttributesAndDefinitions> {
     if (visited.has(entity.id)) {
         throw new Error('Cycle detected in entity hierarchy.');
     }
@@ -86,7 +89,10 @@ async function buildEffectiveEntity(
     }
 
     const parent = await storage().query.entities.findFirst({
-        where: and(eq(entities.id, entity.parentId), eq(entities.isDeleted, false)),
+        where: and(
+            eq(entities.id, entity.parentId),
+            eq(entities.isDeleted, false),
+        ),
         with: {
             attributes: {
                 where: eq(attributeValues.isDeleted, false),
@@ -117,7 +123,8 @@ async function buildEffectiveEntity(
     );
 
     const inheritedAttributes = parentEffective.attributes.filter(
-        (attribute) => !childByDefinitionId.has(attribute.attributeDefinitionId),
+        (attribute) =>
+            !childByDefinitionId.has(attribute.attributeDefinitionId),
     );
 
     return populateMissingAttributes({
@@ -126,15 +133,8 @@ async function buildEffectiveEntity(
     });
 }
 function populateMissingAttributes(
-    entity: SelectEntity & {
-        attributes: (SelectAttributeValue & {
-            attributeDefinition: SelectAttributeDefinition;
-        })[];
-        entityType: SelectEntityType & {
-            attributeDefinitions: SelectAttributeDefinition[];
-        };
-    },
-) {
+    entity: EntityWithAttributesAndDefinitions,
+): EntityWithAttributesAndDefinitions {
     // Create missing attributes that have default value based on entity type definitions
     for (const definition of entity.entityType.attributeDefinitions) {
         const hasAtleastOneAttributeValue = entity.attributes.some(
@@ -201,7 +201,9 @@ export async function getEntitiesRaw(entityTypeName: string, state?: string) {
         },
     });
 
-    return Promise.all(rawEntities.map((entity) => buildEffectiveEntity(entity)));
+    return Promise.all(
+        rawEntities.map((entity) => buildEffectiveEntity(entity)),
+    );
 }
 
 export async function getEntitiesCount(entityTypeName: string, state?: string) {
@@ -225,9 +227,7 @@ export async function getEntitiesCount(entityTypeName: string, state?: string) {
 
 // Add a type for the cache, ensuring attributes and entityType are included
 interface EntityWithAttributesAndType extends SelectEntity {
-    attributes: (SelectAttributeValue & {
-        attributeDefinition: SelectAttributeDefinition;
-    })[];
+    attributes: EntityAttribute[];
     entityType: SelectEntityType;
 }
 interface EntityTypeCache {

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -64,6 +64,67 @@ function parseEntityRefId(value: string | null | undefined) {
     return Number.parseInt(trimmedValue, 10);
 }
 
+
+async function buildEffectiveEntity(
+    entity: SelectEntity & {
+        attributes: (SelectAttributeValue & {
+            attributeDefinition: SelectAttributeDefinition;
+        })[];
+        entityType: SelectEntityType & {
+            attributeDefinitions: SelectAttributeDefinition[];
+        };
+    },
+    visited = new Set<number>(),
+) {
+    if (visited.has(entity.id)) {
+        throw new Error('Cycle detected in entity hierarchy.');
+    }
+    visited.add(entity.id);
+
+    if (!entity.parentId) {
+        return populateMissingAttributes(entity);
+    }
+
+    const parent = await storage().query.entities.findFirst({
+        where: and(eq(entities.id, entity.parentId), eq(entities.isDeleted, false)),
+        with: {
+            attributes: {
+                where: eq(attributeValues.isDeleted, false),
+                with: {
+                    attributeDefinition: true,
+                },
+            },
+            entityType: {
+                with: {
+                    attributeDefinitions: {
+                        where: eq(attributeDefinitions.isDeleted, false),
+                    },
+                },
+            },
+        },
+    });
+
+    if (!parent || parent.entityTypeName !== entity.entityTypeName) {
+        return populateMissingAttributes(entity);
+    }
+
+    const parentEffective = await buildEffectiveEntity(parent, visited);
+    const childByDefinitionId = new Map(
+        entity.attributes.map((attribute) => [
+            attribute.attributeDefinitionId,
+            attribute,
+        ]),
+    );
+
+    const inheritedAttributes = parentEffective.attributes.filter(
+        (attribute) => !childByDefinitionId.has(attribute.attributeDefinitionId),
+    );
+
+    return populateMissingAttributes({
+        ...entity,
+        attributes: [...entity.attributes, ...inheritedAttributes],
+    });
+}
 function populateMissingAttributes(
     entity: SelectEntity & {
         attributes: (SelectAttributeValue & {
@@ -140,7 +201,7 @@ export async function getEntitiesRaw(entityTypeName: string, state?: string) {
         },
     });
 
-    return rawEntities.map(populateMissingAttributes);
+    return Promise.all(rawEntities.map((entity) => buildEffectiveEntity(entity)));
 }
 
 export async function getEntitiesCount(entityTypeName: string, state?: string) {

--- a/packages/storage/tests/entitiesRepo.node.spec.ts
+++ b/packages/storage/tests/entitiesRepo.node.spec.ts
@@ -4,8 +4,10 @@ import test from 'node:test';
 import {
     createAttributeDefinition,
     createEntity,
+    deleteAttributeValue,
     getEntitiesFormatted,
     getEntityIncomingLinks,
+    getEntityRaw,
     updateEntity,
     upsertAttributeValue,
     upsertEntityType,
@@ -22,6 +24,7 @@ type FormattedSort = {
                 name?: string;
             };
         };
+        description?: string;
     };
 };
 
@@ -31,111 +34,72 @@ test('CMS entity references are resolved by entity ID', async () => {
     const plantTypeName = `ref-plant-${suffix}`;
     const sortTypeName = `ref-sort-${suffix}`;
 
-    await upsertEntityType({
-        name: plantTypeName,
-        label: `Reference Plant ${suffix}`,
-    });
-    await upsertEntityType({
-        name: sortTypeName,
-        label: `Reference Sort ${suffix}`,
-    });
+    await upsertEntityType({ name: plantTypeName, label: `Reference Plant ${suffix}` });
+    await upsertEntityType({ name: sortTypeName, label: `Reference Sort ${suffix}` });
 
-    const plantNameDefinitionId = await createAttributeDefinition({
-        category: 'information',
-        name: 'name',
-        label: 'Name',
-        entityTypeName: plantTypeName,
-        dataType: 'text',
-    });
-    const sortNameDefinitionId = await createAttributeDefinition({
-        category: 'information',
-        name: 'name',
-        label: 'Name',
-        entityTypeName: sortTypeName,
-        dataType: 'text',
-    });
-    const sortPlantDefinitionId = await createAttributeDefinition({
-        category: 'information',
-        name: 'plant',
-        label: 'Plant',
-        entityTypeName: sortTypeName,
-        dataType: `ref:${plantTypeName}`,
-    });
+    const plantNameDefinitionId = await createAttributeDefinition({ category: 'information', name: 'name', label: 'Name', entityTypeName: plantTypeName, dataType: 'text' });
+    const sortNameDefinitionId = await createAttributeDefinition({ category: 'information', name: 'name', label: 'Name', entityTypeName: sortTypeName, dataType: 'text' });
+    const sortPlantDefinitionId = await createAttributeDefinition({ category: 'information', name: 'plant', label: 'Plant', entityTypeName: sortTypeName, dataType: `ref:${plantTypeName}` });
 
     const plantId = await createEntity(plantTypeName);
-    await updateEntity({
-        id: plantId,
-        entityTypeName: plantTypeName,
-        state: 'published',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: plantNameDefinitionId,
-        entityTypeName: plantTypeName,
-        entityId: plantId,
-        value: 'Tomato',
-    });
+    await updateEntity({ id: plantId, entityTypeName: plantTypeName, state: 'published' });
+    await upsertAttributeValue({ attributeDefinitionId: plantNameDefinitionId, entityTypeName: plantTypeName, entityId: plantId, value: 'Tomato' });
 
     const sortId = await createEntity(sortTypeName);
-    await updateEntity({
-        id: sortId,
-        entityTypeName: sortTypeName,
-        state: 'published',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: sortNameDefinitionId,
-        entityTypeName: sortTypeName,
-        entityId: sortId,
-        value: 'Cherry Tomato',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: sortPlantDefinitionId,
-        entityTypeName: sortTypeName,
-        entityId: sortId,
-        value: String(plantId),
-    });
+    await updateEntity({ id: sortId, entityTypeName: sortTypeName, state: 'published' });
+    await upsertAttributeValue({ attributeDefinitionId: sortNameDefinitionId, entityTypeName: sortTypeName, entityId: sortId, value: 'Cherry Tomato' });
+    await upsertAttributeValue({ attributeDefinitionId: sortPlantDefinitionId, entityTypeName: sortTypeName, entityId: sortId, value: String(plantId) });
 
     const nameValueSortId = await createEntity(sortTypeName);
-    await updateEntity({
-        id: nameValueSortId,
-        entityTypeName: sortTypeName,
-        state: 'published',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: sortNameDefinitionId,
-        entityTypeName: sortTypeName,
-        entityId: nameValueSortId,
-        value: 'Name Value Tomato',
-    });
-    await upsertAttributeValue({
-        attributeDefinitionId: sortPlantDefinitionId,
-        entityTypeName: sortTypeName,
-        entityId: nameValueSortId,
-        value: 'Tomato',
-    });
+    await updateEntity({ id: nameValueSortId, entityTypeName: sortTypeName, state: 'published' });
+    await upsertAttributeValue({ attributeDefinitionId: sortNameDefinitionId, entityTypeName: sortTypeName, entityId: nameValueSortId, value: 'Name Value Tomato' });
+    await upsertAttributeValue({ attributeDefinitionId: sortPlantDefinitionId, entityTypeName: sortTypeName, entityId: nameValueSortId, value: 'Tomato' });
 
-    const formattedSorts =
-        await getEntitiesFormatted<FormattedSort>(sortTypeName);
+    const formattedSorts = await getEntitiesFormatted<FormattedSort>(sortTypeName);
     const formattedSort = formattedSorts.find((sort) => sort.id === sortId);
-    const nameValueSort = formattedSorts.find(
-        (sort) => sort.id === nameValueSortId,
-    );
+    const nameValueSort = formattedSorts.find((sort) => sort.id === nameValueSortId);
 
     assert.equal(formattedSort?.information.plant?.id, plantId);
     assert.equal(formattedSort?.information.plant?.information?.name, 'Tomato');
     assert.equal(nameValueSort?.information.plant, null);
 
     const incomingLinks = await getEntityIncomingLinks(plantId);
-    assert.deepEqual(incomingLinks, [
-        {
-            entityTypeName: sortTypeName,
-            entityTypeLabel: `Reference Sort ${suffix}`,
-            entities: [
-                {
-                    id: sortId,
-                    displayName: 'Cherry Tomato',
-                    linkedBy: [{ name: 'plant', label: 'Plant' }],
-                },
-            ],
-        },
-    ]);
+    assert.deepEqual(incomingLinks, [{ entityTypeName: sortTypeName, entityTypeLabel: `Reference Sort ${suffix}`, entities: [{ id: sortId, displayName: 'Cherry Tomato', linkedBy: [{ name: 'plant', label: 'Plant' }] }] }]);
+});
+
+test('CMS entity variants inherit parent attributes and allow override reset', async () => {
+    createTestDb();
+    const suffix = randomUUID();
+    const typeName = `variant-sort-${suffix}`;
+
+    await upsertEntityType({ name: typeName, label: `Variant Sort ${suffix}` });
+
+    const nameDefinitionId = await createAttributeDefinition({ category: 'information', name: 'name', label: 'Name', entityTypeName: typeName, dataType: 'text' });
+    const descriptionDefinitionId = await createAttributeDefinition({ category: 'information', name: 'description', label: 'Description', entityTypeName: typeName, dataType: 'text' });
+
+    const baseEntityId = await createEntity(typeName);
+    await upsertAttributeValue({ attributeDefinitionId: nameDefinitionId, entityTypeName: typeName, entityId: baseEntityId, value: 'Base name' });
+    await upsertAttributeValue({ attributeDefinitionId: descriptionDefinitionId, entityTypeName: typeName, entityId: baseEntityId, value: 'Base description' });
+    await updateEntity({ id: baseEntityId, state: 'published' });
+
+    const variantEntityId = await createEntity(typeName);
+    await updateEntity({ id: variantEntityId, parentId: baseEntityId });
+    await upsertAttributeValue({ attributeDefinitionId: nameDefinitionId, entityTypeName: typeName, entityId: variantEntityId, value: 'Variant name' });
+    await updateEntity({ id: variantEntityId, state: 'published' });
+
+    let formattedEntities = await getEntitiesFormatted<FormattedSort>(typeName);
+    let variant = formattedEntities.find((entity) => entity.id === variantEntityId);
+    assert.equal(variant?.information.name, 'Variant name');
+    assert.equal(variant?.information.description, 'Base description');
+
+    const variantRaw = await getEntityRaw(variantEntityId);
+    const variantNameAttribute = variantRaw?.attributes.find((attribute) => attribute.attributeDefinitionId === nameDefinitionId);
+    assert.ok(variantNameAttribute);
+
+    await deleteAttributeValue(variantNameAttribute.id);
+
+    formattedEntities = await getEntitiesFormatted<FormattedSort>(typeName);
+    variant = formattedEntities.find((entity) => entity.id === variantEntityId);
+    assert.equal(variant?.information.name, 'Base name');
+    assert.equal(variant?.information.description, 'Base description');
 });


### PR DESCRIPTION
### Motivation
- Allow entities to act as variants of other entities by inheriting missing attribute values from a parent while preserving child overrides and preventing cycles.

### Description
- Added `buildEffectiveEntity` in `packages/storage/src/repositories/entitiesRepo.ts` to resolve effective attributes by walking the `parentId` chain, inheriting missing attributes and preserving override attributes from children.
- Integrated the inheritance step into raw loaders by returning effective entities from `getEntitiesRaw` and `getEntityRaw` so formatted/public output includes inherited values without changing its shape.
- Preserved cycle detection during traversal and only inherit from parents with the same `entityTypeName`.
- Added a node test `packages/storage/tests/entitiesRepo.node.spec.ts` that verifies inheritance, override precedence, and reset-on-delete behavior.

### Testing
- Ran `pnpm --filter @gredice/storage test -- entitiesRepo.node.spec.ts` which executed the reference-resolution and variant-inheritance tests and completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe94cb16e0832fbc3087286c5f498e)