### PR TITLE
[CMS] Redesign page editor inspector and field controls

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -538,6 +538,9 @@ export function CmsPageForm({
                                                 rawMode ? 'solid' : 'outlined'
                                             }
                                             onClick={() => {
+                                                if (rawMode) {
+                                                    return;
+                                                }
                                                 setRawMode(true);
                                                 setRawError(null);
                                                 setRawContent(builderContent);

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -195,6 +195,21 @@ function validateSection(section: CmsPageEditableSection) {
         .map((field) => `${field.label} je obavezno polje.`);
 }
 
+function sectionFieldErrors(section: CmsPageEditableSection) {
+    const fields =
+        cmsPageSectionComponentsByName.get(section.data.component)?.fields ??
+        [];
+
+    return new Map(
+        fields
+            .filter((field) => field.required)
+            .filter(
+                (field) => sectionValue(section, field.key).trim().length === 0,
+            )
+            .map((field) => [field.key, `${field.label} je obavezno polje.`]),
+    );
+}
+
 function updateSectionField(
     sectionId: string,
     key: string,
@@ -360,6 +375,9 @@ export function CmsPageForm({
     const selectedSection = sections.find(
         (section) => section.id === selectedSectionId,
     );
+    const selectedSectionErrors = selectedSection
+        ? sectionFieldErrors(selectedSection)
+        : new Map<string, string>();
     const selectedSectionIndex = selectedSectionId
         ? sections.findIndex((section) => section.id === selectedSectionId)
         : -1;
@@ -504,25 +522,30 @@ export function CmsPageForm({
                                         Vizualni editor je zadani način rada, a
                                         JSON editor je dostupan kao fallback.
                                     </Typography>
-                                    <label className="flex items-center gap-2 text-sm">
-                                        <input
-                                            type="checkbox"
-                                            checked={rawMode}
-                                            onChange={(event) => {
-                                                const enabled =
-                                                    event.target.checked;
-                                                setRawMode(enabled);
+                                    <Row spacing={2}>
+                                        <Button
+                                            type="button"
+                                            variant={
+                                                !rawMode ? 'solid' : 'outlined'
+                                            }
+                                            onClick={() => setRawMode(false)}
+                                        >
+                                            Vizualni editor
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant={
+                                                rawMode ? 'solid' : 'outlined'
+                                            }
+                                            onClick={() => {
+                                                setRawMode(true);
                                                 setRawError(null);
-                                                if (enabled) {
-                                                    setRawContent(
-                                                        builderContent,
-                                                    );
-                                                }
+                                                setRawContent(builderContent);
                                             }}
-                                        />
-                                        Uredi sadržaj kroz JSON editor
-                                        (fallback)
-                                    </label>
+                                        >
+                                            JSON fallback
+                                        </Button>
+                                    </Row>
                                     {preserveFallbackContent && (
                                         <Card className="p-3 text-sm text-amber-700">
                                             Postojeći sadržaj nije moguće
@@ -739,110 +762,6 @@ export function CmsPageForm({
                                                                 </Button>
                                                             </Row>
                                                         </Row>
-                                                        {(
-                                                            cmsPageSectionComponentsByName.get(
-                                                                section.data
-                                                                    .component,
-                                                            )?.fields ?? []
-                                                        ).map((field) =>
-                                                            field.type ===
-                                                            'textarea' ? (
-                                                                <label
-                                                                    key={
-                                                                        field.key
-                                                                    }
-                                                                    className="space-y-1"
-                                                                >
-                                                                    <span className="block text-sm font-medium">
-                                                                        {
-                                                                            field.label
-                                                                        }
-                                                                    </span>
-                                                                    <textarea
-                                                                        value={sectionValue(
-                                                                            section,
-                                                                            field.key,
-                                                                        )}
-                                                                        rows={
-                                                                            field.rows ??
-                                                                            4
-                                                                        }
-                                                                        className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                                        onChange={(
-                                                                            event,
-                                                                        ) => {
-                                                                            const value =
-                                                                                event
-                                                                                    .target
-                                                                                    .value;
-                                                                            setSections(
-                                                                                (
-                                                                                    current,
-                                                                                ) =>
-                                                                                    current.map(
-                                                                                        (
-                                                                                            currentSection,
-                                                                                        ) =>
-                                                                                            currentSection.id ===
-                                                                                            section.id
-                                                                                                ? {
-                                                                                                      ...currentSection,
-                                                                                                      data: {
-                                                                                                          ...currentSection.data,
-                                                                                                          [field.key]:
-                                                                                                              value,
-                                                                                                      },
-                                                                                                  }
-                                                                                                : currentSection,
-                                                                                    ),
-                                                                            );
-                                                                        }}
-                                                                    />
-                                                                </label>
-                                                            ) : (
-                                                                <Input
-                                                                    key={
-                                                                        field.key
-                                                                    }
-                                                                    label={
-                                                                        field.label
-                                                                    }
-                                                                    value={sectionValue(
-                                                                        section,
-                                                                        field.key,
-                                                                    )}
-                                                                    onChange={(
-                                                                        event,
-                                                                    ) => {
-                                                                        const value =
-                                                                            event
-                                                                                .target
-                                                                                .value;
-                                                                        setSections(
-                                                                            (
-                                                                                current,
-                                                                            ) =>
-                                                                                current.map(
-                                                                                    (
-                                                                                        currentSection,
-                                                                                    ) =>
-                                                                                        currentSection.id ===
-                                                                                        section.id
-                                                                                            ? {
-                                                                                                  ...currentSection,
-                                                                                                  data: {
-                                                                                                      ...currentSection.data,
-                                                                                                      [field.key]:
-                                                                                                          value,
-                                                                                                  },
-                                                                                              }
-                                                                                            : currentSection,
-                                                                                ),
-                                                                        );
-                                                                    }}
-                                                                />
-                                                            ),
-                                                        )}
                                                         {validateSection(
                                                             section,
                                                         ).map((error) => (
@@ -1102,6 +1021,12 @@ export function CmsPageForm({
                                                                         {
                                                                             field.label
                                                                         }
+                                                                        {field.required && (
+                                                                            <span className="text-red-600">
+                                                                                {' '}
+                                                                                *
+                                                                            </span>
+                                                                        )}
                                                                     </span>
                                                                     <textarea
                                                                         value={sectionValue(
@@ -1126,33 +1051,70 @@ export function CmsPageForm({
                                                                             )
                                                                         }
                                                                     />
+                                                                    {selectedSectionErrors.has(
+                                                                        field.key,
+                                                                    ) && (
+                                                                        <Typography
+                                                                            level="body3"
+                                                                            className="text-red-600"
+                                                                        >
+                                                                            {selectedSectionErrors.get(
+                                                                                field.key,
+                                                                            )}
+                                                                        </Typography>
+                                                                    )}
                                                                 </label>
                                                             ) : (
-                                                                <Input
+                                                                <Stack
                                                                     key={
                                                                         field.key
                                                                     }
-                                                                    label={
-                                                                        field.label
-                                                                    }
-                                                                    value={sectionValue(
-                                                                        selectedSection,
-                                                                        field.key,
-                                                                    )}
-                                                                    onChange={(
-                                                                        event,
-                                                                    ) =>
-                                                                        updateSectionField(
-                                                                            selectedSection.id,
+                                                                    spacing={1}
+                                                                >
+                                                                    <Input
+                                                                        label={`${field.label}${field.required ? ' *' : ''}`}
+                                                                        value={sectionValue(
+                                                                            selectedSection,
                                                                             field.key,
-                                                                            event
-                                                                                .target
-                                                                                .value,
-                                                                            setSections,
-                                                                        )
-                                                                    }
-                                                                />
+                                                                        )}
+                                                                        onChange={(
+                                                                            event,
+                                                                        ) =>
+                                                                            updateSectionField(
+                                                                                selectedSection.id,
+                                                                                field.key,
+                                                                                event
+                                                                                    .target
+                                                                                    .value,
+                                                                                setSections,
+                                                                            )
+                                                                        }
+                                                                    />
+                                                                    {selectedSectionErrors.has(
+                                                                        field.key,
+                                                                    ) && (
+                                                                        <Typography
+                                                                            level="body3"
+                                                                            className="text-red-600"
+                                                                        >
+                                                                            {selectedSectionErrors.get(
+                                                                                field.key,
+                                                                            )}
+                                                                        </Typography>
+                                                                    )}
+                                                                </Stack>
                                                             ),
+                                                        )}
+                                                        {selectedSectionErrors.size >
+                                                            0 && (
+                                                            <Typography
+                                                                level="body3"
+                                                                className="text-red-600"
+                                                            >
+                                                                Sekcija ima
+                                                                nepopunjena
+                                                                obavezna polja.
+                                                            </Typography>
                                                         )}
                                                     </>
                                                 )}
@@ -1163,39 +1125,51 @@ export function CmsPageForm({
                             </Stack>
 
                             <Stack spacing={3}>
-                                <Typography level="h3" semiBold>
-                                    Metadata
-                                </Typography>
-                                <Input
-                                    name="metaTitle"
-                                    label="Meta naslov"
-                                    defaultValue={page?.metaTitle ?? ''}
-                                />
-                                <Input
-                                    name="metaDescription"
-                                    label="Meta opis"
-                                    defaultValue={page?.metaDescription ?? ''}
-                                />
-                                <Input
-                                    name="metaImageUrl"
-                                    label="Meta slika URL"
-                                    type="url"
-                                    defaultValue={page?.metaImageUrl ?? ''}
-                                />
-                                <Input
-                                    name="canonicalPath"
-                                    label="Canonical putanja"
-                                    defaultValue={page?.canonicalPath ?? ''}
-                                    placeholder="/primjer-stranice"
-                                />
-                                <label className="flex items-center gap-2 text-sm">
-                                    <input
-                                        type="checkbox"
-                                        name="noIndex"
-                                        defaultChecked={page?.noIndex ?? false}
-                                    />
-                                    Isključi iz indeksiranja (noindex)
-                                </label>
+                                <Card className="p-4">
+                                    <Stack spacing={2}>
+                                        <Typography level="h3" semiBold>
+                                            Metadata
+                                        </Typography>
+                                        <Input
+                                            name="metaTitle"
+                                            label="Meta naslov"
+                                            defaultValue={page?.metaTitle ?? ''}
+                                        />
+                                        <Input
+                                            name="metaDescription"
+                                            label="Meta opis"
+                                            defaultValue={
+                                                page?.metaDescription ?? ''
+                                            }
+                                        />
+                                        <Input
+                                            name="metaImageUrl"
+                                            label="Meta slika URL"
+                                            type="url"
+                                            defaultValue={
+                                                page?.metaImageUrl ?? ''
+                                            }
+                                        />
+                                        <Input
+                                            name="canonicalPath"
+                                            label="Canonical putanja"
+                                            defaultValue={
+                                                page?.canonicalPath ?? ''
+                                            }
+                                            placeholder="/primjer-stranice"
+                                        />
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="checkbox"
+                                                name="noIndex"
+                                                defaultChecked={
+                                                    page?.noIndex ?? false
+                                                }
+                                            />
+                                            Isključi iz indeksiranja (noindex)
+                                        </label>
+                                    </Stack>
+                                </Card>
                             </Stack>
 
                             {state?.message && (


### PR DESCRIPTION
### Motivation
- Concentrate section attribute editing into the right-side inspector so the visual editor is the primary editing surface and users don't need to scan the entire page to find controls. 
- Improve validation and required-field affordances so editors see errors inline in the inspector and section-level invalid state remains visible. 
- Make JSON fallback and metadata editing discoverable without dominating the default visual authoring workflow.

### Description
- Make the inspector the primary place for editing section fields and remove duplicated per-field editors from section cards in the canvas/list area by rendering fields only in the right-side `Postavke sekcije` panel. 
- Replace the prominent JSON checkbox with explicit mode buttons (`Vizualni editor` / `JSON fallback`) and preserve the fallback flow via the existing `rawMode`/`rawContent` state. 
- Add `sectionFieldErrors` and wire `selectedSectionErrors` to show per-field inline required markers and validation messages, and keep section-level validation summaries visible when the selected section has errors. 
- Move page metadata inputs into a dedicated `Card` panel to make metadata discoverable and separate from section controls. 

### Testing
- Ran `pnpm lint --filter app` which completed successfully while reporting unrelated pre-existing warnings in the workspace. 
- Ran `pnpm --filter app exec biome check app/admin/cms/pages/CmsPageForm.tsx` which passed for the modified file. 
- Ran `pnpm test --filter app` but the Playwright test step failed in this environment due to a `config.webServer` timeout (web server did not start before the test timeout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047dde00cc832fbce81930b922b209)