### PR TITLE
Align farm handbook back buttons and show sowing date badge on empty field items

### DIFF
--- a/apps/farm/app/operations/page.tsx
+++ b/apps/farm/app/operations/page.tsx
@@ -2,6 +2,7 @@ import {
     AuthProtectedSection,
     SignedOut,
 } from '@signalco/auth-server/components';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { HomeButton } from '../../components/HomeButton';
@@ -18,10 +19,12 @@ async function OperationsHandbookContent() {
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
             <div className="space-y-2">
-                <HomeButton />
-                <Typography level="h4" component="h1" semiBold>
-                    Priručnik operacija
-                </Typography>
+                <Row spacing={1}>
+                    <HomeButton />
+                    <Typography level="h4" component="h1" semiBold>
+                        Priručnik operacija
+                    </Typography>
+                </Row>
                 <Typography className="text-muted-foreground">
                     Pregled svih operacija i ključnih detalja za brži rad na
                     farmi.

--- a/apps/farm/app/plants/page.tsx
+++ b/apps/farm/app/plants/page.tsx
@@ -2,6 +2,7 @@ import {
     AuthProtectedSection,
     SignedOut,
 } from '@signalco/auth-server/components';
+import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { HomeButton } from '../../components/HomeButton';
@@ -18,10 +19,12 @@ async function PlantsHandbookContent() {
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
             <div className="space-y-2">
-                <HomeButton />
-                <Typography level="h4" component="h1" semiBold>
-                    Priručnik biljaka
-                </Typography>
+                <Row spacing={1}>
+                    <HomeButton />
+                    <Typography level="h4" component="h1" semiBold>
+                        Priručnik biljaka
+                    </Typography>
+                </Row>
                 <Typography className="text-muted-foreground">
                     Pregled sorti, atributa i kalendara uzgoja za planiranje
                     rada na farmi.

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -1,11 +1,47 @@
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { PlantOrSortImage } from '@gredice/ui/plants';
-import { ShoppingCart } from '@signalco/ui-icons';
+import { Calendar, ShoppingCart } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import { PlantPicker } from './RaisedBedPlantPicker';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseScheduledDate(additionalData: string | null | undefined) {
+    if (!additionalData) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(additionalData);
+        if (!isRecord(parsed) || typeof parsed.scheduledDate !== 'string') {
+            return null;
+        }
+
+        const date = new Date(parsed.scheduledDate);
+        return Number.isNaN(date.getTime()) ? null : date;
+    } catch {
+        return null;
+    }
+}
+
+function formatSowingDateLabel(date: Date | null, now = new Date()) {
+    if (!date) {
+        return null;
+    }
+
+    const day = date.getDate();
+    const isCurrentMonth =
+        date.getFullYear() === now.getFullYear() &&
+        date.getMonth() === now.getMonth();
+    const shouldShowMonth = !isCurrentMonth && day >= now.getDate();
+
+    return shouldShowMonth ? `${day}.${date.getMonth() + 1}.` : `${day}`;
+}
 
 export function RaisedBedFieldItemEmpty({
     cartPlantItem,
@@ -33,13 +69,11 @@ export function RaisedBedFieldItemEmpty({
 
     const cartPlantSort = cartPlantItem?.entityData;
     const cartPlantId = cartPlantSort?.information?.plant?.id;
-    const additionalDataRaw = cartPlantItem?.additionalData
-        ? JSON.parse(cartPlantItem.additionalData)
-        : null;
+    const scheduledDate = parseScheduledDate(cartPlantItem?.additionalData);
+    const sowingDateLabel = formatSowingDateLabel(scheduledDate);
+    const sowingDateIncludesMonth = sowingDateLabel?.includes('.') ?? false;
     const cartPlantOptions = {
-        scheduledDate: additionalDataRaw?.scheduledDate
-            ? new Date(additionalDataRaw.scheduledDate)
-            : null,
+        scheduledDate,
     };
 
     const isLoading = isCartPending || isGardenPending;
@@ -79,6 +113,23 @@ export function RaisedBedFieldItemEmpty({
                                     <ShoppingCart className="size-4 stroke-white" />
                                 </div>
                             </div>
+                            {sowingDateLabel && (
+                                <div className="absolute bottom-0.5 left-0.5">
+                                    <div className="relative flex size-8 items-center justify-center rounded-full border-2 border-white bg-stone-200 text-stone-700 shadow-lg">
+                                        <Calendar className="size-6 stroke-stone-600" />
+                                        <span
+                                            className={cx(
+                                                'absolute inset-0 flex items-center justify-center pt-1 font-bold leading-none tabular-nums text-stone-800',
+                                                sowingDateIncludesMonth
+                                                    ? 'text-[7px]'
+                                                    : 'text-[10px]',
+                                            )}
+                                        >
+                                            {sowingDateLabel}
+                                        </span>
+                                    </div>
+                                </div>
+                            )}
                         </>
                     )}
                 </RaisedBedFieldItemButton>


### PR DESCRIPTION
## Summary
- Place the farm handbook back button inline with the page title on the operations and plants pages
- Add a small calendar/date badge to empty raised-bed field items when scheduled sowing data is present
- Parse scheduled date metadata defensively before rendering the badge

## Testing
- Lint and formatting passed
- Targeted `farm` build passed
- Targeted `farm` Playwright test suite passed