### PR TITLE
[Push] Queue per-subscription push delivery attempts for notification fan-out

### DIFF
--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -571,8 +571,6 @@ export async function createNotification(notification: InsertNotification) {
     return result[0].id;
 }
 
-
-
 export async function enqueuePushDeliveryAttemptsForNotification({
     notificationId,
     batchSize = 100,
@@ -595,7 +593,9 @@ export async function enqueuePushDeliveryAttemptsForNotification({
     if (!subscriptions.length) return { queued: 0, skipped: 0 };
 
     const existing = await storage()
-        .select({ pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId })
+        .select({
+            pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId,
+        })
         .from(notificationDeliveryAttempts)
         .where(
             and(
@@ -620,7 +620,7 @@ export async function enqueuePushDeliveryAttemptsForNotification({
         return { queued: 0, skipped: subscriptions.length };
     }
 
-    await storage().insert(notificationDeliveryAttempts).values(
+    const deliveryAttempts: (typeof notificationDeliveryAttempts.$inferInsert)[] =
         pending.map((subscription) => ({
             notificationId,
             userId: notification.userId,
@@ -630,10 +630,16 @@ export async function enqueuePushDeliveryAttemptsForNotification({
             provider: 'web_push_queue',
             pushSubscriptionId: subscription.id,
             providerResponseCode: 'queued_background',
-        })),
-    );
+        }));
 
-    return { queued: pending.length, skipped: subscriptions.length - pending.length };
+    await storage()
+        .insert(notificationDeliveryAttempts)
+        .values(deliveryAttempts);
+
+    return {
+        queued: pending.length,
+        skipped: subscriptions.length - pending.length,
+    };
 }
 export async function routeNotificationDelivery(notificationId: string) {
     const notification = await getNotification(notificationId);

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -571,6 +571,70 @@ export async function createNotification(notification: InsertNotification) {
     return result[0].id;
 }
 
+
+
+export async function enqueuePushDeliveryAttemptsForNotification({
+    notificationId,
+    batchSize = 100,
+}: {
+    notificationId: string;
+    batchSize?: number;
+}) {
+    const notification = await getNotification(notificationId);
+    if (!notification?.userId) return { queued: 0, skipped: 0 };
+
+    const subscriptions = await storage().query.webPushSubscriptions.findMany({
+        where: and(
+            eq(webPushSubscriptions.userId, notification.userId),
+            eq(webPushSubscriptions.enabled, true),
+            isNull(webPushSubscriptions.revokedAt),
+        ),
+        limit: Math.max(1, batchSize),
+    });
+
+    if (!subscriptions.length) return { queued: 0, skipped: 0 };
+
+    const existing = await storage()
+        .select({ pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId })
+        .from(notificationDeliveryAttempts)
+        .where(
+            and(
+                eq(notificationDeliveryAttempts.notificationId, notificationId),
+                inArray(
+                    notificationDeliveryAttempts.pushSubscriptionId,
+                    subscriptions.map((subscription) => subscription.id),
+                ),
+            ),
+        );
+    const existingIds = new Set(
+        existing
+            .map((row) => row.pushSubscriptionId)
+            .filter((id): id is string => Boolean(id)),
+    );
+
+    const pending = subscriptions.filter(
+        (subscription) => !existingIds.has(subscription.id),
+    );
+
+    if (!pending.length) {
+        return { queued: 0, skipped: subscriptions.length };
+    }
+
+    await storage().insert(notificationDeliveryAttempts).values(
+        pending.map((subscription) => ({
+            notificationId,
+            userId: notification.userId,
+            accountId: notification.accountId,
+            channel: 'push',
+            status: 'queued',
+            provider: 'web_push_queue',
+            pushSubscriptionId: subscription.id,
+            providerResponseCode: 'queued_background',
+        })),
+    );
+
+    return { queued: pending.length, skipped: subscriptions.length - pending.length };
+}
 export async function routeNotificationDelivery(notificationId: string) {
     const notification = await getNotification(notificationId);
     if (!notification) return [];

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -72,8 +72,6 @@ test('routeNotificationDelivery returns default immediate email and suppressed p
     );
 });
 
-
-
 test('enqueuePushDeliveryAttemptsForNotification queues enabled subscriptions idempotently', async () => {
     createTestDb();
     await ensureFarmId();

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -7,6 +7,7 @@ import {
     createNotificationCampaign,
     createUserWithPassword,
     enqueueNotificationCampaign,
+    enqueuePushDeliveryAttemptsForNotification,
     gardens,
     getNotificationCampaign,
     getNotificationsByAccount,
@@ -71,6 +72,44 @@ test('routeNotificationDelivery returns default immediate email and suppressed p
     );
 });
 
+
+
+test('enqueuePushDeliveryAttemptsForNotification queues enabled subscriptions idempotently', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userName = `push-queue-${randomUUID()}@example.com`;
+    const userId = await createUserWithPassword(userName, 'password');
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+
+    const subscriptionId = randomUUID();
+    await storage().execute(
+        `insert into web_push_subscriptions (id, account_id, user_id, endpoint, p256dh, auth, enabled)
+         values ('${subscriptionId}', '${accountId}', '${userId}', 'https://example.com/sub', 'k', 'a', true)`,
+    );
+
+    const notificationId = await createNotification({
+        accountId,
+        userId,
+        header: 'Push queued',
+        content: 'Queue push delivery',
+        category: 'general',
+        timestamp: new Date(),
+    });
+
+    const first = await enqueuePushDeliveryAttemptsForNotification({
+        notificationId,
+    });
+    assert.equal(first.queued, 1);
+
+    const second = await enqueuePushDeliveryAttemptsForNotification({
+        notificationId,
+    });
+    assert.equal(second.queued, 0);
+    assert.equal(second.skipped, 1);
+});
 test('notification campaign enqueue records queue intent without synchronous fan-out', async () => {
     createTestDb();
     await ensureFarmId();


### PR DESCRIPTION
### Motivation

- Move push fan-out out of synchronous notification creation into a queued background handoff so API request paths remain responsive for large audiences.
- Ensure delivery enqueue is idempotent and bounded so workers can perform provider-throttled retries and failure handling independently from request latency.

### Description

- Added `enqueuePushDeliveryAttemptsForNotification` to `packages/storage/src/repositories/notificationsRepo.ts` which resolves enabled, non-revoked subscriptions for a notification recipient and inserts per-subscription `notification_delivery_attempts` rows with `status='queued'` and `provider='web_push_queue'`.
- Enqueue path checks existing `notification_delivery_attempts` for the same notification to enforce idempotency and returns counts of `queued` and `skipped` subscriptions.
- The function accepts a configurable `batchSize` to limit per-request work and keep API handlers responsive, and a node test was added in `packages/storage/tests/notificationsRepo.node.spec.ts` to validate queueing and idempotent behavior.

### Testing

- Ran `pnpm test --filter @gredice/storage -- notificationsRepo.node.spec.ts` which passed all subtests after fixing a missing-test setup step (ensuring a farm id); final run shows 6/6 subtests passing.
- Tests executed in the repository test harness (PGlite fallback) and created/removed an ephemeral test DB during runs.
- Note: the test environment emitted an engine warning about Node (`>=24` expected, `v22.22.2` present) but the storage tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09111ed338832fbd98619a05ea0595)