### PR TITLE
[CMS] Polish page editor preview, autosave, and publish readiness flow

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -316,12 +316,7 @@ export function CmsPageForm({
         return rawReadinessContent.isStructured
             ? editableSections(rawReadinessContent.sections)
             : [];
-    }, [
-        rawMode,
-        rawReadinessContent.isStructured,
-        rawReadinessContent.sections,
-        sections,
-    ]);
+    }, [rawMode, rawReadinessContent, sections]);
     const contentReadinessWarning =
         rawMode &&
         rawContent.trim().length > 0 &&

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -265,6 +265,10 @@ export function CmsPageForm({
     const [rawMode, setRawMode] = useState(preserveFallbackContent);
     const [rawContent, setRawContent] = useState(page?.content ?? '');
     const [rawError, setRawError] = useState<string | null>(null);
+    const [metaTitle, setMetaTitle] = useState(page?.metaTitle ?? '');
+    const [metaDescription, setMetaDescription] = useState(
+        page?.metaDescription ?? '',
+    );
     const builderContent = useMemo(
         () => stringifySections(sections),
         [sections],
@@ -300,6 +304,21 @@ export function CmsPageForm({
     const [previewViewport, setPreviewViewport] = useState<
         'mobile' | 'tablet' | 'desktop'
     >('desktop');
+    const rawReadinessContent = useMemo(
+        () => parseSections(rawContent),
+        [rawContent],
+    );
+    const readinessSections = useMemo(
+        () =>
+            rawMode ? editableSections(rawReadinessContent.sections) : sections,
+        [rawMode, rawReadinessContent.sections, sections],
+    );
+    const contentReadinessWarning =
+        rawMode &&
+        rawContent.trim().length > 0 &&
+        !rawReadinessContent.isStructured
+            ? 'JSON fallback mora biti JSON niz sekcija za provjeru obaveznih polja.'
+            : null;
 
     const selectSection = (sectionId: string) => {
         setInsertAtEnd(false);
@@ -424,7 +443,7 @@ export function CmsPageForm({
         }
         return grouped;
     }, [filteredSectionItems]);
-    const missingSectionFields = sections
+    const missingSectionFields = readinessSections
         .map((section, index) => ({
             section,
             index,
@@ -434,11 +453,11 @@ export function CmsPageForm({
     const metadataWarnings = [
         {
             label: 'Meta naslov',
-            value: page?.metaTitle ?? '',
+            value: metaTitle,
         },
         {
             label: 'Meta opis',
-            value: page?.metaDescription ?? '',
+            value: metaDescription,
         },
     ].filter((entry) => entry.value.trim().length === 0);
     const autosaveBadgeClassName =
@@ -1299,7 +1318,8 @@ export function CmsPageForm({
                                             Publish readiness
                                         </Typography>
                                         {missingSectionFields.length === 0 &&
-                                        metadataWarnings.length === 0 ? (
+                                        metadataWarnings.length === 0 &&
+                                        !contentReadinessWarning ? (
                                             <Typography
                                                 level="body3"
                                                 className="text-emerald-500"
@@ -1308,6 +1328,16 @@ export function CmsPageForm({
                                             </Typography>
                                         ) : (
                                             <Stack spacing={1}>
+                                                {contentReadinessWarning && (
+                                                    <Typography
+                                                        level="body3"
+                                                        className="text-amber-500"
+                                                    >
+                                                        {
+                                                            contentReadinessWarning
+                                                        }
+                                                    </Typography>
+                                                )}
                                                 {missingSectionFields.map(
                                                     (entry) => (
                                                         <Typography
@@ -1353,13 +1383,19 @@ export function CmsPageForm({
                                         <Input
                                             name="metaTitle"
                                             label="Meta naslov"
-                                            defaultValue={page?.metaTitle ?? ''}
+                                            value={metaTitle}
+                                            onChange={(event) =>
+                                                setMetaTitle(event.target.value)
+                                            }
                                         />
                                         <Input
                                             name="metaDescription"
                                             label="Meta opis"
-                                            defaultValue={
-                                                page?.metaDescription ?? ''
+                                            value={metaDescription}
+                                            onChange={(event) =>
+                                                setMetaDescription(
+                                                    event.target.value,
+                                                )
                                             }
                                         />
                                         <Input

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -210,6 +210,15 @@ function sectionFieldErrors(section: CmsPageEditableSection) {
     );
 }
 
+function formatLastSavedAt(value: number | null) {
+    if (!value) return null;
+    return new Intl.DateTimeFormat('hr-HR', {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+    }).format(new Date(value));
+}
+
 function updateSectionField(
     sectionId: string,
     key: string,
@@ -274,6 +283,7 @@ export function CmsPageForm({
     const latestAutosaveSnapshot = useRef(autosaveSnapshot);
     const [autosaveStatus, setAutosaveStatus] = useState('saved');
     const [autosaveMessage, setAutosaveMessage] = useState<string | null>(null);
+    const [lastSavedAt, setLastSavedAt] = useState<number | null>(Date.now());
     const [lastSavedSnapshot, setLastSavedSnapshot] =
         useState(autosaveSnapshot);
     const [previewSections, setPreviewSections] = useState<
@@ -284,6 +294,12 @@ export function CmsPageForm({
     );
     const [insertAtEnd, setInsertAtEnd] = useState(false);
     const [sectionSearch, setSectionSearch] = useState('');
+    const [previewMode, setPreviewMode] = useState<'inline' | 'focused'>(
+        'inline',
+    );
+    const [previewViewport, setPreviewViewport] = useState<
+        'mobile' | 'tablet' | 'desktop'
+    >('desktop');
 
     const selectSection = (sectionId: string) => {
         setInsertAtEnd(false);
@@ -336,6 +352,7 @@ export function CmsPageForm({
             setAutosaveStatus('saved');
             setAutosaveMessage(result.message);
             setLastSavedSnapshot(snapshotToSave);
+            setLastSavedAt(Date.now());
         }, 600);
 
         return () => clearTimeout(timer);
@@ -407,6 +424,37 @@ export function CmsPageForm({
         }
         return grouped;
     }, [filteredSectionItems]);
+    const missingSectionFields = sections
+        .map((section, index) => ({
+            section,
+            index,
+            errors: validateSection(section),
+        }))
+        .filter((entry) => entry.errors.length > 0);
+    const metadataWarnings = [
+        {
+            label: 'Meta naslov',
+            value: page?.metaTitle ?? '',
+        },
+        {
+            label: 'Meta opis',
+            value: page?.metaDescription ?? '',
+        },
+    ].filter((entry) => entry.value.trim().length === 0);
+    const autosaveBadgeClassName =
+        autosaveStatus === 'saved'
+            ? 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30'
+            : autosaveStatus === 'saving'
+              ? 'bg-blue-500/15 text-blue-400 border-blue-500/30'
+              : autosaveStatus === 'failed'
+                ? 'bg-red-500/15 text-red-400 border-red-500/30'
+                : 'bg-amber-500/15 text-amber-400 border-amber-500/30';
+    const previewViewportClassName =
+        previewViewport === 'mobile'
+            ? 'max-w-sm'
+            : previewViewport === 'tablet'
+              ? 'max-w-2xl'
+              : 'max-w-none';
 
     const insertSection = (component: string, index?: number) => {
         const sectionId = nextSectionId.current;
@@ -443,20 +491,32 @@ export function CmsPageForm({
                         <Typography level="body3" secondary>
                             /{page?.slug?.trim() || 'slug'} •{' '}
                             {page?.state ?? 'draft'}
-                            {autosaveAction
-                                ? ` • Autosave: ${autosaveStatus}${autosaveMessage ? ` • ${autosaveMessage}` : ''}`
-                                : ''}
                         </Typography>
                     </Stack>
-                    <Button
-                        variant="solid"
-                        type="submit"
-                        form={reactId}
-                        className="w-fit"
-                        loading={pending}
-                    >
-                        {submitLabel}
-                    </Button>
+                    <Row spacing={2} className="items-center">
+                        {autosaveAction && (
+                            <span
+                                className={`rounded-full border px-2 py-1 text-xs font-medium ${autosaveBadgeClassName}`}
+                            >
+                                {autosaveStatus === 'failed'
+                                    ? 'Greška autosavea'
+                                    : autosaveStatus === 'saving'
+                                      ? 'Spremanje...'
+                                      : autosaveStatus === 'unsaved'
+                                        ? 'Nespremljene promjene'
+                                        : 'Spremljeno'}
+                            </span>
+                        )}
+                        <Button
+                            variant="solid"
+                            type="submit"
+                            form={reactId}
+                            className="w-fit"
+                            loading={pending}
+                        >
+                            {submitLabel}
+                        </Button>
+                    </Row>
                 </Row>
             </Card>
             <Card className="w-full">
@@ -487,12 +547,31 @@ export function CmsPageForm({
                         <Stack spacing={4}>
                             <Stack spacing={3}>
                                 {autosaveAction && (
-                                    <Typography level="body3" secondary>
-                                        Autosave: {autosaveStatus}
-                                        {autosaveMessage
-                                            ? ` • ${autosaveMessage}`
-                                            : ''}
-                                    </Typography>
+                                    <Card className="border-border/60 bg-muted/20 p-3">
+                                        <Stack spacing={1}>
+                                            <Typography level="body3" semiBold>
+                                                Autosave status
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                {autosaveMessage ??
+                                                    (autosaveStatus === 'failed'
+                                                        ? 'Spremanje nije uspjelo. Provjeri polja i pokušaj ponovno.'
+                                                        : autosaveStatus ===
+                                                            'unsaved'
+                                                          ? 'Imaš nespremljene promjene.'
+                                                          : autosaveStatus ===
+                                                              'saving'
+                                                            ? 'Promjene se spremaju...'
+                                                            : 'Sve promjene su spremljene.')}
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                Zadnje spremanje:{' '}
+                                                {formatLastSavedAt(
+                                                    lastSavedAt,
+                                                ) ?? 'Nije dostupno'}
+                                            </Typography>
+                                        </Stack>
+                                    </Card>
                                 )}
                                 <Input
                                     name="title"
@@ -866,13 +945,83 @@ export function CmsPageForm({
                                 <Typography level="h3" semiBold>
                                     Live preview
                                 </Typography>
+                                <Row spacing={2} className="flex-wrap">
+                                    <Button
+                                        type="button"
+                                        variant={
+                                            previewMode === 'inline'
+                                                ? 'solid'
+                                                : 'outlined'
+                                        }
+                                        onClick={() => setPreviewMode('inline')}
+                                    >
+                                        Inline preview
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant={
+                                            previewMode === 'focused'
+                                                ? 'solid'
+                                                : 'outlined'
+                                        }
+                                        onClick={() =>
+                                            setPreviewMode('focused')
+                                        }
+                                    >
+                                        Fokusirani preview
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant={
+                                            previewViewport === 'mobile'
+                                                ? 'solid'
+                                                : 'outlined'
+                                        }
+                                        onClick={() =>
+                                            setPreviewViewport('mobile')
+                                        }
+                                    >
+                                        Mobile
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant={
+                                            previewViewport === 'tablet'
+                                                ? 'solid'
+                                                : 'outlined'
+                                        }
+                                        onClick={() =>
+                                            setPreviewViewport('tablet')
+                                        }
+                                    >
+                                        Tablet
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant={
+                                            previewViewport === 'desktop'
+                                                ? 'solid'
+                                                : 'outlined'
+                                        }
+                                        onClick={() =>
+                                            setPreviewViewport('desktop')
+                                        }
+                                    >
+                                        Desktop
+                                    </Button>
+                                </Row>
                                 <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
-                                    <Card className="p-4">
+                                    <Card
+                                        className={`p-4 ${previewMode === 'focused' ? 'lg:col-span-2' : ''}`}
+                                    >
                                         <Stack spacing={2}>
                                             {sections.map((section) => (
                                                 <Stack
                                                     key={section.id}
                                                     spacing={2}
+                                                    className={
+                                                        previewViewportClassName
+                                                    }
                                                 >
                                                     <Card
                                                         className={`p-3 cursor-pointer ${section.id === selectedSectionId ? 'border-primary' : ''}`}
@@ -903,231 +1052,299 @@ export function CmsPageForm({
                                             )}
                                         </Stack>
                                     </Card>
-                                    <Stack
-                                        spacing={3}
-                                        className="h-fit lg:sticky lg:top-24"
-                                    >
-                                        <Card className="p-4">
-                                            <Stack spacing={2}>
-                                                <Typography level="h4" semiBold>
-                                                    Navigator sekcija
-                                                </Typography>
-                                                {sections.length === 0 ? (
+                                    {previewMode === 'inline' && (
+                                        <Stack
+                                            spacing={3}
+                                            className="h-fit lg:sticky lg:top-24"
+                                        >
+                                            <Card className="p-4">
+                                                <Stack spacing={2}>
                                                     <Typography
-                                                        level="body3"
-                                                        secondary
+                                                        level="h4"
+                                                        semiBold
                                                     >
-                                                        Dodaj prvu sekciju iz
-                                                        palete komponenti.
+                                                        Navigator sekcija
                                                     </Typography>
-                                                ) : (
-                                                    sections.map(
-                                                        (section, index) => (
-                                                            <Button
-                                                                key={`navigator-${section.id}`}
-                                                                type="button"
-                                                                variant={
-                                                                    selectedSectionId ===
-                                                                    section.id
-                                                                        ? 'solid'
-                                                                        : 'plain'
-                                                                }
-                                                                className="justify-start"
-                                                                onClick={() =>
-                                                                    selectSection(
-                                                                        section.id,
-                                                                    )
-                                                                }
-                                                            >
-                                                                {index + 1}.{' '}
-                                                                {sectionLabel(
-                                                                    section.data
-                                                                        .component,
-                                                                )}
-                                                            </Button>
-                                                        ),
-                                                    )
-                                                )}
-                                                <Row spacing={2}>
-                                                    <Button
-                                                        type="button"
-                                                        variant={
-                                                            insertAtEnd
-                                                                ? 'solid'
-                                                                : 'outlined'
-                                                        }
-                                                        onClick={
-                                                            selectAppendTarget
-                                                        }
-                                                    >
-                                                        Dodaj na kraj
-                                                    </Button>
-                                                    <Button
-                                                        type="button"
-                                                        variant="outlined"
-                                                        onClick={() =>
-                                                            insertSection(
-                                                                cmsPageSectionItems[0]
-                                                                    ?.value ??
-                                                                    'Heading1',
-                                                                insertionIndex,
-                                                            )
-                                                        }
-                                                    >
-                                                        Brzo dodaj sekciju
-                                                    </Button>
-                                                </Row>
-                                            </Stack>
-                                        </Card>
-                                        <Card className="p-4">
-                                            <Stack spacing={2}>
-                                                <Typography level="h4" semiBold>
-                                                    Postavke sekcije
-                                                </Typography>
-                                                {!selectedSection ? (
-                                                    <Typography
-                                                        level="body3"
-                                                        secondary
-                                                    >
-                                                        Klikni sekciju u preview
-                                                        prikazu za uređivanje
-                                                        atributa.
-                                                    </Typography>
-                                                ) : (
-                                                    <>
+                                                    {sections.length === 0 ? (
                                                         <Typography
-                                                            level="body2"
-                                                            semiBold
+                                                            level="body3"
+                                                            secondary
                                                         >
-                                                            {
-                                                                selectedSection
-                                                                    .data
-                                                                    .component
-                                                            }
+                                                            Dodaj prvu sekciju
+                                                            iz palete
+                                                            komponenti.
                                                         </Typography>
-                                                        {(
-                                                            cmsPageSectionComponentsByName.get(
-                                                                selectedSection
-                                                                    .data
-                                                                    .component,
-                                                            )?.fields ?? []
-                                                        ).map((field) =>
-                                                            field.type ===
-                                                            'textarea' ? (
-                                                                <label
-                                                                    key={
-                                                                        field.key
+                                                    ) : (
+                                                        sections.map(
+                                                            (
+                                                                section,
+                                                                index,
+                                                            ) => (
+                                                                <Button
+                                                                    key={`navigator-${section.id}`}
+                                                                    type="button"
+                                                                    variant={
+                                                                        selectedSectionId ===
+                                                                        section.id
+                                                                            ? 'solid'
+                                                                            : 'plain'
                                                                     }
-                                                                    className="space-y-1"
-                                                                >
-                                                                    <span className="block text-sm font-medium">
-                                                                        {
-                                                                            field.label
-                                                                        }
-                                                                        {field.required && (
-                                                                            <span className="text-red-600">
-                                                                                {' '}
-                                                                                *
-                                                                            </span>
-                                                                        )}
-                                                                    </span>
-                                                                    <textarea
-                                                                        value={sectionValue(
-                                                                            selectedSection,
-                                                                            field.key,
-                                                                        )}
-                                                                        rows={
-                                                                            field.rows ??
-                                                                            4
-                                                                        }
-                                                                        className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                                        onChange={(
-                                                                            event,
-                                                                        ) =>
-                                                                            updateSectionField(
-                                                                                selectedSection.id,
-                                                                                field.key,
-                                                                                event
-                                                                                    .target
-                                                                                    .value,
-                                                                                setSections,
-                                                                            )
-                                                                        }
-                                                                    />
-                                                                    {selectedSectionErrors.has(
-                                                                        field.key,
-                                                                    ) && (
-                                                                        <Typography
-                                                                            level="body3"
-                                                                            className="text-red-600"
-                                                                        >
-                                                                            {selectedSectionErrors.get(
-                                                                                field.key,
-                                                                            )}
-                                                                        </Typography>
-                                                                    )}
-                                                                </label>
-                                                            ) : (
-                                                                <Stack
-                                                                    key={
-                                                                        field.key
+                                                                    className="justify-start"
+                                                                    onClick={() =>
+                                                                        selectSection(
+                                                                            section.id,
+                                                                        )
                                                                     }
-                                                                    spacing={1}
                                                                 >
-                                                                    <Input
-                                                                        label={`${field.label}${field.required ? ' *' : ''}`}
-                                                                        value={sectionValue(
-                                                                            selectedSection,
-                                                                            field.key,
-                                                                        )}
-                                                                        onChange={(
-                                                                            event,
-                                                                        ) =>
-                                                                            updateSectionField(
-                                                                                selectedSection.id,
-                                                                                field.key,
-                                                                                event
-                                                                                    .target
-                                                                                    .value,
-                                                                                setSections,
-                                                                            )
-                                                                        }
-                                                                    />
-                                                                    {selectedSectionErrors.has(
-                                                                        field.key,
-                                                                    ) && (
-                                                                        <Typography
-                                                                            level="body3"
-                                                                            className="text-red-600"
-                                                                        >
-                                                                            {selectedSectionErrors.get(
-                                                                                field.key,
-                                                                            )}
-                                                                        </Typography>
+                                                                    {index + 1}.{' '}
+                                                                    {sectionLabel(
+                                                                        section
+                                                                            .data
+                                                                            .component,
                                                                     )}
-                                                                </Stack>
+                                                                </Button>
                                                             ),
-                                                        )}
-                                                        {selectedSectionErrors.size >
-                                                            0 && (
+                                                        )
+                                                    )}
+                                                    <Row spacing={2}>
+                                                        <Button
+                                                            type="button"
+                                                            variant={
+                                                                insertAtEnd
+                                                                    ? 'solid'
+                                                                    : 'outlined'
+                                                            }
+                                                            onClick={
+                                                                selectAppendTarget
+                                                            }
+                                                        >
+                                                            Dodaj na kraj
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="outlined"
+                                                            onClick={() =>
+                                                                insertSection(
+                                                                    cmsPageSectionItems[0]
+                                                                        ?.value ??
+                                                                        'Heading1',
+                                                                    insertionIndex,
+                                                                )
+                                                            }
+                                                        >
+                                                            Brzo dodaj sekciju
+                                                        </Button>
+                                                    </Row>
+                                                </Stack>
+                                            </Card>
+                                            <Card className="p-4">
+                                                <Stack spacing={2}>
+                                                    <Typography
+                                                        level="h4"
+                                                        semiBold
+                                                    >
+                                                        Postavke sekcije
+                                                    </Typography>
+                                                    {!selectedSection ? (
+                                                        <Typography
+                                                            level="body3"
+                                                            secondary
+                                                        >
+                                                            Klikni sekciju u
+                                                            preview prikazu za
+                                                            uređivanje atributa.
+                                                        </Typography>
+                                                    ) : (
+                                                        <>
                                                             <Typography
-                                                                level="body3"
-                                                                className="text-red-600"
+                                                                level="body2"
+                                                                semiBold
                                                             >
-                                                                Sekcija ima
-                                                                nepopunjena
-                                                                obavezna polja.
+                                                                {
+                                                                    selectedSection
+                                                                        .data
+                                                                        .component
+                                                                }
                                                             </Typography>
-                                                        )}
-                                                    </>
-                                                )}
-                                            </Stack>
-                                        </Card>
-                                    </Stack>
+                                                            {(
+                                                                cmsPageSectionComponentsByName.get(
+                                                                    selectedSection
+                                                                        .data
+                                                                        .component,
+                                                                )?.fields ?? []
+                                                            ).map((field) =>
+                                                                field.type ===
+                                                                'textarea' ? (
+                                                                    <label
+                                                                        key={
+                                                                            field.key
+                                                                        }
+                                                                        className="space-y-1"
+                                                                    >
+                                                                        <span className="block text-sm font-medium">
+                                                                            {
+                                                                                field.label
+                                                                            }
+                                                                            {field.required && (
+                                                                                <span className="text-red-600">
+                                                                                    {' '}
+                                                                                    *
+                                                                                </span>
+                                                                            )}
+                                                                        </span>
+                                                                        <textarea
+                                                                            value={sectionValue(
+                                                                                selectedSection,
+                                                                                field.key,
+                                                                            )}
+                                                                            rows={
+                                                                                field.rows ??
+                                                                                4
+                                                                            }
+                                                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                            onChange={(
+                                                                                event,
+                                                                            ) =>
+                                                                                updateSectionField(
+                                                                                    selectedSection.id,
+                                                                                    field.key,
+                                                                                    event
+                                                                                        .target
+                                                                                        .value,
+                                                                                    setSections,
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                        {selectedSectionErrors.has(
+                                                                            field.key,
+                                                                        ) && (
+                                                                            <Typography
+                                                                                level="body3"
+                                                                                className="text-red-600"
+                                                                            >
+                                                                                {selectedSectionErrors.get(
+                                                                                    field.key,
+                                                                                )}
+                                                                            </Typography>
+                                                                        )}
+                                                                    </label>
+                                                                ) : (
+                                                                    <Stack
+                                                                        key={
+                                                                            field.key
+                                                                        }
+                                                                        spacing={
+                                                                            1
+                                                                        }
+                                                                    >
+                                                                        <Input
+                                                                            label={`${field.label}${field.required ? ' *' : ''}`}
+                                                                            value={sectionValue(
+                                                                                selectedSection,
+                                                                                field.key,
+                                                                            )}
+                                                                            onChange={(
+                                                                                event,
+                                                                            ) =>
+                                                                                updateSectionField(
+                                                                                    selectedSection.id,
+                                                                                    field.key,
+                                                                                    event
+                                                                                        .target
+                                                                                        .value,
+                                                                                    setSections,
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                        {selectedSectionErrors.has(
+                                                                            field.key,
+                                                                        ) && (
+                                                                            <Typography
+                                                                                level="body3"
+                                                                                className="text-red-600"
+                                                                            >
+                                                                                {selectedSectionErrors.get(
+                                                                                    field.key,
+                                                                                )}
+                                                                            </Typography>
+                                                                        )}
+                                                                    </Stack>
+                                                                ),
+                                                            )}
+                                                            {selectedSectionErrors.size >
+                                                                0 && (
+                                                                <Typography
+                                                                    level="body3"
+                                                                    className="text-red-600"
+                                                                >
+                                                                    Sekcija ima
+                                                                    nepopunjena
+                                                                    obavezna
+                                                                    polja.
+                                                                </Typography>
+                                                            )}
+                                                        </>
+                                                    )}
+                                                </Stack>
+                                            </Card>
+                                        </Stack>
+                                    )}
                                 </div>
                             </Stack>
 
                             <Stack spacing={3}>
+                                <Card className="p-4">
+                                    <Stack spacing={2}>
+                                        <Typography level="h3" semiBold>
+                                            Publish readiness
+                                        </Typography>
+                                        {missingSectionFields.length === 0 &&
+                                        metadataWarnings.length === 0 ? (
+                                            <Typography
+                                                level="body3"
+                                                className="text-emerald-500"
+                                            >
+                                                Stranica je spremna za objavu.
+                                            </Typography>
+                                        ) : (
+                                            <Stack spacing={1}>
+                                                {missingSectionFields.map(
+                                                    (entry) => (
+                                                        <Typography
+                                                            key={
+                                                                entry.section.id
+                                                            }
+                                                            level="body3"
+                                                            className="text-amber-500"
+                                                        >
+                                                            Sekcija{' '}
+                                                            {entry.index + 1} (
+                                                            {sectionLabel(
+                                                                entry.section
+                                                                    .data
+                                                                    .component,
+                                                            )}
+                                                            ) ima obavezna
+                                                            prazna polja.
+                                                        </Typography>
+                                                    ),
+                                                )}
+                                                {metadataWarnings.map(
+                                                    (warning) => (
+                                                        <Typography
+                                                            key={warning.label}
+                                                            level="body3"
+                                                            className="text-amber-500"
+                                                        >
+                                                            Nedostaje:{' '}
+                                                            {warning.label}.
+                                                        </Typography>
+                                                    ),
+                                                )}
+                                            </Stack>
+                                        )}
+                                    </Stack>
+                                </Card>
                                 <Card className="p-4">
                                     <Stack spacing={2}>
                                         <Typography level="h3" semiBold>

--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -308,11 +308,20 @@ export function CmsPageForm({
         () => parseSections(rawContent),
         [rawContent],
     );
-    const readinessSections = useMemo(
-        () =>
-            rawMode ? editableSections(rawReadinessContent.sections) : sections,
-        [rawMode, rawReadinessContent.sections, sections],
-    );
+    const readinessSections = useMemo(() => {
+        if (!rawMode) {
+            return sections;
+        }
+
+        return rawReadinessContent.isStructured
+            ? editableSections(rawReadinessContent.sections)
+            : [];
+    }, [
+        rawMode,
+        rawReadinessContent.isStructured,
+        rawReadinessContent.sections,
+        sections,
+    ]);
     const contentReadinessWarning =
         rawMode &&
         rawContent.trim().length > 0 &&


### PR DESCRIPTION
### Motivation

- Make autosave state clear and actionable for editors with compact status indicators and last-saved feedback.
- Provide preview ergonomics (inline vs focused + responsive viewport toggles) so previewing does not compete with editing controls.
- Surface publish readiness proactively by flagging missing required section fields and key metadata before submit.

### Description

- Enhanced `CmsPageForm` (`apps/app/app/admin/cms/pages/CmsPageForm.tsx`) by adding `formatLastSavedAt`, `lastSavedAt`, `previewMode`, and `previewViewport` state and utilities to support the new UX.
- Replaced raw autosave text with a compact badge in the sticky header and an autosave card detailing human-readable states, failure guidance, and a last-saved timestamp.
- Added preview controls for `inline` vs `focused` modes and `mobile|tablet|desktop` viewport toggles, plus layout adjustments so focused preview can span content while inline preserves navigator/inspector.
- Added a publish-readiness card that computes `missingSectionFields` and `metadataWarnings` and surfaces actionable warnings before publishing, while preserving JSON fallback and existing section editing/preview behavior.

### Testing

- Ran `pnpm lint --filter app` which completed successfully (minor warnings surfaced but lint run passed).
- Ran `pnpm test --filter app` which failed in this environment due to Playwright web server startup timing out: `Timed out waiting 60000ms from config.webServer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b89a2edc832f89288d8981b5aac6)