### PR TITLE
[Social] Add Reddit provider adapter boundary for server-side publishing

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,7 @@
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
         "test:prepare": "pnpm --dir ../.. exec turbo build --filter=app",
-        "test:run": "playwright test",
+        "test:run": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --test src/social/providers/reddit/redditAdapter.unit.ts && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "test:local": "pnpm run test:prepare && pnpm run test:run"
     },

--- a/apps/app/src/social/providers/index.ts
+++ b/apps/app/src/social/providers/index.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+
+import { RedditProviderAdapter } from './reddit/redditAdapter';
+import type { SocialProviderAdapter, SocialProviderName } from './types';
+
+export function createSocialProviderAdapter(
+    provider: SocialProviderName,
+): SocialProviderAdapter {
+    switch (provider) {
+        case 'reddit':
+            return new RedditProviderAdapter();
+        default:
+            return assertNever(provider);
+    }
+}
+
+function assertNever(value: never): never {
+    throw new Error(`Unsupported provider: ${String(value)}`);
+}
+
+export * from './reddit/redditAdapter';
+export * from './types';

--- a/apps/app/src/social/providers/reddit/redditAdapter.test.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.test.ts
@@ -1,5 +1,4 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { expect, test } from '@playwright/test';
 
 import { RedditProviderAdapter, readRedditEnv } from './redditAdapter';
 
@@ -20,9 +19,9 @@ test('readRedditEnv builds allowlist and default destination', () => {
         SOCIAL_PROVIDER_REDDIT_ALLOWED_DESTINATIONS: 'gardening, gredice',
     });
 
-    assert.equal(env.enabled, true);
-    assert.equal(env.allowedDestinations.has('gredice'), true);
-    assert.equal(env.allowedDestinations.has('gardening'), true);
+    expect(env.enabled).toBe(true);
+    expect(env.allowedDestinations.has('gredice')).toBe(true);
+    expect(env.allowedDestinations.has('gardening')).toBe(true);
 });
 
 test('publishPost returns operational error when missing credentials', async () => {
@@ -39,8 +38,8 @@ test('publishPost returns operational error when missing credentials', async () 
     );
 
     const result = await adapter.publishPost({ title: 'Hello' });
-    assert.equal(result.ok, false);
-    if (!result.ok) assert.equal(result.code, 'missing_credentials');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('missing_credentials');
 });
 
 test('publishPost submits text post and normalizes success', async () => {
@@ -73,15 +72,14 @@ test('publishPost submits text post and normalizes success', async () => {
     );
 
     const result = await adapter.publishPost({ title: 'Hi', body: 'body' });
-    assert.equal(result.ok, true);
+    expect(result.ok).toBe(true);
     if (result.ok) {
-        assert.equal(result.providerPostId, 'abc123');
-        assert.equal(
-            result.permalink,
+        expect(result.providerPostId).toBe('abc123');
+        expect(result.permalink).toBe(
             'https://reddit.com/r/gredice/comments/abc123/test',
         );
     }
-    assert.equal(calls.length, 2);
+    expect(calls).toHaveLength(2);
 });
 
 test('publishPost maps subreddit failure into sanitized invalid_destination', async () => {
@@ -106,9 +104,61 @@ test('publishPost maps subreddit failure into sanitized invalid_destination', as
     );
 
     const result = await adapter.publishPost({ title: 'Hi' });
-    assert.equal(result.ok, false);
+    expect(result.ok).toBe(false);
     if (!result.ok) {
-        assert.equal(result.code, 'invalid_destination');
-        assert.equal(result.message.includes('credentials'), false);
+        expect(result.code).toBe('invalid_destination');
+        expect(result.message.includes('credentials')).toBe(false);
+    }
+});
+
+test('publishPost maps submit transport failures into retriable provider_unavailable', async () => {
+    const adapter = new RedditProviderAdapter(
+        {
+            enabled: true,
+            clientId: 'id',
+            clientSecret: 'secret',
+            userAgent: 'ua',
+            defaultDestination: 'gredice',
+            allowedDestinations: new Set(['gredice']),
+        },
+        async (url) => {
+            if (url.toString().includes('access_token')) {
+                return response({ access_token: 'token' });
+            }
+            throw new Error('network failed');
+        },
+    );
+
+    const result = await adapter.publishPost({ title: 'Hi' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+        expect(result.code).toBe('provider_unavailable');
+        expect(result.retriable).toBe(true);
+    }
+});
+
+test('publishPost maps non-JSON submit responses into retriable provider_unavailable', async () => {
+    const adapter = new RedditProviderAdapter(
+        {
+            enabled: true,
+            clientId: 'id',
+            clientSecret: 'secret',
+            userAgent: 'ua',
+            defaultDestination: 'gredice',
+            allowedDestinations: new Set(['gredice']),
+        },
+        async (url) => {
+            if (url.toString().includes('access_token')) {
+                return response({ access_token: 'token' });
+            }
+            return new Response('not json', { status: 502 });
+        },
+    );
+
+    const result = await adapter.publishPost({ title: 'Hi' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+        expect(result.code).toBe('provider_unavailable');
+        expect(result.retriable).toBe(true);
     }
 });

--- a/apps/app/src/social/providers/reddit/redditAdapter.test.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { RedditProviderAdapter, readRedditEnv } from './redditAdapter';
+
+function response(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+test('readRedditEnv builds allowlist and default destination', () => {
+    const env = readRedditEnv({
+        SOCIAL_PROVIDER_REDDIT_ENABLED: 'true',
+        SOCIAL_PROVIDER_REDDIT_CLIENT_ID: 'id',
+        SOCIAL_PROVIDER_REDDIT_CLIENT_SECRET: 'secret',
+        SOCIAL_PROVIDER_REDDIT_USER_AGENT: 'ua',
+        SOCIAL_PROVIDER_REDDIT_DEFAULT_DESTINATION: 'gredice',
+        SOCIAL_PROVIDER_REDDIT_ALLOWED_DESTINATIONS: 'gardening, gredice',
+    });
+
+    assert.equal(env.enabled, true);
+    assert.equal(env.allowedDestinations.has('gredice'), true);
+    assert.equal(env.allowedDestinations.has('gardening'), true);
+});
+
+test('publishPost returns operational error when missing credentials', async () => {
+    const adapter = new RedditProviderAdapter(
+        {
+            enabled: true,
+            clientId: '',
+            clientSecret: '',
+            userAgent: '',
+            defaultDestination: '',
+            allowedDestinations: new Set(),
+        },
+        async () => response({}),
+    );
+
+    const result = await adapter.publishPost({ title: 'Hello' });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.code, 'missing_credentials');
+});
+
+test('publishPost submits text post and normalizes success', async () => {
+    const calls: string[] = [];
+    const adapter = new RedditProviderAdapter(
+        {
+            enabled: true,
+            clientId: 'id',
+            clientSecret: 'secret',
+            userAgent: 'ua',
+            defaultDestination: 'gredice',
+            allowedDestinations: new Set(['gredice']),
+        },
+        async (url) => {
+            calls.push(url.toString());
+            if (url.toString().includes('access_token')) {
+                return response({ access_token: 'token' });
+            }
+            return response({
+                json: {
+                    data: {
+                        id: 'abc123',
+                        name: 't3_abc123',
+                        url: '/r/gredice/comments/abc123/test',
+                    },
+                    errors: [],
+                },
+            });
+        },
+    );
+
+    const result = await adapter.publishPost({ title: 'Hi', body: 'body' });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+        assert.equal(result.providerPostId, 'abc123');
+        assert.equal(
+            result.permalink,
+            'https://reddit.com/r/gredice/comments/abc123/test',
+        );
+    }
+    assert.equal(calls.length, 2);
+});
+
+test('publishPost maps subreddit failure into sanitized invalid_destination', async () => {
+    const adapter = new RedditProviderAdapter(
+        {
+            enabled: true,
+            clientId: 'id',
+            clientSecret: 'secret',
+            userAgent: 'ua',
+            defaultDestination: 'gredice',
+            allowedDestinations: new Set(['gredice']),
+        },
+        async (url) => {
+            if (url.toString().includes('access_token')) {
+                return response({ access_token: 'token' });
+            }
+            return response(
+                { json: { errors: [['SUBREDDIT_NOEXIST', 'invalid', 'sr']] } },
+                400,
+            );
+        },
+    );
+
+    const result = await adapter.publishPost({ title: 'Hi' });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+        assert.equal(result.code, 'invalid_destination');
+        assert.equal(result.message.includes('credentials'), false);
+    }
+});

--- a/apps/app/src/social/providers/reddit/redditAdapter.test.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.test.ts
@@ -9,6 +9,21 @@ function response(body: unknown, status = 200): Response {
     });
 }
 
+async function captureWarnings<T>(
+    callback: () => Promise<T>,
+): Promise<{ result: T; warnings: unknown[][] }> {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+        warnings.push(args);
+    };
+    try {
+        return { result: await callback(), warnings };
+    } finally {
+        console.warn = originalWarn;
+    }
+}
+
 test('readRedditEnv builds allowlist and default destination', () => {
     const env = readRedditEnv({
         SOCIAL_PROVIDER_REDDIT_ENABLED: 'true',
@@ -129,12 +144,15 @@ test('publishPost maps submit transport failures into retriable provider_unavail
         },
     );
 
-    const result = await adapter.publishPost({ title: 'Hi' });
+    const { result, warnings } = await captureWarnings(() =>
+        adapter.publishPost({ title: 'Hi' }),
+    );
     expect(result.ok).toBe(false);
     if (!result.ok) {
         expect(result.code).toBe('provider_unavailable');
         expect(result.retriable).toBe(true);
     }
+    expect(warnings).toHaveLength(1);
 });
 
 test('publishPost maps non-JSON submit responses into retriable provider_unavailable', async () => {
@@ -155,10 +173,13 @@ test('publishPost maps non-JSON submit responses into retriable provider_unavail
         },
     );
 
-    const result = await adapter.publishPost({ title: 'Hi' });
+    const { result, warnings } = await captureWarnings(() =>
+        adapter.publishPost({ title: 'Hi' }),
+    );
     expect(result.ok).toBe(false);
     if (!result.ok) {
         expect(result.code).toBe('provider_unavailable');
         expect(result.retriable).toBe(true);
     }
+    expect(warnings).toHaveLength(1);
 });

--- a/apps/app/src/social/providers/reddit/redditAdapter.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.ts
@@ -147,16 +147,17 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
                     body,
                 },
             );
-        } catch {
-            return providerUnavailable('Reddit publish request failed.');
+        } catch (error) {
+            return providerUnavailable('Reddit publish request failed.', error);
         }
 
         let data: RedditSubmitResponse;
         try {
             data = (await response.json()) as RedditSubmitResponse;
-        } catch {
+        } catch (error) {
             return providerUnavailable(
                 'Reddit publish returned an unreadable response.',
+                error,
             );
         }
         const apiErrors = data.json?.errors ?? [];
@@ -211,8 +212,11 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
                     }),
                 },
             );
-        } catch {
-            return providerUnavailable('Reddit authentication request failed.');
+        } catch (error) {
+            return providerUnavailable(
+                'Reddit authentication request failed.',
+                error,
+            );
         }
 
         if (!response.ok) {
@@ -234,9 +238,10 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
         let payload: RedditTokenResponse;
         try {
             payload = (await response.json()) as RedditTokenResponse;
-        } catch {
+        } catch (error) {
             return providerUnavailable(
                 'Reddit authentication returned an unreadable response.',
+                error,
             );
         }
         if (!payload.access_token) {
@@ -297,7 +302,13 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
     }
 }
 
-function providerUnavailable(message: string): SocialPublishError {
+function providerUnavailable(
+    message: string,
+    error?: unknown,
+): SocialPublishError {
+    if (error) {
+        console.warn(message, error);
+    }
     return {
         ok: false,
         code: 'provider_unavailable',

--- a/apps/app/src/social/providers/reddit/redditAdapter.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import type {
     SocialPostInput,
     SocialProviderAdapter,
@@ -59,11 +61,13 @@ export function readRedditEnv(env = process.env): RedditEnv {
 
 export class RedditProviderAdapter implements SocialProviderAdapter {
     readonly name = 'reddit' as const;
+    private readonly config: RedditEnv;
+    private readonly fetchImpl: FetchLike;
 
-    constructor(
-        private readonly config = readRedditEnv(),
-        private readonly fetchImpl: FetchLike = fetch,
-    ) {}
+    constructor(config = readRedditEnv(), fetchImpl: FetchLike = fetch) {
+        this.config = config;
+        this.fetchImpl = fetchImpl;
+    }
 
     validateConfig(): SocialPublishError | null {
         if (!this.config.enabled) {

--- a/apps/app/src/social/providers/reddit/redditAdapter.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import type {
     SocialPostInput,
     SocialProviderAdapter,
@@ -17,6 +15,17 @@ type RedditEnv = {
 };
 
 type FetchLike = typeof fetch;
+
+type RedditSubmitResponse = {
+    json?: {
+        errors?: unknown[][];
+        data?: { id?: string; name?: string; url?: string };
+    };
+};
+
+type RedditTokenResponse = {
+    access_token?: string;
+};
 
 function parseCsvList(value: string): Set<string> {
     return new Set(
@@ -124,25 +133,32 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
             ...(input.url ? { url: input.url } : { text: input.body ?? '' }),
         });
 
-        const response = await this.fetchImpl(
-            'https://oauth.reddit.com/api/submit',
-            {
-                method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${token.accessToken}`,
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'User-Agent': this.config.userAgent,
+        let response: Response;
+        try {
+            response = await this.fetchImpl(
+                'https://oauth.reddit.com/api/submit',
+                {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${token.accessToken}`,
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        'User-Agent': this.config.userAgent,
+                    },
+                    body,
                 },
-                body,
-            },
-        );
+            );
+        } catch {
+            return providerUnavailable('Reddit publish request failed.');
+        }
 
-        const data = (await response.json()) as {
-            json?: {
-                errors?: unknown[][];
-                data?: { id?: string; name?: string; url?: string };
-            };
-        };
+        let data: RedditSubmitResponse;
+        try {
+            data = (await response.json()) as RedditSubmitResponse;
+        } catch {
+            return providerUnavailable(
+                'Reddit publish returned an unreadable response.',
+            );
+        }
         const apiErrors = data.json?.errors ?? [];
         if (!response.ok || apiErrors.length > 0) {
             return this.mapSubmitError(response.status, apiErrors);
@@ -179,18 +195,25 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
         const credentials = Buffer.from(
             `${this.config.clientId}:${this.config.clientSecret}`,
         ).toString('base64');
-        const response = await this.fetchImpl(
-            'https://www.reddit.com/api/v1/access_token',
-            {
-                method: 'POST',
-                headers: {
-                    Authorization: `Basic ${credentials}`,
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'User-Agent': this.config.userAgent,
+        let response: Response;
+        try {
+            response = await this.fetchImpl(
+                'https://www.reddit.com/api/v1/access_token',
+                {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Basic ${credentials}`,
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        'User-Agent': this.config.userAgent,
+                    },
+                    body: new URLSearchParams({
+                        grant_type: 'client_credentials',
+                    }),
                 },
-                body: new URLSearchParams({ grant_type: 'client_credentials' }),
-            },
-        );
+            );
+        } catch {
+            return providerUnavailable('Reddit authentication request failed.');
+        }
 
         if (!response.ok) {
             return response.status === 401 || response.status === 403
@@ -208,7 +231,14 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
                   };
         }
 
-        const payload = (await response.json()) as { access_token?: string };
+        let payload: RedditTokenResponse;
+        try {
+            payload = (await response.json()) as RedditTokenResponse;
+        } catch {
+            return providerUnavailable(
+                'Reddit authentication returned an unreadable response.',
+            );
+        }
         if (!payload.access_token) {
             return {
                 ok: false,
@@ -265,4 +295,13 @@ export class RedditProviderAdapter implements SocialProviderAdapter {
             retriable: false,
         };
     }
+}
+
+function providerUnavailable(message: string): SocialPublishError {
+    return {
+        ok: false,
+        code: 'provider_unavailable',
+        message,
+        retriable: true,
+    };
 }

--- a/apps/app/src/social/providers/reddit/redditAdapter.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.ts
@@ -1,0 +1,268 @@
+import 'server-only';
+
+import type {
+    SocialPostInput,
+    SocialProviderAdapter,
+    SocialPublishError,
+    SocialPublishResult,
+} from '../types';
+
+type RedditEnv = {
+    enabled: boolean;
+    clientId: string;
+    clientSecret: string;
+    userAgent: string;
+    defaultDestination: string;
+    allowedDestinations: Set<string>;
+};
+
+type FetchLike = typeof fetch;
+
+function parseCsvList(value: string): Set<string> {
+    return new Set(
+        value
+            .split(',')
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+    );
+}
+
+export function readRedditEnv(env = process.env): RedditEnv {
+    const defaultDestination = (
+        env.SOCIAL_PROVIDER_REDDIT_DEFAULT_DESTINATION ?? ''
+    ).trim();
+    const allowed = parseCsvList(
+        env.SOCIAL_PROVIDER_REDDIT_ALLOWED_DESTINATIONS ?? '',
+    );
+    if (defaultDestination) {
+        allowed.add(defaultDestination);
+    }
+
+    return {
+        enabled: (env.SOCIAL_PROVIDER_REDDIT_ENABLED ?? 'false') === 'true',
+        clientId: (env.SOCIAL_PROVIDER_REDDIT_CLIENT_ID ?? '').trim(),
+        clientSecret: (env.SOCIAL_PROVIDER_REDDIT_CLIENT_SECRET ?? '').trim(),
+        userAgent: (env.SOCIAL_PROVIDER_REDDIT_USER_AGENT ?? '').trim(),
+        defaultDestination,
+        allowedDestinations: allowed,
+    };
+}
+
+export class RedditProviderAdapter implements SocialProviderAdapter {
+    readonly name = 'reddit' as const;
+
+    constructor(
+        private readonly config = readRedditEnv(),
+        private readonly fetchImpl: FetchLike = fetch,
+    ) {}
+
+    validateConfig(): SocialPublishError | null {
+        if (!this.config.enabled) {
+            return {
+                ok: false,
+                code: 'provider_disabled',
+                message: 'Reddit provider is disabled.',
+                retriable: false,
+            };
+        }
+        if (
+            !this.config.clientId ||
+            !this.config.clientSecret ||
+            !this.config.userAgent
+        ) {
+            return {
+                ok: false,
+                code: 'missing_credentials',
+                message: 'Reddit provider credentials are missing.',
+                retriable: false,
+            };
+        }
+        if (!this.config.defaultDestination) {
+            return {
+                ok: false,
+                code: 'invalid_destination',
+                message: 'Reddit default destination is not configured.',
+                retriable: false,
+            };
+        }
+        if (!this.config.allowedDestinations.size) {
+            return {
+                ok: false,
+                code: 'invalid_destination',
+                message: 'Reddit destination allowlist is empty.',
+                retriable: false,
+            };
+        }
+        return null;
+    }
+
+    async publishPost(input: SocialPostInput): Promise<SocialPublishResult> {
+        const configError = this.validateConfig();
+        if (configError) return configError;
+
+        const destination = (
+            input.destination ?? this.config.defaultDestination
+        ).replace(/^r\//, '');
+        if (!this.config.allowedDestinations.has(destination)) {
+            return {
+                ok: false,
+                code: 'invalid_destination',
+                message: 'Destination subreddit is not allowed.',
+                retriable: false,
+            };
+        }
+
+        const token = await this.getAccessToken();
+        if (!token.ok) return token;
+
+        const kind = input.url ? 'link' : 'self';
+        const body = new URLSearchParams({
+            api_type: 'json',
+            kind,
+            sr: destination,
+            title: input.title,
+            ...(input.url ? { url: input.url } : { text: input.body ?? '' }),
+        });
+
+        const response = await this.fetchImpl(
+            'https://oauth.reddit.com/api/submit',
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${token.accessToken}`,
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'User-Agent': this.config.userAgent,
+                },
+                body,
+            },
+        );
+
+        const data = (await response.json()) as {
+            json?: {
+                errors?: unknown[][];
+                data?: { id?: string; name?: string; url?: string };
+            };
+        };
+        const apiErrors = data.json?.errors ?? [];
+        if (!response.ok || apiErrors.length > 0) {
+            return this.mapSubmitError(response.status, apiErrors);
+        }
+
+        const id = data.json?.data?.id;
+        const permalink = data.json?.data?.url;
+        if (!id || !permalink) {
+            return {
+                ok: false,
+                code: 'provider_unavailable',
+                message: 'Reddit publish succeeded without post metadata.',
+                retriable: true,
+            };
+        }
+
+        return {
+            ok: true,
+            providerPostId: id,
+            permalink: permalink.startsWith('http')
+                ? permalink
+                : `https://reddit.com${permalink}`,
+            metadata: {
+                destination,
+                name: data.json?.data?.name ?? null,
+                kind,
+            },
+        };
+    }
+
+    private async getAccessToken(): Promise<
+        { ok: true; accessToken: string } | SocialPublishError
+    > {
+        const credentials = Buffer.from(
+            `${this.config.clientId}:${this.config.clientSecret}`,
+        ).toString('base64');
+        const response = await this.fetchImpl(
+            'https://www.reddit.com/api/v1/access_token',
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `Basic ${credentials}`,
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'User-Agent': this.config.userAgent,
+                },
+                body: new URLSearchParams({ grant_type: 'client_credentials' }),
+            },
+        );
+
+        if (!response.ok) {
+            return response.status === 401 || response.status === 403
+                ? {
+                      ok: false,
+                      code: 'auth_failed',
+                      message: 'Reddit authentication failed.',
+                      retriable: false,
+                  }
+                : {
+                      ok: false,
+                      code: 'provider_unavailable',
+                      message: 'Reddit authentication is unavailable.',
+                      retriable: true,
+                  };
+        }
+
+        const payload = (await response.json()) as { access_token?: string };
+        if (!payload.access_token) {
+            return {
+                ok: false,
+                code: 'provider_unavailable',
+                message: 'Reddit authentication returned an empty token.',
+                retriable: true,
+            };
+        }
+
+        return { ok: true, accessToken: payload.access_token };
+    }
+
+    private mapSubmitError(
+        status: number,
+        errors: unknown[][],
+    ): SocialPublishError {
+        if (status === 401 || status === 403)
+            return {
+                ok: false,
+                code: 'auth_failed',
+                message: 'Reddit rejected provider authentication.',
+                retriable: false,
+            };
+        if (status === 429)
+            return {
+                ok: false,
+                code: 'rate_limited',
+                message: 'Reddit rate limit reached. Try again later.',
+                retriable: true,
+            };
+        const firstError = errors[0]?.[0];
+        if (
+            typeof firstError === 'string' &&
+            firstError.toUpperCase().includes('SUBREDDIT')
+        ) {
+            return {
+                ok: false,
+                code: 'invalid_destination',
+                message: 'Reddit destination subreddit is not permitted.',
+                retriable: false,
+            };
+        }
+        if (status >= 500)
+            return {
+                ok: false,
+                code: 'provider_unavailable',
+                message: 'Reddit is temporarily unavailable.',
+                retriable: true,
+            };
+        return {
+            ok: false,
+            code: 'invalid_request',
+            message: 'Reddit rejected the post payload.',
+            retriable: false,
+        };
+    }
+}

--- a/apps/app/src/social/providers/reddit/redditAdapter.unit.ts
+++ b/apps/app/src/social/providers/reddit/redditAdapter.unit.ts
@@ -1,6 +1,7 @@
-import { expect, test } from '@playwright/test';
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
-import { RedditProviderAdapter, readRedditEnv } from './redditAdapter';
+import { RedditProviderAdapter, readRedditEnv } from './redditAdapter.ts';
 
 function response(body: unknown, status = 200): Response {
     return new Response(JSON.stringify(body), {
@@ -34,9 +35,9 @@ test('readRedditEnv builds allowlist and default destination', () => {
         SOCIAL_PROVIDER_REDDIT_ALLOWED_DESTINATIONS: 'gardening, gredice',
     });
 
-    expect(env.enabled).toBe(true);
-    expect(env.allowedDestinations.has('gredice')).toBe(true);
-    expect(env.allowedDestinations.has('gardening')).toBe(true);
+    assert.equal(env.enabled, true);
+    assert.equal(env.allowedDestinations.has('gredice'), true);
+    assert.equal(env.allowedDestinations.has('gardening'), true);
 });
 
 test('publishPost returns operational error when missing credentials', async () => {
@@ -53,8 +54,8 @@ test('publishPost returns operational error when missing credentials', async () 
     );
 
     const result = await adapter.publishPost({ title: 'Hello' });
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe('missing_credentials');
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.code, 'missing_credentials');
 });
 
 test('publishPost submits text post and normalizes success', async () => {
@@ -87,14 +88,15 @@ test('publishPost submits text post and normalizes success', async () => {
     );
 
     const result = await adapter.publishPost({ title: 'Hi', body: 'body' });
-    expect(result.ok).toBe(true);
+    assert.equal(result.ok, true);
     if (result.ok) {
-        expect(result.providerPostId).toBe('abc123');
-        expect(result.permalink).toBe(
+        assert.equal(result.providerPostId, 'abc123');
+        assert.equal(
+            result.permalink,
             'https://reddit.com/r/gredice/comments/abc123/test',
         );
     }
-    expect(calls).toHaveLength(2);
+    assert.equal(calls.length, 2);
 });
 
 test('publishPost maps subreddit failure into sanitized invalid_destination', async () => {
@@ -119,10 +121,10 @@ test('publishPost maps subreddit failure into sanitized invalid_destination', as
     );
 
     const result = await adapter.publishPost({ title: 'Hi' });
-    expect(result.ok).toBe(false);
+    assert.equal(result.ok, false);
     if (!result.ok) {
-        expect(result.code).toBe('invalid_destination');
-        expect(result.message.includes('credentials')).toBe(false);
+        assert.equal(result.code, 'invalid_destination');
+        assert.equal(result.message.includes('credentials'), false);
     }
 });
 
@@ -147,12 +149,12 @@ test('publishPost maps submit transport failures into retriable provider_unavail
     const { result, warnings } = await captureWarnings(() =>
         adapter.publishPost({ title: 'Hi' }),
     );
-    expect(result.ok).toBe(false);
+    assert.equal(result.ok, false);
     if (!result.ok) {
-        expect(result.code).toBe('provider_unavailable');
-        expect(result.retriable).toBe(true);
+        assert.equal(result.code, 'provider_unavailable');
+        assert.equal(result.retriable, true);
     }
-    expect(warnings).toHaveLength(1);
+    assert.equal(warnings.length, 1);
 });
 
 test('publishPost maps non-JSON submit responses into retriable provider_unavailable', async () => {
@@ -176,10 +178,10 @@ test('publishPost maps non-JSON submit responses into retriable provider_unavail
     const { result, warnings } = await captureWarnings(() =>
         adapter.publishPost({ title: 'Hi' }),
     );
-    expect(result.ok).toBe(false);
+    assert.equal(result.ok, false);
     if (!result.ok) {
-        expect(result.code).toBe('provider_unavailable');
-        expect(result.retriable).toBe(true);
+        assert.equal(result.code, 'provider_unavailable');
+        assert.equal(result.retriable, true);
     }
-    expect(warnings).toHaveLength(1);
+    assert.equal(warnings.length, 1);
 });

--- a/apps/app/src/social/providers/types.ts
+++ b/apps/app/src/social/providers/types.ts
@@ -1,0 +1,41 @@
+export type SocialProviderName = 'reddit';
+
+export type SocialPostInput = {
+    title: string;
+    body?: string;
+    url?: string;
+    destination?: string;
+};
+
+export type SocialPublishSuccess = {
+    ok: true;
+    providerPostId: string;
+    permalink: string;
+    metadata?: Record<string, unknown>;
+};
+
+export type SocialPublishErrorCode =
+    | 'provider_disabled'
+    | 'missing_credentials'
+    | 'invalid_destination'
+    | 'auth_failed'
+    | 'rate_limited'
+    | 'invalid_request'
+    | 'provider_unavailable'
+    | 'unknown_error';
+
+export type SocialPublishError = {
+    ok: false;
+    code: SocialPublishErrorCode;
+    message: string;
+    retriable: boolean;
+    details?: Record<string, unknown>;
+};
+
+export type SocialPublishResult = SocialPublishSuccess | SocialPublishError;
+
+export interface SocialProviderAdapter {
+    readonly name: SocialProviderName;
+    validateConfig(): SocialPublishError | null;
+    publishPost(input: SocialPostInput): Promise<SocialPublishResult>;
+}


### PR DESCRIPTION
### Motivation
- Introduce a small server-only provider adapter boundary so apps/app can publish social posts without exposing platform credentials to the browser. 
- Ship Reddit as the first provider behind that boundary to validate the contract for immediate publishes (no scheduling). 
- Provide a narrow, provider-neutral surface that future providers can implement without changing the storage lifecycle shape. 

### Description
- Add a typed provider contract and shared types in `apps/app/src/social/providers/types.ts` that define `SocialPostInput`, normalized `SocialPublishResult`, error codes, and the `SocialProviderAdapter` interface. 
- Implement `RedditProviderAdapter` in `apps/app/src/social/providers/reddit/redditAdapter.ts` which reads server-only env config, validates credentials and allowlist/default destination, obtains an OAuth token, submits `self` or `link` posts to Reddit `/api/submit`, and normalizes success and sanitized failure shapes. 
- Add a provider factory entrypoint `createSocialProviderAdapter` in `apps/app/src/social/providers/index.ts` to resolve adapters by provider name and keep the boundary narrow. 
- Add focused unit tests in `apps/app/src/social/providers/reddit/redditAdapter.test.ts` that mock the HTTP/fetch layer to cover env parsing, missing credentials, success normalization, and subreddit failure mapping (no live Reddit dependency). 

### Testing
- Ran `pnpm lint --filter app` and it completed successfully (lint warnings fixed where applicable). 
- Ran `pnpm build --filter app` and the Next.js build completed successfully. 
- Ran `node --test apps/app/src/social/providers/reddit/redditAdapter.test.ts` which failed in this environment because Node does not run the TypeScript test file directly (module resolution/TS loader issue); the tests are present and use mocked fetch responses and should run under the repository's TypeScript-aware test runner/CI configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04339bc99c832f9e34a64b9bb45fff)