### PR TITLE
Fix schedule text visibility and show sowing date badge

### DIFF
--- a/apps/farm/app/globals.css
+++ b/apps/farm/app/globals.css
@@ -24,8 +24,8 @@
         --primary: 29 45% 37%;
         --primary-foreground: 36 43% 93%;
 
-        --secondary: 75 37% 36%;
-        --secondary-foreground: 36 43% 93%;
+        --secondary: 75 32% 88%;
+        --secondary-foreground: 75 35% 24%;
 
         --tertiary: 35 38% 84%;
         --tertiary-foreground: 30 25% 28%;

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -1,11 +1,47 @@
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { PlantOrSortImage } from '@gredice/ui/plants';
-import { ShoppingCart } from '@signalco/ui-icons';
+import { Calendar, ShoppingCart } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import { PlantPicker } from './RaisedBedPlantPicker';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseScheduledDate(additionalData: string | null | undefined) {
+    if (!additionalData) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(additionalData);
+        if (!isRecord(parsed) || typeof parsed.scheduledDate !== 'string') {
+            return null;
+        }
+
+        const date = new Date(parsed.scheduledDate);
+        return Number.isNaN(date.getTime()) ? null : date;
+    } catch {
+        return null;
+    }
+}
+
+function formatSowingDateLabel(date: Date | null, now = new Date()) {
+    if (!date) {
+        return null;
+    }
+
+    const day = date.getDate();
+    const isCurrentMonth =
+        date.getFullYear() === now.getFullYear() &&
+        date.getMonth() === now.getMonth();
+    const shouldShowMonth = !isCurrentMonth && day >= now.getDate();
+
+    return shouldShowMonth ? `${day}.${date.getMonth() + 1}.` : `${day}`;
+}
 
 export function RaisedBedFieldItemEmpty({
     cartPlantItem,
@@ -33,13 +69,11 @@ export function RaisedBedFieldItemEmpty({
 
     const cartPlantSort = cartPlantItem?.entityData;
     const cartPlantId = cartPlantSort?.information?.plant?.id;
-    const additionalDataRaw = cartPlantItem?.additionalData
-        ? JSON.parse(cartPlantItem.additionalData)
-        : null;
+    const scheduledDate = parseScheduledDate(cartPlantItem?.additionalData);
+    const sowingDateLabel = formatSowingDateLabel(scheduledDate);
+    const sowingDateIncludesMonth = sowingDateLabel?.includes('.') ?? false;
     const cartPlantOptions = {
-        scheduledDate: additionalDataRaw?.scheduledDate
-            ? new Date(additionalDataRaw.scheduledDate)
-            : null,
+        scheduledDate,
     };
 
     const isLoading = isCartPending || isGardenPending;
@@ -79,6 +113,23 @@ export function RaisedBedFieldItemEmpty({
                                     <ShoppingCart className="size-4 stroke-white" />
                                 </div>
                             </div>
+                            {sowingDateLabel && (
+                                <div className="absolute bottom-0.5 left-0.5">
+                                    <div className="relative flex size-8 items-center justify-center rounded-full border-2 border-white bg-stone-200 text-stone-700 shadow-lg">
+                                        <Calendar className="size-6 stroke-stone-600" />
+                                        <span
+                                            className={cx(
+                                                'absolute inset-0 flex items-center justify-center pt-1 font-bold leading-none tabular-nums text-stone-800',
+                                                sowingDateIncludesMonth
+                                                    ? 'text-[7px]'
+                                                    : 'text-[10px]',
+                                            )}
+                                        >
+                                            {sowingDateLabel}
+                                        </span>
+                                    </div>
+                                </div>
+                            )}
                         </>
                     )}
                 </RaisedBedFieldItemButton>


### PR DESCRIPTION
## Summary
- Adjust farm theme secondary colors so schedule and handbook body text renders with readable contrast.
- Add a sowing-date calendar badge to empty raised-bed field items in the game HUD.
- Keep the new badge resilient by parsing `additionalData` safely before rendering.

## Testing
- `pnpm lint --filter farm`
- `pnpm build --filter farm`
- `pnpm test --filter farm`