### PR TITLE
Add sowing date calendar badge on carted raised-bed plant cells

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -1,6 +1,6 @@
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { PlantOrSortImage } from '@gredice/ui/plants';
-import { Calendar, ShoppingCart } from '@signalco/ui-icons';
+import { ShoppingCart } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
@@ -9,11 +9,12 @@ import { PlantPicker } from './RaisedBedPlantPicker';
 
 function formatScheduledSowingDateLabel(date: Date, now: Date): string {
     const day = date.getDate();
-    const sameMonth =
+    const sameMonthAndYear =
         date.getFullYear() === now.getFullYear() &&
         date.getMonth() === now.getMonth();
+    const shouldIncludeMonth = !sameMonthAndYear && day >= now.getDate();
 
-    if (sameMonth) {
+    if (!shouldIncludeMonth) {
         return day.toString();
     }
 
@@ -100,13 +101,11 @@ export function RaisedBedFieldItemEmpty({
                             </div>
                             {scheduledDateLabel && (
                                 <div className="absolute left-0.5 bottom-0.5">
-                                    <div className="rounded-full border-2 px-1 py-0.5 bg-stone-200 border-stone-400 text-stone-800 shadow-lg min-w-8">
-                                        <div className="flex items-center gap-0.5">
-                                            <Calendar className="size-3" />
-                                            <span className="text-[10px] font-semibold leading-none">
-                                                {scheduledDateLabel}
-                                            </span>
-                                        </div>
+                                    <div className="relative size-8 rounded-full border-2 bg-stone-200 border-stone-400 text-stone-800 shadow-lg overflow-hidden">
+                                        <div className="absolute inset-x-0 top-0 h-2 bg-stone-300" />
+                                        <span className="absolute inset-0 pt-1.5 flex items-center justify-center text-[9px] font-semibold leading-none">
+                                            {scheduledDateLabel}
+                                        </span>
                                     </div>
                                 </div>
                             )}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -101,8 +101,8 @@ export function RaisedBedFieldItemEmpty({
                             </div>
                             {scheduledDateLabel && (
                                 <div className="absolute left-0.5 bottom-0.5">
-                                    <div className="relative size-8 rounded-full border-2 bg-stone-200 border-stone-400 text-stone-800 shadow-lg overflow-hidden">
-                                        <div className="absolute inset-x-0 top-0 h-2 bg-stone-300" />
+                                    <div className="relative size-6 rounded-lg border-2 bg-stone-200 border-stone-400 text-stone-800 shadow-lg overflow-hidden">
+                                        <div className="absolute inset-x-0 top-0 h-1.5 bg-stone-400" />
                                         <span className="absolute inset-0 pt-1.5 flex items-center justify-center text-[9px] font-semibold leading-none">
                                             {scheduledDateLabel}
                                         </span>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -1,11 +1,24 @@
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { PlantOrSortImage } from '@gredice/ui/plants';
-import { ShoppingCart } from '@signalco/ui-icons';
+import { Calendar, ShoppingCart } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import { PlantPicker } from './RaisedBedPlantPicker';
+
+function formatScheduledSowingDateLabel(date: Date, now: Date): string {
+    const day = date.getDate();
+    const sameMonth =
+        date.getFullYear() === now.getFullYear() &&
+        date.getMonth() === now.getMonth();
+
+    if (sameMonth) {
+        return day.toString();
+    }
+
+    return `${day}.${date.getMonth() + 1}.`;
+}
 
 export function RaisedBedFieldItemEmpty({
     cartPlantItem,
@@ -41,6 +54,12 @@ export function RaisedBedFieldItemEmpty({
             ? new Date(additionalDataRaw.scheduledDate)
             : null,
     };
+    const scheduledDate = cartPlantOptions.scheduledDate;
+    const hasScheduledDate =
+        scheduledDate instanceof Date && !Number.isNaN(scheduledDate.valueOf());
+    const scheduledDateLabel = hasScheduledDate
+        ? formatScheduledSowingDateLabel(scheduledDate, new Date())
+        : null;
 
     const isLoading = isCartPending || isGardenPending;
     if (isLoading) {
@@ -79,6 +98,18 @@ export function RaisedBedFieldItemEmpty({
                                     <ShoppingCart className="size-4 stroke-white" />
                                 </div>
                             </div>
+                            {scheduledDateLabel && (
+                                <div className="absolute left-0.5 bottom-0.5">
+                                    <div className="rounded-full border-2 px-1 py-0.5 bg-stone-200 border-stone-400 text-stone-800 shadow-lg min-w-8">
+                                        <div className="flex items-center gap-0.5">
+                                            <Calendar className="size-3" />
+                                            <span className="text-[10px] font-semibold leading-none">
+                                                {scheduledDateLabel}
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
                         </>
                     )}
                 </RaisedBedFieldItemButton>


### PR DESCRIPTION
### Motivation
- Improve game HUD visibility for plant sorts placed in the shopping cart by showing their planned sowing date directly on the raised-bed field cell. 
- Display the date compactly (never showing year) to avoid clutter while preserving the existing cart badge.

### Description
- Updated `packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx` to import `Calendar` and render a secondary badge anchored bottom-left when a scheduled sowing date exists. 
- Added helper `formatScheduledSowingDateLabel(date: Date, now: Date)` that returns `D` for dates in the current month and `D.M.` for other months, never including the year. 
- Parsed `scheduledDate` from `cartPlantItem.additionalData`, validated it, and computed `scheduledDateLabel` only when the date is valid. 
- Kept the existing top-right shopping cart badge unchanged and applied neutral gray/beige styling with a calendar icon plus compact date text for the new badge.

### Testing
- Ran `pnpm lint --filter @gredice/game` and the lint check completed successfully after fixes. 
- Ran `pnpm build --filter @gredice/game` and the build run completed with no package build tasks to execute in the current Turbo configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0523275904832f8770f3ac0eaf102c)