### PR TITLE
feat(game): show raised bed context icon in notification items

### DIFF
--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -1,6 +1,7 @@
 import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Markdown } from '@gredice/ui/Markdown';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Alert } from '@signalco/ui/Alert';
 import { Check } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
@@ -48,6 +49,13 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
     const setNotificationRead = useSetNotificationRead();
     const { data: currentGarden } = useCurrentGarden();
 
+    const raisedBed = useMemo(() => {
+        if (!raisedBedId || !currentGarden) {
+            return undefined;
+        }
+        return currentGarden.raisedBeds.find((bed) => bed.id === raisedBedId);
+    }, [raisedBedId, currentGarden]);
+
     // TODO: Remove this backward compatibility code after December 9, 2026
     // This generates the raised bed closeup URL from raisedBedId if linkUrl is not present
     // After all notifications have been migrated to include linkUrl, this can be removed
@@ -57,17 +65,12 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
         }
 
         // Backward compatibility: generate URL from raisedBedId if linkUrl is missing
-        if (raisedBedId && currentGarden) {
-            const raisedBed = currentGarden.raisedBeds.find(
-                (bed) => bed.id === raisedBedId,
-            );
-            if (raisedBed?.name) {
-                return getRaisedBedCloseupUrl(raisedBed.name);
-            }
+        if (raisedBed?.name) {
+            return getRaisedBedCloseupUrl(raisedBed.name);
         }
 
         return '#';
-    }, [linkUrl, raisedBedId, currentGarden]);
+    }, [linkUrl, raisedBed]);
 
     const isRead = Boolean(readAt);
 
@@ -166,6 +169,17 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
                     <Check className="size-4 shrink-0 hidden group-hover:block" />
                 )}
             </button>
+            {raisedBed?.physicalId && (
+                <div
+                    className="pointer-events-none absolute bottom-2 right-2 text-muted-foreground"
+                    title={`Gredica ${raisedBed.physicalId}`}
+                >
+                    <RaisedBedIcon
+                        physicalId={raisedBed.physicalId}
+                        className="size-5"
+                    />
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Notification list items now display the `RaisedBedIcon` with the bed's physical identifier in the bottom-right corner when the notification is linked to a raised bed.
- Acts as a lightweight context indicator so users can tell at a glance which bed a notification refers to without opening it.

## Implementation notes
- Extracted the raised bed lookup (by `raisedBedId` against `currentGarden.raisedBeds`) into a shared `useMemo`, reused by both the existing `computedLinkUrl` backward-compat path and the new icon.
- The icon is absolutely positioned at `bottom-2 right-2` and is `pointer-events-none`, so it does not interfere with the item click or the existing top-right mark-as-read button.
- Only renders when the matched raised bed has a `physicalId`.

## Test plan
- [ ] Open notifications panel in the game HUD with a notification that has a `raisedBedId` matching a bed in the current garden → icon with physical ID appears in the bottom-right.
- [ ] Notifications without a `raisedBedId` (or with one not present in the current garden) show no icon.
- [ ] Mark-as-read button in the top-right still works; clicking the body still navigates to the raised bed closeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)