### PR TITLE
feat(cms): shared section manifest + PageHeader support

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { SelectCmsPage } from '@gredice/storage';
+import { cmsPageSectionComponents } from '@gredice/storage/cmsPageSections';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Input } from '@signalco/ui-primitives/Input';
@@ -38,12 +39,10 @@ const cmsPageStateItems = [
     },
 ];
 
-const cmsPageSectionItems = [
-    { value: 'Heading1', label: 'Heading1' },
-    { value: 'Feature1', label: 'Feature1' },
-    { value: 'Faq1', label: 'Faq1' },
-    { value: 'Footer1', label: 'Footer1' },
-];
+const cmsPageSectionItems = cmsPageSectionComponents.map((component) => ({
+    value: component.component,
+    label: component.label,
+}));
 
 function parseSections(content?: string | null) {
     if (!content) {
@@ -304,75 +303,58 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                             </Button>
                                                         </Row>
                                                     </Row>
-                                                    <Input
-                                                        label="Naslov"
-                                                        value={sectionValue(
-                                                            section,
-                                                            'header',
-                                                        )}
-                                                        onChange={(event) => {
-                                                            const value =
-                                                                event.target
-                                                                    .value;
-                                                            setSections(
-                                                                (current) =>
-                                                                    current.map(
-                                                                        (
-                                                                            currentSection,
-                                                                        ) =>
-                                                                            currentSection.id ===
-                                                                            section.id
-                                                                                ? {
-                                                                                      ...currentSection,
-                                                                                      data: {
-                                                                                          ...currentSection.data,
-                                                                                          header: value,
-                                                                                      },
-                                                                                  }
-                                                                                : currentSection,
-                                                                    ),
-                                                            );
-                                                        }}
-                                                    />
-                                                    <label className="space-y-1">
-                                                        <span className="block text-sm font-medium">
-                                                            Opis
-                                                        </span>
-                                                        <textarea
-                                                            value={sectionValue(
-                                                                section,
-                                                                'description',
-                                                            )}
-                                                            rows={4}
-                                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                            onChange={(
-                                                                event,
-                                                            ) => {
-                                                                const value =
-                                                                    event.target
-                                                                        .value;
-                                                                setSections(
-                                                                    (current) =>
-                                                                        current.map(
-                                                                            (
-                                                                                currentSection,
-                                                                            ) =>
-                                                                                currentSection.id ===
-                                                                                section.id
+                                                    {(cmsPageSectionComponents.find((component) => component.component === section.data.component)?.fields ?? []).map((field) =>
+                                                        field.type === 'textarea' ? (
+                                                            <label key={field.key} className="space-y-1">
+                                                                <span className="block text-sm font-medium">
+                                                                    {field.label}
+                                                                </span>
+                                                                <textarea
+                                                                    value={sectionValue(section, field.key)}
+                                                                    rows={field.rows ?? 4}
+                                                                    className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                    onChange={(event) => {
+                                                                        const value = event.target.value;
+                                                                        setSections((current) =>
+                                                                            current.map((currentSection) =>
+                                                                                currentSection.id === section.id
                                                                                     ? {
                                                                                           ...currentSection,
                                                                                           data: {
                                                                                               ...currentSection.data,
-                                                                                              description:
-                                                                                                  value,
+                                                                                              [field.key]: value,
                                                                                           },
                                                                                       }
                                                                                     : currentSection,
+                                                                            ),
+                                                                        );
+                                                                    }}
+                                                                />
+                                                            </label>
+                                                        ) : (
+                                                            <Input
+                                                                key={field.key}
+                                                                label={field.label}
+                                                                value={sectionValue(section, field.key)}
+                                                                onChange={(event) => {
+                                                                    const value = event.target.value;
+                                                                    setSections((current) =>
+                                                                        current.map((currentSection) =>
+                                                                            currentSection.id === section.id
+                                                                                ? {
+                                                                                      ...currentSection,
+                                                                                      data: {
+                                                                                          ...currentSection.data,
+                                                                                          [field.key]: value,
+                                                                                      },
+                                                                                  }
+                                                                                : currentSection,
                                                                         ),
-                                                                );
-                                                            }}
-                                                        />
-                                                    </label>
+                                                                    );
+                                                                }}
+                                                            />
+                                                        ),
+                                                    )}
                                                 </Stack>
                                             </Card>
                                         ))}

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -163,7 +163,8 @@ function copySection(
 
 function validateSection(section: CmsPageEditableSection) {
     const fields =
-        cmsPageSectionComponentsByName.get(section.data.component)?.fields ?? [];
+        cmsPageSectionComponentsByName.get(section.data.component)?.fields ??
+        [];
     return fields
         .filter((field) => field.required)
         .filter((field) => {
@@ -393,7 +394,9 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                                 className="space-y-1"
                                                             >
                                                                 <span className="block text-sm font-medium">
-                                                                    {field.label}
+                                                                    {
+                                                                        field.label
+                                                                    }
                                                                 </span>
                                                                 <textarea
                                                                     value={sectionValue(

--- a/apps/app/components/shared/PageHeader.tsx
+++ b/apps/app/components/shared/PageHeader.tsx
@@ -1,0 +1,77 @@
+import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
+import { cx } from '@signalco/ui-primitives/cx';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+export type PageHeaderProps = {
+    padded?: boolean;
+    visual?: ReactNode;
+    header: string;
+    alternativeName?: ReactNode | string | null;
+    subHeader?: string | null;
+    headerChildren?: ReactNode;
+};
+
+export function PageHeader({
+    children,
+    padded,
+    visual,
+    header,
+    alternativeName,
+    subHeader,
+    headerChildren,
+}: PropsWithChildren<PageHeaderProps>) {
+    const hasVisual = Boolean(visual);
+    const hasChildren = Boolean(children);
+    return (
+        <div
+            className={cx(
+                'grid grid-cols-1 justify-between gap-4',
+                'md:grid-cols-3',
+                hasChildren && hasVisual && 'md:grid-cols-2',
+                !hasChildren && hasVisual && 'md:grid-cols-1',
+                padded && 'py-12 md:py-24',
+            )}
+        >
+            <div
+                className={cx(
+                    'flex flex-col md:flex-row gap-4',
+                    !visual && 'md:col-span-2',
+                )}
+            >
+                {visual && (
+                    <Card className="min-w-48 min-h-48 border-tertiary border-b-4 rounded-none md:rounded-lg -mx-4 md:mx-0 md:size-48 overflow-hidden">
+                        <CardOverflow className="flex justify-center">
+                            {visual}
+                        </CardOverflow>
+                    </Card>
+                )}
+                <Stack spacing={2} className="md:max-w-96">
+                    <Typography level="h2" component="h1">
+                        {header}
+                    </Typography>
+                    {alternativeName &&
+                        (typeof alternativeName === 'string' ? (
+                            <Typography level="body2" secondary>
+                                {alternativeName}
+                            </Typography>
+                        ) : (
+                            alternativeName
+                        ))}
+                    {subHeader && (
+                        <Typography
+                            level="body1"
+                            secondary
+                            className="text-pretty sm:text-balance"
+                        >
+                            {subHeader}
+                        </Typography>
+                    )}
+                    {headerChildren}
+                </Stack>
+            </div>
+            {children}
+        </div>
+    );
+}

--- a/apps/app/components/shared/PageHeaderSection.tsx
+++ b/apps/app/components/shared/PageHeaderSection.tsx
@@ -1,12 +1,11 @@
-import { PageHeader, type PageHeaderProps } from './PageHeader';
+import type { SectionData } from '@signalco/cms-core/SectionData';
+import { PageHeader } from './PageHeader';
 
-type PageHeaderSectionProps = Omit<PageHeaderProps, 'subHeader'> & {
-    description?: string | null;
-};
-
-export function PageHeaderSection({
-    description,
-    ...props
-}: PageHeaderSectionProps) {
-    return <PageHeader {...props} subHeader={description} />;
+export function PageHeaderSection({ header, description }: SectionData) {
+    return (
+        <PageHeader
+            header={typeof header === 'string' ? header : ''}
+            subHeader={typeof description === 'string' ? description : null}
+        />
+    );
 }

--- a/apps/app/components/shared/sectionsComponentRegistry.ts
+++ b/apps/app/components/shared/sectionsComponentRegistry.ts
@@ -3,10 +3,12 @@ import { Feature1 } from '@signalco/cms-components-marketing/Feature';
 import { Footer1 } from '@signalco/cms-components-marketing/Footer';
 import { Heading1 } from '@signalco/cms-components-marketing/Heading';
 import { memo } from 'react';
+import { PageHeader } from './PageHeader';
 
 export const sectionsComponentRegistry = {
     Heading1: memo(Heading1),
     Faq1: memo(Faq1),
     Feature1: memo(Feature1),
     Footer1: memo(Footer1),
+    PageHeader: memo(PageHeader),
 };

--- a/apps/www/components/shared/PageHeaderSection.tsx
+++ b/apps/www/components/shared/PageHeaderSection.tsx
@@ -1,12 +1,11 @@
-import { PageHeader, type PageHeaderProps } from './PageHeader';
+import type { SectionData } from '@signalco/cms-core/SectionData';
+import { PageHeader } from './PageHeader';
 
-type PageHeaderSectionProps = Omit<PageHeaderProps, 'subHeader'> & {
-    description?: string | null;
-};
-
-export function PageHeaderSection({
-    description,
-    ...props
-}: PageHeaderSectionProps) {
-    return <PageHeader {...props} subHeader={description} />;
+export function PageHeaderSection({ header, description }: SectionData) {
+    return (
+        <PageHeader
+            header={typeof header === 'string' ? header : ''}
+            subHeader={typeof description === 'string' ? description : null}
+        />
+    );
 }

--- a/apps/www/components/shared/sectionsComponentRegistry.ts
+++ b/apps/www/components/shared/sectionsComponentRegistry.ts
@@ -3,10 +3,12 @@ import { Feature1 } from '@signalco/cms-components-marketing/Feature';
 import { Footer1 } from '@signalco/cms-components-marketing/Footer';
 import { Heading1 } from '@signalco/cms-components-marketing/Heading';
 import { memo } from 'react';
+import { PageHeader } from './PageHeader';
 
 export const sectionsComponentRegistry = {
     Heading1: memo(Heading1),
     Faq1: memo(Faq1),
     Feature1: memo(Feature1),
     Footer1: memo(Footer1),
+    PageHeader: memo(PageHeader),
 };

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,7 +8,8 @@
     "exports": {
         ".": "./src/index.ts",
         "./entityCompleteness": "./src/helpers/entityCompleteness.ts",
-        "./entityPageSections": "./src/helpers/entityPageSections.ts"
+        "./entityPageSections": "./src/helpers/entityPageSections.ts",
+        "./cmsPageSections": "./src/cmsPageSections.ts"
     },
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",

--- a/packages/storage/src/cmsPageSections.ts
+++ b/packages/storage/src/cmsPageSections.ts
@@ -1,0 +1,63 @@
+export type CmsPageSectionComponent = {
+    component: string;
+    label: string;
+    fields: Array<{
+        key: string;
+        label: string;
+        type: 'text' | 'textarea';
+        rows?: number;
+    }>;
+    isCustom?: boolean;
+};
+
+export const cmsPageSectionComponents = [
+    {
+        component: 'Heading1',
+        label: 'Heading1',
+        fields: [
+            { key: 'header', label: 'Naslov', type: 'text' },
+            { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+        ],
+    },
+    {
+        component: 'Feature1',
+        label: 'Feature1',
+        fields: [
+            { key: 'header', label: 'Naslov', type: 'text' },
+            { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+        ],
+    },
+    {
+        component: 'Faq1',
+        label: 'Faq1',
+        fields: [
+            { key: 'header', label: 'Naslov', type: 'text' },
+            { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+        ],
+    },
+    {
+        component: 'Footer1',
+        label: 'Footer1',
+        fields: [
+            { key: 'header', label: 'Naslov', type: 'text' },
+            { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+        ],
+    },
+    {
+        component: 'PageHeader',
+        label: 'Page header',
+        isCustom: true,
+        fields: [
+            { key: 'header', label: 'Naslov', type: 'text' },
+            { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+        ],
+    },
+] satisfies CmsPageSectionComponent[];
+
+export const supportedCmsPageSectionComponents = new Set(
+    cmsPageSectionComponents.map((section) => section.component),
+);
+
+export function getCmsPageSectionComponent(component: string) {
+    return cmsPageSectionComponents.find((item) => item.component === component);
+}

--- a/packages/storage/src/cmsPageSections.ts
+++ b/packages/storage/src/cmsPageSections.ts
@@ -78,5 +78,7 @@ export const supportedCmsPageSectionComponents = new Set(
 );
 
 export function getCmsPageSectionComponent(component: string) {
-    return cmsPageSectionComponents.find((item) => item.component === component);
+    return cmsPageSectionComponents.find(
+        (item) => item.component === component,
+    );
 }

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -14,6 +14,7 @@ import {
     cacheKeys,
     directoriesCached,
 } from '../cache/directoriesCached';
+import { supportedCmsPageSectionComponents } from '../cmsPageSections';
 
 export type CmsPageState = 'draft' | 'published';
 
@@ -38,13 +39,6 @@ export type GetCmsPagesOptions = {
     state?: CmsPageState;
     includeDeleted?: boolean;
 };
-
-const supportedCmsPageSectionComponents = new Set([
-    'Heading1',
-    'Faq1',
-    'Feature1',
-    'Footer1',
-]);
 
 export function isCmsPageState(value: string): value is CmsPageState {
     return value === 'draft' || value === 'published';


### PR DESCRIPTION
### Motivation
- Consolidate the list of supported CMS page section components and their editor metadata into a single manifest so storage validation, the admin builder, and public rendering use the same source of truth.
- Enable project-specific custom components (e.g. `PageHeader`) to be selectable and previewable in the admin builder and renderable on public pages.

### Description
- Added a shared manifest at `packages/storage/src/cmsPageSections.ts` and exposed it as `@gredice/storage/cmsPageSections` to declare supported `component` ids and editor `fields` in one place.
- Switched storage validation in `packages/storage/src/repositories/cmsPagesRepo.ts` to use the shared `supportedCmsPageSectionComponents` set instead of a local hardcoded list.
- Updated the admin page editor `apps/app/app/admin/cms/pages/CmsPageForm.tsx` to source addable section options from `cmsPageSectionComponents` and to render per-component editor fields dynamically from the manifest.
- Registered the custom `PageHeader` component in both section registries (`apps/www/components/shared/sectionsComponentRegistry.ts` and `apps/app/components/shared/sectionsComponentRegistry.ts`) and added `apps/app/components/shared/PageHeader.tsx` so admin previews and app-side rendering use the same component.

### Testing
- Ran storage package tests with `pnpm -s test --filter @gredice/storage` and the test suite passed (`126` tests, all passing).
- An earlier invocation `pnpm -s test --filter @gredice/storage -- --runInBand` failed because the extra `--runInBand` argument was interpreted as a test file path by the package test wrapper, not due to repository changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe94a5316c832f9d65e9f1aed12530)