### PR TITLE
fix(www): render landing statistics with final values before animation

### DIFF
--- a/packages/ui/src/CountingNumber/CountingNumber.tsx
+++ b/packages/ui/src/CountingNumber/CountingNumber.tsx
@@ -44,7 +44,7 @@ function CountingNumber({
             : numberStr.includes('.')
               ? (numberStr.split('.')[1]?.length ?? 0)
               : 0;
-    const motionVal = useMotionValue(fromNumber);
+    const motionVal = useMotionValue(number);
     const springVal = useSpring(motionVal, transition);
     const inViewResult = useInView(localRef, {
         once: inViewOnce,
@@ -52,8 +52,19 @@ function CountingNumber({
     });
     const isInView = !inView || inViewResult;
     React.useEffect(() => {
-        if (isInView) motionVal.set(number);
-    }, [isInView, number, motionVal]);
+        if (!isInView) return;
+        if (fromNumber === number) {
+            motionVal.set(number);
+            return;
+        }
+
+        motionVal.set(fromNumber);
+        const animationFrame = requestAnimationFrame(() => {
+            motionVal.set(number);
+        });
+
+        return () => cancelAnimationFrame(animationFrame);
+    }, [isInView, fromNumber, number, motionVal]);
     React.useEffect(() => {
         const unsubscribe = springVal.on('change', (latest) => {
             if (localRef.current) {
@@ -82,9 +93,20 @@ function CountingNumber({
         return () => unsubscribe();
     }, [springVal, decimals, padStart, number, decimalSeparator]);
     const finalIntLength = Math.floor(Math.abs(number)).toString().length;
+    const targetNumberText =
+        decimals > 0
+            ? number.toFixed(decimals).replace('.', decimalSeparator)
+            : Math.round(number).toString();
     const initialText = padStart
-        ? `${'0'.padStart(finalIntLength, '0')}${decimals > 0 ? `${decimalSeparator}${'0'.repeat(decimals)}` : ''}`
-        : `0${decimals > 0 ? `${decimalSeparator}${'0'.repeat(decimals)}` : ''}`;
+        ? (() => {
+              const [intPart, fracPart] =
+                  targetNumberText.split(decimalSeparator);
+              const paddedInt = intPart?.padStart(finalIntLength, '0') ?? '';
+              return fracPart
+                  ? `${paddedInt}${decimalSeparator}${fracPart}`
+                  : paddedInt;
+          })()
+        : targetNumberText;
     return (
         <span
             ref={localRef}

--- a/packages/ui/src/CountingNumber/CountingNumber.tsx
+++ b/packages/ui/src/CountingNumber/CountingNumber.tsx
@@ -36,6 +36,7 @@ function CountingNumber({
     ...props
 }: CountingNumberProps) {
     const localRef = React.useRef<HTMLSpanElement>(null);
+    const hasStartedInitialAnimationRef = React.useRef(false);
     React.useImperativeHandle(ref, () => localRef.current as HTMLSpanElement);
     const numberStr = number.toString();
     const decimals =
@@ -53,11 +54,13 @@ function CountingNumber({
     const isInView = !inView || inViewResult;
     React.useEffect(() => {
         if (!isInView) return;
-        if (fromNumber === number) {
+        if (hasStartedInitialAnimationRef.current || fromNumber === number) {
+            hasStartedInitialAnimationRef.current = true;
             motionVal.set(number);
             return;
         }
 
+        hasStartedInitialAnimationRef.current = true;
         motionVal.set(fromNumber);
         const animationFrame = requestAnimationFrame(() => {
             motionVal.set(number);

--- a/packages/ui/src/CountingNumber/CountingNumber.tsx
+++ b/packages/ui/src/CountingNumber/CountingNumber.tsx
@@ -60,9 +60,9 @@ function CountingNumber({
             return;
         }
 
-        hasStartedInitialAnimationRef.current = true;
         motionVal.set(fromNumber);
         const animationFrame = requestAnimationFrame(() => {
+            hasStartedInitialAnimationRef.current = true;
             motionVal.set(number);
         });
 


### PR DESCRIPTION
### Motivation
- Ensure the landing-page statistics are server-rendered and initially visible as the final values so crawlers and no-JS snapshots do not see placeholder zeroes. 
- Keep the count-up animation as a visual enhancement without affecting the meaningful semantic text content.

### Description
- Update `CountingNumber` in `packages/ui/src/CountingNumber/CountingNumber.tsx` to render the target `number` as the initial text instead of `0` for SSR and first paint. 
- Initialize the motion value from the final `number` and, when the element is in-view, set it to `fromNumber` then schedule the animated transition back to `number` (via `requestAnimationFrame`) to preserve the visual count-up. 
- Preserve existing decimal formatting and `padStart` behavior so initial and animated text remain consistent.

### Testing
- Ran `pnpm --filter @gredice/ui lint`, which completed and auto-fixed one file. 
- Ran `pnpm --filter @gredice/ui test`, which executed successfully. 
- No automated failures were produced by these commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe933cf00c832f922afcd3cea987db)