### PR TITLE
Fix grass decoration placement on angled blocks

### DIFF
--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -13,7 +13,8 @@
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
-        "lint:migrate": "biome migrate --write"
+        "lint:migrate": "biome migrate --write",
+        "test": "tsx --test src/entities/groundDecorations/getBlockSurfaceDecorations.unit.ts"
     },
     "devDependencies": {
         "@biomejs/biome": "2.4.15",

--- a/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
+++ b/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
@@ -13,16 +13,21 @@ export type BlockSurfaceDecorationPlacement = {
     spriteName: string;
 };
 
+const angledBlockHighEdgeX = 0.5;
+
 function resolveDecorationBaseY(
     block: Block,
     options: (typeof groundDecorationOptions)[GroundDecorationSurface],
-    z: number,
+    x: number,
 ) {
     if (!block.name.endsWith('_Angle')) {
         return options.baseY;
     }
 
-    return options.baseY + z * options.angleLiftPerUnit;
+    // baseY is tuned for the raised local +X edge of angled block meshes.
+    return (
+        options.baseY + (x - angledBlockHighEdgeX) * options.angleLiftPerUnit
+    );
 }
 
 function getDecorationCount(
@@ -121,7 +126,7 @@ export function getBlockSurfaceDecorations(options: {
             ),
             position: [
                 x,
-                resolveDecorationBaseY(block, decorationOptions, z) +
+                resolveDecorationBaseY(block, decorationOptions, x) +
                     index * 0.002,
                 z,
             ],

--- a/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.unit.ts
+++ b/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.unit.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Block } from '../../types/Block';
+import { getBlockSurfaceDecorations } from './getBlockSurfaceDecorations';
+import { groundDecorationOptions } from './groundDecorationConfig';
+
+function round(value: number) {
+    return Number(value.toFixed(6));
+}
+
+test('positions angled block decorations along the local x slope', () => {
+    const block = {
+        id: 'angled-grass-test',
+        name: 'Block_Grass_Angle',
+        rotation: 0,
+    } satisfies Block;
+    const placements = getBlockSurfaceDecorations({
+        block,
+        gardenId: 42,
+        surface: 'grass',
+    });
+    const firstPlacement = placements[0];
+
+    assert.ok(firstPlacement);
+    assert.ok(
+        Math.abs(firstPlacement.position[0] - firstPlacement.position[2]) >
+            0.01,
+    );
+
+    const expectedY =
+        groundDecorationOptions.grass.baseY +
+        (firstPlacement.position[0] - 0.5) *
+            groundDecorationOptions.grass.angleLiftPerUnit;
+
+    assert.equal(round(firstPlacement.position[1]), round(expectedY));
+});

--- a/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
+++ b/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
@@ -24,7 +24,7 @@ export const groundDecorationOptions: Record<
     GroundDecorationOptions
 > = {
     grass: {
-        angleLiftPerUnit: 0.3,
+        angleLiftPerUnit: 0.4,
         baseY: 0.16,
         clusterChance: 0.42,
         heightRange: [0.09, 0.14],
@@ -35,7 +35,7 @@ export const groundDecorationOptions: Record<
         spawnChance: 1,
     },
     sand: {
-        angleLiftPerUnit: 0.3,
+        angleLiftPerUnit: 0.4,
         baseY: 0.2,
         clusterChance: 0.1,
         heightRange: [0.09, 0.25],


### PR DESCRIPTION
## Summary
- Align angled grass and sand surface decorations to the block mesh slope instead of the wrong local axis
- Tune the angled lift factor to match the exported mesh geometry
- Add a focused unit test covering angled decoration placement

## Testing
- `pnpm lint --filter @gredice/game --filter garden --filter www`
- `pnpm test --filter @gredice/game`
- `pnpm build --filter garden --filter www --force`