### PR TITLE
[Tests] Add social publish action unit coverage and extract payload validation

### DIFF
--- a/apps/app/app/(actions)/socialPublishActions.ts
+++ b/apps/app/app/(actions)/socialPublishActions.ts
@@ -30,6 +30,55 @@ export type PublishSocialPostState = {
     providerPermalink?: string | null;
 };
 
+
+
+type NormalizedPayload = {
+    provider: string;
+    providerAccountKey: string;
+    destination: string;
+    postType: string;
+    title: string;
+    body: string;
+    url: string;
+    submissionToken: string;
+};
+
+function normalizePayload(formData: FormData): NormalizedPayload {
+    return {
+        provider: normalizeTrimmed(formData.get('provider')).toLowerCase(),
+        providerAccountKey: normalizeTrimmed(formData.get('providerAccountKey')),
+        destination: normalizeTrimmed(formData.get('destination')).replace(/^r\//i, ''),
+        postType: normalizeTrimmed(formData.get('postType')).toLowerCase(),
+        title: normalizeTrimmed(formData.get('title')),
+        body: normalizeTrimmed(formData.get('body')),
+        url: normalizeTrimmed(formData.get('url')),
+        submissionToken: normalizeTrimmed(formData.get('submissionToken')),
+    };
+}
+
+function validatePayload(payload: NormalizedPayload):
+    | { ok: true; payload: NormalizedPayload & { provider: SocialProvider; postType: SocialPostType } }
+    | { ok: false; state: PublishSocialPostState } {
+    const { provider, providerAccountKey, destination, postType, title, body, url, submissionToken } = payload;
+
+    if (!isValidProvider(provider) || !isValidPostType(postType)) {
+        return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Neispravan provider ili tip objave.' } };
+    }
+    if (!providerAccountKey) return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Nedostaje ključ provider računa.' } };
+    if (!destination) return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Odredište je obavezno.' } };
+    if (!title || title.length > TITLE_MAX_LENGTH) return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Naslov je obavezan i mora imati najviše 300 znakova.' } };
+    if (url) {
+        try { const parsed = new URL(url); if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') throw new Error('invalid protocol'); }
+        catch { return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Link mora biti valjani http ili https URL.' } }; }
+    }
+    if (!url && !body) return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Potrebno je unijeti sadržaj objave ili link.' } };
+    if (body.length > BODY_MAX_LENGTH) return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Sadržaj objave je predugačak.' } };
+    if (submissionToken.length < SUBMISSION_TOKEN_MIN_LENGTH) return { ok: false, state: { ok: false, errorCode: 'invalid_payload', message: 'Nedostaje valjan token prijave obrasca.' } };
+
+    return { ok: true, payload: { ...payload, provider, postType } };
+}
+
+export const __testUtils = { normalizePayload, validatePayload, sanitizeProviderErrorDetails };
 function normalizeTrimmed(value: FormDataEntryValue | null): string {
     return typeof value === 'string' ? value.trim() : '';
 }
@@ -86,83 +135,13 @@ export async function publishSocialPostAction(
         };
     }
 
-    const provider = normalizeTrimmed(formData.get('provider')).toLowerCase();
-    const providerAccountKey = normalizeTrimmed(
-        formData.get('providerAccountKey'),
-    );
-    const destination = normalizeTrimmed(formData.get('destination')).replace(
-        /^r\//i,
-        '',
-    );
-    const postType = normalizeTrimmed(formData.get('postType')).toLowerCase();
-    const title = normalizeTrimmed(formData.get('title'));
-    const body = normalizeTrimmed(formData.get('body'));
-    const url = normalizeTrimmed(formData.get('url'));
-    const submissionToken = normalizeTrimmed(formData.get('submissionToken'));
+    const normalizedPayload = normalizePayload(formData);
+    const payloadValidation = validatePayload(normalizedPayload);
+    if (!payloadValidation.ok) {
+        return payloadValidation.state;
+    }
 
-    if (!isValidProvider(provider) || !isValidPostType(postType)) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Neispravan provider ili tip objave.',
-        };
-    }
-    if (!providerAccountKey) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Nedostaje ključ provider računa.',
-        };
-    }
-    if (!destination) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Odredište je obavezno.',
-        };
-    }
-    if (!title || title.length > TITLE_MAX_LENGTH) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Naslov je obavezan i mora imati najviše 300 znakova.',
-        };
-    }
-    if (url) {
-        try {
-            const parsed = new URL(url);
-            if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-                throw new Error('invalid protocol');
-            }
-        } catch {
-            return {
-                ok: false,
-                errorCode: 'invalid_payload',
-                message: 'Link mora biti valjani http ili https URL.',
-            };
-        }
-    }
-    if (!url && !body) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Potrebno je unijeti sadržaj objave ili link.',
-        };
-    }
-    if (body.length > BODY_MAX_LENGTH) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Sadržaj objave je predugačak.',
-        };
-    }
-    if (submissionToken.length < SUBMISSION_TOKEN_MIN_LENGTH) {
-        return {
-            ok: false,
-            errorCode: 'invalid_payload',
-            message: 'Nedostaje valjan token prijave obrasca.',
-        };
-    }
+    const { provider, providerAccountKey, destination, postType, title, body, url, submissionToken } = payloadValidation.payload;
 
     const adapter = createSocialProviderAdapter(provider);
     const configError = adapter.validateConfig();

--- a/apps/app/app/(actions)/socialPublishActions.unit.ts
+++ b/apps/app/app/(actions)/socialPublishActions.unit.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  __testUtils,
+} from './socialPublishActions.ts';
+
+test('validatePayload rejects missing required fields', () => {
+  const payload = __testUtils.normalizePayload(new FormData());
+  const result = __testUtils.validatePayload(payload);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.state.errorCode, 'invalid_payload');
+  }
+});
+
+test('validatePayload accepts valid text publish payload', () => {
+  const formData = new FormData();
+  formData.set('provider', 'reddit');
+  formData.set('providerAccountKey', 'default');
+  formData.set('destination', 'r/gardening');
+  formData.set('postType', 'text');
+  formData.set('title', 'Title');
+  formData.set('body', 'Body');
+  formData.set('submissionToken', 'submission-token-123');
+
+  const payload = __testUtils.normalizePayload(formData);
+  const result = __testUtils.validatePayload(payload);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.payload.destination, 'gardening');
+  }
+});
+
+test('sanitizeProviderErrorDetails strips sensitive fields', () => {
+  const sanitized = __testUtils.sanitizeProviderErrorDetails({
+    status: 403,
+    reason: 'blocked',
+    providerErrorId: 'x',
+    accessToken: 'secret',
+  });
+  assert.deepEqual(sanitized, {
+    status: 403,
+    reason: 'blocked',
+    providerErrorId: 'x',
+  });
+});

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,7 @@
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
         "test:prepare": "pnpm --dir ../.. exec turbo build --filter=app",
-        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/social/providers/reddit/redditAdapter.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts",
+        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/social/providers/reddit/redditAdapter.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts 'app/(actions)/socialPublishActions.unit.ts'",
         "test:run": "pnpm run test:unit && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "test:local": "pnpm run test:prepare && pnpm run test:run"


### PR DESCRIPTION
### Motivation
- Improve safety of the provider-neutral social publishing MVP by adding focused unit coverage for action-level validation and provider-error sanitization without requiring live provider credentials.
- Make the `publishSocialPostAction` payload parsing and validation easier to test and reuse by extracting normalization and validation helpers.

### Description
- Extracted payload helpers into `normalizePayload` and `validatePayload`, and exported `__testUtils` (in `apps/app/app/(actions)/socialPublishActions.ts`) so validation logic can be unit tested.
- Rewrote the action to use the new helpers and preserve existing provider-neutral storage behavior and sanitized error handling.
- Added `apps/app/app/(actions)/socialPublishActions.unit.ts` with unit tests that cover missing-field validation, `r/...` destination normalization, and sanitization of provider error details.
- Updated `apps/app/package.json` `test:unit` script to include the new unit test file in the app's unit test run.

### Testing
- Ran `pnpm --filter app test:unit`, which executed the app unit test suite and completed successfully with all tests passing (unit tests included for the social publish action and Reddit adapter).
- The test run emitted a Node engine warning because the environment is `node v22.22.2` while the repo expects `node >=24`, but this did not prevent the unit tests from passing.
- The changes added unit-level coverage only; no database or end-to-end tests were run as part of this PR's automated validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060a2c7d48832fa9fe132ee5f84b56)