### PR TITLE
Make medium cloud shadows hard-edged

### DIFF
--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -14,9 +14,11 @@ import {
 } from 'three';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
+import type { GameCloudShadowMode } from './gameQuality';
 
 const MAX_CLOUDS = 8;
 const CLOUD_ALPHA_TEST = 0.025;
+const CLOUD_SHADOW_ALPHA_TEST = 0.08;
 const CLOUD_MARGIN = 12;
 const CLOUD_WORLD_ALTITUDE = 10;
 const CLOUD_ALTITUDE_VARIATION = 4;
@@ -132,6 +134,7 @@ function getCloudBounds(stacks: Stack[] | undefined) {
 type CloudLayerProps = {
     cloudy: number;
     foggy: number;
+    shadowMode: GameCloudShadowMode;
     shadowStrength: number;
     stacks: Stack[] | undefined;
     timeOfDay: number;
@@ -210,6 +213,7 @@ function spawnCloud(
 export function CloudLayer({
     cloudy,
     foggy,
+    shadowMode,
     shadowStrength,
     stacks,
     timeOfDay,
@@ -478,7 +482,18 @@ export function CloudLayer({
                     }}
                 >
                     <planeGeometry args={[cloud.width, cloud.height]} />
-                    <meshDepthMaterial attach="customDepthMaterial" alphaHash />
+                    {shadowMode === 'hard' ? (
+                        <meshDepthMaterial
+                            attach="customDepthMaterial"
+                            alphaMap={cloudAlphaTexture}
+                            alphaTest={CLOUD_SHADOW_ALPHA_TEST}
+                        />
+                    ) : (
+                        <meshDepthMaterial
+                            attach="customDepthMaterial"
+                            alphaHash
+                        />
+                    )}
                     <meshBasicMaterial
                         alphaMap={cloudAlphaTexture}
                         alphaTest={CLOUD_ALPHA_TEST}

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -824,6 +824,7 @@ export function Environment({
                 <CloudLayer
                     cloudy={blendedWeather.cloudy ?? 0}
                     foggy={blendedWeather.foggy ?? 0}
+                    shadowMode={qualityProfile.cloudShadowMode}
                     shadowStrength={
                         qualityProfile.shadows ? cloudShadowStrength : 0
                     }

--- a/packages/game/src/scene/gameQuality.ts
+++ b/packages/game/src/scene/gameQuality.ts
@@ -1,8 +1,10 @@
 'use client';
 
 export type GameQualityTier = 'low' | 'medium' | 'high';
+export type GameCloudShadowMode = 'hard' | 'soft';
 
 export type GameQualityProfile = {
+    cloudShadowMode: GameCloudShadowMode;
     dpr: number;
     groundDecorationDensity: number;
     rainParticleMultiplier: number;
@@ -15,6 +17,7 @@ export type GameQualityProfile = {
 
 export const gameQualityProfiles = {
     low: {
+        cloudShadowMode: 'hard',
         dpr: 1,
         groundDecorationDensity: 0,
         rainParticleMultiplier: 0.35,
@@ -25,6 +28,7 @@ export const gameQualityProfiles = {
         tier: 'low',
     },
     medium: {
+        cloudShadowMode: 'hard',
         dpr: 1.5,
         groundDecorationDensity: 0.5,
         rainParticleMultiplier: 0.7,
@@ -35,6 +39,7 @@ export const gameQualityProfiles = {
         tier: 'medium',
     },
     high: {
+        cloudShadowMode: 'soft',
         dpr: 2,
         groundDecorationDensity: 1,
         rainParticleMultiplier: 1,


### PR DESCRIPTION
## Summary
- Added a cloud shadow mode to the game quality profile.
- Set `medium` quality to use hard alpha-tested cloud shadows instead of hashed alpha shadows.
- Kept `high` quality on the softer hashed path.

## Testing
- `pnpm --filter @gredice/game exec biome check src/scene/CloudLayer.tsx src/scene/Environment.tsx src/scene/gameQuality.ts`
- `pnpm build --filter garden --filter www`
- Local browser verification of the garden debug scene in production mode