### PR TITLE
Show completeness in EntityTableStateChip and remove separate progress column/sort

### DIFF
--- a/apps/app/components/admin/tables/EntitiesTable.tsx
+++ b/apps/app/components/admin/tables/EntitiesTable.tsx
@@ -23,7 +23,6 @@ import { formatAttributeValueWithUnit } from '../../shared/attributes/formatAttr
 import { InventoryQuantityValue } from '../../shared/inventory/InventoryQuantityValue';
 import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
 import { ServerActionIconButton } from '../../shared/ServerActionIconButton';
-import { EntityAttributeProgress } from '../directories/EntityAttributeProgress';
 import { useFilter } from '../providers';
 import { EntityTableStateChip } from './EntityTableStateChip';
 
@@ -35,12 +34,7 @@ type InventoryItem = {
 };
 type InventoryItemWithEntityId = InventoryItem & { entityId: number };
 type SortDirection = 'asc' | 'desc';
-type SortKey =
-    | 'name'
-    | 'inventory'
-    | 'progress'
-    | 'updatedAt'
-    | `attribute:${number}`;
+type SortKey = 'name' | 'inventory' | 'updatedAt' | `attribute:${number}`;
 type SortState = {
     key: SortKey;
     direction: SortDirection;
@@ -167,7 +161,6 @@ export function EntitiesTable({
                         sortableHead(`attribute:${d.id}`, d.label, d.id),
                     )}
                     {hasInventory && sortableHead('inventory', 'Zalihe')}
-                    {sortableHead('progress', 'Ispunjeno')}
                     {sortableHead('updatedAt', 'Izmjene')}
                     <Table.Head></Table.Head>
                 </Table.Row>
@@ -195,6 +188,10 @@ export function EntitiesTable({
                                 <div className="flex items-center gap-2">
                                     <EntityTableStateChip
                                         initialState={entity.state}
+                                        completeness={getEntityCompleteness(
+                                            entity,
+                                            attributeDefinitions,
+                                        )}
                                         onPublish={() =>
                                             updateEntity({
                                                 id: entity.id,
@@ -236,14 +233,6 @@ export function EntitiesTable({
                                     />
                                 </Table.Cell>
                             )}
-                            <Table.Cell>
-                                <div className="w-20">
-                                    <EntityAttributeProgress
-                                        entity={entity}
-                                        definitions={attributeDefinitions}
-                                    />
-                                </div>
-                            </Table.Cell>
                             <Table.Cell>
                                 <Typography secondary>
                                     <LocalDateTime time={false}>
@@ -383,10 +372,6 @@ function entitySortValue(
         return inventoryByEntityId.get(entity.id)?.quantity ?? null;
     }
 
-    if (key === 'progress') {
-        return getEntityCompleteness(entity, definitions).progress;
-    }
-
     if (key === 'updatedAt') {
         return entity.updatedAt.getTime();
     }
@@ -416,9 +401,7 @@ function compareSortValues(
 }
 
 function defaultSortDirection(key: SortKey): SortDirection {
-    return key === 'updatedAt' || key === 'inventory' || key === 'progress'
-        ? 'desc'
-        : 'asc';
+    return key === 'updatedAt' || key === 'inventory' ? 'desc' : 'asc';
 }
 
 function attributeSortValue(

--- a/apps/app/components/admin/tables/EntityTableStateChip.tsx
+++ b/apps/app/components/admin/tables/EntityTableStateChip.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { SelectEntity } from '@gredice/storage';
-import { Megaphone } from '@signalco/ui-icons';
+import { Check, Megaphone } from '@signalco/ui-icons';
 import { Chip } from '@signalco/ui-primitives/Chip';
 import {
     DropdownMenu,
@@ -9,17 +9,20 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@signalco/ui-primitives/Menu';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 export function EntityTableStateChip({
     initialState,
     onPublish,
+    completeness,
 }: {
     initialState: SelectEntity['state'];
     onPublish: () => Promise<void>;
+    completeness: { progress: number; isComplete: boolean };
 }) {
     const [state, setState] = useState(initialState);
     const [loading, setLoading] = useState(false);
+    const progressRingId = useId();
 
     const handlePublish = async () => {
         setLoading(true);
@@ -33,7 +36,21 @@ export function EntityTableStateChip({
     };
 
     if (state !== 'draft') {
-        return null;
+        if (completeness.isComplete) {
+            return null;
+        }
+
+        return (
+            <span
+                className="inline-flex items-center"
+                title={`Nedostaju obavezni atributi (${Math.round(completeness.progress)}%)`}
+            >
+                <DraftCompletenessIndicator
+                    completeness={completeness}
+                    progressRingId={progressRingId}
+                />
+            </span>
+        );
     }
 
     return (
@@ -50,7 +67,13 @@ export function EntityTableStateChip({
                         className="w-fit"
                         title="Promijeni status zapisa"
                     >
-                        Draft
+                        <span className="inline-flex items-center gap-1">
+                            <DraftCompletenessIndicator
+                                completeness={completeness}
+                                progressRingId={progressRingId}
+                            />
+                            Draft
+                        </span>
                     </Chip>
                 </button>
             </DropdownMenuTrigger>
@@ -64,5 +87,61 @@ export function EntityTableStateChip({
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
+    );
+}
+
+function DraftCompletenessIndicator({
+    completeness,
+    progressRingId,
+}: {
+    completeness: { progress: number; isComplete: boolean };
+    progressRingId: string;
+}) {
+    if (completeness.isComplete) {
+        return (
+            <span className="relative inline-flex size-4 items-center justify-center rounded-full border border-green-500 text-green-500">
+                <Check className="size-3" aria-hidden />
+                <span className="sr-only">
+                    Svi obavezni atributi su ispunjeni
+                </span>
+            </span>
+        );
+    }
+
+    const progress = Math.max(0, Math.min(100, completeness.progress));
+    const radius = 6;
+    const circumference = 2 * Math.PI * radius;
+    const dashOffset = circumference - (progress / 100) * circumference;
+
+    return (
+        <span className="relative inline-flex size-4 items-center justify-center">
+            <svg
+                className="size-4 -rotate-90"
+                viewBox="0 0 16 16"
+                role="img"
+                aria-labelledby={progressRingId}
+            >
+                <title
+                    id={progressRingId}
+                >{`Ispunjeno ${progress.toFixed(0)}% obaveznih atributa`}</title>
+                <circle
+                    cx="8"
+                    cy="8"
+                    r={radius}
+                    className="fill-none stroke-primary/20"
+                    strokeWidth="2"
+                />
+                <circle
+                    cx="8"
+                    cy="8"
+                    r={radius}
+                    className="fill-none stroke-primary"
+                    strokeWidth="2"
+                    strokeDasharray={circumference}
+                    strokeDashoffset={dashOffset}
+                    strokeLinecap="round"
+                />
+            </svg>
+        </span>
     );
 }


### PR DESCRIPTION
### Motivation

- Replace the separate per-row progress column with an inline completeness indicator to surface required-attribute completion more directly. 
- Remove the dedicated `progress` sort key since progress is now shown in the state chip and not a separate column. 
- Make it clearer when drafts are missing required attributes and keep publish flow unchanged.

### Description

- Removed the `EntityAttributeProgress` usage and the progress column from `EntitiesTable.tsx` and deleted the `progress` sort key from the `SortKey` union. 
- Updated sorting logic by removing the `progress` branch from `entitySortValue` and from `defaultSortDirection`. 
- Pass `getEntityCompleteness(entity, attributeDefinitions)` into `EntityTableStateChip` from `EntitiesTable`. 
- Reworked `EntityTableStateChip` to accept a `completeness` prop, use `useId`, and render a new `DraftCompletenessIndicator` that shows either a progress ring or a check icon based on completeness. 
- Adjusted imports and minor UI wiring around the new indicator and retained the publish action behavior via the existing `onPublish` handler.

### Testing

- Ran TypeScript type-check (`tsc`) and the test suite (`yarn test`) and both completed successfully. 
- Performed a local build of the app pages affected and the UI changes rendered as expected in the admin entity list.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0208247a08832fb6c405f87f1cdb77)