### PR TITLE
[Social] Wire provider-neutral immediate publish lifecycle

### DIFF
--- a/apps/app/app/(actions)/socialPublishActions.ts
+++ b/apps/app/app/(actions)/socialPublishActions.ts
@@ -68,7 +68,6 @@ function sanitizeUnexpectedErrorDetails(
     error: unknown,
 ): Record<string, unknown> {
     return {
-        reason: 'unexpected_publish_error',
         errorType: error instanceof Error ? error.name : typeof error,
     };
 }
@@ -188,7 +187,7 @@ export async function publishSocialPostAction(
     duplicateSubmissionKeys.set(submissionToken, now + 5 * 60_000);
 
     let socialPostId: number | undefined;
-    let providerSubmissionAttempted = false;
+    let providerSubmissionMayHaveStarted = false;
 
     try {
         const created = await createSocialPost({
@@ -207,7 +206,7 @@ export async function publishSocialPostAction(
         socialPostId = created.id;
         await updateSocialPostStatus({ id: created.id, status: 'submitting' });
 
-        providerSubmissionAttempted = true;
+        providerSubmissionMayHaveStarted = true;
         const providerResult = await adapter.publishPost({
             title,
             body: body || undefined,
@@ -254,7 +253,7 @@ export async function publishSocialPostAction(
             providerPermalink: providerResult.permalink,
         };
     } catch (error) {
-        if (!providerSubmissionAttempted) {
+        if (!providerSubmissionMayHaveStarted) {
             duplicateSubmissionKeys.delete(submissionToken);
         }
 

--- a/apps/app/app/(actions)/socialPublishActions.ts
+++ b/apps/app/app/(actions)/socialPublishActions.ts
@@ -64,6 +64,15 @@ function sanitizeProviderErrorDetails(
     return Object.keys(sanitized).length ? sanitized : null;
 }
 
+function sanitizeUnexpectedErrorDetails(
+    error: unknown,
+): Record<string, unknown> {
+    return {
+        reason: 'unexpected_publish_error',
+        errorType: error instanceof Error ? error.name : typeof error,
+    };
+}
+
 export async function publishSocialPostAction(
     _prevState: PublishSocialPostState | null,
     formData: FormData,
@@ -244,7 +253,7 @@ export async function publishSocialPostAction(
             status: finalStatus,
             providerPermalink: providerResult.permalink,
         };
-    } catch {
+    } catch (error) {
         if (!providerSubmissionAttempted) {
             duplicateSubmissionKeys.delete(submissionToken);
         }
@@ -256,14 +265,12 @@ export async function publishSocialPostAction(
                     status: 'failed',
                     failureCode: 'unexpected_publish_error',
                     failureMessage: 'Neočekivana greška tijekom slanja objave.',
-                    failureMetadata: { reason: 'unexpected_publish_error' },
+                    failureMetadata: sanitizeUnexpectedErrorDetails(error),
                 });
             } catch {
                 // Keep returning a controlled action state even if persistence fails.
             }
-        }
 
-        if (socialPostId) {
             return {
                 ok: false,
                 errorCode: 'internal_error',

--- a/apps/app/app/(actions)/socialPublishActions.ts
+++ b/apps/app/app/(actions)/socialPublishActions.ts
@@ -1,0 +1,239 @@
+'use server';
+
+import {
+    createSocialPost,
+    type SocialPostType,
+    type SocialProvider,
+    updateSocialPostStatus,
+} from '@gredice/storage';
+import { auth } from '../../lib/auth/auth';
+import { createSocialProviderAdapter } from '../../src/social/providers';
+
+const TITLE_MAX_LENGTH = 300;
+const BODY_MAX_LENGTH = 40000;
+const SUBMISSION_TOKEN_MIN_LENGTH = 12;
+const duplicateSubmissionKeys = new Map<string, number>();
+
+type ActionErrorCode =
+    | 'unauthorized'
+    | 'invalid_payload'
+    | 'duplicate_submission'
+    | 'provider_error'
+    | 'internal_error';
+
+export type PublishSocialPostState = {
+    ok: boolean;
+    errorCode?: ActionErrorCode;
+    message: string;
+    socialPostId?: number;
+    status?: 'submitted' | 'published' | 'failed';
+    providerPermalink?: string | null;
+};
+
+function normalizeTrimmed(value: FormDataEntryValue | null): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function cleanupSubmissionKeyCache(now: number): void {
+    for (const [key, expiresAt] of duplicateSubmissionKeys) {
+        if (expiresAt <= now) {
+            duplicateSubmissionKeys.delete(key);
+        }
+    }
+}
+
+function isValidPostType(postType: string): postType is SocialPostType {
+    return ['text', 'link', 'image', 'video', 'other'].includes(postType);
+}
+
+function isValidProvider(provider: string): provider is SocialProvider {
+    return provider === 'reddit';
+}
+
+function sanitizeProviderErrorDetails(
+    details: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+    if (!details) return null;
+    const safeKeys = new Set(['status', 'providerErrorId', 'reason']);
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(details)) {
+        if (safeKeys.has(key)) {
+            sanitized[key] = value;
+        }
+    }
+    return Object.keys(sanitized).length ? sanitized : null;
+}
+
+export async function publishSocialPostAction(
+    _prevState: PublishSocialPostState | null,
+    formData: FormData,
+): Promise<PublishSocialPostState> {
+    try {
+        await auth(['admin']);
+    } catch {
+        return {
+            ok: false,
+            errorCode: 'unauthorized',
+            message: 'Niste ovlašteni za objavu društvenih objava.',
+        };
+    }
+
+    const provider = normalizeTrimmed(formData.get('provider')).toLowerCase();
+    const providerAccountKey = normalizeTrimmed(
+        formData.get('providerAccountKey'),
+    );
+    const destination = normalizeTrimmed(formData.get('destination')).replace(
+        /^r\//i,
+        '',
+    );
+    const postType = normalizeTrimmed(formData.get('postType')).toLowerCase();
+    const title = normalizeTrimmed(formData.get('title'));
+    const body = normalizeTrimmed(formData.get('body'));
+    const url = normalizeTrimmed(formData.get('url'));
+    const submissionToken = normalizeTrimmed(formData.get('submissionToken'));
+
+    if (!isValidProvider(provider) || !isValidPostType(postType)) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Neispravan provider ili tip objave.',
+        };
+    }
+    if (!providerAccountKey) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Nedostaje ključ provider računa.',
+        };
+    }
+    if (!destination) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Odredište je obavezno.',
+        };
+    }
+    if (!title || title.length > TITLE_MAX_LENGTH) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Naslov je obavezan i mora imati najviše 300 znakova.',
+        };
+    }
+    if (url) {
+        try {
+            const parsed = new URL(url);
+            if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+                throw new Error('invalid protocol');
+            }
+        } catch {
+            return {
+                ok: false,
+                errorCode: 'invalid_payload',
+                message: 'Link mora biti valjani http ili https URL.',
+            };
+        }
+    }
+    if (!url && !body) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Potrebno je unijeti sadržaj objave ili link.',
+        };
+    }
+    if (body.length > BODY_MAX_LENGTH) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Sadržaj objave je predugačak.',
+        };
+    }
+    if (submissionToken.length < SUBMISSION_TOKEN_MIN_LENGTH) {
+        return {
+            ok: false,
+            errorCode: 'invalid_payload',
+            message: 'Nedostaje valjan token prijave obrasca.',
+        };
+    }
+
+    const now = Date.now();
+    cleanupSubmissionKeyCache(now);
+    if (duplicateSubmissionKeys.has(submissionToken)) {
+        return {
+            ok: false,
+            errorCode: 'duplicate_submission',
+            message:
+                'Objava je već poslana. Pričekajte prije ponovnog pokušaja.',
+        };
+    }
+    duplicateSubmissionKeys.set(submissionToken, now + 5 * 60_000);
+
+    const adapter = createSocialProviderAdapter(provider);
+    const configError = adapter.validateConfig();
+    if (configError) {
+        return {
+            ok: false,
+            errorCode: 'provider_error',
+            message: configError.message,
+        };
+    }
+
+    const created = await createSocialPost({
+        provider,
+        providerAccountKey,
+        destination,
+        postType,
+        title,
+        body: body || null,
+        url: url || null,
+        providerMetadata: {
+            requestedBy: 'admin-action',
+        },
+    });
+
+    await updateSocialPostStatus({ id: created.id, status: 'submitting' });
+
+    const providerResult = await adapter.publishPost({
+        title,
+        body: body || undefined,
+        url: url || undefined,
+        destination,
+    });
+
+    if (!providerResult.ok) {
+        await updateSocialPostStatus({
+            id: created.id,
+            status: 'failed',
+            failureCode: providerResult.code,
+            failureMessage: providerResult.message,
+            failureMetadata: sanitizeProviderErrorDetails(
+                providerResult.details,
+            ),
+        });
+
+        return {
+            ok: false,
+            errorCode: 'provider_error',
+            message: providerResult.message,
+            socialPostId: created.id,
+            status: 'failed',
+        };
+    }
+
+    const finalStatus = providerResult.permalink ? 'published' : 'submitted';
+    await updateSocialPostStatus({
+        id: created.id,
+        status: finalStatus,
+        providerSubmissionId: providerResult.providerPostId,
+        providerPermalink: providerResult.permalink,
+        providerMetadata: providerResult.metadata ?? null,
+    });
+
+    return {
+        ok: true,
+        message: 'Objava je uspješno poslana.',
+        socialPostId: created.id,
+        status: finalStatus,
+        providerPermalink: providerResult.permalink,
+    };
+}

--- a/apps/app/app/(actions)/socialPublishActions.ts
+++ b/apps/app/app/(actions)/socialPublishActions.ts
@@ -156,6 +156,16 @@ export async function publishSocialPostAction(
         };
     }
 
+    const adapter = createSocialProviderAdapter(provider);
+    const configError = adapter.validateConfig();
+    if (configError) {
+        return {
+            ok: false,
+            errorCode: 'provider_error',
+            message: configError.message,
+        };
+    }
+
     const now = Date.now();
     cleanupSubmissionKeyCache(now);
     if (duplicateSubmissionKeys.has(submissionToken)) {
@@ -168,72 +178,106 @@ export async function publishSocialPostAction(
     }
     duplicateSubmissionKeys.set(submissionToken, now + 5 * 60_000);
 
-    const adapter = createSocialProviderAdapter(provider);
-    const configError = adapter.validateConfig();
-    if (configError) {
-        return {
-            ok: false,
-            errorCode: 'provider_error',
-            message: configError.message,
-        };
-    }
+    let socialPostId: number | undefined;
+    let providerSubmissionAttempted = false;
 
-    const created = await createSocialPost({
-        provider,
-        providerAccountKey,
-        destination,
-        postType,
-        title,
-        body: body || null,
-        url: url || null,
-        providerMetadata: {
-            requestedBy: 'admin-action',
-        },
-    });
+    try {
+        const created = await createSocialPost({
+            provider,
+            providerAccountKey,
+            destination,
+            postType,
+            title,
+            body: body || null,
+            url: url || null,
+            providerMetadata: {
+                requestedBy: 'admin-action',
+            },
+        });
 
-    await updateSocialPostStatus({ id: created.id, status: 'submitting' });
+        socialPostId = created.id;
+        await updateSocialPostStatus({ id: created.id, status: 'submitting' });
 
-    const providerResult = await adapter.publishPost({
-        title,
-        body: body || undefined,
-        url: url || undefined,
-        destination,
-    });
+        providerSubmissionAttempted = true;
+        const providerResult = await adapter.publishPost({
+            title,
+            body: body || undefined,
+            url: url || undefined,
+            destination,
+        });
 
-    if (!providerResult.ok) {
+        if (!providerResult.ok) {
+            await updateSocialPostStatus({
+                id: created.id,
+                status: 'failed',
+                failureCode: providerResult.code,
+                failureMessage: providerResult.message,
+                failureMetadata: sanitizeProviderErrorDetails(
+                    providerResult.details,
+                ),
+            });
+
+            return {
+                ok: false,
+                errorCode: 'provider_error',
+                message: providerResult.message,
+                socialPostId: created.id,
+                status: 'failed',
+            };
+        }
+
+        const finalStatus = providerResult.permalink
+            ? 'published'
+            : 'submitted';
         await updateSocialPostStatus({
             id: created.id,
-            status: 'failed',
-            failureCode: providerResult.code,
-            failureMessage: providerResult.message,
-            failureMetadata: sanitizeProviderErrorDetails(
-                providerResult.details,
-            ),
+            status: finalStatus,
+            providerSubmissionId: providerResult.providerPostId,
+            providerPermalink: providerResult.permalink,
+            providerMetadata: providerResult.metadata ?? null,
         });
 
         return {
-            ok: false,
-            errorCode: 'provider_error',
-            message: providerResult.message,
+            ok: true,
+            message: 'Objava je uspješno poslana.',
             socialPostId: created.id,
-            status: 'failed',
+            status: finalStatus,
+            providerPermalink: providerResult.permalink,
+        };
+    } catch {
+        if (!providerSubmissionAttempted) {
+            duplicateSubmissionKeys.delete(submissionToken);
+        }
+
+        if (socialPostId) {
+            try {
+                await updateSocialPostStatus({
+                    id: socialPostId,
+                    status: 'failed',
+                    failureCode: 'unexpected_publish_error',
+                    failureMessage: 'Neočekivana greška tijekom slanja objave.',
+                    failureMetadata: { reason: 'unexpected_publish_error' },
+                });
+            } catch {
+                // Keep returning a controlled action state even if persistence fails.
+            }
+        }
+
+        if (socialPostId) {
+            return {
+                ok: false,
+                errorCode: 'internal_error',
+                message:
+                    'Objava nije uspješno poslana zbog neočekivane greške.',
+                socialPostId,
+                status: 'failed',
+            };
+        }
+
+        return {
+            ok: false,
+            errorCode: 'internal_error',
+            message: 'Objava nije uspješno poslana zbog neočekivane greške.',
         };
     }
-
-    const finalStatus = providerResult.permalink ? 'published' : 'submitted';
-    await updateSocialPostStatus({
-        id: created.id,
-        status: finalStatus,
-        providerSubmissionId: providerResult.providerPostId,
-        providerPermalink: providerResult.permalink,
-        providerMetadata: providerResult.metadata ?? null,
-    });
-
-    return {
-        ok: true,
-        message: 'Objava je uspješno poslana.',
-        socialPostId: created.id,
-        status: finalStatus,
-        providerPermalink: providerResult.permalink,
-    };
 }


### PR DESCRIPTION
### Motivation
- Implement an admin-facing immediate publish flow that creates a local social post record and invokes provider adapters (Reddit in MVP) so admins see the final provider status inline.
- Prevent duplicate provider submissions, enforce provider/destination allowlists, and surface sanitized provider errors for observability and trust.

### Description
- Add a server action `publishSocialPostAction` at `apps/app/app/(actions)/socialPublishActions.ts` that enforces `auth(['admin'])`, validates payloads, and normalizes form inputs.
- Route to provider adapters via `createSocialProviderAdapter(provider)` and validate provider configuration before attempting submission.
- Create the local social post with `createSocialPost`, set interim status `submitting`, call the adapter, and persist final state (`submitted`/`published`/`failed`) plus provider IDs, permalink, metadata, or sanitized failure context via `updateSocialPostStatus`.
- Add a short-lived in-memory submission-token duplicate guard and helper sanitization/validation utilities to reduce accidental double-submits and avoid leaking provider internals.

### Testing
- Ran `pnpm --filter app exec biome check "app/(actions)/socialPublishActions.ts"` which completed successfully.
- Ran `pnpm lint --filter app` which completed; it reported unrelated pre-existing warnings but did not block this change.
- Ran `pnpm build --filter app` and the Next.js app build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04eef6437c832faef3995a5b76019e)