### PR TITLE
[WWW] Add GRE-338 llms.txt deployment validation log

### DIFF
--- a/docs/llms-txt-validation.md
+++ b/docs/llms-txt-validation.md
@@ -1,0 +1,54 @@
+# [WWW] llms.txt deployment validation log (GRE-338)
+
+_Last updated: May 13, 2026_
+
+This document captures deployment validation evidence for `llms.txt` and `llms-full.txt` in preview and production, plus crawler-policy compatibility checks tied to GRE-267.
+
+## Validation matrix
+
+| Environment | URL | Expected | Result | Notes |
+| --- | --- | --- | --- | --- |
+| Preview | `<preview-domain>/llms.txt` | `200` plain text | ⚠️ Blocked in agent environment | Preview host URL was not available in Linear issue context, and direct outbound `curl` to public hosts from this execution environment returned `403` at the proxy layer. |
+| Preview | `<preview-domain>/llms-full.txt` | `200` plain text | ⚠️ Blocked in agent environment | Same limitation as above. |
+| Production | `https://www.gredice.com/llms.txt` | `200` plain text | ⚠️ Blocked in agent environment | Direct outbound `curl` returned `403 Forbidden` before origin response, so response headers/body could not be validated from this runtime. |
+| Production | `https://www.gredice.com/llms-full.txt` | `200` plain text | ⚠️ Blocked in agent environment | Same limitation as above. |
+
+## Repository-level verification performed
+
+Although external host validation is blocked from this runtime, repository inspection confirms the deployed behavior intended by GRE-338:
+
+- `apps/www/app/llms.txt/route.ts` returns a plain-text response with explicit `Content-Type: text/plain; charset=utf-8` and cache headers.
+- `apps/www/app/llms-full.txt/route.ts` re-exports the same `GET` handler as `llms.txt`, so both endpoints currently serve identical plain-text content.
+- All links embedded in the current file content are absolute canonical URLs on `https://www.gredice.com/...` except the explicitly optional non-www public service hosts (`vrt.gredice.com`, `status.gredice.com`) that are intentional.
+
+## Crawler/robots policy coordination (GRE-267)
+
+- This validation task should be completed with a network-capable runner to confirm robots interactions live at:
+  - `https://www.gredice.com/robots.txt`
+  - `https://www.gredice.com/sitemap.xml`
+- Any required policy update should be tracked as a linked follow-up under GRE-267.
+
+## Follow-up execution plan
+
+Run these commands from a network environment that can reach production and preview hosts directly:
+
+```bash
+curl -i https://www.gredice.com/llms.txt
+curl -i https://www.gredice.com/llms-full.txt
+curl -i https://www.gredice.com/robots.txt
+curl -i https://www.gredice.com/sitemap.xml
+
+# Repeat for the preview deployment URL
+a=
+
+curl -i "${a}/llms.txt"
+curl -i "${a}/llms-full.txt"
+```
+
+Record:
+
+- HTTP status codes
+- `Content-Type`
+- caching headers
+- any redirect chain/canonical host normalization
+- whether robots policy would block intended crawler access


### PR DESCRIPTION
### Motivation
- Record deployed validation evidence for GRE-338 so preview and production `llms.txt` / `llms-full.txt` checks, crawler-policy coordination with GRE-267, and required follow-up actions are captured in-repo and can be executed from a network-capable runner.

### Description
- Add `docs/llms-txt-validation.md` which includes a validation matrix for preview and production, repository-level verification notes (pointing to `apps/www/app/llms.txt/route.ts` and the `llms-full.txt` re-export), crawler/robots coordination guidance, and a concrete `curl` checklist for live verification.

### Testing
- Ran `rg "llms" -n apps/www` and `sed -n '1,220p' apps/www/app/llms.txt/route.ts` (succeeded), attempted the `curl` matrix against production which was blocked by a proxy-level `403 Forbidden` in this agent environment, and committed the new file with `git` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047e00db08832fac346bf31b1c1daf)