### PR TITLE
Preimenuj priručnik radnji i otvori detalje na zasebnoj stranici

### DIFF
--- a/apps/farm/app/operations/OperationDetails.tsx
+++ b/apps/farm/app/operations/OperationDetails.tsx
@@ -1,0 +1,127 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { Card, CardContent } from '@signalco/ui-primitives/Card';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import {
+    formatMinutes,
+    getOperationDurationMinutes,
+} from '../schedule/scheduleShared';
+import { formatAttributeLabel, formatAttributeValue } from './operationUtils';
+
+interface OperationDetailsProps {
+    operation: EntityStandardized;
+}
+
+interface FormattedAttribute {
+    attributeName: string;
+    formattedValue: string | null;
+}
+
+function hasFormattedValue(
+    attribute: FormattedAttribute,
+): attribute is { attributeName: string; formattedValue: string } {
+    return attribute.formattedValue !== null;
+}
+
+export function OperationDetails({ operation }: OperationDetailsProps) {
+    const durationMinutes = getOperationDurationMinutes(operation);
+    const attributes = Object.entries(operation.attributes ?? {})
+        .filter(
+            ([attributeName, attributeValue]) =>
+                attributeName !== 'duration' &&
+                attributeValue !== null &&
+                attributeValue !== undefined,
+        )
+        .map(([attributeName, attributeValue]) => ({
+            attributeName,
+            formattedValue: formatAttributeValue(attributeValue),
+        }))
+        .filter(hasFormattedValue);
+
+    return (
+        <Card>
+            <CardContent noHeader>
+                <Stack spacing={1}>
+                    {operation.information?.shortDescription && (
+                        <Typography className="text-muted-foreground">
+                            {operation.information.shortDescription}
+                        </Typography>
+                    )}
+                    {operation.information?.description && (
+                        <Typography level="body2">
+                            {operation.information.description}
+                        </Typography>
+                    )}
+                    {operation.information?.instructions && (
+                        <div className="rounded-md border bg-muted/40 p-3">
+                            <Typography level="body2" semiBold>
+                                Upute
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                className="whitespace-pre-wrap"
+                            >
+                                {operation.information.instructions}
+                            </Typography>
+                        </div>
+                    )}
+                    <div className="grid gap-2 text-sm sm:grid-cols-2">
+                        <div className="rounded-md border bg-white p-3">
+                            <Typography level="body2" semiBold>
+                                Trajanje
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                className="text-muted-foreground"
+                            >
+                                {durationMinutes > 0
+                                    ? formatMinutes(durationMinutes)
+                                    : 'Nije definirano'}
+                            </Typography>
+                        </div>
+                        <div className="rounded-md border bg-white p-3">
+                            <Typography level="body2" semiBold>
+                                Dokaz fotografijom
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                className="text-muted-foreground"
+                            >
+                                {!operation.conditions?.completionAttachImages
+                                    ? 'Nije potrebno'
+                                    : operation.conditions
+                                            ?.completionAttachImagesRequired
+                                      ? 'Obavezno priložiti fotografije'
+                                      : 'Preporučeno priložiti fotografije'}
+                            </Typography>
+                        </div>
+                    </div>
+                    {attributes.length > 0 && (
+                        <div className="rounded-md border bg-white p-3">
+                            <Typography level="body2" semiBold>
+                                Dodatni detalji
+                            </Typography>
+                            <dl className="mt-2 grid gap-x-3 gap-y-1 text-sm sm:grid-cols-[1fr_2fr]">
+                                {attributes.map(
+                                    ({ attributeName, formattedValue }) => (
+                                        <div
+                                            key={`${operation.id}-${attributeName}`}
+                                            className="contents"
+                                        >
+                                            <dt className="text-muted-foreground">
+                                                {formatAttributeLabel(
+                                                    attributeName,
+                                                )}
+                                            </dt>
+                                            <dd>{formattedValue}</dd>
+                                        </div>
+                                    ),
+                                )}
+                            </dl>
+                        </div>
+                    )}
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/farm/app/operations/OperationsHandbook.tsx
+++ b/apps/farm/app/operations/OperationsHandbook.tsx
@@ -2,87 +2,20 @@
 
 import type { EntityStandardized } from '@gredice/storage';
 import { FileText, Search } from '@signalco/ui-icons';
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from '@signalco/ui-primitives/Card';
-import { cx } from '@signalco/ui-primitives/cx';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
-import {
-    formatMinutes,
-    getOperationDurationMinutes,
-} from '../schedule/scheduleShared';
+import { getOperationLabel, getOperationSearchText } from './operationUtils';
 
 interface OperationsHandbookProps {
     operationsData: EntityStandardized[];
-}
-
-function formatAttributeLabel(attributeName: string) {
-    return attributeName
-        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-        .replace(/^./, (value) => value.toUpperCase());
-}
-
-function formatAttributeValue(value: unknown) {
-    if (typeof value === 'boolean') {
-        return value ? 'Da' : 'Ne';
-    }
-
-    if (typeof value === 'number') {
-        return value.toLocaleString('hr-HR');
-    }
-
-    if (typeof value === 'string') {
-        return value;
-    }
-
-    if (
-        value &&
-        typeof value === 'object' &&
-        'information' in value &&
-        value.information &&
-        typeof value.information === 'object' &&
-        'label' in value.information &&
-        typeof value.information.label === 'string'
-    ) {
-        return value.information.label;
-    }
-
-    return null;
-}
-
-function getOperationLabel(operation: EntityStandardized) {
-    return (
-        operation.information?.label ??
-        operation.information?.name ??
-        `Operacija #${operation.id}`
-    );
-}
-
-function getOperationSearchText(operation: EntityStandardized) {
-    return [
-        operation.information?.label,
-        operation.information?.name,
-        operation.information?.shortDescription,
-        operation.information?.description,
-        operation.information?.instructions,
-    ]
-        .filter((value) => typeof value === 'string')
-        .join(' ')
-        .toLocaleLowerCase('hr-HR');
 }
 
 export function OperationsHandbook({
     operationsData,
 }: OperationsHandbookProps) {
     const [query, setQuery] = useState('');
-    const [selectedOperationId, setSelectedOperationId] = useState<
-        number | null
-    >(null);
     const normalizedQuery = query.trim().toLocaleLowerCase('hr-HR');
     const sortedOperations = useMemo(
         () =>
@@ -100,10 +33,6 @@ export function OperationsHandbook({
             !normalizedQuery ||
             getOperationSearchText(operation).includes(normalizedQuery),
     );
-    const selectedOperation =
-        filteredOperations.find(
-            (operation) => operation.id === selectedOperationId,
-        ) ?? null;
 
     return (
         <Stack spacing={2}>
@@ -111,186 +40,38 @@ export function OperationsHandbook({
                 <Search className="size-4 shrink-0 text-muted-foreground" />
                 <input
                     value={query}
-                    onChange={(event) => {
-                        setQuery(event.target.value);
-                        setSelectedOperationId(null);
-                    }}
-                    placeholder="Pretraži operacije"
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Pretraži radnje"
                     className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
                 />
             </label>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {filteredOperations.map((operation) => {
-                    const selected = operation.id === selectedOperationId;
+                    const operationLabel = getOperationLabel(operation);
 
                     return (
-                        <button
+                        <Link
                             key={operation.id}
-                            type="button"
-                            onClick={() => setSelectedOperationId(operation.id)}
-                            className={cx(
-                                'rounded-md border bg-white p-4 text-left text-foreground transition-colors hover:border-primary',
-                                selected && 'border-primary bg-tertiary',
-                            )}
+                            href={`/operations/${operation.id}`}
+                            aria-label={`Otvori detalje radnje ${operationLabel}`}
+                            className="rounded-md border bg-white p-4 text-left text-foreground transition-colors hover:border-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                         >
                             <span className="flex items-center gap-2">
                                 <FileText className="size-4 shrink-0 text-primary" />
                                 <span className="font-medium">
-                                    {getOperationLabel(operation)}
+                                    {operationLabel}
                                 </span>
                             </span>
-                        </button>
+                        </Link>
                     );
                 })}
             </div>
             {filteredOperations.length === 0 && (
                 <div className="rounded-md border bg-white p-4">
                     <Typography className="text-muted-foreground">
-                        Nema operacija za prikaz.
+                        Nema radnji za prikaz.
                     </Typography>
                 </div>
-            )}
-            {selectedOperation && (
-                <Card>
-                    <CardHeader>
-                        <CardTitle>
-                            {getOperationLabel(selectedOperation)}
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent noHeader>
-                        <Stack spacing={1}>
-                            {selectedOperation.information
-                                ?.shortDescription && (
-                                <Typography className="text-muted-foreground">
-                                    {
-                                        selectedOperation.information
-                                            .shortDescription
-                                    }
-                                </Typography>
-                            )}
-                            {selectedOperation.information?.description && (
-                                <Typography level="body2">
-                                    {selectedOperation.information.description}
-                                </Typography>
-                            )}
-                            {selectedOperation.information?.instructions && (
-                                <div className="rounded-md border bg-muted/40 p-3">
-                                    <Typography level="body2" semiBold>
-                                        Upute
-                                    </Typography>
-                                    <Typography
-                                        level="body2"
-                                        className="whitespace-pre-wrap"
-                                    >
-                                        {
-                                            selectedOperation.information
-                                                .instructions
-                                        }
-                                    </Typography>
-                                </div>
-                            )}
-                            <div className="grid gap-2 text-sm sm:grid-cols-2">
-                                <div className="rounded-md border bg-white p-3">
-                                    <Typography level="body2" semiBold>
-                                        Trajanje
-                                    </Typography>
-                                    <Typography
-                                        level="body2"
-                                        className="text-muted-foreground"
-                                    >
-                                        {getOperationDurationMinutes(
-                                            selectedOperation,
-                                        ) > 0
-                                            ? formatMinutes(
-                                                  getOperationDurationMinutes(
-                                                      selectedOperation,
-                                                  ),
-                                              )
-                                            : 'Nije definirano'}
-                                    </Typography>
-                                </div>
-                                <div className="rounded-md border bg-white p-3">
-                                    <Typography level="body2" semiBold>
-                                        Dokaz fotografijom
-                                    </Typography>
-                                    <Typography
-                                        level="body2"
-                                        className="text-muted-foreground"
-                                    >
-                                        {!selectedOperation.conditions
-                                            ?.completionAttachImages
-                                            ? 'Nije potrebno'
-                                            : selectedOperation.conditions
-                                                    ?.completionAttachImagesRequired
-                                              ? 'Obavezno priložiti fotografije'
-                                              : 'Preporučeno priložiti fotografije'}
-                                    </Typography>
-                                </div>
-                            </div>
-                            {Object.entries(
-                                selectedOperation.attributes ?? {},
-                            ).filter(
-                                ([attributeName, attributeValue]) =>
-                                    attributeName !== 'duration' &&
-                                    attributeValue !== null &&
-                                    attributeValue !== undefined,
-                            ).length > 0 && (
-                                <div className="rounded-md border bg-white p-3">
-                                    <Typography level="body2" semiBold>
-                                        Dodatni detalji
-                                    </Typography>
-                                    <dl className="mt-2 grid gap-x-3 gap-y-1 text-sm sm:grid-cols-[1fr_2fr]">
-                                        {Object.entries(
-                                            selectedOperation.attributes ?? {},
-                                        )
-                                            .filter(
-                                                ([
-                                                    attributeName,
-                                                    attributeValue,
-                                                ]) =>
-                                                    attributeName !==
-                                                        'duration' &&
-                                                    attributeValue !== null &&
-                                                    attributeValue !==
-                                                        undefined,
-                                            )
-                                            .map(
-                                                ([
-                                                    attributeName,
-                                                    attributeValue,
-                                                ]) => {
-                                                    const formattedValue =
-                                                        formatAttributeValue(
-                                                            attributeValue,
-                                                        );
-
-                                                    if (!formattedValue) {
-                                                        return null;
-                                                    }
-
-                                                    return (
-                                                        <div
-                                                            key={`${selectedOperation.id}-${attributeName}`}
-                                                            className="contents"
-                                                        >
-                                                            <dt className="text-muted-foreground">
-                                                                {formatAttributeLabel(
-                                                                    attributeName,
-                                                                )}
-                                                            </dt>
-                                                            <dd>
-                                                                {formattedValue}
-                                                            </dd>
-                                                        </div>
-                                                    );
-                                                },
-                                            )}
-                                    </dl>
-                                </div>
-                            )}
-                        </Stack>
-                    </CardContent>
-                </Card>
             )}
         </Stack>
     );

--- a/apps/farm/app/operations/[operationId]/page.tsx
+++ b/apps/farm/app/operations/[operationId]/page.tsx
@@ -1,0 +1,79 @@
+import {
+    AuthProtectedSection,
+    SignedOut,
+} from '@signalco/auth-server/components';
+import { ArrowLeft } from '@signalco/ui-icons';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { notFound } from 'next/navigation';
+import LoginDialog from '../../../components/auth/LoginDialog';
+import { auth } from '../../../lib/auth/auth';
+import { getFarmScheduleOperationsData } from '../../schedule/scheduleData';
+import { OperationDetails } from '../OperationDetails';
+import { getOperationLabel } from '../operationUtils';
+
+export const dynamic = 'force-dynamic';
+
+async function OperationDetailPageContent({
+    operationId,
+}: {
+    operationId: number;
+}) {
+    await auth(['farmer', 'admin']);
+    const operationsData = (await getFarmScheduleOperationsData()) ?? [];
+    const operation =
+        operationsData.find((candidate) => candidate.id === operationId) ??
+        null;
+
+    if (!operation) {
+        notFound();
+    }
+
+    return (
+        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+            <Stack spacing={1}>
+                <Button
+                    variant="outlined"
+                    className="w-fit"
+                    href="/operations"
+                    startDecorator={<ArrowLeft className="size-4 shrink-0" />}
+                >
+                    Priručnik radnji
+                </Button>
+                <Typography level="h4" component="h1" semiBold>
+                    {getOperationLabel(operation)}
+                </Typography>
+                <Typography className="text-muted-foreground">
+                    Detalji radnje i upute za izvedbu na farmi.
+                </Typography>
+            </Stack>
+            <OperationDetails operation={operation} />
+        </div>
+    );
+}
+
+export default async function OperationDetailPage({
+    params,
+}: {
+    params: Promise<{ operationId: string }>;
+}) {
+    const { operationId } = await params;
+    const parsedOperationId = Number(operationId);
+    if (!Number.isInteger(parsedOperationId) || parsedOperationId <= 0) {
+        notFound();
+    }
+
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-muted">
+            <AuthProtectedSection auth={authFarmer}>
+                <OperationDetailPageContent operationId={parsedOperationId} />
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/app/operations/operationUtils.ts
+++ b/apps/farm/app/operations/operationUtils.ts
@@ -1,0 +1,56 @@
+import type { EntityStandardized } from '@gredice/storage';
+
+export function formatAttributeLabel(attributeName: string) {
+    return attributeName
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/^./, (value) => value.toUpperCase());
+}
+
+export function formatAttributeValue(value: unknown) {
+    if (typeof value === 'boolean') {
+        return value ? 'Da' : 'Ne';
+    }
+
+    if (typeof value === 'number') {
+        return value.toLocaleString('hr-HR');
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (
+        value &&
+        typeof value === 'object' &&
+        'information' in value &&
+        value.information &&
+        typeof value.information === 'object' &&
+        'label' in value.information &&
+        typeof value.information.label === 'string'
+    ) {
+        return value.information.label;
+    }
+
+    return null;
+}
+
+export function getOperationLabel(operation: EntityStandardized) {
+    return (
+        operation.information?.label ??
+        operation.information?.name ??
+        `Radnja #${operation.id}`
+    );
+}
+
+export function getOperationSearchText(operation: EntityStandardized) {
+    return [
+        operation.information?.label,
+        operation.information?.name,
+        operation.information?.shortDescription,
+        operation.information?.description,
+        operation.information?.instructions,
+    ]
+        .filter((value) => typeof value === 'string')
+        .join(' ')
+        .toLocaleLowerCase('hr-HR');
+}

--- a/apps/farm/app/operations/page.tsx
+++ b/apps/farm/app/operations/page.tsx
@@ -20,11 +20,10 @@ async function OperationsHandbookContent() {
             <div className="space-y-2">
                 <HomeButton />
                 <Typography level="h4" component="h1" semiBold>
-                    Priručnik operacija
+                    Priručnik radnji
                 </Typography>
                 <Typography className="text-muted-foreground">
-                    Pregled svih operacija i ključnih detalja za brži rad na
-                    farmi.
+                    Pregled svih radnji i ključnih detalja za brži rad na farmi.
                 </Typography>
             </div>
             {operationsData.length > 0 ? (
@@ -32,7 +31,7 @@ async function OperationsHandbookContent() {
             ) : (
                 <div className="rounded-lg border bg-white p-6">
                     <Typography className="text-muted-foreground">
-                        Trenutno nema dostupnih operacija.
+                        Trenutno nema dostupnih radnji.
                     </Typography>
                 </div>
             )}

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -161,7 +161,7 @@ async function FarmerDashboard() {
                                 startDecorator={<BookA className="size-4" />}
                                 href="/operations"
                             >
-                                Priručnik operacija
+                                Priručnik radnji
                             </Button>
                             <Button
                                 variant="soft"

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -7,12 +7,35 @@ import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import { PlantPicker } from './RaisedBedPlantPicker';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseScheduledSowingDate(additionalData: string | null | undefined) {
+    if (!additionalData) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(additionalData);
+        if (!isRecord(parsed) || typeof parsed.scheduledDate !== 'string') {
+            return null;
+        }
+
+        const date = new Date(parsed.scheduledDate);
+        return Number.isNaN(date.valueOf()) ? null : date;
+    } catch {
+        return null;
+    }
+}
+
 function formatScheduledSowingDateLabel(date: Date, now: Date): string {
     const day = date.getDate();
     const sameMonthAndYear =
         date.getFullYear() === now.getFullYear() &&
         date.getMonth() === now.getMonth();
-    const shouldIncludeMonth = !sameMonthAndYear && date >= now;
+    const shouldIncludeMonth =
+        !sameMonthAndYear && date.valueOf() >= now.valueOf();
 
     if (!shouldIncludeMonth) {
         return day.toString();
@@ -47,18 +70,13 @@ export function RaisedBedFieldItemEmpty({
 
     const cartPlantSort = cartPlantItem?.entityData;
     const cartPlantId = cartPlantSort?.information?.plant?.id;
-    const additionalDataRaw = cartPlantItem?.additionalData
-        ? JSON.parse(cartPlantItem.additionalData)
-        : null;
+    const scheduledDate = parseScheduledSowingDate(
+        cartPlantItem?.additionalData,
+    );
     const cartPlantOptions = {
-        scheduledDate: additionalDataRaw?.scheduledDate
-            ? new Date(additionalDataRaw.scheduledDate)
-            : null,
+        scheduledDate,
     };
-    const scheduledDate = cartPlantOptions.scheduledDate;
-    const hasScheduledDate =
-        scheduledDate instanceof Date && !Number.isNaN(scheduledDate.valueOf());
-    const scheduledDateLabel = hasScheduledDate
+    const scheduledDateLabel = scheduledDate
         ? formatScheduledSowingDateLabel(scheduledDate, new Date())
         : null;
 


### PR DESCRIPTION
## Summary
- Preimenovan je operations handbook u `Priručnik radnji` na farm dashboardu i na `/operations` stranici.
- Lista radnji sada vodi na zasebne detaljne stranice umjesto da otvara detalje inline.
- Dodan je novi route `/operations/[operationId]` s prikazom detalja radnje i povratkom na pregled.
- Izdvojena je zajednička logika za naziv, pretragu i formatiranje atributa radnje.

## Testing
- Lint i formatiranje prošli za `farm`.
- `pnpm test --filter farm` prošao.
- `pnpm build --filter farm` prošao.
- Lokalna HTTP provjera potvrdila je da `/operations` i `/operations/1` vraćaju `200`.