### PR TITLE
Game: show controls tooltip guidance for edit mode

### DIFF
--- a/packages/game/src/hud/ControlsTooltipHud.tsx
+++ b/packages/game/src/hud/ControlsTooltipHud.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Check, Close, Info } from '@signalco/ui-icons';
+import { Check, Info } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
 import { useEffect, useState } from 'react';
+import { useIsEditMode } from '../hooks/useIsEditMode';
 import { ButtonGreen } from '../shared-ui/ButtonGreen';
 import type { DeviceType } from './controls-tooltip';
 import { ControlsVisualization } from './controls-tooltip';
@@ -54,6 +55,7 @@ function prefersReducedMotion() {
 }
 
 export function ControlsTooltipHud() {
+    const isEditMode = useIsEditMode();
     const [deviceType, setDeviceType] = useState<DeviceType>('desktop');
     const [open, setOpen] = useState(false);
     const [phase, setPhase] = useState(0.75);
@@ -110,7 +112,11 @@ export function ControlsTooltipHud() {
 
     return (
         <div className="pointer-events-auto relative p-2 sm:p-3">
-            <ControlsVisualization deviceType={deviceType} phase={phase} />
+            <ControlsVisualization
+                deviceType={deviceType}
+                phase={phase}
+                isEditMode={isEditMode}
+            />
             <ButtonGreen
                 title="Zatvori"
                 variant="soft"

--- a/packages/game/src/hud/controls-tooltip/ControlsVisualization.tsx
+++ b/packages/game/src/hud/controls-tooltip/ControlsVisualization.tsx
@@ -10,6 +10,7 @@ import { WireframeCube } from './WireframeCube';
 export type ControlsVisualizationProps = {
     deviceType: DeviceType;
     phase: number;
+    isEditMode?: boolean;
 };
 
 function getActivePanKey(phase: number) {
@@ -23,8 +24,11 @@ function getActivePanKey(phase: number) {
     return y > 0 ? ('ArrowUp' as const) : ('ArrowDown' as const);
 }
 
-function getAccessibleDescription(deviceType: DeviceType) {
+function getAccessibleDescription(deviceType: DeviceType, isEditMode: boolean) {
     if (deviceType === 'desktop') {
+        if (isEditMode) {
+            return 'Pomak kamere: povucite desnom tipkom miša ili koristite strelice. Zum: kotačić miša. Rotacija vrta: tipke Q i W ili tipke za rotaciju.';
+        }
         return 'Pomak kamere: povucite mišem ili koristite strelice. Zum: kotačić miša. Rotacija vrta: tipke Q i W ili tipke za rotaciju.';
     }
 
@@ -34,6 +38,7 @@ function getAccessibleDescription(deviceType: DeviceType) {
 export function ControlsVisualization({
     deviceType,
     phase,
+    isEditMode = false,
 }: ControlsVisualizationProps) {
     const isTouchDevice = deviceType !== 'desktop';
     const moveX = Math.sin(phase) * 14;
@@ -45,14 +50,22 @@ export function ControlsVisualization({
 
     return (
         <>
-            <p className="sr-only">{getAccessibleDescription(deviceType)}</p>
+            <p className="sr-only">
+                {getAccessibleDescription(deviceType, isEditMode)}
+            </p>
             <div
                 className="grid grid-cols-3 overflow-hidden rounded-md bg-card border-b-4 border border-tertiary"
                 aria-hidden="true"
             >
                 <VisualizationSection
                     title="Pomak"
-                    label={isTouchDevice ? 'Povuci' : 'Strelice'}
+                    label={
+                        isTouchDevice
+                            ? 'Povuci'
+                            : isEditMode
+                              ? 'Desni klik'
+                              : 'Strelice'
+                    }
                     cube={<WireframeCube translateX={moveX} />}
                     controls={
                         isTouchDevice ? (


### PR DESCRIPTION
### Motivation

- The in-game edit mode uses a different control scheme (right-click panning on desktop), so the on-screen controls tooltip should reflect edit-mode behavior and accessible descriptions.

### Description

- Read edit-mode state in the HUD using `useIsEditMode()` and pass it into the controls visualization component (`ControlsTooltipHud` -> `ControlsVisualization`).
- Add an optional `isEditMode` prop to `ControlsVisualization` and use it to change the sr-only accessible description for desktop and the displayed label for the "Pomak" section to `Desni klik` in edit mode.
- Remove an unused icon import in `ControlsTooltipHud` during the change to satisfy lint rules.

### Testing

- Ran linter with `pnpm lint --filter @gredice/game` (succeeded after removing the unused import). 
- Ran unit tests with `pnpm test --filter @gredice/game` (all tests passed). 
- Ran the package build check with `pnpm build --filter @gredice/game` (Turbo reported no build tasks for this package).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e7001904832f8102c15fa6c86dac)