### PR TITLE
Fix hydration error in admin schedule date rows

### DIFF
--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -285,6 +285,7 @@ export function FarmOperationsScheduleSection({
                                     )}
                                 <Typography
                                     level="body2"
+                                    component="div"
                                     className="select-none"
                                 >
                                     {operation.scheduledDate ? (

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -429,6 +429,7 @@ export function RaisedBedOperationsScheduleSection({
                                         )}
                                     <Typography
                                         level="body2"
+                                        component="div"
                                         className="select-none"
                                     >
                                         {operation.scheduledDate ? (

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -304,6 +304,7 @@ export function RaisedBedPlantingScheduleSection({
                                     </Typography>
                                     <Typography
                                         level="body2"
+                                        component="div"
                                         className="select-none"
                                     >
                                         {field.plantScheduledDate ? (


### PR DESCRIPTION
## Summary
- Change the schedule date wrapper `Typography` elements to render as `div` where they can contain a `Chip` fallback.
- Removes the invalid `<div>` inside `<p>` nesting that caused the hydration warning in admin schedule views.

## Testing
- Lint and formatting passed for the affected app workspace.
- App build passed.
- Local unit tests and Playwright checks passed for the admin app.