### PR TITLE
Add "Aktivnosti" admin page to show latest entity revisions

### DIFF
--- a/apps/app/app/admin/directories/activity/page.tsx
+++ b/apps/app/app/admin/directories/activity/page.tsx
@@ -1,0 +1,85 @@
+import { getLatestEntityRevisions } from '@gredice/storage';
+import { Row } from '@signalco/ui-primitives/Row';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
+import {
+    AdminPageHeader,
+    AdminPageTitle,
+} from '../../../../components/admin/navigation';
+import { KnownPages } from '../../../../src/KnownPages';
+
+const actionLabels: Record<string, string> = {
+    created: 'Kreirano',
+    updated: 'Ažurirano',
+    deleted: 'Obrisano',
+    restored: 'Vraćeno',
+    imported: 'Uvezeno',
+};
+
+function formatAction(action: string): string {
+    const normalizedAction = action.split('.').at(-1) ?? action;
+    return (
+        actionLabels[normalizedAction] ?? normalizedAction.replace(/[_-]/g, ' ')
+    );
+}
+
+function formatDateTime(value: Date): string {
+    return new Intl.DateTimeFormat('hr-HR', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(value);
+}
+
+export default async function DirectoryActivityPage() {
+    const revisions = await getLatestEntityRevisions(200);
+
+    return (
+        <Stack spacing={4}>
+            <AdminPageHeader>
+                <AdminPageTitle title="Aktivnosti" />
+            </AdminPageHeader>
+
+            <Stack spacing={2}>
+                {revisions.length === 0 ? (
+                    <Typography level="body2">Nema aktivnosti.</Typography>
+                ) : (
+                    revisions.map((revision) => (
+                        <div
+                            key={revision.id}
+                            className="rounded-md border p-3"
+                        >
+                            <Row
+                                className="items-center justify-between"
+                                spacing={2}
+                            >
+                                <Stack spacing={0.5}>
+                                    <Typography level="body2" semiBold>
+                                        {formatAction(revision.action)}
+                                    </Typography>
+                                    <Typography
+                                        level="label"
+                                        className="text-muted-foreground"
+                                    >
+                                        {formatDateTime(revision.createdAt)} •{' '}
+                                        {revision.actorName ??
+                                            'Nepoznat korisnik'}
+                                    </Typography>
+                                </Stack>
+                                <Link
+                                    href={KnownPages.DirectoryEntity(
+                                        revision.entityTypeName,
+                                        revision.entityId,
+                                    )}
+                                    className="text-sm underline"
+                                >
+                                    Otvori zapis #{revision.entityId}
+                                </Link>
+                            </Row>
+                        </div>
+                    ))
+                )}
+            </Stack>
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/directories/activity/page.tsx
+++ b/apps/app/app/admin/directories/activity/page.tsx
@@ -24,6 +24,10 @@ function formatAction(action: string): string {
     );
 }
 
+function isDeleteAction(action: string): boolean {
+    return (action.split('.').at(-1) ?? action) === 'deleted';
+}
+
 function formatDateTime(value: Date): string {
     return new Intl.DateTimeFormat('hr-HR', {
         dateStyle: 'medium',
@@ -44,40 +48,54 @@ export default async function DirectoryActivityPage() {
                 {revisions.length === 0 ? (
                     <Typography level="body2">Nema aktivnosti.</Typography>
                 ) : (
-                    revisions.map((revision) => (
-                        <div
-                            key={revision.id}
-                            className="rounded-md border p-3"
-                        >
-                            <Row
-                                className="items-center justify-between"
-                                spacing={2}
+                    revisions.map((revision) => {
+                        const isDeleted = isDeleteAction(revision.action);
+
+                        return (
+                            <div
+                                key={revision.id}
+                                className="rounded-md border p-3"
                             >
-                                <Stack spacing={0.5}>
-                                    <Typography level="body2" semiBold>
-                                        {formatAction(revision.action)}
-                                    </Typography>
-                                    <Typography
-                                        level="label"
-                                        className="text-muted-foreground"
-                                    >
-                                        {formatDateTime(revision.createdAt)} •{' '}
-                                        {revision.actorName ??
-                                            'Nepoznat korisnik'}
-                                    </Typography>
-                                </Stack>
-                                <Link
-                                    href={KnownPages.DirectoryEntity(
-                                        revision.entityTypeName,
-                                        revision.entityId,
-                                    )}
-                                    className="text-sm underline"
+                                <Row
+                                    className="items-center justify-between"
+                                    spacing={2}
                                 >
-                                    Otvori zapis #{revision.entityId}
-                                </Link>
-                            </Row>
-                        </div>
-                    ))
+                                    <Stack spacing={0.5}>
+                                        <Typography level="body2" semiBold>
+                                            {formatAction(revision.action)}
+                                        </Typography>
+                                        <Typography
+                                            level="label"
+                                            className="text-muted-foreground"
+                                        >
+                                            {formatDateTime(revision.createdAt)}{' '}
+                                            •{' '}
+                                            {revision.actorName ??
+                                                'Nepoznat korisnik'}
+                                        </Typography>
+                                    </Stack>
+                                    {isDeleted ? (
+                                        <Typography
+                                            level="label"
+                                            className="text-muted-foreground"
+                                        >
+                                            Obrisani zapis #{revision.entityId}
+                                        </Typography>
+                                    ) : (
+                                        <Link
+                                            href={KnownPages.DirectoryEntity(
+                                                revision.entityTypeName,
+                                                revision.entityId,
+                                            )}
+                                            className="text-sm underline"
+                                        >
+                                            Otvori zapis #{revision.entityId}
+                                        </Link>
+                                    )}
+                                </Row>
+                            </div>
+                        );
+                    })
                 )}
             </Stack>
         </Stack>

--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -80,6 +80,10 @@ const breadcrumbSections: {
                 ...adminPages.Directories,
                 icon: <File className="size-4" />,
             },
+            {
+                ...adminPages.DirectoriesActivity,
+                icon: <File className="size-4" />,
+            },
         ],
     },
     {

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -240,6 +240,13 @@ export function Nav({
                 />
             </NavSection>
             <NavSection label="Zapisi" compact={compact}>
+                <NavItem
+                    href={adminPages.DirectoriesActivity.href}
+                    label={adminPages.DirectoriesActivity.label}
+                    icon={<File className="size-5" />}
+                    onClick={onItemClick}
+                    compact={compact}
+                />
                 {hasDirectoryRecords && (
                     <>
                         {/* Categories with their entity types */}

--- a/apps/app/components/admin/navigation/adminPages.ts
+++ b/apps/app/components/admin/navigation/adminPages.ts
@@ -3,6 +3,10 @@ import { KnownPages } from '../../../src/KnownPages';
 export const adminPages = {
     Dashboard: { href: KnownPages.Dashboard, label: 'Početna' },
     Directories: { href: KnownPages.Directories, label: 'Zapisi' },
+    DirectoriesActivity: {
+        href: KnownPages.DirectoriesActivity,
+        label: 'Aktivnosti',
+    },
     CmsPages: { href: KnownPages.CmsPages, label: 'Stranice' },
     Accounts: { href: KnownPages.Accounts, label: 'Korisnički računi' },
     Achievements: { href: KnownPages.Achievements, label: 'Postignuća' },
@@ -51,6 +55,7 @@ export const adminPages = {
 export const adminBreadcrumbPages = [
     adminPages.Dashboard,
     adminPages.Directories,
+    adminPages.DirectoriesActivity,
     adminPages.CmsPages,
     adminPages.Accounts,
     adminPages.Achievements,

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -5,6 +5,7 @@ export const KnownPages = {
     Dashboard: '/admin',
     Settings: '/admin/settings',
     Directories: '/admin/directories',
+    DirectoriesActivity: '/admin/directories/activity',
     CmsPages: '/admin/cms/pages',
     CmsPageCreate: '/admin/cms/pages/create',
     CmsPage: (pageId: number) => `/admin/cms/pages/${pageId}` as Route,

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -863,3 +863,13 @@ export async function getEntityRevisions(entityId: number) {
         ],
     });
 }
+
+export async function getLatestEntityRevisions(limit = 100) {
+    return storage().query.entityRevisions.findMany({
+        orderBy: (revisions, { desc }) => [
+            desc(revisions.createdAt),
+            desc(revisions.id),
+        ],
+        limit,
+    });
+}

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -8,6 +8,7 @@ import {
     type SelectAttributeDefinition,
     type SelectAttributeValue,
     type SelectEntity,
+    type SelectEntityRevision,
     type SelectEntityType,
     storage,
     type UpdateEntity,
@@ -32,6 +33,17 @@ type EntityWithAttributesAndDefinitions = SelectEntity & {
         attributeDefinitions: SelectAttributeDefinition[];
     };
 };
+
+export type LatestEntityRevision = Pick<
+    SelectEntityRevision,
+    | 'id'
+    | 'entityId'
+    | 'entityTypeName'
+    | 'action'
+    | 'actorId'
+    | 'actorName'
+    | 'createdAt'
+>;
 
 function tryParseAttributeJson(
     value: string,
@@ -864,8 +876,19 @@ export async function getEntityRevisions(entityId: number) {
     });
 }
 
-export async function getLatestEntityRevisions(limit = 100) {
+export async function getLatestEntityRevisions(
+    limit = 100,
+): Promise<LatestEntityRevision[]> {
     return storage().query.entityRevisions.findMany({
+        columns: {
+            id: true,
+            entityId: true,
+            entityTypeName: true,
+            action: true,
+            actorId: true,
+            actorName: true,
+            createdAt: true,
+        },
         orderBy: (revisions, { desc }) => [
             desc(revisions.createdAt),
             desc(revisions.id),


### PR DESCRIPTION
### Motivation
- Provide a single place under the existing “Zapisi” section to surface recent changes across all entity types so admins can quickly review global activity.
- Expose a reusable storage helper to fetch the latest entity revisions that can be consumed by this page and other tools.

### Description
- Added a new server page `apps/app/app/admin/directories/activity/page.tsx` that calls `getLatestEntityRevisions(200)` and renders each revision with action label, timestamp, actor, and a link to the affected record.
- Added `getLatestEntityRevisions(limit = 100)` to `packages/storage/src/repositories/entitiesRepo.ts` which returns revisions ordered by `createdAt` and `id` descending.
- Introduced a route constant `KnownPages.DirectoriesActivity` in `apps/app/src/KnownPages.ts` and wired the new page into navigation by adding `DirectoriesActivity` to `apps/app/components/admin/navigation/adminPages.ts` and inserting a `NavItem` into `apps/app/components/admin/navigation/Nav.tsx` under the `Zapisi` section.
- Included the new `Aktivnosti` entry in the breadcrumb selector via `apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx` for top-level navigation parity.

### Testing
- Ran the app linter with `pnpm --filter app lint`, which completed (reported unrelated warnings elsewhere but finished successfully).
- Ran Biome checks on the changed app files with `pnpm --filter app exec biome check` which inspected the updated files and reported "Checked 5 files... No fixes applied.".
- No automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ac93a1d4832f93ee8bca9f7a67d8)