### PR TITLE
[Search] Preserve header search focus while typing

### DIFF
--- a/apps/www/components/shared/PageFilterInput.tsx
+++ b/apps/www/components/shared/PageFilterInput.tsx
@@ -5,7 +5,7 @@ import { Close, Search } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
-import type { HTMLAttributes } from 'react';
+import type { ChangeEvent, HTMLAttributes } from 'react';
 import { useEffect, useState } from 'react';
 
 export type PageFilterInputProps = HTMLAttributes<HTMLFormElement> & {
@@ -30,25 +30,22 @@ export function PageFilterInput({
         setSearch(value);
     };
 
-    const handleSubmit = (formData: FormData) => {
-        const nextSearch = formData.get(fieldName);
-        if (typeof nextSearch === 'string') {
-            setSearch(nextSearch);
-        }
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        updateSearch(event.target.value);
     };
 
     return (
-        <form action={handleSubmit} {...rest}>
+        <form {...rest}>
             <Input
                 name={fieldName}
                 value={localSearch}
-                onChange={(event) => setLocalSearch(event.target.value)}
+                onChange={handleChange}
                 placeholder="Pretraži..."
                 startDecorator={
                     <IconButton
                         className="hover:bg-neutral-300 ml-1 rounded-full aspect-square"
                         title="Pretraga"
-                        type="submit"
+                        type="button"
                         size="sm"
                         variant="plain"
                     >

--- a/packages/ui/src/ExpandableSearchInput/ExpandableSearchInput.tsx
+++ b/packages/ui/src/ExpandableSearchInput/ExpandableSearchInput.tsx
@@ -21,7 +21,7 @@ export function ExpandableSearchInput({
     className,
     inputClassName,
 }: ExpandableSearchInputProps) {
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(Boolean(value));
     const rootRef = useRef<HTMLDivElement>(null);
     const desktopInputRef = useRef<HTMLInputElement>(null);
     const mobileInputRef = useRef<HTMLInputElement>(null);
@@ -31,6 +31,12 @@ export function ExpandableSearchInput({
             mobileInputRef.current?.focus();
         }
     }, [isExpanded]);
+
+    useEffect(() => {
+        if (value) {
+            setIsExpanded(true);
+        }
+    }, [value]);
 
     useEffect(() => {
         const handlePointerDown = (event: PointerEvent) => {
@@ -61,7 +67,7 @@ export function ExpandableSearchInput({
                 <IconButton
                     variant="plain"
                     title="Pretraži"
-                    onClick={() => setIsExpanded((open) => !open)}
+                    onClick={() => setIsExpanded(true)}
                 >
                     <Search className="size-5" />
                 </IconButton>


### PR DESCRIPTION
### Motivation
- Header search inputs on `apps/www` and the mobile collapsed search in `apps/app` were losing keyboard focus after keypresses, preventing continuous typing and hiding the first-typed character in mobile mode. 
- The visible query could go out of sync with the URL-backed search state because updates relied on form submits rather than immediate sync. 
- Fixing this preserves expected UX for refining searches from page headers across desktop and mobile.

### Description
- Update `apps/www/components/shared/PageFilterInput.tsx` to sync search on every keystroke by wiring the input `onChange` to update both local state and the URL-backed search param instead of depending on form submission. 
- Remove the form `action` handler and change the search icon button to `type="button"` to avoid unintended form submits while typing. 
- Update `packages/ui/src/ExpandableSearchInput/ExpandableSearchInput.tsx` to initialize and keep the mobile search expanded when a `value` exists, add an effect to expand when `value` changes, and make the mobile search icon consistently open the input. 
- Preserve the existing outside-click-to-close behavior and ensure the mobile input gets focused when expanded.

### Testing
- Ran `pnpm lint --filter www --filter app`, which completed successfully but reported a local Node engine warning because the environment is on Node v22 while the repo expects `>=24`. 
- Ran `pnpm --filter www exec biome check components/shared/PageFilterInput.tsx`, which passed with no fixes required. 
- Ran `pnpm --filter @gredice/ui exec biome check src/ExpandableSearchInput/ExpandableSearchInput.tsx`, which passed with no fixes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe941cb670832f8a4a362dafc8508a)