### PR TITLE
Keep unconfirmed schedule tasks visible until verified

### DIFF
--- a/apps/app/app/admin/schedule/scheduleData.ts
+++ b/apps/app/app/admin/schedule/scheduleData.ts
@@ -54,20 +54,27 @@ export const getScheduleOperations = cache(async () => {
     return cacheScheduleRead(
         scheduleCacheKeys.adminActiveOperations(from, completedFrom),
         async () => {
-            const [newOrScheduledOperations, completedOperationsTodayOrLater] =
-                await Promise.all([
-                    getAllOperations({
-                        from,
-                        status: ['new', 'planned'],
-                    }),
-                    getAllOperations({
-                        completedFrom,
-                        status: 'completed',
-                    }),
-                ]);
+            const [
+                newOrScheduledOperations,
+                pendingVerificationOperations,
+                completedOperationsTodayOrLater,
+            ] = await Promise.all([
+                getAllOperations({
+                    from,
+                    status: ['new', 'planned'],
+                }),
+                getAllOperations({
+                    status: 'pendingVerification',
+                }),
+                getAllOperations({
+                    completedFrom,
+                    status: 'completed',
+                }),
+            ]);
 
             const operations = [
                 ...newOrScheduledOperations,
+                ...pendingVerificationOperations,
                 ...completedOperationsTodayOrLater,
             ].sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
 

--- a/apps/app/app/admin/schedule/scheduleDayFilters.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.ts
@@ -30,11 +30,19 @@ export function getScheduledFieldsForDay(
                 return false;
             }
 
-            if (
-                (field.plantStatus === 'sowed' ||
-                    isFieldPendingVerification(field.plantStatus)) &&
-                field.plantSowDate
-            ) {
+            if (isFieldPendingVerification(field.plantStatus)) {
+                if (!field.plantSowDate) {
+                    return isToday;
+                }
+
+                const sowDate = new Date(field.plantSowDate);
+                return (
+                    sowDate.toDateString() === normalizedDate.toDateString() ||
+                    (isToday && normalizedDate > sowDate)
+                );
+            }
+
+            if (field.plantStatus === 'sowed' && field.plantSowDate) {
                 const sowDate = new Date(field.plantSowDate);
                 return sowDate.toDateString() === normalizedDate.toDateString();
             }
@@ -73,11 +81,20 @@ export function getScheduledOperationsForDay(
             return false;
         }
 
-        if (
-            (isOperationCompleted(operation.status) ||
-                isOperationPendingVerification(operation.status)) &&
-            operation.completedAt
-        ) {
+        if (isOperationPendingVerification(operation.status)) {
+            if (!operation.completedAt) {
+                return isToday;
+            }
+
+            const completedDate = new Date(operation.completedAt);
+            return (
+                completedDate.toDateString() ===
+                    normalizedDate.toDateString() ||
+                (isToday && normalizedDate > completedDate)
+            );
+        }
+
+        if (isOperationCompleted(operation.status) && operation.completedAt) {
             const completedDate = new Date(operation.completedAt);
             return (
                 completedDate.toDateString() === normalizedDate.toDateString()

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getScheduledFieldsForDay,
+    getScheduledOperationsForDay,
+} from './scheduleDayFilters.ts';
+import type { Operation, RaisedBed, RaisedBedField } from './types.ts';
+
+const today = new Date(2026, 4, 14);
+const yesterdayNoon = new Date(2026, 4, 13, 12);
+
+function buildField(overrides: Partial<RaisedBedField>): RaisedBedField {
+    return {
+        id: 1,
+        raisedBedId: 10,
+        positionIndex: 0,
+        plantStatus: 'planned',
+        plantScheduledDate: yesterdayNoon,
+        plantSortId: 100,
+        plantSowDate: undefined,
+        plantGrowthDate: undefined,
+        plantReadyDate: undefined,
+        assignedUserId: 'farmer-1',
+        assignedUserIds: ['farmer-1'],
+        assignedBy: 'admin-1',
+        assignedAt: yesterdayNoon,
+        createdAt: yesterdayNoon,
+        updatedAt: yesterdayNoon,
+        isDeleted: false,
+        ...overrides,
+    };
+}
+
+function buildRaisedBed(field: RaisedBedField): RaisedBed {
+    return {
+        id: 10,
+        physicalId: 'A1',
+        name: 'Test raised bed',
+        accountId: 'account-1',
+        gardenId: 20,
+        blockId: null,
+        fields: [field],
+    };
+}
+
+function buildOperation(overrides: Partial<Operation>): Operation {
+    return {
+        id: 1,
+        farmId: null,
+        raisedBedId: 10,
+        raisedBedFieldId: null,
+        entityId: 100,
+        entityTypeName: 'operation',
+        accountId: 'account-1',
+        gardenId: 20,
+        status: 'planned',
+        scheduledDate: yesterdayNoon,
+        completedAt: undefined,
+        completedBy: undefined,
+        timestamp: yesterdayNoon,
+        createdAt: yesterdayNoon,
+        isAccepted: true,
+        isDeleted: false,
+        assignedUserId: 'farmer-1',
+        assignedUserIds: ['farmer-1'],
+        assignedBy: 'admin-1',
+        assignedAt: yesterdayNoon,
+        assignedUser: null,
+        assignedUsers: [],
+        ...overrides,
+    };
+}
+
+test('pending verification sowing remains visible today until verified', () => {
+    const pendingField = buildField({
+        plantStatus: 'pendingVerification',
+        plantSowDate: yesterdayNoon,
+    });
+    const verifiedField = buildField({
+        id: 2,
+        plantStatus: 'sowed',
+        plantSowDate: yesterdayNoon,
+    });
+
+    assert.deepEqual(
+        getScheduledFieldsForDay(true, today, [
+            buildRaisedBed(pendingField),
+            buildRaisedBed(verifiedField),
+        ]).map((field) => field.id),
+        [1],
+    );
+});
+
+test('pending verification operation remains visible today until verified', () => {
+    const pendingOperation = buildOperation({
+        status: 'pendingVerification',
+        completedAt: yesterdayNoon,
+    });
+    const verifiedOperation = buildOperation({
+        id: 2,
+        status: 'completed',
+        completedAt: yesterdayNoon,
+    });
+
+    assert.deepEqual(
+        getScheduledOperationsForDay(true, today, [
+            pendingOperation,
+            verifiedOperation,
+        ]).map((operation) => operation.id),
+        [1],
+    );
+});

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,8 @@
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
         "test:prepare": "pnpm --dir ../.. exec turbo build --filter=app",
-        "test:run": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --test src/social/providers/reddit/redditAdapter.unit.ts && playwright test",
+        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/social/providers/reddit/redditAdapter.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts",
+        "test:run": "pnpm run test:unit && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "test:local": "pnpm run test:prepare && pnpm run test:run"
     },
@@ -75,6 +76,7 @@
         "babel-plugin-react-compiler": "19.1.0-rc.3",
         "postcss": "8.5.14",
         "tailwindcss": "3.4.19",
+        "tsx": "4.21.0",
         "typescript": "6.0.3"
     }
 }

--- a/packages/storage/src/cache/scheduleCache.ts
+++ b/packages/storage/src/cache/scheduleCache.ts
@@ -20,7 +20,7 @@ type DeliveryRequestsSummaryCacheInput = {
     toDate?: Date;
 };
 
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = 'v2';
 
 export const scheduleCacheTtls = {
     day: 45,

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -370,6 +370,24 @@ function getOperationStatusExpression() {
     )`;
 }
 
+function getOperationStatusWhere(
+    status: OperationStatus | OperationStatus[] | undefined,
+) {
+    if (!status) {
+        return undefined;
+    }
+
+    const statusValues = Array.isArray(status) ? status : [status];
+    if (statusValues.length === 0) {
+        return undefined;
+    }
+
+    return sql`${getOperationStatusExpression()} in (${sql.join(
+        statusValues.map((value) => sql`${value}`),
+        sql`, `,
+    )})`;
+}
+
 function getOperationTimelineSortExpression() {
     const scheduledDateExpression = getOperationScheduledDateExpression();
 
@@ -478,6 +496,7 @@ async function getAllOperationsUncached(filter?: {
         const operationsList = await storage().query.operations.findMany({
             where: and(
                 eq(operations.isDeleted, false),
+                getOperationStatusWhere(filter?.status),
                 filter?.from
                     ? gte(operations.timestamp, filter.from)
                     : undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
       tailwindcss:
         specifier: 3.4.19
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
- Include `pendingVerification` operations in the admin schedule source so completed-but-unconfirmed farmer work stays actionable.
- Keep pending-verification sowing and operation rows visible on the schedule until they are verified, instead of dropping them after the completion day.
- Add a focused unit test for the schedule visibility rules and route the app test runner through `tsx` so the new TypeScript unit test runs cleanly.

## Testing
- `pnpm lint --filter app`
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage`
- `pnpm build --filter app`
- `pnpm test --filter app`
- `git diff --check`