### PR TITLE
[API MCP] Gate commerce mutations behind write scope and enforce caller ownership

### DIFF
--- a/apps/api/app/api/mcp/auth.ts
+++ b/apps/api/app/api/mcp/auth.ts
@@ -114,6 +114,10 @@ export function checkMCPPermission(
     return false;
   }
 
+  if (auth.permissions) {
+    return auth.permissions.includes(permission);
+  }
+
   const allowedRoles = MCPPermissions[permission];
   return (allowedRoles as readonly string[]).includes(auth.role);
 }

--- a/apps/api/app/api/mcp/commerce/tools/call/route.ts
+++ b/apps/api/app/api/mcp/commerce/tools/call/route.ts
@@ -187,6 +187,18 @@ export async function POST(request: NextRequest) {
 
         const body = await request.json();
         const { name, arguments: args } = body.params || {};
+        const writeTools = new Set([
+            'commerce/add-to-cart',
+            'commerce/update-cart-item',
+            'commerce/create-order',
+        ]);
+
+        if (writeTools.has(name) && !checkMCPPermission(auth, 'commerce:purchase')) {
+            return NextResponse.json(
+                createMCPAuthError(auth, 'forbidden', correlationId),
+                { status: 403 },
+            );
+        }
 
         logger.info('mcp.commerce.tool.start', {
             toolName: name,
@@ -219,30 +231,60 @@ export async function POST(request: NextRequest) {
 
             case 'commerce/get-cart': {
                 const getCartInput = GetCartSchema.parse(args);
+                if (getCartInput.userId !== auth.userId) {
+                    return NextResponse.json(
+                        createMCPAuthError(auth, 'forbidden', correlationId),
+                        { status: 403 },
+                    );
+                }
                 result = await handleGetCart(getCartInput, auth);
                 break;
             }
 
             case 'commerce/add-to-cart': {
                 const addToCartInput = AddToCartSchema.parse(args);
+                if (addToCartInput.userId !== auth.userId) {
+                    return NextResponse.json(
+                        createMCPAuthError(auth, 'forbidden', correlationId),
+                        { status: 403 },
+                    );
+                }
                 result = await handleAddToCart(addToCartInput, auth);
                 break;
             }
 
             case 'commerce/update-cart-item': {
                 const updateCartInput = UpdateCartItemSchema.parse(args);
+                if (updateCartInput.userId !== auth.userId) {
+                    return NextResponse.json(
+                        createMCPAuthError(auth, 'forbidden', correlationId),
+                        { status: 403 },
+                    );
+                }
                 result = await handleUpdateCartItem(updateCartInput, auth);
                 break;
             }
 
             case 'commerce/create-order': {
                 const createOrderInput = CreateOrderSchema.parse(args);
+                if (createOrderInput.userId !== auth.userId) {
+                    return NextResponse.json(
+                        createMCPAuthError(auth, 'forbidden', correlationId),
+                        { status: 403 },
+                    );
+                }
                 result = await handleCreateOrder(createOrderInput, auth);
                 break;
             }
 
             case 'commerce/get-orders': {
                 const getOrdersInput = GetOrdersSchema.parse(args);
+                if (getOrdersInput.userId !== auth.userId) {
+                    return NextResponse.json(
+                        createMCPAuthError(auth, 'forbidden', correlationId),
+                        { status: 403 },
+                    );
+                }
                 result = await handleGetOrders(getOrdersInput, auth);
                 break;
             }

--- a/apps/api/tests/mcp.spec.ts
+++ b/apps/api/tests/mcp.spec.ts
@@ -4,7 +4,11 @@ import jwt from 'jsonwebtoken';
 const MCP_BASE_URL = '/api/mcp';
 
 // Create a test JWT for authenticated endpoints
-function createTestJWT(userId = 'user-123', role = 'gardener') {
+function createTestJWT(
+    userId = 'user-123',
+    role = 'gardener',
+    permissions = ['gardens:read', 'commerce:read', 'commerce:purchase'],
+) {
     const now = Math.floor(Date.now() / 1000);
     return jwt.sign(
         {
@@ -13,11 +17,7 @@ function createTestJWT(userId = 'user-123', role = 'gardener') {
             role,
             email: 'test@example.com',
             locale: 'hr',
-            permissions: [
-                'gardens:read',
-                'commerce:read',
-                'commerce:purchase',
-            ],
+            permissions,
             iat: now,
             exp: now + 3600, // 1 hour from now
         },
@@ -609,6 +609,67 @@ test.describe('MCP Commerce Server', () => {
                 items: expect.any(Array),
             });
         }
+    });
+
+    test('should reject cart mutation for read-only token', async ({
+        request,
+    }) => {
+        const testJWT = createTestJWT('user-123', 'gardener', ['commerce:read']);
+
+        const response = await request.post(
+            `${MCP_BASE_URL}/commerce/tools/call`,
+            {
+                data: {
+                    jsonrpc: '2.0',
+                    method: 'commerce/add-to-cart',
+                    params: {
+                        name: 'commerce/add-to-cart',
+                        arguments: {
+                            userId: 'user-123',
+                            productId: 'product-seed-tomato-cherry',
+                            quantity: 1,
+                        },
+                    },
+                    id: 6,
+                },
+                headers: {
+                    Authorization: `Bearer ${testJWT}`,
+                },
+            },
+        );
+
+        expect(response.status()).toBe(403);
+        const data = await response.json();
+        expect(data.error.code).toBe(-32001);
+    });
+
+    test('should reject cart access for different userId', async ({ request }) => {
+        const testJWT = createTestJWT('user-123', 'gardener');
+
+        const response = await request.post(
+            `${MCP_BASE_URL}/commerce/tools/call`,
+            {
+                data: {
+                    jsonrpc: '2.0',
+                    method: 'commerce/get-cart',
+                    params: {
+                        name: 'commerce/get-cart',
+                        arguments: {
+                            userId: 'user-456',
+                            locale: 'hr',
+                        },
+                    },
+                    id: 7,
+                },
+                headers: {
+                    Authorization: `Bearer ${testJWT}`,
+                },
+            },
+        );
+
+        expect(response.status()).toBe(403);
+        const data = await response.json();
+        expect(data.error.code).toBe(-32001);
     });
 
     test('should create order with Croatian shipping address', async ({


### PR DESCRIPTION
### Motivation
- Prevent mutating MCP tools from running on read-only tokens and avoid trusting caller-supplied ownership identifiers for commerce operations.
- Meet GRE-344 requirements to require explicit write scopes and account ownership for unsafe mutations.

### Description
- Honor explicit token `auth.permissions` in `checkMCPPermission` so tokens with explicit scopes are enforced before falling back to role grants.
- Gate commerce mutation tools (`commerce/add-to-cart`, `commerce/update-cart-item`, `commerce/create-order`) behind the `commerce:purchase` permission and return a forbidden error when missing.
- Enforce that commerce tools accepting `userId` (`get-cart`, `add-to-cart`, `update-cart-item`, `create-order`, `get-orders`) only operate when `args.userId === auth.userId` and otherwise return a forbidden error.
- Add MCP test coverage to validate denied mutation for a read-only token and denied cross-user cart access, and make the test JWT builder accept custom `permissions`.

### Testing
- Ran `pnpm test --filter api -- mcp.spec.ts` and the Playwright tests completed successfully with all assertions passing.
- Test run emitted a Node engine warning due to the local environment running Node `v22` while the repo requests `>=24`, but the test suite still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060a03baa8832fb49607ad114137d1)