### PR TITLE
[Basket] Design item-filled basket visual

### DIFF
--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -321,12 +321,11 @@ export function ShoppingCartHud() {
                                             .slice(0, 2)
                                             .map((item, index) => {
                                                 const imageUrl =
-                                                    item.entityTypeName ===
-                                                    'plantSort'
-                                                        ? (item.entityData
-                                                              ?.iconImage ??
-                                                          null)
-                                                        : item.shopData.image;
+                                                    item.shopData.image ??
+                                                    item.entityData.image?.cover
+                                                        ?.url ??
+                                                    item.entityData.images
+                                                        ?.cover?.url;
                                                 return imageUrl ? (
                                                     <div
                                                         key={item.id}

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -322,9 +322,9 @@ export function ShoppingCartHud() {
                                             .map((item, index) => {
                                                 const imageUrl =
                                                     item.shopData.image ??
-                                                    item.entityData.image?.cover
-                                                        ?.url ??
-                                                    item.entityData.images
+                                                    item.entityData?.image
+                                                        ?.cover?.url ??
+                                                    item.entityData?.images
                                                         ?.cover?.url;
                                                 return imageUrl ? (
                                                     <div

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -313,7 +313,56 @@ export function ShoppingCartHud() {
                             variant="plain"
                             className="relative rounded-full p-2 gap-2"
                         >
-                            <ShoppingCartIcon className="!stroke-[1.4px] shrink-0  size-6" />
+                            <div className="relative size-7 shrink-0">
+                                <ShoppingCartIcon className="!stroke-[1.4px] size-7 text-foreground" />
+                                {cart.items.length > 0 && (
+                                    <div className="absolute left-[3px] top-[9px] flex items-center gap-0.5 max-w-[22px] overflow-hidden">
+                                        {cart.items
+                                            .slice(0, 2)
+                                            .map((item, index) => {
+                                                const imageUrl =
+                                                    item.entityTypeName ===
+                                                    'plantSort'
+                                                        ? (item.entityData
+                                                              ?.iconImage ??
+                                                          null)
+                                                        : item.shopData.image;
+                                                return imageUrl ? (
+                                                    <div
+                                                        key={item.id}
+                                                        aria-hidden
+                                                        className={cx(
+                                                            'size-2.5 rounded-sm border border-background bg-cover bg-center shadow-sm',
+                                                            index === 1 &&
+                                                                '-ml-0.5',
+                                                        )}
+                                                        style={{
+                                                            backgroundImage: `url(${imageUrl})`,
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <div
+                                                        key={item.id}
+                                                        aria-hidden
+                                                        className={cx(
+                                                            'size-2.5 rounded-sm border border-background bg-muted',
+                                                            index === 1 &&
+                                                                '-ml-0.5',
+                                                        )}
+                                                    />
+                                                );
+                                            })}
+                                        {cart.items.length > 2 && (
+                                            <span
+                                                aria-hidden
+                                                className="-ml-0.5 rounded-sm bg-background/95 px-0.5 text-[8px] leading-none text-foreground border border-muted"
+                                            >
+                                                +{cart.items.length - 2}
+                                            </span>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
                             <Typography
                                 level="body2"
                                 semiBold


### PR DESCRIPTION
### Motivation
- Improve the compact basket HUD affordance so it reads as a basket that contains items without changing layout. 
- Provide an immediate visual signal for empty vs populated states and a compact way to communicate item counts at small sizes.

### Description
- Render miniature item previews inside the basket hub trigger in `packages/game/src/hud/ShoppingCartHud.tsx` by layering a small preview area over the existing basket icon. 
- Show up to two item thumbnails (sourced from `plantSort` `iconImage` or `shopData.image`) and a `+N` overflow badge when more than two items exist. 
- Use a muted fallback tile when an item has no image, and use a `div` with `background-image` for thumbnails (avoids `<img>` usage and satisfies Lint guidance). 
- Preserve existing price label and the existing DotIndicator/count badge so there are no unexpected layout shifts.

### Testing
- Ran `pnpm lint --filter @gredice/game`, fixed an initial lint warning (removed `<img>` use) and final lint run passes.
- Lint output contains an environment warning about Node engine mismatch (`runner Node 22 vs repo required >=24`) but it does not block the checks. 
- Did not run `pnpm test --filter @gredice/game` or `pnpm build --filter @gredice/game` for this quick visual change. If you want full validation, run those commands from the repo root as described in `AGENTS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07306d4a2c832fb7a055dc210b6845)