### PR TITLE
Add live preview and autosave to CMS page editor

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { SelectCmsPage } from '@gredice/storage';
+import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { cmsPageSectionComponents } from '@gredice/storage/cmsPageSections';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
@@ -9,8 +10,9 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useActionState, useId, useMemo, useRef, useState } from 'react';
-import type { CmsPageFormState } from './actions';
+import { useActionState, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { sectionsComponentRegistry } from '../../../../components/shared/sectionsComponentRegistry';
+import type { CmsPageAutosaveState, CmsPageFormState } from './actions';
 
 type CmsPageFormProps = {
   page?: SelectCmsPage;
@@ -19,6 +21,7 @@ type CmsPageFormProps = {
     formData: FormData,
   ) => Promise<CmsPageFormState>;
   submitLabel: string;
+  autosaveAction?: (formData: FormData) => Promise<CmsPageAutosaveState>;
 };
 
 type CmsPageSectionData = {
@@ -175,7 +178,7 @@ function validateSection(section: CmsPageEditableSection) {
         .map((field) => `${field.label} je obavezno polje.`);
 }
 
-export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
+export function CmsPageForm({ page, action, submitLabel, autosaveAction }: CmsPageFormProps) {
   const [state, formAction, pending] = useActionState(action, null);
   const reactId = useId();
   const newSectionIdPrefix = useMemo(
@@ -201,6 +204,52 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
     : preserveFallbackContent && sections.length === 0
       ? page?.content ?? ""
       : builderContent;
+  const [autosaveStatus, setAutosaveStatus] = useState("saved");
+  const [autosaveMessage, setAutosaveMessage] = useState<string | null>(null);
+  const [lastSavedSnapshot, setLastSavedSnapshot] = useState(serializedContent);
+  const [previewSections, setPreviewSections] = useState<CmsPageSectionData[]>([]);
+
+  useEffect(() => {
+    if (!autosaveAction) {
+      return;
+    }
+
+    if (serializedContent === lastSavedSnapshot) {
+      setAutosaveStatus("saved");
+      return;
+    }
+
+    setAutosaveStatus("unsaved");
+    const timer = setTimeout(async () => {
+      setAutosaveStatus("saving");
+      const formData = new FormData();
+      formData.set("title", page?.title ?? "");
+      formData.set("slug", page?.slug ?? "");
+      formData.set("state", "draft");
+      formData.set("content", serializedContent);
+      formData.set("metaTitle", page?.metaTitle ?? "");
+      formData.set("metaDescription", page?.metaDescription ?? "");
+      formData.set("metaImageUrl", page?.metaImageUrl ?? "");
+      formData.set("canonicalPath", page?.canonicalPath ?? "");
+
+      const result = await autosaveAction(formData);
+      if (!result.success) {
+        setAutosaveStatus("failed");
+        setAutosaveMessage(result.message);
+        return;
+      }
+
+      setAutosaveStatus("saved");
+      setAutosaveMessage(result.message);
+      setLastSavedSnapshot(serializedContent);
+    }, 600);
+
+    return () => clearTimeout(timer);
+  }, [autosaveAction, serializedContent, lastSavedSnapshot, page]);
+
+  useEffect(() => {
+    setPreviewSections(parseSections(serializedContent).sections);
+  }, [serializedContent]);
 
   return (
     <Card className="max-w-3xl">
@@ -223,6 +272,11 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
         >
           <Stack spacing={4}>
             <Stack spacing={3}>
+              {autosaveAction && (
+                <Typography level="body3" secondary>
+                  Autosave: {autosaveStatus}{autosaveMessage ? ` • ${autosaveMessage}` : ""}
+                </Typography>
+              )}
               <Input
                 name="title"
                 label="Naslov"
@@ -509,6 +563,16 @@ export function CmsPageForm({ page, action, submitLabel }: CmsPageFormProps) {
                     ))}
                 </Row>
               </Stack>
+            </Stack>
+
+            <Stack spacing={2}>
+              <Typography level="h3" semiBold>Live preview</Typography>
+              <Card className="p-4">
+                <SectionsView
+                  sectionsData={previewSections}
+                  componentsRegistry={sectionsComponentRegistry}
+                />
+              </Card>
             </Stack>
 
             <Stack spacing={3}>

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -204,35 +204,50 @@ export function CmsPageForm({ page, action, submitLabel, autosaveAction }: CmsPa
     : preserveFallbackContent && sections.length === 0
       ? page?.content ?? ""
       : builderContent;
+  const formRef = useRef<HTMLFormElement>(null);
+  const [formRevision, setFormRevision] = useState(0);
+  const autosaveSnapshot = useMemo(
+    () => JSON.stringify({ content: serializedContent, formRevision }),
+    [serializedContent, formRevision],
+  );
+  const latestAutosaveSnapshot = useRef(autosaveSnapshot);
   const [autosaveStatus, setAutosaveStatus] = useState("saved");
   const [autosaveMessage, setAutosaveMessage] = useState<string | null>(null);
-  const [lastSavedSnapshot, setLastSavedSnapshot] = useState(serializedContent);
+  const [lastSavedSnapshot, setLastSavedSnapshot] = useState(autosaveSnapshot);
   const [previewSections, setPreviewSections] = useState<CmsPageSectionData[]>([]);
+
+  useEffect(() => {
+    latestAutosaveSnapshot.current = autosaveSnapshot;
+  }, [autosaveSnapshot]);
 
   useEffect(() => {
     if (!autosaveAction) {
       return;
     }
 
-    if (serializedContent === lastSavedSnapshot) {
+    if (autosaveSnapshot === lastSavedSnapshot) {
       setAutosaveStatus("saved");
       return;
     }
 
     setAutosaveStatus("unsaved");
     const timer = setTimeout(async () => {
+      const form = formRef.current;
+      if (!form) {
+        return;
+      }
+
+      const snapshotToSave = autosaveSnapshot;
       setAutosaveStatus("saving");
-      const formData = new FormData();
-      formData.set("title", page?.title ?? "");
-      formData.set("slug", page?.slug ?? "");
+      const formData = new FormData(form);
       formData.set("state", "draft");
       formData.set("content", serializedContent);
-      formData.set("metaTitle", page?.metaTitle ?? "");
-      formData.set("metaDescription", page?.metaDescription ?? "");
-      formData.set("metaImageUrl", page?.metaImageUrl ?? "");
-      formData.set("canonicalPath", page?.canonicalPath ?? "");
 
       const result = await autosaveAction(formData);
+      if (latestAutosaveSnapshot.current !== snapshotToSave) {
+        return;
+      }
+
       if (!result.success) {
         setAutosaveStatus("failed");
         setAutosaveMessage(result.message);
@@ -241,11 +256,11 @@ export function CmsPageForm({ page, action, submitLabel, autosaveAction }: CmsPa
 
       setAutosaveStatus("saved");
       setAutosaveMessage(result.message);
-      setLastSavedSnapshot(serializedContent);
+      setLastSavedSnapshot(snapshotToSave);
     }, 600);
 
     return () => clearTimeout(timer);
-  }, [autosaveAction, serializedContent, lastSavedSnapshot, page]);
+  }, [autosaveAction, autosaveSnapshot, serializedContent, lastSavedSnapshot]);
 
   useEffect(() => {
     setPreviewSections(parseSections(serializedContent).sections);
@@ -255,7 +270,9 @@ export function CmsPageForm({ page, action, submitLabel, autosaveAction }: CmsPa
     <Card className="max-w-3xl">
       <Stack spacing={4} className="p-6">
         <form
+          ref={formRef}
           action={formAction}
+          onChange={() => setFormRevision((current) => current + 1)}
           onSubmit={(event) => {
             if (!rawMode) {
               return;

--- a/apps/app/app/admin/cms/pages/[pageId]/edit/page.tsx
+++ b/apps/app/app/admin/cms/pages/[pageId]/edit/page.tsx
@@ -7,7 +7,7 @@ import { AdminPageHeader } from '../../../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { auth } from '../../../../../../lib/auth/auth';
 import { KnownPages } from '../../../../../../src/KnownPages';
-import { updateCmsPageAction } from '../../actions';
+import { autosaveCmsPageAction, updateCmsPageAction } from '../../actions';
 import { CmsPageForm } from '../../CmsPageForm';
 
 export const dynamic = 'force-dynamic';
@@ -31,6 +31,7 @@ export default async function EditCmsPagePage({
     }
 
     const updateAction = updateCmsPageAction.bind(null, id);
+    const autosaveAction = autosaveCmsPageAction.bind(null, id);
 
     return (
         <Stack spacing={4}>
@@ -62,6 +63,7 @@ export default async function EditCmsPagePage({
                 page={page}
                 action={updateAction}
                 submitLabel="Spremi promjene"
+                autosaveAction={autosaveAction}
             />
         </Stack>
     );

--- a/apps/app/app/admin/cms/pages/actions.ts
+++ b/apps/app/app/admin/cms/pages/actions.ts
@@ -3,6 +3,7 @@
 import {
     type CreateCmsPageInput,
     createCmsPage,
+    getCmsPage,
     isCmsPageState,
     restoreCmsPageRevision,
     softDeleteCmsPage,
@@ -18,6 +19,12 @@ export type CmsPageFormState = {
     success: false;
     message: string;
 } | null;
+
+export type CmsPageAutosaveState = {
+    success: boolean;
+    message: string;
+    savedAt?: string;
+};
 
 function formText(formData: FormData, key: string) {
     const value = formData.get(key);
@@ -65,6 +72,12 @@ function revalidateCmsPagePaths(pageId: number) {
     revalidatePath(KnownPages.CmsPageEdit(pageId));
 }
 
+function revalidatePublicCmsPagePaths(slug: string) {
+    revalidatePath(`/${slug}`);
+    revalidatePath('/api/directories/pages');
+    revalidatePath(`/api/directories/pages/${slug}`);
+}
+
 export async function createCmsPageAction(
     _previousState: CmsPageFormState,
     formData: FormData,
@@ -95,11 +108,13 @@ export async function updateCmsPageAction(
 ): Promise<CmsPageFormState> {
     const authContext = await auth(['admin']);
 
+    const payload = cmsPageInputFromForm(formData);
+
     try {
         await updateCmsPage(
             {
                 id: pageId,
-                ...cmsPageInputFromForm(formData),
+                ...payload,
             },
             {
                 id: authContext.user.id,
@@ -114,13 +129,55 @@ export async function updateCmsPageAction(
     }
 
     revalidateCmsPagePaths(pageId);
+    if (payload.state === 'published') {
+        revalidatePublicCmsPagePaths(payload.slug);
+    }
     redirect(KnownPages.CmsPage(pageId));
+}
+
+export async function autosaveCmsPageAction(
+    pageId: number,
+    formData: FormData,
+): Promise<CmsPageAutosaveState> {
+    const authContext = await auth(['admin']);
+
+    const payload = cmsPageInputFromForm(formData);
+    payload.state = 'draft';
+
+    try {
+        await updateCmsPage(
+            {
+                id: pageId,
+                ...payload,
+            },
+            {
+                id: authContext.user.id,
+                name: authContext.user.userName,
+            },
+        );
+    } catch (error) {
+        return {
+            success: false,
+            message: cmsPageErrorMessage(error),
+        };
+    }
+
+    revalidateCmsPagePaths(pageId);
+    return {
+        success: true,
+        message: 'Skica spremljena.',
+        savedAt: new Date().toISOString(),
+    };
 }
 
 export async function publishCmsPageAction(pageId: number) {
     const authContext = await auth(['admin']);
 
+    let slug = '';
+
     try {
+        const page = await getCmsPage(pageId);
+        slug = page?.slug ?? '';
         await updateCmsPageState(pageId, 'published', {
             id: authContext.user.id,
             name: authContext.user.userName,
@@ -130,6 +187,9 @@ export async function publishCmsPageAction(pageId: number) {
         redirect(`${KnownPages.CmsPage(pageId)}?publishError=${message}`);
     }
     revalidateCmsPagePaths(pageId);
+    if (slug) {
+        revalidatePublicCmsPagePaths(slug);
+    }
 }
 
 export async function unpublishCmsPageAction(pageId: number) {


### PR DESCRIPTION
### Motivation
- Provide a better editing experience by rendering the current draft inside the editor and persist draft changes automatically so admins don't lose work.
- Ensure autosave cannot accidentally publish content and that published updates trigger the correct public/API cache revalidation.

### Description
- Added a server autosave action `autosaveCmsPageAction` that authenticates, forces `state = 'draft'`, writes drafts via `updateCmsPage`, and returns a typed payload `CmsPageAutosaveState` with success/message/`savedAt` fields (updated file: `apps/app/app/admin/cms/pages/actions.ts`).
- Reused existing form parsing with `cmsPageInputFromForm`, wired `autosaveCmsPageAction` into the edit page and passed it to the form (updated files: `apps/app/app/admin/cms/pages/[pageId]/edit/page.tsx` and `apps/app/app/admin/cms/pages/CmsPageForm.tsx`).
- Implemented debounced client-side autosave (600ms) with visible status (`unsaved`, `saving`, `saved`, `failed`) and non-destructive failure handling in `CmsPageForm` (updated file: `apps/app/app/admin/cms/pages/CmsPageForm.tsx`).
- Added an in-editor live preview using `SectionsView` and the shared `sectionsComponentRegistry` that renders the current draft without a reload (updated file: `apps/app/app/admin/cms/pages/CmsPageForm.tsx`).
- Added public/API path revalidation when published content changes via `revalidatePublicCmsPagePaths` for `/${slug}`, `/api/directories/pages`, and `/api/directories/pages/${slug}`, and invoked it for publish/update flows (updated file: `apps/app/app/admin/cms/pages/actions.ts`).

### Testing
- Attempted a Biome check on the modified files with `biome`, but the `biome` executable was not available in the current environment so the lint/type check could not run (failed).
- No additional automated unit or e2e tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff2316ffbc832f971fe45723cffe8e)