### PR TITLE
Add garden landing smoke tests for React crash regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,11 @@ jobs:
               - pnpm-workspace.yaml
               - turbo.json
             packages_game:
+              - packages/client/**
               - packages/game/**
+              - packages/js/**
+              - packages/stripe/**
+              - packages/ui/**
               - .github/workflows/**
               - package.json
               - pnpm-lock.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,13 @@ jobs:
               - pnpm-lock.yaml
               - pnpm-workspace.yaml
               - turbo.json
+            packages_game:
+              - packages/game/**
+              - .github/workflows/**
+              - package.json
+              - pnpm-lock.yaml
+              - pnpm-workspace.yaml
+              - turbo.json
     outputs:
       app_www: ${{ steps.filter.outputs.app_www }}
       app_garden: ${{ steps.filter.outputs.app_garden }}
@@ -126,6 +133,7 @@ jobs:
       app_storybook: ${{ steps.filter.outputs.app_storybook }}
       app_status: ${{ steps.filter.outputs.app_status }}
       packages_storage: ${{ steps.filter.outputs.packages_storage }}
+      packages_game: ${{ steps.filter.outputs.packages_game }}
 
   ci_www:
     name: "CI - www"
@@ -242,6 +250,45 @@ jobs:
 
       - name: ⚒️ Test app
         run: pnpm test --filter=@gredice/storage
+
+  test_game_package:
+    name: "CI - test @gredice/game"
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: changes
+    if: success() && github.event_name == 'pull_request' &&
+      needs.changes.outputs.packages_game == 'true'
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@v6.0.4
+        name: ✨ Install pnpm
+
+      - name: ✨ Setup Node
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24.15.0"
+
+      - name: ✨ Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v5.0.5
+        name: ✨ Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: 📦️ Install dependencies
+        run: pnpm install --frozen-lockfile --filter @gredice/game... --filter .
+
+      - name: ⚒️ Test package
+        run: pnpm test --filter=@gredice/game
 
   ci_filter_check:
     name: "CI - verify app package filters"
@@ -479,6 +526,7 @@ jobs:
         ci_api,
         ci_status,
         test_packages,
+        test_game_package,
         ci_filter_check,
         ci_visual_www_prepare,
         ci_visual_www,

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -12,6 +12,20 @@ const currentUser = {
     userName: 'test-user',
 };
 
+const adventCalendar = {
+    calendarId: 'calendar-2025',
+    days: Array.from({ length: 24 }, (_, index) => ({
+        day: index + 1,
+        opened: false,
+    })),
+    description: '',
+    nextDay: 1,
+    openedCount: 0,
+    remaining: 24,
+    totalDays: 24,
+    year: 2025,
+};
+
 const crashPatterns = [
     /Maximum update depth exceeded/u,
     /The result of getSnapshot should be cached/u,
@@ -43,7 +57,7 @@ function collectRuntimeFailures(page: Page) {
 async function mockGardenApi(page: Page, signedIn: boolean) {
     await page.route('**/api/gredice/**', async (route) => {
         const { pathname } = new URL(route.request().url());
-        let body: unknown = {};
+        let body: unknown;
 
         if (pathname.endsWith('/api/auth/current-claims')) {
             body = signedIn ? currentUser : null;
@@ -77,6 +91,8 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
                 current: { amount: 0, day: 1 },
                 next: { amount: 1, day: 2 },
             };
+        } else if (pathname.endsWith('/api/occasions/advent/calendar-2025')) {
+            body = adventCalendar;
         } else if (pathname.endsWith('/api/accounts/current/sunflowers')) {
             body = { amount: 0 };
         } else if (pathname.endsWith('/api/accounts/current')) {
@@ -95,6 +111,10 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
             body = { items: [] };
         } else if (pathname.endsWith('/api/notifications')) {
             body = [];
+        }
+
+        if (body === undefined) {
+            throw new Error(`Unexpected garden API request: ${pathname}`);
         }
 
         await route.fulfill({

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -1,6 +1,144 @@
-import { expect, test } from '@playwright/test';
+import { type ConsoleMessage, expect, type Page, test } from '@playwright/test';
 
-test('has title', async ({ page }) => {
-    await page.goto('/');
+const currentUser = {
+    avatarUrl: null,
+    birthday: null,
+    birthdayLastRewardAt: null,
+    birthdayLastUpdatedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    displayName: 'Test User',
+    email: 'test@example.com',
+    id: 'test-user',
+    userName: 'test-user',
+};
+
+const crashPatterns = [
+    /Maximum update depth exceeded/u,
+    /The result of getSnapshot should be cached/u,
+    /Hydration failed/u,
+    /There was an error while hydrating/u,
+    /Minified React error/u,
+];
+
+function shouldFailOnConsoleMessage(message: ConsoleMessage) {
+    const text = message.text();
+    return crashPatterns.some((pattern) => pattern.test(text));
+}
+
+function collectRuntimeFailures(page: Page) {
+    const failures: string[] = [];
+
+    page.on('pageerror', (error) => {
+        failures.push(`pageerror: ${error.message}`);
+    });
+    page.on('console', (message) => {
+        if (shouldFailOnConsoleMessage(message)) {
+            failures.push(`console.${message.type()}: ${message.text()}`);
+        }
+    });
+
+    return failures;
+}
+
+async function mockGardenApi(page: Page, signedIn: boolean) {
+    await page.route('**/api/gredice/**', async (route) => {
+        const { pathname } = new URL(route.request().url());
+        let body: unknown = {};
+
+        if (pathname.endsWith('/api/auth/current-claims')) {
+            body = signedIn ? currentUser : null;
+        } else if (pathname.endsWith('/api/auth/last-login')) {
+            body = {};
+        } else if (pathname.endsWith('/api/users/current')) {
+            body = signedIn ? currentUser : null;
+        } else if (pathname.endsWith('/api/gardens')) {
+            body = signedIn ? [] : null;
+        } else if (pathname.includes('/api/directories/entities/')) {
+            body = [];
+        } else if (pathname.endsWith('/api/data/weather/now')) {
+            body = {
+                cloudy: 0,
+                foggy: 0,
+                measuredTemperature: null,
+                rain: 0,
+                rainy: 0,
+                snowAccumulation: 0,
+                symbol: null,
+                temperature: 20,
+                windDirection: null,
+                windSpeed: 0,
+            };
+        } else if (pathname.endsWith('/api/data/weather')) {
+            body = [];
+        } else if (
+            pathname.endsWith('/api/accounts/current/sunflowers/daily')
+        ) {
+            body = {
+                current: { amount: 0, day: 1 },
+                next: { amount: 1, day: 2 },
+            };
+        } else if (pathname.endsWith('/api/accounts/current/sunflowers')) {
+            body = { amount: 0 };
+        } else if (pathname.endsWith('/api/accounts/current')) {
+            body = signedIn
+                ? { id: 'test-account', name: 'Test Account' }
+                : null;
+        } else if (pathname.endsWith('/api/shopping-cart')) {
+            body = {
+                hasDeliverableItems: false,
+                id: 'test-cart',
+                items: [],
+                total: 0,
+                totalSunflowers: 0,
+            };
+        } else if (pathname.endsWith('/api/inventory')) {
+            body = { items: [] };
+        } else if (pathname.endsWith('/api/notifications')) {
+            body = [];
+        }
+
+        await route.fulfill({
+            body: JSON.stringify(body),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+}
+
+async function expectNoImmediateRuntimeFailures(
+    page: Page,
+    failures: string[],
+) {
+    await page.waitForTimeout(1000);
+    expect(failures).toEqual([]);
+}
+
+test('loads signed-out landing page without immediate runtime failures', async ({
+    page,
+}) => {
+    const failures = collectRuntimeFailures(page);
+    await mockGardenApi(page, false);
+
+    const response = await page.goto('/');
+
+    expect(response?.ok()).toBe(true);
     await expect(page).toHaveTitle(/Gredice/);
+    await expect(
+        page.getByRole('button', { name: 'Prijava' }).first(),
+    ).toBeVisible();
+    await expectNoImmediateRuntimeFailures(page, failures);
+});
+
+test('loads signed-in landing page HUD without immediate runtime failures', async ({
+    page,
+}) => {
+    const failures = collectRuntimeFailures(page);
+    await mockGardenApi(page, true);
+
+    const response = await page.goto('/');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page).toHaveTitle(/Gredice/);
+    await expect(page.getByTitle(/zvuk/u)).toBeVisible();
+    await expectNoImmediateRuntimeFailures(page, failures);
 });

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -14,7 +14,7 @@
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
-        "test": "tsx --test src/entities/groundDecorations/getBlockSurfaceDecorations.unit.ts"
+        "test": "tsx --test \"src/**/*.unit.ts\""
     },
     "devDependencies": {
         "@biomejs/biome": "2.4.15",

--- a/packages/game/src/audio/audioMixer.unit.ts
+++ b/packages/game/src/audio/audioMixer.unit.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DEFAULT_AUDIO_CONFIG } from '../utils/audioConfig';
+import { createGameAudio } from './audioMixer';
+
+test('keeps audio store snapshots stable between updates', () => {
+    const audio = createGameAudio({ ...DEFAULT_AUDIO_CONFIG });
+
+    try {
+        const initialSnapshot = audio.getState();
+
+        assert.equal(
+            audio.getState(),
+            initialSnapshot,
+            'getState must return the cached snapshot until the store emits',
+        );
+
+        let notifications = 0;
+        const unsubscribe = audio.subscribe(() => {
+            notifications += 1;
+        });
+
+        audio.setMasterMuted(true);
+
+        const updatedSnapshot = audio.getState();
+
+        assert.equal(notifications, 1);
+        assert.notEqual(updatedSnapshot, initialSnapshot);
+        assert.equal(updatedSnapshot.master.isMuted, true);
+        assert.equal(audio.getState(), updatedSnapshot);
+
+        unsubscribe();
+    } finally {
+        audio.dispose();
+    }
+});


### PR DESCRIPTION
## Summary
- Added a Playwright smoke test for `garden` landing that exercises both anonymous and mocked signed-in states.
- The test now fails on immediate runtime crashes, React hydration errors, and the `useSyncExternalStore` infinite-loop patterns that broke `vrt.gredice.test`.
- Kept the lower-level `@gredice/game` snapshot regression test and expanded package test coverage in CI.

## Testing
- `pnpm lint --filter garden`
- `pnpm test --filter garden`
- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game --force`
- `pnpm build --filter www`
- `node ./scripts/check-ci-filters.mjs`
- workflow YAML parse check