### PR TITLE
Fix operations status query in admin schedule reads

### DIFF
--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -499,17 +499,22 @@ async function getAllOperationsUncached(filter?: {
         );
     } else {
         // Otherwise, use the original timestamp-based filtering
-        const operationsList = await storage().query.operations.findMany({
-            where: and(
-                eq(operations.isDeleted, false),
-                getOperationStatusWhere(filter?.status),
-                filter?.from
-                    ? gte(operations.timestamp, filter.from)
-                    : undefined,
-                filter?.to ? lte(operations.timestamp, filter.to) : undefined,
-            ),
-            orderBy: desc(operations.timestamp),
-        });
+        const operationsList = await storage()
+            .select()
+            .from(operations)
+            .where(
+                and(
+                    eq(operations.isDeleted, false),
+                    getOperationStatusWhere(filter?.status),
+                    filter?.from
+                        ? gte(operations.timestamp, filter.from)
+                        : undefined,
+                    filter?.to
+                        ? lte(operations.timestamp, filter.to)
+                        : undefined,
+                ),
+            )
+            .orderBy(desc(operations.timestamp));
         operationsWithAggregates =
             await fillOperationAggregates(operationsList);
     }

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -7,6 +7,7 @@ import {
     createEvent,
     createFarm,
     createOperation,
+    getAllOperations,
     getAssignableFarmUsersByOperationIds,
     getFarmUserAcceptedOperations,
     getOperationById,
@@ -93,4 +94,52 @@ test('completed operations expose completion notes and image URLs', async () => 
         'https://cdn.gredice.com/operation-complete.jpg',
     ]);
     assert.strictEqual(operation.completionNotes, 'Zaliveno nakon berbe.');
+});
+
+test('all operations can be filtered by event-derived status', async () => {
+    createTestDb();
+
+    const accountId = randomUUID();
+    const from = new Date('2040-01-01T00:00:00.000Z');
+    const plannedOperationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        accountId,
+        timestamp: new Date('2040-01-02T00:00:00.000Z'),
+    });
+    const newOperationId = await createOperation({
+        entityId: 2,
+        entityTypeName: 'operation',
+        accountId,
+        timestamp: new Date('2040-01-03T00:00:00.000Z'),
+    });
+    const pendingOperationId = await createOperation({
+        entityId: 3,
+        entityTypeName: 'operation',
+        accountId,
+        timestamp: new Date('2040-01-04T00:00:00.000Z'),
+    });
+
+    await createEvent(
+        knownEvents.operations.scheduledV1(plannedOperationId.toString(), {
+            scheduledDate: '2040-01-05T00:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(pendingOperationId.toString(), {
+            completedBy: randomUUID(),
+        }),
+    );
+
+    const operations = await getAllOperations({
+        from,
+        status: ['new', 'planned'],
+    });
+    const operationIds = operations.map((operation) => operation.id);
+
+    assert.deepStrictEqual(
+        new Set(operationIds),
+        new Set([newOperationId, plannedOperationId]),
+    );
+    assert.ok(!operationIds.includes(pendingOperationId));
 });


### PR DESCRIPTION
## Summary
- Switch the admin operations read path to Drizzle's core query builder so the event-derived status subquery is preserved correctly.
- Add a regression test covering `getAllOperations({ status: ['new', 'planned'] })` to prevent the aliasing issue from returning.

## Testing
- Passed the targeted storage repository test suite for operations.
- Passed `pnpm lint --filter @gredice/storage`.
- Verified the edited files with direct Biome checks.