### PR TITLE
feat(admin): keep JSON editor fallback for CMS page configuration

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -1,465 +1,473 @@
-'use client';
+"use client";
 
-import type { SelectCmsPage } from '@gredice/storage';
-import { Button } from '@signalco/ui-primitives/Button';
-import { Card } from '@signalco/ui-primitives/Card';
-import { Input } from '@signalco/ui-primitives/Input';
-import { Row } from '@signalco/ui-primitives/Row';
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
-import { Stack } from '@signalco/ui-primitives/Stack';
-import { Typography } from '@signalco/ui-primitives/Typography';
-import { useActionState, useId, useMemo, useRef, useState } from 'react';
-import type { CmsPageFormState } from './actions';
+import type { SelectCmsPage } from "@gredice/storage";
+import { Button } from "@signalco/ui-primitives/Button";
+import { Card } from "@signalco/ui-primitives/Card";
+import { Input } from "@signalco/ui-primitives/Input";
+import { Row } from "@signalco/ui-primitives/Row";
+import { SelectItems } from "@signalco/ui-primitives/SelectItems";
+import { Stack } from "@signalco/ui-primitives/Stack";
+import { Typography } from "@signalco/ui-primitives/Typography";
+import { useActionState, useId, useMemo, useRef, useState } from "react";
+import type { CmsPageFormState } from "./actions";
 
 type CmsPageFormProps = {
-    page?: SelectCmsPage;
-    action: (
-        previousState: CmsPageFormState,
-        formData: FormData,
-    ) => Promise<CmsPageFormState>;
-    submitLabel: string;
+  page?: SelectCmsPage;
+  action: (
+    previousState: CmsPageFormState,
+    formData: FormData,
+  ) => Promise<CmsPageFormState>;
+  submitLabel: string;
 };
 
 type CmsPageSectionData = {
-    component: string;
-    [key: string]: unknown;
+  component: string;
+  [key: string]: unknown;
 };
 
 type CmsPageEditableSection = {
-    id: string;
-    data: CmsPageSectionData;
+  id: string;
+  data: CmsPageSectionData;
 };
 
 const cmsPageStateItems = [
-    { value: 'draft', label: 'Draft' },
-    {
-        value: 'published',
-        label: 'Objavljeno',
-    },
+  { value: "draft", label: "Draft" },
+  {
+    value: "published",
+    label: "Objavljeno",
+  },
 ];
 
 const cmsPageSectionItems = [
-    { value: 'Heading1', label: 'Heading1' },
-    { value: 'Feature1', label: 'Feature1' },
-    { value: 'Faq1', label: 'Faq1' },
-    { value: 'Footer1', label: 'Footer1' },
+  { value: "Heading1", label: "Heading1" },
+  { value: "Feature1", label: "Feature1" },
+  { value: "Faq1", label: "Faq1" },
+  { value: "Footer1", label: "Footer1" },
 ];
 
 function parseSections(content?: string | null) {
-    if (!content) {
-        return { isStructured: true, sections: [] };
+  if (!content) {
+    return { isStructured: true, sections: [] };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!Array.isArray(parsed)) {
+      return { isStructured: false, sections: [] };
     }
 
-    try {
-        const parsed: unknown = JSON.parse(content);
-        if (!Array.isArray(parsed)) {
-            return { isStructured: false, sections: [] };
-        }
+    return {
+      isStructured: true,
+      sections: parsed.filter(
+        (section): section is CmsPageSectionData =>
+          Boolean(section) &&
+          typeof section === "object" &&
+          "component" in section &&
+          typeof section.component === "string",
+      ),
+    };
+  } catch {
+    return { isStructured: false, sections: [] };
+  }
+}
 
-        return {
-            isStructured: true,
-            sections: parsed.filter(
-                (section): section is CmsPageSectionData =>
-                    Boolean(section) &&
-                    typeof section === 'object' &&
-                    'component' in section &&
-                    typeof section.component === 'string',
-            ),
-        };
-    } catch {
-        return { isStructured: false, sections: [] };
-    }
+function formatJsonContent(content: string) {
+  if (!content.trim()) {
+    return "";
+  }
+
+  const parsed: unknown = JSON.parse(content);
+  return JSON.stringify(parsed, null, 2);
 }
 
 function editableSection(
-    section: CmsPageSectionData,
-    occurrence: number,
+  section: CmsPageSectionData,
+  occurrence: number,
 ): CmsPageEditableSection {
-    return {
-        id: `${section.component}-${occurrence}`,
-        data: section,
-    };
+  return {
+    id: `${section.component}-${occurrence}`,
+    data: section,
+  };
 }
 
 function newSection(
-    component: string,
-    idPrefix: string,
-    id: number,
+  component: string,
+  idPrefix: string,
+  id: number,
 ): CmsPageEditableSection {
-    return {
-        id: `${idPrefix}-${id}`,
-        data: { component },
-    };
+  return {
+    id: `${idPrefix}-${id}`,
+    data: { component },
+  };
 }
 
 function editableSections(sections: CmsPageSectionData[]) {
-    const sectionCounts = new Map<string, number>();
-    return sections.map((section) => {
-        const occurrence = sectionCounts.get(section.component) ?? 0;
-        sectionCounts.set(section.component, occurrence + 1);
-        return editableSection(section, occurrence);
-    });
+  const sectionCounts = new Map<string, number>();
+  return sections.map((section) => {
+    const occurrence = sectionCounts.get(section.component) ?? 0;
+    sectionCounts.set(section.component, occurrence + 1);
+    return editableSection(section, occurrence);
+  });
 }
 
-function stringifySections(
-    sections: CmsPageEditableSection[],
-    fallbackContent?: string | null,
-    preserveFallback = false,
-) {
-    if (preserveFallback && sections.length === 0) {
-        return fallbackContent ?? '';
-    }
-
-    const data = sections.map((section) => section.data);
-    return data.length > 0 ? JSON.stringify(data) : '';
+function stringifySections(sections: CmsPageEditableSection[]) {
+  const data = sections.map((section) => section.data);
+  return data.length > 0 ? JSON.stringify(data, null, 2) : "";
 }
 
 function sectionValue(section: CmsPageEditableSection, key: string) {
-    const value = section.data[key];
-    return typeof value === 'string' ? value : '';
+  const value = section.data[key];
+  return typeof value === "string" ? value : "";
 }
 
 function moveSection(
-    sections: CmsPageEditableSection[],
-    sectionId: string,
-    offset: number,
+  sections: CmsPageEditableSection[],
+  sectionId: string,
+  offset: number,
 ) {
-    const index = sections.findIndex((section) => section.id === sectionId);
-    const targetIndex = index + offset;
-    if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
-        return sections;
-    }
+  const index = sections.findIndex((section) => section.id === sectionId);
+  const targetIndex = index + offset;
+  if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
+    return sections;
+  }
 
-    const next = [...sections];
-    const movingSections = next.splice(index, 1);
-    if (movingSections.length !== 1) {
-        return sections;
-    }
+  const next = [...sections];
+  const movingSections = next.splice(index, 1);
+  if (movingSections.length !== 1) {
+    return sections;
+  }
 
-    const [movingSection] = movingSections;
-    if (!movingSection) {
-        return sections;
-    }
+  const [movingSection] = movingSections;
+  if (!movingSection) {
+    return sections;
+  }
 
-    next.splice(targetIndex, 0, movingSection);
-    return next;
+  next.splice(targetIndex, 0, movingSection);
+  return next;
 }
 
 export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
-    const [state, formAction, pending] = useActionState(action, null);
-    const reactId = useId();
-    const newSectionIdPrefix = useMemo(
-        () => `${reactId}-${page?.id ?? 'new'}`,
-        [page?.id, reactId],
-    );
-    const parsedSections = useMemo(
-        () => parseSections(page?.content),
-        [page?.content],
-    );
-    const nextSectionId = useRef(parsedSections.sections.length);
-    const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
-        editableSections(parsedSections.sections),
-    );
-    const preserveFallbackContent =
-        !parsedSections.isStructured && Boolean(page?.content);
-    const serializedContent = useMemo(
-        () =>
-            stringifySections(sections, page?.content, preserveFallbackContent),
-        [page?.content, preserveFallbackContent, sections],
-    );
+  const [state, formAction, pending] = useActionState(action, null);
+  const reactId = useId();
+  const newSectionIdPrefix = useMemo(
+    () => `${reactId}-${page?.id ?? "new"}`,
+    [page?.id, reactId],
+  );
+  const parsedSections = useMemo(
+    () => parseSections(page?.content),
+    [page?.content],
+  );
+  const nextSectionId = useRef(parsedSections.sections.length);
+  const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
+    editableSections(parsedSections.sections),
+  );
+  const preserveFallbackContent =
+    !parsedSections.isStructured && Boolean(page?.content);
+  const [rawMode, setRawMode] = useState(preserveFallbackContent);
+  const [rawContent, setRawContent] = useState(page?.content ?? "");
+  const [rawError, setRawError] = useState<string | null>(null);
+  const builderContent = useMemo(() => stringifySections(sections), [sections]);
+  const serializedContent = rawMode ? rawContent : builderContent;
 
-    return (
-        <Card className="max-w-3xl">
-            <Stack spacing={4} className="p-6">
-                <form action={formAction}>
-                    <Stack spacing={4}>
-                        <Stack spacing={3}>
-                            <Input
-                                name="title"
-                                label="Naslov"
-                                defaultValue={page?.title ?? ''}
-                                required
-                            />
-                            <Input
-                                name="slug"
-                                label="Slug"
-                                defaultValue={page?.slug ?? ''}
-                                placeholder="npr. sezonski-vodic"
-                                helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
-                                required
-                            />
-                            <SelectItems
-                                name="state"
-                                label="Status"
-                                defaultValue={page?.state ?? 'draft'}
-                                items={cmsPageStateItems}
-                            />
-                            <Stack spacing={2}>
-                                <Typography level="h3" semiBold>
-                                    Sadržaj stranice
-                                </Typography>
-                                <Typography level="body3" secondary>
-                                    Dodaj i uređuj sekcije bez ručnog uređivanja
-                                    JSON-a.
-                                </Typography>
-                                <input
-                                    name="content"
-                                    type="hidden"
-                                    value={serializedContent}
-                                    readOnly
-                                />
-                                {sections.length === 0 ? (
-                                    <Card className="p-4 text-sm text-muted-foreground">
-                                        {preserveFallbackContent
-                                            ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija.'
-                                            : 'Stranica još nema sekcija.'}
-                                    </Card>
-                                ) : (
-                                    <Stack spacing={2}>
-                                        {sections.map((section, index) => (
-                                            <Card
-                                                key={section.id}
-                                                className="p-4"
-                                            >
-                                                <Stack spacing={2}>
-                                                    <Row
-                                                        spacing={2}
-                                                        className="items-center justify-between"
-                                                    >
-                                                        <Typography
-                                                            level="body1"
-                                                            semiBold
-                                                        >
-                                                            {index + 1}.{' '}
-                                                            {
-                                                                section.data
-                                                                    .component
-                                                            }
-                                                        </Typography>
-                                                        <Row spacing={1}>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                disabled={
-                                                                    index === 0
-                                                                }
-                                                                onClick={() =>
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            moveSection(
-                                                                                current,
-                                                                                section.id,
-                                                                                -1,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                Gore
-                                                            </Button>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                disabled={
-                                                                    index ===
-                                                                    sections.length -
-                                                                        1
-                                                                }
-                                                                onClick={() =>
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            moveSection(
-                                                                                current,
-                                                                                section.id,
-                                                                                1,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                Dolje
-                                                            </Button>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                color="danger"
-                                                                onClick={() =>
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            current.filter(
-                                                                                (
-                                                                                    currentSection,
-                                                                                ) =>
-                                                                                    currentSection.id !==
-                                                                                    section.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                Ukloni
-                                                            </Button>
-                                                        </Row>
-                                                    </Row>
-                                                    <Input
-                                                        label="Naslov"
-                                                        value={sectionValue(
-                                                            section,
-                                                            'header',
-                                                        )}
-                                                        onChange={(event) => {
-                                                            const value =
-                                                                event.target
-                                                                    .value;
-                                                            setSections(
-                                                                (current) =>
-                                                                    current.map(
-                                                                        (
-                                                                            currentSection,
-                                                                        ) =>
-                                                                            currentSection.id ===
-                                                                            section.id
-                                                                                ? {
-                                                                                      ...currentSection,
-                                                                                      data: {
-                                                                                          ...currentSection.data,
-                                                                                          header: value,
-                                                                                      },
-                                                                                  }
-                                                                                : currentSection,
-                                                                    ),
-                                                            );
-                                                        }}
-                                                    />
-                                                    <label className="space-y-1">
-                                                        <span className="block text-sm font-medium">
-                                                            Opis
-                                                        </span>
-                                                        <textarea
-                                                            value={sectionValue(
-                                                                section,
-                                                                'description',
-                                                            )}
-                                                            rows={4}
-                                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                            onChange={(
-                                                                event,
-                                                            ) => {
-                                                                const value =
-                                                                    event.target
-                                                                        .value;
-                                                                setSections(
-                                                                    (current) =>
-                                                                        current.map(
-                                                                            (
-                                                                                currentSection,
-                                                                            ) =>
-                                                                                currentSection.id ===
-                                                                                section.id
-                                                                                    ? {
-                                                                                          ...currentSection,
-                                                                                          data: {
-                                                                                              ...currentSection.data,
-                                                                                              description:
-                                                                                                  value,
-                                                                                          },
-                                                                                      }
-                                                                                    : currentSection,
-                                                                        ),
-                                                                );
-                                                            }}
-                                                        />
-                                                    </label>
-                                                </Stack>
-                                            </Card>
-                                        ))}
-                                    </Stack>
-                                )}
-                                <Row spacing={2}>
-                                    {cmsPageSectionItems.map((item) => (
-                                        <Button
-                                            key={item.value}
-                                            type="button"
-                                            variant="outlined"
-                                            onClick={() => {
-                                                setSections((current) => {
-                                                    const sectionId =
-                                                        nextSectionId.current;
-                                                    nextSectionId.current += 1;
-                                                    return [
-                                                        ...current,
-                                                        newSection(
-                                                            item.value,
-                                                            newSectionIdPrefix,
-                                                            sectionId,
-                                                        ),
-                                                    ];
-                                                });
-                                            }}
-                                        >
-                                            Dodaj {item.label}
-                                        </Button>
-                                    ))}
-                                </Row>
-                            </Stack>
-                        </Stack>
+  return (
+    <Card className="max-w-3xl">
+      <Stack spacing={4} className="p-6">
+        <form
+          action={formAction}
+          onSubmit={(event) => {
+            if (!rawMode) {
+              return;
+            }
 
-                        <Stack spacing={3}>
-                            <Typography level="h3" semiBold>
-                                Metadata
+            try {
+              setRawContent(formatJsonContent(rawContent));
+              setRawError(null);
+            } catch {
+              event.preventDefault();
+              setRawError("JSON nije valjan. Ispravi sadržaj prije spremanja.");
+            }
+          }}
+        >
+          <Stack spacing={4}>
+            <Stack spacing={3}>
+              <Input
+                name="title"
+                label="Naslov"
+                defaultValue={page?.title ?? ""}
+                required
+              />
+              <Input
+                name="slug"
+                label="Slug"
+                defaultValue={page?.slug ?? ""}
+                placeholder="npr. sezonski-vodic"
+                helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
+                required
+              />
+              <SelectItems
+                name="state"
+                label="Status"
+                defaultValue={page?.state ?? "draft"}
+                items={cmsPageStateItems}
+              />
+              <Stack spacing={2}>
+                <Typography level="h3" semiBold>
+                  Sadržaj stranice
+                </Typography>
+                <Typography level="body3" secondary>
+                  Vizualni editor je zadani način rada, a JSON editor je
+                  dostupan kao fallback.
+                </Typography>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={rawMode}
+                    onChange={(event) => {
+                      const enabled = event.target.checked;
+                      setRawMode(enabled);
+                      setRawError(null);
+                      if (enabled) {
+                        setRawContent(builderContent);
+                      }
+                    }}
+                  />
+                  Uredi sadržaj kroz JSON editor (fallback)
+                </label>
+                {preserveFallbackContent && (
+                  <Card className="p-3 text-sm text-amber-700">
+                    Postojeći sadržaj nije moguće prikazati u vizualnom editoru
+                    bez gubitka podataka.
+                  </Card>
+                )}
+                <input
+                  name="content"
+                  type="hidden"
+                  value={serializedContent}
+                  readOnly
+                />
+                {rawMode ? (
+                  <label className="space-y-1">
+                    <span className="block text-sm font-medium">
+                      JSON sadržaj
+                    </span>
+                    <textarea
+                      value={rawContent}
+                      rows={16}
+                      className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      onBlur={() => {
+                        try {
+                          setRawContent(formatJsonContent(rawContent));
+                          setRawError(null);
+                        } catch {
+                          setRawError(
+                            "JSON nije valjan. Ispravi sadržaj prije spremanja.",
+                          );
+                        }
+                      }}
+                      onChange={(event) => {
+                        setRawContent(event.target.value);
+                        setRawError(null);
+                      }}
+                    />
+                    {rawError && (
+                      <Typography level="body2" className="text-red-600">
+                        {rawError}
+                      </Typography>
+                    )}
+                  </label>
+                ) : sections.length === 0 ? (
+                  <Card className="p-4 text-sm text-muted-foreground">
+                    {preserveFallbackContent
+                      ? "Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija."
+                      : "Stranica još nema sekcija."}
+                  </Card>
+                ) : (
+                  <Stack spacing={2}>
+                    {sections.map((section, index) => (
+                      <Card key={section.id} className="p-4">
+                        <Stack spacing={2}>
+                          <Row
+                            spacing={2}
+                            className="items-center justify-between"
+                          >
+                            <Typography level="body1" semiBold>
+                              {index + 1}. {section.data.component}
                             </Typography>
-                            <Input
-                                name="metaTitle"
-                                label="Meta naslov"
-                                defaultValue={page?.metaTitle ?? ''}
+                            <Row spacing={1}>
+                              <Button
+                                type="button"
+                                variant="plain"
+                                disabled={index === 0}
+                                onClick={() =>
+                                  setSections((current) =>
+                                    moveSection(current, section.id, -1),
+                                  )
+                                }
+                              >
+                                Gore
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="plain"
+                                disabled={index === sections.length - 1}
+                                onClick={() =>
+                                  setSections((current) =>
+                                    moveSection(current, section.id, 1),
+                                  )
+                                }
+                              >
+                                Dolje
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="plain"
+                                color="danger"
+                                onClick={() =>
+                                  setSections((current) =>
+                                    current.filter(
+                                      (currentSection) =>
+                                        currentSection.id !== section.id,
+                                    ),
+                                  )
+                                }
+                              >
+                                Ukloni
+                              </Button>
+                            </Row>
+                          </Row>
+                          <Input
+                            label="Naslov"
+                            value={sectionValue(section, "header")}
+                            onChange={(event) => {
+                              const value = event.target.value;
+                              setSections((current) =>
+                                current.map((currentSection) =>
+                                  currentSection.id === section.id
+                                    ? {
+                                        ...currentSection,
+                                        data: {
+                                          ...currentSection.data,
+                                          header: value,
+                                        },
+                                      }
+                                    : currentSection,
+                                ),
+                              );
+                            }}
+                          />
+                          <label className="space-y-1">
+                            <span className="block text-sm font-medium">
+                              Opis
+                            </span>
+                            <textarea
+                              value={sectionValue(section, "description")}
+                              rows={4}
+                              className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                              onChange={(event) => {
+                                const value = event.target.value;
+                                setSections((current) =>
+                                  current.map((currentSection) =>
+                                    currentSection.id === section.id
+                                      ? {
+                                          ...currentSection,
+                                          data: {
+                                            ...currentSection.data,
+                                            description: value,
+                                          },
+                                        }
+                                      : currentSection,
+                                  ),
+                                );
+                              }}
                             />
-                            <Input
-                                name="metaDescription"
-                                label="Meta opis"
-                                defaultValue={page?.metaDescription ?? ''}
-                            />
-                            <Input
-                                name="metaImageUrl"
-                                label="Meta slika URL"
-                                type="url"
-                                defaultValue={page?.metaImageUrl ?? ''}
-                            />
-                            <Input
-                                name="canonicalPath"
-                                label="Canonical putanja"
-                                defaultValue={page?.canonicalPath ?? ''}
-                                placeholder="/primjer-stranice"
-                            />
-                            <label className="flex items-center gap-2 text-sm">
-                                <input
-                                    type="checkbox"
-                                    name="noIndex"
-                                    defaultChecked={page?.noIndex ?? false}
-                                />
-                                Isključi iz indeksiranja (noindex)
-                            </label>
+                          </label>
                         </Stack>
-
-                        {state?.message && (
-                            <Typography level="body2" className="text-red-600">
-                                {state.message}
-                            </Typography>
-                        )}
-
-                        <Button
-                            variant="solid"
-                            type="submit"
-                            className="w-fit"
-                            loading={pending}
-                        >
-                            {submitLabel}
-                        </Button>
-                    </Stack>
-                </form>
+                      </Card>
+                    ))}
+                  </Stack>
+                )}
+                <Row spacing={2}>
+                  {!rawMode &&
+                    cmsPageSectionItems.map((item) => (
+                      <Button
+                        key={item.value}
+                        type="button"
+                        variant="outlined"
+                        onClick={() => {
+                          setSections((current) => {
+                            const sectionId = nextSectionId.current;
+                            nextSectionId.current += 1;
+                            return [
+                              ...current,
+                              newSection(
+                                item.value,
+                                newSectionIdPrefix,
+                                sectionId,
+                              ),
+                            ];
+                          });
+                        }}
+                      >
+                        Dodaj {item.label}
+                      </Button>
+                    ))}
+                </Row>
+              </Stack>
             </Stack>
-        </Card>
-    );
+
+            <Stack spacing={3}>
+              <Typography level="h3" semiBold>
+                Metadata
+              </Typography>
+              <Input
+                name="metaTitle"
+                label="Meta naslov"
+                defaultValue={page?.metaTitle ?? ""}
+              />
+              <Input
+                name="metaDescription"
+                label="Meta opis"
+                defaultValue={page?.metaDescription ?? ""}
+              />
+              <Input
+                name="metaImageUrl"
+                label="Meta slika URL"
+                type="url"
+                defaultValue={page?.metaImageUrl ?? ""}
+              />
+              <Input
+                name="canonicalPath"
+                label="Canonical putanja"
+                defaultValue={page?.canonicalPath ?? ""}
+                placeholder="/primjer-stranice"
+              />
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  name="noIndex"
+                  defaultChecked={page?.noIndex ?? false}
+                />
+                Isključi iz indeksiranja (noindex)
+              </label>
+            </Stack>
+
+            {state?.message && (
+              <Typography level="body2" className="text-red-600">
+                {state.message}
+              </Typography>
+            )}
+
+            <Button
+              variant="solid"
+              type="submit"
+              className="w-fit"
+              loading={pending}
+            >
+              {submitLabel}
+            </Button>
+          </Stack>
+        </form>
+      </Stack>
+    </Card>
+  );
 }


### PR DESCRIPTION
### Motivation
- Preserve a raw JSON editing option alongside the visual page builder so admins can inspect and fix page payloads that the visual builder cannot represent without data loss.
- Prevent invalid JSON from being submitted and make round-tripping between visual and raw modes explicit and safe.

### Description
- Add a JSON fallback mode toggled by a checkbox and tracked with `rawMode`, `rawContent`, and `rawError` component state to allow explicit raw editing of the stored `content` payload.
- Add `formatJsonContent` to pretty-print JSON and run client-side validation on `onBlur` and before submit to block saves when the raw JSON is invalid, surfacing inline errors tied to the JSON editor.
- Serialize the hidden `content` input from either the visual builder (`stringifySections` now pretty-prints with `JSON.stringify(..., null, 2)`) or the raw editor depending on the selected mode, and sync builder output into the raw editor when toggling to make round-trips easier.
- Hide builder-specific controls (section add buttons) while in raw mode and show a clear warning when existing stored content cannot be safely represented by the visual editor to avoid silent data loss.

### Testing
- Ran `pnpm -s prettier --write apps/app/app/admin/cms/pages/CmsPageForm.tsx` which formatted the file successfully.
- Ran `pnpm -s tsc --noEmit -p apps/app/tsconfig.json` which failed due to many unrelated, pre-existing TypeScript errors elsewhere in the repository and not related to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9bd1e43c832f8493ceeb66ee8077)