### PR TITLE
www: use Montserrat for heading typography

### DIFF
--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -115,6 +115,15 @@
             "calt" 1;
     }
 
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-family: var(--font-montserrat), sans-serif;
+    }
+
     button,
     [role="button"] {
         @apply cursor-auto;

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -5,6 +5,7 @@ import { PostHogPageView, PostHogProvider } from '@posthog/next';
 import { PageNav } from '@signalco/ui/Nav';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { VercelToolbar } from '@vercel/toolbar/next';
+import { Montserrat } from 'next/font/google';
 import Head from 'next/head';
 import type { ReactNode } from 'react';
 import { PageViewTracker } from '../components/analytics/PageViewTracker';
@@ -14,6 +15,11 @@ import { ClientAppProvider } from '../components/providers/ClientAppProvider';
 import { KnownPages } from '../src/KnownPages';
 import { Footer } from './Footer';
 import { LayoutContainer } from './LayoutContainer';
+
+const montserrat = Montserrat({
+    subsets: ['latin'],
+    variable: '--font-montserrat',
+});
 
 export function generateMetadata(): Metadata {
     return {
@@ -129,7 +135,7 @@ export default async function RootLayout({
                     crossOrigin="anonymous"
                 />
             </Head>
-            <body className="antialiased">
+            <body className={`${montserrat.variable} antialiased`}>
                 {postHogApiKey ? (
                     <PostHogProvider
                         apiKey={postHogApiKey}


### PR DESCRIPTION
### Motivation
- Ensure headings in the `apps/www` site use the Montserrat typeface for consistent heading typography per design requirements.

### Description
- Load Montserrat via `next/font/google` in `apps/www/app/layout.tsx`, expose it as the CSS variable `--font-montserrat` on the `<body>` by adding `montserrat.variable`, and apply `font-family: var(--font-montserrat), sans-serif;` to `h1`–`h6` in `apps/www/app/globals.css`.

### Testing
- Ran `pnpm lint --filter www`, which completed successfully (Biome auto-fixed one file during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085092f7d8832fb61e0f506f084d6b)