### PR TITLE
Prikaži interne radnje u sklopljenom OPG odjeljku i sakrij ih iz garden/game

### DIFF
--- a/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
+++ b/apps/www/app/radnje/[alias]/OperationApplicationsList.tsx
@@ -25,6 +25,18 @@ export async function OperationApplicationsList({
         );
     }
 
+    if (operation.attributes.internal === true) {
+        return (
+            <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                <Card className="border-tertiary border-b-4">
+                    <CardContent noHeader>
+                        <Typography>Za OPG partnere</Typography>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
     if (operation.attributes.application === 'garden') {
         return (
             <div className="py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -1,7 +1,9 @@
+import type { OperationData } from '@gredice/client';
 import type { PlantStageName } from '@gredice/game';
 import { PLANT_STAGES } from '@gredice/game';
 import { ShovelIcon } from '@gredice/ui/ShovelIcon';
 import { slug } from '@signalco/js';
+import { Accordion } from '@signalco/ui/Accordion';
 import {
     Droplet,
     Leaf,
@@ -41,6 +43,25 @@ const stageIcons: Record<
     storage: Store,
 };
 
+const stageOrder = new Map<string, number>(
+    PLANT_STAGES.map((stage, index) => [stage.name, index]),
+);
+
+function compareOperationsByStageAndLabel(
+    a: Pick<OperationData, 'attributes' | 'information'>,
+    b: Pick<OperationData, 'attributes' | 'information'>,
+) {
+    const stageDiff =
+        (stageOrder.get(a.attributes.stage?.information?.name ?? '') ??
+            Number.MAX_SAFE_INTEGER) -
+        (stageOrder.get(b.attributes.stage?.information?.name ?? '') ??
+            Number.MAX_SAFE_INTEGER);
+
+    return stageDiff !== 0
+        ? stageDiff
+        : a.information.label.localeCompare(b.information.label);
+}
+
 const pageDescription = `Sve što trebaš znati o radnjama koje možeš obavljati u svojim gredicama.`;
 export const revalidate = 3600; // 1 hour
 export const metadata: Metadata = {
@@ -56,38 +77,42 @@ export default async function OperationsPage({
         ? params.pretraga[0]?.toLowerCase()
         : params.pretraga?.toLowerCase();
     const operationsData = await getOperationsData();
-    const filteredOperations = operationsData?.filter((op) =>
+    const filteredOperations = operationsData.filter((op) =>
         op.information.label.toLowerCase().includes(search || ''),
     );
+    const publicOperations = filteredOperations.filter(
+        (op) => op.attributes.internal !== true,
+    );
+    const internalOperations = filteredOperations
+        .filter((op) => op.attributes.internal === true)
+        .sort(compareOperationsByStageAndLabel);
 
     // Get unique stage names from filtered operations
     const stageNamesInOperations = new Set<PlantStageName>(
-        filteredOperations
-            ?.map((op) => op.attributes.stage?.information?.name)
-            .filter((name): name is PlantStageName => name !== undefined) || [],
+        publicOperations
+            .map((op) => op.attributes.stage?.information?.name)
+            .filter((name): name is PlantStageName => name !== undefined),
     );
 
     // Order stages according to PLANT_STAGES definition (canonical order)
     const availableStages = PLANT_STAGES.filter((stage) =>
         stageNamesInOperations.has(stage.name),
     );
-    const stageOperations = new Map<
-        PlantStageName,
-        NonNullable<typeof filteredOperations>
-    >(
-        availableStages.map<
-            [PlantStageName, NonNullable<typeof filteredOperations>]
-        >((stage) => [
-            stage.name,
-            filteredOperations
-                ?.filter(
-                    (op) =>
-                        op.attributes.stage?.information?.name === stage.name,
-                )
-                .sort((a, b) =>
-                    a.information.label.localeCompare(b.information.label),
-                ) ?? [],
-        ]),
+    const stageOperations = new Map<PlantStageName, typeof publicOperations>(
+        availableStages.map<[PlantStageName, typeof publicOperations]>(
+            (stage) => [
+                stage.name,
+                publicOperations
+                    .filter(
+                        (op) =>
+                            op.attributes.stage?.information?.name ===
+                            stage.name,
+                    )
+                    .sort((a, b) =>
+                        a.information.label.localeCompare(b.information.label),
+                    ),
+            ],
+        ),
     );
     const orderedOperations = availableStages.flatMap(
         (stage) => stageOperations.get(stage.name) ?? [],
@@ -153,7 +178,7 @@ export default async function OperationsPage({
                 </Stack>
             )}
             <Stack spacing={6}>
-                {!filteredOperations?.length && (
+                {!publicOperations.length && !internalOperations.length && (
                     <div className="border rounded py-4">
                         <NoDataPlaceholder>
                             Nema dostupnih radnji.
@@ -188,6 +213,26 @@ export default async function OperationsPage({
                         </Stack>
                     );
                 })}
+                {internalOperations.length > 0 && (
+                    <Accordion className="h-min border-tertiary border-b-4">
+                        <Row spacing={2} className="px-3">
+                            <Store className="size-5 shrink-0" />
+                            <Typography level="h5" component="h2">
+                                Za OPG partnere
+                            </Typography>
+                        </Row>
+                        <div className="px-3 pb-3">
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                                {internalOperations.map((operation) => (
+                                    <OperationCard
+                                        key={operation.id}
+                                        operation={operation}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    </Accordion>
+                )}
             </Stack>
             <Row spacing={2}>
                 <Typography level="body1">

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 async function getOperations() {
     const operations = await directoriesClient().GET('/entities/operation');
-    return operations.data?.sort((a, b) =>
-        a.information.name.localeCompare(b.information.name),
-    );
+    return operations.data
+        ?.filter((operation) => operation.attributes.internal !== true)
+        .sort((a, b) => a.information.name.localeCompare(b.information.name));
 }
 
 export function useOperations() {


### PR DESCRIPTION
## Summary
- Na stranici `radnje` javne radnje ostaju grupirane po fazama, a interne radnje su premještene u sklopljeni odjeljak na dnu pod naslovom `Za OPG partnere`.
- Detaljni prikaz interne radnje više ne nudi korisničke CTA-ove za vrt i umjesto toga pokazuje OPG oznaku.
- `packages/game` sada filtrira interne radnje iz hooka za odabir u garden/game iskustvu.

## Testing
- `pnpm lint --filter www --filter @gredice/game` (uspješno nakon instalacije ovisnosti)
- `pnpm build --filter www --filter garden` (garden prošao; www je došao do postojećeg problema sa static params za sort `Jagoda Elan`, izvan ovog izmjena)
- Lokalna UI provjera `/radnje` u developmentu pokazala je ispravnu rutu i novi layout, uz nedostupne live directory podatke u ovom okruženju