### PR TITLE
fix(www): stop emitting unsupported Host line in generated robots.txt

### DIFF
--- a/apps/www/next-sitemap.config.cjs
+++ b/apps/www/next-sitemap.config.cjs
@@ -24,6 +24,9 @@ function normalizeSitemapPath(path) {
 module.exports = {
     siteUrl: process.env.SITE_URL || 'https://www.gredice.com',
     generateRobotsTxt: true,
+    robotsTxtOptions: {
+        includeHost: false,
+    },
     transform: async (config, path) => ({
         loc: normalizeSitemapPath(path),
         changefreq: config.changefreq,


### PR DESCRIPTION
### Motivation
- Search Console flagged an unsupported `Host: https://www.gredice.com` line that is emitted into the `robots.txt` generated for the `www` app, so host emission should be disabled at generation time.

### Description
- Added `robotsTxtOptions: { includeHost: false }` to `apps/www/next-sitemap.config.cjs` while keeping `generateRobotsTxt: true` so sitemaps still generate normally.

### Testing
- Loaded the modified config with `node -e "require('./apps/www/next-sitemap.config.cjs')"` to verify the file is valid CommonJS and it succeeded.
- Inspected other app-level `robots.txt` files under `apps/*/app/robots.txt` to confirm none include a `Host:` directive and no further changes were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e1b126e0832f9778da5dcb3c0bd5)