### PR TITLE
[Basket] Rename shopping cart UI copy to basket wording

### DIFF
--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -154,7 +154,7 @@ function InventoryItemModal({
                                     odaberi ovu sortu
                                 </Typography>
                                 <Typography level="body3">
-                                    3. U košarici označi &quot;Koristi iz
+                                    3. U košari označi &quot;Koristi iz
                                     ruksaka&quot;
                                 </Typography>
                             </>
@@ -164,10 +164,10 @@ function InventoryItemModal({
                                     1. Odaberi gredicu u vrtu
                                 </Typography>
                                 <Typography level="body3">
-                                    2. Dodaj radnju u košaricu
+                                    2. Dodaj radnju u košaru
                                 </Typography>
                                 <Typography level="body3">
-                                    3. U košarici označi &quot;Koristi iz
+                                    3. U košari označi &quot;Koristi iz
                                     ruksaka&quot;
                                 </Typography>
                             </>

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -132,7 +132,7 @@ export function ShoppingCart() {
                 <div className="rounded-full bg-tertiary/40 p-3 flex items-center justify-center">
                     <ShoppingCartIcon className="size-7 shrink-0" />
                 </div>
-                <Typography level="h3">Košarica</Typography>
+                <Typography level="h3">Košara</Typography>
             </Row>
             <Stack>
                 <div
@@ -144,7 +144,7 @@ export function ShoppingCart() {
                     )}
                 >
                     <Alert color="primary">
-                        Dio košarice možeš platiti u{' '}
+                        Dio košare možeš platiti u{' '}
                         <span className="text-yellow-500">🌻</span>. Odaberi
                         željeni način plaćanja desno od cijene.
                     </Alert>
@@ -159,7 +159,7 @@ export function ShoppingCart() {
                         )}
                         {isError && (
                             <Typography level="body1">
-                                Greška prilikom učitavanja košarice
+                                Greška prilikom učitavanja košare
                             </Typography>
                         )}
                         {!isLoading &&
@@ -173,7 +173,7 @@ export function ShoppingCart() {
                                 ))
                             ) : (
                                 <NoDataPlaceholder>
-                                    Košarica je prazna
+                                    Košara je prazna
                                 </NoDataPlaceholder>
                             ))}
                     </Stack>
@@ -223,8 +223,8 @@ export function ShoppingCart() {
                             <div className="flex flex-row gap-2 justify-between flex-wrap">
                                 {/* TODO: Localize */}
                                 <ModalConfirm
-                                    title="Potvrdi brisanje košarice"
-                                    header="Brisanje košarice"
+                                    title="Potvrdi brisanje košare"
+                                    header="Brisanje košare"
                                     onConfirm={handleDeleteCart}
                                     trigger={
                                         <Button
@@ -238,13 +238,13 @@ export function ShoppingCart() {
                                                 <Delete className="size-5 shrink-0" />
                                             }
                                         >
-                                            Očisti košaricu
+                                            Očisti košaru
                                         </Button>
                                     }
                                 >
                                     <Typography>
                                         Jeste li sigurni da želite obrisati sve
-                                        stavke iz košarice?
+                                        stavke iz košare?
                                     </Typography>
                                 </ModalConfirm>
                                 {cart?.hasDeliverableItems ? (
@@ -364,11 +364,11 @@ export function ShoppingCartHud() {
                         }
                         setIsOpen(open);
                     }}
-                    title="Košarica"
+                    title="Košara"
                     className="border-tertiary border-b-4 md:max-w-2xl"
                     trigger={
                         <Button
-                            title="Košarica"
+                            title="Košara"
                             variant="plain"
                             className="relative rounded-full p-2 gap-2"
                         >

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -280,7 +280,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                     {!isProcessed && (
                         <ModalConfirm
                             title="Potvrdi brisanje stavke"
-                            header="Brisanje stavke iz košarice"
+                            header="Brisanje stavke iz košare"
                             onConfirm={handleRemoveItem}
                             trigger={
                                 <IconButton
@@ -296,7 +296,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                         >
                             <Typography>
                                 Jeste li sigurni da želite ukloniti ovu stavku
-                                iz košarice?
+                                iz košare?
                             </Typography>
                         </ModalConfirm>
                     )}

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -372,7 +372,7 @@ export function PlantPicker({
                                         <ShoppingCart className="shrink-0 size-5" />
                                     }
                                 >
-                                    Dodaj u košaricu
+                                    Dodaj u košaru
                                 </Button>
                             </Row>
                         </Row>

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -573,7 +573,7 @@ function SensorInfoModal({
                         {!status && isSensorInShoppingCart && (
                             <div className="flex flex-col items-center justify-center h-full gap-4 p-6">
                                 <Typography level="body1">
-                                    Senzor je već u tvojoj košarici.
+                                    Senzor je već u tvojoj košari.
                                 </Typography>
                                 <Typography
                                     level="body2"
@@ -581,7 +581,7 @@ function SensorInfoModal({
                                     center
                                 >
                                     Senzor za praćenje vlažnosti i temperature
-                                    tla te čekaju u košarici. Dovrši kupovinu i
+                                    tla te čekaju u košari. Dovrši kupovinu i
                                     uskoro možeš početi pratiti uvjete u tlu
                                     svoje gredice!
                                 </Typography>

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -197,14 +197,14 @@ export function OperationsList({
                     className="px-1"
                 >
                     <Alert color="warning" className="py-1">
-                        Radnje u košarici (nisu kupljene) su na vrhu popisa.
+                        Radnje u košari (nisu kupljene) su na vrhu popisa.
                     </Alert>
                     <Button
                         size="sm"
                         variant="link"
                         onClick={() => setShoppingCartOpen(true)}
                     >
-                        Otvori košaricu
+                        Otvori košaru
                     </Button>
                 </Row>
             )}

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -88,7 +88,7 @@ export function OperationsListItem({
                     </Typography>
                     {inShoppingCart && (
                         <Typography level="body3" className="text-amber-600">
-                            U košarici (nije kupljeno)
+                            U košari (nije kupljeno)
                         </Typography>
                     )}
                     <Typography level="body1" semiBold>

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -157,7 +157,8 @@ function RainWetOverlayEffect({
         material.uniforms.uTopSurfaceBias.value = topSurfaceBias;
         material.uniforms.uDarkness.value = darkness;
         material.uniforms.uGlossiness.value = glossiness;
-        material.uniforms.uPuddleStrength.value = Math.max(0, rainAmount - 0.66) / 0.34;
+        material.uniforms.uPuddleStrength.value =
+            Math.max(0, rainAmount - 0.66) / 0.34;
     }, [darkness, glossiness, material, rainAmount, topSurfaceBias]);
 
     useEffect(() => {

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -178,7 +178,7 @@ export function DeliveryStep({
             <Typography level="h3">Način dostave</Typography>
 
             <Alert color="info">
-                Tvoja košarica sadrži radnje koje zahtijevaju dostavu ili
+                Tvoja košara sadrži radnje koje zahtijevaju dostavu ili
                 preuzimanje.
             </Alert>
 


### PR DESCRIPTION
### Motivation
- Replace user-facing "shopping cart" / "košarica" terminology with "basket" / "košara" across the garden and checkout UI so in-product language matches the new basket mental model without touching internal data models or routes.
- Maintain internal `ShoppingCart` API/model names and route compatibility to avoid migrations or breaking integrations.

### Description
- Replaced visible Croatian copy from variants of `košarica` to `košara` in multiple `@gredice/game` components including `ShoppingCartHud`, `ShoppingCartItem`, `InventoryHud`, `RaisedBedPlantPicker`, `RaisedBedSensorInfo`, `OperationsList`, `OperationsListItem`, and `DeliveryStep` so HUD, delivery, raised-bed, picker, and sensor messages now use basket wording.
- Kept all hook/query keys, API calls, types and routes unchanged (for example `useShoppingCart`, `useShoppingCartQueryKey`, and `shopping-cart` endpoints remain the same) to preserve internal behaviour and compatibility.
- Included a formatting-only autofix in `packages/game/src/rain/RainWetOverlay.tsx` produced by the linter, which only adjusts a line wrap and does not change runtime behaviour.

### Testing
- Ran `pnpm lint --filter @gredice/game` which completed successfully and applied one formatting fix. 
- Ran `pnpm test --filter @gredice/game` which returned successfully but Turbo reported no package-level test tasks to execute. 
- Ran `pnpm build --filter @gredice/game` which returned successfully but Turbo reported no package-level build tasks to execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027478ac18832f9ab6eb1cac371040)