### PR TITLE
Sanitize uploaded attribute image filenames before storing R2 URLs

### DIFF
--- a/apps/app/app/(actions)/entityActions.ts
+++ b/apps/app/app/(actions)/entityActions.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from 'node:crypto';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { lexinsert } from '@gredice/js/lexorder';
+import { slugify } from '@gredice/js/slug';
 import {
     deleteAttributeValue,
     deleteEntity,
@@ -21,6 +22,61 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
+
+const imageContentTypeExtensions: Record<string, string> = {
+    'image/avif': 'avif',
+    'image/bmp': 'bmp',
+    'image/gif': 'gif',
+    'image/heic': 'heic',
+    'image/heif': 'heif',
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/svg+xml': 'svg',
+    'image/tiff': 'tiff',
+    'image/webp': 'webp',
+};
+
+const safeImageExtensions = new Set([
+    'avif',
+    'bmp',
+    'gif',
+    'heic',
+    'heif',
+    'jpeg',
+    'jpg',
+    'png',
+    'svg',
+    'tif',
+    'tiff',
+    'webp',
+]);
+
+function sanitizeUploadedImageFileName(file: File) {
+    const trimmedName = file.name.trim();
+    const extensionSeparatorIndex = trimmedName.lastIndexOf('.');
+    const hasExtension =
+        extensionSeparatorIndex > 0 &&
+        extensionSeparatorIndex < trimmedName.length - 1;
+    const rawName = hasExtension
+        ? trimmedName.slice(0, extensionSeparatorIndex)
+        : trimmedName;
+    const rawExtension = hasExtension
+        ? trimmedName.slice(extensionSeparatorIndex + 1)
+        : '';
+
+    const readableName =
+        slugify(rawName).slice(0, 80).replace(/-+$/u, '') || 'image';
+    const fileExtension = rawExtension
+        .toLowerCase()
+        .replace(/[^a-z0-9]/gu, '')
+        .slice(0, 12);
+    const contentTypeExtension = imageContentTypeExtensions[file.type];
+    const extension = safeImageExtensions.has(fileExtension)
+        ? fileExtension
+        : contentTypeExtension;
+
+    return extension ? `${readableName}.${extension}` : readableName;
+}
 
 export async function createEntityType(
     entityTypeName: string,
@@ -206,7 +262,8 @@ export async function uploadAttributeImage(formData: FormData) {
     if (!(file instanceof File)) {
         throw new Error('Image file is required');
     }
-    const fileName = `entity-attributes/${randomUUID()}-${file.name}`;
+    const safeFileName = sanitizeUploadedImageFileName(file);
+    const fileName = `entity-attributes/${randomUUID()}-${safeFileName}`;
     const buffer = Buffer.from(await file.arrayBuffer());
     const {
         CDN_R2_ACCESS_KEY_ID,


### PR DESCRIPTION
## Summary
- Sanitize entity attribute image filenames at upload time so new public URLs stay Stripe-safe.
- Preserve a human-readable slug where possible, keep safe image extensions, and fall back to the MIME type when the filename extension is unusable.
- This prevents new CMS image uploads from reintroducing spaces or other unsafe characters into checkout image URLs.

## Testing
- Ran Biome formatting/check on the edited action file.
- Verified the sanitization logic against representative filenames with spaces, diacritics, missing names, and invalid extensions.
- Full TypeScript check for the app was not run to completion because the workspace already has unrelated existing type errors.