### PR TITLE
feat(api): add shared /api/mcp Streamable HTTP foundation

### DIFF
--- a/apps/api/MCP_README.md
+++ b/apps/api/MCP_README.md
@@ -396,3 +396,8 @@ Access monitoring dashboards at:
 
 - **Axiom**: Application logs and metrics
 - **Vercel**: Deployment and performance metrics
+
+
+## Endpoint decision
+
+Gredice now uses a single Streamable HTTP endpoint at `/api/mcp` with namespaced tool names (for example `directories/get-plants`). This keeps protocol negotiation, lifecycle handling, and capability listing in one server implementation while preserving domain boundaries in tool naming.

--- a/apps/api/app/api/mcp/route.ts
+++ b/apps/api/app/api/mcp/route.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from 'next/server';
+import { handleMcpRequest } from './server';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+    return handleMcpRequest(request);
+}
+
+export async function GET() {
+    return Response.json({
+        name: 'gredice-mcp',
+        endpoint: '/api/mcp',
+        transport: 'streamable-http',
+    });
+}

--- a/apps/api/app/api/mcp/server.ts
+++ b/apps/api/app/api/mcp/server.ts
@@ -1,0 +1,136 @@
+import { getEntitiesFormatted } from '@gredice/storage';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const SUPPORTED_PROTOCOL_VERSIONS = ['2025-03-26', '2024-11-05'] as const;
+const DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+const GetPlantsSchema = z.object({
+    limit: z.number().min(1).max(1000).default(100),
+    offset: z.number().min(0).default(0),
+    category: z.string().optional(),
+});
+
+export async function handleMcpRequest(request: NextRequest) {
+    const body = await request.json();
+    const method = body?.method as string | undefined;
+    const id = body?.id ?? null;
+
+    if (method === 'initialize') {
+        const clientVersion = body?.params?.protocolVersion as
+            | string
+            | undefined;
+        const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(
+            clientVersion as never,
+        )
+            ? clientVersion
+            : DEFAULT_PROTOCOL_VERSION;
+
+        return NextResponse.json(
+            {
+                jsonrpc: '2.0',
+                id,
+                result: {
+                    protocolVersion,
+                    capabilities: {
+                        tools: { listChanged: false },
+                        resources: {},
+                        prompts: {},
+                    },
+                    serverInfo: { name: 'gredice-mcp', version: '1.0.0' },
+                },
+            },
+            { headers: { 'MCP-Protocol-Version': protocolVersion } },
+        );
+    }
+
+    if (method === 'tools/list') {
+        return NextResponse.json({
+            jsonrpc: '2.0',
+            id,
+            result: {
+                tools: [
+                    {
+                        name: 'directories/get-plants',
+                        description:
+                            'Get Croatian plant catalog with attributes and calendar data',
+                        inputSchema: {
+                            type: 'object',
+                            properties: {
+                                limit: { type: 'number' },
+                                offset: { type: 'number' },
+                                category: { type: 'string' },
+                            },
+                        },
+                    },
+                ],
+            },
+        });
+    }
+
+    if (method === 'resources/list') {
+        return NextResponse.json({
+            jsonrpc: '2.0',
+            id,
+            result: { resources: [] },
+        });
+    }
+
+    if (method === 'resources/templates/list') {
+        return NextResponse.json({
+            jsonrpc: '2.0',
+            id,
+            result: { resourceTemplates: [] },
+        });
+    }
+
+    if (method === 'prompts/list') {
+        return NextResponse.json({
+            jsonrpc: '2.0',
+            id,
+            result: { prompts: [] },
+        });
+    }
+
+    if (method === 'tools/call') {
+        const name = body?.params?.name as string;
+        if (name !== 'directories/get-plants') {
+            return NextResponse.json(
+                {
+                    jsonrpc: '2.0',
+                    id,
+                    error: {
+                        code: -32601,
+                        message: `Method not found: ${name}`,
+                    },
+                },
+                { status: 404 },
+            );
+        }
+        const input = GetPlantsSchema.parse(body?.params?.arguments ?? {});
+        const allPlants =
+            (await getEntitiesFormatted<Record<string, unknown>>('plant')) ||
+            [];
+        return NextResponse.json({
+            jsonrpc: '2.0',
+            id,
+            result: {
+                plants: allPlants.slice(
+                    input.offset,
+                    input.offset + input.limit,
+                ),
+                total: allPlants.length,
+            },
+        });
+    }
+
+    return NextResponse.json(
+        {
+            jsonrpc: '2.0',
+            id,
+            error: { code: -32601, message: `Method not found: ${method}` },
+        },
+        { status: 400 },
+    );
+}


### PR DESCRIPTION
### Motivation

- Provide a single, shared Streamable HTTP MCP entrypoint to replace ad-hoc JSON-RPC switches spread across domain routes and centralize protocol lifecycle handling. 
- Use a namespaced tool naming convention (for example `directories/get-plants`) so domain-specific behavior can be preserved while registration, negotiation, and dispatch are unified. 

### Description

- Add a centralized MCP request dispatcher in `apps/api/app/api/mcp/server.ts` that implements `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/templates/list`, and `prompts/list`. 
- Add the shared Streamable HTTP entrypoint at `apps/api/app/api/mcp/route.ts` that forwards POSTs to the dispatcher and exposes a simple GET health/metadata response. 
- Implement explicit protocol negotiation with a `SUPPORTED_PROTOCOL_VERSIONS` list and return `MCP-Protocol-Version` on `initialize`. 
- Include an example `directories/get-plants` tool implemented against `@gredice/storage` via `getEntitiesFormatted`, and update `apps/api/MCP_README.md` to document the decision to use one `/api/mcp` endpoint with namespaced tools. 

### Testing

- Ran `pnpm lint --filter api`, which failed due to pre-existing lint errors in existing MCP draft files (implicit `any` usages and other issues); lint reported one error and multiple warnings. 
- Ran `pnpm build --filter api`, which failed because the environment could not resolve `next-axiom` in the existing MCP domain routes; the build also emitted a Node engine warning (`node >=24` vs v22 in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026d3e3a78832f9935fe1ed9cfece5)