### PR TITLE
fix(storage): dedupe watering assignments per raised-bed day after sowing

### DIFF
--- a/packages/storage/src/repositories/seasonalOffersRepo.ts
+++ b/packages/storage/src/repositories/seasonalOffersRepo.ts
@@ -36,34 +36,35 @@ function getSeasonalSowingOffer(date: Date): SeasonalSowingOffer | null {
     return null;
 }
 
+function toUtcDayKey(date: Date) {
+    return date.toISOString().slice(0, 10);
+}
+
+function getScheduledWateringDayKeys(
+    operations: Awaited<ReturnType<typeof getOperations>>,
+) {
+    return new Set(
+        operations.flatMap((operation) => {
+            if (
+                operation.entityId !== FREE_WATERING_OPERATION_ID ||
+                operation.status === 'canceled' ||
+                operation.status === 'failed' ||
+                !operation.scheduledDate
+            ) {
+                return [];
+            }
+
+            return [toUtcDayKey(operation.scheduledDate)];
+        }),
+    );
+}
+
 function addDays(date: Date, days: number) {
     const nextDate = new Date(date);
     nextDate.setUTCDate(nextDate.getUTCDate() + days);
     return nextDate;
 }
 
-function getLatestScheduledFreeWateringDate(
-    operations: Awaited<ReturnType<typeof getOperations>>,
-    now: Date,
-) {
-    const scheduledDates = operations.flatMap((operation) => {
-        if (
-            operation.entityId !== FREE_WATERING_OPERATION_ID ||
-            operation.status === 'canceled' ||
-            operation.status === 'failed' ||
-            !operation.scheduledDate ||
-            operation.scheduledDate < now
-        ) {
-            return [];
-        }
-
-        return [operation.scheduledDate];
-    });
-
-    return scheduledDates.sort(
-        (left, right) => right.getTime() - left.getTime(),
-    )[0];
-}
 
 export async function queueSeasonalSowingOfferOperations({
     accountId,
@@ -87,21 +88,15 @@ export async function queueSeasonalSowingOfferOperations({
         raisedBedId,
     );
 
-    const latestScheduledDate = getLatestScheduledFreeWateringDate(
-        existingOperations,
-        referenceDate,
-    );
-
-    const firstScheduleDate = latestScheduledDate
-        ? addDays(latestScheduledDate, offer.dayInterval)
-        : new Date(referenceDate);
+    const scheduledWateringDayKeys = getScheduledWateringDayKeys(existingOperations);
 
     const createdOperationIds: number[] = [];
     for (let index = 0; index < offer.freeWaterings; index += 1) {
-        const scheduledDate = addDays(
-            firstScheduleDate,
-            index * offer.dayInterval,
-        );
+        const scheduledDate = addDays(referenceDate, index * offer.dayInterval);
+        const scheduledDayKey = toUtcDayKey(scheduledDate);
+        if (scheduledWateringDayKeys.has(scheduledDayKey)) {
+            continue;
+        }
 
         const operationId = await createOperation({
             accountId,
@@ -117,6 +112,7 @@ export async function queueSeasonalSowingOfferOperations({
             }),
         );
 
+        scheduledWateringDayKeys.add(scheduledDayKey);
         createdOperationIds.push(operationId);
     }
 

--- a/packages/storage/tests/seasonalOffersRepo.node.spec.ts
+++ b/packages/storage/tests/seasonalOffersRepo.node.spec.ts
@@ -138,7 +138,7 @@ test('queueSeasonalSowingOfferOperations skips dates without a seasonal offer', 
     );
 });
 
-test('queueSeasonalSowingOfferOperations extends after active scheduled free waterings', async () => {
+test('queueSeasonalSowingOfferOperations skips days with existing scheduled free waterings', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
         await createSeasonalOfferTestContext();
@@ -166,12 +166,44 @@ test('queueSeasonalSowingOfferOperations extends after active scheduled free wat
     assert.deepStrictEqual(
         await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
         [
+            '2026-06-15T08:00:00.000Z',
+            '2026-06-16T08:00:00.000Z',
+            '2026-06-17T08:00:00.000Z',
+            '2026-06-18T08:00:00.000Z',
+            '2026-06-19T08:00:00.000Z',
             '2026-06-20T08:00:00.000Z',
-            '2026-06-21T08:00:00.000Z',
-            '2026-06-22T08:00:00.000Z',
-            '2026-06-23T08:00:00.000Z',
-            '2026-06-24T08:00:00.000Z',
-            '2026-06-25T08:00:00.000Z',
+        ],
+    );
+});
+
+
+test('queueSeasonalSowingOfferOperations does not duplicate existing offer days on repeated sowing', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createSeasonalOfferTestContext();
+
+    const firstRun = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-03-10T08:00:00.000Z'),
+    });
+
+    const secondRun = await queueSeasonalSowingOfferOperations({
+        accountId,
+        gardenId,
+        raisedBedId,
+        referenceDate: new Date('2026-03-10T12:00:00.000Z'),
+    });
+
+    assert.strictEqual(firstRun.length, 3);
+    assert.strictEqual(secondRun.length, 0);
+    assert.deepStrictEqual(
+        await getScheduledFreeWateringDates(accountId, gardenId, raisedBedId),
+        [
+            '2026-03-10T08:00:00.000Z',
+            '2026-03-12T08:00:00.000Z',
+            '2026-03-14T08:00:00.000Z',
         ],
     );
 });


### PR DESCRIPTION
### Motivation
- Sowing created watering operations per plant which could duplicate waterings for the same raised bed/day instead of a single `N-wattering` per sowing day. 
- The promotion logic requires watering to be scheduled by the sowing day window and to skip days that already have a watering scheduled. 

### Description
- Replace the previous “extend from latest scheduled watering” flow with day-level deduplication by adding `toUtcDayKey` and `getScheduledWateringDayKeys` and using the sowing `referenceDate` window to compute candidate days. 
- Skip creating a watering when the raised bed already has a scheduled free-watering operation for the same UTC day, and add scheduled day keys as new operations are created. 
- Files changed: `packages/storage/src/repositories/seasonalOffersRepo.ts` (scheduling logic and helpers) and `packages/storage/tests/seasonalOffersRepo.node.spec.ts` (adjusted expectations and added a test to ensure repeated sowing on the same day does not duplicate waterings). 

### Testing
- Ran `pnpm --filter @gredice/storage test -- seasonalOffersRepo.node.spec.ts` and updated the implementation until all subtests passed. 
- Final test run passed all cases for spring/summer/autumn cadence, skipping existing scheduled days, and preventing duplicate watering on repeated sowing. 
- The test run emitted an engine warning about Node `>=24` while the environment used `v22`, but the tests themselves succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c7da4438832f84022babd153f457)