### PR TITLE
Make schedule actions optimistic

### DIFF
--- a/apps/app/app/admin/schedule/AcceptOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptOperationModal.tsx
@@ -7,19 +7,22 @@ interface AcceptOperationModalProps {
     operationId: number;
     label: string;
     disabled?: boolean;
+    onConfirm?: () => unknown | Promise<unknown>;
 }
 
 export function AcceptOperationModal({
     operationId,
     label,
     disabled = false,
+    onConfirm,
 }: AcceptOperationModalProps) {
     const handleConfirm = async () => {
-        try {
-            await acceptOperationAction(operationId);
-        } catch (error) {
-            console.error('Error accepting operation:', error);
+        if (onConfirm) {
+            await onConfirm();
+            return;
         }
+
+        await acceptOperationAction(operationId);
     };
 
     return (

--- a/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
@@ -2,7 +2,6 @@
 
 import { Check } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
-import { useState } from 'react';
 import { acceptRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
 import { AcceptRequestModal } from './AcceptRequestModal';
 
@@ -11,6 +10,7 @@ interface AcceptRaisedBedFieldModalProps {
     positionIndex: number;
     label: string;
     disabled?: boolean;
+    onConfirm?: () => unknown | Promise<unknown>;
 }
 
 export function AcceptRaisedBedFieldModal({
@@ -18,17 +18,15 @@ export function AcceptRaisedBedFieldModal({
     positionIndex,
     label,
     disabled = false,
+    onConfirm,
 }: AcceptRaisedBedFieldModalProps) {
-    const [loading, setLoading] = useState(false);
     const handleConfirm = async () => {
-        try {
-            setLoading(true);
-            await acceptRaisedBedFieldAction(raisedBedId, positionIndex);
-        } catch (error) {
-            console.error('Error accepting field request:', error);
-        } finally {
-            setLoading(false);
+        if (onConfirm) {
+            await onConfirm();
+            return;
         }
+
+        await acceptRaisedBedFieldAction(raisedBedId, positionIndex);
     };
 
     return (
@@ -39,7 +37,6 @@ export function AcceptRaisedBedFieldModal({
                 <IconButton
                     variant="plain"
                     title="Potvrdi sijanje"
-                    loading={loading}
                     disabled={disabled}
                 >
                     <Check className="size-4 shrink-0" />

--- a/apps/app/app/admin/schedule/AcceptRequestModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRequestModal.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 
 interface AcceptRequestModalProps {
     label: string;
-    onConfirm: () => Promise<void>;
+    onConfirm: () => unknown | Promise<unknown>;
     trigger?: React.ReactElement;
     title?: string;
     header?: string;
@@ -34,6 +34,7 @@ export function AcceptRequestModal({
             setOpen(false);
         } catch (error) {
             console.error('Error confirming request:', error);
+            alert('Potvrda zadatka nije uspjela. Pokušajte ponovno.');
         } finally {
             setIsSubmitting(false);
         }

--- a/apps/app/app/admin/schedule/AssignOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AssignOperationModal.tsx
@@ -27,6 +27,7 @@ interface AssignOperationModalProps {
     farmUsers: AssignableUser[];
     assignedUsers?: OperationAssignedUser[];
     disabled?: boolean;
+    onSubmit?: (selectedUserIds: string[]) => unknown | Promise<unknown>;
 }
 
 function getUserLabel(user: AssignableUser | OperationAssignedUser) {
@@ -41,6 +42,7 @@ export function AssignOperationModal({
     farmUsers,
     assignedUsers,
     disabled = false,
+    onSubmit,
 }: AssignOperationModalProps) {
     const [open, setOpen] = useState(false);
     const initialAssignedUserIds = useMemo(
@@ -100,7 +102,11 @@ export function AssignOperationModal({
         setErrorMessage(null);
 
         try {
-            await assignOperationUserAction(operationId, selectedUserIds);
+            if (onSubmit) {
+                await onSubmit(selectedUserIds);
+            } else {
+                await assignOperationUserAction(operationId, selectedUserIds);
+            }
             setOpen(false);
         } catch (error) {
             console.error('Error assigning operation user:', error);
@@ -181,7 +187,7 @@ export function AssignOperationModal({
                                 key={user.id}
                                 label={getUserLabel(user)}
                                 checked={selectedUserIds.includes(user.id)}
-                                onCheckedChange={(checked) =>
+                                onCheckedChange={(checked: boolean) =>
                                     toggleSelectedUser(
                                         user.id,
                                         Boolean(checked),

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -26,6 +26,7 @@ interface AssignRaisedBedFieldModalProps {
     farmUsers: AssignableUser[];
     assignedUserIds?: string[];
     disabled?: boolean;
+    onSubmit?: (selectedUserIds: string[]) => unknown | Promise<unknown>;
 }
 
 function getUserLabel(user: AssignableUser) {
@@ -40,6 +41,7 @@ export function AssignRaisedBedFieldModal({
     farmUsers,
     assignedUserIds,
     disabled = false,
+    onSubmit,
 }: AssignRaisedBedFieldModalProps) {
     const [open, setOpen] = useState(false);
     const initialAssignedUserIds = useMemo(
@@ -115,10 +117,14 @@ export function AssignRaisedBedFieldModal({
         setErrorMessage(null);
 
         try {
-            await assignRaisedBedFieldUserAction(
-                raisedBedFieldId,
-                selectedUserIds,
-            );
+            if (onSubmit) {
+                await onSubmit(selectedUserIds);
+            } else {
+                await assignRaisedBedFieldUserAction(
+                    raisedBedFieldId,
+                    selectedUserIds,
+                );
+            }
             setOpen(false);
         } catch (error) {
             console.error('Error assigning planting user:', error);
@@ -204,7 +210,7 @@ export function AssignRaisedBedFieldModal({
                                 key={user.id}
                                 label={getUserLabel(user)}
                                 checked={selectedUserIds.includes(user.id)}
-                                onCheckedChange={(checked) =>
+                                onCheckedChange={(checked: boolean) =>
                                     toggleSelectedUser(
                                         user.id,
                                         Boolean(checked),

--- a/apps/app/app/admin/schedule/BulkApproveRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkApproveRaisedBedButton.tsx
@@ -8,6 +8,7 @@ import { acceptRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActio
 import { AcceptRequestModal } from './AcceptRequestModal';
 
 type FieldApprovalTarget = {
+    id?: number;
     raisedBedId: number;
     positionIndex: number;
     label: string;
@@ -22,12 +23,14 @@ interface BulkApproveRaisedBedButtonProps {
     physicalId: string;
     fields: FieldApprovalTarget[];
     operations: OperationApprovalTarget[];
+    onConfirm?: () => unknown | Promise<unknown>;
 }
 
 export function BulkApproveRaisedBedButton({
     physicalId,
     fields,
     operations,
+    onConfirm,
 }: BulkApproveRaisedBedButtonProps) {
     const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -39,25 +42,28 @@ export function BulkApproveRaisedBedButton({
             return;
         }
 
-        setIsSubmitting(true);
-        try {
-            await Promise.all([
-                ...fields.map((field) =>
-                    acceptRaisedBedFieldAction(
-                        field.raisedBedId,
-                        field.positionIndex,
-                    ),
-                ),
-                ...operations.map((operation) =>
-                    acceptOperationAction(operation.id),
-                ),
-            ]);
-        } catch (error) {
-            console.error('Failed to approve all raised bed items:', error);
-            throw error;
-        } finally {
-            setIsSubmitting(false);
+        if (onConfirm) {
+            await onConfirm();
+            return;
         }
+
+        setIsSubmitting(true);
+        void Promise.all([
+            ...fields.map((field) =>
+                acceptRaisedBedFieldAction(
+                    field.raisedBedId,
+                    field.positionIndex,
+                ),
+            ),
+            ...operations.map((operation) =>
+                acceptOperationAction(operation.id),
+            ),
+        ])
+            .catch((error: unknown) => {
+                console.error('Failed to approve all raised bed items:', error);
+                alert('Skupna potvrda zadataka nije uspjela.');
+            })
+            .finally(() => setIsSubmitting(false));
     };
 
     return (

--- a/apps/app/app/admin/schedule/BulkAssignRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkAssignRaisedBedButton.tsx
@@ -40,6 +40,7 @@ interface BulkAssignRaisedBedButtonProps {
     physicalId: string;
     fields: FieldAssignmentTarget[];
     operations: OperationAssignmentTarget[];
+    onSubmit?: (assignedUserIds: string[]) => unknown | Promise<unknown>;
 }
 
 function getUserLabel(user: AssignableUser) {
@@ -52,6 +53,7 @@ export function BulkAssignRaisedBedButton({
     physicalId,
     fields,
     operations,
+    onSubmit,
 }: BulkAssignRaisedBedButtonProps) {
     const [open, setOpen] = useState(false);
     const [selectedUserId, setSelectedUserId] = useState(unassignedValue);
@@ -114,30 +116,34 @@ export function BulkAssignRaisedBedButton({
             return;
         }
 
-        setIsSubmitting(true);
         setErrorMessage(null);
         const assignedUserIds =
             selectedUserId === unassignedValue ? [] : [selectedUserId];
 
-        try {
-            await Promise.all([
-                ...fields.map((field) =>
-                    assignRaisedBedFieldUserAction(field.id, assignedUserIds),
-                ),
-                ...operations.map((operation) =>
-                    assignOperationUserAction(operation.id, assignedUserIds),
-                ),
-            ]);
+        if (onSubmit) {
+            await onSubmit(assignedUserIds);
             setOpen(false);
-        } catch (error) {
-            console.error(
-                'Failed to assign users for all raised bed items:',
-                error,
-            );
-            setErrorMessage('Greška pri spremanju skupne dodjele korisnika.');
-        } finally {
-            setIsSubmitting(false);
+            return;
         }
+
+        setIsSubmitting(true);
+        setOpen(false);
+        void Promise.all([
+            ...fields.map((field) =>
+                assignRaisedBedFieldUserAction(field.id, assignedUserIds),
+            ),
+            ...operations.map((operation) =>
+                assignOperationUserAction(operation.id, assignedUserIds),
+            ),
+        ])
+            .catch((error: unknown) => {
+                console.error(
+                    'Failed to assign users for all raised bed items:',
+                    error,
+                );
+                alert('Skupna dodjela korisnika nije uspjela.');
+            })
+            .finally(() => setIsSubmitting(false));
     }
 
     return (
@@ -172,7 +178,6 @@ export function BulkAssignRaisedBedButton({
                         value: unassignedValue,
                         label: 'Bez dodjele',
                     }}
-                    resetKey={open}
                 />
 
                 {errorMessage && (

--- a/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
@@ -13,6 +13,7 @@ import { rescheduleOperationAction } from '../../(actions)/operationActions';
 import { rescheduleRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
 
 type FieldRescheduleTarget = {
+    id?: number;
     raisedBedId: number;
     positionIndex: number;
 };
@@ -25,6 +26,7 @@ interface BulkRescheduleRaisedBedButtonProps {
     physicalId: string;
     fields: FieldRescheduleTarget[];
     operations: OperationRescheduleTarget[];
+    onSubmit?: (scheduledDate: string) => unknown | Promise<unknown>;
 }
 
 function formatLocalDate(date: Date): string {
@@ -38,6 +40,7 @@ export function BulkRescheduleRaisedBedButton({
     physicalId,
     fields,
     operations,
+    onSubmit,
 }: BulkRescheduleRaisedBedButtonProps) {
     const [open, setOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -69,35 +72,40 @@ export function BulkRescheduleRaisedBedButton({
             return;
         }
 
-        setIsSubmitting(true);
-        try {
-            await Promise.all([
-                ...fields.map((field) => {
-                    const targetFormData = new FormData();
-                    targetFormData.set(
-                        'raisedBedId',
-                        field.raisedBedId.toString(),
-                    );
-                    targetFormData.set(
-                        'positionIndex',
-                        field.positionIndex.toString(),
-                    );
-                    targetFormData.set('scheduledDate', scheduledDate);
-                    return rescheduleRaisedBedFieldAction(targetFormData);
-                }),
-                ...operations.map((operation) => {
-                    const targetFormData = new FormData();
-                    targetFormData.set('operationId', operation.id.toString());
-                    targetFormData.set('scheduledDate', scheduledDate);
-                    return rescheduleOperationAction(targetFormData);
-                }),
-            ]);
+        if (onSubmit) {
+            await onSubmit(scheduledDate);
             setOpen(false);
-        } catch (error) {
-            console.error('Failed to reschedule all raised bed items:', error);
-        } finally {
-            setIsSubmitting(false);
+            return;
         }
+
+        setIsSubmitting(true);
+        setOpen(false);
+        void Promise.all([
+            ...fields.map((field) => {
+                const targetFormData = new FormData();
+                targetFormData.set('raisedBedId', field.raisedBedId.toString());
+                targetFormData.set(
+                    'positionIndex',
+                    field.positionIndex.toString(),
+                );
+                targetFormData.set('scheduledDate', scheduledDate);
+                return rescheduleRaisedBedFieldAction(targetFormData);
+            }),
+            ...operations.map((operation) => {
+                const targetFormData = new FormData();
+                targetFormData.set('operationId', operation.id.toString());
+                targetFormData.set('scheduledDate', scheduledDate);
+                return rescheduleOperationAction(targetFormData);
+            }),
+        ])
+            .catch((error: unknown) => {
+                console.error(
+                    'Failed to reschedule all raised bed items:',
+                    error,
+                );
+                alert('Skupno zakazivanje zadataka nije uspjelo.');
+            })
+            .finally(() => setIsSubmitting(false));
     }
 
     return (

--- a/apps/app/app/admin/schedule/CancelOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CancelOperationModal.tsx
@@ -13,18 +13,20 @@ interface CancelOperationModalProps {
     };
     operationLabel: string;
     trigger: React.ReactElement;
+    onSubmit?: (formData: FormData) => unknown | Promise<unknown>;
 }
 
 export function CancelOperationModal({
     operation,
     operationLabel,
     trigger,
+    onSubmit,
 }: CancelOperationModalProps) {
     return (
         <CancelRequestModal
             label={operationLabel}
             trigger={trigger}
-            onSubmit={cancelOperationAction}
+            onSubmit={onSubmit ?? cancelOperationAction}
             hiddenFields={
                 <input type="hidden" name="operationId" value={operation.id} />
             }

--- a/apps/app/app/admin/schedule/CancelRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/CancelRaisedBedFieldModal.tsx
@@ -10,18 +10,20 @@ interface CancelRaisedBedFieldModalProps {
     };
     fieldLabel: string;
     trigger: React.ReactElement;
+    onSubmit?: (formData: FormData) => unknown | Promise<unknown>;
 }
 
 export function CancelRaisedBedFieldModal({
     field,
     fieldLabel,
     trigger,
+    onSubmit,
 }: CancelRaisedBedFieldModalProps) {
     return (
         <CancelRequestModal
             label={fieldLabel}
             trigger={trigger}
-            onSubmit={cancelRaisedBedFieldAction}
+            onSubmit={onSubmit ?? cancelRaisedBedFieldAction}
             hiddenFields={
                 <>
                     <input

--- a/apps/app/app/admin/schedule/CancelRequestModal.tsx
+++ b/apps/app/app/admin/schedule/CancelRequestModal.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 interface CancelRequestModalProps {
     label: string;
     trigger: React.ReactElement;
-    onSubmit: (formData: FormData) => Promise<void>;
+    onSubmit: (formData: FormData) => unknown | Promise<unknown>;
     hiddenFields: React.ReactNode;
     description?: string;
     confirmLabel?: string;

--- a/apps/app/app/admin/schedule/CompleteOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CompleteOperationModal.tsx
@@ -89,12 +89,17 @@ type CompleteOperationModalProps = {
     operationId: number;
     label: string;
     conditions?: EntityStandardized['conditions'];
+    onConfirm?: (
+        imageUrls: string[] | undefined,
+        notes?: string,
+    ) => unknown | Promise<unknown>;
 };
 
 export function CompleteOperationModal({
     operationId,
     label,
     conditions,
+    onConfirm,
 }: CompleteOperationModalProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [uploadItems, setUploadItems] = useState<UploadItem[]>([]);
@@ -281,19 +286,27 @@ export function CompleteOperationModal({
                     imageUrls.push(uploadedUrl);
                 }
                 setIsOpen(false);
-                await completeOperationWithImageUrls(
-                    operationId,
-                    imageUrls,
-                    completionNotes,
-                );
+                if (onConfirm) {
+                    await onConfirm(imageUrls, completionNotes);
+                } else {
+                    await completeOperationWithImageUrls(
+                        operationId,
+                        imageUrls,
+                        completionNotes,
+                    );
+                }
                 shouldResetModalState = true;
             } else {
                 setIsOpen(false);
-                await completeOperation(
-                    operationId,
-                    undefined,
-                    completionNotes,
-                );
+                if (onConfirm) {
+                    await onConfirm(undefined, completionNotes);
+                } else {
+                    await completeOperation(
+                        operationId,
+                        undefined,
+                        completionNotes,
+                    );
+                }
                 shouldResetModalState = true;
             }
             if (shouldResetModalState) {

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -13,12 +13,25 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 import { KnownPages } from '../../../src/KnownPages';
+import {
+    acceptOperationAction,
+    assignOperationUserAction,
+    cancelOperationAction,
+    completeOperation,
+    completeOperationWithImageUrls,
+    rescheduleOperationAction,
+    verifyOperationAction,
+} from '../../(actions)/operationActions';
 import { AcceptOperationModal } from './AcceptOperationModal';
 import { AssignOperationModal } from './AssignOperationModal';
 import { CancelOperationModal } from './CancelOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
+import {
+    createOperationAssignedUsers,
+    parseScheduledDateInput,
+} from './scheduleOptimisticHelpers';
 import {
     formatMinutes,
     getOperationDurationMinutes,
@@ -27,6 +40,7 @@ import {
     isOperationPendingVerification,
 } from './scheduleShared';
 import type { Operation } from './types';
+import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 import { VerifyOperationModal } from './VerifyOperationModal';
 
 type FarmSummary = {
@@ -62,6 +76,9 @@ export function FarmOperationsScheduleSection({
     operationsData,
     assignableFarmUsersByOperationId,
 }: FarmOperationsScheduleSectionProps) {
+    const { getOperationPatch, runOptimisticAction } =
+        useOptimisticScheduleActions();
+
     const operationDataById = new Map<number, EntityStandardized>();
     if (operationsData) {
         for (const operationData of operationsData) {
@@ -74,6 +91,10 @@ export function FarmOperationsScheduleSection({
             (operation) =>
                 operation.farmId === farm.id && operation.raisedBedId === null,
         )
+        .map((operation) => ({
+            ...operation,
+            ...getOperationPatch(operation.id),
+        }))
         .sort((left, right) =>
             getOperationLabel(left, operationDataById).localeCompare(
                 getOperationLabel(right, operationDataById),
@@ -203,6 +224,26 @@ export function FarmOperationsScheduleSection({
                                     <VerifyOperationModal
                                         operationId={operation.id}
                                         label={operationLabel}
+                                        onConfirm={() =>
+                                            runOptimisticAction({
+                                                operationPatches: [
+                                                    {
+                                                        id: operation.id,
+                                                        patch: {
+                                                            status: 'completed',
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    verifyOperationAction(
+                                                        operation.id,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error verifying operation:',
+                                                errorAlertMessage:
+                                                    'Verifikacija radnje nije uspjela. Promjena je vraćena.',
+                                            })
+                                        }
                                         renderTrigger={({
                                             isSubmitting,
                                             openModal,
@@ -235,12 +276,63 @@ export function FarmOperationsScheduleSection({
                                         operationId={operation.id}
                                         label={operationLabel}
                                         conditions={operationData?.conditions}
+                                        onConfirm={(imageUrls, notes) =>
+                                            runOptimisticAction({
+                                                operationPatches: [
+                                                    {
+                                                        id: operation.id,
+                                                        patch: {
+                                                            completionNotes:
+                                                                notes,
+                                                            imageUrls,
+                                                            status: 'completed',
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    imageUrls
+                                                        ? completeOperationWithImageUrls(
+                                                              operation.id,
+                                                              imageUrls,
+                                                              notes,
+                                                          )
+                                                        : completeOperation(
+                                                              operation.id,
+                                                              undefined,
+                                                              notes,
+                                                          ),
+                                                errorLogMessage:
+                                                    'Error completing operation:',
+                                                errorAlertMessage:
+                                                    'Završetak radnje nije uspio. Promjena je vraćena.',
+                                            })
+                                        }
                                     />
                                 ) : (
                                     <AcceptOperationModal
                                         operationId={operation.id}
                                         label={operationLabel}
                                         disabled={!operation.assignedUserId}
+                                        onConfirm={() =>
+                                            runOptimisticAction({
+                                                operationPatches: [
+                                                    {
+                                                        id: operation.id,
+                                                        patch: {
+                                                            isAccepted: true,
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    acceptOperationAction(
+                                                        operation.id,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error accepting operation:',
+                                                errorAlertMessage:
+                                                    'Potvrda radnje nije uspjela. Promjena je vraćena.',
+                                            })
+                                        }
                                     />
                                 )}
                                 <a
@@ -321,6 +413,44 @@ export function FarmOperationsScheduleSection({
                                     }
                                     assignedUsers={operation.assignedUsers}
                                     disabled={operationLocked}
+                                    onSubmit={(assignedUserIds) => {
+                                        const farmUsers =
+                                            assignableFarmUsersByOperationId[
+                                                operation.id
+                                            ] ?? [];
+                                        const assignedUsers =
+                                            createOperationAssignedUsers(
+                                                assignedUserIds,
+                                                farmUsers,
+                                                operation.assignedUsers,
+                                            );
+                                        runOptimisticAction({
+                                            operationPatches: [
+                                                {
+                                                    id: operation.id,
+                                                    patch: {
+                                                        assignedUser:
+                                                            assignedUsers[0] ??
+                                                            null,
+                                                        assignedUserId:
+                                                            assignedUserIds[0] ??
+                                                            null,
+                                                        assignedUserIds,
+                                                        assignedUsers,
+                                                    },
+                                                },
+                                            ],
+                                            action: () =>
+                                                assignOperationUserAction(
+                                                    operation.id,
+                                                    assignedUserIds,
+                                                ),
+                                            errorLogMessage:
+                                                'Error assigning operation user:',
+                                            errorAlertMessage:
+                                                'Dodjela radnje nije uspjela. Promjena je vraćena.',
+                                        });
+                                    }}
                                 />
                                 <RescheduleOperationModal
                                     operation={{
@@ -329,6 +459,34 @@ export function FarmOperationsScheduleSection({
                                         scheduledDate: operation.scheduledDate,
                                     }}
                                     operationLabel={operationLabel}
+                                    onSubmit={(formData) => {
+                                        const scheduledDate =
+                                            formData.get('scheduledDate');
+                                        runOptimisticAction({
+                                            operationPatches: [
+                                                {
+                                                    id: operation.id,
+                                                    patch: {
+                                                        scheduledDate:
+                                                            typeof scheduledDate ===
+                                                            'string'
+                                                                ? parseScheduledDateInput(
+                                                                      scheduledDate,
+                                                                  )
+                                                                : undefined,
+                                                    },
+                                                },
+                                            ],
+                                            action: () =>
+                                                rescheduleOperationAction(
+                                                    formData,
+                                                ),
+                                            errorLogMessage:
+                                                'Error rescheduling operation:',
+                                            errorAlertMessage:
+                                                'Zakazivanje radnje nije uspjelo. Promjena je vraćena.',
+                                        });
+                                    }}
                                     trigger={
                                         <IconButton
                                             variant="plain"
@@ -351,6 +509,24 @@ export function FarmOperationsScheduleSection({
                                         status: operation.status,
                                     }}
                                     operationLabel={operationLabel}
+                                    onSubmit={(formData) =>
+                                        runOptimisticAction({
+                                            operationPatches: [
+                                                {
+                                                    id: operation.id,
+                                                    patch: {
+                                                        status: 'canceled',
+                                                    },
+                                                },
+                                            ],
+                                            action: () =>
+                                                cancelOperationAction(formData),
+                                            errorLogMessage:
+                                                'Error canceling operation:',
+                                            errorAlertMessage:
+                                                'Otkazivanje radnje nije uspjelo. Promjena je vraćena.',
+                                        })
+                                    }
                                     trigger={
                                         <IconButton
                                             variant="plain"

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -14,6 +14,15 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 import { KnownPages } from '../../../src/KnownPages';
+import {
+    acceptOperationAction,
+    assignOperationUserAction,
+    cancelOperationAction,
+    completeOperation,
+    completeOperationWithImageUrls,
+    rescheduleOperationAction,
+    verifyOperationAction,
+} from '../../(actions)/operationActions';
 import { AcceptOperationModal } from './AcceptOperationModal';
 import { AssignOperationModal } from './AssignOperationModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
@@ -25,6 +34,10 @@ import { CopyTasksButton } from './CopyTasksButton';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
 import {
+    createOperationAssignedUsers,
+    parseScheduledDateInput,
+} from './scheduleOptimisticHelpers';
+import {
     formatMinutes,
     getOperationDurationMinutes,
     isOperationCancelled,
@@ -32,6 +45,7 @@ import {
     isOperationPendingVerification,
 } from './scheduleShared';
 import type { Operation, RaisedBed } from './types';
+import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 import { VerifyOperationModal } from './VerifyOperationModal';
 
 interface RaisedBedOperationsScheduleSectionProps {
@@ -54,6 +68,9 @@ export function RaisedBedOperationsScheduleSection({
     operationsData,
     assignableFarmUsersByOperationId,
 }: RaisedBedOperationsScheduleSectionProps) {
+    const { getOperationPatch, runOptimisticAction } =
+        useOptimisticScheduleActions();
+
     if (raisedBeds.length === 0) {
         return null;
     }
@@ -100,6 +117,7 @@ export function RaisedBedOperationsScheduleSection({
 
             return {
                 ...operation,
+                ...getOperationPatch(operation.id),
                 physicalPositionIndex,
                 sort,
             };
@@ -108,11 +126,13 @@ export function RaisedBedOperationsScheduleSection({
             a.physicalPositionIndex.localeCompare(
                 b.physicalPositionIndex,
                 undefined,
-                {
-                    numeric: true,
-                },
+                { numeric: true },
             ),
         );
+
+    const operationById = new Map(
+        dayOperations.map((operation) => [operation.id, operation]),
+    );
 
     const copyTasks = dayOperations.map((operation) => {
         const operationData = operationDataById.get(operation.entityId);
@@ -204,6 +224,26 @@ export function RaisedBedOperationsScheduleSection({
                     physicalId={physicalId.toString()}
                     fields={[]}
                     operations={operationsToApprove}
+                    onConfirm={() =>
+                        runOptimisticAction({
+                            operationPatches: operationsToApprove.map(
+                                (operation) => ({
+                                    id: operation.id,
+                                    patch: { isAccepted: true },
+                                }),
+                            ),
+                            action: () =>
+                                Promise.all(
+                                    operationsToApprove.map((operation) =>
+                                        acceptOperationAction(operation.id),
+                                    ),
+                                ),
+                            errorLogMessage:
+                                'Failed to approve all raised bed operation items:',
+                            errorAlertMessage:
+                                'Skupna potvrda radnji nije uspjela. Promjena je vraćena.',
+                        })
+                    }
                 />
                 <Row
                     spacing={0.5}
@@ -231,11 +271,90 @@ export function RaisedBedOperationsScheduleSection({
                         physicalId={physicalId.toString()}
                         fields={[]}
                         operations={operationsToAssign}
+                        onSubmit={(assignedUserIds) =>
+                            runOptimisticAction({
+                                operationPatches: operationsToAssign.map(
+                                    (operation) => {
+                                        const currentOperation =
+                                            operationById.get(operation.id);
+                                        const assignedUsers =
+                                            createOperationAssignedUsers(
+                                                assignedUserIds,
+                                                operation.farmUsers,
+                                                currentOperation?.assignedUsers,
+                                            );
+
+                                        return {
+                                            id: operation.id,
+                                            patch: {
+                                                assignedUser:
+                                                    assignedUsers[0] ?? null,
+                                                assignedUserId:
+                                                    assignedUserIds[0] ?? null,
+                                                assignedUserIds,
+                                                assignedUsers,
+                                            },
+                                        };
+                                    },
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToAssign.map((operation) =>
+                                            assignOperationUserAction(
+                                                operation.id,
+                                                assignedUserIds,
+                                            ),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to assign users for all raised bed operation items:',
+                                errorAlertMessage:
+                                    'Skupna dodjela radnji nije uspjela. Promjena je vraćena.',
+                            })
+                        }
                     />
                     <BulkRescheduleRaisedBedButton
                         physicalId={physicalId.toString()}
                         fields={[]}
                         operations={operationsToReschedule}
+                        onSubmit={(scheduledDate) =>
+                            runOptimisticAction({
+                                operationPatches: operationsToReschedule.map(
+                                    (operation) => ({
+                                        id: operation.id,
+                                        patch: {
+                                            scheduledDate:
+                                                parseScheduledDateInput(
+                                                    scheduledDate,
+                                                ),
+                                        },
+                                    }),
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToReschedule.map(
+                                            (operation) => {
+                                                const formData = new FormData();
+                                                formData.set(
+                                                    'operationId',
+                                                    operation.id.toString(),
+                                                );
+                                                formData.set(
+                                                    'scheduledDate',
+                                                    scheduledDate,
+                                                );
+                                                return rescheduleOperationAction(
+                                                    formData,
+                                                );
+                                            },
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to reschedule all raised bed operation items:',
+                                errorAlertMessage:
+                                    'Skupno zakazivanje radnji nije uspjelo. Promjena je vraćena.',
+                            })
+                        }
                     />
                 </Row>
             </Row>
@@ -256,7 +375,6 @@ export function RaisedBedOperationsScheduleSection({
 
                     const operationPendingVerification =
                         isOperationPendingVerification(operation.status);
-
                     const operationLocked =
                         isOperationCancelled(operation.status) ||
                         isOperationCompleted(operation.status) ||
@@ -343,6 +461,26 @@ export function RaisedBedOperationsScheduleSection({
                                         <VerifyOperationModal
                                             operationId={operation.id}
                                             label={operationLabel}
+                                            onConfirm={() =>
+                                                runOptimisticAction({
+                                                    operationPatches: [
+                                                        {
+                                                            id: operation.id,
+                                                            patch: {
+                                                                status: 'completed',
+                                                            },
+                                                        },
+                                                    ],
+                                                    action: () =>
+                                                        verifyOperationAction(
+                                                            operation.id,
+                                                        ),
+                                                    errorLogMessage:
+                                                        'Error verifying operation:',
+                                                    errorAlertMessage:
+                                                        'Verifikacija radnje nije uspjela. Promjena je vraćena.',
+                                                })
+                                            }
                                             renderTrigger={({
                                                 isSubmitting,
                                                 openModal,
@@ -377,12 +515,63 @@ export function RaisedBedOperationsScheduleSection({
                                             conditions={
                                                 operationData?.conditions
                                             }
+                                            onConfirm={(imageUrls, notes) =>
+                                                runOptimisticAction({
+                                                    operationPatches: [
+                                                        {
+                                                            id: operation.id,
+                                                            patch: {
+                                                                completionNotes:
+                                                                    notes,
+                                                                imageUrls,
+                                                                status: 'completed',
+                                                            },
+                                                        },
+                                                    ],
+                                                    action: () =>
+                                                        imageUrls
+                                                            ? completeOperationWithImageUrls(
+                                                                  operation.id,
+                                                                  imageUrls,
+                                                                  notes,
+                                                              )
+                                                            : completeOperation(
+                                                                  operation.id,
+                                                                  undefined,
+                                                                  notes,
+                                                              ),
+                                                    errorLogMessage:
+                                                        'Error completing operation:',
+                                                    errorAlertMessage:
+                                                        'Završetak radnje nije uspio. Promjena je vraćena.',
+                                                })
+                                            }
                                         />
                                     ) : (
                                         <AcceptOperationModal
                                             operationId={operation.id}
                                             label={operationLabel}
                                             disabled={!operation.assignedUserId}
+                                            onConfirm={() =>
+                                                runOptimisticAction({
+                                                    operationPatches: [
+                                                        {
+                                                            id: operation.id,
+                                                            patch: {
+                                                                isAccepted: true,
+                                                            },
+                                                        },
+                                                    ],
+                                                    action: () =>
+                                                        acceptOperationAction(
+                                                            operation.id,
+                                                        ),
+                                                    errorLogMessage:
+                                                        'Error accepting operation:',
+                                                    errorAlertMessage:
+                                                        'Potvrda radnje nije uspjela. Promjena je vraćena.',
+                                                })
+                                            }
                                         />
                                     )}
                                     <a
@@ -465,6 +654,44 @@ export function RaisedBedOperationsScheduleSection({
                                         }
                                         assignedUsers={operation.assignedUsers}
                                         disabled={operationLocked}
+                                        onSubmit={(assignedUserIds) => {
+                                            const farmUsers =
+                                                assignableFarmUsersByOperationId[
+                                                    operation.id
+                                                ] ?? [];
+                                            const assignedUsers =
+                                                createOperationAssignedUsers(
+                                                    assignedUserIds,
+                                                    farmUsers,
+                                                    operation.assignedUsers,
+                                                );
+                                            runOptimisticAction({
+                                                operationPatches: [
+                                                    {
+                                                        id: operation.id,
+                                                        patch: {
+                                                            assignedUser:
+                                                                assignedUsers[0] ??
+                                                                null,
+                                                            assignedUserId:
+                                                                assignedUserIds[0] ??
+                                                                null,
+                                                            assignedUserIds,
+                                                            assignedUsers,
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    assignOperationUserAction(
+                                                        operation.id,
+                                                        assignedUserIds,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error assigning operation user:',
+                                                errorAlertMessage:
+                                                    'Dodjela radnje nije uspjela. Promjena je vraćena.',
+                                            });
+                                        }}
                                     />
                                     <RescheduleOperationModal
                                         operation={{
@@ -477,6 +704,34 @@ export function RaisedBedOperationsScheduleSection({
                                             operationData?.information?.label ??
                                             operation.entityId.toString()
                                         }
+                                        onSubmit={(formData) => {
+                                            const scheduledDate =
+                                                formData.get('scheduledDate');
+                                            runOptimisticAction({
+                                                operationPatches: [
+                                                    {
+                                                        id: operation.id,
+                                                        patch: {
+                                                            scheduledDate:
+                                                                typeof scheduledDate ===
+                                                                'string'
+                                                                    ? parseScheduledDateInput(
+                                                                          scheduledDate,
+                                                                      )
+                                                                    : undefined,
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    rescheduleOperationAction(
+                                                        formData,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error rescheduling operation:',
+                                                errorAlertMessage:
+                                                    'Zakazivanje radnje nije uspjelo. Promjena je vraćena.',
+                                            });
+                                        }}
                                         trigger={
                                             <IconButton
                                                 variant="plain"
@@ -502,6 +757,26 @@ export function RaisedBedOperationsScheduleSection({
                                         operationLabel={
                                             operationData?.information?.label ??
                                             operation.entityId.toString()
+                                        }
+                                        onSubmit={(formData) =>
+                                            runOptimisticAction({
+                                                operationPatches: [
+                                                    {
+                                                        id: operation.id,
+                                                        patch: {
+                                                            status: 'canceled',
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    cancelOperationAction(
+                                                        formData,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error canceling operation:',
+                                                errorAlertMessage:
+                                                    'Otkazivanje radnje nije uspjelo. Promjena je vraćena.',
+                                            })
                                         }
                                         trigger={
                                             <IconButton

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -14,7 +14,14 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Link from 'next/link';
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
 import { KnownPages } from '../../../src/KnownPages';
-import { raisedBedPlanted } from '../../(actions)/raisedBedFieldsActions';
+import {
+    acceptRaisedBedFieldAction,
+    assignRaisedBedFieldUserAction,
+    cancelRaisedBedFieldAction,
+    raisedBedPlanted,
+    rescheduleRaisedBedFieldAction,
+    verifyRaisedBedPlantingAction,
+} from '../../(actions)/raisedBedFieldsActions';
 import { AcceptRaisedBedFieldModal } from './AcceptRaisedBedFieldModal';
 import { AssignRaisedBedFieldModal } from './AssignRaisedBedFieldModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
@@ -24,6 +31,7 @@ import { CancelRaisedBedFieldModal } from './CancelRaisedBedFieldModal';
 import { CompletePlantingModal } from './CompletePlantingModal';
 import { CopyTasksButton } from './CopyTasksButton';
 import { RescheduleRaisedBedFieldModal } from './RescheduleRaisedBedFieldModal';
+import { parseScheduledDateInput } from './scheduleOptimisticHelpers';
 import {
     formatMinutes,
     isFieldApproved,
@@ -32,6 +40,7 @@ import {
     PLANTING_TASK_DURATION_MINUTES,
 } from './scheduleShared';
 import type { RaisedBed, RaisedBedField } from './types';
+import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 import { VerifyPlantingModal } from './VerifyPlantingModal';
 
 interface RaisedBedPlantingScheduleSectionProps {
@@ -52,6 +61,9 @@ export function RaisedBedPlantingScheduleSection({
     plantSorts,
     assignableFarmUsersByRaisedBedFieldId,
 }: RaisedBedPlantingScheduleSectionProps) {
+    const { getFieldPatch, runOptimisticAction } =
+        useOptimisticScheduleActions();
+
     if (raisedBeds.length === 0) {
         return null;
     }
@@ -68,16 +80,21 @@ export function RaisedBedPlantingScheduleSection({
                 (raisedBed) => raisedBed.id === field.raisedBedId,
             ),
         )
-        .map((field) => ({
-            ...field,
-            physicalPositionIndex: sortedRaisedBeds
-                .at(0)
-                ?.fields.find(
-                    (raisedBedField) => raisedBedField.id === field.id,
-                )
-                ? field.positionIndex + 1
-                : field.positionIndex + 10,
-        }))
+        .map((field) => {
+            const optimisticPatch = getFieldPatch(field.id);
+            return {
+                ...field,
+                ...optimisticPatch,
+                physicalPositionIndex: sortedRaisedBeds
+                    .at(0)
+                    ?.fields.find(
+                        (raisedBedField) => raisedBedField.id === field.id,
+                    )
+                    ? field.positionIndex + 1
+                    : field.positionIndex + 10,
+            };
+        })
+        .filter((field) => !field.isDeleted)
         .sort((a, b) => a.physicalPositionIndex - b.physicalPositionIndex);
 
     const copyTasks = dayFields.map((field) => {
@@ -118,6 +135,7 @@ export function RaisedBedPlantingScheduleSection({
                 ) ** 2;
 
             return {
+                id: field.id,
                 raisedBedId: field.raisedBedId,
                 positionIndex: field.positionIndex,
                 label: `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`,
@@ -131,6 +149,7 @@ export function RaisedBedPlantingScheduleSection({
                 !isFieldCompleted(field.plantStatus),
         )
         .map((field) => ({
+            id: field.id,
             raisedBedId: field.raisedBedId,
             positionIndex: field.positionIndex,
         }));
@@ -166,6 +185,27 @@ export function RaisedBedPlantingScheduleSection({
                     physicalId={physicalId.toString()}
                     fields={fieldsToApprove}
                     operations={[]}
+                    onConfirm={() =>
+                        runOptimisticAction({
+                            fieldPatches: fieldsToApprove.map((field) => ({
+                                id: field.id,
+                                patch: { plantStatus: 'planned' },
+                            })),
+                            action: () =>
+                                Promise.all(
+                                    fieldsToApprove.map((field) =>
+                                        acceptRaisedBedFieldAction(
+                                            field.raisedBedId,
+                                            field.positionIndex,
+                                        ),
+                                    ),
+                                ),
+                            errorLogMessage:
+                                'Failed to approve all raised bed planting items:',
+                            errorAlertMessage:
+                                'Skupna potvrda sijanja nije uspjela. Promjena je vraćena.',
+                        })
+                    }
                 />
                 <Row
                     spacing={0.5}
@@ -193,11 +233,76 @@ export function RaisedBedPlantingScheduleSection({
                         physicalId={physicalId.toString()}
                         fields={fieldsToAssign}
                         operations={[]}
+                        onSubmit={(assignedUserIds) =>
+                            runOptimisticAction({
+                                fieldPatches: fieldsToAssign.map((field) => ({
+                                    id: field.id,
+                                    patch: {
+                                        assignedUserId:
+                                            assignedUserIds[0] ?? null,
+                                        assignedUserIds,
+                                    },
+                                })),
+                                action: () =>
+                                    Promise.all(
+                                        fieldsToAssign.map((field) =>
+                                            assignRaisedBedFieldUserAction(
+                                                field.id,
+                                                assignedUserIds,
+                                            ),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to assign users for all raised bed planting items:',
+                                errorAlertMessage:
+                                    'Skupna dodjela sijanja nije uspjela. Promjena je vraćena.',
+                            })
+                        }
                     />
                     <BulkRescheduleRaisedBedButton
                         physicalId={physicalId.toString()}
                         fields={fieldsToReschedule}
                         operations={[]}
+                        onSubmit={(scheduledDate) =>
+                            runOptimisticAction({
+                                fieldPatches: fieldsToReschedule.map(
+                                    (field) => ({
+                                        id: field.id,
+                                        patch: {
+                                            plantScheduledDate:
+                                                parseScheduledDateInput(
+                                                    scheduledDate,
+                                                ),
+                                        },
+                                    }),
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        fieldsToReschedule.map((field) => {
+                                            const formData = new FormData();
+                                            formData.set(
+                                                'raisedBedId',
+                                                field.raisedBedId.toString(),
+                                            );
+                                            formData.set(
+                                                'positionIndex',
+                                                field.positionIndex.toString(),
+                                            );
+                                            formData.set(
+                                                'scheduledDate',
+                                                scheduledDate,
+                                            );
+                                            return rescheduleRaisedBedFieldAction(
+                                                formData,
+                                            );
+                                        }),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to reschedule all raised bed planting items:',
+                                errorAlertMessage:
+                                    'Skupno zakazivanje sijanja nije uspjelo. Promjena je vraćena.',
+                            })
+                        }
                     />
                 </Row>
             </Row>
@@ -219,12 +324,25 @@ export function RaisedBedPlantingScheduleSection({
                         ) ** 2;
 
                     const handlePlantConfirm = async () => {
-                        if (!field.plantSortId) return;
-                        await raisedBedPlanted(
-                            field.raisedBedId,
-                            field.positionIndex,
-                            field.plantSortId,
-                        );
+                        const plantSortId = field.plantSortId;
+                        if (!plantSortId) return;
+                        runOptimisticAction({
+                            fieldPatches: [
+                                {
+                                    id: field.id,
+                                    patch: { plantStatus: 'sowed' },
+                                },
+                            ],
+                            action: () =>
+                                raisedBedPlanted(
+                                    field.raisedBedId,
+                                    field.positionIndex,
+                                    plantSortId,
+                                ),
+                            errorLogMessage: 'Error completing planting:',
+                            errorAlertMessage:
+                                'Završetak sijanja nije uspio. Promjena je vraćena.',
+                        });
                     };
 
                     const fieldLabel = `${field.physicalPositionIndex} - sijanje: ${numberOfPlants} ${field.plantSortId ? `${sortData?.information?.name}` : 'Nepoznato'}`;
@@ -273,6 +391,28 @@ export function RaisedBedPlantingScheduleSection({
                                             raisedBedId={field.raisedBedId}
                                             positionIndex={field.positionIndex}
                                             label={fieldLabel}
+                                            onConfirm={() =>
+                                                runOptimisticAction({
+                                                    fieldPatches: [
+                                                        {
+                                                            id: field.id,
+                                                            patch: {
+                                                                plantStatus:
+                                                                    'sowed',
+                                                            },
+                                                        },
+                                                    ],
+                                                    action: () =>
+                                                        verifyRaisedBedPlantingAction(
+                                                            field.raisedBedId,
+                                                            field.positionIndex,
+                                                        ),
+                                                    errorLogMessage:
+                                                        'Error verifying planting:',
+                                                    errorAlertMessage:
+                                                        'Verifikacija sijanja nije uspjela. Promjena je vraćena.',
+                                                })
+                                            }
                                         />
                                     ) : field.plantSortId && !fieldApproved ? (
                                         <AcceptRaisedBedFieldModal
@@ -280,6 +420,28 @@ export function RaisedBedPlantingScheduleSection({
                                             positionIndex={field.positionIndex}
                                             label={fieldLabel}
                                             disabled={!field.assignedUserId}
+                                            onConfirm={() =>
+                                                runOptimisticAction({
+                                                    fieldPatches: [
+                                                        {
+                                                            id: field.id,
+                                                            patch: {
+                                                                plantStatus:
+                                                                    'planned',
+                                                            },
+                                                        },
+                                                    ],
+                                                    action: () =>
+                                                        acceptRaisedBedFieldAction(
+                                                            field.raisedBedId,
+                                                            field.positionIndex,
+                                                        ),
+                                                    errorLogMessage:
+                                                        'Error accepting field request:',
+                                                    errorAlertMessage:
+                                                        'Potvrda sijanja nije uspjela. Promjena je vraćena.',
+                                                })
+                                            }
                                         />
                                     ) : (
                                         <CompletePlantingModal
@@ -332,6 +494,30 @@ export function RaisedBedPlantingScheduleSection({
                                         }
                                         assignedUserIds={field.assignedUserIds}
                                         disabled={fieldLocked}
+                                        onSubmit={(assignedUserIds) =>
+                                            runOptimisticAction({
+                                                fieldPatches: [
+                                                    {
+                                                        id: field.id,
+                                                        patch: {
+                                                            assignedUserId:
+                                                                assignedUserIds[0] ??
+                                                                null,
+                                                            assignedUserIds,
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    assignRaisedBedFieldUserAction(
+                                                        field.id,
+                                                        assignedUserIds,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error assigning planting user:',
+                                                errorAlertMessage:
+                                                    'Dodjela sijanja nije uspjela. Promjena je vraćena.',
+                                            })
+                                        }
                                     />
                                     <RescheduleRaisedBedFieldModal
                                         field={{
@@ -345,6 +531,34 @@ export function RaisedBedPlantingScheduleSection({
                                             field.plantSortId?.toString() ??
                                             '?'
                                         }
+                                        onSubmit={(formData) => {
+                                            const scheduledDate =
+                                                formData.get('scheduledDate');
+                                            runOptimisticAction({
+                                                fieldPatches: [
+                                                    {
+                                                        id: field.id,
+                                                        patch: {
+                                                            plantScheduledDate:
+                                                                typeof scheduledDate ===
+                                                                'string'
+                                                                    ? parseScheduledDateInput(
+                                                                          scheduledDate,
+                                                                      )
+                                                                    : undefined,
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    rescheduleRaisedBedFieldAction(
+                                                        formData,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error rescheduling planting:',
+                                                errorAlertMessage:
+                                                    'Zakazivanje sijanja nije uspjelo. Promjena je vraćena.',
+                                            });
+                                        }}
                                         trigger={
                                             <IconButton
                                                 variant="plain"
@@ -365,6 +579,26 @@ export function RaisedBedPlantingScheduleSection({
                                             positionIndex: field.positionIndex,
                                         }}
                                         fieldLabel={fieldLabel}
+                                        onSubmit={(formData) =>
+                                            runOptimisticAction({
+                                                fieldPatches: [
+                                                    {
+                                                        id: field.id,
+                                                        patch: {
+                                                            isDeleted: true,
+                                                        },
+                                                    },
+                                                ],
+                                                action: () =>
+                                                    cancelRaisedBedFieldAction(
+                                                        formData,
+                                                    ),
+                                                errorLogMessage:
+                                                    'Error canceling planting:',
+                                                errorAlertMessage:
+                                                    'Otkazivanje sijanja nije uspjelo. Promjena je vraćena.',
+                                            })
+                                        }
                                         trigger={
                                             <IconButton
                                                 variant="plain"

--- a/apps/app/app/admin/schedule/RescheduleModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleModal.tsx
@@ -20,7 +20,7 @@ interface RescheduleModalProps {
     label: string;
     scheduledDate?: Date;
     trigger: React.ReactElement;
-    onSubmit: (formData: FormData) => Promise<void>;
+    onSubmit: (formData: FormData) => unknown | Promise<unknown>;
     hiddenFields: React.ReactNode;
 }
 
@@ -46,6 +46,7 @@ export function RescheduleModal({
             setOpen(false);
         } catch (error) {
             console.error('Error rescheduling item:', error);
+            alert('Zakazivanje zadatka nije uspjelo. Pokušajte ponovno.');
         } finally {
             setIsLoading(false);
         }

--- a/apps/app/app/admin/schedule/RescheduleOperationModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleOperationModal.tsx
@@ -9,19 +9,21 @@ interface RescheduleOperationModalProps {
     };
     operationLabel: string;
     trigger: React.ReactElement;
+    onSubmit?: (formData: FormData) => unknown | Promise<unknown>;
 }
 
 export function RescheduleOperationModal({
     operation,
     operationLabel,
     trigger,
+    onSubmit,
 }: RescheduleOperationModalProps) {
     return (
         <RescheduleModal
             label={operationLabel}
             scheduledDate={operation.scheduledDate}
             trigger={trigger}
-            onSubmit={rescheduleOperationAction}
+            onSubmit={onSubmit ?? rescheduleOperationAction}
             hiddenFields={
                 <input type="hidden" name="operationId" value={operation.id} />
             }

--- a/apps/app/app/admin/schedule/RescheduleRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/RescheduleRaisedBedFieldModal.tsx
@@ -11,19 +11,21 @@ interface RescheduleRaisedBedFieldModalProps {
     };
     fieldLabel: string;
     trigger: React.ReactElement;
+    onSubmit?: (formData: FormData) => unknown | Promise<unknown>;
 }
 
 export function RescheduleRaisedBedFieldModal({
     field,
     fieldLabel,
     trigger,
+    onSubmit,
 }: RescheduleRaisedBedFieldModalProps) {
     return (
         <RescheduleModal
             label={fieldLabel}
             scheduledDate={field.plantScheduledDate}
             trigger={trigger}
-            onSubmit={rescheduleRaisedBedFieldAction}
+            onSubmit={onSubmit ?? rescheduleRaisedBedFieldAction}
             hiddenFields={
                 <>
                     <input

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsBulkActions.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsBulkActions.tsx
@@ -7,7 +7,11 @@ import {
 } from '../../(actions)/operationActions';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
-import { createOperationAssignedUsers } from './scheduleOptimisticHelpers';
+import {
+    createOperationAssignedUsers,
+    isDayBulkOperationApprovalTargetVisible,
+    isDayBulkOperationAssignmentTargetVisible,
+} from './scheduleOptimisticHelpers';
 import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 
 type OperationApprovalTarget = {
@@ -31,11 +35,15 @@ export function ScheduleDayOperationsBulkActions({
 }: ScheduleDayOperationsBulkActionsProps) {
     const { getOperationPatch, runOptimisticAction } =
         useOptimisticScheduleActions();
-    const visibleOperationsToApprove = operationsToApprove.filter(
-        (operation) => !getOperationPatch(operation.id)?.isAccepted,
+    const visibleOperationsToApprove = operationsToApprove.filter((operation) =>
+        isDayBulkOperationApprovalTargetVisible(
+            getOperationPatch(operation.id),
+        ),
     );
-    const visibleOperationsToAssign = operationsToAssign.filter(
-        (operation) => !getOperationPatch(operation.id)?.assignedUserId,
+    const visibleOperationsToAssign = operationsToAssign.filter((operation) =>
+        isDayBulkOperationAssignmentTargetVisible(
+            getOperationPatch(operation.id),
+        ),
     );
 
     return (

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsBulkActions.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsBulkActions.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import type { OperationAssignableFarmUser } from '@gredice/storage';
+import {
+    acceptOperationAction,
+    assignOperationUserAction,
+} from '../../(actions)/operationActions';
+import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
+import { createOperationAssignedUsers } from './scheduleOptimisticHelpers';
+import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
+
+type OperationApprovalTarget = {
+    id: number;
+    label: string;
+};
+
+type OperationAssignmentTarget = {
+    id: number;
+    farmUsers: OperationAssignableFarmUser[];
+};
+
+interface ScheduleDayOperationsBulkActionsProps {
+    operationsToApprove: OperationApprovalTarget[];
+    operationsToAssign: OperationAssignmentTarget[];
+}
+
+export function ScheduleDayOperationsBulkActions({
+    operationsToApprove,
+    operationsToAssign,
+}: ScheduleDayOperationsBulkActionsProps) {
+    const { getOperationPatch, runOptimisticAction } =
+        useOptimisticScheduleActions();
+    const visibleOperationsToApprove = operationsToApprove.filter(
+        (operation) => !getOperationPatch(operation.id)?.isAccepted,
+    );
+    const visibleOperationsToAssign = operationsToAssign.filter(
+        (operation) => !getOperationPatch(operation.id)?.assignedUserId,
+    );
+
+    return (
+        <>
+            <BulkApproveRaisedBedButton
+                physicalId="dan"
+                fields={[]}
+                operations={visibleOperationsToApprove}
+                onConfirm={() =>
+                    runOptimisticAction({
+                        operationPatches: visibleOperationsToApprove.map(
+                            (operation) => ({
+                                id: operation.id,
+                                patch: { isAccepted: true },
+                            }),
+                        ),
+                        action: () =>
+                            Promise.all(
+                                visibleOperationsToApprove.map((operation) =>
+                                    acceptOperationAction(operation.id),
+                                ),
+                            ),
+                        errorLogMessage:
+                            'Failed to approve all day operation items:',
+                        errorAlertMessage:
+                            'Skupna potvrda radnji nije uspjela. Promjena je vraćena.',
+                    })
+                }
+            />
+            <BulkAssignRaisedBedButton
+                physicalId="dan"
+                fields={[]}
+                operations={visibleOperationsToAssign}
+                onSubmit={(assignedUserIds) =>
+                    runOptimisticAction({
+                        operationPatches: visibleOperationsToAssign.map(
+                            (operation) => {
+                                const assignedUsers =
+                                    createOperationAssignedUsers(
+                                        assignedUserIds,
+                                        operation.farmUsers,
+                                        undefined,
+                                    );
+
+                                return {
+                                    id: operation.id,
+                                    patch: {
+                                        assignedUser: assignedUsers[0] ?? null,
+                                        assignedUserId:
+                                            assignedUserIds[0] ?? null,
+                                        assignedUserIds,
+                                        assignedUsers,
+                                    },
+                                };
+                            },
+                        ),
+                        action: () =>
+                            Promise.all(
+                                visibleOperationsToAssign.map((operation) =>
+                                    assignOperationUserAction(
+                                        operation.id,
+                                        assignedUserIds,
+                                    ),
+                                ),
+                            ),
+                        errorLogMessage:
+                            'Failed to assign users for all day operation items:',
+                        errorAlertMessage:
+                            'Skupna dodjela radnji nije uspjela. Promjena je vraćena.',
+                    })
+                }
+            />
+        </>
+    );
+}

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
@@ -5,10 +5,9 @@ import {
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
-import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
 import { FarmOperationsScheduleSection } from './FarmOperationsScheduleSection';
 import { RaisedBedOperationsScheduleSection } from './RaisedBedOperationsScheduleSection';
+import { ScheduleDayOperationsBulkActions } from './ScheduleDayOperationsBulkActions';
 import {
     getScheduleDayData,
     getScheduleOperationsData,
@@ -20,6 +19,7 @@ import {
     isOperationCompleted,
     isOperationPendingVerification,
 } from './scheduleShared';
+import { OptimisticScheduleActionsProvider } from './useOptimisticScheduleActions';
 
 interface ScheduleDayOperationsSectionProps {
     isToday: boolean;
@@ -99,46 +99,44 @@ export async function ScheduleDayOperationsSection({
         }));
 
     return (
-        <Stack spacing={2}>
-            <Row spacing={1} alignItems="center">
-                <Typography level="h6">Radnje</Typography>
-                <BulkApproveRaisedBedButton
-                    physicalId="dan"
-                    fields={[]}
-                    operations={dayOperationsToApprove}
-                />
-                <BulkAssignRaisedBedButton
-                    physicalId="dan"
-                    fields={[]}
-                    operations={dayOperationsToAssign}
-                />
-            </Row>
-            {raisedBedGroups.map(({ key, physicalId, raisedBeds: beds }) => {
-                return (
-                    <RaisedBedOperationsScheduleSection
-                        key={key}
-                        physicalId={physicalId}
-                        raisedBeds={beds}
+        <OptimisticScheduleActionsProvider>
+            <Stack spacing={2}>
+                <Row spacing={1} alignItems="center">
+                    <Typography level="h6">Radnje</Typography>
+                    <ScheduleDayOperationsBulkActions
+                        operationsToApprove={dayOperationsToApprove}
+                        operationsToAssign={dayOperationsToAssign}
+                    />
+                </Row>
+                {raisedBedGroups.map(
+                    ({ key, physicalId, raisedBeds: beds }) => {
+                        return (
+                            <RaisedBedOperationsScheduleSection
+                                key={key}
+                                physicalId={physicalId}
+                                raisedBeds={beds}
+                                scheduledOperations={scheduledOperations}
+                                plantSorts={plantSorts}
+                                operationsData={operationsData}
+                                assignableFarmUsersByOperationId={
+                                    assignableFarmUsersByOperationId
+                                }
+                            />
+                        );
+                    },
+                )}
+                {operationFarms.map((farm) => (
+                    <FarmOperationsScheduleSection
+                        key={farm.id}
+                        farm={farm}
                         scheduledOperations={scheduledOperations}
-                        plantSorts={plantSorts}
                         operationsData={operationsData}
                         assignableFarmUsersByOperationId={
                             assignableFarmUsersByOperationId
                         }
                     />
-                );
-            })}
-            {operationFarms.map((farm) => (
-                <FarmOperationsScheduleSection
-                    key={farm.id}
-                    farm={farm}
-                    scheduledOperations={scheduledOperations}
-                    operationsData={operationsData}
-                    assignableFarmUsersByOperationId={
-                        assignableFarmUsersByOperationId
-                    }
-                />
-            ))}
-        </Stack>
+                ))}
+            </Stack>
+        </OptimisticScheduleActionsProvider>
     );
 }

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsBulkActions.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsBulkActions.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import type { RaisedBedFieldAssignableFarmUser } from '@gredice/storage';
+import {
+    acceptRaisedBedFieldAction,
+    assignRaisedBedFieldUserAction,
+} from '../../(actions)/raisedBedFieldsActions';
+import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
+import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
+
+type FieldApprovalTarget = {
+    id: number;
+    raisedBedId: number;
+    positionIndex: number;
+    label: string;
+};
+
+type FieldAssignmentTarget = {
+    id: number;
+    farmUsers: RaisedBedFieldAssignableFarmUser[];
+};
+
+interface ScheduleDayPlantingsBulkActionsProps {
+    fieldsToApprove: FieldApprovalTarget[];
+    fieldsToAssign: FieldAssignmentTarget[];
+}
+
+export function ScheduleDayPlantingsBulkActions({
+    fieldsToApprove,
+    fieldsToAssign,
+}: ScheduleDayPlantingsBulkActionsProps) {
+    const { getFieldPatch, runOptimisticAction } =
+        useOptimisticScheduleActions();
+    const visibleFieldsToApprove = fieldsToApprove.filter(
+        (field) => getFieldPatch(field.id)?.plantStatus !== 'planned',
+    );
+    const visibleFieldsToAssign = fieldsToAssign.filter(
+        (field) => !getFieldPatch(field.id)?.assignedUserId,
+    );
+
+    return (
+        <>
+            <BulkApproveRaisedBedButton
+                physicalId="dan"
+                fields={visibleFieldsToApprove}
+                operations={[]}
+                onConfirm={() =>
+                    runOptimisticAction({
+                        fieldPatches: visibleFieldsToApprove.map((field) => ({
+                            id: field.id,
+                            patch: { plantStatus: 'planned' },
+                        })),
+                        action: () =>
+                            Promise.all(
+                                visibleFieldsToApprove.map((field) =>
+                                    acceptRaisedBedFieldAction(
+                                        field.raisedBedId,
+                                        field.positionIndex,
+                                    ),
+                                ),
+                            ),
+                        errorLogMessage:
+                            'Failed to approve all day planting items:',
+                        errorAlertMessage:
+                            'Skupna potvrda sijanja nije uspjela. Promjena je vraćena.',
+                    })
+                }
+            />
+            <BulkAssignRaisedBedButton
+                physicalId="dan"
+                fields={visibleFieldsToAssign}
+                operations={[]}
+                onSubmit={(assignedUserIds) =>
+                    runOptimisticAction({
+                        fieldPatches: visibleFieldsToAssign.map((field) => ({
+                            id: field.id,
+                            patch: {
+                                assignedUserId: assignedUserIds[0] ?? null,
+                                assignedUserIds,
+                            },
+                        })),
+                        action: () =>
+                            Promise.all(
+                                visibleFieldsToAssign.map((field) =>
+                                    assignRaisedBedFieldUserAction(
+                                        field.id,
+                                        assignedUserIds,
+                                    ),
+                                ),
+                            ),
+                        errorLogMessage:
+                            'Failed to assign users for all day planting items:',
+                        errorAlertMessage:
+                            'Skupna dodjela sijanja nije uspjela. Promjena je vraćena.',
+                    })
+                }
+            />
+        </>
+    );
+}

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsBulkActions.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsBulkActions.tsx
@@ -7,6 +7,10 @@ import {
 } from '../../(actions)/raisedBedFieldsActions';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
+import {
+    isDayBulkFieldApprovalTargetVisible,
+    isDayBulkFieldAssignmentTargetVisible,
+} from './scheduleOptimisticHelpers';
 import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 
 type FieldApprovalTarget = {
@@ -32,11 +36,11 @@ export function ScheduleDayPlantingsBulkActions({
 }: ScheduleDayPlantingsBulkActionsProps) {
     const { getFieldPatch, runOptimisticAction } =
         useOptimisticScheduleActions();
-    const visibleFieldsToApprove = fieldsToApprove.filter(
-        (field) => getFieldPatch(field.id)?.plantStatus !== 'planned',
+    const visibleFieldsToApprove = fieldsToApprove.filter((field) =>
+        isDayBulkFieldApprovalTargetVisible(getFieldPatch(field.id)),
     );
-    const visibleFieldsToAssign = fieldsToAssign.filter(
-        (field) => !getFieldPatch(field.id)?.assignedUserId,
+    const visibleFieldsToAssign = fieldsToAssign.filter((field) =>
+        isDayBulkFieldAssignmentTargetVisible(getFieldPatch(field.id)),
     );
 
     return (

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
@@ -2,9 +2,8 @@ import { getAssignableFarmUsersByRaisedBedFieldIds } from '@gredice/storage';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
-import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
-import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
 import { RaisedBedPlantingScheduleSection } from './RaisedBedPlantingScheduleSection';
+import { ScheduleDayPlantingsBulkActions } from './ScheduleDayPlantingsBulkActions';
 import { getScheduleDayData, getSchedulePlantSorts } from './scheduleData';
 import {
     groupRaisedBedsForSchedule,
@@ -12,6 +11,7 @@ import {
     isFieldCompleted,
     isFieldPendingVerification,
 } from './scheduleShared';
+import { OptimisticScheduleActionsProvider } from './useOptimisticScheduleActions';
 
 interface ScheduleDayPlantingsSectionProps {
     isToday: boolean;
@@ -51,6 +51,7 @@ export async function ScheduleDayPlantingsSection({
                 !!field.assignedUserId,
         )
         .map((field) => ({
+            id: field.id,
             raisedBedId: field.raisedBedId,
             positionIndex: field.positionIndex,
             label: `${field.positionIndex + 1}`,
@@ -69,34 +70,32 @@ export async function ScheduleDayPlantingsSection({
         }));
 
     return (
-        <Stack spacing={2}>
-            <Row spacing={1} alignItems="center">
-                <Typography level="h6">Sijanje</Typography>
-                <BulkApproveRaisedBedButton
-                    physicalId="dan"
-                    fields={dayFieldsToApprove}
-                    operations={[]}
-                />
-                <BulkAssignRaisedBedButton
-                    physicalId="dan"
-                    fields={dayFieldsToAssign}
-                    operations={[]}
-                />
-            </Row>
-            {raisedBedGroups.map(({ key, physicalId, raisedBeds: beds }) => {
-                return (
-                    <RaisedBedPlantingScheduleSection
-                        key={key}
-                        physicalId={physicalId}
-                        raisedBeds={beds}
-                        scheduledFields={scheduledFields}
-                        plantSorts={plantSorts}
-                        assignableFarmUsersByRaisedBedFieldId={
-                            assignableFarmUsersByRaisedBedFieldId
-                        }
+        <OptimisticScheduleActionsProvider>
+            <Stack spacing={2}>
+                <Row spacing={1} alignItems="center">
+                    <Typography level="h6">Sijanje</Typography>
+                    <ScheduleDayPlantingsBulkActions
+                        fieldsToApprove={dayFieldsToApprove}
+                        fieldsToAssign={dayFieldsToAssign}
                     />
-                );
-            })}
-        </Stack>
+                </Row>
+                {raisedBedGroups.map(
+                    ({ key, physicalId, raisedBeds: beds }) => {
+                        return (
+                            <RaisedBedPlantingScheduleSection
+                                key={key}
+                                physicalId={physicalId}
+                                raisedBeds={beds}
+                                scheduledFields={scheduledFields}
+                                plantSorts={plantSorts}
+                                assignableFarmUsersByRaisedBedFieldId={
+                                    assignableFarmUsersByRaisedBedFieldId
+                                }
+                            />
+                        );
+                    },
+                )}
+            </Stack>
+        </OptimisticScheduleActionsProvider>
     );
 }

--- a/apps/app/app/admin/schedule/VerifyOperationModal.tsx
+++ b/apps/app/app/admin/schedule/VerifyOperationModal.tsx
@@ -19,6 +19,7 @@ interface VerifyOperationModalTriggerProps {
 interface VerifyOperationModalBaseProps {
     operationId: number;
     label: string;
+    onConfirm?: () => unknown | Promise<unknown>;
 }
 
 type VerifyOperationModalProps = VerifyOperationModalBaseProps &
@@ -38,6 +39,7 @@ type VerifyOperationModalProps = VerifyOperationModalBaseProps &
 export function VerifyOperationModal({
     operationId,
     label,
+    onConfirm,
     trigger,
     renderTrigger,
 }: VerifyOperationModalProps) {
@@ -58,10 +60,15 @@ export function VerifyOperationModal({
     const handleConfirm = async () => {
         try {
             setIsSubmitting(true);
-            await verifyOperationAction(operationId);
+            if (onConfirm) {
+                await onConfirm();
+            } else {
+                await verifyOperationAction(operationId);
+            }
             setOpen(false);
         } catch (error) {
             console.error('Error verifying operation:', error);
+            alert('Verifikacija radnje nije uspjela. Pokušajte ponovno.');
         } finally {
             setIsSubmitting(false);
         }

--- a/apps/app/app/admin/schedule/VerifyPlantingModal.tsx
+++ b/apps/app/app/admin/schedule/VerifyPlantingModal.tsx
@@ -14,12 +14,14 @@ interface VerifyPlantingModalProps {
     raisedBedId: number;
     positionIndex: number;
     label: string;
+    onConfirm?: () => unknown | Promise<unknown>;
 }
 
 export function VerifyPlantingModal({
     raisedBedId,
     positionIndex,
     label,
+    onConfirm,
 }: VerifyPlantingModalProps) {
     const [open, setOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -27,10 +29,15 @@ export function VerifyPlantingModal({
     const handleConfirm = async () => {
         try {
             setIsSubmitting(true);
-            await verifyRaisedBedPlantingAction(raisedBedId, positionIndex);
+            if (onConfirm) {
+                await onConfirm();
+            } else {
+                await verifyRaisedBedPlantingAction(raisedBedId, positionIndex);
+            }
             setOpen(false);
         } catch (error) {
             console.error('Error verifying planting:', error);
+            alert('Verifikacija sijanja nije uspjela. Pokušajte ponovno.');
         } finally {
             setIsSubmitting(false);
         }

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -4,6 +4,12 @@ import {
     getScheduledFieldsForDay,
     getScheduledOperationsForDay,
 } from './scheduleDayFilters.ts';
+import {
+    isDayBulkFieldApprovalTargetVisible,
+    isDayBulkFieldAssignmentTargetVisible,
+    isDayBulkOperationApprovalTargetVisible,
+    isDayBulkOperationAssignmentTargetVisible,
+} from './scheduleOptimisticHelpers.ts';
 import type { Operation, RaisedBed, RaisedBedField } from './types.ts';
 
 const today = new Date(2026, 4, 14);
@@ -108,5 +114,65 @@ test('pending verification operation remains visible today until verified', () =
             verifiedOperation,
         ]).map((operation) => operation.id),
         [1],
+    );
+});
+
+test('day operation bulk actions honor optimistic terminal statuses', () => {
+    assert.equal(isDayBulkOperationApprovalTargetVisible(undefined), true);
+    assert.equal(isDayBulkOperationAssignmentTargetVisible(undefined), true);
+
+    for (const status of ['completed', 'canceled', 'pendingVerification']) {
+        assert.equal(
+            isDayBulkOperationApprovalTargetVisible({ status }),
+            false,
+        );
+        assert.equal(
+            isDayBulkOperationAssignmentTargetVisible({ status }),
+            false,
+        );
+    }
+
+    assert.equal(
+        isDayBulkOperationApprovalTargetVisible({ isAccepted: true }),
+        false,
+    );
+    assert.equal(
+        isDayBulkOperationAssignmentTargetVisible({
+            assignedUserId: 'farmer-1',
+        }),
+        false,
+    );
+});
+
+test('day planting bulk actions honor optimistic completed and deleted fields', () => {
+    assert.equal(isDayBulkFieldApprovalTargetVisible(undefined), true);
+    assert.equal(isDayBulkFieldAssignmentTargetVisible(undefined), true);
+
+    for (const plantStatus of ['sowed', 'pendingVerification']) {
+        assert.equal(
+            isDayBulkFieldApprovalTargetVisible({ plantStatus }),
+            false,
+        );
+        assert.equal(
+            isDayBulkFieldAssignmentTargetVisible({ plantStatus }),
+            false,
+        );
+    }
+
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({ plantStatus: 'planned' }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({ isDeleted: true }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldAssignmentTargetVisible({ isDeleted: true }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldAssignmentTargetVisible({ assignedUserId: 'farmer-1' }),
+        false,
     );
 });

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -120,6 +120,10 @@ test('pending verification operation remains visible today until verified', () =
 test('day operation bulk actions honor optimistic terminal statuses', () => {
     assert.equal(isDayBulkOperationApprovalTargetVisible(undefined), true);
     assert.equal(isDayBulkOperationAssignmentTargetVisible(undefined), true);
+    assert.equal(
+        isDayBulkOperationApprovalTargetVisible({ status: 'planned' }),
+        true,
+    );
 
     for (const status of ['completed', 'canceled', 'pendingVerification']) {
         assert.equal(
@@ -147,20 +151,33 @@ test('day operation bulk actions honor optimistic terminal statuses', () => {
 test('day planting bulk actions honor optimistic completed and deleted fields', () => {
     assert.equal(isDayBulkFieldApprovalTargetVisible(undefined), true);
     assert.equal(isDayBulkFieldAssignmentTargetVisible(undefined), true);
-
-    for (const plantStatus of ['sowed', 'pendingVerification']) {
-        assert.equal(
-            isDayBulkFieldApprovalTargetVisible({ plantStatus }),
-            false,
-        );
-        assert.equal(
-            isDayBulkFieldAssignmentTargetVisible({ plantStatus }),
-            false,
-        );
-    }
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({ plantStatus: 'new' }),
+        true,
+    );
 
     assert.equal(
         isDayBulkFieldApprovalTargetVisible({ plantStatus: 'planned' }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({ plantStatus: 'sowed' }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldAssignmentTargetVisible({ plantStatus: 'sowed' }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({
+            plantStatus: 'pendingVerification',
+        }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldAssignmentTargetVisible({
+            plantStatus: 'pendingVerification',
+        }),
         false,
     );
     assert.equal(

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -124,6 +124,13 @@ test('day operation bulk actions honor optimistic terminal statuses', () => {
         isDayBulkOperationApprovalTargetVisible({ status: 'planned' }),
         true,
     );
+    assert.equal(
+        isDayBulkOperationApprovalTargetVisible({
+            assignedUserId: null,
+            status: 'planned',
+        }),
+        false,
+    );
 
     for (const status of ['completed', 'canceled', 'pendingVerification']) {
         assert.equal(
@@ -154,6 +161,20 @@ test('day planting bulk actions honor optimistic completed and deleted fields', 
     assert.equal(
         isDayBulkFieldApprovalTargetVisible({ plantStatus: 'new' }),
         true,
+    );
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({
+            isDeleted: true,
+            plantStatus: 'new',
+        }),
+        false,
+    );
+    assert.equal(
+        isDayBulkFieldApprovalTargetVisible({
+            assignedUserId: null,
+            plantStatus: 'new',
+        }),
+        false,
     );
 
     assert.equal(

--- a/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
+++ b/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
@@ -74,7 +74,11 @@ type DayBulkFieldPatch = {
 function hasOptimisticUnassignment(
     patch: { assignedUserId?: string | null } | undefined,
 ) {
-    return patch && 'assignedUserId' in patch && !patch.assignedUserId;
+    return (
+        patch !== undefined &&
+        Object.hasOwn(patch, 'assignedUserId') &&
+        !patch.assignedUserId
+    );
 }
 
 export function isDayBulkOperationApprovalTargetVisible(

--- a/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
+++ b/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
@@ -2,6 +2,14 @@ import type {
     OperationAssignableFarmUser,
     OperationAssignedUser,
 } from '@gredice/storage';
+import {
+    isFieldApproved,
+    isFieldCompleted,
+    isFieldPendingVerification,
+    isOperationCancelled,
+    isOperationCompleted,
+    isOperationPendingVerification,
+} from './scheduleShared';
 
 type AssignableOperationUser = Pick<
     OperationAssignableFarmUser,
@@ -48,5 +56,69 @@ export function createOperationAssignedUsers(
                 displayName: null,
                 avatarUrl: null,
             },
+    );
+}
+
+type DayBulkOperationPatch = {
+    assignedUserId?: string | null;
+    isAccepted?: boolean;
+    status?: string;
+};
+
+type DayBulkFieldPatch = {
+    assignedUserId?: string | null;
+    isDeleted?: boolean;
+    plantStatus?: string;
+};
+
+function hasOptimisticUnassignment(
+    patch: { assignedUserId?: string | null } | undefined,
+) {
+    return patch && 'assignedUserId' in patch && !patch.assignedUserId;
+}
+
+export function isDayBulkOperationApprovalTargetVisible(
+    patch: DayBulkOperationPatch | undefined,
+) {
+    return (
+        !patch?.isAccepted &&
+        !hasOptimisticUnassignment(patch) &&
+        !isOperationCompleted(patch?.status) &&
+        !isOperationPendingVerification(patch?.status) &&
+        !isOperationCancelled(patch?.status)
+    );
+}
+
+export function isDayBulkOperationAssignmentTargetVisible(
+    patch: DayBulkOperationPatch | undefined,
+) {
+    return (
+        !patch?.assignedUserId &&
+        !isOperationCompleted(patch?.status) &&
+        !isOperationPendingVerification(patch?.status) &&
+        !isOperationCancelled(patch?.status)
+    );
+}
+
+export function isDayBulkFieldApprovalTargetVisible(
+    patch: DayBulkFieldPatch | undefined,
+) {
+    return (
+        !patch?.isDeleted &&
+        !hasOptimisticUnassignment(patch) &&
+        !isFieldApproved(patch?.plantStatus) &&
+        !isFieldPendingVerification(patch?.plantStatus) &&
+        !isFieldCompleted(patch?.plantStatus)
+    );
+}
+
+export function isDayBulkFieldAssignmentTargetVisible(
+    patch: DayBulkFieldPatch | undefined,
+) {
+    return (
+        !patch?.isDeleted &&
+        !patch?.assignedUserId &&
+        !isFieldPendingVerification(patch?.plantStatus) &&
+        !isFieldCompleted(patch?.plantStatus)
     );
 }

--- a/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
+++ b/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
@@ -1,0 +1,52 @@
+import type {
+    OperationAssignableFarmUser,
+    OperationAssignedUser,
+} from '@gredice/storage';
+
+type AssignableOperationUser = Pick<
+    OperationAssignableFarmUser,
+    'avatarUrl' | 'displayName' | 'id' | 'userName'
+>;
+
+export function parseScheduledDateInput(value: string) {
+    const [year, month, day] = value
+        .split('-')
+        .map((part) => Number.parseInt(part, 10));
+
+    if (!year || !month || !day) {
+        return undefined;
+    }
+
+    return new Date(year, month - 1, day);
+}
+
+export function createOperationAssignedUsers(
+    selectedUserIds: string[],
+    farmUsers: AssignableOperationUser[],
+    assignedUsers: OperationAssignedUser[] | undefined,
+) {
+    const usersById = new Map<string, OperationAssignedUser>();
+
+    for (const farmUser of farmUsers) {
+        usersById.set(farmUser.id, {
+            id: farmUser.id,
+            userName: farmUser.userName,
+            displayName: farmUser.displayName,
+            avatarUrl: farmUser.avatarUrl,
+        });
+    }
+
+    for (const assignedUser of assignedUsers ?? []) {
+        usersById.set(assignedUser.id, assignedUser);
+    }
+
+    return selectedUserIds.map(
+        (selectedUserId) =>
+            usersById.get(selectedUserId) ?? {
+                id: selectedUserId,
+                userName: selectedUserId,
+                displayName: null,
+                avatarUrl: null,
+            },
+    );
+}

--- a/apps/app/app/admin/schedule/useOptimisticScheduleActions.ts
+++ b/apps/app/app/admin/schedule/useOptimisticScheduleActions.ts
@@ -1,0 +1,202 @@
+'use client';
+
+import {
+    createContext,
+    createElement,
+    type ReactNode,
+    useCallback,
+    useContext,
+    useRef,
+    useState,
+} from 'react';
+import type { Operation, RaisedBedField } from './types';
+
+export type OperationOptimisticPatch = Partial<
+    Pick<
+        Operation,
+        | 'assignedUser'
+        | 'assignedUserId'
+        | 'assignedUserIds'
+        | 'assignedUsers'
+        | 'completionNotes'
+        | 'imageUrls'
+        | 'isAccepted'
+        | 'scheduledDate'
+        | 'status'
+    >
+>;
+
+export type RaisedBedFieldOptimisticPatch = Partial<
+    Pick<
+        RaisedBedField,
+        | 'assignedUserId'
+        | 'assignedUserIds'
+        | 'isDeleted'
+        | 'plantScheduledDate'
+        | 'plantStatus'
+    >
+>;
+
+type PatchEntry<TPatch> = {
+    token: number;
+    patch: TPatch;
+};
+
+type PatchTarget<TPatch> = {
+    id: number;
+    patch: TPatch;
+};
+
+type OptimisticScheduleAction = {
+    operationPatches?: PatchTarget<OperationOptimisticPatch>[];
+    fieldPatches?: PatchTarget<RaisedBedFieldOptimisticPatch>[];
+    action: () => Promise<unknown>;
+    errorLogMessage: string;
+    errorAlertMessage: string;
+};
+
+function addPatchEntries<TPatch>(
+    currentEntriesById: Map<number, PatchEntry<TPatch>[]>,
+    patches: PatchTarget<TPatch>[],
+    token: number,
+) {
+    if (patches.length === 0) {
+        return currentEntriesById;
+    }
+
+    const nextEntriesById = new Map(currentEntriesById);
+    for (const { id, patch } of patches) {
+        nextEntriesById.set(id, [
+            ...(nextEntriesById.get(id) ?? []),
+            { token, patch },
+        ]);
+    }
+
+    return nextEntriesById;
+}
+
+function removePatchToken<TPatch>(
+    currentEntriesById: Map<number, PatchEntry<TPatch>[]>,
+    token: number,
+) {
+    const nextEntriesById = new Map<number, PatchEntry<TPatch>[]>();
+
+    for (const [id, entries] of currentEntriesById) {
+        const nextEntries = entries.filter((entry) => entry.token !== token);
+        if (nextEntries.length > 0) {
+            nextEntriesById.set(id, nextEntries);
+        }
+    }
+
+    return nextEntriesById;
+}
+
+function mergePatchEntries<TPatch extends object>(
+    entries: PatchEntry<TPatch>[] | undefined,
+) {
+    if (!entries?.length) {
+        return undefined;
+    }
+
+    const mergedPatch: Partial<TPatch> = {};
+    for (const entry of entries) {
+        Object.assign(mergedPatch, entry.patch);
+    }
+
+    return mergedPatch;
+}
+
+type OptimisticScheduleActionsContextValue = {
+    getFieldPatch: (
+        fieldId: number,
+    ) => RaisedBedFieldOptimisticPatch | undefined;
+    getOperationPatch: (
+        operationId: number,
+    ) => OperationOptimisticPatch | undefined;
+    runOptimisticAction: (action: OptimisticScheduleAction) => void;
+};
+
+const OptimisticScheduleActionsContext =
+    createContext<OptimisticScheduleActionsContextValue | null>(null);
+
+function useOptimisticScheduleActionState(): OptimisticScheduleActionsContextValue {
+    const tokenRef = useRef(0);
+    const [operationEntriesById, setOperationEntriesById] = useState<
+        Map<number, PatchEntry<OperationOptimisticPatch>[]>
+    >(() => new Map());
+    const [fieldEntriesById, setFieldEntriesById] = useState<
+        Map<number, PatchEntry<RaisedBedFieldOptimisticPatch>[]>
+    >(() => new Map());
+
+    const runOptimisticAction = useCallback(
+        ({
+            operationPatches = [],
+            fieldPatches = [],
+            action,
+            errorLogMessage,
+            errorAlertMessage,
+        }: OptimisticScheduleAction) => {
+            const token = tokenRef.current;
+            tokenRef.current += 1;
+
+            setOperationEntriesById((currentEntriesById) =>
+                addPatchEntries(currentEntriesById, operationPatches, token),
+            );
+            setFieldEntriesById((currentEntriesById) =>
+                addPatchEntries(currentEntriesById, fieldPatches, token),
+            );
+
+            void Promise.resolve()
+                .then(action)
+                .catch((error: unknown) => {
+                    console.error(errorLogMessage, error);
+                    setOperationEntriesById((currentEntriesById) =>
+                        removePatchToken(currentEntriesById, token),
+                    );
+                    setFieldEntriesById((currentEntriesById) =>
+                        removePatchToken(currentEntriesById, token),
+                    );
+                    alert(errorAlertMessage);
+                });
+        },
+        [],
+    );
+
+    const getOperationPatch = useCallback(
+        (operationId: number) =>
+            mergePatchEntries(operationEntriesById.get(operationId)),
+        [operationEntriesById],
+    );
+
+    const getFieldPatch = useCallback(
+        (fieldId: number) => mergePatchEntries(fieldEntriesById.get(fieldId)),
+        [fieldEntriesById],
+    );
+
+    return {
+        getFieldPatch,
+        getOperationPatch,
+        runOptimisticAction,
+    };
+}
+
+export function OptimisticScheduleActionsProvider({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    const actions = useOptimisticScheduleActionState();
+
+    return createElement(
+        OptimisticScheduleActionsContext.Provider,
+        { value: actions },
+        children,
+    );
+}
+
+export function useOptimisticScheduleActions() {
+    const contextActions = useContext(OptimisticScheduleActionsContext);
+    const localActions = useOptimisticScheduleActionState();
+
+    return contextActions ?? localActions;
+}


### PR DESCRIPTION
## Summary
- Make schedule task actions update the UI optimistically instead of waiting for the server response
- Roll back the optimistic change and show an error notification if the action fails
- Apply the same behavior across schedule verification, accept, assign, reschedule, cancel, complete, and bulk actions

## Testing
- Lint and formatting passed for the schedule workspace
- Local unit coverage passed for the affected schedule filter logic
- App production build passed
- `pnpm test --filter app` still fails in this environment because the app test script uses a POSIX-style `NODE_OPTIONS=...` assignment that PowerShell cannot execute