### PR TITLE
Fix cron query ordering in delivery ready email polling

### DIFF
--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -1115,7 +1115,7 @@ export async function getPendingDeliveryReadyEmailRequestIds({
         'delivery_ready_email_processed_events',
     );
     const pendingReadyEvents = await storage()
-        .selectDistinct({
+        .select({
             requestId: events.aggregateId,
             readyEventId: events.id,
         })
@@ -1158,7 +1158,7 @@ export async function getPendingDeliveryReadyEmailRequestIds({
                 ),
             ),
         )
-        .orderBy(asc(events.createdAt))
+        .orderBy(asc(events.createdAt), asc(events.id))
         .limit(limit);
 
     if (pendingReadyEvents.length === 0) {

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    DeliveryRequestStates,
+    events,
+    getPendingDeliveryReadyEmailRequestIds,
+    knownEventTypes,
+    storage,
+} from '@gredice/storage';
+import { createTestDb } from './testDb';
+
+async function insertDeliveryReadyEvent(
+    aggregateId: string,
+    createdAt: Date,
+): Promise<number> {
+    const [inserted] = await storage()
+        .insert(events)
+        .values({
+            type: knownEventTypes.delivery.requestReady,
+            version: 1,
+            aggregateId,
+            data: {
+                status: DeliveryRequestStates.READY,
+            },
+            createdAt,
+        })
+        .returning({ id: events.id });
+
+    assert.ok(inserted);
+    return inserted.id;
+}
+
+async function insertDeliveryReadyEmailProcessedEvent({
+    aggregateId,
+    readyEventId,
+    sentTo = [],
+    completed,
+    skipped,
+}: {
+    aggregateId: string;
+    readyEventId: number;
+    sentTo?: string[];
+    completed?: boolean;
+    skipped?: boolean;
+}) {
+    await storage()
+        .insert(events)
+        .values({
+            type: knownEventTypes.delivery.requestReadyEmailProcessed,
+            version: 1,
+            aggregateId,
+            data: {
+                readyEventId,
+                sentTo,
+                batchRequestIds: [aggregateId],
+                completed,
+                skipped,
+            },
+        });
+}
+
+test('getPendingDeliveryReadyEmailRequestIds returns ordered retryable ready events', async () => {
+    createTestDb();
+
+    const prefix = `delivery-ready-email-${randomUUID()}`;
+    const firstRequestId = `${prefix}-first`;
+    const partialRequestId = `${prefix}-partial`;
+    const secondRequestId = `${prefix}-second`;
+    const completedRequestId = `${prefix}-completed`;
+    const skippedRequestId = `${prefix}-skipped`;
+    const futureRequestId = `${prefix}-future`;
+
+    const firstReadyEventId = await insertDeliveryReadyEvent(
+        firstRequestId,
+        new Date('2026-05-09T06:00:00.000Z'),
+    );
+    const completedReadyEventId = await insertDeliveryReadyEvent(
+        completedRequestId,
+        new Date('2026-05-09T06:01:00.000Z'),
+    );
+    const partialReadyEventId = await insertDeliveryReadyEvent(
+        partialRequestId,
+        new Date('2026-05-09T06:02:00.000Z'),
+    );
+    const skippedReadyEventId = await insertDeliveryReadyEvent(
+        skippedRequestId,
+        new Date('2026-05-09T06:03:00.000Z'),
+    );
+    const secondReadyEventId = await insertDeliveryReadyEvent(
+        secondRequestId,
+        new Date('2026-05-09T06:04:00.000Z'),
+    );
+    await insertDeliveryReadyEvent(
+        futureRequestId,
+        new Date('2026-05-09T08:00:00.000Z'),
+    );
+
+    await insertDeliveryReadyEmailProcessedEvent({
+        aggregateId: completedRequestId,
+        readyEventId: completedReadyEventId,
+        sentTo: ['completed@example.com'],
+        completed: true,
+    });
+    await insertDeliveryReadyEmailProcessedEvent({
+        aggregateId: skippedRequestId,
+        readyEventId: skippedReadyEventId,
+        skipped: true,
+    });
+    await insertDeliveryReadyEmailProcessedEvent({
+        aggregateId: partialRequestId,
+        readyEventId: partialReadyEventId,
+        sentTo: ['already-sent@example.com'],
+    });
+
+    const pendingRequests = await getPendingDeliveryReadyEmailRequestIds({
+        readyBefore: new Date('2026-05-09T07:00:00.000Z'),
+        limit: 200,
+    });
+    const matchingRequests = pendingRequests.filter((request) =>
+        request.requestId.startsWith(prefix),
+    );
+
+    assert.deepEqual(
+        matchingRequests.map((request) => ({
+            requestId: request.requestId,
+            readyEventId: request.readyEventId,
+            processedRecipients: request.processedRecipients,
+        })),
+        [
+            {
+                requestId: firstRequestId,
+                readyEventId: firstReadyEventId,
+                processedRecipients: [],
+            },
+            {
+                requestId: partialRequestId,
+                readyEventId: partialReadyEventId,
+                processedRecipients: ['already-sent@example.com'],
+            },
+            {
+                requestId: secondRequestId,
+                readyEventId: secondReadyEventId,
+                processedRecipients: [],
+            },
+        ],
+    );
+});


### PR DESCRIPTION
## Summary
- Removed the unnecessary `DISTINCT` from the delivery-ready email polling query so Postgres no longer rejects the `ORDER BY` clause.
- Added a stable secondary sort on `events.id` to keep batch ordering deterministic.
- Added a storage regression test covering retryable, completed, skipped, and future ready events.

## Testing
- `pnpm --filter @gredice/storage test -- deliveryRequestsRepo.node.spec.ts`
- `pnpm --filter @gredice/storage exec biome check --write src/repositories/deliveryRequestsRepo.ts tests/deliveryRequestsRepo.node.spec.ts`
- `git diff --check`