### PR TITLE
Fix raised-bed stacked plant modal close on mobile and icon contrast in dark mode

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -158,7 +158,7 @@ export function RaisedBedFieldItemEmpty({
                         trigger={
                             <button
                                 type="button"
-                                className="inline-flex size-8 items-center justify-center rounded-full border-2 hover:bg-gray-100 border-white bg-card p-0 shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-700"
+                                className="inline-flex size-8 items-center justify-center rounded-full border-2 border-white bg-white p-0 hover:bg-gray-100 shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-700"
                                 title={`Povijest biljaka (${plantHistory.length})`}
                                 aria-label={`Prikaži povijest biljaka za polje ${positionIndex + 1}`}
                                 onPointerDown={(event) =>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -214,7 +214,7 @@ export function RaisedBedFieldItemPlanted({
         triggerVariant === 'avatar' ? (
             <button
                 type="button"
-                className="inline-flex size-8 items-center justify-center overflow-hidden rounded-full border-2 hover:bg-gray-100 border-white bg-card p-0.5 shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-700"
+                className="inline-flex size-8 items-center justify-center overflow-hidden rounded-full border-2 border-white bg-white p-0.5 hover:bg-gray-100 shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-700"
                 title={`Povijest biljke: ${plantSort.information.name}`}
                 aria-label={`Povijest biljke ${plantSort.information.name}`}
                 onPointerDown={(event) => event.stopPropagation()}
@@ -253,7 +253,7 @@ export function RaisedBedFieldItemPlanted({
                                 trigger={
                                     <button
                                         type="button"
-                                        className="inline-flex size-8 items-center justify-center rounded-full border-2 border-white bg-card p-0 shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-700"
+                                        className="inline-flex size-8 items-center justify-center rounded-full border-2 border-white bg-white p-0 shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-700"
                                         title={`Povijest biljaka (${plantHistory.length})`}
                                         aria-label={`Prikaži povijest biljaka za polje ${positionIndex + 1}`}
                                         onPointerDown={(event) =>
@@ -429,6 +429,18 @@ export function RaisedBedFieldItemPlanted({
                         />
                     </TabsContent>
                 </Tabs>
+                <button
+                    type="button"
+                    className="sm:hidden self-end rounded-md border px-3 py-1.5 text-sm font-medium"
+                    onClick={() => {
+                        if (!isOpenControlled) {
+                            setInternalOpen(false);
+                        }
+                        onOpenChange?.(false);
+                    }}
+                >
+                    Zatvori
+                </button>
             </Stack>
         </Modal>
     );


### PR DESCRIPTION
### Motivation
- The plant details modal opened from stacked field indicators on mobile had no obvious way to close, preventing dismissal in some touch flows.
- Stacked indicator avatars and the cart bubble used `bg-card` which resulted in low contrast in dark mode; these should remain white for readability.

### Description
- Added a small-screen-only close button (`Zatvori`) inside `RaisedBedFieldItemPlanted.tsx` that calls the modal `onOpenChange` and updates the internal open state so the modal can always be dismissed on mobile.
- Switched stacked indicator trigger and history/avatar/cart trigger containers from `bg-card` to `bg-white` and adjusted class ordering in `RaisedBedFieldItemPlanted.tsx` and `RaisedBedFieldItemEmpty.tsx` to keep hover/focus behavior while ensuring white backgrounds in dark mode.
- Preserved existing `onPointerDown`/`onClick`/`onKeyDown` propagation guards and other interaction logic so stack behavior remains unchanged.

### Testing
- Ran `pnpm lint --filter @gredice/game` and the lint run completed successfully (no fixes applied).  
- Ran `pnpm test --filter @gredice/game` and the package tests passed (`1` test passed).  
- Ran `pnpm build --filter @gredice/game` which reported there are no build tasks for this package in the Turbo config, so no build was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06193ddc78832fbe318b0b9d78bda1)