### PR TITLE
docs(www): define llms.txt canonical URLs and ownership

### DIFF
--- a/SEO.md
+++ b/SEO.md
@@ -27,6 +27,13 @@ SEO usually does not apply to authenticated `garden`, `farm`, `app`, or API rout
 - Use stable slugs and aliases already present in directory/API data.
 - Redirect outdated paths rather than rendering duplicate content when the app already has redirect/proxy conventions.
 
+## llms.txt and llms-full.txt
+
+- Keep `llms.txt` and `llms-full.txt` on the same canonical public domain as other SEO metadata (`https://www.gredice.com`).
+- If `/.well-known/llms.txt` is provided for discovery, redirect it to the canonical `/llms.txt` path.
+- Include only public, canonical, indexable resources; exclude private app routes, staging domains, and internal documentation.
+- See `docs/llms-txt-policy.md` for ownership and inclusion decisions (GRE-335).
+
 ## Structured data
 
 - Use structured data only when it accurately represents rendered page content.

--- a/docs/llms-txt-policy.md
+++ b/docs/llms-txt-policy.md
@@ -1,0 +1,75 @@
+# [WWW] llms.txt canonical URL and content ownership decisions
+
+_Last updated: May 12, 2026_
+
+This note documents the implementation decisions for GRE-335 and should be referenced by implementation tasks in the `[WWW] Add llms.txt support` project.
+
+## Canonical public URLs
+
+Production should serve these canonical files on the public website domain:
+
+- `https://www.gredice.com/llms.txt` (concise index file)
+- `https://www.gredice.com/llms-full.txt` (expanded file)
+
+The app already treats `https://www.gredice.com` as canonical for public metadata, so llms files should follow the same domain convention.
+
+## Alias and redirect behavior
+
+Support discovery alias:
+
+- `https://www.gredice.com/.well-known/llms.txt`
+
+Behavior:
+
+- `/.well-known/llms.txt` should redirect (`308`) to `/llms.txt`.
+- Non-canonical host variants (for example `https://gredice.com` when redirected to `www`) should inherit existing host canonicalization and end at `https://www.gredice.com/llms.txt`.
+
+## Content ownership model
+
+- **Primary owner:** `app › 🌐 www` maintainers.
+- **Content authority:** public website content owners (marketing/public content maintainers) provide and approve included URLs.
+- **Technical enforcement:** website/platform engineers keep file generation and routing aligned with canonical/SEO policy.
+
+Update expectations:
+
+- llms file updates are part of normal public content review.
+- Add or remove resources only if the linked page is public, indexable, and intentionally owned by website content.
+
+## Resource inclusion policy
+
+### `llms.txt` (concise)
+
+Include only top-level, high-signal canonical resources, such as:
+
+- Primary product/landing pages.
+- Core public knowledge hubs (for example plants, operations, recipes indexes).
+- Policy/trust pages that clarify legal and data usage context.
+
+Keep this file intentionally short and navigational.
+
+### `llms-full.txt` (expanded)
+
+Include broader public documentation/content URLs that are still safe for public ingestion, including deeper canonical pages that are already public and indexable.
+
+Do not include:
+
+- Private/authenticated app routes (`app`, `farm`, `garden`, admin, account-scoped pages).
+- Internal docs, runbooks, or repository-only documentation.
+- Staging, preview, localhost, or non-production domains.
+- API endpoints that are not intended as public human-facing reference content.
+
+## Canonical domain rule
+
+For all entries in both files:
+
+- Use absolute canonical URLs on `https://www.gredice.com/...`.
+- Do not mix `www` and apex variants in listed links.
+- Respect existing canonical URL and sitemap behavior in `apps/www`.
+
+## Compatibility with crawler and SEO policy
+
+These decisions are designed to remain compatible with the existing SEO and crawler direction (including robots/sitemap work tracked in GRE-267):
+
+- llms files remain public, deterministic, and canonical.
+- They do not expose internal documentation or private routes.
+- They align with existing domain canonicalization used by public metadata.


### PR DESCRIPTION
### Motivation

- Provide a clear, reviewable decision record for GRE-335 to determine canonical public URLs and content ownership before implementing `llms.txt` support. 
- Ensure any future implementation aligns with existing SEO/canonicalization rules used by `apps/www` and avoids exposing private or staging resources.

### Description

- Added `docs/llms-txt-policy.md` which documents canonical URLs (`https://www.gredice.com/llms.txt` and `https://www.gredice.com/llms-full.txt`), `/.well-known/llms.txt` redirect behavior, ownership, inclusion/exclusion rules, and compatibility guidance. 
- Updated `SEO.md` to include an `llms.txt and llms-full.txt` section that points to the new policy note and restates canonical-domain and inclusion guardrails. 
- The policy mandates using absolute `https://www.gredice.com/...` URLs, redirecting `/.well-known/llms.txt` to `/llms.txt`, and excluding private/authenticated, staging, and internal documentation URLs from both files. 
- Changes are documentation-only and were committed with the branch PR payload prepared for review.

### Testing

- No automated tests, lint, or build commands were run because this is a documentation-only change. 
- No runtime code paths were modified, so no test failures were observed or expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027b4bcf30832fb81c0aa5f0a90f98)