### PR TITLE
fix(game): dismiss stacked-plant drawers on touch by guarding icon-stack capture handlers

### DIFF
--- a/apps/garden/playwright/index.tsx
+++ b/apps/garden/playwright/index.tsx
@@ -1,1 +1,1 @@
-// import '../app/globals.css';
+import '../app/globals.css';

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -314,6 +314,10 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             />,
         );
 
+        // Icons in the stack visually overlap until hover spreads them out, so
+        // hover the stack first to make the MoreHorizontal trigger clickable
+        // without being intercepted by sibling icons stacked on top of it.
+        await page.locator('[data-field-icon-stack]').hover();
         await page
             .getByRole('button', {
                 name: 'Prikaži povijest biljaka za polje 1',
@@ -436,6 +440,8 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
 
         const dialog = page.getByRole('dialog');
         await expect(dialog).toBeVisible();
+        // Wait for the vaul slide-in animation to complete before measuring.
+        await page.waitForTimeout(700);
         const dialogBox = await dialog.boundingBox();
         if (!dialogBox) {
             throw new Error('Expected drawer to have a bounding box.');
@@ -494,6 +500,9 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         const dialog = page.getByRole('dialog');
         await expect(dialog).toBeVisible();
         await expect(dialog).toHaveAttribute('data-vaul-drawer', '');
+        // Let vaul's slide-in animation settle so layout measurements are
+        // taken against the resting position rather than mid-transform values.
+        await page.waitForTimeout(700);
         return dialog;
     }
 
@@ -565,21 +574,25 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
             cancelable: true,
             pointerType: 'touch',
         });
-        await allHistoryButton.click({ force: true });
+        await allHistoryButton.dispatchEvent('click', { bubbles: true });
         await expect(stack).toHaveAttribute('data-touch-expanded', 'true');
 
-        // Second tap actually opens the "Povijest polja" list drawer.
+        // Second tap actually opens the "Povijest polja" list drawer. Use
+        // dispatchEvent so we hit the trigger element directly instead of
+        // relying on position-based click while CSS transitions are running.
         await allHistoryButton.dispatchEvent('pointerdown', {
             bubbles: true,
             cancelable: true,
             pointerType: 'touch',
         });
-        await allHistoryButton.click({ force: true });
+        await allHistoryButton.dispatchEvent('click', { bubbles: true });
 
         const historyListDrawer = page.getByRole('dialog', {
             name: 'Povijest polja',
         });
         await expect(historyListDrawer).toBeVisible();
+        // Allow the slide-in animation to settle before sampling layout.
+        await page.waitForTimeout(700);
 
         await historyListDrawer
             .getByRole('button', { name: /Otvori detalje biljke / })
@@ -591,6 +604,7 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
             .filter({ hasText: /Prethodna biljka/ });
         await expect(detailsDrawer).toBeVisible();
         await expect(detailsDrawer).toHaveAttribute('data-vaul-drawer', '');
+        await page.waitForTimeout(700);
         return { detailsDrawer, historyListDrawer };
     }
 
@@ -703,6 +717,99 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         const tapX = MOBILE_VIEWPORT.width / 2;
         const tapY = Math.max(20, dialogBox.y - 40);
         await page.mouse.click(tapX, tapY);
+
+        await expect(dialog).toBeHidden();
+    });
+
+    // Reproductions for the production bug where dismissal silently failed on
+    // real touch input because the icon stack's capture-phase handlers fired
+    // for events on the drawer overlay (which lives in a portal but is still a
+    // React-tree descendant of the fieldset). Use real `touchscreen.tap` here
+    // because the bug only manifests with `pointerType === 'touch'`.
+    test('[regression] backdrop tap with real touch dismisses a stacked-plant drawer', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const historyButton = page
+            .getByRole('button', { name: /Povijest biljke / })
+            .last();
+        // First tap expands the stack, second tap activates the avatar.
+        await historyButton.tap();
+        await historyButton.tap();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        // Wait for vaul's slide-in animation to settle before sampling layout.
+        await page.waitForTimeout(700);
+
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected history drawer to have a bounding box.');
+        }
+        const tapX = dialogBox.x + dialogBox.width / 2;
+        const tapY = Math.max(20, dialogBox.y - 50);
+        await page.touchscreen.tap(tapX, tapY);
+
+        await expect(dialog).toBeHidden();
+    });
+
+    test('[regression] swipe-down with real touch dismisses a stacked-plant drawer', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={emptyWithHistoryScenario(2)}
+                positionIndex={0}
+            />,
+        );
+
+        const historyButton = page
+            .getByRole('button', { name: /Povijest biljke / })
+            .last();
+        await historyButton.tap();
+        await historyButton.tap();
+
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await page.waitForTimeout(700);
+
+        const dialogBox = await dialog.boundingBox();
+        if (!dialogBox) {
+            throw new Error('Expected history drawer to have a bounding box.');
+        }
+
+        // Swipe via CDP touch events so we exercise the real-touch dismissal
+        // path that the bug hides behind.
+        const cdp = await page.context().newCDPSession(page);
+        const startX = dialogBox.x + dialogBox.width / 2;
+        const startY = dialogBox.y + 16;
+        const endY = MOBILE_VIEWPORT.height + 200;
+        await cdp.send('Input.dispatchTouchEvent', {
+            type: 'touchStart',
+            touchPoints: [{ x: startX, y: startY }],
+        });
+        const steps = 10;
+        for (let i = 1; i <= steps; i += 1) {
+            await cdp.send('Input.dispatchTouchEvent', {
+                type: 'touchMove',
+                touchPoints: [
+                    { x: startX, y: startY + ((endY - startY) * i) / steps },
+                ],
+            });
+        }
+        await cdp.send('Input.dispatchTouchEvent', {
+            type: 'touchEnd',
+            touchPoints: [],
+        });
+        await cdp.detach();
 
         await expect(dialog).toBeHidden();
     });

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx
@@ -72,13 +72,36 @@ export function RaisedBedFieldIconStack({ children }: { children: ReactNode }) {
         }
     }
 
+    // React's event delegation walks the *component* tree, so capture-phase
+    // handlers on the fieldset also fire for events on React children that
+    // were rendered through portals (for example, the vaul drawer overlay
+    // attached to a stacked-plant modal). If we treat those events as taps
+    // inside the stack we will both `setIsTouchExpanded(true)` again and call
+    // `event.stopPropagation()`, which prevents Radix's document-level
+    // pointerdown listener from firing — so backdrop-tap-to-dismiss and
+    // swipe-down dismissal of the opened drawer silently break. Guard every
+    // capture-phase handler with a DOM `contains` check.
+    function isEventInsideStack(
+        event:
+            | ReactPointerEvent<HTMLFieldSetElement>
+            | ReactMouseEvent<HTMLFieldSetElement>,
+    ) {
+        const target = event.target;
+        return (
+            target instanceof Node &&
+            stackRef.current !== null &&
+            stackRef.current.contains(target)
+        );
+    }
+
     function handlePointerDownCapture(
         event: ReactPointerEvent<HTMLFieldSetElement>,
     ) {
         if (
             items.length < 2 ||
             event.pointerType !== 'touch' ||
-            isTouchExpanded
+            isTouchExpanded ||
+            !isEventInsideStack(event)
         ) {
             return;
         }
@@ -96,6 +119,10 @@ export function RaisedBedFieldIconStack({ children }: { children: ReactNode }) {
     }
 
     function handleClickCapture(event: ReactMouseEvent<HTMLFieldSetElement>) {
+        if (!isEventInsideStack(event)) {
+            return;
+        }
+
         if (swallowNextClickRef.current) {
             clearSwallowedClick();
             event.preventDefault();


### PR DESCRIPTION
## Summary

The merged fix in #2808 (collapse icon stack on activating click) didn't actually resolve the bug — user reported it was still reproducible in Chrome DevTools mobile/touch mode. Investigation with `devices['Pixel 5']` + `page.touchscreen.tap` reproduced it cleanly, and the real root cause is one level deeper:

**React event delegation walks the *component* tree, not the DOM tree.** The vaul drawer's overlay (and content) are rendered through a `Portal`, but they remain React-tree descendants of the icon-stack `<fieldset>`. So when the user taps the backdrop on an opened stacked-plant drawer:

1. The fieldset's `onPointerDownCapture` fires for the overlay's pointerdown (because of the React-tree relationship)
2. It re-runs the "tap-to-expand" branch and calls `event.stopPropagation()` (since `isTouchExpanded` was already collapsed after activation)
3. `stopPropagation()` on the React synthetic event also stops the native event
4. Radix's document-level pointerdown listener never fires → `dismissableLayer.pointerDownOutside` is never dispatched → drawer doesn't close

Diagnostic confirmation (with `globals.css` properly loaded so vaul renders at `position: fixed` for real):
- Single-item stack (no expand-on-touch path): real touch backdrop tap → `RADIX pointerDownOutside fired` → drawer closes ✅
- Multi-item stack: real touch backdrop tap → no Radix event → drawer stays open ❌
- Same multi-item stack with `element.click()` programmatic dispatch → drawer closes (because the bypass goes around the React event tree)

## The fix

[packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx](packages/game/src/hud/raisedBed/RaisedBedFieldIconStack.tsx) — guard both `handlePointerDownCapture` and `handleClickCapture` with a DOM `stackRef.current.contains(event.target)` check. Events originating from portal-mounted descendants of the stack (drawer overlay, drawer content, etc.) are now ignored, so the stack neither re-expands nor calls `event.stopPropagation()` on them. The expand-on-touch behavior still works for taps on the actual visible icons.

## Test changes

- [apps/garden/playwright/index.tsx](apps/garden/playwright/index.tsx) — load `globals.css` in the CT bundle so vaul drawers render with the real `position: fixed inset-0` layout. Without this, the overlay had `position: static; height: 0` and tests couldn't observe overlay-mediated dismissal at all.
- [apps/garden/tests/raised-bed-field-hud.spec.tsx](apps/garden/tests/raised-bed-field-hud.spec.tsx) — two new `[regression]` tests that exercise the previously-broken path with real touch (`page.touchscreen.tap` for backdrop, CDP `Input.dispatchTouchEvent` swipe sequence for drag-handle). Both originally failed against the old code path; they pass with the fix.
- Adjusted existing dismissal tests for the now-accurate animated drawer positioning (`page.waitForTimeout(700)` after open so `boundingBox()` reflects the resting position) and switched stack-icon activation in the all-history helper from position-based `click({ force: true })` to `dispatchEvent('click')` so CSS transitions during expansion don't shift the click position onto a different icon.

## Test plan

- [x] `pnpm test --filter garden` — 29/29 pass (1 landing E2E + 3 icon-stack CT + 1 plant-picker CT + 24 HUD CT covering all desktop scenarios, the mobile bottom-drawer dismissals, and the two new real-touch regression tests).
- [x] `pnpm lint --filter garden --filter @gredice/game` — clean.
- [ ] Manual verification by reporter in Chrome DevTools mobile/touch mode: open a raised bed with ≥2 stacked items, tap to expand, tap an avatar/MoreHorizontal/cart icon, then dismiss via swipe-down or backdrop tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)