### PR TITLE
Document Codex environment and validation expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository is the **Gredice** monorepo. It hosts multiple Next.js applicati
 - Before editing code, look for additional `AGENTS.md` files inside the path you plan to touch. Nested instructions override this file.
 - Keep the worktree clean. Commit only intentional source changes and never commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless explicitly requested.
 - Use targeted Turbo commands from the repo root whenever possible.
+- Before handing off code changes, identify the affected workspace(s) and run targeted lint, test, and build checks unless the user explicitly asks to skip validation.
 
 ## Read the relevant guides
 
@@ -30,6 +31,28 @@ This repository is the **Gredice** monorepo. It hosts multiple Next.js applicati
 - Do not run `pnpm db-push`. Database migrations are applied manually during deployment.
 - For shared PRs, leave new migration files out of version control unless explicitly requested.
 - Follow existing Biome, TypeScript, React, Next.js, Tailwind, and package conventions.
+
+## Task validation
+
+For code changes, use the narrowest reliable validation set from the repo root:
+
+```bash
+pnpm lint --filter <workspace>
+pnpm test --filter <workspace>
+pnpm build --filter <workspace>
+```
+
+Examples:
+
+```bash
+pnpm lint --filter garden
+pnpm test --filter garden
+pnpm build --filter garden
+```
+
+For shared package changes, also validate the consuming app(s) that exercise the changed behavior. For storage changes, run `pnpm test --filter @gredice/storage` and build affected consumers such as `app`, `api`, or `farm`.
+
+If validation cannot run because of missing secrets, unavailable services, or time constraints, state exactly which command was skipped and why.
 
 ## GitHub issues
 

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -17,7 +17,7 @@ Aim for `3` on small low-risk changes and `4` or higher on shared, public, payme
 
 ## Validation commands
 
-Use targeted commands first.
+Use targeted commands first. Before handing off code changes, identify the affected workspace(s) and run lint, test, and build for each relevant workspace unless the user explicitly asks to skip validation.
 
 ```bash
 pnpm lint --filter <workspace>
@@ -34,11 +34,23 @@ pnpm build --filter www
 pnpm test --filter www
 ```
 
+For shared package changes, validate both the changed package and the consuming app(s) that exercise the behavior. Examples:
+
+```bash
+pnpm lint --filter @gredice/storage
+pnpm test --filter @gredice/storage
+pnpm build --filter app
+pnpm build --filter api
+pnpm build --filter farm
+```
+
 For docs-only changes, at minimum check formatting-sensitive diffs with:
 
 ```bash
 git diff --check
 ```
+
+If a required command cannot run because of missing secrets, unavailable services, unsupported local tooling, or time constraints, note the skipped command and the concrete reason in the handoff.
 
 ## Testing expectations
 

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -137,6 +137,62 @@ pnpm env:pull
 
 `pnpm env:pull` runs `vercel env pull .env` in `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, `apps/storybook`, `apps/api`, and `apps/status`.
 
+### Codex environment setup
+
+Use a lean Codex environment for routine code tasks. Pin Node.js to `24.15.0` when the environment UI asks for an exact version, and use pnpm `10.33.2`.
+
+Recommended Codex setup script:
+
+```bash
+set -euo pipefail
+
+corepack enable
+corepack prepare pnpm@10.33.2 --activate
+
+pnpm install --frozen-lockfile
+
+for f in apps/*/.env.example packages/*/.env.example; do
+  target="${f%.example}"
+  [ -f "$target" ] || cp "$f" "$target"
+done
+
+pnpm --filter www exec playwright install --with-deps chromium
+pnpm lint:ci-filters
+```
+
+Recommended Codex maintenance script:
+
+```bash
+set -euo pipefail
+
+corepack enable
+corepack prepare pnpm@10.33.2 --activate
+pnpm install --frozen-lockfile --prefer-offline
+```
+
+Recommended Codex environment variables:
+
+```bash
+CI=true
+NEXT_TELEMETRY_DISABLED=1
+TURBO_TELEMETRY_DISABLED=1
+PLAYWRIGHT_HTML_OPEN=never
+```
+
+Keep agent internet access off by default. Setup scripts already have internet access for dependency installation. If a task truly needs runtime internet access, prefer the common dependency allowlist and read-only HTTP methods.
+
+Do not use `pnpm dev` as the default Codex validation path. It starts the local HTTPS proxy and expects Docker, host entries, and Caddy certificate setup. Use targeted `pnpm lint --filter <workspace>`, `pnpm test --filter <workspace>`, and `pnpm build --filter <workspace>` commands instead.
+
+Avoid `pnpm bootstrap` in Codex unless Vercel auth and project access are configured. It links projects and pulls real environment variables. For most Codex tasks, the checked-in `.env.example` files provide enough safe smoke-test configuration.
+
+For secret-backed integration or visual tests, create a separate Codex environment with the required Vercel credentials, then run:
+
+```bash
+npm i -g vercel@latest
+pnpm vercel:link
+pnpm env:pull
+```
+
 ## Storage test database (Docker, local Postgres, and PGlite)
 
 `@gredice/storage` tests start a disposable Postgres database automatically through `pnpm --filter @gredice/storage test`.


### PR DESCRIPTION
## Summary
- Added a Codex-focused environment setup section to `WORKSPACE.md` with pinned tool versions, setup/maintenance scripts, recommended env vars, and guidance for when to avoid `pnpm dev` and `pnpm bootstrap`.
- Tightened `AGENTS.md` so code changes must run targeted lint, test, and build checks for the affected workspaces before handoff.
- Updated `QUALITY_SCORE.md` to make the validation contract explicit for shared packages and to require clear reporting when checks cannot run.

## Testing
- Not run (not requested).
- Performed docs-only verification with formatting-sensitive diff checks during implementation.