### PR TITLE
Fallback to WebPage schema when per-plant price is missing and log missing price

### DIFF
--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -168,48 +168,80 @@ export default async function PlantSortPage(
         }
     };
 
+    const sortUrl = `https://www.gredice.com${KnownPages.PlantSort(alias, sortData.information.name)}`;
+    const hasPerPlantPrice = typeof basePlantData.prices?.perPlant === 'number';
+
+    if (!hasPerPlantPrice) {
+        console.error('Missing per-plant price for plant sort product schema', {
+            alias,
+            plantId: basePlantData.id,
+            plantName: basePlantData.information.name,
+            sortAlias,
+            sortId: sortData.id,
+            sortName: sortData.information.name,
+            sortUrl,
+        });
+    }
+
     return (
         <div className="py-8">
             <StructuredDataScript
-                data={{
-                    '@context': 'https://schema.org',
-                    '@type': 'Product',
-                    name: sortData.information.name,
-                    description:
-                        sortData.information.shortDescription ??
-                        sortData.information.description ??
-                        basePlantData.information.description,
-                    category: 'Sorta biljke',
-                    image:
-                        sortData.image?.cover?.url ??
-                        basePlantData.image?.cover?.url,
-                    brand: {
-                        '@type': 'Brand',
-                        name: 'Gredice',
-                    },
-                    isVariantOf: {
-                        '@type': 'Product',
-                        name: basePlantData.information.name,
-                        url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
-                    },
-                    url: `https://www.gredice.com${KnownPages.PlantSort(alias, sortData.information.name)}`,
-                    offers:
-                        typeof basePlantData.prices?.perPlant === 'number'
-                            ? {
-                                '@type': 'Offer',
-                                price: basePlantData.prices.perPlant.toFixed(
-                                    2,
-                                ),
-                                priceCurrency: 'EUR',
-                                availability:
-                                    sortData.store?.availableInStore === false
-                                        ? 'https://schema.org/OutOfStock'
-                                        : 'https://schema.org/InStock',
-                                url: `https://www.gredice.com${KnownPages.PlantSort(alias, sortData.information.name)}`,
-                                hasMerchantReturnPolicy: merchantReturnPolicy,
-                            }
-                            : undefined,
-                }}
+                data={
+                    hasPerPlantPrice
+                        ? {
+                              '@context': 'https://schema.org',
+                              '@type': 'Product',
+                              name: sortData.information.name,
+                              description:
+                                  sortData.information.shortDescription ??
+                                  sortData.information.description ??
+                                  basePlantData.information.description,
+                              category: 'Sorta biljke',
+                              image:
+                                  sortData.image?.cover?.url ??
+                                  basePlantData.image?.cover?.url,
+                              brand: {
+                                  '@type': 'Brand',
+                                  name: 'Gredice',
+                              },
+                              isVariantOf: {
+                                  '@type': 'Product',
+                                  name: basePlantData.information.name,
+                                  url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
+                              },
+                              url: sortUrl,
+                              offers: {
+                                  '@type': 'Offer',
+                                  price: basePlantData.prices.perPlant.toFixed(
+                                      2,
+                                  ),
+                                  priceCurrency: 'EUR',
+                                  availability:
+                                      sortData.store?.availableInStore === false
+                                          ? 'https://schema.org/OutOfStock'
+                                          : 'https://schema.org/InStock',
+                                  url: sortUrl,
+                                  hasMerchantReturnPolicy: merchantReturnPolicy,
+                              },
+                          }
+                        : {
+                              '@context': 'https://schema.org',
+                              '@type': 'WebPage',
+                              name: sortData.information.name,
+                              description:
+                                  sortData.information.shortDescription ??
+                                  sortData.information.description ??
+                                  basePlantData.information.description,
+                              image:
+                                  sortData.image?.cover?.url ??
+                                  basePlantData.image?.cover?.url,
+                              url: sortUrl,
+                              about: {
+                                  '@type': 'Thing',
+                                  name: basePlantData.information.name,
+                              },
+                          }
+                }
             />
             <Stack spacing={4}>
                 <Breadcrumbs

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -176,7 +176,7 @@ export default async function PlantSortPage(
             alias,
             plantId: basePlantData.id,
             plantName: basePlantData.information.name,
-            sortAlias,
+            sortAlias: sort,
             sortId: sortData.id,
             sortName: sortData.information.name,
             sortUrl,


### PR DESCRIPTION
### Motivation

- Ensure structured data remains valid when a plant sort has no per-plant price by avoiding an incomplete `Product`/`Offer` schema.
- Surface missing pricing information to logs to aid debugging and data quality monitoring.
- Make the canonical sort URL explicit and reuse it in the structured data object.

### Description

- Added `sortUrl` variable computed from `KnownPages.PlantSort` and extracted `hasPerPlantPrice` as a boolean check for `basePlantData.prices?.perPlant`.
- Log an error with context when `hasPerPlantPrice` is false using `console.error` to report missing per-plant price details.
- Render `StructuredDataScript` with a `Product` + `Offer` schema when `hasPerPlantPrice` is true, and with a `WebPage` schema (including an `about` `Thing`) as a fallback when the price is missing.
- Simplified usage of the `sortUrl` variable for the schema `url` and `offers.url` fields.

### Testing

- Ran TypeScript type checks (`tsc`) and no type errors were reported. 
- Ran linting (`eslint`) and autofixes where applicable with no blocking errors. 
- Ran the project's unit tests and integration tests and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01de317e44832fba93e5521df15882)