### PR TITLE
Derive pnpm checks from packageManager and remove hardcoded version docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the **Gredice** monorepo. It hosts multiple Next.js applicati
 
 ## First steps
 
-- Use Node.js `>=24` and pnpm `10.33.2`.
+- Use Node.js `>=24` and the pnpm version pinned by the root `packageManager` field.
 - Install dependencies from the repo root with `pnpm install`.
 - Before editing code, look for additional `AGENTS.md` files inside the path you plan to touch. Nested instructions override this file.
 - Keep the worktree clean. Commit only intentional source changes and never commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless explicitly requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please also follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Local setup
 
-Use Node.js `>=24`, pnpm `10.33.2`, Docker, and the Vercel CLI.
+Use Node.js `>=24`, the pnpm version pinned by `packageManager`, Docker, and the Vercel CLI.
 
 ```bash
 pnpm install

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Gredice is a Turborepo monorepo for the Gredice platform. It includes the public
 
 ## Getting Started
 
-Use [Node.js](https://nodejs.org/en/) `>=24`, [pnpm](https://pnpm.io/) `10.33.2`, [Docker](https://www.docker.com/), and the [Vercel CLI](https://vercel.com/download).
+Use [Node.js](https://nodejs.org/en/) `>=24`, the [pnpm](https://pnpm.io/) version pinned by `packageManager`, [Docker](https://www.docker.com/), and the [Vercel CLI](https://vercel.com/download).
 
 ```bash
 pnpm bootstrap

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -18,7 +18,7 @@ Use this guide for repo layout, setup, commands, package boundaries, and local d
 ## Tooling
 
 - Runtime: Node.js `>=24`.
-- Package manager: pnpm `10.33.2`.
+- Package manager: pnpm, pinned by the root `packageManager` field.
 - Task runner: Turborepo.
 - Formatting and linting: Biome per app/package.
 - Framework: Next.js 16 with React 19 and TypeScript 6.
@@ -139,7 +139,7 @@ pnpm env:pull
 
 ### Codex environment setup
 
-Use a lean Codex environment for routine code tasks. Pin Node.js to `24.15.0` when the environment UI asks for an exact version, and use pnpm `10.33.2`.
+Use a lean Codex environment for routine code tasks. Pin Node.js to `24.15.0` when the environment UI asks for an exact version, and use Corepack to install the pnpm version pinned by `packageManager`.
 
 Recommended Codex setup script:
 
@@ -147,7 +147,7 @@ Recommended Codex setup script:
 set -euo pipefail
 
 corepack enable
-corepack prepare pnpm@10.33.2 --activate
+corepack install
 
 pnpm install --frozen-lockfile
 
@@ -166,7 +166,7 @@ Recommended Codex maintenance script:
 set -euo pipefail
 
 corepack enable
-corepack prepare pnpm@10.33.2 --activate
+corepack install
 pnpm install --frozen-lockfile --prefer-offline
 ```
 

--- a/scripts/worktree-health.mjs
+++ b/scripts/worktree-health.mjs
@@ -17,6 +17,21 @@ const checks = [];
 function addCheck(name, required, ok, detail, next) { checks.push({ name, required, ok, detail, next }); }
 function run(cmd, args, options = {}) { return spawnSync(cmd, args, { encoding: 'utf8', ...options }); }
 function hasFailedRequiredChecks() { return checks.some((c) => c.required && !c.ok); }
+function readConfiguredPnpm() {
+  const packageJsonPath = resolve(rootDir, 'package.json');
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    const packageManager = typeof packageJson.packageManager === 'string' ? packageJson.packageManager : '';
+    const versionMatch = /^pnpm@([^+\s]+)(?:\+.+)?$/.exec(packageManager);
+    if (!versionMatch) {
+      return { ok: false, detail: packageManager ? `Unsupported packageManager: ${packageManager}.` : 'Missing packageManager in package.json.' };
+    }
+    return { ok: true, packageManager, version: versionMatch[1] };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, detail: `Could not read ${packageJsonPath}: ${message}.` };
+  }
+}
 
 function checkNode() {
   const major = Number(process.versions.node.split('.')[0]);
@@ -24,9 +39,15 @@ function checkNode() {
 }
 
 function checkPnpm() {
+  const configured = readConfiguredPnpm();
+  if (!configured.ok) {
+    addCheck('pnpm packageManager', true, false, configured.detail, 'Set the root packageManager field to pnpm@<version>.');
+    return;
+  }
+
   const r = run('pnpm', ['--version']);
   const v = (r.stdout || '').trim();
-  addCheck('pnpm 10.33.2', true, r.status === 0 && v === '10.33.2', `Detected ${v || 'not found'}.`, 'Use corepack and pin pnpm 10.33.2.');
+  addCheck(`pnpm ${configured.version}`, true, r.status === 0 && v === configured.version, `Detected ${v || 'not found'}; expected ${configured.packageManager}.`, 'Run `corepack install` from the repo root and retry.');
 }
 
 function checkDependencies() {


### PR DESCRIPTION
## Summary
- Make `worktree-health` read the expected pnpm version from the root `packageManager` field instead of hardcoding a version string.
- Replace exact pnpm version mentions in repo docs with references to the pinned `packageManager` source of truth.
- Update Codex setup snippets to use `corepack install` so they follow the repo pin automatically.

## Testing
- `node --check scripts/worktree-health.mjs`
- `corepack install`
- `pnpm --version`
- `git diff --check`