### PR TITLE
Show cart operations in the game operations popup

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -88,18 +88,28 @@ function buildGarden() {
     };
 }
 
-function buildOperationCartItem(): ShoppingCartItemData {
+function buildOperationCartItem({
+    id,
+    scheduledDate,
+    positionIndex,
+}: {
+    id: number;
+    scheduledDate?: string;
+    positionIndex: number;
+}): ShoppingCartItemData {
     return {
-        id: 91,
+        id,
         cartId: 1,
         entityId: cartOperation.id.toString(),
         entityTypeName: 'operation',
         gardenId: TEST_GARDEN_ID,
         raisedBedId: TEST_RAISED_BED_ID,
-        positionIndex: 2,
-        additionalData: JSON.stringify({
-            scheduledDate: '2026-05-20T00:00:00.000Z',
-        }),
+        positionIndex,
+        additionalData: scheduledDate
+            ? JSON.stringify({
+                  scheduledDate,
+              })
+            : null,
         amount: 1,
         currency: 'eur',
         status: 'new',
@@ -141,7 +151,17 @@ function createQueryClient() {
     queryClient.setQueryData(['operations'], [cartOperation]);
     queryClient.setQueryData(['shopping-cart'], {
         id: 1,
-        items: [buildOperationCartItem()],
+        items: [
+            buildOperationCartItem({
+                id: 91,
+                scheduledDate: '2026-05-20T00:00:00.000Z',
+                positionIndex: 2,
+            }),
+            buildOperationCartItem({
+                id: 92,
+                positionIndex: 3,
+            }),
+        ],
     });
     queryClient.setQueryData(
         ['garden-operations', TEST_GARDEN_ID, false, 10],

--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -10,6 +10,7 @@ import {
     GameStateContext,
 } from '../../../packages/game/src/useGameState';
 import {
+    buildCartItem,
     buildField,
     TEST_GARDEN_ID,
     TEST_RAISED_BED_ID,
@@ -160,6 +161,12 @@ function createQueryClient() {
             buildOperationCartItem({
                 id: 92,
                 positionIndex: 3,
+            }),
+            buildCartItem({
+                id: 93,
+                sort: testSorts.lettuce,
+                scheduledDate: '2026-05-21T00:00:00.000Z',
+                positionIndex: 4,
             }),
         ],
     });

--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -1,0 +1,190 @@
+import type { OperationData } from '@gredice/client';
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
+import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
+import { GardenOperationsHud } from '../../../packages/game/src/hud/GardenOperationsHud';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+import {
+    buildField,
+    TEST_GARDEN_ID,
+    TEST_RAISED_BED_ID,
+    testSorts,
+} from './raisedBedFieldHudScenarios';
+
+const now = '2026-05-13T00:00:00.000Z';
+const raisedBedOrientation = 'horizontal';
+
+export const cartOperation = {
+    id: 501,
+    entityType: { id: 10, name: 'operation', label: 'Radnje' },
+    attributes: {
+        frequency: 'once',
+        stage: {
+            id: 1,
+            information: { name: 'growth', label: 'Rast' },
+        },
+        application: 'plant',
+        deliverable: false,
+        duration: 30,
+    },
+    information: {
+        description: 'Mock cart operation.',
+        shortDescription: 'Mock operation in cart.',
+        name: 'mock-cart-watering',
+        label: 'Zalijevanje u košari',
+        instructions: 'Mock instructions.',
+    },
+    prices: {
+        perOperation: 3,
+    },
+    image: { cover: { url: '' } },
+    conditions: {
+        completionAttachImages: false,
+        completionAttachImagesRequired: false,
+        completionAttachNotes: false,
+        completionAttachNotesRequired: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+} satisfies OperationData;
+
+function buildGarden() {
+    return {
+        id: TEST_GARDEN_ID,
+        name: 'Test garden',
+        stacks: [],
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [
+            {
+                id: TEST_RAISED_BED_ID,
+                name: 'Raised Bed 1',
+                blockId: 'raised-bed-1',
+                physicalId: '1',
+                fields: [
+                    buildField(
+                        {
+                            positionIndex: 2,
+                            plantSortId: testSorts.tomato.id,
+                            plantStatus: 'sprouted',
+                            plantSowDate: now,
+                            plantGrowthDate: now,
+                        },
+                        1,
+                    ),
+                ],
+                appliedOperations: [],
+                status: 'new',
+                isValid: true,
+                orientation: raisedBedOrientation,
+                createdAt: now,
+                updatedAt: now,
+            },
+        ],
+    };
+}
+
+function buildOperationCartItem(): ShoppingCartItemData {
+    return {
+        id: 91,
+        cartId: 1,
+        entityId: cartOperation.id.toString(),
+        entityTypeName: 'operation',
+        gardenId: TEST_GARDEN_ID,
+        raisedBedId: TEST_RAISED_BED_ID,
+        positionIndex: 2,
+        additionalData: JSON.stringify({
+            scheduledDate: '2026-05-20T00:00:00.000Z',
+        }),
+        amount: 1,
+        currency: 'eur',
+        status: 'new',
+        isDeleted: false,
+        createdAt: now,
+        updatedAt: now,
+        usesInventory: false,
+        inventoryAvailable: 0,
+        shopData: {
+            name: cartOperation.information.label,
+            description: cartOperation.information.shortDescription,
+            image: '',
+            price: cartOperation.prices.perOperation,
+            discountPrice: undefined,
+            discountDescription: undefined,
+        },
+        entityData: cartOperation,
+    };
+}
+
+function createQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+    const garden = buildGarden();
+    const emptyOperationPage = {
+        pages: [{ items: [], nextCursor: null, total: 0 }],
+        pageParams: [0],
+    };
+
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(['gardens'], [{ id: TEST_GARDEN_ID }]);
+    queryClient.setQueryData(
+        ['gardens', 'current', 'summer', TEST_GARDEN_ID],
+        garden,
+    );
+    queryClient.setQueryData(['operations'], [cartOperation]);
+    queryClient.setQueryData(['shopping-cart'], {
+        id: 1,
+        items: [buildOperationCartItem()],
+    });
+    queryClient.setQueryData(
+        ['garden-operations', TEST_GARDEN_ID, false, 10],
+        emptyOperationPage,
+    );
+    queryClient.setQueryData(
+        ['garden-operations', TEST_GARDEN_ID, true, 20],
+        emptyOperationPage,
+    );
+
+    return queryClient;
+}
+
+function Providers({ children }: PropsWithChildren) {
+    const queryClient = useMemo(() => createQueryClient(), []);
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date('2026-05-13T12:00:00.000Z'),
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
+
+    return (
+        <NuqsTestingAdapter>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameStore}>
+                    <GameAnalyticsProvider capture={() => undefined}>
+                        {children}
+                    </GameAnalyticsProvider>
+                </GameStateContext.Provider>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+export function GardenOperationsHudStory() {
+    return (
+        <Providers>
+            <GardenOperationsHud />
+        </Providers>
+    );
+}

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -11,8 +11,13 @@ test.describe('Garden operations HUD', () => {
         await page.getByTitle('Status radnji').click();
 
         await expect(page.getByText('Radnje u košari')).toBeVisible();
-        await expect(page.getByText('Zalijevanje u košari')).toBeVisible();
+        await expect(page.getByText('Zalijevanje u košari')).toHaveCount(2);
         await expect(page.getByText('Polje 3 • Raised Bed 1')).toBeVisible();
+        await expect(page.getByText('Polje 4 • Raised Bed 1')).toBeVisible();
+        await expect(
+            page.getByText('Zakazano: 20. svibnja 2026.'),
+        ).toBeVisible();
+        await expect(page.getByText('Zakazano: sutra')).toBeVisible();
         await expect(page.getByText('U košari').last()).toBeVisible();
         await expect(page.getByText('Nema nedovršenih radnji.')).toHaveCount(0);
     });

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -12,10 +12,18 @@ test.describe('Garden operations HUD', () => {
 
         await expect(page.getByText('Radnje u košari')).toBeVisible();
         await expect(page.getByText('Zalijevanje u košari')).toHaveCount(2);
+        await expect(page.getByText('Sadnja: Maslac salata')).toBeVisible();
+        await expect(
+            page.getByRole('img', { name: 'Maslac salata' }),
+        ).toBeVisible();
         await expect(page.getByText('Polje 3 • Raised Bed 1')).toBeVisible();
         await expect(page.getByText('Polje 4 • Raised Bed 1')).toBeVisible();
+        await expect(page.getByText('Polje 5 • Raised Bed 1')).toBeVisible();
         await expect(
             page.getByText('Zakazano: 20. svibnja 2026.'),
+        ).toBeVisible();
+        await expect(
+            page.getByText('Zakazano: 21. svibnja 2026.'),
         ).toBeVisible();
         await expect(page.getByText('Zakazano: sutra')).toBeVisible();
         await expect(page.getByText('U košari').last()).toBeVisible();

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { GardenOperationsHudStory } from './GardenOperationsHudStory';
+
+test.describe('Garden operations HUD', () => {
+    test('shows operation items that are still in the shopping cart', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<GardenOperationsHudStory />);
+
+        await page.getByTitle('Status radnji').click();
+
+        await expect(page.getByText('Radnje u košari')).toBeVisible();
+        await expect(page.getByText('Zalijevanje u košari')).toBeVisible();
+        await expect(page.getByText('Polje 3 • Raised Bed 1')).toBeVisible();
+        await expect(page.getByText('U košari').last()).toBeVisible();
+        await expect(page.getByText('Nema nedovršenih radnji.')).toHaveCount(0);
+    });
+});

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -9,6 +9,7 @@ import {
     Inbox,
     ListTodo,
     MailCheck,
+    ShoppingCart,
 } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { cx } from '@signalco/ui-primitives/cx';
@@ -22,16 +23,25 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { type ComponentType, useCallback, useMemo, useRef } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { SegmentedProgress } from '../controls/components/SegmentedProgress';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import {
     type GardenOperationItem,
     type GardenOperationStatus,
     useGardenOperations,
 } from '../hooks/useGardenOperations';
 import { useOperations } from '../hooks/useOperations';
+import {
+    type ShoppingCartItemData,
+    useShoppingCart,
+} from '../hooks/useShoppingCart';
+import { useShoppingCartOpenParam } from '../useUrlState';
 
 type OperationData = NonNullable<
     ReturnType<typeof useOperations>['data']
 >[number];
+type CurrentGardenData = NonNullable<
+    ReturnType<typeof useCurrentGarden>['data']
+>;
 
 const uiPipeline: GardenOperationStatus[] = [
     'new',
@@ -116,6 +126,50 @@ function formatDate(value?: string | null) {
 function formatDateTime(value?: string | null) {
     if (!value) return null;
     return new Date(value).toLocaleString('hr-HR');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseScheduledDate(additionalData: string | null | undefined) {
+    if (!additionalData) return null;
+
+    try {
+        const parsed: unknown = JSON.parse(additionalData);
+        if (!isRecord(parsed) || typeof parsed.scheduledDate !== 'string') {
+            return null;
+        }
+
+        const date = new Date(parsed.scheduledDate);
+        return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    } catch {
+        return null;
+    }
+}
+
+function getTimestamp(value: string | Date | null | undefined) {
+    const timestamp = value ? new Date(value).getTime() : 0;
+    return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function getCartOperationTargetLabel(
+    item: ShoppingCartItemData,
+    garden: CurrentGardenData,
+) {
+    const raisedBed = item.raisedBedId
+        ? garden.raisedBeds.find((bed) => bed.id === item.raisedBedId)
+        : null;
+
+    if (raisedBed && typeof item.positionIndex === 'number') {
+        return `Polje ${item.positionIndex + 1} • ${raisedBed.name}`;
+    }
+
+    if (raisedBed) {
+        return `Gredica: ${raisedBed.name}`;
+    }
+
+    return garden.name || 'Vrt';
 }
 
 function StatusBadge({
@@ -357,6 +411,74 @@ function OperationCard({
     );
 }
 
+function CartOperationCard({
+    item,
+    operationData,
+    targetLabel,
+    onOpenCart,
+}: {
+    item: ShoppingCartItemData;
+    operationData?: OperationData;
+    targetLabel: string;
+    onOpenCart: () => void;
+}) {
+    const scheduledDate = parseScheduledDate(item.additionalData);
+    const operationName =
+        operationData?.information.label ??
+        item.shopData.name ??
+        `Radnja #${item.entityId}`;
+
+    return (
+        <div className="rounded-xl border border-amber-200 bg-amber-50/50 p-3">
+            <Row spacing={1.5} alignItems="start">
+                <div className="size-12 rounded-lg bg-card flex items-center justify-center overflow-hidden shrink-0">
+                    {operationData ? (
+                        <OperationImage operation={operationData} size={40} />
+                    ) : (
+                        <ShoppingCart className="size-5 text-amber-600" />
+                    )}
+                </div>
+                <Stack spacing={0.75} className="min-w-0 flex-1">
+                    <Stack spacing={0.25}>
+                        <Typography level="body2" semiBold noWrap>
+                            {operationName}
+                        </Typography>
+                        <Typography level="body3" secondary>
+                            {targetLabel}
+                        </Typography>
+                    </Stack>
+                    <Row spacing={1} className="flex-wrap">
+                        <Typography level="body3" secondary>
+                            U košari, još nije kupljeno
+                        </Typography>
+                        {scheduledDate && (
+                            <Typography level="body3" secondary>
+                                Zakazano: {formatDate(scheduledDate)}
+                            </Typography>
+                        )}
+                    </Row>
+                    <Row justifyContent="space-between" spacing={1}>
+                        <Row spacing={0.5} className="text-amber-600">
+                            <ShoppingCart className="size-3.5 shrink-0" />
+                            <Typography level="body3" semiBold>
+                                U košari
+                            </Typography>
+                        </Row>
+                        <Button
+                            variant="link"
+                            size="sm"
+                            className="px-0"
+                            onClick={onOpenCart}
+                        >
+                            Otvori košaru
+                        </Button>
+                    </Row>
+                </Stack>
+            </Row>
+        </div>
+    );
+}
+
 function HistoryModal({
     trigger,
     operations,
@@ -448,7 +570,10 @@ function sortScheduledSoonestFirst(operations: GardenOperationItem[]) {
 
 export function GardenOperationsHud() {
     const { track } = useGameAnalytics();
+    const { data: currentGarden } = useCurrentGarden();
     const { data: operationsData } = useOperations();
+    const { data: cart } = useShoppingCart();
+    const [, setShoppingCartOpen] = useShoppingCartOpenParam();
     const pending = useGardenOperations({
         includeCompleted: false,
         pageSize: 10,
@@ -496,6 +621,43 @@ export function GardenOperationsHud() {
             ),
         [operationsData],
     );
+    const cartOperations = useMemo(() => {
+        if (!currentGarden) {
+            return [];
+        }
+
+        return (cart?.items ?? [])
+            .flatMap((item) => {
+                if (
+                    item.entityTypeName !== 'operation' ||
+                    item.status !== 'new' ||
+                    item.gardenId !== currentGarden.id
+                ) {
+                    return [];
+                }
+
+                const operationId = Number(item.entityId);
+                return [
+                    {
+                        item,
+                        operationData: Number.isFinite(operationId)
+                            ? operationDataById.get(operationId)
+                            : undefined,
+                        targetLabel: getCartOperationTargetLabel(
+                            item,
+                            currentGarden,
+                        ),
+                    },
+                ];
+            })
+            .sort(
+                (a, b) =>
+                    getTimestamp(b.item.createdAt) -
+                    getTimestamp(a.item.createdAt),
+            );
+    }, [cart?.items, currentGarden, operationDataById]);
+    const activeOperationCount =
+        pendingOperations.length + cartOperations.length;
 
     return (
         <Popper
@@ -513,7 +675,7 @@ export function GardenOperationsHud() {
                         })
                     }
                 >
-                    {pendingOperations.length > 0 && (
+                    {activeOperationCount > 0 && (
                         <div className="absolute right-1 top-1">
                             <DotIndicator color={'success'} />
                         </div>
@@ -537,24 +699,66 @@ export function GardenOperationsHud() {
                     data-infinite-scroll-root
                     className="max-h-[50vh] overflow-y-auto p-3"
                 >
-                    {pendingOperations.length === 0 ? (
+                    {activeOperationCount === 0 ? (
                         <Typography level="body3" secondary>
                             Nema nedovršenih radnji.
                         </Typography>
                     ) : (
-                        pendingOperations.map((operation) => (
-                            <OperationCard
-                                key={operation.id}
-                                operation={operation}
-                                operationName={
-                                    operationDataById.get(operation.entityId)
-                                        ?.information.label
-                                }
-                                operationData={operationDataById.get(
-                                    operation.entityId,
-                                )}
-                            />
-                        ))
+                        <>
+                            {cartOperations.length > 0 && (
+                                <Stack spacing={1}>
+                                    <Row
+                                        justifyContent="space-between"
+                                        alignItems="center"
+                                    >
+                                        <Typography level="body3" semiBold>
+                                            Radnje u košari
+                                        </Typography>
+                                        <Button
+                                            variant="link"
+                                            size="sm"
+                                            className="px-0"
+                                            onClick={() =>
+                                                setShoppingCartOpen(true)
+                                            }
+                                        >
+                                            Otvori košaru
+                                        </Button>
+                                    </Row>
+                                    {cartOperations.map((cartOperation) => (
+                                        <CartOperationCard
+                                            key={cartOperation.item.id}
+                                            item={cartOperation.item}
+                                            operationData={
+                                                cartOperation.operationData
+                                            }
+                                            targetLabel={
+                                                cartOperation.targetLabel
+                                            }
+                                            onOpenCart={() =>
+                                                setShoppingCartOpen(true)
+                                            }
+                                        />
+                                    ))}
+                                </Stack>
+                            )}
+                            {cartOperations.length > 0 &&
+                                pendingOperations.length > 0 && <Divider />}
+                            {pendingOperations.map((operation) => (
+                                <OperationCard
+                                    key={operation.id}
+                                    operation={operation}
+                                    operationName={
+                                        operationDataById.get(
+                                            operation.entityId,
+                                        )?.information.label
+                                    }
+                                    operationData={operationDataById.get(
+                                        operation.entityId,
+                                    )}
+                                />
+                            ))}
+                        </>
                     )}
                     <div ref={pendingRef} className="h-1" />
                 </Stack>

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -62,9 +62,10 @@ const hiddenFromActive = new Set<GardenOperationStatus>([
     'failed',
     'canceled',
 ]);
-const cartOperationEntityType = 'operation';
-const cartPlantSortEntityType = 'plantSort';
+const cartOperationEntityType = 'operation' as const;
+const cartPlantSortEntityType = 'plantSort' as const;
 const plantingOperationLabel = 'Sadnja';
+const plantSortFallbackLabel = 'Sorta';
 
 type StatusConfig = {
     label: string;
@@ -453,7 +454,7 @@ function CartOperationCard({
             : null;
     const operationName =
         item.entityTypeName === cartPlantSortEntityType
-            ? `${plantingOperationLabel}: ${item.shopData.name ?? `Sorta #${item.entityId}`}`
+            ? `${plantingOperationLabel}: ${item.shopData.name ?? `${plantSortFallbackLabel} #${item.entityId}`}`
             : (operationData?.information.label ??
               item.shopData.name ??
               `Radnja #${item.entityId}`);
@@ -465,7 +466,7 @@ function CartOperationCard({
                     {plantSort ? (
                         <PlantOrSortImage
                             plantSort={plantSort}
-                            alt={item.shopData.name ?? 'Sadnja'}
+                            alt={item.shopData.name ?? plantingOperationLabel}
                             width={40}
                             height={40}
                         />

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -148,6 +148,16 @@ function parseScheduledDate(additionalData: string | null | undefined) {
     }
 }
 
+function getTomorrowDate() {
+    const today = new Date();
+    return new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+}
+
+function getCartOperationScheduledDate(item: ShoppingCartItemData) {
+    const scheduledDate = parseScheduledDate(item.additionalData);
+    return scheduledDate ? new Date(scheduledDate) : getTomorrowDate();
+}
+
 function getTimestamp(value: string | Date | null | undefined) {
     const timestamp = value ? new Date(value).getTime() : 0;
     return Number.isFinite(timestamp) ? timestamp : 0;
@@ -422,7 +432,10 @@ function CartOperationCard({
     targetLabel: string;
     onOpenCart: () => void;
 }) {
-    const scheduledDate = parseScheduledDate(item.additionalData);
+    const scheduledDate = getCartOperationScheduledDate(item);
+    const scheduledDateLabel = parseScheduledDate(item.additionalData)
+        ? formatDate(scheduledDate.toISOString())
+        : 'sutra';
     const operationName =
         operationData?.information.label ??
         item.shopData.name ??
@@ -451,11 +464,9 @@ function CartOperationCard({
                         <Typography level="body3" secondary>
                             U košari, još nije kupljeno
                         </Typography>
-                        {scheduledDate && (
-                            <Typography level="body3" secondary>
-                                Zakazano: {formatDate(scheduledDate)}
-                            </Typography>
-                        )}
+                        <Typography level="body3" secondary>
+                            Zakazano: {scheduledDateLabel}
+                        </Typography>
                     </Row>
                     <Row justifyContent="space-between" spacing={1}>
                         <Row spacing={0.5} className="text-amber-600">
@@ -631,15 +642,18 @@ export function GardenOperationsHud() {
                 if (
                     item.entityTypeName !== 'operation' ||
                     item.status !== 'new' ||
-                    item.gardenId !== currentGarden.id
+                    (item.gardenId != null &&
+                        item.gardenId !== currentGarden.id)
                 ) {
                     return [];
                 }
 
                 const operationId = Number(item.entityId);
+                const scheduledDate = getCartOperationScheduledDate(item);
                 return [
                     {
                         item,
+                        scheduledDate,
                         operationData: Number.isFinite(operationId)
                             ? operationDataById.get(operationId)
                             : undefined,
@@ -650,11 +664,13 @@ export function GardenOperationsHud() {
                     },
                 ];
             })
-            .sort(
-                (a, b) =>
-                    getTimestamp(b.item.createdAt) -
-                    getTimestamp(a.item.createdAt),
-            );
+            .sort((a, b) => {
+                const dateDiff =
+                    getTimestamp(a.scheduledDate) -
+                    getTimestamp(b.scheduledDate);
+
+                return dateDiff !== 0 ? dateDiff : a.item.id - b.item.id;
+            });
     }, [cart?.items, currentGarden, operationDataById]);
     const activeOperationCount =
         pendingOperations.length + cartOperations.length;

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -62,6 +62,9 @@ const hiddenFromActive = new Set<GardenOperationStatus>([
     'failed',
     'canceled',
 ]);
+const cartOperationEntityType = 'operation';
+const cartPlantSortEntityType = 'plantSort';
+const plantingOperationLabel = 'Sadnja';
 
 type StatusConfig = {
     label: string;
@@ -185,8 +188,8 @@ function getCartOperationTargetLabel(
 
 function isCartOperationsPopupItem(item: ShoppingCartItemData) {
     return (
-        item.entityTypeName === 'operation' ||
-        item.entityTypeName === 'plantSort'
+        item.entityTypeName === cartOperationEntityType ||
+        item.entityTypeName === cartPlantSortEntityType
     );
 }
 
@@ -445,10 +448,12 @@ function CartOperationCard({
         ? formatDate(scheduledDate.toISOString())
         : 'sutra';
     const plantSort =
-        item.entityTypeName === 'plantSort' ? item.entityData : null;
+        item.entityTypeName === cartPlantSortEntityType
+            ? item.entityData
+            : null;
     const operationName =
-        item.entityTypeName === 'plantSort'
-            ? `Sadnja: ${item.shopData.name ?? `Sorta #${item.entityId}`}`
+        item.entityTypeName === cartPlantSortEntityType
+            ? `${plantingOperationLabel}: ${item.shopData.name ?? `Sorta #${item.entityId}`}`
             : (operationData?.information.label ??
               item.shopData.name ??
               `Radnja #${item.entityId}`);

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1,4 +1,5 @@
 import { OperationImage } from '@gredice/ui/OperationImage';
+import { PlantOrSortImage } from '@gredice/ui/plants';
 import {
     Approved,
     Calendar,
@@ -153,7 +154,7 @@ function getTomorrowDate() {
     return new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
 }
 
-function getCartOperationScheduledDate(item: ShoppingCartItemData) {
+function getCartItemScheduledDate(item: ShoppingCartItemData) {
     const scheduledDate = parseScheduledDate(item.additionalData);
     return scheduledDate ? new Date(scheduledDate) : getTomorrowDate();
 }
@@ -180,6 +181,13 @@ function getCartOperationTargetLabel(
     }
 
     return garden.name || 'Vrt';
+}
+
+function isCartOperationsPopupItem(item: ShoppingCartItemData) {
+    return (
+        item.entityTypeName === 'operation' ||
+        item.entityTypeName === 'plantSort'
+    );
 }
 
 function StatusBadge({
@@ -432,20 +440,31 @@ function CartOperationCard({
     targetLabel: string;
     onOpenCart: () => void;
 }) {
-    const scheduledDate = getCartOperationScheduledDate(item);
+    const scheduledDate = getCartItemScheduledDate(item);
     const scheduledDateLabel = parseScheduledDate(item.additionalData)
         ? formatDate(scheduledDate.toISOString())
         : 'sutra';
+    const plantSort =
+        item.entityTypeName === 'plantSort' ? item.entityData : null;
     const operationName =
-        operationData?.information.label ??
-        item.shopData.name ??
-        `Radnja #${item.entityId}`;
+        item.entityTypeName === 'plantSort'
+            ? `Sadnja: ${item.shopData.name ?? `Sorta #${item.entityId}`}`
+            : (operationData?.information.label ??
+              item.shopData.name ??
+              `Radnja #${item.entityId}`);
 
     return (
         <div className="rounded-xl border border-amber-200 bg-amber-50/50 p-3">
             <Row spacing={1.5} alignItems="start">
                 <div className="size-12 rounded-lg bg-card flex items-center justify-center overflow-hidden shrink-0">
-                    {operationData ? (
+                    {plantSort ? (
+                        <PlantOrSortImage
+                            plantSort={plantSort}
+                            alt={item.shopData.name ?? 'Sadnja'}
+                            width={40}
+                            height={40}
+                        />
+                    ) : operationData ? (
                         <OperationImage operation={operationData} size={40} />
                     ) : (
                         <ShoppingCart className="size-5 text-amber-600" />
@@ -640,7 +659,7 @@ export function GardenOperationsHud() {
         return (cart?.items ?? [])
             .flatMap((item) => {
                 if (
-                    item.entityTypeName !== 'operation' ||
+                    !isCartOperationsPopupItem(item) ||
                     item.status !== 'new' ||
                     (item.gardenId != null &&
                         item.gardenId !== currentGarden.id)
@@ -649,7 +668,7 @@ export function GardenOperationsHud() {
                 }
 
                 const operationId = Number(item.entityId);
-                const scheduledDate = getCartOperationScheduledDate(item);
+                const scheduledDate = getCartItemScheduledDate(item);
                 return [
                     {
                         item,


### PR DESCRIPTION
## Summary
- Added shopping-cart operation items to the in-game operations popup so unpaid operations are visible there too.
- Kept cart operations grouped at the top of the popup and linked the entry to the cart drawer.
- Added a regression component test covering the cart-operation case.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm test --filter @gredice/game`
- `pnpm build --filter garden`
- `pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx`
- `pnpm build --filter www --force`