### PR TITLE
Improve entity details history tab UX and readability

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
@@ -22,7 +22,10 @@ const actionLabels: Record<string, string> = {
 
 function formatAction(action: string): string {
     const normalizedAction = action.split('.').at(-1) ?? action;
-    return actionLabels[normalizedAction] ?? action.replace(/[._-]/g, ' ');
+    return (
+        actionLabels[normalizedAction] ??
+        normalizedAction.replace(/[._-]/g, ' ')
+    );
 }
 
 function formatDateTime(value: Date): string {

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
@@ -21,7 +21,8 @@ const actionLabels: Record<string, string> = {
 };
 
 function formatAction(action: string): string {
-    return actionLabels[action] ?? action.replace(/[-_]/g, ' ');
+    const normalizedAction = action.split('.').at(-1) ?? action;
+    return actionLabels[normalizedAction] ?? action.replace(/[._-]/g, ' ');
 }
 
 function formatDateTime(value: Date): string {

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
@@ -23,8 +23,7 @@ const actionLabels: Record<string, string> = {
 function formatAction(action: string): string {
     const normalizedAction = action.split('.').at(-1) ?? action;
     return (
-        actionLabels[normalizedAction] ??
-        normalizedAction.replace(/[._-]/g, ' ')
+        actionLabels[normalizedAction] ?? normalizedAction.replace(/[_-]/g, ' ')
     );
 }
 

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import type {
+    SelectAttributeDefinition,
+    SelectEntityRevision,
+} from '@gredice/storage';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { useMemo, useState } from 'react';
+import { Field } from '../../../../../components/shared/fields/Field';
+
+const actionLabels: Record<string, string> = {
+    created: 'Kreirano',
+    updated: 'Ažurirano',
+    deleted: 'Obrisano',
+    restored: 'Vraćeno',
+    imported: 'Uvezeno',
+};
+
+function formatAction(action: string): string {
+    return actionLabels[action] ?? action.replace(/[-_]/g, ' ');
+}
+
+function formatDateTime(value: Date): string {
+    return new Intl.DateTimeFormat('hr-HR', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(value);
+}
+
+export function HistoryRevisionListClient({
+    revisions,
+    attributeDefinitions,
+}: {
+    revisions: SelectEntityRevision[];
+    attributeDefinitions: SelectAttributeDefinition[];
+}) {
+    const [selectedRevision, setSelectedRevision] =
+        useState<SelectEntityRevision | null>(null);
+
+    const labelsByDefinitionId = useMemo(
+        () =>
+            new Map(
+                attributeDefinitions.map((definition) => [
+                    definition.id,
+                    definition.label,
+                ]),
+            ),
+        [attributeDefinitions],
+    );
+
+    return (
+        <>
+            {revisions.map((revision) => {
+                const attributeLabel = revision.attributeDefinitionId
+                    ? labelsByDefinitionId.get(revision.attributeDefinitionId)
+                    : null;
+                return (
+                    <Field
+                        key={revision.id}
+                        name={
+                            attributeLabel
+                                ? `${formatAction(revision.action)} • ${attributeLabel}`
+                                : formatAction(revision.action)
+                        }
+                        value={
+                            <Row
+                                className="items-center justify-between"
+                                spacing={2}
+                            >
+                                <Row className="items-center" spacing={2}>
+                                    <UserAvatar
+                                        avatarUrl={null}
+                                        userName={
+                                            revision.actorName ??
+                                            'Nepoznat korisnik'
+                                        }
+                                        className="size-6"
+                                    />
+                                    <span>
+                                        {formatDateTime(revision.createdAt)}
+                                    </span>
+                                </Row>
+                                <Button
+                                    variant="outlined"
+                                    size="sm"
+                                    onClick={() =>
+                                        setSelectedRevision(revision)
+                                    }
+                                >
+                                    Prikaži promjenu
+                                </Button>
+                            </Row>
+                        }
+                    />
+                );
+            })}
+
+            <Modal
+                open={Boolean(selectedRevision)}
+                title="Sadržaj promjene"
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setSelectedRevision(null);
+                    }
+                }}
+            >
+                {selectedRevision && (
+                    <div className="p-4">
+                        <Stack spacing={3}>
+                            <Row className="grid grid-cols-2 gap-4">
+                                <Stack spacing={1}>
+                                    <h4 className="font-medium">Original</h4>
+                                    <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-md border p-3 text-xs">
+                                        {selectedRevision.previousValue ??
+                                            selectedRevision.previousState ??
+                                            '-'}
+                                    </pre>
+                                </Stack>
+                                <Stack spacing={1}>
+                                    <h4 className="font-medium">Novo</h4>
+                                    <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-md border p-3 text-xs">
+                                        {selectedRevision.nextValue ??
+                                            selectedRevision.nextState ??
+                                            '-'}
+                                    </pre>
+                                </Stack>
+                            </Row>
+                        </Stack>
+                    </div>
+                )}
+            </Modal>
+        </>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -42,6 +42,7 @@ import { EntityDetailsSaveProvider } from './EntityDetailsSaveProvider';
 import { EntityDetailsStickyHeader } from './EntityDetailsStickyHeader';
 import { EntityInventoryCard } from './EntityInventoryCard';
 import { EntityLinksPanel } from './EntityLinksPanel';
+import { HistoryRevisionListClient } from './HistoryRevisionListClient';
 
 export const dynamic = 'force-dynamic';
 
@@ -202,7 +203,7 @@ export default async function EntityDetailsPage(props: {
                         <TabsList>
                             {[
                                 ...attributeCategories,
-                                { name: 'history', label: 'Historija' },
+                                { name: 'history', label: 'Povijest' },
                             ].map((category) => (
                                 <TabsTrigger
                                     key={category.name}
@@ -300,7 +301,7 @@ export default async function EntityDetailsPage(props: {
                     </Stack>
                     {[
                         ...attributeCategories,
-                        { name: 'history', label: 'Historija' },
+                        { name: 'history', label: 'Povijest' },
                     ].map((category) => (
                         <TabsContent value={category.name} key={category.name}>
                             <AttributeCategoryDetails
@@ -314,15 +315,12 @@ export default async function EntityDetailsPage(props: {
                     <TabsContent value="history" key="history">
                         <FieldSet>
                             {revisions.length === 0 ? (
-                                <Field name="Historija" value="Nema promjena" />
+                                <Field name="Povijest" value="Nema promjena" />
                             ) : (
-                                revisions.map((revision) => (
-                                    <Field
-                                        key={revision.id}
-                                        name={`${revision.action} • ${revision.actorName ?? 'Nepoznat korisnik'}`}
-                                        value={`${revision.createdAt.toISOString()} | ${revision.previousValue ?? revision.previousState ?? '-'} → ${revision.nextValue ?? revision.nextState ?? '-'}`}
-                                    />
-                                ))
+                                <HistoryRevisionListClient
+                                    revisions={revisions}
+                                    attributeDefinitions={attributeDefinitions}
+                                />
                             )}
                         </FieldSet>
                     </TabsContent>


### PR DESCRIPTION
### Motivation
- Present entity revision history with clearer, localized labels and a friendlier layout instead of raw inline diffs.
- Replace raw actor username text with avatar-first UI and show human-friendly timestamps.
- Surface the attribute label associated with each revision to give context for attribute-level changes.
- Move content comparison into a focused two-column modal so the history list remains compact and scannable.

### Description
- Renamed the history tab and empty-state field from `Historija` to `Povijest` in `apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx`.
- Replaced the inline revision rendering with a new client component `HistoryRevisionListClient` at `apps/app/app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx` that receives `revisions` and `attributeDefinitions` and renders the list interactively.
- Implemented user-friendly action labels (e.g., `created` → `Kreirano`) and a fallback formatter for unknown action keys in the new component.
- Displayed an avatar-first actor element using `UserAvatar`, localized date/time formatting (`hr-HR`), attribute definition label lookup, and a modal side-by-side diff view that shows `Original` and `Novo` content (falling back from `previousValue`/`nextValue` to `previousState`/`nextState`).

### Testing
- Ran `pnpm --filter app exec biome check app/admin/directories/[entityType]/[entityId]/page.tsx app/admin/directories/[entityType]/[entityId]/HistoryRevisionListClient.tsx` and the targeted Biome checks passed for the updated files.
- Ran `pnpm --filter app lint` (Biome), which completed but surfaced unrelated pre-existing warnings; unrelated auto-fix edits were reverted before finalizing these changes.
- The updated UI code was compiled/checked in the app package and committed after validation steps above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019fc9a49c832fbc2a3dceec3a2911)