### PR TITLE
Handle entity publish validation errors without server render crash

### DIFF
--- a/apps/app/app/(actions)/entityActions.ts
+++ b/apps/app/app/(actions)/entityActions.ts
@@ -201,6 +201,42 @@ export async function updateEntity(entity: UpdateEntity) {
     revalidatePath(KnownPages.DirectoryEntityPath, 'layout');
 }
 
+function entityActionErrorMessage(error: unknown) {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return 'Promjena statusa nije uspjela.';
+}
+
+export async function updateEntityStateAction(entity: UpdateEntity) {
+    await auth(['admin']);
+
+    const authData = await auth(['admin']);
+
+    try {
+        await storageUpdateEntity(entity, {
+            id: authData.userId,
+            name: authData.user.userName,
+        });
+    } catch (error) {
+        return {
+            success: false,
+            message: entityActionErrorMessage(error),
+        };
+    }
+
+    revalidatePath(KnownPages.Directories);
+    revalidatePath(KnownPages.DirectoryEntityTypePath, 'page');
+    revalidatePath(KnownPages.DirectoryEntityTypePath, 'layout');
+    revalidatePath(KnownPages.DirectoryEntityPath, 'page');
+    revalidatePath(KnownPages.DirectoryEntityPath, 'layout');
+
+    return {
+        success: true,
+        message: null,
+    };
+}
+
 export async function duplicateEntity(
     entityTypeName: string,
     entityId: number,

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx
@@ -23,7 +23,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import Link from 'next/link';
 import { startTransition, useState } from 'react';
 import { KnownPages } from '../../../../../src/KnownPages';
-import { updateEntity } from '../../../../(actions)/entityActions';
+import { updateEntityStateAction } from '../../../../(actions)/entityActions';
 import { useEntityDetailsSave } from './EntityDetailsSaveContext';
 
 export function EntityActions({
@@ -47,12 +47,16 @@ export function EntityActions({
         setState(newState);
         setPublishError(null);
         try {
-            await trackSave(() =>
-                updateEntity({
+            const result = await trackSave(() =>
+                updateEntityStateAction({
                     id: entity.id,
                     state: newState,
                 }),
             );
+            if (!result.success) {
+                setState(previousState);
+                setPublishError(result.message);
+            }
         } catch (error) {
             setState(previousState);
             setPublishError(

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityActions.tsx
@@ -47,16 +47,17 @@ export function EntityActions({
         setState(newState);
         setPublishError(null);
         try {
-            const result = await trackSave(() =>
-                updateEntityStateAction({
+            await trackSave(async () => {
+                const result = await updateEntityStateAction({
                     id: entity.id,
                     state: newState,
-                }),
-            );
-            if (!result.success) {
-                setState(previousState);
-                setPublishError(result.message);
-            }
+                });
+                if (!result.success) {
+                    throw new Error(
+                        result.message ?? 'Promjena statusa nije uspjela.',
+                    );
+                }
+            });
         } catch (error) {
             setState(previousState);
             setPublishError(


### PR DESCRIPTION
### Motivation

- Publishing an entity with missing required fields caused an error to bubble up from the storage layer and trigger a generic Server Components render failure instead of showing the concrete validation message to the user.

### Description

- Add a new server action `updateEntityStateAction` that wraps `storageUpdateEntity` and returns a structured `{ success, message }` response when errors occur.
- Add a helper `entityActionErrorMessage` to convert caught errors into a user-facing message string.
- Update the client `EntityActions` component to call `updateEntityStateAction`, revert optimistic state changes on failure, and surface validation text in the UI via `publishError` while preserving the existing revalidation behavior on success.

### Testing

- Ran `pnpm --filter app exec biome check 'app/(actions)/entityActions.ts' 'app/admin/directories/[entityType]/[entityId]/EntityActions.tsx'` which passed for the modified files.
- Ran `pnpm --filter app lint` which completed successfully for the app and reported pre-existing unrelated warnings in other files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00854b0830832f819c11a330b93a12)