### PR TITLE
feat(game): Rain wetness overlay for exposed entities

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -35,6 +35,13 @@ export const lsystemPlantsFlag = flag<boolean>({
     options: booleanOptions,
 });
 
+export const rainWetOverlayFlag = flag<boolean>({
+    key: 'rainWetOverlay',
+    description: 'Enable rain wetness overlays on exposed garden entities.',
+    decide: () => false,
+    options: booleanOptions,
+});
+
 export const enableDebugCloseupFlag = flag<boolean>({
     key: 'enableDebugCloseup',
     decide: () => false,

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -5,6 +5,7 @@ import { GameSceneWithAnalytics } from '../components/game/GameSceneWithAnalytic
 import {
     enableDebugHudFlag,
     lsystemPlantsFlag,
+    rainWetOverlayFlag,
     raisedBedImageAIFlag,
 } from './flags';
 
@@ -12,6 +13,7 @@ export default async function Home() {
     const flags: ComponentProps<typeof GameSceneWithAnalytics>['flags'] = {
         enableDebugHudFlag: await enableDebugHudFlag(),
         enablePlantGeneratorFlag: await lsystemPlantsFlag(),
+        enableRainWetOverlayFlag: await rainWetOverlayFlag(),
         raisedBedImageAI: await raisedBedImageAIFlag(),
     };
 

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -11,6 +11,7 @@ export interface GameFeatureFlags {
     enableRaisedBedFieldOperationsFlag?: boolean;
     enableRaisedBedFieldWateringFlag?: boolean;
     enableRaisedBedFieldDiaryFlag?: boolean;
+    enableRainWetOverlayFlag?: boolean;
     raisedBedImageAI?: boolean;
 }
 

--- a/packages/game/src/entities/Bucket.tsx
+++ b/packages/game/src/entities/Bucket.tsx
@@ -1,5 +1,6 @@
 import { animated } from '@react-spring/three';
 import { MeshDistortMaterial } from '@react-three/drei';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
@@ -42,6 +43,11 @@ export function Bucket({ stack, block, rotation }: EntityInstanceProps) {
                     noiseScale={3.5}
                     coverageMultiplier={0.5}
                 />
+                <RainWetOverlay
+                    geometry={nodes.Bucket_2.geometry}
+                    topSurfaceBias={2.6}
+                    glossiness={0.9}
+                />
             </mesh>
             <mesh
                 castShadow
@@ -55,6 +61,7 @@ export function Bucket({ stack, block, rotation }: EntityInstanceProps) {
                     slopeExponent={2.8}
                     noiseScale={3.2}
                 />
+                <RainWetOverlay geometry={nodes.Bucket_3.geometry} />
             </mesh>
             <mesh
                 castShadow
@@ -69,6 +76,12 @@ export function Bucket({ stack, block, rotation }: EntityInstanceProps) {
                     slopeExponent={4.5}
                     noiseScale={5}
                     coverageMultiplier={0.4}
+                />
+                <RainWetOverlay
+                    geometry={nodes['Bucket_-_Handle'].geometry}
+                    topSurfaceBias={3}
+                    darkness={0.7}
+                    glossiness={0.85}
                 />
             </mesh>
         </animated.group>

--- a/packages/game/src/entities/Fence.tsx
+++ b/packages/game/src/entities/Fence.tsx
@@ -1,4 +1,5 @@
 import { animated } from '@react-spring/three';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
@@ -83,6 +84,7 @@ export function Fence({ stack, block, rotation }: EntityInstanceProps) {
                     slopeExponent={2.9}
                     noiseScale={3.3}
                 />
+                <RainWetOverlay geometry={nodes[variant].geometry} />
             </mesh>
         </animated.group>
     );

--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -1,6 +1,7 @@
 import { animated } from '@react-spring/three';
 import { Vector3 } from 'three';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
@@ -121,6 +122,7 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
                     noiseScale={3}
                     coverageMultiplier={0.9}
                 />
+                <RainWetOverlay geometry={nodes[shape1].geometry} />
                 <mesh
                     castShadow
                     receiveShadow
@@ -142,6 +144,7 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
                     noiseScale={3}
                     coverageMultiplier={0.9}
                 />
+                <RainWetOverlay geometry={nodes[shape2].geometry} />
             </animated.group>
             <group position={raisedBedPosition}>
                 <RaisedBedFields blockId={block.id} />

--- a/packages/game/src/entities/ShovelSmall.tsx
+++ b/packages/game/src/entities/ShovelSmall.tsx
@@ -1,4 +1,5 @@
 import { animated } from '@react-spring/three';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import { snowPresets } from '../snow/snowPresets';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -25,6 +26,12 @@ export function ShovelSmall({ stack, block, rotation }: EntityInstanceProps) {
                 <SnowOverlay
                     geometry={nodes.Shovel_Small.geometry}
                     {...snowPresets.tool}
+                />
+                <RainWetOverlay
+                    geometry={nodes.Shovel_Small.geometry}
+                    topSurfaceBias={2.8}
+                    darkness={0.8}
+                    glossiness={0.9}
                 />
             </mesh>
         </animated.group>

--- a/packages/game/src/entities/StoneLarge.tsx
+++ b/packages/game/src/entities/StoneLarge.tsx
@@ -1,4 +1,5 @@
 import { animated } from '@react-spring/three';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import { snowPresets } from '../snow/snowPresets';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -27,6 +28,7 @@ export function StoneLarge({ stack, block, rotation }: EntityInstanceProps) {
                     geometry={nodes.Stone_Large.geometry}
                     {...snowPresets.stone}
                 />
+                <RainWetOverlay geometry={nodes.Stone_Large.geometry} />
             </mesh>
         </animated.group>
     );

--- a/packages/game/src/entities/StoneMedium.tsx
+++ b/packages/game/src/entities/StoneMedium.tsx
@@ -1,4 +1,5 @@
 import { animated } from '@react-spring/three';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import { snowPresets } from '../snow/snowPresets';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -27,6 +28,7 @@ export function StoneMedium({ stack, block, rotation }: EntityInstanceProps) {
                     geometry={nodes.Stone_Medium.geometry}
                     {...snowPresets.stone}
                 />
+                <RainWetOverlay geometry={nodes.Stone_Medium.geometry} />
             </mesh>
         </animated.group>
     );

--- a/packages/game/src/entities/StoneSmall.tsx
+++ b/packages/game/src/entities/StoneSmall.tsx
@@ -1,4 +1,5 @@
 import { animated } from '@react-spring/three';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import { snowPresets } from '../snow/snowPresets';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -27,6 +28,7 @@ export function StoneSmall({ stack, block, rotation }: EntityInstanceProps) {
                     geometry={nodes.Stone_Small.geometry}
                     {...snowPresets.stone}
                 />
+                <RainWetOverlay geometry={nodes.Stone_Small.geometry} />
             </mesh>
         </animated.group>
     );

--- a/packages/game/src/entities/Stool.tsx
+++ b/packages/game/src/entities/Stool.tsx
@@ -1,4 +1,5 @@
 import { animated } from '@react-spring/three';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
@@ -27,6 +28,7 @@ export function Stool({ stack, block, rotation }: EntityInstanceProps) {
                     slopeExponent={2.9}
                     noiseScale={3}
                 />
+                <RainWetOverlay geometry={nodes.Stool.geometry} />
             </mesh>
         </animated.group>
     );

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -66,10 +66,12 @@ export function GardenBox({
                 geometry={nodes.GiftBox_Box.geometry}
                 {...snowPresets.giftBox}
             />
+            <RainWetOverlay geometry={nodes.GiftBox_Box.geometry} />
             <SnowOverlay
                 geometry={nodes.GiftBox_Strip.geometry}
                 {...snowPresets.giftBox}
             />
+            <RainWetOverlay geometry={nodes.GiftBox_Strip.geometry} />
         </animated.group>
     );
 }

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -1,5 +1,6 @@
 import { animated } from '@react-spring/three';
 import { useHoveredBlockStore } from '../../controls/useHoveredBlockStore';
+import { RainWetOverlay } from '../../rain/RainWetOverlay';
 import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -1,0 +1,170 @@
+import { useFrame } from '@react-three/fiber';
+import { useEffect, useMemo } from 'react';
+import type { BufferGeometry, Vector3Tuple } from 'three';
+import {
+    MathUtils,
+    ShaderMaterial,
+    UniformsLib,
+    UniformsUtils,
+    Vector3,
+} from 'three';
+import { useGameState } from '../useGameState';
+
+type RainWetOverlayProps = {
+    geometry: BufferGeometry;
+    minRain?: number;
+    intensityMultiplier?: number;
+    drySpeed?: number;
+    wetSpeed?: number;
+    topSurfaceBias?: number;
+    darkness?: number;
+    glossiness?: number;
+    bounds?: {
+        min: Vector3Tuple;
+        max: Vector3Tuple;
+    };
+};
+
+const fallbackBounds = {
+    min: [-0.5, -0.5, -0.5] as Vector3Tuple,
+    max: [0.5, 0.5, 0.5] as Vector3Tuple,
+};
+
+const rainOverlayVertexShader = `
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec4 worldPos = modelMatrix * vec4(position, 1.0);
+    vWorldPos = worldPos.xyz;
+    vWorldNormal = normalize(mat3(modelMatrix) * normal);
+    gl_Position = projectionMatrix * viewMatrix * worldPos;
+}
+`;
+
+const rainOverlayFragmentShader = `
+uniform float uWetness;
+uniform float uTopSurfaceBias;
+uniform float uDarkness;
+uniform float uGlossiness;
+uniform vec3 uBoundsMin;
+uniform vec3 uBoundsMax;
+
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+float noise(vec3 p) {
+    return fract(sin(dot(p, vec3(12.9898, 78.233, 45.164))) * 43758.5453123);
+}
+
+void main() {
+    float topness = clamp(pow(max(vWorldNormal.y, 0.0), uTopSurfaceBias), 0.0, 1.0);
+    vec3 local = (vWorldPos - uBoundsMin) / max(vec3(0.001), (uBoundsMax - uBoundsMin));
+    float variation = 0.75 + noise(local * 17.0) * 0.25;
+    float wet = clamp(uWetness * topness * variation, 0.0, 1.0);
+
+    float alpha = wet * 0.4;
+    vec3 color = vec3(0.02) * uDarkness;
+
+    // Subtle fake glint for pooled highlights on horizontal surfaces
+    float glint = pow(max(vWorldNormal.y, 0.0), 20.0) * wet * uGlossiness;
+    color += vec3(glint * 0.18);
+
+    gl_FragColor = vec4(color, alpha);
+}
+`;
+
+export function RainWetOverlay({
+    geometry,
+    minRain = 0.35,
+    intensityMultiplier = 1,
+    drySpeed = 1.8,
+    wetSpeed = 5,
+    topSurfaceBias = 1.8,
+    darkness = 1,
+    glossiness = 0.7,
+    bounds,
+}: RainWetOverlayProps) {
+    const rainAmount = useGameState((state) => state.weather?.rainy ?? 0);
+    const shouldRender = rainAmount * intensityMultiplier >= minRain;
+
+    const resolvedBounds = useMemo(() => {
+        if (bounds) return bounds;
+        if (!geometry.boundingBox) {
+            geometry.computeBoundingBox();
+        }
+        const box = geometry.boundingBox;
+        if (!box) return fallbackBounds;
+        return {
+            min: [box.min.x, box.min.y, box.min.z] as Vector3Tuple,
+            max: [box.max.x, box.max.y, box.max.z] as Vector3Tuple,
+        };
+    }, [bounds, geometry]);
+
+    const material = useMemo(() => {
+        const mat = new ShaderMaterial({
+            transparent: true,
+            fog: true,
+            depthWrite: false,
+            depthTest: true,
+            lights: false,
+            uniforms: UniformsUtils.merge([
+                UniformsLib.fog,
+                {
+                    uWetness: { value: 0 },
+                    uTopSurfaceBias: { value: topSurfaceBias },
+                    uDarkness: { value: darkness },
+                    uGlossiness: { value: glossiness },
+                    uBoundsMin: { value: new Vector3(...resolvedBounds.min) },
+                    uBoundsMax: { value: new Vector3(...resolvedBounds.max) },
+                },
+            ]),
+            vertexShader: rainOverlayVertexShader,
+            fragmentShader: rainOverlayFragmentShader,
+        });
+        mat.polygonOffset = true;
+        mat.polygonOffsetFactor = -1;
+        mat.polygonOffsetUnits = -1;
+        return mat;
+    }, [
+        darkness,
+        glossiness,
+        resolvedBounds.max,
+        resolvedBounds.min,
+        topSurfaceBias,
+    ]);
+
+    useEffect(() => {
+        material.uniforms.uTopSurfaceBias.value = topSurfaceBias;
+        material.uniforms.uDarkness.value = darkness;
+        material.uniforms.uGlossiness.value = glossiness;
+    }, [darkness, glossiness, material, topSurfaceBias]);
+
+    useEffect(() => {
+        material.uniforms.uBoundsMin.value.set(...resolvedBounds.min);
+        material.uniforms.uBoundsMax.value.set(...resolvedBounds.max);
+    }, [material, resolvedBounds.max, resolvedBounds.min]);
+
+    useEffect(() => () => material.dispose(), [material]);
+
+    useFrame((_, delta) => {
+        const target = Math.min(
+            1,
+            Math.max(0, rainAmount * intensityMultiplier),
+        );
+        const speed =
+            target > material.uniforms.uWetness.value ? wetSpeed : drySpeed;
+        material.uniforms.uWetness.value = MathUtils.damp(
+            material.uniforms.uWetness.value,
+            target,
+            speed,
+            delta,
+        );
+    });
+
+    if (!shouldRender && material.uniforms.uWetness.value < 0.01) {
+        return null;
+    }
+
+    return <mesh geometry={geometry} material={material} />;
+}

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -8,6 +8,7 @@ import {
     UniformsUtils,
     Vector3,
 } from 'three';
+import { useGameFlags } from '../GameFlagsContext';
 import { useGameState } from '../useGameState';
 
 type RainWetOverlayProps = {
@@ -74,7 +75,17 @@ void main() {
 }
 `;
 
-export function RainWetOverlay({
+export function RainWetOverlay(props: RainWetOverlayProps) {
+    const flags = useGameFlags();
+
+    if (!flags.enableRainWetOverlayFlag) {
+        return null;
+    }
+
+    return <RainWetOverlayEffect {...props} />;
+}
+
+function RainWetOverlayEffect({
     geometry,
     minRain = 0.35,
     intensityMultiplier = 1,


### PR DESCRIPTION
### Motivation
- Make exposed garden entities respond to rain so decorations, raised beds, tools, fences, and stones feel grounded in the same weather system. 
- Provide a subtle, material-aware wetness pass that darkens/top-coats top-facing surfaces without changing interaction targets or readability. 
- Ensure wetness composes predictably with existing seasonal overlays (snow/autumn) and fades naturally when rain stops. 

### Description
- Added a reusable shader component `RainWetOverlay` at `packages/game/src/rain/RainWetOverlay.tsx` that reads `state.weather.rainy` and drives a top-surface wetness, darkness, and glossy glint with damped in/out transitions. 
- Shader emphasizes top-facing surfaces via a `uTopSurfaceBias` parameter, supports bounds-based variation, and exposes tuning props such as `minRain`, `intensityMultiplier`, `drySpeed`, `wetSpeed`, `darkness`, and `glossiness`. 
- Integrated `RainWetOverlay` alongside existing `SnowOverlay` on common exposed entities: `Fence`, `RaisedBed`, `StoneLarge`, `StoneMedium`, `StoneSmall`, `Bucket` (metal and handle parts), `ShovelSmall`, `Stool`, and the `GardenBox` helper, with per-entity parameter tuning to preserve material/readability. 
- The overlay is additive to existing snow passes and uses damped smoothing so wetness persists briefly and dries naturally when rain decreases. 

### Testing
- Ran `pnpm --filter @gredice/game lint`, which completed successfully with `biome` and auto-fixed one file. 
- The lint run produced a node engine warning about the environment (`node >=24` recommended) but finished successfully; no additional automated unit or integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b6dab77c832fb8397441f0666e5d)