### PR TITLE
Preuredi postavke obavijesti u zasebne kartice i lokalizira kopiju

### DIFF
--- a/apps/api/app/api/[...route]/notificationsRoutes.ts
+++ b/apps/api/app/api/[...route]/notificationsRoutes.ts
@@ -669,6 +669,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
                             .max(1439)
                             .nullable()
                             .optional(),
+                        digestFrequency: z
+                            .enum(['off', 'hourly', 'daily', 'weekly'])
+                            .optional(),
                     }),
                 ),
             }),
@@ -692,6 +695,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                             preference.quietHoursStartMinute ?? null,
                         quietHoursEndMinute:
                             preference.quietHoursEndMinute ?? null,
+                        digestFrequency: preference.digestFrequency ?? 'off',
                     })
                     .onConflictDoUpdate({
                         target:
@@ -717,6 +721,12 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                 preference.quietHoursStartMinute ?? null,
                             quietHoursEndMinute:
                                 preference.quietHoursEndMinute ?? null,
+                            ...(preference.digestFrequency === undefined
+                                ? {}
+                                : {
+                                      digestFrequency:
+                                          preference.digestFrequency,
+                                  }),
                             updatedAt: new Date(),
                         },
                     });

--- a/apps/garden/public/push-notifications-sw.js
+++ b/apps/garden/public/push-notifications-sw.js
@@ -3,133 +3,151 @@ const DEFAULT_BADGE = '/badge.svg';
 const ALLOWED_PROTOCOLS = new Set(['https:', 'http:']);
 
 function isObject(value) {
-  return typeof value === 'object' && value !== null;
+    return typeof value === 'object' && value !== null;
 }
 
 function safeString(value) {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+    return typeof value === 'string' && value.trim().length > 0
+        ? value.trim()
+        : undefined;
 }
 
 function normalizeUrl(rawUrl) {
-  const safe = safeString(rawUrl);
-  if (!safe) return undefined;
-  try {
-    const url = new URL(safe, self.location.origin);
-    if (!ALLOWED_PROTOCOLS.has(url.protocol)) return undefined;
-    if (url.origin !== self.location.origin) return undefined;
-    return url.toString();
-  } catch {
-    return undefined;
-  }
+    const safe = safeString(rawUrl);
+    if (!safe) return undefined;
+    try {
+        const url = new URL(safe, self.location.origin);
+        if (!ALLOWED_PROTOCOLS.has(url.protocol)) return undefined;
+        if (url.origin !== self.location.origin) return undefined;
+        return url.toString();
+    } catch {
+        return undefined;
+    }
 }
 
 function normalizeActions(actions) {
-  if (!Array.isArray(actions)) return undefined;
-  const normalized = actions
-    .filter((action) => isObject(action))
-    .map((action) => ({
-      action: safeString(action.action),
-      title: safeString(action.title),
-      icon: normalizeUrl(action.icon),
-      url: normalizeUrl(action.url),
-    }))
-    .filter((action) => action.action && action.title)
-    .slice(0, Number(self.Notification?.maxActions ?? 2));
+    if (!Array.isArray(actions)) return undefined;
+    const normalized = actions
+        .filter((action) => isObject(action))
+        .map((action) => ({
+            action: safeString(action.action),
+            title: safeString(action.title),
+            icon: normalizeUrl(action.icon),
+            url: normalizeUrl(action.url),
+        }))
+        .filter((action) => action.action && action.title)
+        .slice(0, Number(self.Notification?.maxActions ?? 2));
 
-  return normalized.length > 0 ? normalized : undefined;
+    return normalized.length > 0 ? normalized : undefined;
 }
 
 function createPayload(rawData) {
-  const source = isObject(rawData) ? rawData : {};
-  const data = isObject(source.data) ? source.data : {};
+    const source = isObject(rawData) ? rawData : {};
+    const data = isObject(source.data) ? source.data : {};
 
-  const title = safeString(source.title) ?? 'Gredice';
-  const body = safeString(source.body) ?? '';
-  const icon = normalizeUrl(source.icon) ?? normalizeUrl(source.image) ?? DEFAULT_ICON;
-  const image = normalizeUrl(source.image);
-  const badge = normalizeUrl(source.badge) ?? DEFAULT_BADGE;
-  const url = normalizeUrl(source.url) ?? self.location.origin;
-  const tag = safeString(source.tag) ?? safeString(source.collapseKey) ?? safeString(source.threadKey);
-  const actions = normalizeActions(source.actions);
+    const title = safeString(source.title) ?? 'Gredice';
+    const body = safeString(source.body) ?? '';
+    const icon =
+        normalizeUrl(source.icon) ?? normalizeUrl(source.image) ?? DEFAULT_ICON;
+    const image = normalizeUrl(source.image);
+    const badge = normalizeUrl(source.badge) ?? DEFAULT_BADGE;
+    const url = normalizeUrl(source.url) ?? self.location.origin;
+    const tag =
+        safeString(source.tag) ??
+        safeString(source.collapseKey) ??
+        safeString(source.threadKey);
+    const actions = normalizeActions(source.actions);
 
-  return {
-    title,
-    options: {
-      body,
-      icon,
-      image,
-      badge,
-      tag,
-      renotify: Boolean(source.renotify && tag),
-      requireInteraction: Boolean(source.requireInteraction),
-      silent: Boolean(source.silent),
-      actions,
-      data: {
-        url,
-        analytics: {
-          notificationId: safeString(source.notificationId),
-          campaignId: safeString(source.campaignId),
-          category: safeString(source.category),
+    return {
+        title,
+        options: {
+            body,
+            icon,
+            image,
+            badge,
+            tag,
+            renotify: Boolean(source.renotify && tag),
+            requireInteraction: Boolean(source.requireInteraction),
+            silent: Boolean(source.silent),
+            actions,
+            data: {
+                url,
+                analytics: {
+                    notificationId: safeString(source.notificationId),
+                    campaignId: safeString(source.campaignId),
+                    category: safeString(source.category),
+                },
+                payload: data,
+            },
         },
-        payload: data,
-      },
-    },
-  };
+    };
 }
 
 async function emitAnalytics(type, notificationData, action) {
-  const analytics = notificationData?.analytics;
-  if (!analytics?.notificationId) return;
-  const body = {
-    type,
-    action: safeString(action),
-    notificationId: analytics.notificationId,
-    campaignId: analytics.campaignId,
-    category: analytics.category,
-    at: new Date().toISOString(),
-  };
+    const analytics = notificationData?.analytics;
+    if (!analytics?.notificationId) return;
+    const body = {
+        type,
+        action: safeString(action),
+        notificationId: analytics.notificationId,
+        campaignId: analytics.campaignId,
+        category: analytics.category,
+        at: new Date().toISOString(),
+    };
 
-  try {
-    await fetch('/api/notifications/events', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-      keepalive: true,
-      credentials: 'include',
-    });
-  } catch {
-    // swallow analytics transport failures in service worker
-  }
+    try {
+        await fetch('/api/notifications/events', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body),
+            keepalive: true,
+            credentials: 'include',
+        });
+    } catch {
+        // swallow analytics transport failures in service worker
+    }
 }
 
 self.addEventListener('push', (event) => {
-  const raw = event.data ? event.data.json() : {};
-  const payload = createPayload(raw);
-  event.waitUntil(self.registration.showNotification(payload.title, payload.options));
+    const raw = event.data ? event.data.json() : {};
+    const payload = createPayload(raw);
+    event.waitUntil(
+        self.registration.showNotification(payload.title, payload.options),
+    );
 });
 
 self.addEventListener('notificationclick', (event) => {
-  const data = event.notification?.data;
-  const actionCandidate = safeString(event.action);
-  const actionMatch = event.notification?.actions?.find((action) => action.action === actionCandidate);
-  const targetUrl = actionMatch?.url ?? data?.url ?? self.location.origin;
-  event.notification.close();
+    const data = event.notification?.data;
+    const actionCandidate = safeString(event.action);
+    const actionMatch = event.notification?.actions?.find(
+        (action) => action.action === actionCandidate,
+    );
+    const targetUrl = actionMatch?.url ?? data?.url ?? self.location.origin;
+    event.notification.close();
 
-  event.waitUntil((async () => {
-    await emitAnalytics('clicked', data, actionCandidate);
-    const allClients = await clients.matchAll({ type: 'window', includeUncontrolled: true });
-    for (const client of allClients) {
-      if ('focus' in client && normalizeUrl(client.url) === normalizeUrl(targetUrl)) {
-        await client.focus();
-        return;
-      }
-    }
-    if (clients.openWindow) {
-      await clients.openWindow(targetUrl);
-    }
-  })());
+    event.waitUntil(
+        (async () => {
+            await emitAnalytics('clicked', data, actionCandidate);
+            const allClients = await clients.matchAll({
+                type: 'window',
+                includeUncontrolled: true,
+            });
+            for (const client of allClients) {
+                if (
+                    'focus' in client &&
+                    normalizeUrl(client.url) === normalizeUrl(targetUrl)
+                ) {
+                    await client.focus();
+                    return;
+                }
+            }
+            if (clients.openWindow) {
+                await clients.openWindow(targetUrl);
+            }
+        })(),
+    );
 });
 
 self.addEventListener('notificationclose', (event) => {
-  event.waitUntil(emitAnalytics('dismissed', event.notification?.data));
+    event.waitUntil(emitAnalytics('dismissed', event.notification?.data));
 });

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -7,9 +7,15 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useMarkAllNotificationsRead } from '../../hooks/useMarkAllNotificationsRead';
 import { usePushPermissionOnboarding } from '../../hooks/usePushPermissionOnboarding';
@@ -25,15 +31,136 @@ type PushDeviceUpdate = NonNullable<
     Parameters<ApiClient['api']['notifications']['devices'][':id']['$patch']>[0]
 >['json'];
 
+type DigestFrequency = NonNullable<
+    NotificationPreferenceUpdate['digestFrequency']
+>;
+type DigestPeriod = Exclude<DigestFrequency, 'off'>;
+
+type NotificationsView = 'notifications' | 'settings';
+type NotificationsFilter = 'unread' | 'all';
+
 const notificationPreferencesKey = ['notifications', 'preferences'];
 const notificationDevicesKey = ['notifications', 'devices'];
 const notificationPushStatusKey = ['notifications', 'push-status'];
+const defaultQuietHoursStartMinute = 22 * 60;
+const defaultQuietHoursEndMinute = 7 * 60;
+
+const categoryPreferences: Array<{
+    category: string;
+    label: string;
+    channel: NotificationPreferenceUpdate['channel'];
+}> = [
+    {
+        category: 'garden_activity',
+        label: 'Aktivnosti vrta',
+        channel: 'push',
+    },
+    {
+        category: 'orders',
+        label: 'Narudžbe i dostava',
+        channel: 'push',
+    },
+    {
+        category: 'promotions',
+        label: 'Promocije i preporuke',
+        channel: 'email',
+    },
+];
+
+const digestFrequencyItems: Array<{
+    label: string;
+    value: DigestPeriod;
+}> = [
+    { label: 'Svaki sat', value: 'hourly' },
+    { label: 'Dnevno', value: 'daily' },
+    { label: 'Tjedno', value: 'weekly' },
+];
+
+function isNotificationsView(value: string): value is NotificationsView {
+    return value === 'notifications' || value === 'settings';
+}
+
+function isNotificationsFilter(value: string): value is NotificationsFilter {
+    return value === 'unread' || value === 'all';
+}
+
+function isDigestPeriod(value: string): value is DigestPeriod {
+    return digestFrequencyItems.some((item) => item.value === value);
+}
+
+function minuteToTimeValue(minute: number) {
+    const normalizedMinute = ((minute % 1440) + 1440) % 1440;
+    const hours = Math.floor(normalizedMinute / 60)
+        .toString()
+        .padStart(2, '0');
+    const minutes = (normalizedMinute % 60).toString().padStart(2, '0');
+    return `${hours}:${minutes}`;
+}
+
+function timeValueToMinute(value: string) {
+    const [hoursText, minutesText] = value.split(':');
+    const hours = Number(hoursText);
+    const minutes = Number(minutesText);
+    if (
+        !Number.isInteger(hours) ||
+        !Number.isInteger(minutes) ||
+        hours < 0 ||
+        hours > 23 ||
+        minutes < 0 ||
+        minutes > 59
+    ) {
+        return null;
+    }
+    return hours * 60 + minutes;
+}
+
+function permissionStatusLabel(status: string) {
+    switch (status) {
+        case 'granted':
+            return 'dopušteno';
+        case 'denied':
+            return 'odbijeno';
+        case 'unsupported':
+            return 'nije podržano';
+        case 'prompt-dismissed':
+            return 'odgođeno';
+        default:
+            return 'nije odlučeno';
+    }
+}
+
+function pushStatusLabel(status: string | undefined) {
+    switch (status) {
+        case 'subscribed':
+            return 'uključeno';
+        case 'unsubscribed':
+            return 'nije uključeno';
+        case 'denied':
+            return 'blokirano';
+        case 'disabled':
+            return 'isključeno';
+        case undefined:
+            return 'učitavanje';
+        default:
+            return status;
+    }
+}
 
 export function NotificationsTab() {
-    const [notificationsFilter, setNotificationsFilter] = useState('unread');
-    const [quietHoursStartMinute, setQuietHoursStartMinute] = useState(1320);
-    const [quietHoursEndMinute, setQuietHoursEndMinute] = useState(420);
-    const [digestFrequency, setDigestFrequency] = useState('daily');
+    const [activeView, setActiveView] =
+        useState<NotificationsView>('notifications');
+    const [notificationsFilter, setNotificationsFilter] =
+        useState<NotificationsFilter>('unread');
+    const [quietHoursEnabled, setQuietHoursEnabled] = useState(false);
+    const [quietHoursStartMinute, setQuietHoursStartMinute] = useState(
+        defaultQuietHoursStartMinute,
+    );
+    const [quietHoursEndMinute, setQuietHoursEndMinute] = useState(
+        defaultQuietHoursEndMinute,
+    );
+    const [digestEnabled, setDigestEnabled] = useState(false);
+    const [digestFrequency, setDigestFrequency] =
+        useState<DigestPeriod>('daily');
     const markAllNotificationsRead = useMarkAllNotificationsRead();
     const { track } = useGameAnalytics();
     const pushOnboarding = usePushPermissionOnboarding();
@@ -44,7 +171,8 @@ export function NotificationsTab() {
         queryFn: async () => {
             const response =
                 await clientAuthenticated().api.notifications.preferences.$get();
-            if (!response.ok) throw new Error('Failed to load preferences');
+            if (!response.ok)
+                throw new Error('Postavke obavijesti nisu učitane');
             return (await response.json()).preferences;
         },
     });
@@ -54,7 +182,8 @@ export function NotificationsTab() {
         queryFn: async () => {
             const response =
                 await clientAuthenticated().api.notifications.devices.$get();
-            if (!response.ok) throw new Error('Failed to load devices');
+            if (!response.ok)
+                throw new Error('Uređaji za obavijesti nisu učitani');
             return (await response.json()).devices;
         },
     });
@@ -66,7 +195,7 @@ export function NotificationsTab() {
                 await clientAuthenticated().api.notifications[
                     'push-status'
                 ].$get();
-            if (!response.ok) throw new Error('Failed to load push status');
+            if (!response.ok) throw new Error('Status obavijesti nije učitan');
             return response.json();
         },
     });
@@ -77,7 +206,8 @@ export function NotificationsTab() {
                 await clientAuthenticated().api.notifications.preferences.$put({
                     json: { preferences },
                 });
-            if (!response.ok) throw new Error('Failed to save preferences');
+            if (!response.ok)
+                throw new Error('Postavke obavijesti nisu spremljene');
         },
         onSuccess: () =>
             queryClient.invalidateQueries({
@@ -100,7 +230,7 @@ export function NotificationsTab() {
                     param: { id },
                     json: payload,
                 });
-            if (!response.ok) throw new Error('Failed to update device');
+            if (!response.ok) throw new Error('Uređaj nije ažuriran');
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
@@ -118,7 +248,7 @@ export function NotificationsTab() {
                 ].$delete({
                     param: { id },
                 });
-            if (!response.ok) throw new Error('Failed to revoke device');
+            if (!response.ok) throw new Error('Uređaj nije uklonjen');
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
@@ -132,31 +262,102 @@ export function NotificationsTab() {
         mutationFn: async () => {
             const response =
                 await clientAuthenticated().api.notifications.test.$post();
-            if (!response.ok)
-                throw new Error('Failed to send test notification');
+            if (!response.ok) throw new Error('Probna obavijest nije poslana');
         },
     });
 
-    const categoryPreferences = useMemo(
-        () => [
-            {
-                category: 'garden_activity',
-                label: 'Aktivnosti vrta',
-                channel: 'push' as const,
-            },
-            {
-                category: 'orders',
-                label: 'Narudžbe i dostava',
-                channel: 'push' as const,
-            },
-            {
-                category: 'promotions',
-                label: 'Promocije i preporuke',
-                channel: 'email' as const,
-            },
-        ],
-        [],
-    );
+    useEffect(() => {
+        if (!preferencesQuery.data?.length) {
+            return;
+        }
+
+        const quietHoursPreference = preferencesQuery.data.find(
+            (preference) =>
+                preference.quietHoursStartMinute !== null &&
+                preference.quietHoursEndMinute !== null,
+        );
+        if (
+            typeof quietHoursPreference?.quietHoursStartMinute === 'number' &&
+            typeof quietHoursPreference.quietHoursEndMinute === 'number'
+        ) {
+            setQuietHoursEnabled(true);
+            setQuietHoursStartMinute(
+                quietHoursPreference.quietHoursStartMinute,
+            );
+            setQuietHoursEndMinute(quietHoursPreference.quietHoursEndMinute);
+        } else {
+            setQuietHoursEnabled(false);
+        }
+
+        const digestPreference = preferencesQuery.data.find(
+            (preference) =>
+                preference.digestFrequency &&
+                preference.digestFrequency !== 'off',
+        );
+        if (
+            digestPreference?.digestFrequency &&
+            isDigestPeriod(digestPreference.digestFrequency)
+        ) {
+            setDigestEnabled(true);
+            setDigestFrequency(digestPreference.digestFrequency);
+        } else {
+            setDigestEnabled(false);
+        }
+    }, [preferencesQuery.data]);
+
+    function findPreference(item: (typeof categoryPreferences)[number]) {
+        return preferencesQuery.data?.find(
+            (preference) =>
+                preference.category === item.category &&
+                preference.channel === item.channel &&
+                preference.scope === 'global',
+        );
+    }
+
+    function buildPreferenceUpdate(
+        item: (typeof categoryPreferences)[number],
+        enabled: boolean,
+        options: {
+            quietEnabled?: boolean;
+            quietStart?: number;
+            quietEnd?: number;
+            summaryEnabled?: boolean;
+            summaryFrequency?: DigestPeriod;
+        } = {},
+    ): NotificationPreferenceUpdate {
+        const nextQuietEnabled = options.quietEnabled ?? quietHoursEnabled;
+        const nextSummaryEnabled = options.summaryEnabled ?? digestEnabled;
+
+        return {
+            scope: 'global',
+            category: item.category,
+            channel: item.channel,
+            enabled,
+            quietHoursStartMinute: nextQuietEnabled
+                ? (options.quietStart ?? quietHoursStartMinute)
+                : null,
+            quietHoursEndMinute: nextQuietEnabled
+                ? (options.quietEnd ?? quietHoursEndMinute)
+                : null,
+            digestFrequency: nextSummaryEnabled
+                ? (options.summaryFrequency ?? digestFrequency)
+                : 'off',
+        };
+    }
+
+    function saveAllPreferenceSettings(
+        options: Parameters<typeof buildPreferenceUpdate>[2] = {},
+    ) {
+        savePreferencesMutation.mutate(
+            categoryPreferences.map((item) =>
+                buildPreferenceUpdate(
+                    item,
+                    findPreference(item)?.enabled ?? false,
+                    options,
+                ),
+            ),
+        );
+    }
 
     const handleEnablePush = async () => {
         track('game_push_enable_clicked', {
@@ -175,262 +376,403 @@ export function NotificationsTab() {
         markAllNotificationsRead.mutate({ readWhere: 'game' });
     };
 
-    const permissionLabel =
-        pushOnboarding.status === 'granted'
-            ? 'Dopušteno'
-            : pushOnboarding.status === 'denied'
-              ? 'Odbijeno'
-              : pushOnboarding.status === 'unsupported'
-                ? 'Nije podržano'
-                : 'Nije odlučeno';
+    const notificationsSupported =
+        typeof window !== 'undefined' && 'Notification' in window;
+    const settingsBusy = savePreferencesMutation.isPending;
 
     return (
-        <Stack spacing={1}>
+        <Stack spacing={2}>
             <Typography level="h4" className="hidden md:block">
                 🔔 Obavijesti
             </Typography>
-            <Card className="bg-card p-2">
-                <Stack spacing={1}>
-                    <Typography level="body2" secondary>
-                        Podrška preglednika:{' '}
-                        {'Notification' in window
-                            ? 'Podržano'
-                            : 'Nije podržano'}{' '}
-                        · Dozvola: {permissionLabel} · Push status:{' '}
-                        {pushStatusQuery.data?.status ?? 'učitavanje...'}
-                    </Typography>
-                    {pushOnboarding.status === 'denied' && (
-                        <Typography level="body3" secondary>
-                            Push je blokiran u pregledniku. Otvori postavke
-                            preglednika i omogući obavijesti za ovu stranicu.
-                        </Typography>
-                    )}
-                    {pushOnboarding.canPrompt && (
-                        <Row justifyContent="end">
-                            <Button
-                                size="sm"
-                                onClick={handleEnablePush}
-                                startDecorator={
-                                    <Megaphone className="size-4" />
-                                }
-                            >
-                                Uključi push
-                            </Button>
-                        </Row>
-                    )}
-                </Stack>
-            </Card>
-
-            <Card className="bg-card p-2">
-                <Stack spacing={1}>
-                    <Row justifyContent="space-between">
+            <Tabs
+                value={activeView}
+                onValueChange={(value: string) => {
+                    if (isNotificationsView(value)) {
+                        setActiveView(value);
+                    }
+                }}
+                className="flex flex-col"
+            >
+                <TabsList className="grid w-full grid-cols-2 border">
+                    <TabsTrigger value="notifications">Obavijesti</TabsTrigger>
+                    <TabsTrigger value="settings">Postavke</TabsTrigger>
+                </TabsList>
+                <TabsContent value="notifications" className="mt-3">
+                    <Stack spacing={1}>
                         <Typography level="body1" semiBold>
-                            Tipovi obavijesti
+                            Popis obavijesti
                         </Typography>
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            onClick={() =>
-                                savePreferencesMutation.mutate(
-                                    categoryPreferences.map((item) => ({
-                                        scope: 'global',
-                                        category: item.category,
-                                        channel: item.channel,
-                                        enabled: true,
-                                        quietHoursStartMinute,
-                                        quietHoursEndMinute,
-                                    })),
-                                )
-                            }
-                        >
-                            Omogući sve
-                        </Button>
-                    </Row>
-                    {categoryPreferences.map((item) => {
-                        const preference = preferencesQuery.data?.find(
-                            (pref) =>
-                                pref.category === item.category &&
-                                pref.channel === item.channel &&
-                                pref.scope === 'global',
-                        );
-                        return (
+                        <Card className="bg-card p-1">
+                            <Row justifyContent="space-between">
+                                <SelectItems
+                                    value={notificationsFilter}
+                                    onValueChange={(value) => {
+                                        if (!isNotificationsFilter(value)) {
+                                            return;
+                                        }
+                                        track(
+                                            'game_notifications_filter_changed',
+                                            {
+                                                filter: value,
+                                            },
+                                        );
+                                        setNotificationsFilter(value);
+                                    }}
+                                    items={[
+                                        {
+                                            label: 'Nepročitane',
+                                            value: 'unread',
+                                            icon: <Empty className="size-4" />,
+                                        },
+                                        {
+                                            label: 'Sve obavijesti',
+                                            value: 'all',
+                                            icon: (
+                                                <Approved className="size-4" />
+                                            ),
+                                        },
+                                    ]}
+                                />
+                                <Button
+                                    variant="plain"
+                                    size="sm"
+                                    onClick={handleMarkAllNotificationsRead}
+                                    startDecorator={
+                                        <Approved className="size-4" />
+                                    }
+                                >
+                                    Sve pročitano
+                                </Button>
+                            </Row>
+                        </Card>
+                        <div className="overflow-y-auto max-h-[calc(100dvh-18rem)] md:max-h-[calc(100dvh-24rem)] rounded-lg text-card-foreground bg-card shadow-sm p-0">
+                            <NotificationList
+                                read={notificationsFilter === 'all'}
+                            />
+                        </div>
+                    </Stack>
+                </TabsContent>
+                <TabsContent value="settings" className="mt-3">
+                    <Stack spacing={1}>
+                        <Card className="bg-card p-2">
+                            <Stack spacing={1}>
+                                <Typography level="body1" semiBold>
+                                    Obavijesti na ovom uređaju
+                                </Typography>
+                                <Typography level="body2" secondary>
+                                    Preglednik:{' '}
+                                    {notificationsSupported
+                                        ? 'podržava obavijesti'
+                                        : 'ne podržava obavijesti'}{' '}
+                                    · Dozvola:{' '}
+                                    {permissionStatusLabel(
+                                        pushOnboarding.status,
+                                    )}{' '}
+                                    · Status:{' '}
+                                    {pushStatusLabel(
+                                        pushStatusQuery.data?.status,
+                                    )}
+                                </Typography>
+                                {pushOnboarding.status === 'denied' && (
+                                    <Typography level="body3" secondary>
+                                        Obavijesti su blokirane u pregledniku.
+                                        Otvori postavke preglednika i omogući
+                                        obavijesti za ovu stranicu.
+                                    </Typography>
+                                )}
+                                {pushOnboarding.canPrompt && (
+                                    <Row justifyContent="end">
+                                        <Button
+                                            size="sm"
+                                            onClick={handleEnablePush}
+                                            startDecorator={
+                                                <Megaphone className="size-4" />
+                                            }
+                                        >
+                                            Uključi obavijesti
+                                        </Button>
+                                    </Row>
+                                )}
+                            </Stack>
+                        </Card>
+
+                        <Card className="bg-card p-2">
+                            <Stack spacing={1}>
+                                <Row justifyContent="space-between">
+                                    <Typography level="body1" semiBold>
+                                        Vrste obavijesti
+                                    </Typography>
+                                    <Button
+                                        size="sm"
+                                        variant="plain"
+                                        disabled={settingsBusy}
+                                        onClick={() =>
+                                            savePreferencesMutation.mutate(
+                                                categoryPreferences.map(
+                                                    (item) =>
+                                                        buildPreferenceUpdate(
+                                                            item,
+                                                            true,
+                                                        ),
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        Omogući sve
+                                    </Button>
+                                </Row>
+                                {categoryPreferences.map((item) => {
+                                    const preference = findPreference(item);
+                                    return (
+                                        <Row
+                                            key={item.category}
+                                            justifyContent="space-between"
+                                            alignItems="center"
+                                        >
+                                            <Typography>
+                                                {item.label}
+                                            </Typography>
+                                            <Checkbox
+                                                checked={
+                                                    preference?.enabled ?? false
+                                                }
+                                                disabled={settingsBusy}
+                                                onCheckedChange={(
+                                                    checked: boolean,
+                                                ) =>
+                                                    savePreferencesMutation.mutate(
+                                                        [
+                                                            buildPreferenceUpdate(
+                                                                item,
+                                                                Boolean(
+                                                                    checked,
+                                                                ),
+                                                            ),
+                                                        ],
+                                                    )
+                                                }
+                                            />
+                                        </Row>
+                                    );
+                                })}
+                            </Stack>
+                        </Card>
+
+                        <Card className="bg-card p-2">
+                            <Stack spacing={1}>
+                                <Checkbox
+                                    label="Ne ometaj"
+                                    checked={quietHoursEnabled}
+                                    disabled={settingsBusy}
+                                    onCheckedChange={(checked: boolean) => {
+                                        const enabled = Boolean(checked);
+                                        setQuietHoursEnabled(enabled);
+                                        saveAllPreferenceSettings({
+                                            quietEnabled: enabled,
+                                        });
+                                    }}
+                                />
+                                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                                    <Input
+                                        label="Od"
+                                        type="time"
+                                        value={minuteToTimeValue(
+                                            quietHoursStartMinute,
+                                        )}
+                                        disabled={
+                                            !quietHoursEnabled || settingsBusy
+                                        }
+                                        onChange={(event) => {
+                                            const minute = timeValueToMinute(
+                                                event.target.value,
+                                            );
+                                            if (minute === null) {
+                                                return;
+                                            }
+                                            setQuietHoursStartMinute(minute);
+                                            if (quietHoursEnabled) {
+                                                saveAllPreferenceSettings({
+                                                    quietStart: minute,
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Input
+                                        label="Do"
+                                        type="time"
+                                        value={minuteToTimeValue(
+                                            quietHoursEndMinute,
+                                        )}
+                                        disabled={
+                                            !quietHoursEnabled || settingsBusy
+                                        }
+                                        onChange={(event) => {
+                                            const minute = timeValueToMinute(
+                                                event.target.value,
+                                            );
+                                            if (minute === null) {
+                                                return;
+                                            }
+                                            setQuietHoursEndMinute(minute);
+                                            if (quietHoursEnabled) {
+                                                saveAllPreferenceSettings({
+                                                    quietEnd: minute,
+                                                });
+                                            }
+                                        }}
+                                    />
+                                </div>
+                            </Stack>
+                        </Card>
+
+                        <Card className="bg-card p-2">
+                            <Stack spacing={1}>
+                                <Checkbox
+                                    label="Primaj sažetak obavijesti"
+                                    checked={digestEnabled}
+                                    disabled={settingsBusy}
+                                    onCheckedChange={(checked: boolean) => {
+                                        const enabled = Boolean(checked);
+                                        setDigestEnabled(enabled);
+                                        saveAllPreferenceSettings({
+                                            summaryEnabled: enabled,
+                                        });
+                                    }}
+                                />
+                                <Stack spacing={0.5}>
+                                    <Typography level="body2" semiBold>
+                                        Razdoblje sažetka
+                                    </Typography>
+                                    <div
+                                        className={
+                                            digestEnabled
+                                                ? undefined
+                                                : 'pointer-events-none opacity-50'
+                                        }
+                                    >
+                                        <SelectItems
+                                            value={digestFrequency}
+                                            onValueChange={(value) => {
+                                                if (!isDigestPeriod(value)) {
+                                                    return;
+                                                }
+                                                setDigestFrequency(value);
+                                                if (digestEnabled) {
+                                                    saveAllPreferenceSettings({
+                                                        summaryFrequency: value,
+                                                    });
+                                                }
+                                            }}
+                                            items={digestFrequencyItems}
+                                        />
+                                    </div>
+                                </Stack>
+                            </Stack>
+                        </Card>
+
+                        <Card className="bg-card p-2">
                             <Row
-                                key={item.category}
                                 justifyContent="space-between"
                                 alignItems="center"
                             >
-                                <Typography>{item.label}</Typography>
-                                <Checkbox
-                                    checked={preference?.enabled ?? false}
-                                    onCheckedChange={(checked: boolean) =>
-                                        savePreferencesMutation.mutate([
-                                            {
-                                                scope: 'global',
-                                                category: item.category,
-                                                channel: item.channel,
-                                                enabled: Boolean(checked),
-                                                quietHoursStartMinute,
-                                                quietHoursEndMinute,
-                                            },
-                                        ])
+                                <Typography level="body1" semiBold>
+                                    Uređaji za obavijesti
+                                </Typography>
+                                <Button
+                                    size="sm"
+                                    onClick={() => sendTestMutation.mutate()}
+                                    startDecorator={
+                                        <Megaphone className="size-4" />
                                     }
-                                />
+                                >
+                                    Pošalji probnu obavijest
+                                </Button>
                             </Row>
-                        );
-                    })}
-                    <Row spacing={1}>
-                        <Input
-                            label="Tišina od (minute)"
-                            type="number"
-                            value={quietHoursStartMinute.toString()}
-                            onChange={(event) =>
-                                setQuietHoursStartMinute(
-                                    Number(event.target.value),
-                                )
-                            }
-                        />
-                        <Input
-                            label="Tišina do (minute)"
-                            type="number"
-                            value={quietHoursEndMinute.toString()}
-                            onChange={(event) =>
-                                setQuietHoursEndMinute(
-                                    Number(event.target.value),
-                                )
-                            }
-                        />
-                        <SelectItems
-                            value={digestFrequency}
-                            onValueChange={setDigestFrequency}
-                            items={[
-                                { label: 'Bez sažetka', value: 'off' },
-                                { label: 'Satno', value: 'hourly' },
-                                { label: 'Dnevno', value: 'daily' },
-                                { label: 'Tjedno', value: 'weekly' },
-                            ]}
-                        />
-                    </Row>
-                </Stack>
-            </Card>
-
-            <Card className="bg-card p-2">
-                <Row justifyContent="space-between" alignItems="center">
-                    <Typography level="body1" semiBold>
-                        Push uređaji
-                    </Typography>
-                    <Button
-                        size="sm"
-                        onClick={() => sendTestMutation.mutate()}
-                        startDecorator={<Megaphone className="size-4" />}
-                    >
-                        Pošalji test
-                    </Button>
-                </Row>
-                <Stack spacing={1} className="pt-2">
-                    {devicesQuery.data?.length ? (
-                        devicesQuery.data.map((device) => (
-                            <Card key={device.id} className="p-1 bg-muted/20">
-                                <Stack spacing={0.5}>
-                                    <Typography semiBold>
-                                        {device.deviceLabel ||
-                                            'Nepoznati uređaj'}
-                                    </Typography>
-                                    <Typography level="body3" secondary>
-                                        {device.userAgent ||
-                                            'Nepoznat preglednik'}
-                                    </Typography>
-                                    <Typography level="body3" secondary>
-                                        Stanje:{' '}
-                                        {device.enabled
-                                            ? 'Aktivan'
-                                            : 'Isključen'}{' '}
-                                        · Zadnji put viđen:{' '}
-                                        {device.lastSeenAt
-                                            ? new Date(
-                                                  device.lastSeenAt,
-                                              ).toLocaleString('hr-HR')
-                                            : 'Nema podataka'}
-                                    </Typography>
-                                    <Row spacing={1}>
-                                        <Button
-                                            size="sm"
-                                            variant="plain"
-                                            onClick={() =>
-                                                updateDeviceMutation.mutate({
-                                                    id: device.id,
-                                                    payload: {
-                                                        enabled:
-                                                            !device.enabled,
-                                                    },
-                                                })
-                                            }
+                            <Stack spacing={1} className="pt-2">
+                                {devicesQuery.data?.length ? (
+                                    devicesQuery.data.map((device) => (
+                                        <Card
+                                            key={device.id}
+                                            className="p-1 bg-muted/20"
                                         >
-                                            {device.enabled
-                                                ? 'Onemogući'
-                                                : 'Omogući'}
-                                        </Button>
-                                        <Button
-                                            size="sm"
-                                            variant="plain"
-                                            startDecorator={
-                                                <Close className="size-4" />
-                                            }
-                                            onClick={() =>
-                                                revokeDeviceMutation.mutate(
-                                                    device.id,
-                                                )
-                                            }
-                                        >
-                                            Opozovi
-                                        </Button>
-                                    </Row>
-                                </Stack>
-                            </Card>
-                        ))
-                    ) : (
-                        <Typography level="body2" secondary>
-                            Nema registriranih push uređaja.
-                        </Typography>
-                    )}
-                </Stack>
-            </Card>
-
-            <Card className="bg-card p-1">
-                <Row justifyContent="space-between">
-                    <SelectItems
-                        value={notificationsFilter}
-                        onValueChange={(value) => {
-                            track('game_notifications_filter_changed', {
-                                filter: value,
-                            });
-                            setNotificationsFilter(value);
-                        }}
-                        items={[
-                            {
-                                label: 'Nepročitane',
-                                value: 'unread',
-                                icon: <Empty className="size-4" />,
-                            },
-                            {
-                                label: 'Sve obavijesti',
-                                value: 'all',
-                                icon: <Approved className="size-4" />,
-                            },
-                        ]}
-                    />
-                    <Button
-                        variant="plain"
-                        size="sm"
-                        onClick={handleMarkAllNotificationsRead}
-                        startDecorator={<Approved className="size-4" />}
-                    >
-                        Sve pročitano
-                    </Button>
-                </Row>
-            </Card>
-            <div className="overflow-y-auto max-h-[calc(100dvh-18rem)] md:max-h-[calc(100dvh-24rem)] rounded-lg text-card-foreground bg-card shadow-sm p-0">
-                <NotificationList read={notificationsFilter === 'all'} />
-            </div>
+                                            <Stack spacing={0.5}>
+                                                <Typography semiBold>
+                                                    {device.deviceLabel ||
+                                                        'Nepoznati uređaj'}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    {device.userAgent ||
+                                                        'Nepoznat preglednik'}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    Status:{' '}
+                                                    {device.enabled
+                                                        ? 'aktivan'
+                                                        : 'isključen'}{' '}
+                                                    · Zadnji put viđen:{' '}
+                                                    {device.lastSeenAt
+                                                        ? new Date(
+                                                              device.lastSeenAt,
+                                                          ).toLocaleString(
+                                                              'hr-HR',
+                                                          )
+                                                        : 'nema podataka'}
+                                                </Typography>
+                                                <Row spacing={1}>
+                                                    <Button
+                                                        size="sm"
+                                                        variant="plain"
+                                                        onClick={() =>
+                                                            updateDeviceMutation.mutate(
+                                                                {
+                                                                    id: device.id,
+                                                                    payload: {
+                                                                        enabled:
+                                                                            !device.enabled,
+                                                                    },
+                                                                },
+                                                            )
+                                                        }
+                                                    >
+                                                        {device.enabled
+                                                            ? 'Isključi'
+                                                            : 'Uključi'}
+                                                    </Button>
+                                                    <Button
+                                                        size="sm"
+                                                        variant="plain"
+                                                        startDecorator={
+                                                            <Close className="size-4" />
+                                                        }
+                                                        onClick={() =>
+                                                            revokeDeviceMutation.mutate(
+                                                                device.id,
+                                                            )
+                                                        }
+                                                    >
+                                                        Ukloni
+                                                    </Button>
+                                                </Row>
+                                            </Stack>
+                                        </Card>
+                                    ))
+                                ) : (
+                                    <Typography level="body2" secondary>
+                                        Nema uređaja prijavljenih za obavijesti.
+                                    </Typography>
+                                )}
+                            </Stack>
+                        </Card>
+                    </Stack>
+                </TabsContent>
+            </Tabs>
         </Stack>
     );
 }


### PR DESCRIPTION
**Sažetak**
- Odvojene su liste obavijesti i postavke u zasebne kartice unutar modala.
- Sva vidljiva kopija u notifications sučelju prevedena je na hrvatski.
- `Tišina od` i `Tišina do` zamijenjene su toggleabilnim `Ne ometaj` kontrolama s vremenskim pickerima.
- Dodan je checkbox za uključivanje sažetaka i odabir razdoblja sažetka.
- Preimenovan je `Push uređaji` u korisniku jasniji naziv.
- API za spremanje preferencija sada prima i sprema `digestFrequency`.

**Testing**
- Provedeni su targeted lint i build provjere za `api`, `garden`, `www` i `@gredice/game`.
- Pokrenuti su `@gredice/game` testovi i `api` node testovi.
- Urađena je lokalna UI provjera garden dev okruženja; authenticated modal nije bilo moguće potpuno otvoriti bez aktivnog lokalnog auth/API backenda.