### PR TITLE
Add Sjetva page link to website footer

### DIFF
--- a/apps/www/app/Footer.tsx
+++ b/apps/www/app/Footer.tsx
@@ -58,6 +58,7 @@ const sectionsData: SectionData[] = [
                 header: 'Aplikacija',
                 ctas: [
                     { label: 'Podignuta gredica', href: KnownPages.RaisedBeds },
+                    { label: 'Sjetva biljaka', href: KnownPages.Sowing },
                     { label: 'Biljke', href: KnownPages.Plants },
                     { label: 'Radnje', href: KnownPages.Operations },
                     { label: 'Blokovi', href: KnownPages.Blocks },


### PR DESCRIPTION
### Motivation
- Add a sitewide internal link to `/sjetva` to improve discoverability and address the "1 page has only one incoming internal link" warning.

### Description
- Inserted `{ label: 'Sjetva biljaka', href: KnownPages.Sowing }` into the `Aplikacija` section in `apps/www/app/Footer.tsx` so the Sjetva page appears in the footer navigation.

### Testing
- Ran `git status --short` and verified the working tree is clean after committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e3a845e8832f8afe2d7ae111f779)