### PR TITLE
test(garden): cover raised-bed field HUD; fix touch-stack dismissal interference

### DIFF
--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -58,6 +58,7 @@
         "@tailwindcss/typography": "0.5.19",
         "@tanstack/react-query": "5.100.9",
         "@types/node": "24.12.2",
+        "nuqs": "2.8.9",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vercel/analytics": "2.0.1",

--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -55,6 +55,9 @@ export const config: PlaywrightTestConfig = {
             optimizeDeps: {
                 exclude: ['next/font/google'],
             },
+            resolve: {
+                dedupe: ['nuqs', 'react', 'react-dom'],
+            },
         },
     },
     projects: [

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -1,0 +1,155 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
+import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
+import { RaisedBedFieldItem } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldItem';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+import {
+    allPlants,
+    allSorts,
+    buildField,
+    type RaisedBedScenario,
+    TEST_GARDEN_ID,
+    TEST_RAISED_BED_ID,
+} from './raisedBedFieldHudScenarios';
+
+const now = '2026-05-13T00:00:00.000Z';
+
+function buildGarden(scenario: RaisedBedScenario) {
+    const fields = scenario.fields.map((config, index) =>
+        buildField(config, index + 1),
+    );
+    return {
+        id: TEST_GARDEN_ID,
+        name: 'Test garden',
+        stacks: [],
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [
+            {
+                id: TEST_RAISED_BED_ID,
+                name: 'Raised Bed 1',
+                blockId: 'raised-bed-1',
+                physicalId: '1',
+                fields,
+                appliedOperations: [],
+                status: 'new',
+                isValid: true,
+                orientation: 'horizontal' as const,
+                createdAt: now,
+                updatedAt: now,
+            },
+        ],
+    };
+}
+
+function createScenarioQueryClient(scenario: RaisedBedScenario) {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+    const garden = buildGarden(scenario);
+
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(['gardens'], [{ id: TEST_GARDEN_ID }]);
+    queryClient.setQueryData(
+        ['gardens', 'current', 'summer', TEST_GARDEN_ID],
+        garden,
+    );
+    queryClient.setQueryData(['shopping-cart'], {
+        id: 1,
+        items: scenario.cartItems ?? [],
+    });
+    queryClient.setQueryData(['inventory'], { items: [] });
+    queryClient.setQueryData(['plants'], allPlants);
+    queryClient.setQueryData(['sorts'], allSorts);
+
+    return queryClient;
+}
+
+type ProvidersProps = PropsWithChildren<{
+    scenario: RaisedBedScenario;
+    enablePlantHistory?: boolean;
+}>;
+
+function RaisedBedHudTestProviders({
+    children,
+    scenario,
+    enablePlantHistory = true,
+}: ProvidersProps) {
+    const queryClient = useMemo(
+        () => createScenarioQueryClient(scenario),
+        [scenario],
+    );
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date('2026-05-13T12:00:00.000Z'),
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
+
+    return (
+        <NuqsTestingAdapter>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameStore}>
+                    <GameFlagsContext.Provider
+                        value={{ enablePlantHistoryFlag: enablePlantHistory }}
+                    >
+                        <GameAnalyticsProvider capture={() => undefined}>
+                            {children}
+                        </GameAnalyticsProvider>
+                    </GameFlagsContext.Provider>
+                </GameStateContext.Provider>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+export function RaisedBedFieldHudStory({
+    scenario,
+    positionIndex,
+    enablePlantHistory = true,
+    cellSize = 80,
+}: {
+    scenario: RaisedBedScenario;
+    positionIndex: number;
+    enablePlantHistory?: boolean;
+    cellSize?: number;
+}) {
+    const cartItem =
+        scenario.cartItems?.find(
+            (item) => item.positionIndex === positionIndex,
+        ) ?? null;
+    return (
+        <RaisedBedHudTestProviders
+            scenario={scenario}
+            enablePlantHistory={enablePlantHistory}
+        >
+            <div
+                data-testid="hud-cell"
+                className="relative"
+                style={{
+                    width: `${cellSize}px`,
+                    height: `${cellSize}px`,
+                    margin: '40px',
+                }}
+            >
+                <RaisedBedFieldItem
+                    cartPlantItem={cartItem}
+                    gardenId={TEST_GARDEN_ID}
+                    isCartPending={false}
+                    raisedBedId={TEST_RAISED_BED_ID}
+                    positionIndex={positionIndex}
+                />
+            </div>
+        </RaisedBedHudTestProviders>
+    );
+}

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1,0 +1,709 @@
+import { expect, type Page, test } from '@playwright/experimental-ct-react';
+import { RaisedBedFieldHudStory } from './RaisedBedFieldHudStory';
+import {
+    buildCartItem,
+    type RaisedBedScenario,
+    testSorts,
+} from './raisedBedFieldHudScenarios';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+
+function emptyScenario(): RaisedBedScenario {
+    return { fields: [] };
+}
+
+function cartScenario(): RaisedBedScenario {
+    return {
+        fields: [],
+        cartItems: [
+            buildCartItem({
+                id: 11,
+                sort: testSorts.tomato,
+                positionIndex: 0,
+                scheduledDate: '2026-05-20T00:00:00.000Z',
+            }),
+        ],
+    };
+}
+
+function plantedGrowingScenario(): RaisedBedScenario {
+    return {
+        fields: [
+            {
+                positionIndex: 0,
+                plantSortId: testSorts.tomato.id,
+                plantStatus: 'sprouted',
+                plantSowDate: daysAgoIso(40),
+                plantGrowthDate: daysAgoIso(30),
+            },
+        ],
+    };
+}
+
+function plantedReadyScenario(): RaisedBedScenario {
+    return {
+        fields: [
+            {
+                positionIndex: 0,
+                plantSortId: testSorts.tomato.id,
+                plantStatus: 'ready',
+                plantSowDate: daysAgoIso(60),
+                plantGrowthDate: daysAgoIso(45),
+                plantReadyDate: daysAgoIso(2),
+            },
+        ],
+    };
+}
+
+function plantedHarvestedScenario(): RaisedBedScenario {
+    return {
+        fields: [
+            {
+                positionIndex: 0,
+                plantSortId: testSorts.tomato.id,
+                plantStatus: 'ready',
+                plantSowDate: daysAgoIso(80),
+                plantGrowthDate: daysAgoIso(70),
+                plantReadyDate: daysAgoIso(20),
+                plantHarvestedDate: daysAgoIso(5),
+            },
+        ],
+    };
+}
+
+function plantedWithHistoryScenario(historyCount = 2): RaisedBedScenario {
+    const history = Array.from({ length: historyCount }).map((_, index) => ({
+        positionIndex: 0,
+        plantSortId:
+            index % 2 === 0 ? testSorts.basil.id : testSorts.lettuce.id,
+        plantStatus: 'ready' as const,
+        plantSowDate: daysAgoIso(200 - index * 30),
+        plantGrowthDate: daysAgoIso(190 - index * 30),
+        plantReadyDate: daysAgoIso(170 - index * 30),
+        plantHarvestedDate: daysAgoIso(150 - index * 30),
+        active: false,
+    }));
+    return {
+        fields: [
+            ...history,
+            {
+                positionIndex: 0,
+                plantSortId: testSorts.tomato.id,
+                plantStatus: 'ready',
+                plantSowDate: daysAgoIso(60),
+                plantGrowthDate: daysAgoIso(45),
+                plantReadyDate: daysAgoIso(2),
+            },
+        ],
+    };
+}
+
+function emptyWithHistoryScenario(historyCount = 2): RaisedBedScenario {
+    const history = Array.from({ length: historyCount }).map((_, index) => ({
+        positionIndex: 0,
+        plantSortId:
+            index % 2 === 0 ? testSorts.basil.id : testSorts.lettuce.id,
+        plantStatus: 'ready' as const,
+        plantSowDate: daysAgoIso(200 - index * 30),
+        plantGrowthDate: daysAgoIso(190 - index * 30),
+        plantReadyDate: daysAgoIso(170 - index * 30),
+        plantHarvestedDate: daysAgoIso(150 - index * 30),
+        active: false,
+    }));
+    return { fields: history };
+}
+
+function daysAgoIso(days: number): string {
+    const date = new Date('2026-05-13T12:00:00.000Z');
+    date.setDate(date.getDate() - days);
+    return date.toISOString();
+}
+
+test.describe('RaisedBedFieldItem HUD (desktop)', () => {
+    test.use({ viewport: DESKTOP_VIEWPORT });
+
+    test('empty field shows sowing seed icon and no indicator stack', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await expect(page.getByRole('button').first()).toBeVisible();
+        await expect(page.locator('[data-field-icon-stack]')).toHaveCount(0);
+    });
+
+    test('cart item shows cart indicator and scheduled date badge', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={cartScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        const cartButton = page.getByRole('button', {
+            name: 'Otvori sadnju u košarici',
+        });
+        await expect(cartButton).toBeVisible();
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toHaveCount(1);
+        await expect(stack).toHaveAttribute('data-touch-expanded', 'false');
+        const fieldButton = page.getByRole('button').first();
+        await expect(fieldButton).toContainText('20');
+    });
+
+    test('planted growing field renders lifecycle progress and no indicator stack', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await expect(page.locator('svg circle').first()).toBeVisible();
+        await expect(page.locator('[data-field-icon-stack]')).toHaveCount(0);
+    });
+
+    test('ready-to-harvest field shows the sprout status badge', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedReadyScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toBeVisible();
+        await expect(
+            stack.locator('span.bg-blue-600 svg.lucide-sprout'),
+        ).toBeVisible();
+    });
+
+    test('harvested field shows check indicator', async ({ mount, page }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedHarvestedScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toBeVisible();
+        await expect(
+            stack.locator('span.bg-green-600 svg.lucide-check'),
+        ).toBeVisible();
+    });
+
+    test('empty field with 2 historical plants stacks avatar indicators', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toBeVisible();
+        const avatars = page.getByRole('button', {
+            name: /Povijest biljke /,
+        });
+        await expect(avatars).toHaveCount(2);
+        await expect(
+            page.getByRole('button', {
+                name: 'Prikaži povijest biljaka za polje 1',
+            }),
+        ).toHaveCount(0);
+    });
+
+    test('empty field with 4 historical plants collapses extras into history modal trigger', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(4)}
+                positionIndex={0}
+            />,
+        );
+
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toBeVisible();
+        await expect(
+            page.getByRole('button', {
+                name: /Povijest biljke /,
+            }),
+        ).toHaveCount(2);
+        await expect(
+            page.getByRole('button', {
+                name: 'Prikaži povijest biljaka za polje 1',
+            }),
+        ).toBeVisible();
+    });
+
+    test('planted field with history stacks status badge with historical avatars', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toBeVisible();
+        await expect(
+            stack.locator('span.bg-blue-600 svg.lucide-sprout'),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: /Povijest biljke / }),
+        ).toHaveCount(2);
+    });
+
+    test('clicking planted field opens lifecycle modal on desktop', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(
+            dialog.getByRole('heading', { name: /Biljka "Cherry rajčica"/ }),
+        ).toBeVisible();
+        await expect(dialog.getByRole('tab', { name: /Biljka/ })).toBeVisible();
+        await expect(
+            dialog.getByRole('tab', { name: /Dnevnik/ }),
+        ).toBeVisible();
+        await expect(dialog.getByRole('tab', { name: /Radnje/ })).toBeVisible();
+    });
+
+    test('opening the plant history modal lists prior plants newest first', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(4)}
+                positionIndex={0}
+            />,
+        );
+
+        await page
+            .getByRole('button', {
+                name: 'Prikaži povijest biljaka za polje 1',
+            })
+            .click();
+
+        await expect(
+            page.getByRole('heading', { name: 'Povijest polja' }),
+        ).toBeVisible();
+        const entries = page.getByRole('button', {
+            name: /Otvori detalje biljke /,
+        });
+        await expect(entries).toHaveCount(4);
+    });
+});
+
+test.describe('RaisedBedFieldItem HUD (mobile)', () => {
+    test.use({
+        viewport: MOBILE_VIEWPORT,
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('cart item still renders cart indicator on mobile', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={cartScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await expect(
+            page.getByRole('button', { name: 'Otvori sadnju u košarici' }),
+        ).toBeVisible();
+        await expect(page.locator('[data-field-icon-stack]')).toHaveAttribute(
+            'data-touch-expanded',
+            'false',
+        );
+    });
+
+    test('first touch on a multi-icon stack expands instead of activating the icon', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const stack = page.locator('[data-field-icon-stack]');
+        await expect(stack).toHaveAttribute('data-touch-expanded', 'false');
+
+        const historyButton = page
+            .getByRole('button', { name: /Povijest biljke / })
+            .last();
+        await historyButton.dispatchEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            pointerType: 'touch',
+        });
+        await historyButton.click({ force: true });
+
+        await expect(stack).toHaveAttribute('data-touch-expanded', 'true');
+        await expect(page.getByRole('dialog')).toHaveCount(0);
+
+        await historyButton.dispatchEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            pointerType: 'touch',
+        });
+        await historyButton.click({ force: true });
+
+        await expect(page.getByRole('dialog')).toBeVisible();
+    });
+
+    test('planted field opens as a bottom drawer with a drag handle', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(dialog).toHaveAttribute('data-vaul-drawer', '');
+        await expect(dialog).toHaveAttribute(
+            'data-vaul-drawer-direction',
+            'bottom',
+        );
+        await expect(
+            dialog.locator(
+                'div.bg-muted.mx-auto.h-2.w-\\[100px\\].rounded-full',
+            ),
+        ).toHaveCount(1);
+    });
+
+    test('mobile drawer dismisses via swipe down on the drag handle', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected drawer to have a bounding box.');
+        }
+
+        const startX = dialogBox.x + dialogBox.width / 2;
+        const startY = dialogBox.y + 16;
+        const endY = MOBILE_VIEWPORT.height + 200;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX, startY + 80, { steps: 5 });
+        await page.mouse.move(startX, startY + 240, { steps: 5 });
+        await page.mouse.move(startX, endY, { steps: 5 });
+        await page.mouse.up();
+
+        await expect(page.getByRole('dialog')).toBeHidden();
+    });
+
+    test('mobile drawer can also be dismissed with the inline close button', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+
+        await page.getByRole('button', { name: 'Zatvori' }).click();
+
+        await expect(page.getByRole('dialog')).toBeHidden();
+    });
+
+    async function openHistoryAvatarDrawer(page: Page) {
+        const historyButton = page
+            .getByRole('button', { name: /Povijest biljke / })
+            .last();
+        await historyButton.dispatchEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            pointerType: 'touch',
+        });
+        await historyButton.click({ force: true });
+        await historyButton.dispatchEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            pointerType: 'touch',
+        });
+        await historyButton.click({ force: true });
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(dialog).toHaveAttribute('data-vaul-drawer', '');
+        return dialog;
+    }
+
+    test('history avatar drawer dismisses via swipe down on the drag handle', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const dialog = await openHistoryAvatarDrawer(page);
+
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected history drawer to have a bounding box.');
+        }
+
+        const startX = dialogBox.x + dialogBox.width / 2;
+        const startY = dialogBox.y + 16;
+        const endY = MOBILE_VIEWPORT.height + 200;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX, startY + 80, { steps: 5 });
+        await page.mouse.move(startX, startY + 240, { steps: 5 });
+        await page.mouse.move(startX, endY, { steps: 5 });
+        await page.mouse.up();
+
+        await expect(dialog).toBeHidden();
+    });
+
+    test('history avatar drawer dismisses by tapping the backdrop', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const dialog = await openHistoryAvatarDrawer(page);
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected history drawer to have a bounding box.');
+        }
+
+        const tapX = MOBILE_VIEWPORT.width / 2;
+        const tapY = Math.max(20, dialogBox.y - 40);
+        await page.mouse.click(tapX, tapY);
+
+        await expect(dialog).toBeHidden();
+    });
+
+    async function openPlantDetailsFromAllHistoryModal(page: Page) {
+        const stack = page.locator('[data-field-icon-stack]');
+        const allHistoryButton = page.getByRole('button', {
+            name: 'Prikaži povijest biljaka za polje 1',
+        });
+
+        // First tap expands the icon stack on mobile.
+        await allHistoryButton.dispatchEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            pointerType: 'touch',
+        });
+        await allHistoryButton.click({ force: true });
+        await expect(stack).toHaveAttribute('data-touch-expanded', 'true');
+
+        // Second tap actually opens the "Povijest polja" list drawer.
+        await allHistoryButton.dispatchEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            pointerType: 'touch',
+        });
+        await allHistoryButton.click({ force: true });
+
+        const historyListDrawer = page.getByRole('dialog', {
+            name: 'Povijest polja',
+        });
+        await expect(historyListDrawer).toBeVisible();
+
+        await historyListDrawer
+            .getByRole('button', { name: /Otvori detalje biljke / })
+            .first()
+            .click();
+
+        const detailsDrawer = page
+            .getByRole('dialog')
+            .filter({ hasText: /Prethodna biljka/ });
+        await expect(detailsDrawer).toBeVisible();
+        await expect(detailsDrawer).toHaveAttribute('data-vaul-drawer', '');
+        return { detailsDrawer, historyListDrawer };
+    }
+
+    test('[regression] plant details opened from all-history list drawer dismisses via swipe down', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(4)}
+                positionIndex={0}
+            />,
+        );
+
+        const { detailsDrawer } =
+            await openPlantDetailsFromAllHistoryModal(page);
+
+        const dialogBox = await detailsDrawer.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected details drawer to have a bounding box.');
+        }
+
+        const startX = dialogBox.x + dialogBox.width / 2;
+        const startY = dialogBox.y + 16;
+        const endY = MOBILE_VIEWPORT.height + 200;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX, startY + 80, { steps: 5 });
+        await page.mouse.move(startX, startY + 240, { steps: 5 });
+        await page.mouse.move(startX, endY, { steps: 5 });
+        await page.mouse.up();
+
+        await expect(detailsDrawer).toBeHidden();
+    });
+
+    test('[regression] plant details opened from all-history list drawer dismisses via backdrop tap', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(4)}
+                positionIndex={0}
+            />,
+        );
+
+        const { detailsDrawer } =
+            await openPlantDetailsFromAllHistoryModal(page);
+
+        const dialogBox = await detailsDrawer.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected details drawer to have a bounding box.');
+        }
+        const tapX = MOBILE_VIEWPORT.width / 2;
+        const tapY = Math.max(20, dialogBox.y - 40);
+        await page.mouse.click(tapX, tapY);
+
+        await expect(detailsDrawer).toBeHidden();
+    });
+
+    test('[regression] history avatar drawer opened from a planted field dismisses via swipe down', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const dialog = await openHistoryAvatarDrawer(page);
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected history drawer to have a bounding box.');
+        }
+
+        const startX = dialogBox.x + dialogBox.width / 2;
+        const startY = dialogBox.y + 16;
+        const endY = MOBILE_VIEWPORT.height + 200;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX, startY + 80, { steps: 5 });
+        await page.mouse.move(startX, startY + 240, { steps: 5 });
+        await page.mouse.move(startX, endY, { steps: 5 });
+        await page.mouse.up();
+
+        await expect(dialog).toBeHidden();
+    });
+
+    test('[regression] history avatar drawer opened from a planted field dismisses via backdrop tap', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const dialog = await openHistoryAvatarDrawer(page);
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected history drawer to have a bounding box.');
+        }
+
+        const tapX = MOBILE_VIEWPORT.width / 2;
+        const tapY = Math.max(20, dialogBox.y - 40);
+        await page.mouse.click(tapX, tapY);
+
+        await expect(dialog).toBeHidden();
+    });
+});

--- a/apps/garden/tests/raised-bed-field-icon-stack.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-icon-stack.spec.tsx
@@ -103,6 +103,47 @@ test('field icon stack keeps newest indicators on top and prepares spread offset
     await expect(stack).toHaveAttribute('data-touch-expanded', 'false');
 });
 
+test('field icon stack collapses after a multi-icon child is activated', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <div className="relative size-20">
+            <RaisedBedFieldIconStack>
+                <button type="button" data-testid="older-plant">
+                    1
+                </button>
+                <button type="button" data-testid="cart">
+                    cart
+                </button>
+            </RaisedBedFieldIconStack>
+        </div>,
+    );
+
+    const stack = page.locator('[data-field-icon-stack]');
+    const cart = page.getByTestId('cart');
+
+    // First touch expands the stack and swallows the activating click.
+    await cart.dispatchEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        pointerType: 'touch',
+    });
+    await cart.click({ force: true });
+    await expect(stack).toHaveAttribute('data-touch-expanded', 'true');
+
+    // Second touch activates the child; the stack must collapse so that the
+    // document-level pointerdown listener detaches before any opened drawer
+    // tries to receive swipe-to-dismiss/backdrop touches.
+    await cart.dispatchEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        pointerType: 'touch',
+    });
+    await cart.click({ force: true });
+    await expect(stack).toHaveAttribute('data-touch-expanded', 'false');
+});
+
 test('field icon stack activates a single indicator on first touch', async ({
     mount,
     page,

--- a/apps/garden/tests/raisedBedFieldHudScenarios.ts
+++ b/apps/garden/tests/raisedBedFieldHudScenarios.ts
@@ -1,0 +1,210 @@
+import type { PlantData, PlantSortData } from '@gredice/client';
+import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
+
+const now = '2026-05-13T00:00:00.000Z';
+
+const tomatoPlant = {
+    id: 1,
+    entityType: { id: 1, name: 'plant', label: 'Biljka' },
+    calendar: { harvest: [] },
+    information: {
+        name: 'Rajčica',
+        latinName: 'Solanum lycopersicum',
+        origin: 'Mock',
+        description: 'Mock plant for HUD tests.',
+        soilPreparation: '',
+        growth: '',
+        maintenance: '',
+        watering: '',
+        harvest: '',
+        storage: '',
+        operations: [],
+    },
+    attributes: {
+        yieldMin: 1000,
+        yieldMax: 2000,
+        harvestWindowMin: 14,
+        harvestWindowMax: 30,
+        soil: 'Srednje',
+        light: 1,
+        seedingDepth: 1,
+        nutrients: 'Srednje',
+        water: 'Vlažno',
+        seedingDistance: 30,
+        germinationType: 'Klijanje pod svijetlosti',
+        gernimationTemperature: 20,
+        germinationWindowMin: 5,
+        germinationWindowMax: 10,
+        growthWindowMin: 60,
+        growthWindowMax: 90,
+        yieldType: 'perField',
+        cleanHarvest: true,
+    },
+    image: { cover: { url: '' } },
+    prices: { perPlant: 1.5 },
+    store: { availableInStore: true },
+    createdAt: now,
+    updatedAt: now,
+    isRecommended: true,
+} satisfies PlantData & { isRecommended: boolean };
+
+const basilPlant = {
+    ...tomatoPlant,
+    id: 2,
+    information: {
+        ...tomatoPlant.information,
+        name: 'Bosiljak',
+        latinName: 'Ocimum basilicum',
+    },
+    isRecommended: false,
+} satisfies PlantData & { isRecommended: boolean };
+
+const lettucePlant = {
+    ...tomatoPlant,
+    id: 3,
+    information: {
+        ...tomatoPlant.information,
+        name: 'Zelena salata',
+        latinName: 'Lactuca sativa',
+    },
+    isRecommended: false,
+} satisfies PlantData & { isRecommended: boolean };
+
+const tomatoSort = {
+    id: 101,
+    entityType: { id: 11, name: 'plantSort', label: 'Sorta biljke' },
+    information: {
+        plant: tomatoPlant,
+        name: 'Cherry rajčica',
+        shortDescription: 'Mock plant sort.',
+    },
+    image: { cover: { url: '' } },
+    store: { availableInStore: true },
+    attributes: { reproductionType: 'seed' },
+    createdAt: now,
+    updatedAt: now,
+} satisfies PlantSortData;
+
+const basilSort = {
+    ...tomatoSort,
+    id: 102,
+    information: {
+        plant: basilPlant,
+        name: 'Klasični bosiljak',
+        shortDescription: 'Mock basil sort.',
+    },
+} satisfies PlantSortData;
+
+const lettuceSort = {
+    ...tomatoSort,
+    id: 103,
+    information: {
+        plant: lettucePlant,
+        name: 'Maslac salata',
+        shortDescription: 'Mock lettuce sort.',
+    },
+} satisfies PlantSortData;
+
+export const TEST_GARDEN_ID = 1;
+export const TEST_RAISED_BED_ID = 1;
+
+export const allPlants = [tomatoPlant, basilPlant, lettucePlant];
+export const allSorts = [tomatoSort, basilSort, lettuceSort];
+
+export const testSorts = {
+    tomato: tomatoSort,
+    basil: basilSort,
+    lettuce: lettuceSort,
+};
+
+export type FieldConfig = {
+    positionIndex: number;
+    plantSortId?: number;
+    plantStatus?: 'sowed' | 'sprouted' | 'ready' | 'died';
+    plantSowDate?: string;
+    plantGrowthDate?: string;
+    plantReadyDate?: string;
+    plantHarvestedDate?: string;
+    plantDeadDate?: string;
+    plantRemovedDate?: string;
+    toBeRemoved?: boolean;
+    active?: boolean;
+    stoppedDate?: string;
+};
+
+export type RaisedBedScenario = {
+    fields: FieldConfig[];
+    cartItems?: ShoppingCartItemData[];
+};
+
+export function buildField(config: FieldConfig, id: number) {
+    return {
+        id,
+        raisedBedId: TEST_RAISED_BED_ID,
+        isDeleted: false,
+        active: config.active ?? true,
+        toBeRemoved: config.toBeRemoved ?? false,
+        stoppedDate: config.stoppedDate,
+        positionIndex: config.positionIndex,
+        plantSortId: config.plantSortId,
+        plantStatus: config.plantStatus,
+        plantScheduledDate: undefined,
+        plantSowDate: config.plantSowDate,
+        plantGrowthDate: config.plantGrowthDate,
+        plantReadyDate: config.plantReadyDate,
+        plantDeadDate: config.plantDeadDate,
+        plantHarvestedDate: config.plantHarvestedDate,
+        plantRemovedDate: config.plantRemovedDate,
+        plantCycles: [],
+        assignedUserId: null,
+        assignedUserIds: [],
+        assignedBy: null,
+        assignedAt: undefined,
+        createdAt: config.plantSowDate ?? now,
+        updatedAt:
+            config.plantHarvestedDate ??
+            config.plantRemovedDate ??
+            config.plantReadyDate ??
+            config.plantGrowthDate ??
+            config.plantSowDate ??
+            now,
+    };
+}
+
+export function buildCartItem({
+    id,
+    sort,
+    positionIndex,
+    scheduledDate,
+}: {
+    id: number;
+    sort: PlantSortData;
+    positionIndex: number;
+    scheduledDate?: string;
+}): ShoppingCartItemData {
+    return {
+        id,
+        cartId: 1,
+        entityId: sort.id.toString(),
+        entityTypeName: 'plantSort',
+        gardenId: TEST_GARDEN_ID,
+        raisedBedId: TEST_RAISED_BED_ID,
+        positionIndex,
+        additionalData: scheduledDate
+            ? JSON.stringify({ scheduledDate })
+            : null,
+        amount: 1,
+        currency: 'eur',
+        status: 'new',
+        isDeleted: false,
+        createdAt: now,
+        updatedAt: now,
+        shopData: {
+            name: sort.information.name,
+            description: sort.information.shortDescription ?? '',
+            image: '',
+            price: 1.5,
+        },
+        entityData: sort,
+    } as unknown as ShoppingCartItemData;
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx
@@ -96,13 +96,20 @@ export function RaisedBedFieldIconStack({ children }: { children: ReactNode }) {
     }
 
     function handleClickCapture(event: ReactMouseEvent<HTMLFieldSetElement>) {
-        if (!swallowNextClickRef.current) {
+        if (swallowNextClickRef.current) {
+            clearSwallowedClick();
+            event.preventDefault();
+            event.stopPropagation();
             return;
         }
 
-        clearSwallowedClick();
-        event.preventDefault();
-        event.stopPropagation();
+        // A click that survived the swallow guard is activating a child icon
+        // (typically opening a modal/drawer). Collapse the stack now so the
+        // document-level pointerdown listener detaches before the child's
+        // drawer starts handling swipe-to-dismiss and backdrop-tap gestures.
+        if (isTouchExpanded) {
+            setIsTouchExpanded(false);
+        }
     }
 
     if (items.length === 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,13 +153,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -237,7 +237,7 @@ importers:
         version: 0.217.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.4.47
-        version: 0.4.47(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.4.47(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vercel/blob':
         specifier: 2.3.3
         version: 2.3.3
@@ -249,7 +249,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.4.5)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -316,31 +316,31 @@ importers:
         version: 1.60.0
       '@signalco/auth-client':
         specifier: 0.3.0
-        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(@tanstack/react-query@5.100.9(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(@tanstack/react-query@5.100.9(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/auth-server':
         specifier: 0.5.3
-        version: 0.5.3(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.5.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/cms-components-marketing':
         specifier: 0.1.1
-        version: 0.1.1(860066df641078306f40fdab43468a57)
+        version: 0.1.1(a7df69ee2ebfeea8ceca3d9fa7cd50df)
       '@signalco/cms-core':
         specifier: 0.1.1
-        version: 0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -361,7 +361,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
       '@zxing/library':
         specifier: 0.23.0
         version: 0.23.0
@@ -470,7 +470,7 @@ importers:
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -509,7 +509,7 @@ importers:
     dependencies:
       '@flags-sdk/hypertune':
         specifier: 0.3.2
-        version: 0.3.2(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
+        version: 0.3.2(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
       '@opentelemetry/api-logs':
         specifier: 0.217.0
         version: 0.217.0
@@ -524,19 +524,19 @@ importers:
         version: 0.217.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.4.47
-        version: 0.4.47(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.4.47(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vercel/toolbar':
         specifier: 0.2.5
-        version: 0.2.5(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.5(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))
       flags:
         specifier: 4.0.6
-        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       hypertune:
         specifier: 2.10.1
         version: 2.10.1
       next:
         specifier: 16.2.6
-        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -564,34 +564,34 @@ importers:
         version: link:../../packages/ui
       '@playwright/experimental-ct-react':
         specifier: 1.60.0
-        version: 1.60.0(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))(yaml@2.8.4)
+        version: 1.60.0(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))(yaml@2.8.4)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
       '@signalco/auth-client':
         specifier: 0.3.0
-        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(@tanstack/react-query@5.100.9(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.3.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(@tanstack/react-query@5.100.9(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/auth-server':
         specifier: 0.5.3
-        version: 0.5.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.5.3(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/hooks':
         specifier: 0.2.1
-        version: 0.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/js':
         specifier: 0.1.0
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-notifications':
         specifier: 0.2.0
-        version: 0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -612,10 +612,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3
+      nuqs:
+        specifier: 2.8.9
+        version: 2.8.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
       postcss:
         specifier: 8.5.14
         version: 8.5.14
@@ -685,13 +688,13 @@ importers:
         version: link:../../packages/ui
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -788,7 +791,7 @@ importers:
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -843,7 +846,7 @@ importers:
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -1053,7 +1056,7 @@ importers:
         version: 6.198.0
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.15
@@ -1111,13 +1114,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -1420,13 +1423,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       motion:
         specifier: 12.38.0
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1435,7 +1438,7 @@ importers:
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -10961,9 +10964,9 @@ snapshots:
   '@ffmpeg-installer/win32-x64@4.1.0':
     optional: true
 
-  '@flags-sdk/hypertune@0.3.2(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))':
+  '@flags-sdk/hypertune@0.3.2(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))':
     dependencies:
-      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
+      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))
       hypertune: 2.8.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -11860,6 +11863,24 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/experimental-ct-core@1.60.0(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)':
+    dependencies:
+      playwright: 1.60.0
+      playwright-core: 1.60.0
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   '@playwright/experimental-ct-core@1.60.0(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)':
     dependencies:
       playwright: 1.60.0
@@ -11876,6 +11897,25 @@ snapshots:
       - sugarss
       - terser
       - tsx
+      - yaml
+
+  '@playwright/experimental-ct-react@1.60.0(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))(yaml@2.8.4)':
+    dependencies:
+      '@playwright/experimental-ct-core': 1.60.0(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)
+      '@vitejs/plugin-react': 4.7.0(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - vite
       - yaml
 
   '@playwright/experimental-ct-react@1.60.0(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))(yaml@2.8.4)':
@@ -13085,23 +13125,10 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@signalco/cms-components-marketing@0.1.1(860066df641078306f40fdab43468a57)':
-    dependencies:
-      '@signalco/cms-core': 0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@signalco/ui': 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   '@signalco/cms-components-marketing@0.1.1(a7df69ee2ebfeea8ceca3d9fa7cd50df)':
     dependencies:
       '@signalco/cms-core': 0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui': 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@signalco/cms-core@0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -13133,9 +13160,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@signalco/ui-notifications@0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@signalco/ui-notifications@0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -13148,6 +13175,14 @@ snapshots:
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
 
   '@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
+      tailwindcss-animate: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+
+  '@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       react: 19.2.6
@@ -13176,6 +13211,14 @@ snapshots:
   '@signalco/ui@0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
+      tailwindcss-animate: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+
+  '@signalco/ui@0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4)))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
@@ -13959,12 +14002,35 @@ snapshots:
 
   '@vercel/edge-config-fs@0.1.0': {}
 
-  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))':
+  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))':
     dependencies:
       '@vercel/edge-config-fs': 0.1.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+
+  '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@next/env': 16.0.10
+      '@types/md5': 2.3.6
+      ajv: 8.20.0
+      commander: 12.1.0
+      cookie: 1.0.2
+      fast-glob: 3.3.3
+      http-proxy: 1.18.1
+      jsonc-parser: 3.3.1
+      md5: 2.3.0
+      nanoid: 3.3.12
+      path-to-regexp: 6.3.0
+      semver: 7.8.0
+    optionalDependencies:
+      '@vercel/analytics': 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      vite: 8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - debug
 
   '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -13993,6 +14059,26 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/toolbar@0.2.5(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@tinyhttp/app': 1.3.0
+      '@vercel/microfrontends': 2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))
+      chokidar: 3.6.0
+      execa: 5.1.1
+      find-up: 5.0.0
+      get-port: 5.1.1
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react: 19.2.6
+      vite: 8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
+      - '@vercel/analytics'
+      - '@vercel/speed-insights'
+      - debug
+      - react-dom
+
   '@vercel/toolbar@0.2.5(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)(vue@3.5.34(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tinyhttp/app': 1.3.0
@@ -14012,6 +14098,18 @@ snapshots:
       - '@vercel/speed-insights'
       - debug
       - react-dom
+
+  '@vitejs/plugin-react@4.7.0(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@4.7.0(vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -14162,7 +14260,7 @@ snapshots:
       '@vueuse/shared': 13.9.0(vue@3.5.34(typescript@6.0.3))
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
-      axios: 1.15.0(debug@4.4.3)
+      axios: 1.15.0
       change-case: 5.4.4
       focus-trap: 7.8.0
       fuse.js: 7.3.0
@@ -14354,6 +14452,15 @@ snapshots:
       js-md4: 0.3.2
     transitivePeerDependencies:
       - debug
+
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3)
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+    optional: true
 
   axios@1.15.0(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
@@ -15236,6 +15343,16 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -16784,7 +16901,14 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  nuqs@2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6):
+  nuqs@2.8.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.6
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+
+  nuqs@2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.6
@@ -18347,6 +18471,23 @@ snapshots:
       - supports-color
       - typescript
 
+  vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.32.0
+      sass: 1.99.0
+      tsx: 4.21.0
+      yaml: 2.8.4
+
   vite@6.4.2(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.25.12
@@ -18360,6 +18501,22 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.32.0
+      sass: 1.99.0
+      tsx: 4.21.0
+      yaml: 2.8.4
+
+  vite@8.0.12(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.4):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
       sass: 1.99.0
       tsx: 4.21.0
       yaml: 2.8.4


### PR DESCRIPTION
## Summary

- Adds Playwright component tests for the raised-bed field HUD covering every normal state (empty, cart, growing, ready, harvested, stacked history avatars, nested "Povijest polja" details) on both desktop and mobile viewports — including swipe-down and backdrop tap dismissal for the mobile vaul drawer.
- Fixes a touch-only bug in [`RaisedBedFieldIconStack`](packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx): when the stack had ≥2 items and the user tapped to expand it, the `document`-level capture-phase pointerdown listener stayed attached after a child drawer opened, which on real touch devices interfered with vaul/Radix dismissal handling (reported as "can't close plant sort details by swiping or tapping backdrop when there are multiple items in the stack"). The stack now collapses on the activating click so the listener detaches before the drawer starts handling touch gestures.

## Investigation notes

- Headless Playwright with `page.mouse` (pointerType = mouse) couldn't reproduce the report — the icon-stack's `pointerType !== 'touch'` early-return in [`RaisedBedFieldIconStack.tsx:34`](packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx) skips the suspect handler entirely for mouse events.
- Synthesized touch pointer events via `dispatchEvent` and CDP `Input.dispatchTouchEvent` both bypass the browser's pointer-capture machinery that vaul relies on, so they produce false negatives regardless of stack size. Those experimental repros were removed; the mouse-based dismissals stay in place to document the working code path.
- The fix is rooted in code review: the listener at [`RaisedBedFieldIconStack.tsx:31-57`](packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx) calls `setIsTouchExpanded(false)` synchronously during a touch pointerdown on the drawer, which fires a React render in the middle of the event sequence vaul/Radix is tracking. Collapsing earlier — on the click that activates the child — keeps that render out of the drawer's first touch.

## Infrastructure changes

- Added `nuqs` to `apps/garden` devDependencies and `resolve.dedupe: ['nuqs', 'react', 'react-dom']` in [`apps/garden/playwright.config.ts`](apps/garden/playwright.config.ts) so the test's `NuqsTestingAdapter` and `@gredice/game`'s `useQueryState` share a single React Context (otherwise pnpm's peer-dep splitting produced two adapter contexts and `useCurrentGardenIdParam` threw "nuqs requires an adapter").
- Test scaffolding split into [`RaisedBedFieldHudStory.tsx`](apps/garden/tests/RaisedBedFieldHudStory.tsx) (JSX provider wrapper) and [`raisedBedFieldHudScenarios.ts`](apps/garden/tests/raisedBedFieldHudScenarios.ts) (data builders + cart-item factory) so the Playwright CT babel transform doesn't re-declare the JSX component identifier.

## Test plan

- [x] `pnpm test --filter garden` — 26/26 pass (1 landing E2E + 3 icon-stack CT incl. new collapse-on-activate assertion + 1 plant-picker CT + 21 HUD CT).
- [x] `pnpm lint --filter garden --filter @gredice/game` — clean.
- [ ] Manual smoke on a real iOS/Android device: open a raised-bed field with ≥2 stacked history avatars, tap to expand, tap an avatar, swipe the drag handle down → drawer should now dismiss; backdrop tap on the same drawer → drawer should now dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)