### PR TITLE
[Weather] Add thunder-driven lightning flashes in garden scene

### DIFF
--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import chroma from 'chroma-js';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getPosition } from 'suncalc';
 import { Color, Quaternion, Vector3 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
@@ -134,6 +134,7 @@ type EnvironmentWeather = {
     rainy?: number;
     snowAccumulation?: number;
     snowy?: number;
+    thundery?: number;
     windDirection?: string | null;
     windSpeed?: number;
 };
@@ -144,6 +145,7 @@ const fallbackWeather = {
     rainy: 0,
     snowAccumulation: 0,
     snowy: 0,
+    thundery: 0,
     windDirection: 'N',
     windSpeed: 0,
 };
@@ -566,6 +568,77 @@ export function Environment({
             ? (compassToDirection[actualWeather.windDirection] ?? 0)
             : 0;
 
+    const [lightningFlash, setLightningFlash] = useState(0);
+    const lightningScheduleTimeout = useRef<number | null>(null);
+    const lightningClearTimeout = useRef<number | null>(null);
+
+    useEffect(() => {
+        const thunderLevel = actualWeather?.thundery ?? 0;
+        if (weatherDisabled || thunderLevel <= 0) {
+            setLightningFlash(0);
+            if (lightningScheduleTimeout.current !== null) {
+                window.clearTimeout(lightningScheduleTimeout.current);
+                lightningScheduleTimeout.current = null;
+            }
+            if (lightningClearTimeout.current !== null) {
+                window.clearTimeout(lightningClearTimeout.current);
+                lightningClearTimeout.current = null;
+            }
+            return;
+        }
+
+        const stormStrength = Math.min(
+            1,
+            thunderLevel * 0.6 +
+                (actualWeather?.rainy ?? 0) * 0.3 +
+                (actualWeather?.cloudy ?? 0) * 0.2,
+        );
+        const nightFactor =
+            0.2 + Math.max(dawnVisibility, duskVisibility) * 0.6;
+        const flashStrength = Math.min(
+            1,
+            0.35 + stormStrength * 0.45 + nightFactor,
+        );
+
+        const scheduleNextFlash = () => {
+            const minimumDelayMs = 8000;
+            const maximumDelayMs = 22000;
+            const chanceWindowMs =
+                maximumDelayMs -
+                (maximumDelayMs - minimumDelayMs) * Math.min(1, stormStrength);
+            const delayMs =
+                minimumDelayMs + Math.random() * Math.max(2000, chanceWindowMs);
+
+            lightningScheduleTimeout.current = window.setTimeout(() => {
+                setLightningFlash(flashStrength);
+                lightningClearTimeout.current = window.setTimeout(() => {
+                    setLightningFlash(0);
+                }, 120);
+                scheduleNextFlash();
+            }, delayMs);
+        };
+
+        scheduleNextFlash();
+
+        return () => {
+            if (lightningScheduleTimeout.current !== null) {
+                window.clearTimeout(lightningScheduleTimeout.current);
+                lightningScheduleTimeout.current = null;
+            }
+            if (lightningClearTimeout.current !== null) {
+                window.clearTimeout(lightningClearTimeout.current);
+                lightningClearTimeout.current = null;
+            }
+        };
+    }, [
+        actualWeather?.cloudy,
+        actualWeather?.rainy,
+        actualWeather?.thundery,
+        dawnVisibility,
+        duskVisibility,
+        weatherDisabled,
+    ]);
+
     return (
         <>
             {!noBackground && (
@@ -575,6 +648,12 @@ export function Environment({
                 />
             )}
             <ambientLight intensity={ambient.intensity} />
+            {lightningFlash > 0 && (
+                <ambientLight
+                    color={0xf8fbff}
+                    intensity={lightningFlash * 1.2}
+                />
+            )}
             <hemisphereLight
                 position={[0, 1, 0]}
                 color={hemisphere.color}
@@ -632,6 +711,16 @@ export function Environment({
                     count={snowParticleCount}
                     windSpeed={windSpeed}
                     windDirection={windDirection}
+                />
+            )}
+            {lightningFlash > 0 && (
+                <fog
+                    attach="fog"
+                    args={[
+                        new Color(0xdde9ff),
+                        Math.max(80, fogNear - 20),
+                        220,
+                    ]}
                 />
             )}
         </>

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -613,6 +613,7 @@ export function Environment({
                 setLightningFlash(flashStrength);
                 lightningClearTimeout.current = window.setTimeout(() => {
                     setLightningFlash(0);
+                    lightningClearTimeout.current = null;
                 }, 120);
                 scheduleNextFlash();
             }, delayMs);
@@ -628,6 +629,7 @@ export function Environment({
             if (lightningClearTimeout.current !== null) {
                 window.clearTimeout(lightningClearTimeout.current);
                 lightningClearTimeout.current = null;
+                setLightningFlash(0);
             }
         };
     }, [


### PR DESCRIPTION
### Motivation
- Surface thunder-based visual feedback in the garden scene by using the existing `thundery` signal to produce occasional, believable lightning flashes while avoiding photosensitive-risk patterns and respecting weather-visuals settings.

### Description
- Add `thundery?: number` to the local `EnvironmentWeather` type and include a `thundery: 0` default in `fallbackWeather` in `packages/game/src/scene/Environment.tsx`.
- Implement a scheduled lightning system in `Environment` using `useState`, `useRef`, and `useEffect` that emits brief one-shot flashes (120ms) with long randomized gaps (approx. 8–22s) and scales intensity by `thundery`, `rainy`, `cloudy`, and time-of-day factors.
- Render flashes by temporarily boosting ambient light and applying a short fog tint/near-distance override during each flash, and disable scheduling when `weatherVisualizationDisabled` / `noWeather` are active.
- Apply minor lint-driven formatting fixes (the formatter/autofixer updated one additional file during validation).

### Testing
- Ran `pnpm lint --filter @gredice/game`, resolved initial hook dependency issues, and the lint pass completed successfully after fixes.
- Ran `pnpm test --filter @gredice/game`, which executed but no test tasks are defined for this workspace (no failures).
- Ran `pnpm build --filter @gredice/game`, which completed but this workspace has no build tasks defined (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026e69e290832fa8a22c43cf5f0f8f)