### PR TITLE
app: redirect root route to /admin

### DIFF
--- a/apps/app/app/page.tsx
+++ b/apps/app/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function Home() {
-    redirect('https://www.gredice.com');
+    redirect('/admin');
 }

--- a/apps/app/tests/landing.spec.ts
+++ b/apps/app/tests/landing.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
-test('redirects root to the public website', async ({ request }) => {
+test('redirects root to admin login page', async ({ request }) => {
     const response = await request.get('/', { maxRedirects: 0 });
 
     expect(response.status()).toBe(307);
-    expect(response.headers().location).toBe('https://www.gredice.com');
+    expect(response.headers().location).toBe('/admin');
 });


### PR DESCRIPTION
### Motivation
- Ensure visits to the app root route (`/`) take users to the admin login flow instead of the public website.

### Description
- Update `apps/app/app/page.tsx` to `redirect('/admin')` and adjust `apps/app/tests/landing.spec.ts` to assert the new `/admin` redirect.

### Testing
- Ran `pnpm --filter app test -- tests/landing.spec.ts`; unit tests passed, but Playwright failed to start the web server because a production `.next` build is not present (required by `next start`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fa768dc0832fbbadbf600d8d8d8a)