### PR TITLE
Add semantic H1 to pages and update referral copy/metadata

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -279,7 +279,7 @@ export default function Home() {
                         <Card className="w-fit border-tertiary border-b-4">
                             <CardContent noHeader className="p-6 lg:pr-10">
                                 <Stack spacing={2}>
-                                    <Typography level="h2">
+                                    <Typography level="h2" component="h1">
                                         Vrt po tvom 🌱
                                     </Typography>
                                     <Typography level="body1">

--- a/apps/www/app/preporuke/page.tsx
+++ b/apps/www/app/preporuke/page.tsx
@@ -1,18 +1,27 @@
-import type { Metadata } from 'next';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
     title: 'Preporuke',
-    description: 'Program preporuka i pravila za dijeljenje referral koda.',
+    description: 'Program preporuka i pravila za dijeljenje koda preporuke.',
+    keywords: [
+        'Gredice',
+        'program preporuka',
+        'kod preporuke',
+        'suncokreti',
+        'nagrade',
+    ],
 };
 export default function ReferralsLandingPage() {
     return (
         <main className="container py-10">
             <Stack spacing={3}>
-                <Typography level="h2">💮 Gredice referral program</Typography>
+                <Typography level="h2" component="h1">
+                    💮 Gredice program preporuka
+                </Typography>
                 <Typography>
-                    Podijeli svoj referral kod i zaradi{' '}
+                    Podijeli svoj kod preporuke i zaradi{' '}
                     <strong>10.000 suncokreta</strong> kada novi račun ispuni
                     uvjet aktivne gredice.
                 </Typography>
@@ -23,7 +32,7 @@ export default function ReferralsLandingPage() {
                 </Typography>
                 <Typography>
                     Nagrađivanje se obrađuje kada novi račun ima barem jednu
-                    aktivnu gredicu. Broj dijeljenja referral koda nije
+                    aktivnu gredicu. Broj dijeljenja koda preporuke nije
                     ograničen.
                 </Typography>
             </Stack>


### PR DESCRIPTION
### Motivation
- Improve accessibility and document semantics by ensuring the main page headings are rendered as `h1` elements.
- Clarify and localize the referral page copy and enrich the page metadata with `keywords` for better discoverability.

### Description
- Added the `component="h1"` prop to the main `Typography` headings in `apps/www/app/page.tsx` and `apps/www/app/preporuke/page.tsx` to render them as `h1` elements for semantics.
- Updated referral page copy to use localized wording (`referral` -> `kod preporuke`) and changed the title text to `💮 Gredice program preporuka` in `apps/www/app/preporuke/page.tsx`.
- Enhanced the `metadata` in `apps/www/app/preporuke/page.tsx` by updating the `description` and adding a `keywords` array, and applied a minor import reordering.

### Testing
- No automated unit tests were added or modified; a local TypeScript type-check and development build were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01deb49de4832f87bbe05101777f97)