### PR TITLE
[Social] Define Reddit post storage model and repository

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -42,6 +42,7 @@ export * from './repositories/refreshTokensRepo';
 export * from './repositories/seasonalOffersRepo';
 export * from './repositories/settingsRepo';
 export * from './repositories/shoppingCartRepo';
+export * from './repositories/socialPostsRepo';
 export * from './repositories/timeSlotsRepo';
 export * from './repositories/transactionsRepo';
 export * from './repositories/usersRepo';

--- a/packages/storage/src/repositories/socialPostsRepo.ts
+++ b/packages/storage/src/repositories/socialPostsRepo.ts
@@ -1,0 +1,106 @@
+import 'server-only';
+
+import { and, desc, eq } from 'drizzle-orm';
+import { storage } from '..';
+import {
+    type SelectSocialPost,
+    type SocialPostProvider,
+    type SocialPostStatus,
+    type SocialPostType,
+    socialPosts,
+} from '../schema';
+
+export type CreateSocialPostInput = {
+    provider: SocialPostProvider;
+    subreddit: string;
+    postType: SocialPostType;
+    title: string;
+    bodyText?: string | null;
+    url?: string | null;
+    status?: SocialPostStatus;
+};
+
+export type UpdateSocialPostInput = {
+    id: number;
+    status?: SocialPostStatus;
+    redditSubmissionId?: string | null;
+    redditPermalink?: string | null;
+    failureReason?: string | null;
+    failureCode?: string | null;
+    failureContext?: string | null;
+};
+
+export async function createSocialPost(
+    input: CreateSocialPostInput,
+): Promise<SelectSocialPost> {
+    const [created] = await storage()
+        .insert(socialPosts)
+        .values({
+            provider: input.provider,
+            subreddit: input.subreddit,
+            postType: input.postType,
+            title: input.title,
+            bodyText: input.bodyText ?? null,
+            url: input.url ?? null,
+            status: input.status ?? 'draft',
+        })
+        .returning();
+
+    if (!created) {
+        throw new Error('Failed to create social post');
+    }
+
+    return created;
+}
+
+export async function updateSocialPost(
+    input: UpdateSocialPostInput,
+): Promise<SelectSocialPost | null> {
+    const [updated] = await storage()
+        .update(socialPosts)
+        .set({
+            status: input.status,
+            redditSubmissionId: input.redditSubmissionId,
+            redditPermalink: input.redditPermalink,
+            failureReason: input.failureReason,
+            failureCode: input.failureCode,
+            failureContext: input.failureContext,
+            updatedAt: new Date(),
+        })
+        .where(eq(socialPosts.id, input.id))
+        .returning();
+
+    return updated ?? null;
+}
+
+export async function getSocialPostById(
+    id: number,
+): Promise<SelectSocialPost | null> {
+    const [post] = await storage()
+        .select()
+        .from(socialPosts)
+        .where(eq(socialPosts.id, id))
+        .limit(1);
+
+    return post ?? null;
+}
+
+export async function listSocialPosts(options?: {
+    provider?: SocialPostProvider;
+    status?: SocialPostStatus;
+    limit?: number;
+}): Promise<SelectSocialPost[]> {
+    const conditions = [
+        options?.provider
+            ? eq(socialPosts.provider, options.provider)
+            : undefined,
+        options?.status ? eq(socialPosts.status, options.status) : undefined,
+    ].filter((condition) => condition !== undefined);
+
+    return storage()
+        .select()
+        .from(socialPosts)
+        .where(conditions.length > 0 ? and(...conditions) : undefined)
+        .orderBy(desc(socialPosts.createdAt))
+        .limit(options?.limit ?? 50);
+}

--- a/packages/storage/src/schema/index.ts
+++ b/packages/storage/src/schema/index.ts
@@ -16,5 +16,6 @@ export * from './operationsSchema';
 export * from './refreshTokensSchema';
 export * from './settingsSchema';
 export * from './shoppingCartSchema';
+export * from './socialSchema';
 export * from './transactionSchema';
 export * from './usersSchema';

--- a/packages/storage/src/schema/socialSchema.ts
+++ b/packages/storage/src/schema/socialSchema.ts
@@ -1,0 +1,58 @@
+import {
+    index,
+    pgEnum,
+    pgTable,
+    serial,
+    text,
+    timestamp,
+} from 'drizzle-orm/pg-core';
+
+export const socialPostProviderEnum = pgEnum('social_post_provider', [
+    'reddit',
+]);
+
+export const socialPostTypeEnum = pgEnum('social_post_type', ['text', 'link']);
+
+export const socialPostStatusEnum = pgEnum('social_post_status', [
+    'draft',
+    'submitting',
+    'published',
+    'failed',
+]);
+
+export const socialPosts = pgTable(
+    'social_posts',
+    {
+        id: serial('id').primaryKey(),
+        provider: socialPostProviderEnum('provider')
+            .notNull()
+            .default('reddit'),
+        subreddit: text('subreddit').notNull(),
+        postType: socialPostTypeEnum('post_type').notNull(),
+        title: text('title').notNull(),
+        bodyText: text('body_text'),
+        url: text('url'),
+        status: socialPostStatusEnum('status').notNull().default('draft'),
+        redditSubmissionId: text('reddit_submission_id'),
+        redditPermalink: text('reddit_permalink'),
+        failureReason: text('failure_reason'),
+        failureCode: text('failure_code'),
+        failureContext: text('failure_context'),
+        createdAt: timestamp('created_at').notNull().defaultNow(),
+        updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    },
+    (table) => [
+        index('social_posts_provider_idx').on(table.provider),
+        index('social_posts_subreddit_idx').on(table.subreddit),
+        index('social_posts_status_idx').on(table.status),
+        index('social_posts_created_at_idx').on(table.createdAt),
+    ],
+);
+
+export type SocialPostProvider =
+    (typeof socialPostProviderEnum.enumValues)[number];
+export type SocialPostType = (typeof socialPostTypeEnum.enumValues)[number];
+export type SocialPostStatus = (typeof socialPostStatusEnum.enumValues)[number];
+
+export type InsertSocialPost = typeof socialPosts.$inferInsert;
+export type SelectSocialPost = typeof socialPosts.$inferSelect;

--- a/packages/storage/tests/socialPostsRepo.node.spec.ts
+++ b/packages/storage/tests/socialPostsRepo.node.spec.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createSocialPost,
+    getSocialPostById,
+    listSocialPosts,
+    updateSocialPost,
+} from '@gredice/storage';
+import { sql } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+async function ensureSocialPostsTable() {
+    const db = createTestDb();
+    await db.execute(sql`
+        DO $$ BEGIN
+            CREATE TYPE social_post_provider AS ENUM ('reddit');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    `);
+    await db.execute(sql`
+        DO $$ BEGIN
+            CREATE TYPE social_post_type AS ENUM ('text', 'link');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    `);
+    await db.execute(sql`
+        DO $$ BEGIN
+            CREATE TYPE social_post_status AS ENUM ('draft', 'submitting', 'published', 'failed');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    `);
+    await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS social_posts (
+            id serial PRIMARY KEY,
+            provider social_post_provider NOT NULL DEFAULT 'reddit',
+            subreddit text NOT NULL,
+            post_type social_post_type NOT NULL,
+            title text NOT NULL,
+            body_text text,
+            url text,
+            status social_post_status NOT NULL DEFAULT 'draft',
+            reddit_submission_id text,
+            reddit_permalink text,
+            failure_reason text,
+            failure_code text,
+            failure_context text,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now()
+        );
+    `);
+}
+
+test('socialPostsRepo supports create and detail retrieval', async () => {
+    await ensureSocialPostsTable();
+
+    const created = await createSocialPost({
+        provider: 'reddit',
+        subreddit: 'gardening',
+        postType: 'text',
+        title: 'Fresh garden update',
+        bodyText: 'Season kickoff post',
+    });
+
+    assert.equal(created.provider, 'reddit');
+    assert.equal(created.status, 'draft');
+
+    const found = await getSocialPostById(created.id);
+    assert.ok(found);
+    assert.equal(found.title, 'Fresh garden update');
+});
+
+test('socialPostsRepo supports status lifecycle and successful publish update', async () => {
+    await ensureSocialPostsTable();
+
+    const created = await createSocialPost({
+        provider: 'reddit',
+        subreddit: 'croatia',
+        postType: 'link',
+        title: 'Planting tips',
+        url: 'https://example.com/tips',
+    });
+
+    const submitting = await updateSocialPost({
+        id: created.id,
+        status: 'submitting',
+    });
+    assert.ok(submitting);
+    assert.equal(submitting.status, 'submitting');
+
+    const published = await updateSocialPost({
+        id: created.id,
+        status: 'published',
+        redditSubmissionId: 't3_abc123',
+        redditPermalink: '/r/croatia/comments/abc123/planting_tips/',
+        failureReason: null,
+        failureCode: null,
+        failureContext: null,
+    });
+
+    assert.ok(published);
+    assert.equal(published.status, 'published');
+    assert.equal(published.redditSubmissionId, 't3_abc123');
+});
+
+test('socialPostsRepo preserves failure context and supports list filtering', async () => {
+    await ensureSocialPostsTable();
+
+    const failed = await createSocialPost({
+        provider: 'reddit',
+        subreddit: 'homestead',
+        postType: 'text',
+        title: 'Failed attempt post',
+        bodyText: 'Will fail',
+        status: 'submitting',
+    });
+
+    await updateSocialPost({
+        id: failed.id,
+        status: 'failed',
+        failureReason: 'Subreddit requires flair',
+        failureCode: 'reddit_rule_violation',
+        failureContext: '{"httpStatus":403,"requestId":"req_123"}',
+    });
+
+    const list = await listSocialPosts({
+        provider: 'reddit',
+        status: 'failed',
+        limit: 10,
+    });
+
+    assert.ok(list.some((post) => post.id === failed.id));
+    const failedPost = list.find((post) => post.id === failed.id);
+    assert.ok(failedPost);
+    assert.equal(failedPost.failureCode, 'reddit_rule_violation');
+    assert.equal(await updateSocialPost({ id: -1, status: 'failed' }), null);
+});


### PR DESCRIPTION
### Motivation
- Record every Reddit post and immediate publish attempt in storage so admins can inspect what was submitted, its outcome, and sanitized failure details. 
- Provide a minimal schema and repository API compatible with immediate publish flows and future scheduling without adding scheduling behavior now.
- Keep sensitive data out of post records and preserve only admin-safe diagnostic context for failures.

### Description
- Add a new Drizzle schema `socialSchema.ts` defining `social_posts` plus enum types `social_post_provider`, `social_post_type`, and `social_post_status` and indexes for common queries. 
- Implement `socialPostsRepo.ts` with `createSocialPost`, `updateSocialPost`, `getSocialPostById`, and `listSocialPosts` to support create/update/detail/list workflows and status transitions. 
- Export the new schema and repository from `packages/storage/src/schema/index.ts` and `packages/storage/src/index.ts`. 
- Add `socialPostsRepo.node.spec.ts` tests that bootstrap the enum types/table at runtime (via an `ensureSocialPostsTable` helper) so tests can run without committing migration SQL.

### Testing
- Ran `pnpm db-generate` to validate Drizzle schema generation and produce a migration locally (migration SQL was not committed per repo guidance). — succeeded. 
- Ran the targeted node test `pnpm --filter @gredice/storage run test:node -- tests/socialPostsRepo.node.spec.ts` which executed the new tests against the embedded test DB and passed. 
- Ran `pnpm lint --filter @gredice/storage` and `pnpm build --filter @gredice/storage`, both of which completed successfully. 
- Running the full suite `pnpm test --filter @gredice/storage` failed earlier due to the test runner expecting committed migration artifacts, so the targeted test was used to validate the new repo instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031ca61a28832faf4b1bca2ae1cab5)