### PR TITLE
Add single-operation creation option on admin operations page

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -77,6 +77,96 @@ export async function createOperationAction(formData: FormData) {
     return { success: true };
 }
 
+export type SingleCreateOperationActionState = {
+    success: boolean;
+    message: string;
+};
+
+export async function singleCreateOperationAction(
+    _previousState: SingleCreateOperationActionState | null,
+    formData: FormData,
+): Promise<SingleCreateOperationActionState> {
+    try {
+        const { userId } = await auth(['admin']);
+        const entityId = formData.get('entityId')
+            ? Number(formData.get('entityId'))
+            : undefined;
+        if (!entityId) {
+            throw new Error('Entity ID is required');
+        }
+        const target = (formData.get('target') as string | null)?.trim();
+        if (!target) {
+            throw new Error('Odaberite jednu ciljnu lokaciju.');
+        }
+        const selectedAssignedUserId =
+            (formData.get('assignedUserId') as string | null)?.trim() ||
+            undefined;
+        const scheduledDate = formData.get('scheduledDate')
+            ? new Date(formData.get('scheduledDate') as string)
+            : undefined;
+
+        const [accountId, gardenId, raisedBedId, raisedBedFieldId] =
+            target.split('|');
+
+        if (selectedAssignedUserId && gardenId) {
+            const assignableFarmUsersByGardenId =
+                await getAssignableFarmUsersByGardenIds([Number(gardenId)]);
+            const isUserAssignableToGarden =
+                assignableFarmUsersByGardenId[Number(gardenId)]?.some(
+                    (user) => user.id === selectedAssignedUserId,
+                ) ?? false;
+            if (!isUserAssignableToGarden) {
+                throw new Error(
+                    'Odabrani korisnik nije dostupan za odabranu radnju.',
+                );
+            }
+        }
+
+        const operationId = await createOperation({
+            entityId,
+            entityTypeName: 'operation',
+            accountId: accountId || undefined,
+            gardenId: gardenId ? Number(gardenId) : undefined,
+            raisedBedId: raisedBedId ? Number(raisedBedId) : undefined,
+            raisedBedFieldId: raisedBedFieldId
+                ? Number(raisedBedFieldId)
+                : undefined,
+            timestamp: undefined,
+        });
+
+        if (scheduledDate) {
+            await createEvent(
+                knownEvents.operations.scheduledV1(operationId.toString(), {
+                    scheduledDate: scheduledDate.toISOString(),
+                }),
+            );
+            await notifyOperationUpdate(operationId, 'scheduled', {
+                scheduledDate: scheduledDate.toISOString(),
+            });
+        }
+        if (selectedAssignedUserId) {
+            await createEvent(
+                knownEvents.operations.assignedV1(operationId.toString(), {
+                    assignedUserId: selectedAssignedUserId,
+                    assignedBy: userId,
+                }),
+            );
+        }
+
+        revalidatePath(KnownPages.Schedule);
+        revalidatePath(KnownPages.Operations);
+
+        return { success: true, message: 'Radnja je uspješno kreirana.' };
+    } catch (error) {
+        return {
+            success: false,
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'Došlo je do greške pri kreiranju radnje.',
+        };
+    }
+}
 export type BulkCreateOperationsActionState = {
     success: boolean;
     message: string;

--- a/apps/app/app/admin/operations/SingleOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/SingleOperationCreateModal.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Modal } from '@signalco/ui-primitives/Modal';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useActionState, useEffect, useMemo, useRef, useState } from 'react';
+import { getEntities } from '../../../components/shared/attributes/actions/entitiesActions';
+import { UserPickerField } from '../../../components/shared/fields/UserPickerField';
+import {
+    type SingleCreateOperationActionState,
+    singleCreateOperationAction,
+} from '../../(actions)/operationActions';
+import { SelectEntity } from '../raised-beds/[raisedBedId]/SelectEntity';
+import { TargetsSelectionList } from './TargetsSelectionList';
+
+const unassignedValue = '__unassigned__';
+
+export type SingleOperationCreateModalProps = {
+    gardens: Array<{
+        id: number;
+        name?: string | null;
+        accountId?: string | null;
+    }>;
+    raisedBeds: Array<{
+        id: number;
+        name?: string | null;
+        physicalId?: string | null;
+        accountId?: string | null;
+        gardenId?: number | null;
+        fields: Array<{ id: number; positionIndex: number }>;
+    }>;
+    assignableUsers: Array<{
+        id: string;
+        userName: string;
+        displayName: string | null;
+    }>;
+};
+
+export function SingleOperationCreateModal({
+    gardens,
+    raisedBeds,
+    assignableUsers,
+}: SingleOperationCreateModalProps) {
+    const [open, setOpen] = useState(false);
+    const [selectedOperationId, setSelectedOperationId] = useState<
+        string | null
+    >(null);
+    const [selectedTarget, setSelectedTarget] = useState<string | null>(null);
+    const [operations, setOperations] =
+        useState<Awaited<ReturnType<typeof getEntities>>>();
+    const [selectedAssignedUserId, setSelectedAssignedUserId] =
+        useState(unassignedValue);
+    const [state, formAction] = useActionState<
+        SingleCreateOperationActionState | null,
+        FormData
+    >(singleCreateOperationAction, null);
+    const formRef = useRef<HTMLFormElement>(null);
+
+    useEffect(() => {
+        getEntities('operation')
+            .then((ops) => setOperations(ops))
+            .catch((e) => console.error('Failed to load operations', e));
+    }, []);
+
+    const selectionMode = useMemo(() => {
+        if (!selectedOperationId) return undefined;
+        const application = operations?.find(
+            (o) => o.id?.toString() === selectedOperationId,
+        )?.attributes?.application as
+            | 'garden'
+            | 'raisedBedFull'
+            | 'raisedBed1m'
+            | 'plant'
+            | undefined;
+        if (!application) return undefined;
+        if (application === 'garden') return 'garden' as const;
+        if (application === 'plant') return 'plant' as const;
+        return 'raisedBed' as const;
+    }, [operations, selectedOperationId]);
+
+    useEffect(() => {
+        if (!state?.success) return;
+        setOpen(false);
+        setSelectedOperationId(null);
+        setSelectedTarget(null);
+        setSelectedAssignedUserId(unassignedValue);
+        formRef.current?.reset();
+    }, [state?.success]);
+
+    return (
+        <Modal
+            title={'Nova radnja'}
+            trigger={<Button variant="outlined">Dodaj jednu</Button>}
+            open={open}
+            onOpenChange={setOpen}
+        >
+            <form ref={formRef} action={formAction} className="space-y-4">
+                <Stack spacing={2}>
+                    <Typography level="h5">Nova radnja</Typography>
+                    <SelectEntity
+                        name="entityId"
+                        label="Radnja"
+                        required
+                        entityTypeName={'operation'}
+                        value={selectedOperationId}
+                        onChange={setSelectedOperationId}
+                    />
+                    <Input
+                        name="scheduledDate"
+                        type="datetime-local"
+                        label="Planirani datum (opcionalno)"
+                    />
+                    <UserPickerField
+                        users={assignableUsers.map((user) => ({
+                            id: user.id,
+                            label: user.displayName
+                                ? `${user.displayName} (${user.userName})`
+                                : user.userName,
+                            searchText: `${user.displayName ?? ''} ${user.userName}`,
+                        }))}
+                        value={selectedAssignedUserId}
+                        onValueChange={setSelectedAssignedUserId}
+                        label="Dodijeljeni korisnik (opcionalno)"
+                        emptyOption={{
+                            value: unassignedValue,
+                            label: 'Bez dodjele',
+                        }}
+                    />
+                    <input
+                        type="hidden"
+                        name="assignedUserId"
+                        value={
+                            selectedAssignedUserId === unassignedValue
+                                ? ''
+                                : selectedAssignedUserId
+                        }
+                    />
+                    <TargetsSelectionList
+                        name="target"
+                        gardens={gardens}
+                        raisedBeds={raisedBeds}
+                        mode={selectionMode}
+                        selectionType="single"
+                        selectedValue={selectedTarget}
+                        onSelectedValueChange={setSelectedTarget}
+                    />
+                    <Button type="submit">Kreiraj</Button>
+                    {state?.message && (
+                        <Typography
+                            level="body2"
+                            className={
+                                state.success
+                                    ? 'text-green-600'
+                                    : 'text-red-600'
+                            }
+                        >
+                            {state.message}
+                        </Typography>
+                    )}
+                </Stack>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/app/app/admin/operations/TargetsSelectionList.tsx
+++ b/apps/app/app/admin/operations/TargetsSelectionList.tsx
@@ -26,6 +26,9 @@ export type TargetsSelectionListProps = {
      * - undefined: default behavior (all levels visible and selectable)
      */
     mode?: 'garden' | 'raisedBed' | 'plant';
+    selectionType?: 'multiple' | 'single';
+    selectedValue?: string | null;
+    onSelectedValueChange?: (value: string | null) => void;
 };
 
 export function TargetsSelectionList({
@@ -34,6 +37,9 @@ export function TargetsSelectionList({
     gardens,
     raisedBeds,
     mode,
+    selectionType = 'multiple',
+    selectedValue,
+    onSelectedValueChange,
 }: TargetsSelectionListProps) {
     // Only show gardens that have raised beds with physicalId
     const visibleGardens = gardens.filter((garden) =>
@@ -48,6 +54,7 @@ export function TargetsSelectionList({
     const selectableField = mode === undefined || mode === 'plant';
 
     const baseClass = 'max-h-64 overflow-y-auto border rounded p-2 space-y-2';
+    const inputType = selectionType === 'single' ? 'radio' : 'checkbox';
     return (
         <div className={className ? `${baseClass} ${className}` : baseClass}>
             {visibleGardens.map((garden) => {
@@ -60,9 +67,24 @@ export function TargetsSelectionList({
                         {selectableGarden ? (
                             <label className="font-semibold flex items-center gap-2">
                                 <input
-                                    type="checkbox"
+                                    type={inputType}
                                     name={name}
                                     value={`${garden.accountId}|${garden.id}`}
+                                    checked={
+                                        selectionType === 'single'
+                                            ? selectedValue ===
+                                              `${garden.accountId}|${garden.id}`
+                                            : undefined
+                                    }
+                                    onChange={(event) => {
+                                        if (selectionType === 'single') {
+                                            onSelectedValueChange?.(
+                                                event.target.checked
+                                                    ? event.target.value
+                                                    : null,
+                                            );
+                                        }
+                                    }}
                                 />
                                 {garden.name || `Vrt ${garden.id}`}
                             </label>
@@ -80,10 +102,29 @@ export function TargetsSelectionList({
                                     <div key={rb.id} className="space-y-1">
                                         <label className="flex items-center gap-2">
                                             <input
-                                                type="checkbox"
+                                                type={inputType}
                                                 name={name}
                                                 disabled={!selectableRaisedBed}
                                                 value={`${rb.accountId}|${rb.gardenId ?? ''}|${rb.id}`}
+                                                checked={
+                                                    selectionType === 'single'
+                                                        ? selectedValue ===
+                                                          `${rb.accountId}|${rb.gardenId ?? ''}|${rb.id}`
+                                                        : undefined
+                                                }
+                                                onChange={(event) => {
+                                                    if (
+                                                        selectionType ===
+                                                        'single'
+                                                    ) {
+                                                        onSelectedValueChange?.(
+                                                            event.target.checked
+                                                                ? event.target
+                                                                      .value
+                                                                : null,
+                                                        );
+                                                    }
+                                                }}
                                             />
                                             {rb.physicalId ? (
                                                 <RaisedBedLabel
@@ -102,12 +143,37 @@ export function TargetsSelectionList({
                                                         className="flex items-center gap-2"
                                                     >
                                                         <input
-                                                            type="checkbox"
+                                                            type={inputType}
                                                             name={name}
                                                             disabled={
                                                                 !selectableField
                                                             }
                                                             value={`${rb.accountId}|${rb.gardenId ?? ''}|${rb.id}|${field.id}`}
+                                                            checked={
+                                                                selectionType ===
+                                                                'single'
+                                                                    ? selectedValue ===
+                                                                      `${rb.accountId}|${rb.gardenId ?? ''}|${rb.id}|${field.id}`
+                                                                    : undefined
+                                                            }
+                                                            onChange={(
+                                                                event,
+                                                            ) => {
+                                                                if (
+                                                                    selectionType ===
+                                                                    'single'
+                                                                ) {
+                                                                    onSelectedValueChange?.(
+                                                                        event
+                                                                            .target
+                                                                            .checked
+                                                                            ? event
+                                                                                  .target
+                                                                                  .value
+                                                                            : null,
+                                                                    );
+                                                                }
+                                                            }}
                                                         />
                                                         {`Polje ${
                                                             field.positionIndex +

--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -11,6 +11,7 @@ import { auth } from '../../../lib/auth/auth';
 import { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
 import { BulkOperationCreateModal } from './BulkOperationCreateModal';
 import { OperationsFilters } from './OperationsFilters';
+import { SingleOperationCreateModal } from './SingleOperationCreateModal';
 
 export const dynamic = 'force-dynamic';
 
@@ -43,11 +44,18 @@ export default async function OperationsPage({
         <Stack spacing={2}>
             <AdminPageHeader
                 actions={
-                    <BulkOperationCreateModal
-                        gardens={gardens}
-                        raisedBeds={raisedBeds}
-                        assignableUsers={assignableUsers}
-                    />
+                    <div className="flex gap-2">
+                        <SingleOperationCreateModal
+                            gardens={gardens}
+                            raisedBeds={raisedBeds}
+                            assignableUsers={assignableUsers}
+                        />
+                        <BulkOperationCreateModal
+                            gardens={gardens}
+                            raisedBeds={raisedBeds}
+                            assignableUsers={assignableUsers}
+                        />
+                    </div>
                 }
             />
             <OperationsFilters />


### PR DESCRIPTION
### Motivation
- Provide an option to create a single operation from the operations page with the same fields as the bulk flow but constrained to one target selection. 
- Reuse existing UI and server-side patterns to keep behavior consistent with the bulk creation flow and to validate assignee availability and optional scheduling.

### Description
- Added a new client component `apps/app/app/admin/operations/SingleOperationCreateModal.tsx` that mirrors the bulk modal UI but uses a single-target form field named `target` and a radio-style selection UI. 
- Implemented `singleCreateOperationAction` in `apps/app/app/(actions)/operationActions.ts` which validates input, checks assignee availability for the selected garden, creates the operation, emits schedule/assigned events when appropriate, and revalidates related pages. 
- Extended `TargetsSelectionList` in `apps/app/app/admin/operations/TargetsSelectionList.tsx` to support both multiple (`checkbox`) and single (`radio`) selection via new props `selectionType`, `selectedValue`, and `onSelectedValueChange`. 
- Updated the operations page header in `apps/app/app/admin/operations/page.tsx` to show both `Dodaj jednu` and `Dodaj više` actions side-by-side.

### Testing
- Ran `pnpm lint --filter app`, which completed and reported only environment engine warnings but no blocking errors. 
- Ran `pnpm build --filter app`, which completed successfully and produced a successful Next.js build despite the node engine warning in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a050b456144832f826f6420f43a0639)