### PR TITLE
Add sensible alt text fallbacks and download filenames for image components

### DIFF
--- a/apps/www/app/PlantsShowcase.tsx
+++ b/apps/www/app/PlantsShowcase.tsx
@@ -57,7 +57,7 @@ export async function PlantsShowcase() {
                             >
                                 <PlantOrSortImage
                                     plant={plant}
-                                    alt=""
+                                    alt={plant.information.name ?? 'Biljka'}
                                     fill
                                     className="object-contain"
                                     sizes="60px"

--- a/packages/ui/src/ImageGallery/ImageGallery.tsx
+++ b/packages/ui/src/ImageGallery/ImageGallery.tsx
@@ -53,6 +53,9 @@ export function ImageGallery({
         : 0;
     const activeImage = images[safeIndex];
 
+    const resolveAlt = (imageAlt: string | null | undefined, index: number) =>
+        imageAlt?.trim() || `Slika ${index + 1}`;
+
     const stackedImages = useMemo(() => images.slice(0, 4), [images]);
 
     const resetTransform = useCallback(() => {
@@ -88,7 +91,7 @@ export function ImageGallery({
             const url = window.URL.createObjectURL(blob);
             const link = document.createElement('a');
             link.href = url;
-            link.download = activeImage.alt || 'image';
+            link.download = resolveAlt(activeImage.alt, safeIndex) || 'image';
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
@@ -305,7 +308,7 @@ export function ImageGallery({
                         >
                             <Image
                                 src={image.src}
-                                alt={image.alt}
+                                alt={resolveAlt(image.alt, index)}
                                 fill
                                 sizes={`${previewWidth}px`}
                                 className="h-full w-full object-cover"
@@ -363,7 +366,7 @@ export function ImageGallery({
                                 >
                                     <Image
                                         src={image.src}
-                                        alt={image.alt}
+                                        alt={resolveAlt(image.alt, index)}
                                         fill
                                         sizes={`${previewWidth}px`}
                                         className="h-full w-full object-cover"
@@ -471,7 +474,7 @@ export function ImageGallery({
                                 {/** biome-ignore lint/performance/noImgElement: Using raw <img> intentionally for fallback display */}
                                 <img
                                     src={activeImage.src}
-                                    alt={activeImage.alt}
+                                    alt={resolveAlt(activeImage?.alt, safeIndex)}
                                     className="max-h-full max-w-full select-none object-contain"
                                     draggable={false}
                                 />
@@ -513,7 +516,7 @@ export function ImageGallery({
                                 >
                                     <Image
                                         src={image.src}
-                                        alt={image.alt}
+                                        alt={resolveAlt(image.alt, index)}
                                         fill
                                         sizes="80px"
                                         className="h-full w-full object-cover"

--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -28,6 +28,7 @@ export function ImageViewer({
     previewHeight = 200,
     previewAs = 'button',
 }: ImageViewerProps) {
+    const resolvedAlt = alt?.trim() || 'Slika';
     const [isExpanded, setIsExpanded] = useState(false);
     const [zoomLevel, setZoomLevel] = useState(1);
     const [position, setPosition] = useState({ x: 0, y: 0 });
@@ -61,7 +62,7 @@ export function ImageViewer({
             const url = window.URL.createObjectURL(blob);
             const link = document.createElement('a');
             link.href = url;
-            link.download = alt || 'image';
+            link.download = resolvedAlt || 'image';
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
@@ -227,7 +228,7 @@ export function ImageViewer({
             >
                 <Image
                     src={src}
-                    alt={alt}
+                    alt={resolvedAlt}
                     fill
                     sizes={`${previewWidth}px`}
                     className="h-full w-full object-cover"
@@ -333,7 +334,7 @@ export function ImageViewer({
                                 {/** biome-ignore lint/performance/noImgElement: Using raw <img> intentionally for fallback display */}
                                 <img
                                     src={src}
-                                    alt={alt}
+                                    alt={resolvedAlt}
                                     className="max-h-full max-w-full object-contain select-none"
                                     draggable={false}
                                 />


### PR DESCRIPTION
### Motivation
- Improve accessibility by ensuring image elements always have meaningful `alt` text instead of empty or missing values.
- Provide better default download filenames when users download images.

### Description
- Added a `resolveAlt` helper in `ImageGallery` to return trimmed alt text or a fallback `Slika {n}` and replaced direct `image.alt` usages with `resolveAlt(image.alt, index)` across previews, stacked images, thumbnails, and the expanded view.
- In `ImageViewer` introduced a `resolvedAlt` variable that falls back to `Slika` and used it for `alt` attributes and as the `link.download` filename when downloading the image.
- Updated `PlantsShowcase` to use the plant name (or `Biljka` as a fallback) for the image `alt` instead of an empty string to improve semantics.
- Updated image download logic to use the resolved alt text as the suggested filename where applicable.

### Testing
- Ran a TypeScript build with `yarn build` which completed successfully.
- Ran the test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e11cbf7c832f8f7ed1763f98892e)