### PR TITLE
Add automated Vercel preview aliasing per PR branch

### DIFF
--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   alias_app:
     runs-on: ubuntu-latest
@@ -44,6 +48,7 @@ jobs:
         run: npm i --global vercel@latest
 
       - name: Alias app preview to branch domain
+        id: alias_app
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_SCOPE: gredice
@@ -51,3 +56,19 @@ jobs:
           GREDICE_PREVIEW_DOMAIN: preview.gredice.com
           GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: node ./scripts/alias-preview.mjs
+
+      - name: Sticky PR comment with preview alias
+        uses: marocchino/sticky-pull-request-comment@v2.9.4
+        with:
+          header: vercel-preview-alias
+          message: |
+            ✅ Preview alias updated for this PR.
+
+            - Branch: `${{ github.head_ref }}`
+            - Alias: `https://${{ steps.alias_app.outputs.alias_domain }}`
+            - Deployment: `https://${{ steps.app_deployment.outputs.url }}`
+
+            Cloudflare + Vercel requirements for `*.preview.gredice.com`:
+            - In Cloudflare DNS, create `CNAME  *.preview  cname.vercel-dns.com` (DNS only / gray cloud).
+            - Ensure there is no conflicting `A`, `AAAA`, or `CNAME` for the same host.
+            - In Vercel project settings, add `preview.gredice.com` (or `*.preview.gredice.com`) as a domain and verify it.

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Vercel creates preview deployments asynchronously, so wait up to 10 minutes.
+          # Vercel creates preview deployments asynchronously; tune MAX_ATTEMPTS and SLEEP_SECONDS to control the wait.
           max_attempts="${MAX_ATTEMPTS}"
           sleep_seconds="${SLEEP_SECONDS}"
           deployment_url=""

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -44,8 +44,8 @@ jobs:
 
           max_attempts="${MAX_ATTEMPTS}"
           sleep_seconds="${SLEEP_SECONDS}"
-          aliases_table="| App | Preview |
-          | --- | --- |"
+          aliases_table="| App | Preview |"
+          aliases_table+=$'\n| --- | --- |'
           alias_count=0
           apps=(www garden farm app storybook api status)
           declare -A pending_project_ids
@@ -64,14 +64,13 @@ jobs:
               GITHUB_HEAD_REF="${BRANCH_NAME}" \
               node ./scripts/alias-preview.mjs
 
-            alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}" | tail -n 1)
-            if [ -z "${alias_domain}" ]; then
+            alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}")
+            if [ -z "${alias_domain}" ] || [[ "${alias_domain}" == *$'\n'* ]]; then
               echo "Failed to read alias domain for ${app_name}."
               exit 1
             fi
 
-            aliases_table="${aliases_table}
-          | [${app_name}](https://vercel.com/${VERCEL_SCOPE}/${app_name}) | [Preview](https://${alias_domain}) |"
+            aliases_table+=$'\n'"| [${app_name}](https://vercel.com/${VERCEL_SCOPE}/${app_name}) | [Preview](https://${alias_domain}) |"
             alias_count=$((alias_count + 1))
           }
 
@@ -96,7 +95,7 @@ jobs:
             fi
 
             for app_name in "${apps[@]}"; do
-              if [ -z "${pending_project_ids[${app_name}]+set}" ]; then
+              if ! [[ -v pending_project_ids[$app_name] ]]; then
                 continue
               fi
 
@@ -140,7 +139,7 @@ jobs:
 
             if [ "${attempt}" -eq "${max_attempts}" ]; then
               for app_name in "${apps[@]}"; do
-                if [ -n "${pending_project_ids[${app_name}]+set}" ]; then
+                if [[ -v pending_project_ids[$app_name] ]]; then
                   echo "Timed out waiting for ready ${app_name} preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
                 fi
               done
@@ -152,8 +151,7 @@ jobs:
           done
 
           if [ "${alias_count}" -eq 0 ]; then
-            aliases_table="${aliases_table}
-          | — | No preview aliases available yet. |"
+            aliases_table+=$'\n| — | No preview aliases available yet. |'
           fi
 
           {

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -66,6 +66,7 @@ jobs:
             local project_name="${vercel_project_names[$app_name]}"
             local alias_output
             local alias_domain
+            local alias_domain_newline_count
 
             alias_output=$(mktemp)
             if ! GITHUB_OUTPUT="${alias_output}" \
@@ -78,7 +79,8 @@ jobs:
             fi
 
             alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}")
-            if [ -z "${alias_domain}" ] || [[ "${alias_domain}" == *$'\n'* ]]; then
+            alias_domain_newline_count=$(printf '%s' "${alias_domain}" | wc -l | tr -d ' ')
+            if [ -z "${alias_domain}" ] || [ "${alias_domain_newline_count}" -gt 0 ]; then
               echo "Failed to read alias domain for ${app_name}."
               exit 1
             fi
@@ -155,7 +157,7 @@ jobs:
             if [ "${attempt}" -eq "${max_attempts}" ]; then
               for app_name in "${apps[@]}"; do
                 if [[ -v pending_project_ids[$app_name] ]]; then
-                  echo "::warning title=Vercel preview alias timeout::Timed out waiting for ready ${app_name} preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
+                  echo "::warning title=Vercel preview alias timeout::Timed out waiting for ready ${app_name} preview deployment."
                 fi
               done
               break

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -1,0 +1,53 @@
+name: Vercel preview alias
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  alias_app:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Resolve latest preview deployment URL (app)
+        id: app_deployment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_ORG_ID }}
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          deployment_url=$(curl -fsSL -G \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            --data-urlencode "projectId=${VERCEL_PROJECT_ID}" \
+            --data-urlencode "target=preview" \
+            --data-urlencode "state=READY" \
+            --data-urlencode "meta-githubCommitRef=${BRANCH_NAME}" \
+            --data-urlencode "limit=1" \
+            "https://api.vercel.com/v6/deployments?teamId=${VERCEL_TEAM_ID}" | \
+            jq -r '.deployments[0].url // empty')
+
+          if [ -z "${deployment_url}" ]; then
+            echo "No ready app preview deployment found for branch ${BRANCH_NAME}."
+            exit 1
+          fi
+
+          echo "url=${deployment_url}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24.15.0"
+
+      - name: Install Vercel CLI
+        run: npm i --global vercel@latest
+
+      - name: Alias app preview to branch domain
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: gredice
+          VERCEL_DEPLOYMENT_URL: ${{ steps.app_deployment.outputs.url }}
+          GREDICE_PREVIEW_DOMAIN: preview.gredice.com
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: node ./scripts/alias-preview.mjs

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -65,13 +65,16 @@ jobs:
               node ./scripts/alias-preview.mjs
 
             alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}")
+            # Validate the generated alias as a DNS subdomain before adding it to the PR comment.
             alias_domain_pattern='^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$'
             if ! [[ "${alias_domain}" =~ ${alias_domain_pattern} ]]; then
               echo "Failed to read alias domain for ${app_name}."
               exit 1
             fi
 
-            aliases_table+=$'\n'"| [${app_name}](https://vercel.com/${VERCEL_SCOPE}/${app_name}) | [Preview](https://${alias_domain}) |"
+            app_link="[${app_name}](https://vercel.com/${VERCEL_SCOPE}/${app_name})"
+            preview_link="[Preview](https://${alias_domain})"
+            aliases_table+=$'\n'"| ${app_link} | ${preview_link} |"
             alias_count=$((alias_count + 1))
           }
 

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -9,67 +9,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  alias_app:
+  alias_previews:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-
-      - name: Resolve latest preview deployment URL (app)
-        id: app_deployment
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_ORG_ID }}
-          BRANCH_NAME: ${{ github.head_ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          MAX_ATTEMPTS: 30
-          SLEEP_SECONDS: 20
-        run: |
-          set -euo pipefail
-
-          # Vercel creates preview deployments asynchronously; tune MAX_ATTEMPTS and SLEEP_SECONDS to control the wait.
-          max_attempts="${MAX_ATTEMPTS}"
-          sleep_seconds="${SLEEP_SECONDS}"
-          deployment_url=""
-
-          for attempt in $(seq 1 "${max_attempts}"); do
-            deployment=$(curl -fsSL -G \
-              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              --data-urlencode "projectId=${VERCEL_PROJECT_ID}" \
-              --data-urlencode "target=preview" \
-              --data-urlencode "meta-githubCommitRef=${BRANCH_NAME}" \
-              --data-urlencode "meta-githubCommitSha=${HEAD_SHA}" \
-              --data-urlencode "limit=1" \
-              "https://api.vercel.com/v6/deployments?teamId=${VERCEL_TEAM_ID}" | \
-              jq -r '.deployments[0] // empty | [.url, .state] | @tsv')
-
-            if [ -n "${deployment}" ]; then
-              deployment_url=$(cut -f1 <<< "${deployment}")
-              deployment_state=$(cut -f2 <<< "${deployment}")
-              echo "Found app preview deployment ${deployment_url} with state ${deployment_state} for ${HEAD_SHA}."
-
-              if [ "${deployment_state}" = "READY" ]; then
-                break
-              fi
-
-              if [ "${deployment_state}" = "ERROR" ] || [ "${deployment_state}" = "CANCELED" ]; then
-                echo "App preview deployment for ${HEAD_SHA} finished with state ${deployment_state}."
-                exit 1
-              fi
-            else
-              echo "No app preview deployment found for branch ${BRANCH_NAME} at ${HEAD_SHA} yet."
-            fi
-
-            if [ "${attempt}" -eq "${max_attempts}" ]; then
-              echo "Timed out waiting for ready app preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
-              exit 1
-            fi
-
-            echo "Waiting ${sleep_seconds}s before retry ${attempt}/${max_attempts}."
-            sleep "${sleep_seconds}"
-          done
-
-          echo "url=${deployment_url}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v6.4.0
         with:
@@ -78,30 +21,150 @@ jobs:
       - name: Install Vercel CLI
         run: npm i --global vercel@latest
 
-      - name: Alias app preview to branch domain
-        id: alias_app
+      - name: Alias preview deployments
+        id: alias_previews
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_SCOPE: gredice
-          VERCEL_DEPLOYMENT_URL: ${{ steps.app_deployment.outputs.url }}
           GREDICE_PREVIEW_DOMAIN: preview.gredice.com
-          GREDICE_PREVIEW_ALIAS_PREFIX: app
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
-        run: node ./scripts/alias-preview.mjs
+          VERCEL_PROJECT_ID_WWW: ${{ secrets.VERCEL_PROJECT_ID_WWW }}
+          VERCEL_PROJECT_ID_GARDEN: ${{ secrets.VERCEL_PROJECT_ID_GARDEN }}
+          VERCEL_PROJECT_ID_FARM: ${{ secrets.VERCEL_PROJECT_ID_FARM }}
+          VERCEL_PROJECT_ID_APP: ${{ secrets.VERCEL_PROJECT_ID_APP }}
+          VERCEL_PROJECT_ID_STORYBOOK: ${{ secrets.VERCEL_PROJECT_ID_STORYBOOK }}
+          VERCEL_PROJECT_ID_API: ${{ secrets.VERCEL_PROJECT_ID_API }}
+          VERCEL_PROJECT_ID_STATUS: ${{ secrets.VERCEL_PROJECT_ID_STATUS }}
+          BRANCH_NAME: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MAX_ATTEMPTS: 30
+          SLEEP_SECONDS: 20
+        run: |
+          set -euo pipefail
 
-      - name: Sticky PR comment with preview alias
+          max_attempts="${MAX_ATTEMPTS}"
+          sleep_seconds="${SLEEP_SECONDS}"
+          aliases_table="| App | Preview |
+          | --- | --- |"
+          alias_count=0
+          apps=(www garden farm app storybook api status)
+          declare -A pending_project_ids
+          pending_count=0
+
+          alias_deployment() {
+            local app_name="$1"
+            local deployment_url="$2"
+            local alias_output
+            local alias_domain
+
+            alias_output=$(mktemp)
+            GITHUB_OUTPUT="${alias_output}" \
+              VERCEL_DEPLOYMENT_URL="${deployment_url}" \
+              GREDICE_PREVIEW_ALIAS_PREFIX="${app_name}" \
+              GITHUB_HEAD_REF="${BRANCH_NAME}" \
+              node ./scripts/alias-preview.mjs
+
+            alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}" | tail -n 1)
+            if [ -z "${alias_domain}" ]; then
+              echo "Failed to read alias domain for ${app_name}."
+              exit 1
+            fi
+
+            aliases_table="${aliases_table}
+          | [${app_name}](https://vercel.com/${VERCEL_SCOPE}/${app_name}) | [Preview](https://${alias_domain}) |"
+            alias_count=$((alias_count + 1))
+          }
+
+          for app_name in "${apps[@]}"; do
+            app_key="${app_name^^}"
+            project_id_var="VERCEL_PROJECT_ID_${app_key}"
+            project_id="${!project_id_var:-}"
+
+            if [ -z "${project_id}" ]; then
+              echo "Skipping ${app_name}; ${project_id_var} is not configured."
+              continue
+            fi
+
+            pending_project_ids["${app_name}"]="${project_id}"
+            pending_count=$((pending_count + 1))
+          done
+
+          # Vercel creates preview deployments asynchronously; tune MAX_ATTEMPTS and SLEEP_SECONDS to control the wait.
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if [ "${pending_count}" -eq 0 ]; then
+              break
+            fi
+
+            for app_name in "${apps[@]}"; do
+              if [ -z "${pending_project_ids[${app_name}]+set}" ]; then
+                continue
+              fi
+
+              project_id="${pending_project_ids[${app_name}]}"
+              deployment=$(curl -fsSL -G \
+                -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                --data-urlencode "projectId=${project_id}" \
+                --data-urlencode "target=preview" \
+                --data-urlencode "meta-githubCommitRef=${BRANCH_NAME}" \
+                --data-urlencode "meta-githubCommitSha=${HEAD_SHA}" \
+                --data-urlencode "limit=1" \
+                "https://api.vercel.com/v6/deployments?teamId=${VERCEL_TEAM_ID}" | \
+                jq -r '.deployments[0] // empty | [.url, .state] | @tsv')
+
+              if [ -z "${deployment}" ]; then
+                echo "No ${app_name} preview deployment found for branch ${BRANCH_NAME} at ${HEAD_SHA} yet."
+                continue
+              fi
+
+              deployment_url=$(cut -f1 <<< "${deployment}")
+              deployment_state=$(cut -f2 <<< "${deployment}")
+              echo "Found ${app_name} preview deployment ${deployment_url} with state ${deployment_state} for ${HEAD_SHA}."
+
+              if [ "${deployment_state}" = "READY" ]; then
+                alias_deployment "${app_name}" "${deployment_url}"
+                unset "pending_project_ids[${app_name}]"
+                pending_count=$((pending_count - 1))
+                continue
+              fi
+
+              if [ "${deployment_state}" = "ERROR" ] || [ "${deployment_state}" = "CANCELED" ]; then
+                echo "Skipping ${app_name}; preview deployment for ${HEAD_SHA} finished with state ${deployment_state}."
+                unset "pending_project_ids[${app_name}]"
+                pending_count=$((pending_count - 1))
+              fi
+            done
+
+            if [ "${pending_count}" -eq 0 ]; then
+              break
+            fi
+
+            if [ "${attempt}" -eq "${max_attempts}" ]; then
+              for app_name in "${apps[@]}"; do
+                if [ -n "${pending_project_ids[${app_name}]+set}" ]; then
+                  echo "Timed out waiting for ready ${app_name} preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
+                fi
+              done
+              break
+            fi
+
+            echo "Waiting ${sleep_seconds}s before retry ${attempt}/${max_attempts}."
+            sleep "${sleep_seconds}"
+          done
+
+          if [ "${alias_count}" -eq 0 ]; then
+            aliases_table="${aliases_table}
+          | — | No preview aliases available yet. |"
+          fi
+
+          {
+            echo "aliases_table<<ALIASES"
+            echo "${aliases_table}"
+            echo "ALIASES"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sticky PR comment with preview aliases
         uses: marocchino/sticky-pull-request-comment@v2.9.4
         with:
           header: vercel-preview-alias
           message: |
-            ✅ Preview alias updated for this PR.
-
-            - App: `app`
-            - Branch: `${{ github.head_ref }}`
-            - Alias: `https://${{ steps.alias_app.outputs.alias_domain }}`
-            - Deployment: `https://${{ steps.app_deployment.outputs.url }}`
-
-            Cloudflare + Vercel requirements for `*.preview.gredice.com`:
-            - In Cloudflare DNS, create `CNAME  *.preview  cname.vercel-dns.com` (DNS only / gray cloud).
-            - Ensure there is no conflicting `A`, `AAAA`, or `CNAME` for the same host.
-            - In Vercel project settings, add `preview.gredice.com` (or `*.preview.gredice.com`) as a domain and verify it.
+            ${{ steps.alias_previews.outputs.aliases_table }}

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -21,22 +21,50 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_APP }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_ORG_ID }}
           BRANCH_NAME: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          deployment_url=$(curl -fsSL -G \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            --data-urlencode "projectId=${VERCEL_PROJECT_ID}" \
-            --data-urlencode "target=preview" \
-            --data-urlencode "state=READY" \
-            --data-urlencode "meta-githubCommitRef=${BRANCH_NAME}" \
-            --data-urlencode "limit=1" \
-            "https://api.vercel.com/v6/deployments?teamId=${VERCEL_TEAM_ID}" | \
-            jq -r '.deployments[0].url // empty')
 
-          if [ -z "${deployment_url}" ]; then
-            echo "No ready app preview deployment found for branch ${BRANCH_NAME}."
-            exit 1
-          fi
+          max_attempts=30
+          sleep_seconds=20
+          deployment_url=""
+
+          for attempt in $(seq 1 "${max_attempts}"); do
+            deployment=$(curl -fsSL -G \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              --data-urlencode "projectId=${VERCEL_PROJECT_ID}" \
+              --data-urlencode "target=preview" \
+              --data-urlencode "meta-githubCommitRef=${BRANCH_NAME}" \
+              --data-urlencode "meta-githubCommitSha=${HEAD_SHA}" \
+              --data-urlencode "limit=1" \
+              "https://api.vercel.com/v6/deployments?teamId=${VERCEL_TEAM_ID}" | \
+              jq -r '.deployments[0] // empty | [.url, .state] | @tsv')
+
+            if [ -n "${deployment}" ]; then
+              deployment_url=$(cut -f1 <<< "${deployment}")
+              deployment_state=$(cut -f2 <<< "${deployment}")
+              echo "Found app preview deployment ${deployment_url} with state ${deployment_state} for ${HEAD_SHA}."
+
+              if [ "${deployment_state}" = "READY" ]; then
+                break
+              fi
+
+              if [ "${deployment_state}" = "ERROR" ] || [ "${deployment_state}" = "CANCELED" ]; then
+                echo "App preview deployment for ${HEAD_SHA} finished with state ${deployment_state}."
+                exit 1
+              fi
+            else
+              echo "No app preview deployment found for branch ${BRANCH_NAME} at ${HEAD_SHA} yet."
+            fi
+
+            if [ "${attempt}" = "${max_attempts}" ]; then
+              echo "Timed out waiting for ready app preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
+              exit 1
+            fi
+
+            echo "Waiting ${sleep_seconds}s before retry ${attempt}/${max_attempts}."
+            sleep "${sleep_seconds}"
+          done
 
           echo "url=${deployment_url}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -85,6 +85,7 @@ jobs:
           VERCEL_SCOPE: gredice
           VERCEL_DEPLOYMENT_URL: ${{ steps.app_deployment.outputs.url }}
           GREDICE_PREVIEW_DOMAIN: preview.gredice.com
+          GREDICE_PREVIEW_ALIAS_PREFIX: app
           GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: node ./scripts/alias-preview.mjs
 
@@ -95,6 +96,7 @@ jobs:
           message: |
             ✅ Preview alias updated for this PR.
 
+            - App: `app`
             - Branch: `${{ github.head_ref }}`
             - Alias: `https://${{ steps.alias_app.outputs.alias_domain }}`
             - Deployment: `https://${{ steps.app_deployment.outputs.url }}`

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -65,7 +65,8 @@ jobs:
               node ./scripts/alias-preview.mjs
 
             alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}")
-            if [ -z "${alias_domain}" ] || [[ "${alias_domain}" == *$'\n'* ]]; then
+            alias_domain_pattern='^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$'
+            if ! [[ "${alias_domain}" =~ ${alias_domain_pattern} ]]; then
               echo "Failed to read alias domain for ${app_name}."
               exit 1
             fi
@@ -151,7 +152,7 @@ jobs:
           done
 
           if [ "${alias_count}" -eq 0 ]; then
-            aliases_table+=$'\n| — | No preview aliases available yet. |'
+            aliases_table+=$'\n| - | No preview aliases available yet. |'
           fi
 
           {

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Vercel creates preview deployments asynchronously, so wait up to 10 minutes.
           max_attempts=30
           sleep_seconds=20
           deployment_url=""
@@ -57,7 +58,7 @@ jobs:
               echo "No app preview deployment found for branch ${BRANCH_NAME} at ${HEAD_SHA} yet."
             fi
 
-            if [ "${attempt}" = "${max_attempts}" ]; then
+            if [ "${attempt}" -eq "${max_attempts}" ]; then
               echo "Timed out waiting for ready app preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
               exit 1
             fi

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -49,30 +49,41 @@ jobs:
           alias_count=0
           apps=(www garden farm app storybook api status)
           declare -A pending_project_ids
+          declare -A vercel_project_names=(
+            [www]=www
+            [garden]=garden
+            [farm]=farm
+            [app]=app
+            [storybook]=storybook
+            [api]=api
+            [status]=status
+          )
           pending_count=0
 
           alias_deployment() {
             local app_name="$1"
             local deployment_url="$2"
+            local project_name="${vercel_project_names[$app_name]}"
             local alias_output
             local alias_domain
 
             alias_output=$(mktemp)
-            GITHUB_OUTPUT="${alias_output}" \
+            if ! GITHUB_OUTPUT="${alias_output}" \
               VERCEL_DEPLOYMENT_URL="${deployment_url}" \
               GREDICE_PREVIEW_ALIAS_PREFIX="${app_name}" \
               GITHUB_HEAD_REF="${BRANCH_NAME}" \
-              node ./scripts/alias-preview.mjs
+              node ./scripts/alias-preview.mjs; then
+              echo "Failed to alias ${app_name} preview deployment."
+              exit 1
+            fi
 
             alias_domain=$(sed -n 's/^alias_domain=//p' "${alias_output}")
-            # Validate the generated alias as a DNS subdomain before adding it to the PR comment.
-            alias_domain_pattern='^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$'
-            if ! [[ "${alias_domain}" =~ ${alias_domain_pattern} ]]; then
+            if [ -z "${alias_domain}" ] || [[ "${alias_domain}" == *$'\n'* ]]; then
               echo "Failed to read alias domain for ${app_name}."
               exit 1
             fi
 
-            app_link="[${app_name}](https://vercel.com/${VERCEL_SCOPE}/${app_name})"
+            app_link="[${app_name}](https://vercel.com/${VERCEL_SCOPE}/${project_name})"
             preview_link="[Preview](https://${alias_domain})"
             aliases_table+=$'\n'"| ${app_link} | ${preview_link} |"
             alias_count=$((alias_count + 1))
@@ -144,7 +155,7 @@ jobs:
             if [ "${attempt}" -eq "${max_attempts}" ]; then
               for app_name in "${apps[@]}"; do
                 if [[ -v pending_project_ids[$app_name] ]]; then
-                  echo "Timed out waiting for ready ${app_name} preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
+                  echo "::warning title=Vercel preview alias timeout::Timed out waiting for ready ${app_name} preview deployment for branch ${BRANCH_NAME} at ${HEAD_SHA}."
                 fi
               done
               break

--- a/.github/workflows/vercel-preview-alias.yml
+++ b/.github/workflows/vercel-preview-alias.yml
@@ -22,12 +22,14 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_ORG_ID }}
           BRANCH_NAME: ${{ github.head_ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MAX_ATTEMPTS: 30
+          SLEEP_SECONDS: 20
         run: |
           set -euo pipefail
 
           # Vercel creates preview deployments asynchronously, so wait up to 10 minutes.
-          max_attempts=30
-          sleep_seconds=20
+          max_attempts="${MAX_ATTEMPTS}"
+          sleep_seconds="${SLEEP_SECONDS}"
           deployment_url=""
 
           for attempt in $(seq 1 "${max_attempts}"); do

--- a/package.json
+++ b/package.json
@@ -1,33 +1,34 @@
 {
-    "name": "gredice-monorepo",
-    "private": true,
-    "type": "module",
-    "scripts": {
-        "build": "turbo build",
-        "clean": "turbo clean",
-        "dev": "node ./scripts/dev-with-proxy.mjs",
-        "env:pull": "node ./scripts/pull-envs.mjs",
-        "vercel:link": "node ./scripts/link-vercel.mjs",
-        "lint": "turbo lint",
-        "lint:migrate": "turbo lint:migrate",
-        "lint:ci-filters": "node ./scripts/check-ci-filters.mjs",
-        "db-generate": "turbo db-generate",
-        "db-push": "turbo db-push",
-        "regenerate": "turbo regenerate",
-        "test": "turbo test",
-        "generate:models-types": "turbo generate:models-types",
-        "generate:game-assets": "node ./scripts/generate-game-assets.mjs",
-        "doctor": "node ./scripts/worktree-health.mjs doctor",
-        "bootstrap": "node ./scripts/worktree-health.mjs setup",
-        "dev:all": "node ./scripts/dev-with-proxy.mjs --all-apps"
-    },
-    "devDependencies": {
-        "rimraf": "6.1.3",
-        "turbo": "2.9.12",
-        "typescript": "6.0.3"
-    },
-    "packageManager": "pnpm@11.1.0+sha512.0c44e842e5686b2c061a81adda8b2258bd8818e9704b2cf2c63d56b931a7b2e910092e085027003b96ca3911ab56a07f6df5abaed2be9925034cdd686a535b14",
-    "engines": {
-        "node": ">=24"
-    }
+  "name": "gredice-monorepo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "turbo build",
+    "clean": "turbo clean",
+    "dev": "node ./scripts/dev-with-proxy.mjs",
+    "env:pull": "node ./scripts/pull-envs.mjs",
+    "vercel:link": "node ./scripts/link-vercel.mjs",
+    "lint": "turbo lint",
+    "lint:migrate": "turbo lint:migrate",
+    "lint:ci-filters": "node ./scripts/check-ci-filters.mjs",
+    "db-generate": "turbo db-generate",
+    "db-push": "turbo db-push",
+    "regenerate": "turbo regenerate",
+    "test": "turbo test",
+    "generate:models-types": "turbo generate:models-types",
+    "generate:game-assets": "node ./scripts/generate-game-assets.mjs",
+    "doctor": "node ./scripts/worktree-health.mjs doctor",
+    "bootstrap": "node ./scripts/worktree-health.mjs setup",
+    "dev:all": "node ./scripts/dev-with-proxy.mjs --all-apps",
+    "vercel:alias-preview": "node ./scripts/alias-preview.mjs"
+  },
+  "devDependencies": {
+    "rimraf": "6.1.3",
+    "turbo": "2.9.12",
+    "typescript": "6.0.3"
+  },
+  "packageManager": "pnpm@11.1.0+sha512.0c44e842e5686b2c061a81adda8b2258bd8818e9704b2cf2c63d56b931a7b2e910092e085027003b96ca3911ab56a07f6df5abaed2be9925034cdd686a535b14",
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -94,10 +94,12 @@ async function main() {
       `Alias prefix ${aliasPrefix} results in empty slug after sanitization`,
     );
 
-  if (prefixSlug && prefixSlug.length > maxAliasPrefixLength)
-    throw new Error(
-      `Alias prefix ${aliasPrefix} exceeds maximum length of ${maxAliasPrefixLength} characters after sanitization for preview domain ${previewDomain}`,
-    );
+  if (aliasPrefix) {
+    if (prefixSlug.length > maxAliasPrefixLength)
+      throw new Error(
+        `Alias prefix ${aliasPrefix} exceeds maximum length of ${maxAliasPrefixLength} characters after sanitization for preview domain ${previewDomain}`,
+      );
+  }
 
   const maxBranchSlugLength = prefixSlug
     ? maxAliasNameLength - prefixSlug.length - ALIAS_SEPARATOR_LENGTH

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -85,7 +85,7 @@ async function main() {
 
   if (maxAliasNameLength < MIN_BRANCH_SLUG_LENGTH)
     throw new Error(
-      `Preview domain ${previewDomain} is too long: preview domain length plus separator must leave at least ${MIN_BRANCH_SLUG_LENGTH} characters within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
+      `Preview domain ${previewDomain} is too long: preview domain length plus separator must leave room for a branch slug within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
     );
 
   const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -85,7 +85,7 @@ async function main() {
 
   if (maxAliasNameLength < MIN_BRANCH_SLUG_LENGTH)
     throw new Error(
-      `Preview domain ${previewDomain} is too long to create a certificate-safe alias`,
+      `Preview domain ${previewDomain} is too long: preview domain length plus separator must leave at least ${MIN_BRANCH_SLUG_LENGTH} character within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
     );
 
   const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";
@@ -94,12 +94,10 @@ async function main() {
       `Alias prefix ${aliasPrefix} results in empty slug after sanitization`,
     );
 
-  if (aliasPrefix) {
-    if (prefixSlug.length > maxAliasPrefixLength)
-      throw new Error(
-        `Alias prefix ${aliasPrefix} exceeds maximum length of ${maxAliasPrefixLength} characters after sanitization for preview domain ${previewDomain}`,
-      );
-  }
+  if (aliasPrefix && prefixSlug.length > maxAliasPrefixLength)
+    throw new Error(
+      `Alias prefix ${aliasPrefix} exceeds maximum length of ${maxAliasPrefixLength} characters after sanitization for preview domain ${previewDomain}`,
+    );
 
   const maxBranchSlugLength = prefixSlug
     ? maxAliasNameLength - prefixSlug.length - ALIAS_SEPARATOR_LENGTH

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -85,7 +85,7 @@ async function main() {
 
   if (maxAliasNameLength < MIN_BRANCH_SLUG_LENGTH)
     throw new Error(
-      `Preview domain ${previewDomain} is too long: preview domain length plus separator must leave at least ${MIN_BRANCH_SLUG_LENGTH} character within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
+      `Preview domain ${previewDomain} is too long: preview domain length plus separator must leave at least ${MIN_BRANCH_SLUG_LENGTH} characters within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
     );
 
   const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
+import { spawn } from "node:child_process";
+import { appendFileSync } from "node:fs";
 
 function required(name) {
   const value = process.env[name]?.trim();
@@ -11,46 +12,62 @@ function required(name) {
 function sanitizeBranch(branch) {
   return branch
     .toLowerCase()
-    .replace(/^refs\/heads\//, '')
-    .replace(/[^a-z0-9-]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
+    .replace(/^refs\/heads\//, "")
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
     .slice(0, 63);
+}
+
+function writeGithubOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+  appendFileSync(outputFile, `${key}=${value}\n`);
 }
 
 function run(command, args) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: 'pipe', env: process.env });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (c) => { const t = c.toString(); stdout += t; process.stdout.write(t); });
-    child.stderr.on('data', (c) => { const t = c.toString(); stderr += t; process.stderr.write(t); });
-    child.on('error', reject);
-    child.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+    const child = spawn(command, args, { stdio: "pipe", env: process.env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => {
+      const t = c.toString();
+      stdout += t;
+      process.stdout.write(t);
+    });
+    child.stderr.on("data", (c) => {
+      const t = c.toString();
+      stderr += t;
+      process.stderr.write(t);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
   });
 }
 
 async function main() {
-  const token = required('VERCEL_TOKEN');
-  const scope = required('VERCEL_SCOPE');
-  const deploymentUrl = required('VERCEL_DEPLOYMENT_URL');
-  const previewDomain = required('GREDICE_PREVIEW_DOMAIN');
-  const branch = required('GITHUB_HEAD_REF');
+  const token = required("VERCEL_TOKEN");
+  const scope = required("VERCEL_SCOPE");
+  const deploymentUrl = required("VERCEL_DEPLOYMENT_URL");
+  const previewDomain = required("GREDICE_PREVIEW_DOMAIN");
+  const branch = required("GITHUB_HEAD_REF");
 
   const branchSlug = sanitizeBranch(branch);
-  if (!branchSlug) throw new Error(`Branch name ${branch} results in empty slug`);
+  if (!branchSlug)
+    throw new Error(`Branch name ${branch} results in empty slug`);
 
   const aliasDomain = `${branchSlug}.${previewDomain}`;
   console.log(`Aliasing ${deploymentUrl} to ${aliasDomain}`);
+  writeGithubOutput("alias_domain", aliasDomain);
 
-  const result = await run('vercel', [
-    'alias',
-    'set',
+  const result = await run("vercel", [
+    "alias",
+    "set",
     deploymentUrl,
     aliasDomain,
-    '--scope',
+    "--scope",
     scope,
-    '--token',
+    "--token",
     token,
   ]);
 

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -4,10 +4,9 @@ import { spawn } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
 const MAX_DNS_LABEL_LENGTH = 63;
+const MAX_CERT_COMMON_NAME_LENGTH = 64;
 const ALIAS_SEPARATOR_LENGTH = 1;
 const MIN_BRANCH_SLUG_LENGTH = 1;
-const MAX_ALIAS_PREFIX_LENGTH =
-  MAX_DNS_LABEL_LENGTH - ALIAS_SEPARATOR_LENGTH - MIN_BRANCH_SLUG_LENGTH;
 
 function required(name) {
   const value = process.env[name]?.trim();
@@ -74,6 +73,17 @@ async function main() {
   const previewDomain = required("GREDICE_PREVIEW_DOMAIN");
   const branch = required("GITHUB_HEAD_REF");
   const aliasPrefix = process.env.GREDICE_PREVIEW_ALIAS_PREFIX?.trim();
+  const maxAliasNameLength = Math.min(
+    MAX_DNS_LABEL_LENGTH,
+    MAX_CERT_COMMON_NAME_LENGTH - previewDomain.length - ALIAS_SEPARATOR_LENGTH,
+  );
+  const maxAliasPrefixLength =
+    maxAliasNameLength - ALIAS_SEPARATOR_LENGTH - MIN_BRANCH_SLUG_LENGTH;
+
+  if (maxAliasNameLength < MIN_BRANCH_SLUG_LENGTH)
+    throw new Error(
+      `Preview domain ${previewDomain} is too long to create a certificate-safe alias`,
+    );
 
   const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";
   if (aliasPrefix && !prefixSlug)
@@ -81,14 +91,14 @@ async function main() {
       `Alias prefix ${aliasPrefix} results in empty slug after sanitization`,
     );
 
-  if (prefixSlug.length > MAX_ALIAS_PREFIX_LENGTH)
+  if (prefixSlug && prefixSlug.length > maxAliasPrefixLength)
     throw new Error(
-      `Alias prefix ${aliasPrefix} exceeds maximum length of ${MAX_ALIAS_PREFIX_LENGTH} characters after sanitization`,
+      `Alias prefix ${aliasPrefix} exceeds maximum length of ${Math.max(maxAliasPrefixLength, 0)} characters after sanitization`,
     );
 
   const maxBranchSlugLength = prefixSlug
-    ? MAX_DNS_LABEL_LENGTH - prefixSlug.length - ALIAS_SEPARATOR_LENGTH
-    : MAX_DNS_LABEL_LENGTH;
+    ? maxAliasNameLength - prefixSlug.length - ALIAS_SEPARATOR_LENGTH
+    : maxAliasNameLength;
 
   const branchSlug = sanitizeLabel(branch, maxBranchSlugLength);
   if (!branchSlug)

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -5,6 +5,7 @@ import { appendFileSync } from "node:fs";
 
 const MAX_DNS_LABEL_LENGTH = 63;
 const MAX_CERT_COMMON_NAME_LENGTH = 64;
+const DOMAIN_SEPARATOR_LENGTH = 1;
 const ALIAS_SEPARATOR_LENGTH = 1;
 const MIN_BRANCH_SLUG_LENGTH = 1;
 
@@ -75,7 +76,9 @@ async function main() {
   const aliasPrefix = process.env.GREDICE_PREVIEW_ALIAS_PREFIX?.trim();
   const maxAliasNameLength = Math.min(
     MAX_DNS_LABEL_LENGTH,
-    MAX_CERT_COMMON_NAME_LENGTH - previewDomain.length - ALIAS_SEPARATOR_LENGTH,
+    MAX_CERT_COMMON_NAME_LENGTH -
+      previewDomain.length -
+      DOMAIN_SEPARATOR_LENGTH,
   );
   const maxAliasPrefixLength =
     maxAliasNameLength - ALIAS_SEPARATOR_LENGTH - MIN_BRANCH_SLUG_LENGTH;
@@ -93,7 +96,7 @@ async function main() {
 
   if (prefixSlug && prefixSlug.length > maxAliasPrefixLength)
     throw new Error(
-      `Alias prefix ${aliasPrefix} exceeds maximum length of ${Math.max(maxAliasPrefixLength, 0)} characters after sanitization`,
+      `Alias prefix ${aliasPrefix} exceeds maximum length of ${maxAliasPrefixLength} characters after sanitization for preview domain ${previewDomain}`,
     );
 
   const maxBranchSlugLength = prefixSlug

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -66,12 +66,12 @@ async function main() {
   const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";
   if (aliasPrefix && !prefixSlug)
     throw new Error(
-      `Alias prefix ${aliasPrefix} contains no valid DNS label characters after sanitization`,
+      `Alias prefix ${aliasPrefix} results in empty slug after sanitization`,
     );
 
   if (prefixSlug.length > MAX_ALIAS_PREFIX_LENGTH)
     throw new Error(
-      `Alias prefix ${aliasPrefix} sanitizes to ${prefixSlug} (length ${prefixSlug.length}), exceeding the maximum allowed length of ${MAX_ALIAS_PREFIX_LENGTH} characters`,
+      `Alias prefix ${aliasPrefix} exceeds maximum length of ${MAX_ALIAS_PREFIX_LENGTH} characters after sanitization`,
     );
 
   const maxBranchSlugLength = prefixSlug

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -3,13 +3,16 @@
 import { spawn } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
+const MAX_DNS_LABEL_LENGTH = 63;
+const MAX_ALIAS_PREFIX_LENGTH = MAX_DNS_LABEL_LENGTH - 2;
+
 function required(name) {
   const value = process.env[name]?.trim();
   if (!value) throw new Error(`Missing required env var: ${name}`);
   return value;
 }
 
-function sanitizeLabel(value, maxLength = 63) {
+function sanitizeLabel(value, maxLength = MAX_DNS_LABEL_LENGTH) {
   const sanitized = value
     .toLowerCase()
     .replace(/^refs\/heads\//, "")
@@ -60,10 +63,12 @@ async function main() {
       `Alias prefix ${aliasPrefix} contains no valid DNS label characters after sanitization`,
     );
 
-  const maxBranchSlugLength = prefixSlug ? 63 - prefixSlug.length - 1 : 63;
+  const maxBranchSlugLength = prefixSlug
+    ? MAX_DNS_LABEL_LENGTH - prefixSlug.length - 1
+    : MAX_DNS_LABEL_LENGTH;
   if (maxBranchSlugLength < 1)
     throw new Error(
-      `Alias prefix ${aliasPrefix} (length ${prefixSlug.length}) exceeds maximum allowed length of 62 characters`,
+      `Alias prefix ${aliasPrefix} (length ${prefixSlug.length}) exceeds maximum allowed length of ${MAX_ALIAS_PREFIX_LENGTH} characters, which leaves room for the hyphen and branch name`,
     );
 
   const branchSlug = sanitizeLabel(branch, maxBranchSlugLength);

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -10,14 +10,14 @@ function required(name) {
 }
 
 function sanitizeLabel(value, maxLength = 63) {
-  return value
+  const sanitized = value
     .toLowerCase()
     .replace(/^refs\/heads\//, "")
     .replace(/[^a-z0-9-]/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, maxLength)
-    .replace(/-$/g, "");
+    .replace(/^-|-$/g, "");
+
+  return sanitized.slice(0, maxLength).replace(/-+$/g, "");
 }
 
 function writeGithubOutput(key, value) {
@@ -56,11 +56,15 @@ async function main() {
 
   const prefixSlug = aliasPrefix ? sanitizeLabel(aliasPrefix) : "";
   if (aliasPrefix && !prefixSlug)
-    throw new Error(`Alias prefix ${aliasPrefix} results in empty slug`);
+    throw new Error(
+      `Alias prefix ${aliasPrefix} contains no valid DNS label characters after sanitization`,
+    );
 
   const maxBranchSlugLength = prefixSlug ? 63 - prefixSlug.length - 1 : 63;
   if (maxBranchSlugLength < 1)
-    throw new Error(`Alias prefix ${aliasPrefix} is too long`);
+    throw new Error(
+      `Alias prefix ${aliasPrefix} (length ${prefixSlug.length}) exceeds maximum allowed length of 62 characters`,
+    );
 
   const branchSlug = sanitizeLabel(branch, maxBranchSlugLength);
   if (!branchSlug)

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+function sanitizeBranch(branch) {
+  return branch
+    .toLowerCase()
+    .replace(/^refs\/heads\//, '')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 63);
+}
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'pipe', env: process.env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { const t = c.toString(); stdout += t; process.stdout.write(t); });
+    child.stderr.on('data', (c) => { const t = c.toString(); stderr += t; process.stderr.write(t); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+async function main() {
+  const token = required('VERCEL_TOKEN');
+  const scope = required('VERCEL_SCOPE');
+  const deploymentUrl = required('VERCEL_DEPLOYMENT_URL');
+  const previewDomain = required('GREDICE_PREVIEW_DOMAIN');
+  const branch = required('GITHUB_HEAD_REF');
+
+  const branchSlug = sanitizeBranch(branch);
+  if (!branchSlug) throw new Error(`Branch name ${branch} results in empty slug`);
+
+  const aliasDomain = `${branchSlug}.${previewDomain}`;
+  console.log(`Aliasing ${deploymentUrl} to ${aliasDomain}`);
+
+  const result = await run('vercel', [
+    'alias',
+    'set',
+    deploymentUrl,
+    aliasDomain,
+    '--scope',
+    scope,
+    '--token',
+    token,
+  ]);
+
+  if (result.code !== 0) {
+    throw new Error(`vercel alias failed with exit code ${result.code}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -9,14 +9,15 @@ function required(name) {
   return value;
 }
 
-function sanitizeBranch(branch) {
-  return branch
+function sanitizeLabel(value, maxLength = 63) {
+  return value
     .toLowerCase()
     .replace(/^refs\/heads\//, "")
     .replace(/[^a-z0-9-]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
-    .slice(0, 63);
+    .slice(0, maxLength)
+    .replace(/-$/g, "");
 }
 
 function writeGithubOutput(key, value) {
@@ -51,12 +52,22 @@ async function main() {
   const deploymentUrl = required("VERCEL_DEPLOYMENT_URL");
   const previewDomain = required("GREDICE_PREVIEW_DOMAIN");
   const branch = required("GITHUB_HEAD_REF");
+  const aliasPrefix = process.env.GREDICE_PREVIEW_ALIAS_PREFIX?.trim();
 
-  const branchSlug = sanitizeBranch(branch);
+  const prefixSlug = aliasPrefix ? sanitizeLabel(aliasPrefix) : "";
+  if (aliasPrefix && !prefixSlug)
+    throw new Error(`Alias prefix ${aliasPrefix} results in empty slug`);
+
+  const maxBranchSlugLength = prefixSlug ? 62 - prefixSlug.length : 63;
+  if (maxBranchSlugLength < 1)
+    throw new Error(`Alias prefix ${aliasPrefix} is too long`);
+
+  const branchSlug = sanitizeLabel(branch, maxBranchSlugLength);
   if (!branchSlug)
     throw new Error(`Branch name ${branch} results in empty slug`);
 
-  const aliasDomain = `${branchSlug}.${previewDomain}`;
+  const aliasName = prefixSlug ? `${prefixSlug}-${branchSlug}` : branchSlug;
+  const aliasDomain = `${aliasName}.${previewDomain}`;
   console.log(`Aliasing ${deploymentUrl} to ${aliasDomain}`);
   writeGithubOutput("alias_domain", aliasDomain);
 

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -29,6 +29,18 @@ function sanitizeLabel(value, maxLength = MAX_DNS_LABEL_LENGTH) {
   return sanitized.slice(0, maxLength).replace(/-+$/g, "");
 }
 
+function isDnsLabel(value) {
+  return (
+    value.length >= 1 &&
+    value.length <= MAX_DNS_LABEL_LENGTH &&
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(value)
+  );
+}
+
+function isDnsSubdomain(value) {
+  return value.split(".").every(isDnsLabel);
+}
+
 function writeGithubOutput(key, value) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (!outputFile) return;
@@ -84,6 +96,9 @@ async function main() {
 
   const aliasName = prefixSlug ? `${prefixSlug}-${branchSlug}` : branchSlug;
   const aliasDomain = `${aliasName}.${previewDomain}`;
+  if (!isDnsSubdomain(aliasDomain))
+    throw new Error(`Alias domain ${aliasDomain} is not DNS-safe`);
+
   console.log(`Aliasing ${deploymentUrl} to ${aliasDomain}`);
   writeGithubOutput("alias_domain", aliasDomain);
 

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -4,7 +4,10 @@ import { spawn } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
 const MAX_DNS_LABEL_LENGTH = 63;
-const MAX_ALIAS_PREFIX_LENGTH = MAX_DNS_LABEL_LENGTH - 2;
+const ALIAS_SEPARATOR_LENGTH = 1;
+const MIN_BRANCH_SLUG_LENGTH = 1;
+const MAX_ALIAS_PREFIX_LENGTH =
+  MAX_DNS_LABEL_LENGTH - ALIAS_SEPARATOR_LENGTH - MIN_BRANCH_SLUG_LENGTH;
 
 function required(name) {
   const value = process.env[name]?.trim();
@@ -63,13 +66,14 @@ async function main() {
       `Alias prefix ${aliasPrefix} contains no valid DNS label characters after sanitization`,
     );
 
-  const maxBranchSlugLength = prefixSlug
-    ? MAX_DNS_LABEL_LENGTH - prefixSlug.length - 1
-    : MAX_DNS_LABEL_LENGTH;
-  if (maxBranchSlugLength < 1)
+  if (prefixSlug.length > MAX_ALIAS_PREFIX_LENGTH)
     throw new Error(
       `Alias prefix ${aliasPrefix} (length ${prefixSlug.length}) exceeds maximum allowed length of ${MAX_ALIAS_PREFIX_LENGTH} characters, which leaves room for the hyphen and branch name`,
     );
+
+  const maxBranchSlugLength = prefixSlug
+    ? MAX_DNS_LABEL_LENGTH - prefixSlug.length - ALIAS_SEPARATOR_LENGTH
+    : MAX_DNS_LABEL_LENGTH;
 
   const branchSlug = sanitizeLabel(branch, maxBranchSlugLength);
   if (!branchSlug)

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -15,14 +15,17 @@ function required(name) {
   return value;
 }
 
-function sanitizeLabel(value, maxLength = MAX_DNS_LABEL_LENGTH) {
-  const sanitized = value
+function sanitizeLabelValue(value) {
+  return value
     .toLowerCase()
     .replace(/^refs\/heads\//, "")
     .replace(/[^a-z0-9-]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
+}
 
+function sanitizeLabel(value, maxLength = MAX_DNS_LABEL_LENGTH) {
+  const sanitized = sanitizeLabelValue(value);
   return sanitized.slice(0, maxLength).replace(/-+$/g, "");
 }
 
@@ -60,7 +63,7 @@ async function main() {
   const branch = required("GITHUB_HEAD_REF");
   const aliasPrefix = process.env.GREDICE_PREVIEW_ALIAS_PREFIX?.trim();
 
-  const prefixSlug = aliasPrefix ? sanitizeLabel(aliasPrefix) : "";
+  const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";
   if (aliasPrefix && !prefixSlug)
     throw new Error(
       `Alias prefix ${aliasPrefix} contains no valid DNS label characters after sanitization`,
@@ -68,7 +71,7 @@ async function main() {
 
   if (prefixSlug.length > MAX_ALIAS_PREFIX_LENGTH)
     throw new Error(
-      `Alias prefix ${aliasPrefix} (length ${prefixSlug.length}) exceeds maximum allowed length of ${MAX_ALIAS_PREFIX_LENGTH} characters, which leaves room for the hyphen and branch name`,
+      `Alias prefix ${aliasPrefix} sanitizes to ${prefixSlug} (length ${prefixSlug.length}), exceeding the maximum allowed length of ${MAX_ALIAS_PREFIX_LENGTH} characters`,
     );
 
   const maxBranchSlugLength = prefixSlug

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -83,9 +83,9 @@ async function main() {
   const maxAliasPrefixLength =
     maxAliasNameLength - ALIAS_SEPARATOR_LENGTH - MIN_BRANCH_SLUG_LENGTH;
 
-  if (maxAliasNameLength < MIN_BRANCH_SLUG_LENGTH)
+  if (maxAliasNameLength <= 0)
     throw new Error(
-      `Preview domain ${previewDomain} is too long: preview domain length plus separator must leave room for a branch slug within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
+      `Preview domain ${previewDomain} (${previewDomain.length} characters) is too long: with separator, it must leave at least ${MIN_BRANCH_SLUG_LENGTH} character(s) for branch slug within the ${MAX_CERT_COMMON_NAME_LENGTH}-character certificate common-name limit`,
     );
 
   const prefixSlug = aliasPrefix ? sanitizeLabelValue(aliasPrefix) : "";

--- a/scripts/alias-preview.mjs
+++ b/scripts/alias-preview.mjs
@@ -58,7 +58,7 @@ async function main() {
   if (aliasPrefix && !prefixSlug)
     throw new Error(`Alias prefix ${aliasPrefix} results in empty slug`);
 
-  const maxBranchSlugLength = prefixSlug ? 62 - prefixSlug.length : 63;
+  const maxBranchSlugLength = prefixSlug ? 63 - prefixSlug.length - 1 : 63;
   if (maxBranchSlugLength < 1)
     throw new Error(`Alias prefix ${aliasPrefix} is too long`);
 

--- a/scripts/alias-preview.test.mjs
+++ b/scripts/alias-preview.test.mjs
@@ -82,6 +82,6 @@ test("fails when the preview domain leaves no room for an alias", async () => {
   assert.equal(result.code, 1);
   assert.match(
     result.stderr,
-    /Preview domain .* is too long: preview domain length plus separator must leave room for a branch slug within the 64-character certificate common-name limit/,
+    /Preview domain .* \(\d+ characters\) is too long: with separator, it must leave at least 1 character\(s\) for branch slug within the 64-character certificate common-name limit/,
   );
 });

--- a/scripts/alias-preview.test.mjs
+++ b/scripts/alias-preview.test.mjs
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const scriptPath = resolve(repoRoot, "scripts", "alias-preview.mjs");
+
+async function runAliasPreview(env) {
+  const tempDir = await mkdtemp(join(tmpdir(), "alias-preview-test-"));
+  const outputPath = join(tempDir, "github-output");
+  const vercelPath = join(tempDir, "vercel");
+
+  await writeFile(
+    vercelPath,
+    "#!/usr/bin/env bash\nprintf 'vercel %s\\n' \"$*\"\n",
+    { mode: 0o755 },
+  );
+
+  const result = await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH}`,
+        VERCEL_TOKEN: "test-token",
+        VERCEL_SCOPE: "gredice",
+        VERCEL_DEPLOYMENT_URL: "farm-preview.vercel.app",
+        GITHUB_OUTPUT: outputPath,
+        ...env,
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", rejectPromise);
+    child.on("close", (code) => {
+      resolvePromise({ code, stdout, stderr, outputPath, tempDir });
+    });
+  });
+
+  try {
+    result.githubOutput = await readFile(outputPath, "utf8");
+  } catch {
+    result.githubOutput = "";
+  }
+
+  await rm(tempDir, { recursive: true, force: true });
+  return result;
+}
+
+test("caps generated alias domains to Vercel certificate common-name length", async () => {
+  const result = await runAliasPreview({
+    GREDICE_PREVIEW_DOMAIN: "preview.gredice.com",
+    GREDICE_PREVIEW_ALIAS_PREFIX: "farm",
+    GITHUB_HEAD_REF: "feat/set-up-custom-preview-deployment-urls",
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  const aliasDomain = result.githubOutput.match(/^alias_domain=(.+)$/m)?.[1];
+  assert.equal(
+    aliasDomain,
+    "farm-feat-set-up-custom-preview-deployment-u.preview.gredice.com",
+  );
+  assert.ok(aliasDomain.length <= 64);
+});
+
+test("fails when the preview domain leaves no room for an alias", async () => {
+  const result = await runAliasPreview({
+    GREDICE_PREVIEW_DOMAIN:
+      "too-long-preview-domain-name-for-common-name-limit.example.invalid.test",
+    GITHUB_HEAD_REF: "branch",
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(
+    result.stderr,
+    /Preview domain .* is too long to create a certificate-safe alias/,
+  );
+});

--- a/scripts/alias-preview.test.mjs
+++ b/scripts/alias-preview.test.mjs
@@ -82,6 +82,6 @@ test("fails when the preview domain leaves no room for an alias", async () => {
   assert.equal(result.code, 1);
   assert.match(
     result.stderr,
-    /Preview domain .* is too long: preview domain length plus separator must leave at least 1 characters within the 64-character certificate common-name limit/,
+    /Preview domain .* is too long: preview domain length plus separator must leave room for a branch slug within the 64-character certificate common-name limit/,
   );
 });

--- a/scripts/alias-preview.test.mjs
+++ b/scripts/alias-preview.test.mjs
@@ -82,6 +82,6 @@ test("fails when the preview domain leaves no room for an alias", async () => {
   assert.equal(result.code, 1);
   assert.match(
     result.stderr,
-    /Preview domain .* is too long: preview domain length plus separator must leave at least 1 character within the 64-character certificate common-name limit/,
+    /Preview domain .* is too long: preview domain length plus separator must leave at least 1 characters within the 64-character certificate common-name limit/,
   );
 });

--- a/scripts/alias-preview.test.mjs
+++ b/scripts/alias-preview.test.mjs
@@ -82,6 +82,6 @@ test("fails when the preview domain leaves no room for an alias", async () => {
   assert.equal(result.code, 1);
   assert.match(
     result.stderr,
-    /Preview domain .* is too long to create a certificate-safe alias/,
+    /Preview domain .* is too long: preview domain length plus separator must leave at least 1 character within the 64-character certificate common-name limit/,
   );
 });


### PR DESCRIPTION
### Motivation
- Make PR preview deployments reachable at `<branch>.preview.gredice.com` so cookie-based auth and other same-site behaviors work during testing instead of using random `*.vercel.app` URLs.
- Automate mapping of the latest ready preview for a branch to a stable preview subdomain to reduce manual steps and flakiness when testing PRs.
- Require a wildcard DNS and the `preview.gredice.com` domain to be added to the Vercel project/team for this to function.

### Description
- Add a GitHub Actions workflow `.github/workflows/vercel-preview-alias.yml` that runs on PR events, queries the Vercel Deployments API for the latest `READY` preview matching the branch, and triggers aliasing.
- Add `scripts/alias-preview.mjs`, a small Node script that validates environment variables, normalizes the branch name into a DNS-safe slug, and runs `vercel alias set` to map the deployment URL to `<branch>.preview.gredice.com`.
- Add a root npm script `vercel:alias-preview` in `package.json` to allow manual/local invocation via `pnpm vercel:alias-preview`.
- The workflow currently targets the `app` project and expects the secrets `VERCEL_TOKEN`, `VERCEL_PROJECT_ID_APP`, and `VERCEL_ORG_ID` to be available in the repository.

### Testing
- Ran `node --check scripts/alias-preview.mjs` to verify the script has no syntax errors and it succeeded.
- Ran `prettier --check` on the new files, applied `prettier --write` to fix formatting, and re-checked which passed.
- No Vercel API integration or CI runtime tests were executed locally because those require repository secrets and DNS configuration (these are exercised by the new workflow in CI when secrets and domain are configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0345bdda60832f921f43a53dc2a453)