### PR TITLE
Show cross-account gardens in the picker and switch active account on selection

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -33,6 +33,7 @@ import {
     accountCookieName,
     cookieDomain,
 } from '../../../lib/auth/sessionConfig';
+import { authSecurity } from '../../../lib/docs/security';
 import { sendAccountInvitation } from '../../../lib/email/transactional';
 import {
     type AuthVariables,
@@ -758,10 +759,59 @@ const app = new Hono<{ Variables: AuthVariables }>()
             );
         },
     )
+    .get(
+        '/gardens',
+        describeRoute({
+            description:
+                'Get garden picker groups for every account the current user can access.',
+            security: authSecurity,
+        }),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const {
+                accountId: currentAccountId,
+                user,
+                userId,
+            } = context.get('authContext');
+            const currentUser = await getUser(userId);
+            const fallbackEmail = currentUser?.userName ?? 'Gredice';
+            const orderedAccountIds = [
+                currentAccountId,
+                ...user.accountIds.filter(
+                    (accountId) => accountId !== currentAccountId,
+                ),
+            ];
+
+            const accountGardenGroups = await Promise.all(
+                orderedAccountIds.map(async (accountId) => {
+                    const [accountUsers, gardens] = await Promise.all([
+                        getAccountUsers(accountId),
+                        getAccountGardens(accountId),
+                    ]);
+                    const accountEmail =
+                        accountUsers[0]?.user.userName ?? fallbackEmail;
+
+                    return {
+                        accountId,
+                        name: `${accountEmail} račun`,
+                        isCurrent: accountId === currentAccountId,
+                        gardens: gardens.map((garden) => ({
+                            id: garden.id,
+                            name: garden.name,
+                            createdAt: garden.createdAt,
+                        })),
+                    };
+                }),
+            );
+
+            return context.json(accountGardenGroups);
+        },
+    )
     .post(
         '/switch',
         describeRoute({
             description: 'Switch the active account for the current user',
+            security: authSecurity,
         }),
         zValidator(
             'json',

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -67,6 +67,17 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
             body = signedIn ? currentUser : null;
         } else if (pathname.endsWith('/api/gardens')) {
             body = signedIn ? [] : null;
+        } else if (pathname.endsWith('/api/accounts/gardens')) {
+            body = signedIn
+                ? [
+                      {
+                          accountId: 'test-account',
+                          name: 'test@example.com račun',
+                          isCurrent: true,
+                          gardens: [],
+                      },
+                  ]
+                : null;
         } else if (pathname.includes('/api/directories/entities/')) {
             body = [];
         } else if (pathname.endsWith('/api/data/weather/now')) {

--- a/packages/game/src/hooks/useGardenAccountGroups.ts
+++ b/packages/game/src/hooks/useGardenAccountGroups.ts
@@ -1,0 +1,26 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+import { useGardensKeys } from './useGardens';
+
+export const gardenAccountGroupsKeys = [...useGardensKeys, 'accountGroups'];
+
+export function useGardenAccountGroups(disabled?: boolean) {
+    return useQuery({
+        queryKey: gardenAccountGroupsKeys,
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.accounts.gardens.$get();
+            if (response.status === 401) return null;
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to fetch account garden groups: ${response.status} ${response.statusText}`,
+                );
+            }
+
+            return response.json();
+        },
+        retry: false,
+        enabled: !disabled,
+        staleTime: 1000 * 60 * 5,
+    });
+}

--- a/packages/game/src/hooks/useSwitchGardenAccount.ts
+++ b/packages/game/src/hooks/useSwitchGardenAccount.ts
@@ -1,0 +1,24 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation } from '@tanstack/react-query';
+
+type SwitchGardenAccountVariables = {
+    accountId: string;
+};
+
+export function useSwitchGardenAccount() {
+    return useMutation({
+        mutationFn: async ({ accountId }: SwitchGardenAccountVariables) => {
+            const response =
+                await clientAuthenticated().api.accounts.switch.$post({
+                    json: { accountId },
+                });
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to switch account: ${response.status} ${response.statusText}`,
+                );
+            }
+
+            return response.json();
+        },
+    });
+}

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -1,18 +1,15 @@
 import { useSearchParam } from '@signalco/hooks/useSearchParam';
 import {
     Approved,
-    Check,
     Comment,
     Configuration,
     ExternalLink,
     Inbox,
     LogOut,
-    MapPinHouse,
     Sprout,
     User,
 } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
-import { cx } from '@signalco/ui-primitives/cx';
 import { Divider } from '@signalco/ui-primitives/Divider';
 import { DotIndicator } from '@signalco/ui-primitives/DotIndicator';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
@@ -20,27 +17,24 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
-    DropdownMenuLabel,
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@signalco/ui-primitives/Menu';
 import { Popper } from '@signalco/ui-primitives/Popper';
 import { Row } from '@signalco/ui-primitives/Row';
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Skeleton } from '@signalco/ui-primitives/Skeleton';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useCurrentUser } from '../hooks/useCurrentUser';
-import { useGardens } from '../hooks/useGardens';
 import { useMarkAllNotificationsRead } from '../hooks/useMarkAllNotificationsRead';
 import { useNotifications } from '../hooks/useNotifications';
 import { KnownPages } from '../knownPages';
 import { ProfileAvatar } from '../shared-ui/ProfileAvatar';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
-import { useCurrentGardenIdParam } from '../useUrlState';
 import { HudCard } from './components/HudCard';
+import { GardenAccountMenuItems } from './GardenAccountMenuItems';
 import { GardenOperationsHud } from './GardenOperationsHud';
 import { NotificationList } from './NotificationList';
 
@@ -101,11 +95,8 @@ function NotificationsCard() {
 
 function ProfileCard() {
     const [, setProfileModalOpen] = useSearchParam('pregled');
-    const [, setSelectedGardenId] = useCurrentGardenIdParam();
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser();
-    const { data: currentGarden } = useCurrentGarden();
-    const { data: gardens, isLoading: gardensLoading } = useGardens();
     const { data: notifications } = useNotifications(currentUser?.id, false);
     const hasUnreadNotifications = notifications?.some(
         (notification) => !notification.readAt,
@@ -115,48 +106,9 @@ function ProfileCard() {
         <DropdownMenuContent className="w-80 p-4" align="end" sideOffset={12}>
             <ProfileInfo />
             <DropdownMenuSeparator className="my-4" />
-            {gardensLoading && (
-                <DropdownMenuLabel>
-                    <Skeleton className="h-5 w-32 ml-6" />
-                </DropdownMenuLabel>
-            )}
-            {gardens?.map((garden) => (
-                <DropdownMenuItem
-                    key={garden.id}
-                    className="gap-3"
-                    onClick={() => {
-                        track('game_garden_switched', {
-                            from_garden_id: currentGarden?.id,
-                            to_garden_id: garden.id,
-                            to_garden_name: garden.name,
-                        });
-                        setSelectedGardenId(garden.id);
-                    }}
-                >
-                    <Check
-                        aria-hidden={garden.id !== currentGarden?.id}
-                        className={cx(
-                            'size-4 shrink-0 opacity-0',
-                            garden.id === currentGarden?.id && 'opacity-100',
-                        )}
-                    />
-                    <Typography noWrap>{garden.name}</Typography>
-                </DropdownMenuItem>
-            ))}
-            {!gardensLoading && (gardens?.length ?? 0) <= 0 && (
-                <>
-                    <DropdownMenuLabel className="text-muted-foreground text-center">
-                        Još nemaš svoj vrt
-                    </DropdownMenuLabel>
-                    <DropdownMenuItem
-                        className="gap-3"
-                        onClick={() => setProfileModalOpen('vrt')}
-                    >
-                        <MapPinHouse className="size-4" />
-                        <span>Pregled tvojih vrtovima</span>
-                    </DropdownMenuItem>
-                </>
-            )}
+            <GardenAccountMenuItems
+                onGardenOverviewOpen={() => setProfileModalOpen('vrt')}
+            />
             <DropdownMenuSeparator className="my-4" />
             <DropdownMenuItem
                 className="gap-3"
@@ -228,8 +180,6 @@ export function AccountHud() {
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser();
     const { data: currentGarden, isLoading } = useCurrentGarden();
-    const { data: gardens } = useGardens();
-    const [, setSelectedGardenId] = useCurrentGardenIdParam();
     const { data: notifications } = useNotifications(currentUser?.id, false);
     const hasUnreadNotifications = notifications?.some(
         (notification) => !notification.readAt,
@@ -263,33 +213,27 @@ export function AccountHud() {
                     {isLoading ? (
                         <Skeleton className="w-32 h-7" />
                     ) : (
-                        gardens &&
                         currentGarden && (
-                            <SelectItems
-                                className="w-32"
-                                variant="plain"
-                                value={currentGarden.id.toString()}
-                                onValueChange={(value) => {
-                                    const gardenId = Number.parseInt(value, 10);
-                                    // Set to null when selecting the first garden (default)
-                                    const isDefault =
-                                        gardens?.[0]?.id === gardenId;
-                                    track('game_garden_switched', {
-                                        from_garden_id: currentGarden.id,
-                                        to_garden_id: gardenId,
-                                        to_garden_name: gardens?.find(
-                                            (garden) => garden.id === gardenId,
-                                        )?.name,
-                                    });
-                                    setSelectedGardenId(
-                                        isDefault ? null : gardenId,
-                                    );
-                                }}
-                                items={gardens?.map((garden) => ({
-                                    label: garden.name,
-                                    value: garden.id.toString(),
-                                }))}
-                            />
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        className="w-32 justify-start overflow-hidden px-2"
+                                        variant="plain"
+                                        title="Odaberi vrt"
+                                    >
+                                        <Typography noWrap>
+                                            {currentGarden.name}
+                                        </Typography>
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                    className="w-72 p-2"
+                                    align="start"
+                                    sideOffset={12}
+                                >
+                                    <GardenAccountMenuItems />
+                                </DropdownMenuContent>
+                            </DropdownMenu>
                         )
                     )}
                 </div>

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -59,8 +59,8 @@ export function GardenAccountMenuItems({
                 await switchGardenAccount.mutateAsync({
                     accountId: accountGroup.accountId,
                 });
-                await setSelectedGardenId(garden.id);
                 await queryClient.invalidateQueries();
+                await setSelectedGardenId(garden.id);
                 return;
             }
 

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -1,0 +1,136 @@
+import { Check, MapPinHouse } from '@signalco/ui-icons';
+import { cx } from '@signalco/ui-primitives/cx';
+import {
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+} from '@signalco/ui-primitives/Menu';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import { useQueryClient } from '@tanstack/react-query';
+import { Fragment } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useGardenAccountGroups } from '../hooks/useGardenAccountGroups';
+import { useGardens } from '../hooks/useGardens';
+import { useSwitchGardenAccount } from '../hooks/useSwitchGardenAccount';
+import { useCurrentGardenIdParam } from '../useUrlState';
+
+type GardenAccountMenuItemsProps = {
+    onGardenOverviewOpen?: () => void;
+};
+
+export function GardenAccountMenuItems({
+    onGardenOverviewOpen,
+}: GardenAccountMenuItemsProps) {
+    const queryClient = useQueryClient();
+    const [, setSelectedGardenId] = useCurrentGardenIdParam();
+    const { track } = useGameAnalytics();
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: currentAccountGardens, isLoading: currentGardensLoading } =
+        useGardens();
+    const { data: accountGroups, isLoading: accountGroupsLoading } =
+        useGardenAccountGroups();
+    const switchGardenAccount = useSwitchGardenAccount();
+    const visibleGroups =
+        accountGroups?.filter((group) => group.gardens.length > 0) ?? [];
+    const showAccountLabels =
+        visibleGroups.length > 1 ||
+        visibleGroups.some((accountGroup) => !accountGroup.isCurrent);
+    const isLoading = currentGardensLoading || accountGroupsLoading;
+
+    async function handleGardenSelect(
+        accountGroup: (typeof visibleGroups)[number],
+        garden: (typeof visibleGroups)[number]['gardens'][number],
+    ) {
+        if (switchGardenAccount.isPending) {
+            return;
+        }
+
+        track('game_garden_switched', {
+            from_garden_id: currentGarden?.id,
+            to_garden_id: garden.id,
+            to_garden_name: garden.name,
+            to_account_id: accountGroup.accountId,
+            switched_account: !accountGroup.isCurrent,
+        });
+
+        try {
+            if (!accountGroup.isCurrent) {
+                await switchGardenAccount.mutateAsync({
+                    accountId: accountGroup.accountId,
+                });
+                await setSelectedGardenId(garden.id);
+                await queryClient.invalidateQueries();
+                return;
+            }
+
+            const isDefault = currentAccountGardens?.[0]?.id === garden.id;
+            await setSelectedGardenId(isDefault ? null : garden.id);
+        } catch (error) {
+            console.error('Failed to switch garden account:', error);
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <DropdownMenuLabel className="text-muted-foreground">
+                Učitavanje vrtova...
+            </DropdownMenuLabel>
+        );
+    }
+
+    if (visibleGroups.length <= 0) {
+        return (
+            <>
+                <DropdownMenuLabel className="text-muted-foreground text-center">
+                    Još nemaš svoj vrt
+                </DropdownMenuLabel>
+                {onGardenOverviewOpen && (
+                    <DropdownMenuItem
+                        className="gap-3"
+                        onClick={onGardenOverviewOpen}
+                    >
+                        <MapPinHouse className="size-4" />
+                        <span>Pregled tvojih vrtovima</span>
+                    </DropdownMenuItem>
+                )}
+            </>
+        );
+    }
+
+    return (
+        <>
+            {visibleGroups.map((accountGroup, groupIndex) => (
+                <Fragment key={accountGroup.accountId}>
+                    {groupIndex > 0 && (
+                        <DropdownMenuSeparator className="my-2" />
+                    )}
+                    {showAccountLabels && (
+                        <DropdownMenuLabel className="text-muted-foreground text-xs px-2 py-1">
+                            <Typography noWrap>{accountGroup.name}</Typography>
+                        </DropdownMenuLabel>
+                    )}
+                    {accountGroup.gardens.map((garden) => (
+                        <DropdownMenuItem
+                            key={`${accountGroup.accountId}:${garden.id}`}
+                            className="gap-3"
+                            onClick={() =>
+                                handleGardenSelect(accountGroup, garden)
+                            }
+                        >
+                            <Check
+                                aria-hidden={garden.id !== currentGarden?.id}
+                                className={cx(
+                                    'size-4 shrink-0 opacity-0',
+                                    garden.id === currentGarden?.id &&
+                                        'opacity-100',
+                                )}
+                            />
+                            <Typography noWrap>{garden.name}</Typography>
+                        </DropdownMenuItem>
+                    ))}
+                </Fragment>
+            ))}
+        </>
+    );
+}

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -31,8 +31,24 @@ export function GardenAccountMenuItems({
     const { data: accountGroups, isLoading: accountGroupsLoading } =
         useGardenAccountGroups();
     const switchGardenAccount = useSwitchGardenAccount();
-    const visibleGroups =
-        accountGroups?.filter((group) => group.gardens.length > 0) ?? [];
+    const fallbackGroups =
+        currentAccountGardens && currentAccountGardens.length > 0
+            ? [
+                  {
+                      accountId: 'current',
+                      name: 'Trenutni račun',
+                      isCurrent: true,
+                      gardens: currentAccountGardens,
+                  },
+              ]
+            : [];
+    const gardenGroups =
+        accountGroups && accountGroups.length > 0
+            ? accountGroups
+            : fallbackGroups;
+    const visibleGroups = gardenGroups.filter(
+        (group) => group.gardens.length > 0,
+    );
     const showAccountLabels =
         visibleGroups.length > 1 ||
         visibleGroups.some((accountGroup) => !accountGroup.isCurrent);

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -2,13 +2,21 @@ import { Add } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card, CardContent } from '@signalco/ui-primitives/Card';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+} from '@signalco/ui-primitives/Menu';
 import { Row } from '@signalco/ui-primitives/Row';
-import { SelectItems } from '@signalco/ui-primitives/SelectItems';
+import { Skeleton } from '@signalco/ui-primitives/Skeleton';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useGardenAccountGroups } from '../../hooks/useGardenAccountGroups';
 import { useGardens } from '../../hooks/useGardens';
+import { GardenAccountMenuItems } from '../../hud/GardenAccountMenuItems';
 import { useCurrentGardenIdParam } from '../../useUrlState';
 import { CreateGardenModal } from './CreateGardenModal';
 import { GardenNameCard } from './GardenNameCard';
@@ -50,49 +58,36 @@ function NoGardensCard() {
 
 function GardensSelector() {
     const { data: gardens } = useGardens();
+    const { data: currentGarden } = useCurrentGarden();
     const [createGardenModalOpen, setCreateGardenModalOpen] = useState(false);
-    const [selectedGardenId, setSelectedGardenId] = useCurrentGardenIdParam();
+    const [selectedGardenId] = useCurrentGardenIdParam();
     const { track } = useGameAnalytics();
     const selectedGarden =
-        gardens?.find((g) => g.id === selectedGardenId) ?? gardens?.[0];
+        gardens?.find((g) => g.id === selectedGardenId) ??
+        currentGarden ??
+        gardens?.[0];
 
     return (
         <>
             <Row>
-                <div className="bg-card rounded grow">
-                    <SelectItems
-                        value={
-                            selectedGardenId?.toString() ??
-                            selectedGarden?.id.toString()
-                        }
-                        onValueChange={(value) => {
-                            const nextGardenId =
-                                Number.parseInt(value, 10) || 0;
-                            const nextGarden = gardens?.find(
-                                (garden) => garden.id === nextGardenId,
-                            );
-                            track('game_garden_switched', {
-                                from_garden_id: selectedGarden?.id,
-                                to_garden_id: nextGardenId,
-                                to_garden_name: nextGarden?.name,
-                            });
-                            setSelectedGardenId(nextGardenId);
-                        }}
-                        items={
-                            gardens?.map((g) => ({
-                                label: (
-                                    <>
-                                        <Row spacing={1}>
-                                            <span>🏡</span>
-                                            <Typography>{g.name}</Typography>
-                                        </Row>
-                                    </>
-                                ),
-                                value: g.id.toString(),
-                            })) ?? []
-                        }
-                    />
-                </div>
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            className="bg-card rounded grow justify-start overflow-hidden"
+                            variant="plain"
+                        >
+                            <Row spacing={1} className="min-w-0">
+                                <span>🏡</span>
+                                <Typography noWrap>
+                                    {selectedGarden?.name ?? 'Odaberi vrt'}
+                                </Typography>
+                            </Row>
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-80 p-2" align="start">
+                        <GardenAccountMenuItems />
+                    </DropdownMenuContent>
+                </DropdownMenu>
                 <IconButton
                     title="Kreiraj novi vrt"
                     variant="plain"
@@ -115,10 +110,20 @@ function GardensSelector() {
 }
 
 export function GardenTab() {
-    const { data: gardens } = useGardens();
+    const {
+        data: gardens,
+        isLoading: gardensLoading,
+        isError: gardensError,
+    } = useGardens();
+    const { data: accountGroups, isLoading: accountGroupsLoading } =
+        useGardenAccountGroups();
     const [selectedGardenId] = useCurrentGardenIdParam();
     const selectedGarden =
         gardens?.find((g) => g.id === selectedGardenId) ?? gardens?.[0];
+    const hasAnyGarden =
+        (gardens?.length ?? 0) > 0 ||
+        (accountGroups?.some((group) => group.gardens.length > 0) ?? false);
+    const isLoading = gardensLoading || accountGroupsLoading;
 
     return (
         <Stack spacing={4}>
@@ -126,7 +131,9 @@ export function GardenTab() {
                 🏡 Vrt
             </Typography>
             <Stack spacing={1}>
-                {gardens && gardens.length > 0 ? (
+                {isLoading && !hasAnyGarden ? (
+                    <Skeleton className="h-10 w-full" />
+                ) : hasAnyGarden || gardensError ? (
                     <>
                         <GardensSelector />
                         {selectedGarden && (


### PR DESCRIPTION
## Summary
- Added a grouped `GET /api/accounts/gardens` endpoint so the picker can show gardens from every account the current user can access.
- Updated the game HUD picker to group gardens by account and fall back to `"<email> račun"` when no account name exists.
- When selecting a garden from another account, the UI now switches the active account first and then selects that garden.
- Updated the garden landing mock to cover the new accounts gardens endpoint.

## Testing
- Lint passed for `api`, `@gredice/game`, and `garden`.
- API node tests passed.
- Game package tests passed.
- API and garden production builds passed.
- Garden Playwright landing tests passed in Chromium.