### PR TITLE
Format the sunflower info tooltip with conversion details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,6 @@ apps/www/generate/test-cases.json
 ## Ignore test results
 test-results/
 scripts/dev/.caddy-data/
+
+## Claude Code worktrees
+.claude/worktrees/

--- a/apps/storybook/stories/packages/game/hud/SunflowersHud.stories.tsx
+++ b/apps/storybook/stories/packages/game/hud/SunflowersHud.stories.tsx
@@ -1,0 +1,30 @@
+import { SunflowersInfoTooltipContent } from '@packages/game/hud/SunflowersHud';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/game/hud/SunflowersHud',
+    component: SunflowersInfoTooltipContent,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Sunflower HUD help content explaining how sunflowers are collected, spent, and converted from euro prices.',
+            },
+        },
+    },
+    decorators: [
+        (Story) => (
+            <div className="w-[min(calc(100vw-2rem),28rem)] overflow-hidden rounded-md border border-border border-b-4 border-b-tertiary bg-popover shadow-sm">
+                <Story />
+            </div>
+        ),
+    ],
+} satisfies Meta<typeof SunflowersInfoTooltipContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InfoTooltip: Story = {
+    name: 'Info tooltip content',
+};

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -35,6 +35,84 @@ function DailyRewardInfo() {
     );
 }
 
+export function SunflowersInfoTooltipContent() {
+    return (
+        <Stack className="p-4" spacing={3}>
+            <Row spacing={2} alignItems="start">
+                <Image
+                    src="https://cdn.gredice.com/sunflower-large.svg"
+                    alt="Suncokret"
+                    width={72}
+                    height={72}
+                    className="size-16 shrink-0"
+                />
+                <Stack spacing={1}>
+                    <Typography level="body2" bold>
+                        Što su suncokreti?
+                    </Typography>
+                    <Typography level="body2">
+                        Sakupljaj i koristi suncokrete za uređenje i dekoraciju
+                        vrta ili kupnju i brigu o svojim biljkama 🌱
+                    </Typography>
+                </Stack>
+            </Row>
+            <Stack spacing={1.5}>
+                <Typography
+                    level="body3"
+                    semiBold
+                    className="uppercase text-muted-foreground"
+                >
+                    Pretvorba
+                </Typography>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <Stack
+                        spacing={0.5}
+                        className="rounded-md border bg-muted/40 p-3"
+                    >
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Plaćanje
+                        </Typography>
+                        <Typography level="body1" bold className="tabular-nums">
+                            1 € = 1.000 🌻
+                        </Typography>
+                    </Stack>
+                    <Stack
+                        spacing={0.5}
+                        className="rounded-md border bg-muted/40 p-3"
+                    >
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Bonus za kupnju
+                        </Typography>
+                        <Typography level="body1" bold className="tabular-nums">
+                            1 € = 10 🌻
+                        </Typography>
+                    </Stack>
+                </div>
+                <Typography level="body3" className="text-muted-foreground">
+                    Kod plaćanja suncokretima cijena se računa iz eura i
+                    zaokružuje na cijeli broj.
+                </Typography>
+            </Stack>
+            <Button
+                variant="solid"
+                size="sm"
+                href={KnownPages.GrediceSunflowers}
+                target="_blank"
+                className="self-start"
+                endDecorator={<Navigate className="size-5" />}
+            >
+                Saznaj više
+            </Button>
+        </Stack>
+    );
+}
+
 function SunflowersCard() {
     const [, setProfileModalOpen] = useSearchParam('pregled');
 
@@ -55,91 +133,7 @@ function SunflowersCard() {
                         </IconButton>
                     }
                 >
-                    <Stack className="p-4" spacing={3}>
-                        <Row spacing={2} alignItems="start">
-                            <Image
-                                src="https://cdn.gredice.com/sunflower-large.svg"
-                                alt="Suncokret"
-                                width={72}
-                                height={72}
-                                className="size-16 shrink-0"
-                            />
-                            <Stack spacing={1}>
-                                <Typography level="body2" bold>
-                                    Što su suncokreti?
-                                </Typography>
-                                <Typography level="body2">
-                                    Sakupljaj i koristi suncokrete za uređenje i
-                                    dekoraciju vrta ili kupnju i brigu o svojim
-                                    biljkama 🌱
-                                </Typography>
-                            </Stack>
-                        </Row>
-                        <Stack spacing={1.5}>
-                            <Typography
-                                level="body3"
-                                semiBold
-                                className="uppercase text-muted-foreground"
-                            >
-                                Pretvorba
-                            </Typography>
-                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                                <Stack
-                                    spacing={0.5}
-                                    className="rounded-md border bg-muted/40 p-3"
-                                >
-                                    <Typography
-                                        level="body3"
-                                        className="text-muted-foreground"
-                                    >
-                                        Plaćanje
-                                    </Typography>
-                                    <Typography
-                                        level="body1"
-                                        bold
-                                        className="tabular-nums"
-                                    >
-                                        1 € = 1.000 🌻
-                                    </Typography>
-                                </Stack>
-                                <Stack
-                                    spacing={0.5}
-                                    className="rounded-md border bg-muted/40 p-3"
-                                >
-                                    <Typography
-                                        level="body3"
-                                        className="text-muted-foreground"
-                                    >
-                                        Bonus za kupnju
-                                    </Typography>
-                                    <Typography
-                                        level="body1"
-                                        bold
-                                        className="tabular-nums"
-                                    >
-                                        1 € = 10 🌻
-                                    </Typography>
-                                </Stack>
-                            </div>
-                            <Typography
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                Kod plaćanja suncokretima cijena se računa iz
-                                eura i zaokružuje na cijeli broj.
-                            </Typography>
-                        </Stack>
-                        <Button
-                            variant="solid"
-                            size="sm"
-                            href={KnownPages.GrediceSunflowers}
-                            target="_blank"
-                            className="self-start"
-                            endDecorator={<Navigate className="size-5" />}
-                        >
-                            Saznaj više
-                        </Button>
-                    </Stack>
+                    <SunflowersInfoTooltipContent />
                 </Popper>
             </Row>
             <Divider />

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -37,7 +37,7 @@ function DailyRewardInfo() {
 
 export function SunflowersInfoTooltipContent() {
     return (
-        <Stack className="p-4" spacing={3}>
+        <Stack className="p-4" spacing={2}>
             <Row spacing={2} alignItems="start">
                 <Image
                     src="https://cdn.gredice.com/sunflower-large.svg"
@@ -56,14 +56,7 @@ export function SunflowersInfoTooltipContent() {
                     </Typography>
                 </Stack>
             </Row>
-            <Stack spacing={1.5}>
-                <Typography
-                    level="body3"
-                    semiBold
-                    className="uppercase text-muted-foreground"
-                >
-                    Pretvorba
-                </Typography>
+            <Stack spacing={1}>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                     <Stack
                         spacing={0.5}

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -48,38 +48,98 @@ function SunflowersCard() {
                     Suncokreti
                 </Typography>
                 <Popper
-                    className="min-w-80 border-tertiary border-b-4"
+                    className="w-[min(calc(100vw-2rem),28rem)] border-tertiary border-b-4"
                     trigger={
                         <IconButton title="Što su suncokreti?" variant="plain">
                             <Info className="size-4 shrink-0" />
                         </IconButton>
                     }
                 >
-                    <Row className="p-4" spacing={2}>
-                        <Image
-                            src="https://cdn.gredice.com/sunflower-large.svg"
-                            alt="Suncokret"
-                            width={80}
-                            height={80}
-                            className="size-20"
-                        />
-                        <Stack spacing={2}>
-                            <Typography level="body2">
-                                Sakupljaj i koristi suncokrete za uređenje i
-                                dekoraciju vrta ili kupnju i brigu o svojim
-                                biljkama 🌱
-                            </Typography>
-                            <Button
-                                variant="solid"
-                                size="sm"
-                                href={KnownPages.GrediceSunflowers}
-                                target="_blank"
-                                endDecorator={<Navigate className="size-5" />}
+                    <Stack className="p-4" spacing={3}>
+                        <Row spacing={2} alignItems="start">
+                            <Image
+                                src="https://cdn.gredice.com/sunflower-large.svg"
+                                alt="Suncokret"
+                                width={72}
+                                height={72}
+                                className="size-16 shrink-0"
+                            />
+                            <Stack spacing={1}>
+                                <Typography level="body2" bold>
+                                    Što su suncokreti?
+                                </Typography>
+                                <Typography level="body2">
+                                    Sakupljaj i koristi suncokrete za uređenje i
+                                    dekoraciju vrta ili kupnju i brigu o svojim
+                                    biljkama 🌱
+                                </Typography>
+                            </Stack>
+                        </Row>
+                        <Stack spacing={1.5}>
+                            <Typography
+                                level="body3"
+                                semiBold
+                                className="uppercase text-muted-foreground"
                             >
-                                Saznaj više
-                            </Button>
+                                Pretvorba
+                            </Typography>
+                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                <Stack
+                                    spacing={0.5}
+                                    className="rounded-md border bg-muted/40 p-3"
+                                >
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        Plaćanje
+                                    </Typography>
+                                    <Typography
+                                        level="body1"
+                                        bold
+                                        className="tabular-nums"
+                                    >
+                                        1 € = 1.000 🌻
+                                    </Typography>
+                                </Stack>
+                                <Stack
+                                    spacing={0.5}
+                                    className="rounded-md border bg-muted/40 p-3"
+                                >
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        Bonus za kupnju
+                                    </Typography>
+                                    <Typography
+                                        level="body1"
+                                        bold
+                                        className="tabular-nums"
+                                    >
+                                        1 € = 10 🌻
+                                    </Typography>
+                                </Stack>
+                            </div>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Kod plaćanja suncokretima cijena se računa iz
+                                eura i zaokružuje na cijeli broj.
+                            </Typography>
                         </Stack>
-                    </Row>
+                        <Button
+                            variant="solid"
+                            size="sm"
+                            href={KnownPages.GrediceSunflowers}
+                            target="_blank"
+                            className="self-start"
+                            endDecorator={<Navigate className="size-5" />}
+                        >
+                            Saznaj više
+                        </Button>
+                    </Stack>
                 </Popper>
             </Row>
             <Divider />

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -198,7 +198,7 @@ export function RaisedBedFieldItemEmpty({
                                 }
                                 onKeyDown={(event) => event.stopPropagation()}
                             >
-                                <ShoppingCart className="size-[18px] stroke-foreground" />
+                                <ShoppingCart className="size-[18px] stroke-tertiary" />
                             </button>
                         }
                         {...plantPickerProps}


### PR DESCRIPTION
## Summary
- Expanded the "Što su suncokreti?" tooltip in the game HUD
- Added conversion details for sunflower pricing and earnings
- Increased the popper width and reformatted the content into a clearer, denser layout

## Testing
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game test`
- `pnpm build --filter garden`
- `pnpm build --filter www`
- `pnpm --filter www test:prepare`
- `pnpm --filter www test:run`
- `pnpm --filter garden test:run` was not clean because of two pre-existing mobile drawer regression failures unrelated to this change