### PR TITLE
[Weather] Add rain wet accumulation overlays for block surfaces

### DIFF
--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -146,6 +146,7 @@ export function EntityInstances({
             <EntityInstancesBlock
                 stacks={stacks}
                 name="Block_Grass"
+                renderRainWetOverlay
                 yOffset={0.2}
                 geometry={nodes.Block_Grass_1_2.geometry}
                 material={nodes.Block_Grass_1_2.material}
@@ -156,6 +157,7 @@ export function EntityInstances({
             <EntityInstancesBlock
                 stacks={stacks}
                 name="Block_Grass_Angle"
+                renderRainWetOverlay
                 yOffset={0.2}
                 geometry={nodes.Block_Grass_Angle_1_2.geometry}
                 material={nodes.Block_Grass_Angle_1_2.material}
@@ -166,6 +168,7 @@ export function EntityInstances({
             <EntityInstancesBlock
                 stacks={stacks}
                 name="Block_Sand"
+                renderRainWetOverlay
                 yOffset={0.2}
                 geometry={nodes.Block_Sand_1.geometry}
                 material={nodes.Block_Sand_1.material}
@@ -176,6 +179,7 @@ export function EntityInstances({
             <EntityInstancesBlock
                 stacks={stacks}
                 name="Block_Sand_Angle"
+                renderRainWetOverlay
                 yOffset={0.2}
                 geometry={nodes.Block_Sand_Angle_1.geometry}
                 material={nodes.Block_Sand_Angle_1.material}

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import { useBlockData } from '../hooks/useBlockData';
+import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
@@ -18,6 +19,7 @@ type EntityInstancesBlockBaseProps = {
     scale?: [number, number, number];
     geometry: BufferGeometry;
     snow?: SnowMaterialOptions;
+    renderRainWetOverlay?: boolean;
 };
 
 type EntityInstancesBlockMaterialProps =
@@ -43,6 +45,7 @@ export function EntityInstancesBlock(
         scale,
         geometry,
         snow,
+        renderRainWetOverlay = false,
     } = props;
     const { data: blockData } = useBlockData();
     const pickupBlock = useGameState((state) => state.pickupBlock);
@@ -104,6 +107,20 @@ export function EntityInstancesBlock(
                   </group>
               ));
 
+    const renderRainOverlays = () =>
+        !renderRainWetOverlay
+            ? null
+            : (blockInstances ?? []).map((data) => (
+                  <group
+                      key={`block-${name}-rain-${data.id}`}
+                      position={data.position}
+                      rotation={[0, data.rotation * (Math.PI / 2), 0]}
+                      scale={scale}
+                  >
+                      <RainWetOverlay geometry={geometry} />
+                  </group>
+              ));
+
     return (
         <>
             <Instances
@@ -116,6 +133,7 @@ export function EntityInstancesBlock(
                 {'materialNode' in props ? props.materialNode : null}
                 {renderInstances('base')}
             </Instances>
+            {renderRainOverlays()}
             {renderSnowOverlays()}
         </>
     );

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -48,6 +48,7 @@ uniform float uWetness;
 uniform float uTopSurfaceBias;
 uniform float uDarkness;
 uniform float uGlossiness;
+uniform float uPuddleStrength;
 uniform vec3 uBoundsMin;
 uniform vec3 uBoundsMax;
 
@@ -67,9 +68,15 @@ void main() {
     float alpha = wet * 0.4;
     vec3 color = vec3(0.02) * uDarkness;
 
+    // Persistent puddle pockets emerge mainly during heavy rain on flatter surfaces.
+    float puddleMask = smoothstep(0.6, 1.0, wet) * topness;
+    float puddleNoise = noise(local * 23.0 + vec3(3.1, 7.9, 1.4));
+    float puddle = smoothstep(0.78, 0.98, puddleNoise) * puddleMask * uPuddleStrength;
+
     // Subtle fake glint for pooled highlights on horizontal surfaces
     float glint = pow(max(vWorldNormal.y, 0.0), 20.0) * wet * uGlossiness;
-    color += vec3(glint * 0.18);
+    color += vec3(glint * 0.18 + puddle * 0.12);
+    alpha = max(alpha, puddle * 0.5);
 
     gl_FragColor = vec4(color, alpha);
 }
@@ -87,7 +94,7 @@ export function RainWetOverlay(props: RainWetOverlayProps) {
 
 function RainWetOverlayEffect({
     geometry,
-    minRain = 0.35,
+    minRain = 0.08,
     intensityMultiplier = 1,
     drySpeed = 1.8,
     wetSpeed = 5,
@@ -126,6 +133,7 @@ function RainWetOverlayEffect({
                     uTopSurfaceBias: { value: topSurfaceBias },
                     uDarkness: { value: darkness },
                     uGlossiness: { value: glossiness },
+                    uPuddleStrength: { value: 0 },
                     uBoundsMin: { value: new Vector3(...resolvedBounds.min) },
                     uBoundsMax: { value: new Vector3(...resolvedBounds.max) },
                 },
@@ -149,7 +157,8 @@ function RainWetOverlayEffect({
         material.uniforms.uTopSurfaceBias.value = topSurfaceBias;
         material.uniforms.uDarkness.value = darkness;
         material.uniforms.uGlossiness.value = glossiness;
-    }, [darkness, glossiness, material, topSurfaceBias]);
+        material.uniforms.uPuddleStrength.value = Math.max(0, rainAmount - 0.66) / 0.34;
+    }, [darkness, glossiness, material, rainAmount, topSurfaceBias]);
 
     useEffect(() => {
         material.uniforms.uBoundsMin.value.set(...resolvedBounds.min);


### PR DESCRIPTION
### Motivation

- Implement GRE-291 to make rain visibly accumulate on block surfaces (grass, sand, ground variants) so weather affects the garden world, not just sky/particles.
- Keep wetness visual only (shader/overlay) rather than persisting block data, and ensure wetness fades smoothly after rain stops.

### Description

- Added a per-entity opt-in `renderRainWetOverlay` prop to `EntityInstancesBlock` and hooked an instanced per-block render path that places `RainWetOverlay` groups for each block instance. 
- Enabled `renderRainWetOverlay` for `Block_Grass`, `Block_Grass_Angle`, `Block_Sand`, and `Block_Sand_Angle` in `EntityInstances` so ground blocks receive wet overlays.
- Extended `RainWetOverlay` shader with a new `uPuddleStrength` uniform and noise-driven puddle pockets for heavier rain, lowered the activation threshold (`minRain` from 0.35 → 0.08) so light rain yields subtle wetness, and kept damping logic so wetness decays smoothly.
- Computed `uPuddleStrength` from the current `rainAmount` in the overlay `useEffect` so puddles appear only during heavier rain while normal wetness remains proportional to `rainy` intensity.

### Testing

- Attempted to run a style/static check with `biome` via `pnpm -C /workspace/gredice exec biome check packages/game/src/rain/RainWetOverlay.tsx packages/game/src/entities/EntityInstancesBlock.tsx packages/game/src/entities/EntityInstances.tsx`, which failed in this environment because `biome` is not installed (dependency environment not prepared), so no automated checks completed.
- No unit or integration tests were run in this session; changes were committed locally as `feat(game): add rain wet accumulation overlays for block surfaces`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02657e7c70832fa4400f5652be30da)