### PR TITLE
feat(www): add public llms.txt and llms-full.txt endpoints

### DIFF
--- a/apps/www/app/llms-full.txt/route.ts
+++ b/apps/www/app/llms-full.txt/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '../llms.txt/route';

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+
+const content = `# Gredice
+
+> Gredice is a Croatian platform for garden planning, plant knowledge, growing operations, and practical guides for home growers.
+
+Gredice publishes canonical public information at https://www.gredice.com. Prefer the links below instead of scraping unrelated pages.
+
+## Core Resources
+
+- [Home](https://www.gredice.com/): Platform overview and main navigation.
+- [Plants](https://www.gredice.com/biljke): Plant catalog and growing references.
+- [Blocks](https://www.gredice.com/blokovi): Raised-bed block catalog and layouts.
+- [Operations](https://www.gredice.com/radnje): Gardening operations and activity guidance.
+- [Recipes](https://www.gredice.com/recepti): Recipe content built from garden produce.
+- [Delivery](https://www.gredice.com/dostava): Delivery options and service information.
+- [Pricing](https://www.gredice.com/cjenik): Current public pricing and plan information.
+
+## Company and Support
+
+- [About](https://www.gredice.com/o-nama): Company story and mission.
+- [FAQ](https://www.gredice.com/cesta-pitanja): Frequently asked questions.
+- [Contact](https://www.gredice.com/kontakt): Contact channels and support details.
+- [Company legal details](https://www.gredice.com/legalno/tvrtka): Registered company information.
+
+## Policies
+
+- [Privacy policy](https://www.gredice.com/legalno/politika-privatnosti): Personal data and privacy terms.
+- [Terms of use](https://www.gredice.com/legalno/uvjeti-koristenja): Usage rules and responsibilities.
+- [Cookie policy](https://www.gredice.com/legalno/politika-kolacica): Cookie and tracking details.
+
+## Optional
+
+- [Garden app](https://vrt.gredice.com): Interactive garden application.
+- [Service status](https://status.gredice.com): Availability and incident history.`;
+
+export function GET() {
+    return new NextResponse(content, {
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Cache-Control':
+                'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+        },
+    });
+}


### PR DESCRIPTION
### Motivation
- Provide stable, machine-readable `llms.txt` and `llms-full.txt` endpoints so LLM agents and crawlers can discover canonical Gredice resources without scraping unrelated pages.
- Ensure the responses are plain-text, include a concise platform summary and high-value public links, and expose crawler-friendly caching headers.

### Description
- Added `apps/www/app/llms.txt/route.ts` which returns a spec-structured plain-text `llms.txt` response containing a title, summary, core resource links, company/support links, and policies.
- Added `apps/www/app/llms-full.txt/route.ts` which re-exports the same `GET` handler to expose `llms-full.txt` at the canonical path.
- Set explicit response headers `Content-Type: text/plain; charset=utf-8` and `Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400` appropriate for public crawler access.

### Testing
- Ran `pnpm lint --filter www` which completed successfully and auto-fixed minor issues. 
- Ran `pnpm test --filter www` which executed the build and test pipeline but the Playwright accessibility suite failed in this environment; build/test logs also show repeated `ENETUNREACH` fetch warnings from page data fetching during the build.
- The test run produced the expected app routes (including `/llms.txt` and `/llms-full.txt`) during the Next.js build step prior to the environment-specific test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027d75b958832f8e296e53f483e529)