### PR TITLE
Prevent block buy button layout shift while loading

### DIFF
--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -128,7 +128,6 @@ function PlaceEntityButton({
                 onClick={placeEntity}
                 size={simple ? 'sm' : 'md'}
                 disabled={!block.prices.sunflowers || placeBlock.isPending}
-                loading={placeBlock.isPending}
                 endDecorator={
                     <Row
                         className={cx(
@@ -138,7 +137,7 @@ function PlaceEntityButton({
                         )}
                     >
                         {block.prices.sunflowers
-                            ? `🌻 ${block.prices.sunflowers}`
+                            ? `${placeBlock.isPending ? '⏳' : '🌻'} ${block.prices.sunflowers}`
                             : 'Nedostupno'}
                     </Row>
                 }


### PR DESCRIPTION
### Motivation
- Prevent the buy/place button from resizing and shifting when a block placement is pending by keeping the button footprint stable and showing loading feedback inside the existing price area.

### Description
- Remove the Button `loading={placeBlock.isPending}` and instead swap the sunflower icon for an hourglass in the existing price decorator when `placeBlock.isPending`, so the price area shows `⏳ <price>` without changing the button width (updated `packages/game/src/hud/ItemsHud.tsx`).

### Testing
- Ran `pnpm lint --filter garden`, which completed successfully (lint passed; environment showed a Node engine warning because local Node is `v22` while the repo expects `>=24`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e0efcfe4832f9c1a38d96751deee)