### PR TITLE
Ispravi tekst za postavljanje novih gredica u košarici

### DIFF
--- a/apps/api/lib/checkout/cartInfo.node.spec.ts
+++ b/apps/api/lib/checkout/cartInfo.node.spec.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getNewRaisedBedPlantingNote } from './cartInfo';
+
+describe('getNewRaisedBedPlantingNote', () => {
+    it('uses singular raised-bed copy for two raised-bed blocks', () => {
+        assert.strictEqual(
+            getNewRaisedBedPlantingNote(8, 2),
+            'Potrebno je još 8 biljaka u ovoj gredici za postavljanje nove gredice.',
+        );
+    });
+
+    it('uses plural raised-bed copy for multiple raised beds', () => {
+        assert.strictEqual(
+            getNewRaisedBedPlantingNote(18, 4),
+            'Potrebno je još 18 biljaka u novim gredicama za postavljanje novih gredica.',
+        );
+    });
+});

--- a/apps/api/lib/checkout/cartInfo.ts
+++ b/apps/api/lib/checkout/cartInfo.ts
@@ -26,6 +26,38 @@ export type ShoppingCartItemWithShopData = SelectShoppingCartItem & {
     inventoryAvailable?: number;
 };
 
+const RAISED_BED_BLOCKS_PER_BED = 2;
+const REQUIRED_PLANT_ITEMS_PER_NEW_RAISED_BED = 9;
+
+function getNewRaisedBedCount(newRaisedBedBlockCount: number) {
+    return Math.ceil(newRaisedBedBlockCount / RAISED_BED_BLOCKS_PER_BED);
+}
+
+export function getNewRaisedBedPlantingNote(
+    missingItemsCount: number,
+    newRaisedBedBlockCount: number,
+) {
+    const newRaisedBedCount = getNewRaisedBedCount(newRaisedBedBlockCount);
+    const neededPlural =
+        missingItemsCount === 1
+            ? 'Potrebna je'
+            : missingItemsCount > 4
+              ? 'Potrebno je'
+              : 'Potrebne su';
+    const plantPlural =
+        missingItemsCount === 1
+            ? 'biljka'
+            : missingItemsCount > 4
+              ? 'biljaka'
+              : 'biljke';
+    const raisedBedsPlural =
+        newRaisedBedCount === 1 ? 'nove gredice' : 'novih gredica';
+    const raisedBedsLocation =
+        newRaisedBedCount === 1 ? 'u ovoj gredici' : 'u novim gredicama';
+
+    return `${neededPlural} još ${missingItemsCount} ${plantPlural} ${raisedBedsLocation} za postavljanje ${raisedBedsPlural}.`;
+}
+
 export async function getCartInfo(
     items: SelectShoppingCartItem[],
     accountId?: string,
@@ -181,7 +213,9 @@ export async function getCartInfo(
     const newRaisedBeds = mentionedRaisedBeds.filter(
         (rb) => rb && rb.status === 'new',
     );
-    const requiredItemsCount = Math.ceil(newRaisedBeds.length / 2) * 9;
+    const requiredItemsCount =
+        getNewRaisedBedCount(newRaisedBeds.length) *
+        REQUIRED_PLANT_ITEMS_PER_NEW_RAISED_BED;
 
     const cartItemsInNewRaisedBeds = cartItemsWithShopInfo.filter(
         (item) =>
@@ -193,24 +227,11 @@ export async function getCartInfo(
     if (cartItemsInNewRaisedBeds.length < requiredItemsCount) {
         const missingItemsCount =
             requiredItemsCount - cartItemsInNewRaisedBeds.length;
-        const neededPlural =
-            missingItemsCount === 1
-                ? 'Potrebna je'
-                : missingItemsCount > 4
-                  ? 'Potrebno je'
-                  : 'Potrebne su';
-        const plantPlural =
-            missingItemsCount === 1
-                ? 'biljka'
-                : missingItemsCount > 4
-                  ? 'biljaka'
-                  : 'biljke';
-        const raisedBedsPlural =
-            newRaisedBeds.length === 1 ? 'nove gredice' : 'novih gredica';
-        const raisedBedsLocation =
-            newRaisedBeds.length === 1 ? 'u ovoj gredici' : 'u novim gredicama';
         notes.push(
-            `${neededPlural} još ${missingItemsCount} ${plantPlural} ${raisedBedsLocation} za postavljanje ${raisedBedsPlural}.`,
+            getNewRaisedBedPlantingNote(
+                missingItemsCount,
+                newRaisedBeds.length,
+            ),
         );
         allowPurchase = false;
     }


### PR DESCRIPTION
## Summary
- U checkout napomeni sada se množina za `postavljanje novih gredica` računa prema broju stvarnih gredica, a ne prema broju blokova u košarici.
- Izvedena je mala helper funkcija za generiranje poruke i dodani su node testovi za jedninu i množinu.

## Testing
- `pnpm --filter api test:node`
- `pnpm lint --filter api`
- `pnpm build --filter api`