### PR TITLE
fix(www): remove duplicate H1 from delivery page

### DIFF
--- a/apps/www/app/dostava/page.tsx
+++ b/apps/www/app/dostava/page.tsx
@@ -37,7 +37,6 @@ export default function DeliveryPage() {
     return (
         <Container maxWidth="md">
             <Stack>
-                <h1 className="sr-only">Dostava</h1>
                 <PageHeader
                     padded
                     header="🚚 Dostava"


### PR DESCRIPTION
### Motivation
- An SEO scan reported multiple top-level headings on the Delivery page, so the page must expose a single H1 for correct semantics and SEO.

### Description
- Removed the extra visually-hidden `<h1>` from `apps/www/app/dostava/page.tsx` and kept `PageHeader` as the single page-level heading.

### Testing
- Verified the duplicate literal `<h1>` was removed by searching with `rg -n "<h1" apps/www/app/dostava/page.tsx`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01df300eac832f8e62f9ba5031f641)