### PR TITLE
Add header to time popover and simplify TimeDisplay

### DIFF
--- a/packages/game/src/hud/WeatherHud.tsx
+++ b/packages/game/src/hud/WeatherHud.tsx
@@ -119,7 +119,7 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
                             </Button>
                         }
                     >
-                        <TimeDisplay variant="card" />
+                        <TimeDisplay />
                     </Popper>
                 )}
             </Row>

--- a/packages/game/src/hud/components/TimeDisplay.tsx
+++ b/packages/game/src/hud/components/TimeDisplay.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Divider } from '@signalco/ui-primitives/Divider';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
@@ -7,11 +8,7 @@ import { useLiveTime } from '../../hooks/useLiveTime';
 import { useGameState } from '../../useGameState';
 import { DayNightVisualization } from './DayNightVisualization';
 
-export function TimeDisplay({
-    variant = 'overlay',
-}: {
-    variant?: 'card' | 'overlay';
-}) {
+export function TimeDisplay() {
     const currentTime = useLiveTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const sunrise = useGameState((state) => state.sunriseTime);
@@ -20,39 +17,46 @@ export function TimeDisplay({
     const isDaytime = timeOfDay > 0.2 && timeOfDay < 0.8;
 
     return (
-        <Stack
-            className={variant === 'overlay' ? 'pt-16 pb-2 px-4' : 'px-4 py-3'}
-        >
-            {variant === 'card' && (
-                <DayNightVisualization className="w-full h-12 overflow-visible mb-2" />
-            )}
-            <Row justifyContent="space-between">
-                <Typography level="body3">
-                    {(isDaytime ? sunrise : sunset)?.toLocaleTimeString(
-                        'hr-HR',
-                        { hour: '2-digit', minute: '2-digit' },
-                    )}
-                </Typography>
-                <Typography center className="font-[Arial,sans-serif]">
-                    {currentTime?.toLocaleTimeString('hr-HR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                    })}
-                </Typography>
-                <Typography level="body3">
-                    {(isDaytime ? sunset : sunrise)?.toLocaleTimeString(
-                        'hr-HR',
-                        { hour: '2-digit', minute: '2-digit' },
-                    )}
+        <Stack>
+            <Row
+                className="bg-background px-4 py-2"
+                justifyContent="space-between"
+            >
+                <Typography level="body2" bold>
+                    Doba dana
                 </Typography>
             </Row>
-            <Typography level="body2" center>
-                {new Date().toLocaleDateString('hr-HR', {
-                    day: 'numeric',
-                    month: 'long',
-                    year: 'numeric',
-                })}
-            </Typography>
+            <Divider />
+            <Stack className="px-4 py-3">
+                <DayNightVisualization className="w-full h-12 overflow-visible mb-2" />
+                <Row justifyContent="space-between">
+                    <Typography level="body3">
+                        {(isDaytime ? sunrise : sunset)?.toLocaleTimeString(
+                            'hr-HR',
+                            { hour: '2-digit', minute: '2-digit' },
+                        )}
+                    </Typography>
+                    <Typography center className="font-[Arial,sans-serif]">
+                        {currentTime?.toLocaleTimeString('hr-HR', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                        })}
+                    </Typography>
+                    <Typography level="body3">
+                        {(isDaytime ? sunset : sunrise)?.toLocaleTimeString(
+                            'hr-HR',
+                            { hour: '2-digit', minute: '2-digit' },
+                        )}
+                    </Typography>
+                </Row>
+                <Typography level="body2" center>
+                    {new Date().toLocaleDateString('hr-HR', {
+                        day: 'numeric',
+                        month: 'long',
+                        year: 'numeric',
+                    })}
+                </Typography>
+            </Stack>
         </Stack>
     );
 }


### PR DESCRIPTION
## Summary
- Add a "Doba dana" header to the time popover in `WeatherHud`, matching the header pattern used by the "Aktualno vrijeme" and "Prognoza" weather popovers.
- Drop the unused `overlay` variant from `TimeDisplay` (only the `card` variant was ever rendered) and remove the now-redundant `variant` prop at the callsite.

## Test plan
- [ ] Open the game HUD, click the current-time button in the weather card, and confirm the popover shows the new bold "Doba dana" header with a divider above the day/night visualization.
- [ ] Confirm the weather "Aktualno vrijeme" and "Prognoza" popovers still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)