### PR TITLE
[Weather] Add snow accumulation debug presets for block coverage QA

### DIFF
--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -768,7 +768,7 @@ export function DebugHud() {
                                         }
                                     }}
                                 />
-                                <div className="flex flex-wrap gap-1">
+                                <div className="flex flex-wrap gap-2">
                                     {SNOW_ACCUMULATION_PRESETS.map((preset) => (
                                         <Button
                                             key={preset.label}

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -3,6 +3,7 @@
 import { DebugPanel, DebugPanelSection } from '@gredice/ui/DebugControls';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Slider } from '@signalco/ui-primitives/Slider';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
@@ -768,7 +769,7 @@ export function DebugHud() {
                                         }
                                     }}
                                 />
-                                <div className="flex flex-wrap gap-2">
+                                <Row spacing={1} className="flex-wrap">
                                     {SNOW_ACCUMULATION_PRESETS.map((preset) => (
                                         <Button
                                             key={preset.label}
@@ -789,7 +790,7 @@ export function DebugHud() {
                                             {preset.label}
                                         </Button>
                                     ))}
-                                </div>
+                                </Row>
                             </Stack>
                         </DebugPanelSection>
                     </Stack>

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DebugPanel, DebugPanelSection } from '@gredice/ui/DebugControls';
+import { Button } from '@signalco/ui-primitives/Button';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Slider } from '@signalco/ui-primitives/Slider';
 import { Stack } from '@signalco/ui-primitives/Stack';
@@ -155,6 +156,13 @@ function useProfileHudSnapshot() {
 
     return snapshot;
 }
+
+const SNOW_ACCUMULATION_PRESETS = [
+    { label: '0 cm', value: 0 },
+    { label: 'Light 5 cm', value: 5 },
+    { label: 'Medium 15 cm', value: 15 },
+    { label: 'Heavy 30 cm', value: 30 },
+] as const;
 
 const PANEL_MARGIN_PX = 16;
 const PANEL_STORAGE_KEY = 'gredice.debugPanel.position';
@@ -760,6 +768,28 @@ export function DebugHud() {
                                         }
                                     }}
                                 />
+                                <Stack direction="row" spacing={1} wrap>
+                                    {SNOW_ACCUMULATION_PRESETS.map((preset) => (
+                                        <Button
+                                            key={preset.label}
+                                            size="sm"
+                                            disabled={weatherControlsDisabled}
+                                            onClick={() =>
+                                                setSnowAccumulation(
+                                                    preset.value,
+                                                )
+                                            }
+                                            variant={
+                                                snowAccumulation ===
+                                                preset.value
+                                                    ? 'solid'
+                                                    : 'outlined'
+                                            }
+                                        >
+                                            {preset.label}
+                                        </Button>
+                                    ))}
+                                </Stack>
                             </Stack>
                         </DebugPanelSection>
                     </Stack>

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -768,7 +768,7 @@ export function DebugHud() {
                                         }
                                     }}
                                 />
-                                <Stack direction="row" spacing={1} wrap>
+                                <div className="flex flex-wrap gap-1">
                                     {SNOW_ACCUMULATION_PRESETS.map((preset) => (
                                         <Button
                                             key={preset.label}
@@ -789,7 +789,7 @@ export function DebugHud() {
                                             {preset.label}
                                         </Button>
                                     ))}
-                                </Stack>
+                                </div>
                             </Stack>
                         </DebugPanelSection>
                     </Stack>


### PR DESCRIPTION
### Motivation
- Provide quick, reproducible debug controls for GRE-301 so QA can validate progressive snow coverage and melt behavior without manually dragging sliders.

### Description
- Add `SNOW_ACCUMULATION_PRESETS` and a row of preset `Button`s (0, 5, 15, 30 cm) to `packages/game/src/hud/DebugHud.tsx` wired to the existing `setSnowAccumulation` override state.
- Import `Button` from `@signalco/ui-primitives/Button` and keep the original accumulation `Slider` so both controls remain consistent.
- Preserve existing behavior and only modify debug tooling/UI; no gameplay or snow shader logic was changed.

### Testing
- Ran the package lint command with `pnpm lint src/hud/DebugHud.tsx` from `packages/game`, which completed and fixed one file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9af270c4832f97d4638d08ef2495)