### PR TITLE
Show the notifications popover trigger on mobile

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -237,9 +237,9 @@ export function AccountHud() {
                         )
                     )}
                 </div>
-                <div className="hidden md:block md:order-2">
+                <div className="md:order-2">
                     <Popper
-                        className="overflow-hidden border-tertiary border-b-4 w-96"
+                        className="w-[min(24rem,calc(100vw-1rem))] overflow-hidden border-tertiary border-b-4"
                         side="bottom"
                         sideOffset={12}
                         trigger={


### PR DESCRIPTION
**Summary**
- Make the garden account HUD notifications trigger visible on small screens.
- Constrain the popover width so it fits within the mobile viewport.

**Testing**
- Lint passed for `@gredice/game` and `garden`.
- Unit tests passed for `@gredice/game`.
- Built the affected consumer apps (`garden` and `www`).
- Verified the mobile garden HUD in the browser and confirmed the `Obavijesti` button opens the notifications popover.