### PR TITLE
Add repo-local docs skills for API, CMS, SEO, workflows, and game assets

### DIFF
--- a/.codex/skills/gredice-api-reference/SKILL.md
+++ b/.codex/skills/gredice-api-reference/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: gredice-api-reference
+description: Maintain Gredice API documentation and contracts. Use when changing Hono route docs, describeRoute metadata, OpenAPI generation, Scalar API reference pages, API auth/security schemes, Zod validation schemas, directories API schemas, generated directory types, packages/client API helpers, or any docs under apps/api.
+---
+
+# Gredice API Reference
+
+## Overview
+
+Keep API reference behavior aligned with route implementation, validation, auth, and generated TypeScript contracts. Treat docs metadata as part of the API surface.
+
+## Current API Shape
+
+Primary files and ownership:
+
+- Route composition: `apps/api/app/api/[...route]/route.ts`.
+- Hono route modules: `apps/api/app/api/[...route]/*Routes.ts` and nested `data/*Routes.ts`.
+- Scalar page: `apps/api/app/docs/[slug]/page.tsx`.
+- OpenAPI helper for directory/CMS docs: `apps/api/lib/docs/openApiDocs.ts`.
+- API docs tests: `apps/api/lib/docs/openApiDocs.node.spec.ts`.
+- Security helpers: `apps/api/lib/docs/security.ts`.
+- Public directory type package: `packages/directory-types`.
+- Client helper: `packages/client/src/directories-api.ts`.
+
+The API app uses Hono, `hono-openapi`, Zod validators, and Next.js App Router route handlers. The reference UI reads `/api/docs/{slug}` specs through Scalar.
+
+## Route Documentation Workflow
+
+When adding or changing an API endpoint:
+
+1. Read the route implementation and validators before editing docs.
+2. Ensure `describeRoute` describes the actual behavior, not intended future behavior.
+3. Keep `security` accurate:
+   - Use `authSecurity` for endpoints that require session cookie or bearer token.
+   - Use `publicSecurity` for intentionally public endpoints.
+   - Use explicit mixed security only when the route supports both public and authenticated access.
+4. Keep `tags` consistent within the route group when tags are already used.
+5. Add request validators with `zValidator` before relying on values from params, query, or JSON bodies.
+6. Document status codes only when the route really returns them.
+7. For auth, account, payment, delivery, inventory, and private data endpoints, verify the server-side authorization path, not just the documented security scheme.
+
+## Directory And CMS OpenAPI
+
+`apps/api/lib/docs/openApiDocs.ts` builds OpenAPI 3.1 docs for directory entities and CMS pages.
+
+Respect these details:
+
+- Entity schemas come from `@gredice/storage` entity types and attribute definitions.
+- Attribute `dataType` controls the OpenAPI schema. Unsupported types should fail loudly through `UnsupportedCmsAttributeDataTypeError`.
+- `json|...`, `ref:...`, `range`, and `range|...` data types have custom handling.
+- CMS page docs include `/pages` and `/pages/{slug}`.
+- `image` is a shared component schema.
+- Tests in `openApiDocs.node.spec.ts` should cover parser and schema behavior when this logic changes.
+
+Do not hand-edit generated `packages/directory-types/src/v1.d.ts` or `apps/api/lib/@types/directories-api/v1.d.ts` without regenerating from the API docs source.
+
+## Generated Type Contracts
+
+When API docs affect generated clients:
+
+- `packages/directory-types` re-exports OpenAPI `paths` and `components` from `src/v1.d.ts`.
+- `packages/client/src/directories-api.ts` builds an `openapi-fetch` client from those generated types.
+- Run `pnpm --filter @gredice/directory-types regenerate` after CMS entity types or public directory API docs change.
+- Use `pnpm --filter @gredice/directory-types regenerate:cms-types` only when `src/v1.d.ts` is already current.
+- `apps/api` also has `pnpm --filter api regenerate:directories-api` for its local generated type.
+
+## Description Quality
+
+Write API descriptions that help consumers call the endpoint:
+
+- State the resource and actor, for example "Get delivery requests for the current user".
+- Include lifecycle or side effects for mutations, for example notifications, Stripe sessions, account switching, or cache invalidation.
+- Avoid generic descriptions like "Change notification" when the route is more specific.
+- Keep examples and defaults grounded in validators and returned data.
+- Do not expose secret names, internal stack traces, private IDs, or webhook payload details unless they are part of the public contract.
+
+## Validation
+
+Choose the smallest check that covers the change:
+
+```bash
+pnpm --filter api test:node
+pnpm test --filter api
+pnpm build --filter api
+pnpm --filter @gredice/directory-types regenerate
+pnpm lint --filter @gredice/directory-types
+```
+
+For visual API reference changes, start the API app and inspect `https://api.gredice.test/docs/{slug}` or the local test URL defined by `scripts/app-registry.ts`.
+
+Only query a live API or database when source code and tests cannot answer whether a documented response matches production data.

--- a/.codex/skills/gredice-api-reference/agents/openai.yaml
+++ b/.codex/skills/gredice-api-reference/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice API Reference"
+  short_description: "Maintain Gredice API docs and contracts"
+  default_prompt: "Use $gredice-api-reference to update Gredice API docs, OpenAPI metadata, and generated client contracts."

--- a/.codex/skills/gredice-cms-page-authoring/SKILL.md
+++ b/.codex/skills/gredice-cms-page-authoring/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: gredice-cms-page-authoring
+description: Author, review, or implement Gredice CMS page content and CMS page tooling. Use for SectionData JSON, supported CMS page sections, admin CMS page forms, public CMS rendering, slug validation, publish readiness, preview behavior, meta title, meta description, canonical path, noIndex, and CMS page routes in apps/app, apps/www, apps/api, or packages/storage.
+---
+
+# Gredice CMS Page Authoring
+
+## Overview
+
+Create CMS page content and tooling that passes repository validation, renders in preview and public routes, and is safe to publish.
+
+## Current CMS Page Flow
+
+Primary files:
+
+- Section definitions: `packages/storage/src/cmsPageSections.ts`.
+- CMS page repository: `packages/storage/src/repositories/cmsPagesRepo.ts`.
+- CMS schema: `packages/storage/src/schema/cmsSchema.ts`.
+- Admin CMS UI: `apps/app/app/admin/cms/pages`.
+- Admin section registry: `apps/app/components/shared/sectionsComponentRegistry.tsx`.
+- Public section registry: `apps/www/components/shared/sectionsComponentRegistry.tsx`.
+- Public catch-all CMS route: `apps/www/app/[...slug]/page.tsx`.
+- Public route utilities and tests: `apps/www/app/[...slug]/cmsPageRouteUtils.ts`.
+- Public API docs for pages: `apps/api/lib/docs/openApiDocs.ts`.
+
+CMS content is stored as a JSON array of SectionData blocks in `cms_pages.content`.
+
+## Supported Sections
+
+The supported section components currently are:
+
+- `Heading1`: required `header`, required `description`.
+- `Feature1`: required `header`, required `description`.
+- `Faq1`: required `header`, required `description`.
+- `Footer1`: optional `header`, optional `description`.
+- `PageHeader`: custom section, optional `header`, optional `description`.
+
+A minimal content array:
+
+```json
+[
+  {
+    "component": "PageHeader",
+    "header": "Page title",
+    "description": "Short page introduction."
+  },
+  {
+    "component": "Heading1",
+    "header": "Section title",
+    "description": "Section body."
+  }
+]
+```
+
+Do not use unsupported component names. Add new components only by updating `cmsPageSectionComponents` and both section registries.
+
+## Slug And Publish Rules
+
+`packages/storage/src/repositories/cmsPagesRepo.ts` enforces:
+
+- Slugs are normalized with `slugify` per segment.
+- Empty slugs are invalid.
+- Reserved first segments cannot be used.
+- Existing active page slugs must be unique.
+- Published pages require content, meta title, and meta description.
+- Meta description is capped at 160 characters.
+- Content must parse as a JSON array of objects with a string `component`.
+
+Check both reserved route lists when touching behavior:
+
+- `reservedCmsPageFirstSegments` in `cmsPagesRepo.ts`.
+- `reservedFirstSegments` in `apps/www/app/[...slug]/cmsPageRouteUtils.ts`.
+
+## Authoring Checklist
+
+For a publish-ready CMS page, provide:
+
+- `slug`: non-reserved public path, without leading slash.
+- `title`: admin/internal page title.
+- `content`: valid SectionData JSON array using supported components.
+- `metaTitle`: specific public page title.
+- `metaDescription`: concise, no more than 160 characters.
+- `canonicalPath`: only when the canonical URL differs from `/{slug}`.
+- `metaImageUrl`: only when a safe, representative image exists.
+- `noIndex`: true only for pages that should be excluded from search.
+
+Keep public copy concrete and consistent with nearby Croatian pages. Do not invent plant, delivery, pricing, legal, or availability facts.
+
+## Rendering And Preview
+
+The admin app previews CMS pages through `apps/app/app/admin/cms/pages/[pageId]/preview/page.tsx`.
+
+The public app renders published pages through `apps/www/app/[...slug]/page.tsx`. Draft preview uses Next draft mode plus `CMS_PAGES_PREVIEW_SECRET`.
+
+Public metadata uses:
+
+- `page.metaTitle || page.title`.
+- `page.metaDescription`.
+- `page.canonicalPath || /{page.slug}`.
+- `page.noIndex`.
+- `page.metaImageUrl` for Open Graph.
+
+## Validation
+
+For repository logic changes:
+
+```bash
+pnpm test --filter @gredice/storage
+pnpm test --filter www
+pnpm build --filter www
+pnpm build --filter app
+```
+
+For CMS content JSON only, validate it parses as an array and uses supported components. If editing docs or sample JSON only, run:
+
+```bash
+git diff --check
+```
+
+Query the database only when asked to inspect or modify existing CMS page rows. Prefer source-defined validation for authoring guidance.

--- a/.codex/skills/gredice-cms-page-authoring/agents/openai.yaml
+++ b/.codex/skills/gredice-cms-page-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice CMS Authoring"
+  short_description: "Author CMS pages that publish cleanly"
+  default_prompt: "Use $gredice-cms-page-authoring to draft or review a Gredice CMS page with valid sections and publish metadata."

--- a/.codex/skills/gredice-docs-auditor/SKILL.md
+++ b/.codex/skills/gredice-docs-auditor/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: gredice-docs-auditor
+description: Audit, create, or update Gredice repository documentation. Use for README, CONTRIBUTING, AGENTS.md, root guides, docs/*.md, setup docs, command docs, contributor guidance, app/package maps, validation instructions, generated artifact rules, and any change that may make documentation stale against package scripts, app registry, workspace layout, or source behavior.
+---
+
+# Gredice Docs Auditor
+
+## Overview
+
+Keep Gredice repository documentation accurate to the current monorepo. Prefer concrete paths, package names, commands, and ownership boundaries over generic guidance.
+
+## Source Of Truth
+
+Read the relevant current source before writing or auditing docs:
+
+- Root operating guides: `AGENTS.md`, `WORKSPACE.md`, `FRONTEND.md`, `DESIGN.md`, `PRODUCT_SENSE.md`, `QUALITY_SCORE.md`, `RELIABILITY.md`, `SECURITY.md`, `SEO.md`.
+- Contributor guide and repo overview: `README.md`, `CONTRIBUTING.md`.
+- Package manager and scripts: root `package.json`, app/package `package.json`, `turbo.json`, `pnpm-workspace.yaml`.
+- App names, local domains, ports, Vercel project names, and default dev stack: `scripts/app-registry.ts`.
+- Existing focused docs: `docs/notification-workflows.md`, `docs/game-scene-performance.md`, package README files.
+- Generated asset and schema rules: `WORKSPACE.md`, `RELIABILITY.md`, package scripts under `packages/storage`, `packages/cdn`, `packages/game`, and app scripts.
+
+Use `rg` and `rg --files` first. Confirm paths exist before documenting them.
+
+## Audit Workflow
+
+1. Identify the doc scope: setup, app map, contributor process, API, public content, reliability, security, generated assets, or workflow behavior.
+2. Read the closest existing docs and the owning source files. Do not update a broad guide from memory.
+3. Check whether names, commands, paths, app domains, and validation instructions still match code.
+4. Remove stale instructions when replacing behavior. Do not leave contradictory old/new guidance.
+5. Keep docs repo-specific. Prefer "run `pnpm test --filter @gredice/storage`" over "run tests".
+6. Keep docs scoped. Do not rewrite unrelated sections for tone or style while fixing one stale fact.
+
+## Repo Map Facts
+
+Use the current app registry and workspace guide as the source of truth:
+
+- `apps/www`: public marketing, commerce, CMS-rendered pages, SEO, sitemap, public tests.
+- `apps/garden`: customer garden/game experience.
+- `apps/farm`: farm back office.
+- `apps/app`: internal operations/admin.
+- `apps/storybook`: public component documentation.
+- `apps/api`: Hono API routes, Scalar API reference, API docs, Stripe cron/webhooks.
+- `apps/status`: public status page, not part of default root dev.
+- `packages/*`: shared packages such as `@gredice/ui`, `@gredice/client`, `@gredice/storage`, `@gredice/game`, `@gredice/transactional`, `@gredice/stripe`.
+- `assets`: source brand and game assets.
+
+Local domains come from `scripts/app-registry.ts`, not hand-written lists. The default stack is started by `pnpm dev`; `status` starts separately with `pnpm --filter=status dev`.
+
+## Command Accuracy
+
+Before documenting commands, check the relevant `package.json` script. Current common commands:
+
+```bash
+pnpm bootstrap
+pnpm doctor
+pnpm dev
+pnpm dev:all
+pnpm lint --filter <workspace>
+pnpm test --filter <workspace>
+pnpm build --filter <workspace>
+pnpm db-generate
+pnpm regenerate
+git diff --check
+```
+
+Use `pnpm install` only when the task is dependency setup. The README currently emphasizes `pnpm bootstrap`, `pnpm doctor`, and `pnpm dev` for fresh worktrees.
+
+Document these non-negotiables when relevant:
+
+- Runtime is Node.js `>=24`; package manager is pnpm `10.33.2`.
+- Use `workspace:*` for internal dependencies.
+- Schema changes live in `packages/storage`; run `pnpm db-generate`.
+- Do not run `pnpm db-push`.
+- Do not commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless they are established tracked outputs required by the source change.
+
+## Documentation Style
+
+Write for contributors who need to act:
+
+- Use exact app/package names and paths.
+- Use exact command names and filters.
+- Explain ownership boundaries when behavior spans apps and packages.
+- Prefer tables only when comparing multiple items.
+- Avoid future promises, vague best practices, and generic framework descriptions.
+- Preserve Croatian product terms and nearby public-copy tone when documenting user-facing content.
+- Call out secrets, migrations, generated assets, deployments, or manual coordination explicitly.
+
+## Validation
+
+For docs-only edits, run:
+
+```bash
+git diff --check
+```
+
+For docs that describe a command or generated output, run the smallest harmless check that proves the instruction is still valid. Do not run `pnpm db-push`.
+
+If live product state matters, query the API, database, Linear, or GitHub only after the static source does not answer the question.

--- a/.codex/skills/gredice-docs-auditor/agents/openai.yaml
+++ b/.codex/skills/gredice-docs-auditor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Docs Auditor"
+  short_description: "Audit Gredice docs and repo guidance"
+  default_prompt: "Use $gredice-docs-auditor to audit repository documentation for stale commands, paths, and contributor guidance."

--- a/.codex/skills/gredice-domain-workflow-docs/SKILL.md
+++ b/.codex/skills/gredice-domain-workflow-docs/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: gredice-domain-workflow-docs
+description: Document Gredice business and operational workflows across apps and packages. Use for delivery, checkout, payments, Stripe, notifications, Slack, email, inventory, garden operations, farm/admin workflows, scheduled jobs, background work, state transitions, failure handling, environment configuration, and cross-app workflow docs under docs/ or package guides.
+---
+
+# Gredice Domain Workflow Docs
+
+## Overview
+
+Write workflow documentation that traces real behavior across UI, API, storage, background work, notifications, and external services. Make state transitions and failure behavior explicit.
+
+## Ownership Map
+
+Start from `RELIABILITY.md` and `PRODUCT_SENSE.md`, then trace the owning files:
+
+- Database schema and repositories: `packages/storage`.
+- API behavior: `apps/api`.
+- Shared API clients: `packages/client`.
+- Public/content flows: `apps/www`.
+- Customer garden/game flows: `apps/garden`, `packages/game`.
+- Farm operations: `apps/farm`.
+- Internal admin operations: `apps/app`.
+- Payments: `packages/stripe`, `apps/api/lib/stripe`, API checkout and webhook routes.
+- Notifications: `packages/notifications`, `packages/slack`, `packages/email`, `packages/transactional`, notification APIs and admin settings.
+- Generated assets and models: `assets`, `packages/game`, `packages/cdn`, `apps/garden/public`.
+
+## Trace Workflow
+
+For any workflow doc:
+
+1. Identify actors: public visitor, customer, farm operator, internal admin, system cron, webhook, external service.
+2. Find entry points: page action, API route, Server Action, cron route, webhook, background script.
+3. Trace storage reads/writes and event history.
+4. Trace side effects: notifications, email, Slack, Stripe, PostHog, Redis/cache busting, revalidation.
+5. List state transitions and terminal states.
+6. Document retries, idempotency keys, skipped work, and partial failure behavior.
+7. Record required environment variables and admin settings.
+8. Include exact file paths and commands for validation.
+
+Use `rg` with business terms and event/status names. Do not rely on a single UI file when the source of truth lives in storage or API code.
+
+## Recommended Document Shape
+
+Use this structure for workflow docs unless nearby docs use a stronger established pattern:
+
+```markdown
+# Workflow name
+
+## Summary
+
+## Actors
+
+## Configuration
+
+## Entry points
+
+## State model
+
+## Happy path
+
+## Failure handling
+
+## Observability
+
+## Validation
+```
+
+For short docs, collapse sections but keep configuration, entry points, and failure handling visible.
+
+## Domain Rules
+
+Follow current Gredice product and reliability expectations:
+
+- Preserve domain meaning. Use "raised bed", "field", "operation", "delivery request", "cart", "invoice", and "account" precisely.
+- Keep money, inventory, delivery, fiscalization, and scheduled operation behavior explicit and auditable.
+- Treat payment, checkout, delivery, inventory, notification, and cron work as retryable.
+- Validate external metadata before trusting it.
+- Do not log or document secrets, auth headers, full webhook payloads, or private user data.
+- Explain whether missing configuration skips work, fails work, or retries later.
+
+## Notification Example Facts
+
+For Slack notification docs, use current keys and behavior from `docs/notification-workflows.md` and source:
+
+- `SLACK_BOT_TOKEN` provides the bot token.
+- Delivery channel setting key: `slack.delivery.channel`.
+- New user channel setting key: `slack.new_users.channel`.
+- Shopping channel setting key: `slack.shopping.channel`.
+- Farm-specific Slack channel lives on `farms.slack_channel_id`.
+- Missing channel configuration skips the notification and logs the omission.
+- Slack delivery errors are logged and should not interrupt the primary business flow.
+
+## Validation
+
+Use the smallest commands that exercise the source you documented:
+
+```bash
+pnpm test --filter @gredice/storage
+pnpm test --filter api
+pnpm build --filter app
+pnpm build --filter farm
+pnpm build --filter garden
+git diff --check
+```
+
+Query Linear, GitHub, the API, or the database only when documenting current operational state, open work, live configuration, or production data that cannot be inferred from source.

--- a/.codex/skills/gredice-domain-workflow-docs/agents/openai.yaml
+++ b/.codex/skills/gredice-domain-workflow-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Workflow Docs"
+  short_description: "Document cross-app business workflows"
+  default_prompt: "Use $gredice-domain-workflow-docs to document a Gredice workflow across apps, packages, state, and notifications."

--- a/.codex/skills/gredice-game-asset-docs/SKILL.md
+++ b/.codex/skills/gredice-game-asset-docs/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: gredice-game-asset-docs
+description: Document Gredice garden game, 3D scene, generated assets, model exports, sprite atlases, performance profiling, quality tiers, canvas behavior, game asset source files, and verification workflows in apps/garden, packages/game, packages/cdn, assets, or docs/game-scene-performance.md.
+---
+
+# Gredice Game Asset Docs
+
+## Overview
+
+Keep game and asset documentation accurate to the actual source, generated outputs, and profiling commands. Distinguish source assets from generated artifacts.
+
+## Ownership Map
+
+Primary files and directories:
+
+- Garden app: `apps/garden`.
+- Game runtime package: `packages/game`.
+- Game scene root: `packages/game/src/GameScene.tsx`.
+- Game quality policy: `packages/game/src/scene/gameQuality.ts`.
+- Source Blender asset: `assets/GameAssets.blend`.
+- Blender version marker: `assets/BLENDER_VERSION`.
+- Source brand/game texture examples: `assets/GredicePixPal_BaseColor.png`, `assets/brand/gredice-logotype.svg`.
+- Export scripts: `assets/export.sh`, `assets/export.ps1`.
+- Generated GLB: `apps/garden/public/assets/models/GameAssets.glb`.
+- Generated model types: `packages/game/src/models/GameAssets.tsx`.
+- CDN asset scripts: `packages/cdn/scripts`.
+- Performance doc: `docs/game-scene-performance.md`.
+
+## Asset Pipeline
+
+Document this pipeline exactly when it is relevant:
+
+1. Edit source assets under `assets`, especially `assets/GameAssets.blend`.
+2. Run:
+
+```bash
+pnpm generate:game-assets
+```
+
+3. The script exports the GLB to `apps/garden/public/assets/models/GameAssets.glb`.
+4. The script runs model type generation for `packages/game/src/models/GameAssets.tsx`.
+5. Review generated output and only commit generated artifacts when the source change requires them and they are established tracked outputs.
+
+If the steps need to run separately:
+
+```bash
+cd assets
+./export.sh
+cd ..
+pnpm generate:models-types
+```
+
+On Windows, use `assets/export.ps1`. Blender must be installed where `WORKSPACE.md` documents it.
+
+## Decoration Sprite Atlas
+
+The decoration atlas pipeline lives in `packages/cdn/scripts` and writes runtime sprite assets under `apps/garden/public/assets/sprites/decorations`.
+
+Document this command when atlas assets change:
+
+```bash
+pnpm --filter @gredice/cdn run regenerate-cdn:decoration-atlas
+```
+
+Keep sprite names stable. The manifest uses relative input paths as sprite IDs.
+
+## Performance Documentation
+
+Use `docs/game-scene-performance.md` as the current performance narrative. When updating it:
+
+- Date new measurements.
+- State whether numbers come from dev, production build, headless Playwright, or a real device.
+- Prefer repeated production profiling for budget decisions.
+- Record canvas backing size, reported DPR, quality tier, draw calls, triangles, FPS, long tasks, and budget pass/fail when available.
+- Separate source asset complexity from runtime render policy.
+- Identify whether changes affect shadows, DPR caps, particles, overlays, decorations, plant LOD, frame loops, or app-level providers.
+
+Relevant profiling commands currently documented by the garden app:
+
+```bash
+cd apps/garden
+pnpm run profile:game
+pnpm run profile:game:ci
+pnpm run profile:game:existing
+pnpm run profile:game:start
+```
+
+Useful overrides:
+
+```bash
+GAME_PROFILE_BASE_URL=http://localhost:3001 pnpm run profile:game:existing
+GAME_PROFILE_WARMUP_MS=8000 GAME_PROFILE_SAMPLE_MS=10000 pnpm run profile:game
+GAME_PROFILE_FAIL_ON_BUDGET=1 pnpm run profile:game
+```
+
+## Visual Verification
+
+When docs claim visual behavior, verify with a browser or screenshots:
+
+- Garden app: `https://vrt.gredice.test`.
+- Debug/profile routes when available under `apps/garden/app/debug`.
+- Check desktop and mobile viewports when layout, canvas framing, or touch interaction is involved.
+- Confirm the canvas is nonblank and the referenced assets render.
+
+## Validation
+
+Use targeted checks:
+
+```bash
+pnpm build --filter garden
+pnpm test --filter garden
+pnpm lint --filter @gredice/game
+pnpm generate:game-assets
+pnpm --filter @gredice/cdn run regenerate-cdn:decoration-atlas
+git diff --check
+```
+
+Do not hand-edit generated model output unless the generator is broken and the temporary nature of the change is explicitly documented.

--- a/.codex/skills/gredice-game-asset-docs/agents/openai.yaml
+++ b/.codex/skills/gredice-game-asset-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Game Asset Docs"
+  short_description: "Document garden game and asset pipelines"
+  default_prompt: "Use $gredice-game-asset-docs to document game scene behavior, generated assets, or profiling workflows."

--- a/.codex/skills/gredice-public-docs-seo/SKILL.md
+++ b/.codex/skills/gredice-public-docs-seo/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gredice-public-docs-seo
+description: Create, update, or review public Gredice documentation, content pages, metadata, structured data, sitemap behavior, public Croatian copy, FAQ/legal/plant/operation/block/recipe pages, CMS-rendered public routes, and SEO-sensitive work in apps/www or apps/status.
+---
+
+# Gredice Public Docs SEO
+
+## Overview
+
+Protect public content quality, SEO, metadata, and structured data for Gredice public surfaces. Ground claims in existing data and nearby copy.
+
+## Scope
+
+Primary public docs/content surface:
+
+- `apps/www`: marketing, commerce, CMS pages, plant pages, block pages, recipe pages, operation pages, legal pages, FAQ, delivery, pricing, sitemap, public tests.
+- `apps/status`: public status page metadata when touched.
+
+Read first:
+
+- `SEO.md`.
+- `PRODUCT_SENSE.md`.
+- `DESIGN.md` for public page presentation.
+- `apps/www/src/KnownPages.ts`.
+- `apps/www/src/pageAliases.ts`.
+- Nearby route files under `apps/www/app`.
+
+## Public Page Workflow
+
+When changing a public page:
+
+1. Identify whether it is a static route, dynamic data page, or CMS-rendered route.
+2. Preserve route ownership and `KnownPages` helpers.
+3. Add or update `metadata` or `generateMetadata`.
+4. Keep title and description specific to the rendered page.
+5. Derive dynamic metadata from the same data source used to render the page.
+6. Return the established not-found behavior when dynamic content is missing.
+7. Check canonical path behavior for duplicate or alias routes.
+8. Update structured data only when it exactly matches rendered content.
+9. Keep copy consistent with existing public Croatian tone and product terminology.
+10. Run the smallest public-page validation that covers the change.
+
+## Metadata Patterns
+
+Use Next.js App Router metadata:
+
+- Static pages export `metadata`.
+- Dynamic pages export `generateMetadata`.
+- `apps/www/app/layout.tsx` owns `metadataBase` for `https://www.gredice.com`.
+- CMS pages in `apps/www/app/[...slug]/page.tsx` derive metadata from public directory page data.
+- Open Graph images should represent the actual page or item when available.
+
+Do not use generic fallback metadata for missing plant, sort, operation, recipe, or CMS content when the page should be a 404.
+
+## Structured Data
+
+Use `apps/www/components/shared/seo/StructuredDataScript.tsx` for JSON-LD.
+
+Existing public structured data includes products for plants, plant sorts, and operations. Preserve these constraints:
+
+- Do not invent price, availability, reviews, ratings, legal terms, delivery promises, or plant facts.
+- Use `apps/www/src/merchantReturnPolicy.ts` where product offers already include the merchant return policy.
+- Use stable URLs from `KnownPages`.
+- Ensure schema data is also visible or implied by rendered page content.
+
+## Sitemap And Public Tests
+
+`apps/www` runs `next-sitemap` in `postbuild`. CMS pages are added by `apps/www/next-sitemap.config.cjs` from the directories API, filtered to published pages with `publishedAt` and no `noIndex`.
+
+Public tests use sitemap-generated cases:
+
+- `apps/www/tests/populate-test-cases.ts`.
+- `apps/www/tests/a11y.spec.ts`.
+- `apps/www/tests/titlesPresent.spec.ts`.
+- `apps/www/tests/visual.spec.ts`.
+
+If a route should not be indexed, make it explicit through metadata or sitemap config.
+
+## Copy Rules
+
+Follow `PRODUCT_SENSE.md`:
+
+- Do not invent facts about plants, delivery, pricing, legal terms, fiscalization, or availability.
+- Keep domain language precise: gardens, raised beds, fields, plants, sorts, operations, carts, deliveries, invoices, accounts.
+- Public pages should make the offer or content clear without explaining implementation internals.
+- Headings should describe page content, not code concepts.
+- Use actual product, plant, operation, or Gredice imagery where relevant.
+
+## Validation
+
+Use targeted commands:
+
+```bash
+pnpm build --filter www
+pnpm test --filter www
+pnpm lint --filter www
+```
+
+For content-only changes, `git diff --check` may be enough when metadata, routing, sitemap, and rendering behavior are untouched.
+
+For visual layout changes, start the app and inspect responsive behavior:
+
+```bash
+pnpm --filter www dev
+```
+
+Use screenshots when validating public first-view content, responsive layout, or structured visual changes.

--- a/.codex/skills/gredice-public-docs-seo/agents/openai.yaml
+++ b/.codex/skills/gredice-public-docs-seo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Public Docs SEO"
+  short_description: "Protect public content and SEO quality"
+  default_prompt: "Use $gredice-public-docs-seo to update a public Gredice content page with accurate metadata and structured data."

--- a/.codex/skills/gredice-storybook-component-docs/SKILL.md
+++ b/.codex/skills/gredice-storybook-component-docs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: gredice-storybook-component-docs
+description: Create, update, or review Gredice Storybook component documentation. Use for apps/storybook stories, MDX docs, autodocs metadata, shared UI examples, @gredice/ui components, app-adjacent reusable components, component state coverage, accessibility story setup, and docs changes required after reusable UI changes.
+---
+
+# Gredice Storybook Component Docs
+
+## Overview
+
+Make Storybook a useful component reference for contributors. Stories should show real Gredice usage, stable mock data, meaningful states, and clear source ownership.
+
+## Current Storybook Shape
+
+Primary files:
+
+- App: `apps/storybook`.
+- Story config: `apps/storybook/.storybook/main.ts`, `apps/storybook/.storybook/preview.tsx`, `apps/storybook/.storybook/themes.ts`.
+- Intro MDX: `apps/storybook/stories/Introduction.mdx`.
+- Story globs: `apps/storybook/stories/**/*.mdx` and `apps/storybook/stories/**/*.stories.@(ts|tsx)`.
+- Public local domain: `https://storybook.dev.gredice.test`.
+
+The project uses Storybook 10 with `@storybook/nextjs-vite`, addon docs, addon a11y, and addon MCP. `next/image` is mocked in Storybook.
+
+## Story Placement
+
+Place stories by source ownership:
+
+- `packages/ui/...`: shared reusable components.
+- `apps/www/...`: public site and content components.
+- `apps/garden/...`: customer garden experience components.
+- `apps/farm/...`: farm back-office components.
+- `apps/app/...`: internal admin and operations components.
+
+Use grouped titles such as:
+
+```ts
+title: 'packages/ui/Media/ImageGallery'
+title: 'apps/www/Layout/PageHeader'
+```
+
+When changing a reusable UI component, add or update a Storybook story in the same change.
+
+## Story Pattern
+
+Prefer the existing TypeScript pattern:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Category/ComponentName',
+    component: ComponentName,
+    tags: ['autodocs'],
+    args: {},
+    parameters: {
+        docs: {
+            description: {
+                component: 'One concrete sentence about product usage.',
+            },
+        },
+    },
+} satisfies Meta<typeof ComponentName>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+```
+
+Use `render` only when the component needs surrounding layout, providers, or child composition. Keep mock data deterministic and local to the story file.
+
+## Coverage Expectations
+
+Cover states that matter for the component:
+
+- Default.
+- Loading.
+- Empty or no data.
+- Disabled.
+- Error.
+- Long content.
+- Small viewport or constrained container when layout can break.
+- Important variants and modes.
+- Realistic visual media when the component displays products, plants, operations, gardens, or user avatars.
+
+Do not make stories depend on live services, authentication, database state, real secrets, or current production data.
+
+## Design And Accessibility
+
+Follow `FRONTEND.md` and `DESIGN.md`:
+
+- Reuse `@gredice/ui`, `@signalco/ui`, `@signalco/ui-primitives`, and established app components first.
+- Keep examples close to real product usage rather than decoration.
+- Include accessible labels and keyboard-reachable interactions.
+- Avoid nested cards, oversized hero typography inside component examples, and one-note palettes.
+- Keep text inside controls from overflowing at mobile and desktop widths.
+- Use `layout: 'fullscreen'` only when the component naturally needs page width.
+
+## Validation
+
+Run targeted checks:
+
+```bash
+pnpm lint --filter storybook
+pnpm build --filter storybook
+```
+
+When a story documents changed source code from another workspace, also run the smallest relevant check for that workspace.
+
+For visual confidence, start Storybook with:
+
+```bash
+pnpm --filter storybook dev
+```
+
+Open `https://storybook.dev.gredice.test` and inspect the changed story. Use screenshots when layout, responsive behavior, or visual state is part of the change.

--- a/.codex/skills/gredice-storybook-component-docs/agents/openai.yaml
+++ b/.codex/skills/gredice-storybook-component-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gredice Storybook Docs"
+  short_description: "Document reusable UI in Storybook"
+  default_prompt: "Use $gredice-storybook-component-docs to add or review Storybook stories for a reusable Gredice component."


### PR DESCRIPTION
## Summary
- Added seven repo-scoped Codex skills under `.codex/skills` for documentation-heavy work in Gredice.
- Covered API reference upkeep, CMS page authoring, repo docs auditing, cross-app workflow docs, public docs/SEO, Storybook component docs, and game asset/performance docs.
- Grounded each skill in the current repo structure, package scripts, validation commands, and domain rules from the existing guides and source code.
- Added `agents/openai.yaml` metadata for each skill so they show up with usable UI labels and prompts.

## Testing
- Ran the official skill validator for all seven skills.
- Verified the skill files are free of template leftovers and stale placeholder prompts.
- Ran `git diff --check` on the added skill files.