### PR TITLE
[Notifications] Add preference-aware delivery router in storage

### DIFF
--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -5,12 +5,112 @@ import { isTargetHourInTimeZone } from '../helpers/timezoneUtils';
 import {
     accountUsers,
     type InsertNotification,
+    notificationDeliveryAttempts,
     notificationEmailLog,
     notifications,
+    notificationUserChannelPreferences,
     type SelectNotification,
+    type SelectNotificationUserChannelPreference,
     userNotificationSettings,
     users,
+    webPushSubscriptions,
 } from '../schema';
+
+type DeliveryChannel = 'email' | 'push';
+type DeliveryOutcome = 'immediate' | 'digest' | 'suppressed' | 'required';
+
+export type NotificationDeliveryDecision = {
+    channel: DeliveryChannel;
+    outcome: DeliveryOutcome;
+    reason: string;
+    required: boolean;
+};
+
+function minutesInTimezone(date: Date, timeZone?: string): number | undefined {
+    if (!timeZone) return undefined;
+    const formatter = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        hour: '2-digit',
+        minute: '2-digit',
+        hourCycle: 'h23',
+    });
+    const parts = formatter.formatToParts(date);
+    const hour = Number(parts.find((p) => p.type === 'hour')?.value ?? '0');
+    const minute = Number(parts.find((p) => p.type === 'minute')?.value ?? '0');
+    return hour * 60 + minute;
+}
+
+function isInsideQuietHours(
+    nowMinute: number | undefined,
+    preference: SelectNotificationUserChannelPreference,
+): boolean {
+    if (
+        nowMinute === undefined ||
+        preference.quietHoursStartMinute === null ||
+        preference.quietHoursEndMinute === null
+    ) {
+        return false;
+    }
+    const start = preference.quietHoursStartMinute;
+    const end = preference.quietHoursEndMinute;
+    if (start === end) return false;
+    return start < end
+        ? nowMinute >= start && nowMinute < end
+        : nowMinute >= start || nowMinute < end;
+}
+
+function decideDeliveryOutcome({
+    channel,
+    preference,
+    hasPushSubscription,
+    now,
+}: {
+    channel: DeliveryChannel;
+    preference?: SelectNotificationUserChannelPreference;
+    hasPushSubscription: boolean;
+    now: Date;
+}): NotificationDeliveryDecision {
+    const required = preference?.required ?? false;
+    if (channel === 'push' && !hasPushSubscription) {
+        return {
+            channel,
+            outcome: required ? 'required' : 'suppressed',
+            reason: 'missing_push_subscription',
+            required,
+        };
+    }
+    if ((preference?.enabled ?? true) === false) {
+        return {
+            channel,
+            outcome: required ? 'required' : 'suppressed',
+            reason: 'preference_disabled',
+            required,
+        };
+    }
+    const nowMinute = minutesInTimezone(now, preference?.timezone ?? undefined);
+    if (!required && preference && isInsideQuietHours(nowMinute, preference)) {
+        return {
+            channel,
+            outcome: 'digest',
+            reason: 'quiet_hours',
+            required: false,
+        };
+    }
+    if (!required && (preference?.digestFrequency ?? 'off') !== 'off') {
+        return {
+            channel,
+            outcome: 'digest',
+            reason: `digest_${preference?.digestFrequency}`,
+            required: false,
+        };
+    }
+    return {
+        channel,
+        outcome: required ? 'required' : 'immediate',
+        reason: required ? 'required_notification' : 'eligible_immediate',
+        required,
+    };
+}
 
 export async function getNotification(
     id: string,
@@ -30,6 +130,81 @@ export async function createNotification(notification: InsertNotification) {
         })
         .returning({ id: notifications.id });
     return result[0].id;
+}
+
+export async function routeNotificationDelivery(notificationId: string) {
+    const notification = await getNotification(notificationId);
+    if (!notification) return [];
+    const now = new Date();
+    const targetChannels: DeliveryChannel[] = ['email', 'push'];
+    const preferences = notification.userId
+        ? await storage().query.notificationUserChannelPreferences.findMany({
+              where: eq(
+                  notificationUserChannelPreferences.userId,
+                  notification.userId,
+              ),
+          })
+        : [];
+    const pushSubscriptionCount = notification.userId
+        ? await storage()
+              .select({ id: webPushSubscriptions.id })
+              .from(webPushSubscriptions)
+              .where(
+                  and(
+                      eq(webPushSubscriptions.userId, notification.userId),
+                      eq(webPushSubscriptions.enabled, true),
+                  ),
+              )
+              .limit(1)
+        : [];
+    const hasPushSubscription = pushSubscriptionCount.length > 0;
+
+    const decisions: NotificationDeliveryDecision[] = targetChannels.map(
+        (channel) => {
+            const accountPref = preferences.find(
+                (p) =>
+                    p.scope === 'account' &&
+                    p.accountId === notification.accountId &&
+                    p.category === notification.category &&
+                    p.channel === channel,
+            );
+            const globalPref = preferences.find(
+                (p) =>
+                    p.scope === 'global' &&
+                    p.category === notification.category &&
+                    p.channel === channel,
+            );
+            return decideDeliveryOutcome({
+                channel,
+                preference: accountPref ?? globalPref,
+                hasPushSubscription,
+                now,
+            });
+        },
+    );
+
+    if (notification.userId || notification.accountId) {
+        await storage()
+            .insert(notificationDeliveryAttempts)
+            .values(
+                decisions.map((decision) => ({
+                    notificationId,
+                    userId: notification.userId ?? null,
+                    accountId: notification.accountId,
+                    channel: decision.channel,
+                    status:
+                        decision.outcome === 'suppressed'
+                            ? 'dropped'
+                            : decision.outcome === 'digest'
+                              ? 'queued'
+                              : 'accepted',
+                    provider: 'router',
+                    providerResponseCode: decision.reason,
+                })),
+            );
+    }
+
+    return decisions;
 }
 
 export function getNotificationsByUser(

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -18,6 +18,7 @@ import {
 
 type DeliveryChannel = 'email' | 'push';
 type DeliveryOutcome = 'immediate' | 'digest' | 'suppressed' | 'required';
+type DeliveryAttemptStatus = 'accepted' | 'queued' | 'dropped';
 
 export type NotificationDeliveryDecision = {
     channel: DeliveryChannel;
@@ -112,6 +113,14 @@ function decideDeliveryOutcome({
     };
 }
 
+function deliveryAttemptStatusForOutcome(
+    outcome: DeliveryOutcome,
+): DeliveryAttemptStatus {
+    if (outcome === 'suppressed') return 'dropped';
+    if (outcome === 'digest') return 'queued';
+    return 'accepted';
+}
+
 export async function getNotification(
     id: string,
 ): Promise<SelectNotification | undefined> {
@@ -192,12 +201,7 @@ export async function routeNotificationDelivery(notificationId: string) {
                     userId: notification.userId ?? null,
                     accountId: notification.accountId,
                     channel: decision.channel,
-                    status:
-                        decision.outcome === 'suppressed'
-                            ? 'dropped'
-                            : decision.outcome === 'digest'
-                              ? 'queued'
-                              : 'accepted',
+                    status: deliveryAttemptStatusForOutcome(decision.outcome),
                     provider: 'router',
                     providerResponseCode: decision.reason,
                 })),

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     createNotification,
     getNotificationsByAccount,
+    routeNotificationDelivery,
 } from '@gredice/storage';
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
@@ -24,4 +25,32 @@ test('createNotification and getNotificationsByAccount basic usage', async () =>
     );
     assert.ok(Array.isArray(notifications));
     assert.ok(notifications.some((n) => n.id === notificationId));
+});
+
+test('routeNotificationDelivery returns default immediate email and suppressed push without subscription', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const notificationId = await createNotification({
+        accountId,
+        header: 'Routing',
+        content: 'Routing notification',
+        category: 'general',
+        timestamp: new Date(),
+    });
+    const decisions = await routeNotificationDelivery(notificationId);
+    assert.equal(decisions.length, 2);
+    assert.ok(
+        decisions.some(
+            (decision) =>
+                decision.channel === 'email' &&
+                decision.outcome === 'immediate',
+        ),
+    );
+    assert.ok(
+        decisions.some(
+            (decision) =>
+                decision.channel === 'push' &&
+                decision.outcome === 'suppressed',
+        ),
+    );
 });


### PR DESCRIPTION
### Motivation
- Introduce a single delivery policy layer that evaluates per-category preferences, channel defaults, quiet hours, digest settings, and required notification rules before sending email/push. 
- Keep creation of in-app notifications separate from delivery attempts while recording delivery decisions for observability.

### Description
- Added `routeNotificationDelivery(notificationId)` in `packages/storage/src/repositories/notificationsRepo.ts` which returns per-channel delivery decisions and persists `notification_delivery_attempts` for observability. 
- Implemented shared decision logic (`decideDeliveryOutcome`, `minutesInTimezone`, `isInsideQuietHours`) that evaluates account-scoped override then global fallback preferences, `digestFrequency`, quiet-hours (timezone-aware), enabled/required flags, and push subscription presence. 
- Supported outcomes `immediate`, `digest`, `suppressed`, and `required`, and mapped outcomes to attempt `status` (`suppressed` -> `dropped`, `digest` -> `queued`, otherwise `accepted`). 
- Added a unit test in `packages/storage/tests/notificationsRepo.node.spec.ts` that asserts default routing behavior (email immediate and push suppressed when no push subscription exists).

### Testing
- Ran `pnpm lint --filter @gredice/storage` which completed successfully (Biomes autofixed one file). 
- Ran `pnpm test --filter @gredice/storage` which completed successfully and reported all tests passing (including the new routing test). 
- Ran `pnpm build --filter @gredice/storage` which reported no build tasks to run for this package in the current workspace setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0788a6727c832fa45757f374957296)