### PR TITLE
Raise cloud render order above ground decorations

### DIFF
--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -32,6 +32,7 @@ const CLOUD_MIN_COVERAGE_SCALE = 0.62;
 const CLOUD_MAX_COVERAGE_SCALE = 1.14;
 const CLOUD_BASE_DRIFT_SPEED = 0.35;
 const CLOUD_WIND_DRIFT_SPEED = 0.5;
+const CLOUD_RENDER_ORDER = 30;
 
 function smoothstep(edge0: number, edge1: number, value: number) {
     const t = Math.min(1, Math.max(0, (value - edge0) / (edge1 - edge0)));
@@ -473,6 +474,7 @@ export function CloudLayer({
                     key={cloud.id}
                     castShadow={index < shadowCasterCount}
                     frustumCulled={false}
+                    renderOrder={CLOUD_RENDER_ORDER}
                     ref={(mesh) => {
                         cloudRefs.current[index] = mesh;
                     }}


### PR DESCRIPTION
## Summary
- Set an explicit render order for cloud meshes so they composite after transparent ground decoration sprites
- Fix grass sprites appearing above clouds in the garden scene without changing the grass sprite ordering itself

## Testing
- `pnpm --filter @gredice/game exec biome check src/scene/CloudLayer.tsx`
- `pnpm build --filter garden --force`
- `pnpm build --filter www --force`
- Local browser verification on the garden debug rain profile