### PR TITLE
Fix plant picker search input losing focus on each keystroke

### DIFF
--- a/packages/game/src/hud/raisedBed/PlantsList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsList.tsx
@@ -5,7 +5,6 @@ import {
     PlantYieldTooltip,
     SeedTimeInformationBadge,
 } from '@gredice/ui/plants';
-import { useSearchParam } from '@signalco/hooks/useSearchParam';
 import { Alert } from '@signalco/ui/Alert';
 import { NoDataPlaceholder } from '@signalco/ui/NoDataPlaceholder';
 import { Button } from '@signalco/ui-primitives/Button';
@@ -21,12 +20,13 @@ import { PlantListItemSkeleton } from './PlantListItemSkeleton';
 
 export function PlantsList({
     onChange,
+    search,
 }: {
     onChange: (plant: PlantData) => void;
+    search: string;
 }) {
     const { track } = useGameAnalytics();
     const { data: plants, isLoading, isError } = usePlants();
-    const [search] = useSearchParam('pretraga', '');
     // Filter plants based on search query
     const filteredPlants =
         search.length > 0

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -1,9 +1,9 @@
 import type { PlantData, PlantSortData } from '@gredice/client';
 import { BackpackIcon } from '@gredice/ui/BackpackIcon';
-import { FilterInput } from '@gredice/ui/FilterInput';
 import { useSearchParam } from '@signalco/hooks/useSearchParam';
-import { Left, ShoppingCart } from '@signalco/ui-icons';
+import { Close, Left, Search, ShoppingCart } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -78,6 +78,7 @@ export function PlantPicker({
     } | null>(preselectedPlantOptions ?? null);
     const [flyToShoppingCart, setFlyToShoppingCart] = useState(false);
     const [useInventoryItem, setUseInventoryItem] = useState(false);
+    const [searchValue, setSearchValue] = useState('');
 
     let currentStep = 0;
     if (selectedPlantId) {
@@ -196,6 +197,7 @@ export function PlantPicker({
         setSelectedPlantId(preselectedPlantId ?? null);
         setSelectedSortId(preselectedSortId ?? null);
         setPlantOptions(preselectedPlantOptions ?? null);
+        setSearchValue('');
         const existingItem = cart?.items.find(
             (item) =>
                 item.entityTypeName === 'plantSort' &&
@@ -274,14 +276,34 @@ export function PlantPicker({
                     </Typography>
                 </Stack>
                 {currentStep < 1 && (
-                    <FilterInput
-                        searchParamName={'pretraga'}
-                        fieldName={'search'}
-                        instant
+                    <Input
+                        name="search"
+                        value={searchValue}
+                        onChange={(event) => setSearchValue(event.target.value)}
+                        placeholder="Pretraži..."
+                        startDecorator={
+                            <Search className="size-5 shrink-0 ml-3" />
+                        }
+                        endDecorator={
+                            <IconButton
+                                className="hover:bg-neutral-300 mr-1 rounded-full aspect-square"
+                                title="Očisti pretragu"
+                                onClick={() => setSearchValue('')}
+                                size="sm"
+                                variant="plain"
+                            >
+                                <Close className="size-5" />
+                            </IconButton>
+                        }
+                        className="min-w-60"
+                        variant="soft"
                     />
                 )}
                 {currentStep === 0 && (
-                    <PlantsList onChange={handlePlantSelect} />
+                    <PlantsList
+                        onChange={handlePlantSelect}
+                        search={searchValue}
+                    />
                 )}
                 {currentStep === 1 && selectedPlantId && (
                     <>


### PR DESCRIPTION
### Motivation
- Typing in the plant picker search updated a URL search param on every keystroke which triggered rerenders/navigation side-effects and caused the input to lose focus. 

### Description
- Replaced the URL-driven instant `FilterInput` in the raised-bed plant picker with a local controlled `Input` bound to `searchValue` to avoid route updates on each character. 
- Updated `PlantsList` to accept a `search` prop and removed its direct `useSearchParam('pretraga')` dependency so filtering is driven by the parent component. 
- Reset the local `searchValue` when the picker modal opens to keep behavior consistent across openings. 
- Files modified: `packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx` and `packages/game/src/hud/raisedBed/PlantsList.tsx`.

### Testing
- Ran `pnpm lint --filter @gredice/game` and the lint step completed successfully (one automatic fix applied). 
- Ran `pnpm test --filter @gredice/game` and no test tasks were executed in this environment. 
- Ran `pnpm build --filter garden` and the build completed successfully. 
- Ran `pnpm build --filter www` and the build completed successfully but the environment emitted expected `ENETUNREACH` fetch warnings for external data during static generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ccac07dc832fa809041dc3f95def)