### PR TITLE
feat(cms): inline selectable preview + right-side section settings panel

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import type { SelectCmsPage } from '@gredice/storage';
-import { cmsPageSectionComponents } from '@gredice/storage/cmsPageSections';
+import {
+    type CmsPageSectionComponent,
+    cmsPageSectionComponents,
+} from '@gredice/storage/cmsPageSections';
 import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
@@ -54,7 +57,7 @@ const cmsPageSectionItems = cmsPageSectionComponents.map((component) => ({
     label: component.label,
 }));
 
-const cmsPageSectionComponentsByName = new Map(
+const cmsPageSectionComponentsByName = new Map<string, CmsPageSectionComponent>(
     cmsPageSectionComponents.map((component) => [
         component.component,
         component,
@@ -791,7 +794,7 @@ export function CmsPageForm({
                                                 >
                                                     <SectionsView
                                                         sectionsData={[
-                                                            previewSection,
+                                                            section.data,
                                                         ]}
                                                         componentsRegistry={
                                                             sectionsComponentRegistry

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
 import type { SelectCmsPage } from '@gredice/storage';
-import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { cmsPageSectionComponents } from '@gredice/storage/cmsPageSections';
+import { SectionsView } from '@signalco/cms-core/SectionsView';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Input } from '@signalco/ui-primitives/Input';
@@ -10,36 +10,43 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { useActionState, useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+    useActionState,
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { sectionsComponentRegistry } from '../../../../components/shared/sectionsComponentRegistry';
 import type { CmsPageAutosaveState, CmsPageFormState } from './actions';
 
 type CmsPageFormProps = {
-  page?: SelectCmsPage;
-  action: (
-    previousState: CmsPageFormState,
-    formData: FormData,
-  ) => Promise<CmsPageFormState>;
-  submitLabel: string;
-  autosaveAction?: (formData: FormData) => Promise<CmsPageAutosaveState>;
+    page?: SelectCmsPage;
+    action: (
+        previousState: CmsPageFormState,
+        formData: FormData,
+    ) => Promise<CmsPageFormState>;
+    submitLabel: string;
+    autosaveAction?: (formData: FormData) => Promise<CmsPageAutosaveState>;
 };
 
 type CmsPageSectionData = {
-  component: string;
-  [key: string]: unknown;
+    component: string;
+    [key: string]: unknown;
 };
 
 type CmsPageEditableSection = {
-  id: string;
-  data: CmsPageSectionData;
+    id: string;
+    data: CmsPageSectionData;
 };
 
 const cmsPageStateItems = [
-  { value: "draft", label: "Draft" },
-  {
-    value: "published",
-    label: "Objavljeno",
-  },
+    { value: 'draft', label: 'Draft' },
+    {
+        value: 'published',
+        label: 'Objavljeno',
+    },
 ];
 
 const cmsPageSectionItems = cmsPageSectionComponents.map((component) => ({
@@ -55,104 +62,104 @@ const cmsPageSectionComponentsByName = new Map(
 );
 
 function parseSections(content?: string | null) {
-  if (!content) {
-    return { isStructured: true, sections: [] };
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(content);
-    if (!Array.isArray(parsed)) {
-      return { isStructured: false, sections: [] };
+    if (!content) {
+        return { isStructured: true, sections: [] };
     }
 
-    return {
-      isStructured: true,
-      sections: parsed.filter(
-        (section): section is CmsPageSectionData =>
-          Boolean(section) &&
-          typeof section === "object" &&
-          "component" in section &&
-          typeof section.component === "string",
-      ),
-    };
-  } catch {
-    return { isStructured: false, sections: [] };
-  }
+    try {
+        const parsed: unknown = JSON.parse(content);
+        if (!Array.isArray(parsed)) {
+            return { isStructured: false, sections: [] };
+        }
+
+        return {
+            isStructured: true,
+            sections: parsed.filter(
+                (section): section is CmsPageSectionData =>
+                    Boolean(section) &&
+                    typeof section === 'object' &&
+                    'component' in section &&
+                    typeof section.component === 'string',
+            ),
+        };
+    } catch {
+        return { isStructured: false, sections: [] };
+    }
 }
 
 function formatJsonContent(content: string) {
-  if (!content.trim()) {
-    return "";
-  }
+    if (!content.trim()) {
+        return '';
+    }
 
-  const parsed: unknown = JSON.parse(content);
-  return JSON.stringify(parsed, null, 2);
+    const parsed: unknown = JSON.parse(content);
+    return JSON.stringify(parsed, null, 2);
 }
 
 function editableSection(
-  section: CmsPageSectionData,
-  occurrence: number,
+    section: CmsPageSectionData,
+    occurrence: number,
 ): CmsPageEditableSection {
-  return {
-    id: `${section.component}-${occurrence}`,
-    data: section,
-  };
+    return {
+        id: `${section.component}-${occurrence}`,
+        data: section,
+    };
 }
 
 function newSection(
-  component: string,
-  idPrefix: string,
-  id: number,
+    component: string,
+    idPrefix: string,
+    id: number,
 ): CmsPageEditableSection {
-  return {
-    id: `${idPrefix}-${id}`,
-    data: { component },
-  };
+    return {
+        id: `${idPrefix}-${id}`,
+        data: { component },
+    };
 }
 
 function editableSections(sections: CmsPageSectionData[]) {
-  const sectionCounts = new Map<string, number>();
-  return sections.map((section) => {
-    const occurrence = sectionCounts.get(section.component) ?? 0;
-    sectionCounts.set(section.component, occurrence + 1);
-    return editableSection(section, occurrence);
-  });
+    const sectionCounts = new Map<string, number>();
+    return sections.map((section) => {
+        const occurrence = sectionCounts.get(section.component) ?? 0;
+        sectionCounts.set(section.component, occurrence + 1);
+        return editableSection(section, occurrence);
+    });
 }
 
 function stringifySections(sections: CmsPageEditableSection[]) {
-  const data = sections.map((section) => section.data);
-  return data.length > 0 ? JSON.stringify(data, null, 2) : "";
+    const data = sections.map((section) => section.data);
+    return data.length > 0 ? JSON.stringify(data, null, 2) : '';
 }
 
 function sectionValue(section: CmsPageEditableSection, key: string) {
-  const value = section.data[key];
-  return typeof value === "string" ? value : "";
+    const value = section.data[key];
+    return typeof value === 'string' ? value : '';
 }
 
 function moveSection(
-  sections: CmsPageEditableSection[],
-  sectionId: string,
-  offset: number,
+    sections: CmsPageEditableSection[],
+    sectionId: string,
+    offset: number,
 ) {
-  const index = sections.findIndex((section) => section.id === sectionId);
-  const targetIndex = index + offset;
-  if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
-    return sections;
-  }
+    const index = sections.findIndex((section) => section.id === sectionId);
+    const targetIndex = index + offset;
+    if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
+        return sections;
+    }
 
-  const next = [...sections];
-  const movingSections = next.splice(index, 1);
-  if (movingSections.length !== 1) {
-    return sections;
-  }
+    const next = [...sections];
+    const movingSections = next.splice(index, 1);
+    if (movingSections.length !== 1) {
+        return sections;
+    }
 
-  const [movingSection] = movingSections;
-  if (!movingSection) {
-    return sections;
-  }
+    const [movingSection] = movingSections;
+    if (!movingSection) {
+        return sections;
+    }
 
-  next.splice(targetIndex, 0, movingSection);
-  return next;
+    next.splice(targetIndex, 0, movingSection);
+    return next;
 }
 
 function copySection(
@@ -178,473 +185,814 @@ function validateSection(section: CmsPageEditableSection) {
         .map((field) => `${field.label} je obavezno polje.`);
 }
 
-export function CmsPageForm({ page, action, submitLabel, autosaveAction }: CmsPageFormProps) {
-  const [state, formAction, pending] = useActionState(action, null);
-  const reactId = useId();
-  const newSectionIdPrefix = useMemo(
-    () => `${reactId}-${page?.id ?? "new"}`,
-    [page?.id, reactId],
-  );
-  const parsedSections = useMemo(
-    () => parseSections(page?.content),
-    [page?.content],
-  );
-  const nextSectionId = useRef(parsedSections.sections.length);
-  const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
-    editableSections(parsedSections.sections),
-  );
-  const preserveFallbackContent =
-    !parsedSections.isStructured && Boolean(page?.content);
-  const [rawMode, setRawMode] = useState(preserveFallbackContent);
-  const [rawContent, setRawContent] = useState(page?.content ?? "");
-  const [rawError, setRawError] = useState<string | null>(null);
-  const builderContent = useMemo(() => stringifySections(sections), [sections]);
-  const serializedContent = rawMode
-    ? rawContent
-    : preserveFallbackContent && sections.length === 0
-      ? page?.content ?? ""
-      : builderContent;
-  const formRef = useRef<HTMLFormElement>(null);
-  const [formRevision, setFormRevision] = useState(0);
-  const autosaveSnapshot = useMemo(
-    () => JSON.stringify({ content: serializedContent, formRevision }),
-    [serializedContent, formRevision],
-  );
-  const latestAutosaveSnapshot = useRef(autosaveSnapshot);
-  const [autosaveStatus, setAutosaveStatus] = useState("saved");
-  const [autosaveMessage, setAutosaveMessage] = useState<string | null>(null);
-  const [lastSavedSnapshot, setLastSavedSnapshot] = useState(autosaveSnapshot);
-  const [previewSections, setPreviewSections] = useState<CmsPageSectionData[]>([]);
+function updateSectionField(
+    sectionId: string,
+    key: string,
+    value: string,
+    setSections: React.Dispatch<React.SetStateAction<CmsPageEditableSection[]>>,
+) {
+    setSections((current) =>
+        current.map((currentSection) =>
+            currentSection.id === sectionId
+                ? {
+                      ...currentSection,
+                      data: {
+                          ...currentSection.data,
+                          [key]: value,
+                      },
+                  }
+                : currentSection,
+        ),
+    );
+}
 
-  useEffect(() => {
-    latestAutosaveSnapshot.current = autosaveSnapshot;
-  }, [autosaveSnapshot]);
+export function CmsPageForm({
+    page,
+    action,
+    submitLabel,
+    autosaveAction,
+}: CmsPageFormProps) {
+    const [state, formAction, pending] = useActionState(action, null);
+    const reactId = useId();
+    const newSectionIdPrefix = useMemo(
+        () => `${reactId}-${page?.id ?? 'new'}`,
+        [page?.id, reactId],
+    );
+    const parsedSections = useMemo(
+        () => parseSections(page?.content),
+        [page?.content],
+    );
+    const nextSectionId = useRef(parsedSections.sections.length);
+    const [sections, setSections] = useState<CmsPageEditableSection[]>(() =>
+        editableSections(parsedSections.sections),
+    );
+    const preserveFallbackContent =
+        !parsedSections.isStructured && Boolean(page?.content);
+    const [rawMode, setRawMode] = useState(preserveFallbackContent);
+    const [rawContent, setRawContent] = useState(page?.content ?? '');
+    const [rawError, setRawError] = useState<string | null>(null);
+    const builderContent = useMemo(
+        () => stringifySections(sections),
+        [sections],
+    );
+    const serializedContent = rawMode
+        ? rawContent
+        : preserveFallbackContent && sections.length === 0
+          ? (page?.content ?? '')
+          : builderContent;
+    const formRef = useRef<HTMLFormElement>(null);
+    const [formRevision, setFormRevision] = useState(0);
+    const autosaveSnapshot = useMemo(
+        () => JSON.stringify({ content: serializedContent, formRevision }),
+        [serializedContent, formRevision],
+    );
+    const latestAutosaveSnapshot = useRef(autosaveSnapshot);
+    const [autosaveStatus, setAutosaveStatus] = useState('saved');
+    const [autosaveMessage, setAutosaveMessage] = useState<string | null>(null);
+    const [lastSavedSnapshot, setLastSavedSnapshot] =
+        useState(autosaveSnapshot);
+    const [previewSections, setPreviewSections] = useState<
+        CmsPageSectionData[]
+    >([]);
+    const [selectedSectionId, setSelectedSectionId] = useState<string | null>(
+        null,
+    );
 
-  useEffect(() => {
-    if (!autosaveAction) {
-      return;
-    }
+    useEffect(() => {
+        latestAutosaveSnapshot.current = autosaveSnapshot;
+    }, [autosaveSnapshot]);
 
-    if (autosaveSnapshot === lastSavedSnapshot) {
-      setAutosaveStatus("saved");
-      return;
-    }
+    useEffect(() => {
+        if (!autosaveAction) {
+            return;
+        }
 
-    setAutosaveStatus("unsaved");
-    const timer = setTimeout(async () => {
-      const form = formRef.current;
-      if (!form) {
-        return;
-      }
+        if (autosaveSnapshot === lastSavedSnapshot) {
+            setAutosaveStatus('saved');
+            return;
+        }
 
-      const snapshotToSave = autosaveSnapshot;
-      setAutosaveStatus("saving");
-      const formData = new FormData(form);
-      formData.set("state", "draft");
-      formData.set("content", serializedContent);
-
-      const result = await autosaveAction(formData);
-      if (latestAutosaveSnapshot.current !== snapshotToSave) {
-        return;
-      }
-
-      if (!result.success) {
-        setAutosaveStatus("failed");
-        setAutosaveMessage(result.message);
-        return;
-      }
-
-      setAutosaveStatus("saved");
-      setAutosaveMessage(result.message);
-      setLastSavedSnapshot(snapshotToSave);
-    }, 600);
-
-    return () => clearTimeout(timer);
-  }, [autosaveAction, autosaveSnapshot, serializedContent, lastSavedSnapshot]);
-
-  useEffect(() => {
-    setPreviewSections(parseSections(serializedContent).sections);
-  }, [serializedContent]);
-
-  return (
-    <Card className="max-w-3xl">
-      <Stack spacing={4} className="p-6">
-        <form
-          ref={formRef}
-          action={formAction}
-          onChange={() => setFormRevision((current) => current + 1)}
-          onSubmit={(event) => {
-            if (!rawMode) {
-              return;
+        setAutosaveStatus('unsaved');
+        const timer = setTimeout(async () => {
+            const form = formRef.current;
+            if (!form) {
+                return;
             }
 
-            try {
-              setRawContent(formatJsonContent(rawContent));
-              setRawError(null);
-            } catch {
-              event.preventDefault();
-              setRawError("JSON nije valjan. Ispravi sadržaj prije spremanja.");
+            const snapshotToSave = autosaveSnapshot;
+            setAutosaveStatus('saving');
+            const formData = new FormData(form);
+            formData.set('state', 'draft');
+            formData.set('content', serializedContent);
+
+            const result = await autosaveAction(formData);
+            if (latestAutosaveSnapshot.current !== snapshotToSave) {
+                return;
             }
-          }}
-        >
-          <Stack spacing={4}>
-            <Stack spacing={3}>
-              {autosaveAction && (
-                <Typography level="body3" secondary>
-                  Autosave: {autosaveStatus}{autosaveMessage ? ` • ${autosaveMessage}` : ""}
-                </Typography>
-              )}
-              <Input
-                name="title"
-                label="Naslov"
-                defaultValue={page?.title ?? ""}
-                required
-              />
-              <Input
-                name="slug"
-                label="Slug"
-                defaultValue={page?.slug ?? ""}
-                placeholder="npr. sezonski-vodic"
-                helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
-                required
-              />
-              <SelectItems
-                name="state"
-                label="Status"
-                defaultValue={page?.state ?? "draft"}
-                items={cmsPageStateItems}
-              />
-              <Stack spacing={2}>
-                <Typography level="h3" semiBold>
-                  Sadržaj stranice
-                </Typography>
-                <Typography level="body3" secondary>
-                  Vizualni editor je zadani način rada, a JSON editor je
-                  dostupan kao fallback.
-                </Typography>
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={rawMode}
-                    onChange={(event) => {
-                      const enabled = event.target.checked;
-                      setRawMode(enabled);
-                      setRawError(null);
-                      if (enabled) {
-                        setRawContent(builderContent);
-                      }
-                    }}
-                  />
-                  Uredi sadržaj kroz JSON editor (fallback)
-                </label>
-                {preserveFallbackContent && (
-                  <Card className="p-3 text-sm text-amber-700">
-                    Postojeći sadržaj nije moguće prikazati u vizualnom editoru
-                    bez gubitka podataka.
-                  </Card>
-                )}
-                <input
-                  name="content"
-                  type="hidden"
-                  value={serializedContent}
-                  readOnly
-                />
-                {rawMode ? (
-                  <label className="space-y-1">
-                    <span className="block text-sm font-medium">
-                      JSON sadržaj
-                    </span>
-                    <textarea
-                      value={rawContent}
-                      rows={16}
-                      className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      onBlur={() => {
-                        try {
-                          setRawContent(formatJsonContent(rawContent));
-                          setRawError(null);
-                        } catch {
-                          setRawError(
-                            "JSON nije valjan. Ispravi sadržaj prije spremanja.",
-                          );
+
+            if (!result.success) {
+                setAutosaveStatus('failed');
+                setAutosaveMessage(result.message);
+                return;
+            }
+
+            setAutosaveStatus('saved');
+            setAutosaveMessage(result.message);
+            setLastSavedSnapshot(snapshotToSave);
+        }, 600);
+
+        return () => clearTimeout(timer);
+    }, [
+        autosaveAction,
+        autosaveSnapshot,
+        serializedContent,
+        lastSavedSnapshot,
+    ]);
+
+    useEffect(() => {
+        setPreviewSections(parseSections(serializedContent).sections);
+    }, [serializedContent]);
+
+    useEffect(() => {
+        if (sections.length === 0) {
+            setSelectedSectionId(null);
+            return;
+        }
+
+        if (
+            selectedSectionId &&
+            sections.some((section) => section.id === selectedSectionId)
+        ) {
+            return;
+        }
+
+        setSelectedSectionId(sections[0]?.id ?? null);
+    }, [sections, selectedSectionId]);
+
+    const selectedSection = sections.find(
+        (section) => section.id === selectedSectionId,
+    );
+
+    return (
+        <Card className="max-w-3xl">
+            <Stack spacing={4} className="p-6">
+                <form
+                    ref={formRef}
+                    action={formAction}
+                    onChange={() => setFormRevision((current) => current + 1)}
+                    onSubmit={(event) => {
+                        if (!rawMode) {
+                            return;
                         }
-                      }}
-                      onChange={(event) => {
-                        setRawContent(event.target.value);
-                        setRawError(null);
-                      }}
-                    />
-                    {rawError && (
-                      <Typography level="body2" className="text-red-600">
-                        {rawError}
-                      </Typography>
-                    )}
-                    {preserveFallbackContent && (
-                      <Button
-                        type="button"
-                        variant="plain"
-                        onClick={() => {
-                          setRawContent(page?.content ?? "");
-                          setRawError(null);
-                        }}
-                      >
-                        Vrati spremljeni sadržaj
-                      </Button>
-                    )}
-                  </label>
-                ) : sections.length === 0 ? (
-                  <Card className="p-4 text-sm text-muted-foreground">
-                    {preserveFallbackContent
-                      ? "Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija."
-                      : "Stranica još nema sekcija."}
-                  </Card>
-                ) : (
-                  <Stack spacing={2}>
-                    {sections.map((section, index) => (
-                      <Card key={section.id} className="p-4">
-                        <Stack spacing={2}>
-                          <Row
-                            spacing={2}
-                            className="items-center justify-between"
-                          >
-                            <Typography level="body1" semiBold>
-                              {index + 1}.{' '}
-                              {section.data.component}
-                            </Typography>
-                            <Row spacing={1}>
-                              <Button
-                                type="button"
-                                variant="plain"
-                                disabled={index === 0}
-                                onClick={() =>
-                                  setSections((current) =>
-                                    moveSection(current, section.id, -1),
-                                  )
-                                }
-                              >
-                                Gore
-                              </Button>
-                              <Button
-                                type="button"
-                                variant="plain"
-                                disabled={index === sections.length - 1}
-                                onClick={() =>
-                                  setSections((current) =>
-                                    moveSection(current, section.id, 1),
-                                  )
-                                }
-                              >
-                                Dolje
-                              </Button>
-                              <Button
-                                type="button"
-                                variant="plain"
-                                onClick={() => {
-                                  setSections((current) => {
-                                    const idx = current.findIndex(
-                                      (candidate) =>
-                                        candidate.id === section.id,
-                                    );
-                                    if (idx < 0) {
-                                      return current;
-                                    }
-                                    const sectionId = nextSectionId.current;
-                                    nextSectionId.current += 1;
-                                    const duplicate = copySection(
-                                      section,
-                                      `${newSectionIdPrefix}-${sectionId}`,
-                                    );
-                                    return [
-                                      ...current.slice(0, idx + 1),
-                                      duplicate,
-                                      ...current.slice(idx + 1),
-                                    ];
-                                  });
-                                }}
-                              >
-                                Dupliciraj
-                              </Button>
-                              <Button
-                                type="button"
-                                variant="plain"
-                                color="danger"
-                                onClick={() =>
-                                  setSections((current) =>
-                                    current.filter(
-                                      (currentSection) =>
-                                        currentSection.id !== section.id,
-                                    ),
-                                  )
-                                }
-                              >
-                                Ukloni
-                              </Button>
-                            </Row>
-                          </Row>
-                          {(
-                            cmsPageSectionComponentsByName.get(
-                              section.data.component,
-                            )?.fields ?? []
-                          ).map((field) =>
-                            field.type === 'textarea' ? (
-                              <label
-                                key={field.key}
-                                className="space-y-1"
-                              >
-                                <span className="block text-sm font-medium">
-                                  {field.label}
-                                </span>
-                                <textarea
-                                  value={sectionValue(section, field.key)}
-                                  rows={field.rows ?? 4}
-                                  className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                  onChange={(event) => {
-                                    const value = event.target.value;
-                                    setSections((current) =>
-                                      current.map((currentSection) =>
-                                        currentSection.id === section.id
-                                          ? {
-                                              ...currentSection,
-                                              data: {
-                                                ...currentSection.data,
-                                                [field.key]: value,
-                                              },
+
+                        try {
+                            setRawContent(formatJsonContent(rawContent));
+                            setRawError(null);
+                        } catch {
+                            event.preventDefault();
+                            setRawError(
+                                'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                            );
+                        }
+                    }}
+                >
+                    <Stack spacing={4}>
+                        <Stack spacing={3}>
+                            {autosaveAction && (
+                                <Typography level="body3" secondary>
+                                    Autosave: {autosaveStatus}
+                                    {autosaveMessage
+                                        ? ` • ${autosaveMessage}`
+                                        : ''}
+                                </Typography>
+                            )}
+                            <Input
+                                name="title"
+                                label="Naslov"
+                                defaultValue={page?.title ?? ''}
+                                required
+                            />
+                            <Input
+                                name="slug"
+                                label="Slug"
+                                defaultValue={page?.slug ?? ''}
+                                placeholder="npr. sezonski-vodic"
+                                helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
+                                required
+                            />
+                            <SelectItems
+                                name="state"
+                                label="Status"
+                                defaultValue={page?.state ?? 'draft'}
+                                items={cmsPageStateItems}
+                            />
+                            <Stack spacing={2}>
+                                <Typography level="h3" semiBold>
+                                    Sadržaj stranice
+                                </Typography>
+                                <Typography level="body3" secondary>
+                                    Vizualni editor je zadani način rada, a JSON
+                                    editor je dostupan kao fallback.
+                                </Typography>
+                                <label className="flex items-center gap-2 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        checked={rawMode}
+                                        onChange={(event) => {
+                                            const enabled =
+                                                event.target.checked;
+                                            setRawMode(enabled);
+                                            setRawError(null);
+                                            if (enabled) {
+                                                setRawContent(builderContent);
                                             }
-                                          : currentSection,
-                                      ),
-                                    );
-                                  }}
+                                        }}
+                                    />
+                                    Uredi sadržaj kroz JSON editor (fallback)
+                                </label>
+                                {preserveFallbackContent && (
+                                    <Card className="p-3 text-sm text-amber-700">
+                                        Postojeći sadržaj nije moguće prikazati
+                                        u vizualnom editoru bez gubitka
+                                        podataka.
+                                    </Card>
+                                )}
+                                <input
+                                    name="content"
+                                    type="hidden"
+                                    value={serializedContent}
+                                    readOnly
                                 />
-                              </label>
-                            ) : (
-                              <Input
-                                key={field.key}
-                                label={field.label}
-                                value={sectionValue(section, field.key)}
-                                onChange={(event) => {
-                                  const value = event.target.value;
-                                  setSections((current) =>
-                                    current.map((currentSection) =>
-                                      currentSection.id === section.id
-                                        ? {
-                                            ...currentSection,
-                                            data: {
-                                              ...currentSection.data,
-                                              [field.key]: value,
-                                            },
-                                          }
-                                        : currentSection,
-                                    ),
-                                  );
-                                }}
-                              />
-                            ),
-                          )}
-                          {validateSection(section).map((error) => (
-                            <Typography
-                              key={error}
-                              level="body3"
-                              className="text-red-600"
-                            >
-                              {error}
-                            </Typography>
-                          ))}
+                                {rawMode ? (
+                                    <label className="space-y-1">
+                                        <span className="block text-sm font-medium">
+                                            JSON sadržaj
+                                        </span>
+                                        <textarea
+                                            value={rawContent}
+                                            rows={16}
+                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            onBlur={() => {
+                                                try {
+                                                    setRawContent(
+                                                        formatJsonContent(
+                                                            rawContent,
+                                                        ),
+                                                    );
+                                                    setRawError(null);
+                                                } catch {
+                                                    setRawError(
+                                                        'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                                                    );
+                                                }
+                                            }}
+                                            onChange={(event) => {
+                                                setRawContent(
+                                                    event.target.value,
+                                                );
+                                                setRawError(null);
+                                            }}
+                                        />
+                                        {rawError && (
+                                            <Typography
+                                                level="body2"
+                                                className="text-red-600"
+                                            >
+                                                {rawError}
+                                            </Typography>
+                                        )}
+                                        {preserveFallbackContent && (
+                                            <Button
+                                                type="button"
+                                                variant="plain"
+                                                onClick={() => {
+                                                    setRawContent(
+                                                        page?.content ?? '',
+                                                    );
+                                                    setRawError(null);
+                                                }}
+                                            >
+                                                Vrati spremljeni sadržaj
+                                            </Button>
+                                        )}
+                                    </label>
+                                ) : sections.length === 0 ? (
+                                    <Card className="p-4 text-sm text-muted-foreground">
+                                        {preserveFallbackContent
+                                            ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija.'
+                                            : 'Stranica još nema sekcija.'}
+                                    </Card>
+                                ) : (
+                                    <Stack spacing={2}>
+                                        {sections.map((section, index) => (
+                                            <Card
+                                                key={section.id}
+                                                className={`p-4 cursor-pointer ${selectedSectionId === section.id ? 'border-primary' : ''}`}
+                                                onClick={() =>
+                                                    setSelectedSectionId(
+                                                        section.id,
+                                                    )
+                                                }
+                                            >
+                                                <Stack spacing={2}>
+                                                    <Row
+                                                        spacing={2}
+                                                        className="items-center justify-between"
+                                                    >
+                                                        <Typography
+                                                            level="body1"
+                                                            semiBold
+                                                        >
+                                                            {index + 1}.{' '}
+                                                            {
+                                                                section.data
+                                                                    .component
+                                                            }
+                                                        </Typography>
+                                                        <Row spacing={1}>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                disabled={
+                                                                    index === 0
+                                                                }
+                                                                onClick={() =>
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) =>
+                                                                            moveSection(
+                                                                                current,
+                                                                                section.id,
+                                                                                -1,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                Gore
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                disabled={
+                                                                    index ===
+                                                                    sections.length -
+                                                                        1
+                                                                }
+                                                                onClick={() =>
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) =>
+                                                                            moveSection(
+                                                                                current,
+                                                                                section.id,
+                                                                                1,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                Dolje
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                onClick={() => {
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) => {
+                                                                            const idx =
+                                                                                current.findIndex(
+                                                                                    (
+                                                                                        candidate,
+                                                                                    ) =>
+                                                                                        candidate.id ===
+                                                                                        section.id,
+                                                                                );
+                                                                            if (
+                                                                                idx <
+                                                                                0
+                                                                            ) {
+                                                                                return current;
+                                                                            }
+                                                                            const sectionId =
+                                                                                nextSectionId.current;
+                                                                            nextSectionId.current += 1;
+                                                                            const duplicate =
+                                                                                copySection(
+                                                                                    section,
+                                                                                    `${newSectionIdPrefix}-${sectionId}`,
+                                                                                );
+                                                                            return [
+                                                                                ...current.slice(
+                                                                                    0,
+                                                                                    idx +
+                                                                                        1,
+                                                                                ),
+                                                                                duplicate,
+                                                                                ...current.slice(
+                                                                                    idx +
+                                                                                        1,
+                                                                                ),
+                                                                            ];
+                                                                        },
+                                                                    );
+                                                                }}
+                                                            >
+                                                                Dupliciraj
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="plain"
+                                                                color="danger"
+                                                                onClick={() =>
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) =>
+                                                                            current.filter(
+                                                                                (
+                                                                                    currentSection,
+                                                                                ) =>
+                                                                                    currentSection.id !==
+                                                                                    section.id,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                Ukloni
+                                                            </Button>
+                                                        </Row>
+                                                    </Row>
+                                                    {(
+                                                        cmsPageSectionComponentsByName.get(
+                                                            section.data
+                                                                .component,
+                                                        )?.fields ?? []
+                                                    ).map((field) =>
+                                                        field.type ===
+                                                        'textarea' ? (
+                                                            <label
+                                                                key={field.key}
+                                                                className="space-y-1"
+                                                            >
+                                                                <span className="block text-sm font-medium">
+                                                                    {
+                                                                        field.label
+                                                                    }
+                                                                </span>
+                                                                <textarea
+                                                                    value={sectionValue(
+                                                                        section,
+                                                                        field.key,
+                                                                    )}
+                                                                    rows={
+                                                                        field.rows ??
+                                                                        4
+                                                                    }
+                                                                    className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                    onChange={(
+                                                                        event,
+                                                                    ) => {
+                                                                        const value =
+                                                                            event
+                                                                                .target
+                                                                                .value;
+                                                                        setSections(
+                                                                            (
+                                                                                current,
+                                                                            ) =>
+                                                                                current.map(
+                                                                                    (
+                                                                                        currentSection,
+                                                                                    ) =>
+                                                                                        currentSection.id ===
+                                                                                        section.id
+                                                                                            ? {
+                                                                                                  ...currentSection,
+                                                                                                  data: {
+                                                                                                      ...currentSection.data,
+                                                                                                      [field.key]:
+                                                                                                          value,
+                                                                                                  },
+                                                                                              }
+                                                                                            : currentSection,
+                                                                                ),
+                                                                        );
+                                                                    }}
+                                                                />
+                                                            </label>
+                                                        ) : (
+                                                            <Input
+                                                                key={field.key}
+                                                                label={
+                                                                    field.label
+                                                                }
+                                                                value={sectionValue(
+                                                                    section,
+                                                                    field.key,
+                                                                )}
+                                                                onChange={(
+                                                                    event,
+                                                                ) => {
+                                                                    const value =
+                                                                        event
+                                                                            .target
+                                                                            .value;
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) =>
+                                                                            current.map(
+                                                                                (
+                                                                                    currentSection,
+                                                                                ) =>
+                                                                                    currentSection.id ===
+                                                                                    section.id
+                                                                                        ? {
+                                                                                              ...currentSection,
+                                                                                              data: {
+                                                                                                  ...currentSection.data,
+                                                                                                  [field.key]:
+                                                                                                      value,
+                                                                                              },
+                                                                                          }
+                                                                                        : currentSection,
+                                                                            ),
+                                                                    );
+                                                                }}
+                                                            />
+                                                        ),
+                                                    )}
+                                                    {validateSection(
+                                                        section,
+                                                    ).map((error) => (
+                                                        <Typography
+                                                            key={error}
+                                                            level="body3"
+                                                            className="text-red-600"
+                                                        >
+                                                            {error}
+                                                        </Typography>
+                                                    ))}
+                                                </Stack>
+                                            </Card>
+                                        ))}
+                                    </Stack>
+                                )}
+                                <Row spacing={2}>
+                                    {!rawMode &&
+                                        cmsPageSectionItems.map((item) => (
+                                            <Button
+                                                key={item.value}
+                                                type="button"
+                                                variant="outlined"
+                                                onClick={() => {
+                                                    setSections((current) => {
+                                                        const sectionId =
+                                                            nextSectionId.current;
+                                                        nextSectionId.current += 1;
+                                                        return [
+                                                            ...current,
+                                                            newSection(
+                                                                item.value,
+                                                                newSectionIdPrefix,
+                                                                sectionId,
+                                                            ),
+                                                        ];
+                                                    });
+                                                }}
+                                            >
+                                                Dodaj {item.label}
+                                            </Button>
+                                        ))}
+                                </Row>
+                            </Stack>
                         </Stack>
-                      </Card>
-                    ))}
-                  </Stack>
-                )}
-                <Row spacing={2}>
-                  {!rawMode &&
-                    cmsPageSectionItems.map((item) => (
-                      <Button
-                        key={item.value}
-                        type="button"
-                        variant="outlined"
-                        onClick={() => {
-                          setSections((current) => {
-                            const sectionId = nextSectionId.current;
-                            nextSectionId.current += 1;
-                            return [
-                              ...current,
-                              newSection(
-                                item.value,
-                                newSectionIdPrefix,
-                                sectionId,
-                              ),
-                            ];
-                          });
-                        }}
-                      >
-                        Dodaj {item.label}
-                      </Button>
-                    ))}
-                </Row>
-              </Stack>
+
+                        <Stack spacing={2}>
+                            <Typography level="h3" semiBold>
+                                Live preview
+                            </Typography>
+                            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+                                <Card className="p-4">
+                                    <Stack spacing={2}>
+                                        {sections.map((section, index) => (
+                                            <Stack key={section.id} spacing={2}>
+                                                <Card
+                                                    className={`p-3 cursor-pointer ${sections[index]?.id === selectedSectionId ? 'border-primary' : ''}`}
+                                                    onClick={() =>
+                                                        setSelectedSectionId(
+                                                            sections[index]
+                                                                ?.id ?? null,
+                                                        )
+                                                    }
+                                                >
+                                                    <SectionsView
+                                                        sectionsData={[
+                                                            previewSection,
+                                                        ]}
+                                                        componentsRegistry={
+                                                            sectionsComponentRegistry
+                                                        }
+                                                    />
+                                                </Card>
+                                                <Row spacing={2}>
+                                                    {cmsPageSectionItems.map(
+                                                        (item) => (
+                                                            <Button
+                                                                key={`${section.id}-${item.value}`}
+                                                                type="button"
+                                                                variant="outlined"
+                                                                onClick={() => {
+                                                                    const sectionId =
+                                                                        nextSectionId.current;
+                                                                    nextSectionId.current += 1;
+                                                                    const id = `${newSectionIdPrefix}-${sectionId}`;
+                                                                    setSections(
+                                                                        (
+                                                                            current,
+                                                                        ) => [
+                                                                            ...current.slice(
+                                                                                0,
+                                                                                index +
+                                                                                    1,
+                                                                            ),
+                                                                            {
+                                                                                id,
+                                                                                data: {
+                                                                                    component:
+                                                                                        item.value,
+                                                                                },
+                                                                            },
+                                                                            ...current.slice(
+                                                                                index +
+                                                                                    1,
+                                                                            ),
+                                                                        ],
+                                                                    );
+                                                                    setSelectedSectionId(
+                                                                        id,
+                                                                    );
+                                                                }}
+                                                            >
+                                                                Dodaj{' '}
+                                                                {item.label}{' '}
+                                                                ispod
+                                                            </Button>
+                                                        ),
+                                                    )}
+                                                </Row>
+                                            </Stack>
+                                        ))}
+                                        {previewSections.length === 0 && (
+                                            <Typography level="body3" secondary>
+                                                Nema sekcija za prikaz.
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                </Card>
+                                <Card className="h-fit p-4 lg:sticky lg:top-24">
+                                    <Stack spacing={2}>
+                                        <Typography level="h4" semiBold>
+                                            Postavke sekcije
+                                        </Typography>
+                                        {!selectedSection ? (
+                                            <Typography level="body3" secondary>
+                                                Klikni sekciju u preview prikazu
+                                                za uređivanje atributa.
+                                            </Typography>
+                                        ) : (
+                                            <>
+                                                <Typography
+                                                    level="body2"
+                                                    semiBold
+                                                >
+                                                    {
+                                                        selectedSection.data
+                                                            .component
+                                                    }
+                                                </Typography>
+                                                {(
+                                                    cmsPageSectionComponentsByName.get(
+                                                        selectedSection.data
+                                                            .component,
+                                                    )?.fields ?? []
+                                                ).map((field) =>
+                                                    field.type ===
+                                                    'textarea' ? (
+                                                        <label
+                                                            key={field.key}
+                                                            className="space-y-1"
+                                                        >
+                                                            <span className="block text-sm font-medium">
+                                                                {field.label}
+                                                            </span>
+                                                            <textarea
+                                                                value={sectionValue(
+                                                                    selectedSection,
+                                                                    field.key,
+                                                                )}
+                                                                rows={
+                                                                    field.rows ??
+                                                                    4
+                                                                }
+                                                                className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                onChange={(
+                                                                    event,
+                                                                ) =>
+                                                                    updateSectionField(
+                                                                        selectedSection.id,
+                                                                        field.key,
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                        setSections,
+                                                                    )
+                                                                }
+                                                            />
+                                                        </label>
+                                                    ) : (
+                                                        <Input
+                                                            key={field.key}
+                                                            label={field.label}
+                                                            value={sectionValue(
+                                                                selectedSection,
+                                                                field.key,
+                                                            )}
+                                                            onChange={(event) =>
+                                                                updateSectionField(
+                                                                    selectedSection.id,
+                                                                    field.key,
+                                                                    event.target
+                                                                        .value,
+                                                                    setSections,
+                                                                )
+                                                            }
+                                                        />
+                                                    ),
+                                                )}
+                                            </>
+                                        )}
+                                    </Stack>
+                                </Card>
+                            </div>
+                        </Stack>
+
+                        <Stack spacing={3}>
+                            <Typography level="h3" semiBold>
+                                Metadata
+                            </Typography>
+                            <Input
+                                name="metaTitle"
+                                label="Meta naslov"
+                                defaultValue={page?.metaTitle ?? ''}
+                            />
+                            <Input
+                                name="metaDescription"
+                                label="Meta opis"
+                                defaultValue={page?.metaDescription ?? ''}
+                            />
+                            <Input
+                                name="metaImageUrl"
+                                label="Meta slika URL"
+                                type="url"
+                                defaultValue={page?.metaImageUrl ?? ''}
+                            />
+                            <Input
+                                name="canonicalPath"
+                                label="Canonical putanja"
+                                defaultValue={page?.canonicalPath ?? ''}
+                                placeholder="/primjer-stranice"
+                            />
+                            <label className="flex items-center gap-2 text-sm">
+                                <input
+                                    type="checkbox"
+                                    name="noIndex"
+                                    defaultChecked={page?.noIndex ?? false}
+                                />
+                                Isključi iz indeksiranja (noindex)
+                            </label>
+                        </Stack>
+
+                        {state?.message && (
+                            <Typography level="body2" className="text-red-600">
+                                {state.message}
+                            </Typography>
+                        )}
+
+                        <Button
+                            variant="solid"
+                            type="submit"
+                            className="w-fit"
+                            loading={pending}
+                        >
+                            {submitLabel}
+                        </Button>
+                    </Stack>
+                </form>
             </Stack>
-
-            <Stack spacing={2}>
-              <Typography level="h3" semiBold>Live preview</Typography>
-              <Card className="p-4">
-                <SectionsView
-                  sectionsData={previewSections}
-                  componentsRegistry={sectionsComponentRegistry}
-                />
-              </Card>
-            </Stack>
-
-            <Stack spacing={3}>
-              <Typography level="h3" semiBold>
-                Metadata
-              </Typography>
-              <Input
-                name="metaTitle"
-                label="Meta naslov"
-                defaultValue={page?.metaTitle ?? ""}
-              />
-              <Input
-                name="metaDescription"
-                label="Meta opis"
-                defaultValue={page?.metaDescription ?? ""}
-              />
-              <Input
-                name="metaImageUrl"
-                label="Meta slika URL"
-                type="url"
-                defaultValue={page?.metaImageUrl ?? ""}
-              />
-              <Input
-                name="canonicalPath"
-                label="Canonical putanja"
-                defaultValue={page?.canonicalPath ?? ""}
-                placeholder="/primjer-stranice"
-              />
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  name="noIndex"
-                  defaultChecked={page?.noIndex ?? false}
-                />
-                Isključi iz indeksiranja (noindex)
-              </label>
-            </Stack>
-
-            {state?.message && (
-              <Typography level="body2" className="text-red-600">
-                {state.message}
-              </Typography>
-            )}
-
-            <Button
-              variant="solid"
-              type="submit"
-              className="w-fit"
-              loading={pending}
-            >
-              {submitLabel}
-            </Button>
-          </Stack>
-        </form>
-      </Stack>
-    </Card>
-  );
+        </Card>
+    );
 }


### PR DESCRIPTION
### Motivation
- Improve the CMS page editor UX by letting editors select and edit individual sections from the live preview rather than only from the stacked builder form. 
- Make section attribute editing use a single side-panel workflow so future tabs/options and global page edits can be routed through the panel.

### Description
- Added section selection state and selection lifecycle so clicking a section in the builder or preview selects it and the selection survives reorder/add/remove operations (new `selectedSectionId` state and selection syncing). 
- Introduced `updateSectionField` helper to apply field edits to a section via `setSections` and wired the right-side panel to use it for field updates. 
- Reworked the Live preview area to render clickable per-section preview cards, add inline "add below" controls, and highlight the selected section. 
- Added a sticky right-side section settings panel that displays the selected section component and its fields (textarea and input handling preserved), while keeping the existing raw-JSON fallback and previous section management actions (move/duplicate/remove).
- Primary changes live in `apps/app/app/admin/cms/pages/CmsPageForm.tsx` and connect into the existing `sectionsComponentRegistry` and `cmsPageSectionComponentsByName` data.

### Testing
- Ran formatter for the modified file with `biome format --write app/admin/cms/pages/CmsPageForm.tsx` which formatted and saved the file. (succeeded)
- Ran file-level checks with `biome check app/admin/cms/pages/CmsPageForm.tsx` which reported no remaining errors for the changed file. (succeeded)
- Ran the package lint via `pnpm --filter app lint`, which surfaced pre-existing unrelated lint errors in other files and an environment Node engine warning; these failures are not caused by the changes in this PR. (noted)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a2af7534832f880a322037611a0b)