### PR TITLE
[CMS] Page editor - modern editor shell with sticky header

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -337,324 +337,405 @@ export function CmsPageForm({
     );
 
     return (
-        <Card className="max-w-3xl">
-            <Stack spacing={4} className="p-6">
-                <form
-                    ref={formRef}
-                    action={formAction}
-                    onChange={() => setFormRevision((current) => current + 1)}
-                    onSubmit={(event) => {
-                        if (!rawMode) {
-                            return;
-                        }
-
-                        try {
-                            setRawContent(formatJsonContent(rawContent));
-                            setRawError(null);
-                        } catch {
-                            event.preventDefault();
-                            setRawError(
-                                'JSON nije valjan. Ispravi sadržaj prije spremanja.',
-                            );
-                        }
-                    }}
+        <Stack spacing={4}>
+            <Card className="sticky top-4 z-10 border-border/70 bg-background/95 p-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+                <Row
+                    spacing={2}
+                    className="flex-wrap items-center justify-between"
                 >
-                    <Stack spacing={4}>
-                        <Stack spacing={3}>
-                            {autosaveAction && (
-                                <Typography level="body3" secondary>
-                                    Autosave: {autosaveStatus}
-                                    {autosaveMessage
-                                        ? ` • ${autosaveMessage}`
-                                        : ''}
-                                </Typography>
-                            )}
-                            <Input
-                                name="title"
-                                label="Naslov"
-                                defaultValue={page?.title ?? ''}
-                                required
-                            />
-                            <Input
-                                name="slug"
-                                label="Slug"
-                                defaultValue={page?.slug ?? ''}
-                                placeholder="npr. sezonski-vodic"
-                                helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
-                                required
-                            />
-                            <SelectItems
-                                name="state"
-                                label="Status"
-                                defaultValue={page?.state ?? 'draft'}
-                                items={cmsPageStateItems}
-                            />
-                            <Stack spacing={2}>
-                                <Typography level="h3" semiBold>
-                                    Sadržaj stranice
-                                </Typography>
-                                <Typography level="body3" secondary>
-                                    Vizualni editor je zadani način rada, a JSON
-                                    editor je dostupan kao fallback.
-                                </Typography>
-                                <label className="flex items-center gap-2 text-sm">
-                                    <input
-                                        type="checkbox"
-                                        checked={rawMode}
-                                        onChange={(event) => {
-                                            const enabled =
-                                                event.target.checked;
-                                            setRawMode(enabled);
-                                            setRawError(null);
-                                            if (enabled) {
-                                                setRawContent(builderContent);
-                                            }
-                                        }}
-                                    />
-                                    Uredi sadržaj kroz JSON editor (fallback)
-                                </label>
-                                {preserveFallbackContent && (
-                                    <Card className="p-3 text-sm text-amber-700">
-                                        Postojeći sadržaj nije moguće prikazati
-                                        u vizualnom editoru bez gubitka
-                                        podataka.
-                                    </Card>
+                    <Stack spacing={1}>
+                        <Typography level="h4" semiBold>
+                            {page?.title?.trim() || 'Nova CMS stranica'}
+                        </Typography>
+                        <Typography level="body3" secondary>
+                            /{page?.slug?.trim() || 'slug'} •{' '}
+                            {page?.state ?? 'draft'}
+                            {autosaveAction
+                                ? ` • Autosave: ${autosaveStatus}${autosaveMessage ? ` • ${autosaveMessage}` : ''}`
+                                : ''}
+                        </Typography>
+                    </Stack>
+                    <Button
+                        variant="solid"
+                        type="submit"
+                        form={reactId}
+                        className="w-fit"
+                        loading={pending}
+                    >
+                        {submitLabel}
+                    </Button>
+                </Row>
+            </Card>
+            <Card className="w-full">
+                <Stack spacing={4} className="p-4 md:p-6">
+                    <form
+                        id={reactId}
+                        ref={formRef}
+                        action={formAction}
+                        onChange={() =>
+                            setFormRevision((current) => current + 1)
+                        }
+                        onSubmit={(event) => {
+                            if (!rawMode) {
+                                return;
+                            }
+
+                            try {
+                                setRawContent(formatJsonContent(rawContent));
+                                setRawError(null);
+                            } catch {
+                                event.preventDefault();
+                                setRawError(
+                                    'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                                );
+                            }
+                        }}
+                    >
+                        <Stack spacing={4}>
+                            <Stack spacing={3}>
+                                {autosaveAction && (
+                                    <Typography level="body3" secondary>
+                                        Autosave: {autosaveStatus}
+                                        {autosaveMessage
+                                            ? ` • ${autosaveMessage}`
+                                            : ''}
+                                    </Typography>
                                 )}
-                                <input
-                                    name="content"
-                                    type="hidden"
-                                    value={serializedContent}
-                                    readOnly
+                                <Input
+                                    name="title"
+                                    label="Naslov"
+                                    defaultValue={page?.title ?? ''}
+                                    required
                                 />
-                                {rawMode ? (
-                                    <label className="space-y-1">
-                                        <span className="block text-sm font-medium">
-                                            JSON sadržaj
-                                        </span>
-                                        <textarea
-                                            value={rawContent}
-                                            rows={16}
-                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                            onBlur={() => {
-                                                try {
+                                <Input
+                                    name="slug"
+                                    label="Slug"
+                                    defaultValue={page?.slug ?? ''}
+                                    placeholder="npr. sezonski-vodic"
+                                    helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
+                                    required
+                                />
+                                <SelectItems
+                                    name="state"
+                                    label="Status"
+                                    defaultValue={page?.state ?? 'draft'}
+                                    items={cmsPageStateItems}
+                                />
+                                <Stack spacing={2}>
+                                    <Typography level="h3" semiBold>
+                                        Sadržaj stranice
+                                    </Typography>
+                                    <Typography level="body3" secondary>
+                                        Vizualni editor je zadani način rada, a
+                                        JSON editor je dostupan kao fallback.
+                                    </Typography>
+                                    <label className="flex items-center gap-2 text-sm">
+                                        <input
+                                            type="checkbox"
+                                            checked={rawMode}
+                                            onChange={(event) => {
+                                                const enabled =
+                                                    event.target.checked;
+                                                setRawMode(enabled);
+                                                setRawError(null);
+                                                if (enabled) {
                                                     setRawContent(
-                                                        formatJsonContent(
-                                                            rawContent,
-                                                        ),
-                                                    );
-                                                    setRawError(null);
-                                                } catch {
-                                                    setRawError(
-                                                        'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                                                        builderContent,
                                                     );
                                                 }
                                             }}
-                                            onChange={(event) => {
-                                                setRawContent(
-                                                    event.target.value,
-                                                );
-                                                setRawError(null);
-                                            }}
                                         />
-                                        {rawError && (
-                                            <Typography
-                                                level="body2"
-                                                className="text-red-600"
-                                            >
-                                                {rawError}
-                                            </Typography>
-                                        )}
-                                        {preserveFallbackContent && (
-                                            <Button
-                                                type="button"
-                                                variant="plain"
-                                                onClick={() => {
+                                        Uredi sadržaj kroz JSON editor
+                                        (fallback)
+                                    </label>
+                                    {preserveFallbackContent && (
+                                        <Card className="p-3 text-sm text-amber-700">
+                                            Postojeći sadržaj nije moguće
+                                            prikazati u vizualnom editoru bez
+                                            gubitka podataka.
+                                        </Card>
+                                    )}
+                                    <input
+                                        name="content"
+                                        type="hidden"
+                                        value={serializedContent}
+                                        readOnly
+                                    />
+                                    {rawMode ? (
+                                        <label className="space-y-1">
+                                            <span className="block text-sm font-medium">
+                                                JSON sadržaj
+                                            </span>
+                                            <textarea
+                                                value={rawContent}
+                                                rows={16}
+                                                className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                onBlur={() => {
+                                                    try {
+                                                        setRawContent(
+                                                            formatJsonContent(
+                                                                rawContent,
+                                                            ),
+                                                        );
+                                                        setRawError(null);
+                                                    } catch {
+                                                        setRawError(
+                                                            'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                                                        );
+                                                    }
+                                                }}
+                                                onChange={(event) => {
                                                     setRawContent(
-                                                        page?.content ?? '',
+                                                        event.target.value,
                                                     );
                                                     setRawError(null);
                                                 }}
-                                            >
-                                                Vrati spremljeni sadržaj
-                                            </Button>
-                                        )}
-                                    </label>
-                                ) : sections.length === 0 ? (
-                                    <Card className="p-4 text-sm text-muted-foreground">
-                                        {preserveFallbackContent
-                                            ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija.'
-                                            : 'Stranica još nema sekcija.'}
-                                    </Card>
-                                ) : (
-                                    <Stack spacing={2}>
-                                        {sections.map((section, index) => (
-                                            <Card
-                                                key={section.id}
-                                                className={`p-4 cursor-pointer ${selectedSectionId === section.id ? 'border-primary' : ''}`}
-                                                onClick={() =>
-                                                    setSelectedSectionId(
-                                                        section.id,
-                                                    )
-                                                }
-                                            >
-                                                <Stack spacing={2}>
-                                                    <Row
-                                                        spacing={2}
-                                                        className="items-center justify-between"
-                                                    >
-                                                        <Typography
-                                                            level="body1"
-                                                            semiBold
+                                            />
+                                            {rawError && (
+                                                <Typography
+                                                    level="body2"
+                                                    className="text-red-600"
+                                                >
+                                                    {rawError}
+                                                </Typography>
+                                            )}
+                                            {preserveFallbackContent && (
+                                                <Button
+                                                    type="button"
+                                                    variant="plain"
+                                                    onClick={() => {
+                                                        setRawContent(
+                                                            page?.content ?? '',
+                                                        );
+                                                        setRawError(null);
+                                                    }}
+                                                >
+                                                    Vrati spremljeni sadržaj
+                                                </Button>
+                                            )}
+                                        </label>
+                                    ) : sections.length === 0 ? (
+                                        <Card className="p-4 text-sm text-muted-foreground">
+                                            {preserveFallbackContent
+                                                ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija.'
+                                                : 'Stranica još nema sekcija.'}
+                                        </Card>
+                                    ) : (
+                                        <Stack spacing={2}>
+                                            {sections.map((section, index) => (
+                                                <Card
+                                                    key={section.id}
+                                                    className={`p-4 cursor-pointer ${selectedSectionId === section.id ? 'border-primary' : ''}`}
+                                                    onClick={() =>
+                                                        setSelectedSectionId(
+                                                            section.id,
+                                                        )
+                                                    }
+                                                >
+                                                    <Stack spacing={2}>
+                                                        <Row
+                                                            spacing={2}
+                                                            className="items-center justify-between"
                                                         >
-                                                            {index + 1}.{' '}
-                                                            {
-                                                                section.data
-                                                                    .component
-                                                            }
-                                                        </Typography>
-                                                        <Row spacing={1}>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                disabled={
-                                                                    index === 0
+                                                            <Typography
+                                                                level="body1"
+                                                                semiBold
+                                                            >
+                                                                {index + 1}.{' '}
+                                                                {
+                                                                    section.data
+                                                                        .component
                                                                 }
-                                                                onClick={() =>
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            moveSection(
+                                                            </Typography>
+                                                            <Row spacing={1}>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="plain"
+                                                                    disabled={
+                                                                        index ===
+                                                                        0
+                                                                    }
+                                                                    onClick={() =>
+                                                                        setSections(
+                                                                            (
                                                                                 current,
-                                                                                section.id,
-                                                                                -1,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                Gore
-                                                            </Button>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                disabled={
-                                                                    index ===
-                                                                    sections.length -
-                                                                        1
-                                                                }
-                                                                onClick={() =>
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            moveSection(
-                                                                                current,
-                                                                                section.id,
-                                                                                1,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                Dolje
-                                                            </Button>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                onClick={() => {
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) => {
-                                                                            const idx =
-                                                                                current.findIndex(
-                                                                                    (
-                                                                                        candidate,
-                                                                                    ) =>
-                                                                                        candidate.id ===
-                                                                                        section.id,
-                                                                                );
-                                                                            if (
-                                                                                idx <
-                                                                                0
-                                                                            ) {
-                                                                                return current;
-                                                                            }
-                                                                            const sectionId =
-                                                                                nextSectionId.current;
-                                                                            nextSectionId.current += 1;
-                                                                            const duplicate =
-                                                                                copySection(
-                                                                                    section,
-                                                                                    `${newSectionIdPrefix}-${sectionId}`,
-                                                                                );
-                                                                            return [
-                                                                                ...current.slice(
-                                                                                    0,
-                                                                                    idx +
-                                                                                        1,
-                                                                                ),
-                                                                                duplicate,
-                                                                                ...current.slice(
-                                                                                    idx +
-                                                                                        1,
-                                                                                ),
-                                                                            ];
-                                                                        },
-                                                                    );
-                                                                }}
-                                                            >
-                                                                Dupliciraj
-                                                            </Button>
-                                                            <Button
-                                                                type="button"
-                                                                variant="plain"
-                                                                color="danger"
-                                                                onClick={() =>
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            current.filter(
-                                                                                (
-                                                                                    currentSection,
-                                                                                ) =>
-                                                                                    currentSection.id !==
+                                                                            ) =>
+                                                                                moveSection(
+                                                                                    current,
                                                                                     section.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                Ukloni
-                                                            </Button>
+                                                                                    -1,
+                                                                                ),
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Gore
+                                                                </Button>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="plain"
+                                                                    disabled={
+                                                                        index ===
+                                                                        sections.length -
+                                                                            1
+                                                                    }
+                                                                    onClick={() =>
+                                                                        setSections(
+                                                                            (
+                                                                                current,
+                                                                            ) =>
+                                                                                moveSection(
+                                                                                    current,
+                                                                                    section.id,
+                                                                                    1,
+                                                                                ),
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Dolje
+                                                                </Button>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="plain"
+                                                                    onClick={() => {
+                                                                        setSections(
+                                                                            (
+                                                                                current,
+                                                                            ) => {
+                                                                                const idx =
+                                                                                    current.findIndex(
+                                                                                        (
+                                                                                            candidate,
+                                                                                        ) =>
+                                                                                            candidate.id ===
+                                                                                            section.id,
+                                                                                    );
+                                                                                if (
+                                                                                    idx <
+                                                                                    0
+                                                                                ) {
+                                                                                    return current;
+                                                                                }
+                                                                                const sectionId =
+                                                                                    nextSectionId.current;
+                                                                                nextSectionId.current += 1;
+                                                                                const duplicate =
+                                                                                    copySection(
+                                                                                        section,
+                                                                                        `${newSectionIdPrefix}-${sectionId}`,
+                                                                                    );
+                                                                                return [
+                                                                                    ...current.slice(
+                                                                                        0,
+                                                                                        idx +
+                                                                                            1,
+                                                                                    ),
+                                                                                    duplicate,
+                                                                                    ...current.slice(
+                                                                                        idx +
+                                                                                            1,
+                                                                                    ),
+                                                                                ];
+                                                                            },
+                                                                        );
+                                                                    }}
+                                                                >
+                                                                    Dupliciraj
+                                                                </Button>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="plain"
+                                                                    color="danger"
+                                                                    onClick={() =>
+                                                                        setSections(
+                                                                            (
+                                                                                current,
+                                                                            ) =>
+                                                                                current.filter(
+                                                                                    (
+                                                                                        currentSection,
+                                                                                    ) =>
+                                                                                        currentSection.id !==
+                                                                                        section.id,
+                                                                                ),
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Ukloni
+                                                                </Button>
+                                                            </Row>
                                                         </Row>
-                                                    </Row>
-                                                    {(
-                                                        cmsPageSectionComponentsByName.get(
-                                                            section.data
-                                                                .component,
-                                                        )?.fields ?? []
-                                                    ).map((field) =>
-                                                        field.type ===
-                                                        'textarea' ? (
-                                                            <label
-                                                                key={field.key}
-                                                                className="space-y-1"
-                                                            >
-                                                                <span className="block text-sm font-medium">
-                                                                    {
+                                                        {(
+                                                            cmsPageSectionComponentsByName.get(
+                                                                section.data
+                                                                    .component,
+                                                            )?.fields ?? []
+                                                        ).map((field) =>
+                                                            field.type ===
+                                                            'textarea' ? (
+                                                                <label
+                                                                    key={
+                                                                        field.key
+                                                                    }
+                                                                    className="space-y-1"
+                                                                >
+                                                                    <span className="block text-sm font-medium">
+                                                                        {
+                                                                            field.label
+                                                                        }
+                                                                    </span>
+                                                                    <textarea
+                                                                        value={sectionValue(
+                                                                            section,
+                                                                            field.key,
+                                                                        )}
+                                                                        rows={
+                                                                            field.rows ??
+                                                                            4
+                                                                        }
+                                                                        className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                        onChange={(
+                                                                            event,
+                                                                        ) => {
+                                                                            const value =
+                                                                                event
+                                                                                    .target
+                                                                                    .value;
+                                                                            setSections(
+                                                                                (
+                                                                                    current,
+                                                                                ) =>
+                                                                                    current.map(
+                                                                                        (
+                                                                                            currentSection,
+                                                                                        ) =>
+                                                                                            currentSection.id ===
+                                                                                            section.id
+                                                                                                ? {
+                                                                                                      ...currentSection,
+                                                                                                      data: {
+                                                                                                          ...currentSection.data,
+                                                                                                          [field.key]:
+                                                                                                              value,
+                                                                                                      },
+                                                                                                  }
+                                                                                                : currentSection,
+                                                                                    ),
+                                                                            );
+                                                                        }}
+                                                                    />
+                                                                </label>
+                                                            ) : (
+                                                                <Input
+                                                                    key={
+                                                                        field.key
+                                                                    }
+                                                                    label={
                                                                         field.label
                                                                     }
-                                                                </span>
-                                                                <textarea
                                                                     value={sectionValue(
                                                                         section,
                                                                         field.key,
                                                                     )}
-                                                                    rows={
-                                                                        field.rows ??
-                                                                        4
-                                                                    }
-                                                                    className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                                                     onChange={(
                                                                         event,
                                                                     ) => {
@@ -685,6 +766,210 @@ export function CmsPageForm({
                                                                         );
                                                                     }}
                                                                 />
+                                                            ),
+                                                        )}
+                                                        {validateSection(
+                                                            section,
+                                                        ).map((error) => (
+                                                            <Typography
+                                                                key={error}
+                                                                level="body3"
+                                                                className="text-red-600"
+                                                            >
+                                                                {error}
+                                                            </Typography>
+                                                        ))}
+                                                    </Stack>
+                                                </Card>
+                                            ))}
+                                        </Stack>
+                                    )}
+                                    <Row spacing={2}>
+                                        {!rawMode &&
+                                            cmsPageSectionItems.map((item) => (
+                                                <Button
+                                                    key={item.value}
+                                                    type="button"
+                                                    variant="outlined"
+                                                    onClick={() => {
+                                                        setSections(
+                                                            (current) => {
+                                                                const sectionId =
+                                                                    nextSectionId.current;
+                                                                nextSectionId.current += 1;
+                                                                return [
+                                                                    ...current,
+                                                                    newSection(
+                                                                        item.value,
+                                                                        newSectionIdPrefix,
+                                                                        sectionId,
+                                                                    ),
+                                                                ];
+                                                            },
+                                                        );
+                                                    }}
+                                                >
+                                                    Dodaj {item.label}
+                                                </Button>
+                                            ))}
+                                    </Row>
+                                </Stack>
+                            </Stack>
+
+                            <Stack spacing={2}>
+                                <Typography level="h3" semiBold>
+                                    Live preview
+                                </Typography>
+                                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+                                    <Card className="p-4">
+                                        <Stack spacing={2}>
+                                            {sections.map((section, index) => (
+                                                <Stack
+                                                    key={section.id}
+                                                    spacing={2}
+                                                >
+                                                    <Card
+                                                        className={`p-3 cursor-pointer ${sections[index]?.id === selectedSectionId ? 'border-primary' : ''}`}
+                                                        onClick={() =>
+                                                            setSelectedSectionId(
+                                                                sections[index]
+                                                                    ?.id ??
+                                                                    null,
+                                                            )
+                                                        }
+                                                    >
+                                                        <SectionsView
+                                                            sectionsData={[
+                                                                section.data,
+                                                            ]}
+                                                            componentsRegistry={
+                                                                sectionsComponentRegistry
+                                                            }
+                                                        />
+                                                    </Card>
+                                                    <Row spacing={2}>
+                                                        {cmsPageSectionItems.map(
+                                                            (item) => (
+                                                                <Button
+                                                                    key={`${section.id}-${item.value}`}
+                                                                    type="button"
+                                                                    variant="outlined"
+                                                                    onClick={() => {
+                                                                        const sectionId =
+                                                                            nextSectionId.current;
+                                                                        nextSectionId.current += 1;
+                                                                        const id = `${newSectionIdPrefix}-${sectionId}`;
+                                                                        setSections(
+                                                                            (
+                                                                                current,
+                                                                            ) => [
+                                                                                ...current.slice(
+                                                                                    0,
+                                                                                    index +
+                                                                                        1,
+                                                                                ),
+                                                                                {
+                                                                                    id,
+                                                                                    data: {
+                                                                                        component:
+                                                                                            item.value,
+                                                                                    },
+                                                                                },
+                                                                                ...current.slice(
+                                                                                    index +
+                                                                                        1,
+                                                                                ),
+                                                                            ],
+                                                                        );
+                                                                        setSelectedSectionId(
+                                                                            id,
+                                                                        );
+                                                                    }}
+                                                                >
+                                                                    Dodaj{' '}
+                                                                    {item.label}{' '}
+                                                                    ispod
+                                                                </Button>
+                                                            ),
+                                                        )}
+                                                    </Row>
+                                                </Stack>
+                                            ))}
+                                            {previewSections.length === 0 && (
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    Nema sekcija za prikaz.
+                                                </Typography>
+                                            )}
+                                        </Stack>
+                                    </Card>
+                                    <Card className="h-fit p-4 lg:sticky lg:top-24">
+                                        <Stack spacing={2}>
+                                            <Typography level="h4" semiBold>
+                                                Postavke sekcije
+                                            </Typography>
+                                            {!selectedSection ? (
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    Klikni sekciju u preview
+                                                    prikazu za uređivanje
+                                                    atributa.
+                                                </Typography>
+                                            ) : (
+                                                <>
+                                                    <Typography
+                                                        level="body2"
+                                                        semiBold
+                                                    >
+                                                        {
+                                                            selectedSection.data
+                                                                .component
+                                                        }
+                                                    </Typography>
+                                                    {(
+                                                        cmsPageSectionComponentsByName.get(
+                                                            selectedSection.data
+                                                                .component,
+                                                        )?.fields ?? []
+                                                    ).map((field) =>
+                                                        field.type ===
+                                                        'textarea' ? (
+                                                            <label
+                                                                key={field.key}
+                                                                className="space-y-1"
+                                                            >
+                                                                <span className="block text-sm font-medium">
+                                                                    {
+                                                                        field.label
+                                                                    }
+                                                                </span>
+                                                                <textarea
+                                                                    value={sectionValue(
+                                                                        selectedSection,
+                                                                        field.key,
+                                                                    )}
+                                                                    rows={
+                                                                        field.rows ??
+                                                                        4
+                                                                    }
+                                                                    className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                    onChange={(
+                                                                        event,
+                                                                    ) =>
+                                                                        updateSectionField(
+                                                                            selectedSection.id,
+                                                                            field.key,
+                                                                            event
+                                                                                .target
+                                                                                .value,
+                                                                            setSections,
+                                                                        )
+                                                                    }
+                                                                />
                                                             </label>
                                                         ) : (
                                                             <Input
@@ -693,215 +978,9 @@ export function CmsPageForm({
                                                                     field.label
                                                                 }
                                                                 value={sectionValue(
-                                                                    section,
-                                                                    field.key,
-                                                                )}
-                                                                onChange={(
-                                                                    event,
-                                                                ) => {
-                                                                    const value =
-                                                                        event
-                                                                            .target
-                                                                            .value;
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) =>
-                                                                            current.map(
-                                                                                (
-                                                                                    currentSection,
-                                                                                ) =>
-                                                                                    currentSection.id ===
-                                                                                    section.id
-                                                                                        ? {
-                                                                                              ...currentSection,
-                                                                                              data: {
-                                                                                                  ...currentSection.data,
-                                                                                                  [field.key]:
-                                                                                                      value,
-                                                                                              },
-                                                                                          }
-                                                                                        : currentSection,
-                                                                            ),
-                                                                    );
-                                                                }}
-                                                            />
-                                                        ),
-                                                    )}
-                                                    {validateSection(
-                                                        section,
-                                                    ).map((error) => (
-                                                        <Typography
-                                                            key={error}
-                                                            level="body3"
-                                                            className="text-red-600"
-                                                        >
-                                                            {error}
-                                                        </Typography>
-                                                    ))}
-                                                </Stack>
-                                            </Card>
-                                        ))}
-                                    </Stack>
-                                )}
-                                <Row spacing={2}>
-                                    {!rawMode &&
-                                        cmsPageSectionItems.map((item) => (
-                                            <Button
-                                                key={item.value}
-                                                type="button"
-                                                variant="outlined"
-                                                onClick={() => {
-                                                    setSections((current) => {
-                                                        const sectionId =
-                                                            nextSectionId.current;
-                                                        nextSectionId.current += 1;
-                                                        return [
-                                                            ...current,
-                                                            newSection(
-                                                                item.value,
-                                                                newSectionIdPrefix,
-                                                                sectionId,
-                                                            ),
-                                                        ];
-                                                    });
-                                                }}
-                                            >
-                                                Dodaj {item.label}
-                                            </Button>
-                                        ))}
-                                </Row>
-                            </Stack>
-                        </Stack>
-
-                        <Stack spacing={2}>
-                            <Typography level="h3" semiBold>
-                                Live preview
-                            </Typography>
-                            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
-                                <Card className="p-4">
-                                    <Stack spacing={2}>
-                                        {sections.map((section, index) => (
-                                            <Stack key={section.id} spacing={2}>
-                                                <Card
-                                                    className={`p-3 cursor-pointer ${sections[index]?.id === selectedSectionId ? 'border-primary' : ''}`}
-                                                    onClick={() =>
-                                                        setSelectedSectionId(
-                                                            sections[index]
-                                                                ?.id ?? null,
-                                                        )
-                                                    }
-                                                >
-                                                    <SectionsView
-                                                        sectionsData={[
-                                                            section.data,
-                                                        ]}
-                                                        componentsRegistry={
-                                                            sectionsComponentRegistry
-                                                        }
-                                                    />
-                                                </Card>
-                                                <Row spacing={2}>
-                                                    {cmsPageSectionItems.map(
-                                                        (item) => (
-                                                            <Button
-                                                                key={`${section.id}-${item.value}`}
-                                                                type="button"
-                                                                variant="outlined"
-                                                                onClick={() => {
-                                                                    const sectionId =
-                                                                        nextSectionId.current;
-                                                                    nextSectionId.current += 1;
-                                                                    const id = `${newSectionIdPrefix}-${sectionId}`;
-                                                                    setSections(
-                                                                        (
-                                                                            current,
-                                                                        ) => [
-                                                                            ...current.slice(
-                                                                                0,
-                                                                                index +
-                                                                                    1,
-                                                                            ),
-                                                                            {
-                                                                                id,
-                                                                                data: {
-                                                                                    component:
-                                                                                        item.value,
-                                                                                },
-                                                                            },
-                                                                            ...current.slice(
-                                                                                index +
-                                                                                    1,
-                                                                            ),
-                                                                        ],
-                                                                    );
-                                                                    setSelectedSectionId(
-                                                                        id,
-                                                                    );
-                                                                }}
-                                                            >
-                                                                Dodaj{' '}
-                                                                {item.label}{' '}
-                                                                ispod
-                                                            </Button>
-                                                        ),
-                                                    )}
-                                                </Row>
-                                            </Stack>
-                                        ))}
-                                        {previewSections.length === 0 && (
-                                            <Typography level="body3" secondary>
-                                                Nema sekcija za prikaz.
-                                            </Typography>
-                                        )}
-                                    </Stack>
-                                </Card>
-                                <Card className="h-fit p-4 lg:sticky lg:top-24">
-                                    <Stack spacing={2}>
-                                        <Typography level="h4" semiBold>
-                                            Postavke sekcije
-                                        </Typography>
-                                        {!selectedSection ? (
-                                            <Typography level="body3" secondary>
-                                                Klikni sekciju u preview prikazu
-                                                za uređivanje atributa.
-                                            </Typography>
-                                        ) : (
-                                            <>
-                                                <Typography
-                                                    level="body2"
-                                                    semiBold
-                                                >
-                                                    {
-                                                        selectedSection.data
-                                                            .component
-                                                    }
-                                                </Typography>
-                                                {(
-                                                    cmsPageSectionComponentsByName.get(
-                                                        selectedSection.data
-                                                            .component,
-                                                    )?.fields ?? []
-                                                ).map((field) =>
-                                                    field.type ===
-                                                    'textarea' ? (
-                                                        <label
-                                                            key={field.key}
-                                                            className="space-y-1"
-                                                        >
-                                                            <span className="block text-sm font-medium">
-                                                                {field.label}
-                                                            </span>
-                                                            <textarea
-                                                                value={sectionValue(
                                                                     selectedSection,
                                                                     field.key,
                                                                 )}
-                                                                rows={
-                                                                    field.rows ??
-                                                                    4
-                                                                }
-                                                                className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                                                 onChange={(
                                                                     event,
                                                                 ) =>
@@ -915,87 +994,63 @@ export function CmsPageForm({
                                                                     )
                                                                 }
                                                             />
-                                                        </label>
-                                                    ) : (
-                                                        <Input
-                                                            key={field.key}
-                                                            label={field.label}
-                                                            value={sectionValue(
-                                                                selectedSection,
-                                                                field.key,
-                                                            )}
-                                                            onChange={(event) =>
-                                                                updateSectionField(
-                                                                    selectedSection.id,
-                                                                    field.key,
-                                                                    event.target
-                                                                        .value,
-                                                                    setSections,
-                                                                )
-                                                            }
-                                                        />
-                                                    ),
-                                                )}
-                                            </>
-                                        )}
-                                    </Stack>
-                                </Card>
-                            </div>
-                        </Stack>
+                                                        ),
+                                                    )}
+                                                </>
+                                            )}
+                                        </Stack>
+                                    </Card>
+                                </div>
+                            </Stack>
 
-                        <Stack spacing={3}>
-                            <Typography level="h3" semiBold>
-                                Metadata
-                            </Typography>
-                            <Input
-                                name="metaTitle"
-                                label="Meta naslov"
-                                defaultValue={page?.metaTitle ?? ''}
-                            />
-                            <Input
-                                name="metaDescription"
-                                label="Meta opis"
-                                defaultValue={page?.metaDescription ?? ''}
-                            />
-                            <Input
-                                name="metaImageUrl"
-                                label="Meta slika URL"
-                                type="url"
-                                defaultValue={page?.metaImageUrl ?? ''}
-                            />
-                            <Input
-                                name="canonicalPath"
-                                label="Canonical putanja"
-                                defaultValue={page?.canonicalPath ?? ''}
-                                placeholder="/primjer-stranice"
-                            />
-                            <label className="flex items-center gap-2 text-sm">
-                                <input
-                                    type="checkbox"
-                                    name="noIndex"
-                                    defaultChecked={page?.noIndex ?? false}
+                            <Stack spacing={3}>
+                                <Typography level="h3" semiBold>
+                                    Metadata
+                                </Typography>
+                                <Input
+                                    name="metaTitle"
+                                    label="Meta naslov"
+                                    defaultValue={page?.metaTitle ?? ''}
                                 />
-                                Isključi iz indeksiranja (noindex)
-                            </label>
+                                <Input
+                                    name="metaDescription"
+                                    label="Meta opis"
+                                    defaultValue={page?.metaDescription ?? ''}
+                                />
+                                <Input
+                                    name="metaImageUrl"
+                                    label="Meta slika URL"
+                                    type="url"
+                                    defaultValue={page?.metaImageUrl ?? ''}
+                                />
+                                <Input
+                                    name="canonicalPath"
+                                    label="Canonical putanja"
+                                    defaultValue={page?.canonicalPath ?? ''}
+                                    placeholder="/primjer-stranice"
+                                />
+                                <label className="flex items-center gap-2 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        name="noIndex"
+                                        defaultChecked={page?.noIndex ?? false}
+                                    />
+                                    Isključi iz indeksiranja (noindex)
+                                </label>
+                            </Stack>
+
+                            {state?.message && (
+                                <Typography
+                                    level="body2"
+                                    className="text-red-600"
+                                >
+                                    {state.message}
+                                </Typography>
+                            )}
                         </Stack>
-
-                        {state?.message && (
-                            <Typography level="body2" className="text-red-600">
-                                {state.message}
-                            </Typography>
-                        )}
-
-                        <Button
-                            variant="solid"
-                            type="submit"
-                            className="w-fit"
-                            loading={pending}
-                        >
-                            {submitLabel}
-                        </Button>
-                    </Stack>
-                </form>
-            </Stack>
-        </Card>
+                    </form>
+                </Stack>
+            </Card>
+        </Stack>
     );
 }


### PR DESCRIPTION
### Motivation
- Replace the narrow single-card editor surface with a full-width, focused editor workspace to improve scanning and alignment with a modern CMS editor shell.  
- Keep primary page state and actions visible and persistent while editing (title, slug/path, status, autosave, save action).  
- Preserve all existing create/update/autosave/content behavior and JSON-fallback editing while improving layout and action placement.

### Description
- Reworked `CmsPageForm` root layout: removed the `Card` constrained by `max-w-3xl` and introduced a full-width `Stack` wrapper with a compact sticky header card for identity and actions.  
- Added a sticky header showing page title, slug/path preview, status, autosave indicator/message, and a primary save button bound to the form via `form={reactId}`.  
- Moved the `<form>` into the main content card with an `id={reactId}` and preserved the hidden `content` input, raw/visual editor modes, section builder, preview, and inspector logic without changing submission or autosave semantics.  
- No schema, storage, or migration changes were introduced.

### Testing
- Ran `pnpm lint --filter app` which completed successfully but reported a small set of unrelated existing warnings in the workspace.  
- Ran `pnpm test --filter app` which invoked a Next.js build that compiled successfully, but the Playwright test run failed because the configured `webServer` timed out waiting for startup (environment web server startup timeout at 60000ms).  
- No additional automated validation was possible in this environment due to the Playwright webServer startup failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026c46ef54832f9943d8173369c457)