### PR TITLE
Replace seed time checkbox with toggle button

### DIFF
--- a/apps/www/app/biljke/PlantsSeedTimeFilterToggle.tsx
+++ b/apps/www/app/biljke/PlantsSeedTimeFilterToggle.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useSearchParam } from '@signalco/hooks/useSearchParam';
-import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { ThumbsUp } from '@signalco/ui-icons';
+import { cx } from '@signalco/ui-primitives/cx';
 
 const filterParamName = 'vrijemeZaSijanje';
 
@@ -10,13 +11,52 @@ export function PlantsSeedTimeFilterToggle() {
     const isEnabled = seedTimeFilter === '1';
 
     return (
-        <Checkbox
-            aria-label="Uključi filter vrijeme za sijanje"
-            checked={isEnabled}
-            onCheckedChange={(checked: boolean | 'indeterminate') =>
-                setSeedTimeFilter(checked === true ? '1' : '')
+        <button
+            type="button"
+            aria-pressed={isEnabled}
+            aria-label={
+                isEnabled
+                    ? 'Isključi filter vrijeme za sijanje'
+                    : 'Uključi filter vrijeme za sijanje'
             }
-            label='Samo "Vrijeme za sijanje"'
-        />
+            onClick={() => setSeedTimeFilter(isEnabled ? '' : '1')}
+            className={cx(
+                'inline-flex min-h-10 w-full max-w-full items-center justify-between gap-2 rounded-full border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary md:w-auto',
+                isEnabled
+                    ? 'border-lime-600 bg-lime-600 text-white shadow-sm hover:bg-lime-700'
+                    : 'border-tertiary bg-background text-foreground hover:border-lime-600 hover:bg-lime-50 dark:hover:bg-lime-950/30',
+            )}
+        >
+            <span className="inline-flex min-w-0 items-center gap-2">
+                <span
+                    aria-hidden
+                    className={cx(
+                        'flex size-6 shrink-0 items-center justify-center rounded-full transition-colors',
+                        isEnabled
+                            ? 'bg-white/20 text-white'
+                            : 'bg-lime-100 text-lime-700',
+                    )}
+                >
+                    <ThumbsUp className="size-3.5" />
+                </span>
+                <span className="min-w-0 text-left leading-tight">
+                    Samo &quot;Vrijeme za sijanje&quot;
+                </span>
+            </span>
+            <span
+                aria-hidden
+                className={cx(
+                    'relative h-5 w-9 shrink-0 rounded-full transition-colors',
+                    isEnabled ? 'bg-white/30' : 'bg-tertiary',
+                )}
+            >
+                <span
+                    className={cx(
+                        'absolute top-0.5 size-4 rounded-full bg-white shadow transition-transform',
+                        isEnabled ? 'translate-x-4' : 'translate-x-0.5',
+                    )}
+                />
+            </span>
+        </button>
     );
 }


### PR DESCRIPTION
## Summary
- Replaced the `Samo "Vrijeme za sijanje"` checkbox with a pill-style toggle button.
- Kept the existing `vrijemeZaSijanje=1` query-param behavior and added pressed-state semantics with `aria-pressed`.
- Updated the control styling to read as an explicit on/off action in the plants page header.

## Testing
- Lint and formatting passed for the `www` workspace.
- Ran a local `www` build successfully.
- Verified the control in desktop and mobile browser checks, including URL updates and stable layout.