### PR TITLE
fix(game): use white checkmark on unread notification toggle

### DIFF
--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -166,7 +166,7 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
                 onClick={handleSetNotificationRead}
             >
                 {!isRead && (
-                    <Check className="size-4 shrink-0 hidden group-hover:block" />
+                    <Check className="size-4 shrink-0 hidden group-hover:block text-white" />
                 )}
             </button>
             {raisedBed?.physicalId && (


### PR DESCRIPTION
## Summary
- The hover checkmark on the "Označi kao pročitano" toggle in notification list items rendered in the default dark text color on top of `bg-green-600`, which had poor contrast and was hard to see.
- Add `text-white` to the `Check` icon so it reads clearly against the green pill.

## Test plan
- [ ] Open the notifications panel in the game HUD.
- [ ] Hover an unread notification's status pill (the green dot in the top-right): the checkmark inside it should now appear in white and be clearly visible.
- [ ] Read notifications still show the outlined ring with no checkmark — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)