### PR TITLE
[Garden] Replace automatic push prompt with consent-first onboarding

### DIFF
--- a/packages/game/src/hooks/usePushPermissionOnboarding.ts
+++ b/packages/game/src/hooks/usePushPermissionOnboarding.ts
@@ -61,10 +61,7 @@ export function usePushPermissionOnboarding() {
         return 'default' as const;
     }, []);
 
-    const canPrompt = useMemo(
-        () => status === 'default' || status === 'prompt-dismissed',
-        [status],
-    );
+    const canPrompt = useMemo(() => status === 'default', [status]);
 
     return {
         status,

--- a/packages/game/src/hooks/usePushPermissionOnboarding.ts
+++ b/packages/game/src/hooks/usePushPermissionOnboarding.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type PushSetupStatus =
+    | 'unsupported'
+    | 'default'
+    | 'denied'
+    | 'granted'
+    | 'prompt-dismissed';
+
+const pushPromptDismissedKey = 'game:push:prompt-dismissed';
+
+function readPromptDismissed(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(pushPromptDismissedKey) === '1';
+}
+
+function resolvePermissionStatus(): PushSetupStatus {
+    if (typeof window === 'undefined' || !('Notification' in window)) {
+        return 'unsupported';
+    }
+
+    if (window.Notification.permission === 'denied') return 'denied';
+    if (window.Notification.permission === 'granted') return 'granted';
+    return readPromptDismissed() ? 'prompt-dismissed' : 'default';
+}
+
+export function usePushPermissionOnboarding() {
+    const [status, setStatus] = useState<PushSetupStatus>(() =>
+        resolvePermissionStatus(),
+    );
+
+    useEffect(() => {
+        setStatus(resolvePermissionStatus());
+    }, []);
+
+    const dismissPrompt = useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.localStorage.setItem(pushPromptDismissedKey, '1');
+        }
+        setStatus('prompt-dismissed');
+    }, []);
+
+    const requestPermission = useCallback(async () => {
+        if (typeof window === 'undefined' || !('Notification' in window)) {
+            setStatus('unsupported');
+            return 'unsupported' as const;
+        }
+
+        const permission = await window.Notification.requestPermission();
+        if (permission === 'granted') {
+            setStatus('granted');
+            return 'granted' as const;
+        }
+
+        if (permission === 'denied') {
+            setStatus('denied');
+            return 'denied' as const;
+        }
+
+        setStatus('default');
+        return 'default' as const;
+    }, []);
+
+    const canPrompt = useMemo(
+        () => status === 'default' || status === 'prompt-dismissed',
+        [status],
+    );
+
+    return {
+        status,
+        canPrompt,
+        dismissPrompt,
+        requestPermission,
+    };
+}

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -1,4 +1,4 @@
-import { Approved, Empty } from '@signalco/ui-icons';
+import { Approved, Bell, Close, Empty } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -8,12 +8,34 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useMarkAllNotificationsRead } from '../../hooks/useMarkAllNotificationsRead';
+import { usePushPermissionOnboarding } from '../../hooks/usePushPermissionOnboarding';
 import { NotificationList } from '../../hud/NotificationList';
 
 export function NotificationsTab() {
     const [notificationsFilter, setNotificationsFilter] = useState('unread');
     const markAllNotificationsRead = useMarkAllNotificationsRead();
     const { track } = useGameAnalytics();
+    const pushOnboarding = usePushPermissionOnboarding();
+
+    const handleEnablePush = async () => {
+        track('game_push_enable_clicked', {
+            source: 'overview_notifications_tab',
+            status: pushOnboarding.status,
+        });
+
+        const result = await pushOnboarding.requestPermission();
+        track('game_push_permission_result', {
+            source: 'overview_notifications_tab',
+            result,
+        });
+    };
+
+    const handleDismissPushPrompt = () => {
+        track('game_push_prompt_dismissed', {
+            source: 'overview_notifications_tab',
+        });
+        pushOnboarding.dismissPrompt();
+    };
 
     const handleMarkAllNotificationsRead = () => {
         track('game_notifications_mark_all_read', {
@@ -30,6 +52,50 @@ export function NotificationsTab() {
                 </Typography>
             </Row>
             <Stack spacing={1}>
+                {pushOnboarding.canPrompt && (
+                    <Card className="bg-card p-2">
+                        <Stack spacing={1}>
+                            <Row
+                                justifyContent="space-between"
+                                alignItems="start"
+                            >
+                                <Row spacing={1}>
+                                    <Bell className="size-5 text-warning" />
+                                    <Stack spacing={0.5}>
+                                        <Typography level="body1" semiBold>
+                                            Uključi push obavijesti
+                                        </Typography>
+                                        <Typography level="body2" secondary>
+                                            Primaj obavijesti o novim
+                                            aktivnostima vrta i narudžbama odmah
+                                            nakon objave.
+                                        </Typography>
+                                    </Stack>
+                                </Row>
+                                <Button
+                                    variant="plain"
+                                    size="sm"
+                                    onClick={handleDismissPushPrompt}
+                                    title="Sakrij"
+                                    startDecorator={
+                                        <Close className="size-4" />
+                                    }
+                                >
+                                    Kasnije
+                                </Button>
+                            </Row>
+                            <Row justifyContent="end">
+                                <Button
+                                    size="sm"
+                                    onClick={handleEnablePush}
+                                    startDecorator={<Bell className="size-4" />}
+                                >
+                                    Uključi push
+                                </Button>
+                            </Row>
+                        </Stack>
+                    </Card>
+                )}
                 <Card className="bg-card p-1">
                     <Row justifyContent="space-between">
                         <SelectItems

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -1,4 +1,4 @@
-import { Approved, Bell, Close, Empty } from '@signalco/ui-icons';
+import { Approved, Close, Empty, Megaphone } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -60,7 +60,7 @@ export function NotificationsTab() {
                                 alignItems="start"
                             >
                                 <Row spacing={1}>
-                                    <Bell className="size-5 text-warning" />
+                                    <Megaphone className="size-5 text-warning" />
                                     <Stack spacing={0.5}>
                                         <Typography level="body1" semiBold>
                                             Uključi push obavijesti
@@ -88,7 +88,9 @@ export function NotificationsTab() {
                                 <Button
                                     size="sm"
                                     onClick={handleEnablePush}
-                                    startDecorator={<Bell className="size-4" />}
+                                    startDecorator={
+                                        <Megaphone className="size-4" />
+                                    }
                                 >
                                     Uključi push
                                 </Button>


### PR DESCRIPTION
### Motivation
- Avoid triggering `Notification.requestPermission()` automatically and follow a consent-first UX so permission requests occur only after explicit user intent.
- Provide a lightweight, retryable soft prompt in the notifications UI and persist dismissal state to avoid repeated prompts.
- Centralize browser push permission state for game notifications to make downstream feature work (registering service worker/subscription) conditional on explicit user opt-in.

### Description
- Added a new hook `usePushPermissionOnboarding` that exposes `status`, `canPrompt`, `dismissPrompt`, and `requestPermission` and persists soft-prompt dismissal in `localStorage` (`game:push:prompt-dismissed`).
- Updated the Garden notifications tab (`NotificationsTab.tsx`) to render a consent-first soft prompt card with an explicit **Uključi push** CTA that calls `requestPermission` and a **Kasnije** dismiss action that records dismissal without invoking `requestPermission`.
- Added analytics tracking for push enable clicks, prompt dismissals, and permission results and ensured no automatic permission prompt runs on load or login.

### Testing
- Ran `pnpm lint --filter @gredice/game`, which completed successfully (one non-blocking lint warning reported). 
- Ran `pnpm test --filter @gredice/game`, which completed successfully (all tests passed).
- Ran `pnpm build --filter @gredice/game`, which reported no build tasks executed for the package (no build step run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e3e861c8832fb4d6cbb6c3374b7f)