### PR TITLE
Hide internal operations from plant detail pages

### DIFF
--- a/apps/www/app/biljke/[alias]/InformationSection.tsx
+++ b/apps/www/app/biljke/[alias]/InformationSection.tsx
@@ -1,4 +1,4 @@
-import type { PlantData } from '@gredice/client';
+import type { OperationData, PlantData } from '@gredice/client';
 import { Markdown } from '@gredice/ui/Markdown';
 import { slug } from '@signalco/js';
 import { cx } from '@signalco/ui-primitives/cx';
@@ -25,6 +25,10 @@ export type InformationSectionProps = {
     attributeCards?: ReactNode;
 };
 
+function isPublicOperation(operation: Pick<OperationData, 'attributes'>) {
+    return operation.attributes?.internal !== true;
+}
+
 export async function InformationSection({
     plantId,
     id,
@@ -43,24 +47,25 @@ export async function InformationSection({
     }
 
     // Filter operations based on stage
-    const allOperations = await getOperationsData();
-    const gardenOperations = allOperations?.filter(
+    const allOperations = (await getOperationsData()).filter(isPublicOperation);
+    const gardenOperations = allOperations.filter(
         (operation) =>
             operation.attributes?.application === 'garden' &&
             operation.attributes?.stage.information?.name === id,
     );
-    const raisedBedFullOperations = allOperations?.filter(
+    const raisedBedFullOperations = allOperations.filter(
         (operation) =>
             operation.attributes?.application === 'raisedBedFull' &&
             operation.attributes?.stage.information?.name === id,
     );
-    const raisedBedSquareOperations = allOperations?.filter(
+    const raisedBedSquareOperations = allOperations.filter(
         (operation) =>
             operation.attributes?.application === 'raisedBed1m' &&
             operation.attributes?.stage.information?.name === id,
     );
     const plantOperations = operations?.filter(
         (operation) =>
+            isPublicOperation(operation) &&
             operation.attributes?.application === 'plant' &&
             operation.attributes?.stage.information?.name === id,
     );


### PR DESCRIPTION
## Summary
- Filter internal operations out of the plant and plant sort detail page operations lists.
- Apply the public-only check both to globally loaded operations and to plant-provided operations before rendering.

## Testing
- Lint and formatting passed for `www`.
- Built `www` successfully.
- Ran the full `www` Playwright suite, including public plant and sort page checks, and it passed.