### PR TITLE
Fix reference attribute labels in directory entity views

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -2,6 +2,7 @@ import {
     createInventoryItem,
     getAttributeDefinitionCategories,
     getAttributeDefinitions,
+    getEntitiesRaw,
     getEntityRaw,
     getEntityRevisions,
     getInventoryConfigByEntityTypeName,
@@ -56,6 +57,26 @@ function imageAttributeValue(value: string) {
     }
 
     return null;
+}
+
+function getEntityLabel(
+    attributes: {
+        attributeDefinition: { category: string; name: string };
+        value: string | null;
+    }[],
+) {
+    return (
+        attributes.find(
+            (attribute) =>
+                attribute.attributeDefinition.category === 'information' &&
+                attribute.attributeDefinition.name === 'label',
+        )?.value ??
+        attributes.find(
+            (attribute) =>
+                attribute.attributeDefinition.category === 'information' &&
+                attribute.attributeDefinition.name === 'name',
+        )?.value
+    );
 }
 
 export default async function EntityDetailsPage(props: {
@@ -150,6 +171,41 @@ export default async function EntityDetailsPage(props: {
     }
 
     const displayDefinitions = attributeDefinitions.filter((d) => d.display);
+    const refDefinitions = displayDefinitions.filter((definition) =>
+        definition.dataType.startsWith('ref:'),
+    );
+    const refEntityTypes = Array.from(
+        new Set(
+            refDefinitions.map(
+                (definition) => definition.dataType.split(':')[1],
+            ),
+        ),
+    );
+    const refEntitiesByType = await Promise.all(
+        refEntityTypes.map(async (refEntityTypeName) => ({
+            refEntityTypeName,
+            entities: await getEntitiesRaw(refEntityTypeName, 'published'),
+        })),
+    );
+    const refLabelsByDefinitionId = Object.fromEntries(
+        refDefinitions.map((definition) => {
+            const refEntityTypeName = definition.dataType.split(':')[1];
+            const refEntities =
+                refEntitiesByType.find(
+                    (entry) => entry.refEntityTypeName === refEntityTypeName,
+                )?.entities ?? [];
+            return [
+                definition.id,
+                Object.fromEntries(
+                    refEntities.map((refEntity) => [
+                        refEntity.id.toString(),
+                        getEntityLabel(refEntity.attributes) ??
+                            `${refEntity.entityType.label} ${refEntity.id}`,
+                    ]),
+                ),
+            ];
+        }),
+    );
     const completeness = getEntityCompleteness(entity, attributeDefinitions);
     const categoriesWithMissingRequiredAttributes = new Set(
         completeness.missingRequiredDefinitions.map(
@@ -286,6 +342,14 @@ export default async function EntityDetailsPage(props: {
                                         if (d.dataType === 'barcode') {
                                             return (
                                                 <BarcodeValue value={value} />
+                                            );
+                                        }
+
+                                        if (d.dataType.startsWith('ref:')) {
+                                            return (
+                                                refLabelsByDefinitionId[d.id]?.[
+                                                    value
+                                                ] ?? value
                                             );
                                         }
 

--- a/apps/app/app/admin/directories/[entityType]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/page.tsx
@@ -29,6 +29,26 @@ import { EntitiesFilters } from './EntitiesFilters';
 
 export const dynamic = 'force-dynamic';
 
+function getEntityLabel(
+    attributes: {
+        attributeDefinition: { category: string; name: string };
+        value: string | null;
+    }[],
+) {
+    return (
+        attributes.find(
+            (attribute) =>
+                attribute.attributeDefinition.category === 'information' &&
+                attribute.attributeDefinition.name === 'label',
+        )?.value ??
+        attributes.find(
+            (attribute) =>
+                attribute.attributeDefinition.category === 'information' &&
+                attribute.attributeDefinition.name === 'name',
+        )?.value
+    );
+}
+
 export default async function EntitiesPage({
     params,
     searchParams,
@@ -56,6 +76,41 @@ export default async function EntitiesPage({
     const inventoryItems = inventoryConfig
         ? await getInventoryItemsByConfig(inventoryConfig.id)
         : [];
+    const refDefinitions = attributeDefinitions.filter((definition) =>
+        definition.dataType.startsWith('ref:'),
+    );
+    const refEntityTypes = Array.from(
+        new Set(
+            refDefinitions.map(
+                (definition) => definition.dataType.split(':')[1],
+            ),
+        ),
+    );
+    const refEntitiesByType = await Promise.all(
+        refEntityTypes.map(async (refEntityTypeName) => ({
+            refEntityTypeName,
+            entities: await getEntitiesRaw(refEntityTypeName, 'published'),
+        })),
+    );
+    const refLabelsByDefinitionId = Object.fromEntries(
+        refDefinitions.map((definition) => {
+            const refEntityTypeName = definition.dataType.split(':')[1];
+            const refEntities =
+                refEntitiesByType.find(
+                    (entry) => entry.refEntityTypeName === refEntityTypeName,
+                )?.entities ?? [];
+            return [
+                definition.id,
+                Object.fromEntries(
+                    refEntities.map((entity) => [
+                        entity.id.toString(),
+                        getEntityLabel(entity.attributes) ??
+                            `${entity.entityType.label} ${entity.id}`,
+                    ]),
+                ),
+            ];
+        }),
+    );
 
     return (
         <FilterProvider>
@@ -115,6 +170,7 @@ export default async function EntitiesPage({
                             completionFilter={completionFilter}
                             stateFilter={stateFilter}
                             onDuplicate={duplicateEntityBound}
+                            refLabelsByDefinitionId={refLabelsByDefinitionId}
                         />
                     </CardOverflow>
                 </Card>

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -60,6 +60,7 @@ type EntitiesTableProps = {
     completionFilter?: string;
     stateFilter?: string;
     onDuplicate: (entityId: number) => Promise<void>;
+    refLabelsByDefinitionId?: Record<number, Record<string, string>>;
 };
 
 export function EntitiesTable({
@@ -71,6 +72,7 @@ export function EntitiesTable({
     completionFilter = '',
     stateFilter = '',
     onDuplicate,
+    refLabelsByDefinitionId = {},
 }: EntitiesTableProps) {
     const { filter } = useFilter();
     const [sort, setSort] = useState<SortState>(defaultSort);
@@ -217,6 +219,9 @@ export function EntitiesTable({
                                     <EntityAttributeValueCell
                                         entity={entity}
                                         definition={d}
+                                        refLabelsByDefinitionId={
+                                            refLabelsByDefinitionId
+                                        }
                                     />
                                 </Table.Cell>
                             ))}
@@ -270,6 +275,7 @@ function EntityAttributeValueCell({
 }: {
     entity: Entities[number];
     definition: SelectAttributeDefinition;
+    refLabelsByDefinitionId: Record<number, Record<string, string>>;
 }) {
     const value = entityAttributeValueByDefinitionId(entity, definition.id);
     if (!value) {
@@ -307,6 +313,12 @@ function EntityAttributeValueCell({
 
     if (definition.dataType === 'barcode') {
         return <BarcodeValue value={value} />;
+    }
+
+    if (definition.dataType.startsWith('ref:')) {
+        const resolvedLabel =
+            refLabelsByDefinitionId[definition.id]?.[value] ?? value;
+        return <Typography secondary>{resolvedLabel}</Typography>;
     }
 
     return (

--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -272,6 +272,7 @@ export function EntitiesTable({
 function EntityAttributeValueCell({
     entity,
     definition,
+    refLabelsByDefinitionId,
 }: {
     entity: Entities[number];
     definition: SelectAttributeDefinition;


### PR DESCRIPTION
### Motivation
- Restore user-friendly display for `ref:*` attributes after a migration that started showing raw reference IDs instead of referenced entity `label`/`name` values. 
- Ensure both the directory entity details (info/display fields) and the entities list table use the same resolution logic so administrators see meaningful labels. 
- Keep the original fallback behavior to show the raw ID when a referenced entity has no `information.label`/`information.name`.

### Description
- Add `getEntityLabel` helper to extract `information.label` or `information.name` from an entity's attributes. 
- In `apps/app/app/admin/directories/[entityType]/page.tsx` build `refLabelsByDefinitionId` by loading published referenced entities and mapping their IDs to labels, then pass this map into `EntitiesTable` via a new prop. 
- In `apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx` build an equivalent `refLabelsByDefinitionId` for display/info fields and use it when rendering `display` attributes. 
- Update `apps/app/components/admin/tables/EntitiesTable.tsx` to accept a new `refLabelsByDefinitionId?: Record<number, Record<string,string>>` prop and render referenced attribute values using the provided label map (falling back to the raw value when missing). 

### Testing
- Ran lint via `pnpm --filter app lint`, which executed `biome check --write` and completed successfully while reporting a pre-existing Node engine warning. 
- Attempted a targeted `biome check` invocation for changed files but the invocation hit an environment/path issue in this run; the change-set was still linted as above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0084c67e7c832f9b7391593dc5abac)