### PR TITLE
feat(app): support section duplication and validation in CMS page builder

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -45,6 +45,31 @@ const cmsPageSectionItems = [
     { value: 'Footer1', label: 'Footer1' },
 ];
 
+type SectionFieldRule = {
+    key: string;
+    label: string;
+    required?: boolean;
+};
+
+const sectionFieldRules: Record<string, SectionFieldRule[]> = {
+    Heading1: [
+        { key: 'header', label: 'Naslov', required: true },
+        { key: 'description', label: 'Opis', required: true },
+    ],
+    Feature1: [
+        { key: 'header', label: 'Naslov', required: true },
+        { key: 'description', label: 'Opis', required: true },
+    ],
+    Faq1: [
+        { key: 'header', label: 'Naslov', required: true },
+        { key: 'description', label: 'Opis', required: true },
+    ],
+    Footer1: [
+        { key: 'header', label: 'Naslov' },
+        { key: 'description', label: 'Opis' },
+    ],
+};
+
 function parseSections(content?: string | null) {
     if (!content) {
         return { isStructured: true, sections: [] };
@@ -143,6 +168,27 @@ function moveSection(
 
     next.splice(targetIndex, 0, movingSection);
     return next;
+}
+
+function copySection(
+    section: CmsPageEditableSection,
+    id: string,
+): CmsPageEditableSection {
+    return {
+        id,
+        data: JSON.parse(JSON.stringify(section.data)) as CmsPageSectionData,
+    };
+}
+
+function validateSection(section: CmsPageEditableSection) {
+    const rules = sectionFieldRules[section.data.component] ?? [];
+    return rules
+        .filter((rule) => rule.required)
+        .filter((rule) => {
+            const value = section.data[rule.key];
+            return !(typeof value === 'string' && value.trim().length > 0);
+        })
+        .map((rule) => `${rule.label} je obavezno polje.`);
 }
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
@@ -284,6 +330,54 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                             <Button
                                                                 type="button"
                                                                 variant="plain"
+                                                                onClick={() => {
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) => {
+                                                                            const index =
+                                                                                current.findIndex(
+                                                                                    (
+                                                                                        candidate,
+                                                                                    ) =>
+                                                                                        candidate.id ===
+                                                                                        section.id,
+                                                                                );
+                                                                            if (
+                                                                                index <
+                                                                                0
+                                                                            ) {
+                                                                                return current;
+                                                                            }
+                                                                            const sectionId =
+                                                                                nextSectionId.current;
+                                                                            nextSectionId.current += 1;
+                                                                            const duplicate =
+                                                                                copySection(
+                                                                                    section,
+                                                                                    `${newSectionIdPrefix}-${sectionId}`,
+                                                                                );
+                                                                            return [
+                                                                                ...current.slice(
+                                                                                    0,
+                                                                                    index +
+                                                                                        1,
+                                                                                ),
+                                                                                duplicate,
+                                                                                ...current.slice(
+                                                                                    index +
+                                                                                        1,
+                                                                                ),
+                                                                            ];
+                                                                        },
+                                                                    );
+                                                                }}
+                                                            >
+                                                                Dupliciraj
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
                                                                 color="danger"
                                                                 onClick={() =>
                                                                     setSections(
@@ -304,75 +398,74 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                                                             </Button>
                                                         </Row>
                                                     </Row>
-                                                    <Input
-                                                        label="Naslov"
-                                                        value={sectionValue(
-                                                            section,
-                                                            'header',
-                                                        )}
-                                                        onChange={(event) => {
-                                                            const value =
-                                                                event.target
-                                                                    .value;
-                                                            setSections(
-                                                                (current) =>
-                                                                    current.map(
+                                                    {(
+                                                        sectionFieldRules[
+                                                            section.data
+                                                                .component
+                                                        ] ?? []
+                                                    ).map((field) => (
+                                                        <label
+                                                            key={field.key}
+                                                            className="space-y-1"
+                                                        >
+                                                            <span className="block text-sm font-medium">
+                                                                {field.label}
+                                                            </span>
+                                                            <textarea
+                                                                value={sectionValue(
+                                                                    section,
+                                                                    field.key,
+                                                                )}
+                                                                rows={
+                                                                    field.key ===
+                                                                    'description'
+                                                                        ? 4
+                                                                        : 2
+                                                                }
+                                                                className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                onChange={(
+                                                                    event,
+                                                                ) => {
+                                                                    const value =
+                                                                        event
+                                                                            .target
+                                                                            .value;
+                                                                    setSections(
                                                                         (
-                                                                            currentSection,
+                                                                            current,
                                                                         ) =>
-                                                                            currentSection.id ===
-                                                                            section.id
-                                                                                ? {
-                                                                                      ...currentSection,
-                                                                                      data: {
-                                                                                          ...currentSection.data,
-                                                                                          header: value,
-                                                                                      },
-                                                                                  }
-                                                                                : currentSection,
-                                                                    ),
-                                                            );
-                                                        }}
-                                                    />
-                                                    <label className="space-y-1">
-                                                        <span className="block text-sm font-medium">
-                                                            Opis
-                                                        </span>
-                                                        <textarea
-                                                            value={sectionValue(
-                                                                section,
-                                                                'description',
-                                                            )}
-                                                            rows={4}
-                                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                            onChange={(
-                                                                event,
-                                                            ) => {
-                                                                const value =
-                                                                    event.target
-                                                                        .value;
-                                                                setSections(
-                                                                    (current) =>
-                                                                        current.map(
-                                                                            (
-                                                                                currentSection,
-                                                                            ) =>
-                                                                                currentSection.id ===
-                                                                                section.id
-                                                                                    ? {
-                                                                                          ...currentSection,
-                                                                                          data: {
-                                                                                              ...currentSection.data,
-                                                                                              description:
-                                                                                                  value,
-                                                                                          },
-                                                                                      }
-                                                                                    : currentSection,
-                                                                        ),
-                                                                );
-                                                            }}
-                                                        />
-                                                    </label>
+                                                                            current.map(
+                                                                                (
+                                                                                    currentSection,
+                                                                                ) =>
+                                                                                    currentSection.id ===
+                                                                                    section.id
+                                                                                        ? {
+                                                                                              ...currentSection,
+                                                                                              data: {
+                                                                                                  ...currentSection.data,
+                                                                                                  [field.key]:
+                                                                                                      value,
+                                                                                              },
+                                                                                          }
+                                                                                        : currentSection,
+                                                                            ),
+                                                                    );
+                                                                }}
+                                                            />
+                                                        </label>
+                                                    ))}
+                                                    {validateSection(
+                                                        section,
+                                                    ).map((error) => (
+                                                        <Typography
+                                                            key={error}
+                                                            level="body3"
+                                                            className="text-red-600"
+                                                        >
+                                                            {error}
+                                                        </Typography>
+                                                    ))}
                                                 </Stack>
                                             </Card>
                                         ))}


### PR DESCRIPTION
### Motivation
- Improve the CMS page builder editor UX by making section fields editable via a small per-component schema and surface validation errors inline. 
- Provide a safe duplication action so admins can copy sections without mutating unrelated sections while keeping existing reorder behavior.

### Description
- Added a `SectionFieldRule` type and a `sectionFieldRules` map to define editable fields and required rules for supported components in `apps/app/app/admin/cms/pages/CmsPageForm.tsx`.
- Implemented `copySection` to deep-copy section data and `validateSection` to return localized required-field errors for each section.
- Replaced the hardcoded `header`/`description` inputs with a dynamic field renderer driven by `sectionFieldRules`, and added inline error rendering via `validateSection`.
- Added a `Dupliciraj` (Duplicate) button that inserts a deep-copied section immediately after the original and preserved deterministic serialization and existing up/down reorder controls (`moveSection`, `stringifySections`).

### Testing
- Ran formatting/type check with `pnpm --filter app exec biome check --write app/admin/cms/pages/CmsPageForm.tsx`, which succeeded and auto-fixed the edited file.
- The run emitted a non-blocking engine warning due to the environment Node version being older than the repo `>=24` requirement, but the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9be86554832f81cd121c07e10c20)