### PR TITLE
[Search] Expose directory search API and OpenAPI contract

### DIFF
--- a/apps/api/app/api/[...route]/directoriesRoutes.ts
+++ b/apps/api/app/api/[...route]/directoriesRoutes.ts
@@ -4,6 +4,7 @@ import {
     getCmsPages,
     getEntitiesFormatted,
     getEntityFormatted,
+    searchDirectoryEntities,
 } from '@gredice/storage';
 import { Hono } from 'hono';
 import { validator as zValidator } from 'hono-openapi';
@@ -14,6 +15,67 @@ import {
 } from '../../../lib/http/cacheControl';
 
 const app = new Hono()
+    .get(
+        '/search',
+        zValidator(
+            'query',
+            z.object({
+                q: z.string().trim().min(2).max(200),
+                category: z.union([z.string(), z.array(z.string())]).optional(),
+                entityType: z
+                    .union([z.string(), z.array(z.string())])
+                    .optional(),
+                limit: z.coerce.number().int().min(1).max(50).optional(),
+                offset: z.coerce.number().int().min(0).max(500).optional(),
+            }),
+        ),
+        async (context) => {
+            const query = context.req.valid('query');
+            const limit = query.limit ?? 20;
+            const offset = query.offset ?? 0;
+            const categoriesRaw = Array.isArray(query.category)
+                ? query.category
+                : query.category
+                  ? [query.category]
+                  : [];
+            const categories = categoriesRaw.map((value) =>
+                value === 'operation' ? 'operations' : value,
+            );
+            const entityTypes = Array.isArray(query.entityType)
+                ? query.entityType
+                : query.entityType
+                  ? [query.entityType]
+                  : [];
+            const rows = await searchDirectoryEntities({
+                query: query.q,
+                publicCategories: categories,
+                entityTypeNames: entityTypes,
+                limit,
+                offset,
+            });
+            setCacheControl(context, cacheControlPresets.directories);
+            return context.json({
+                query: query.q,
+                limit,
+                offset,
+                count: rows.length,
+                results: rows.map((row) => ({
+                    entityId: row.entityId,
+                    entityType: row.entityTypeName,
+                    category: row.publicCategory,
+                    categoryLabel: row.publicCategoryLabel,
+                    title: row.title,
+                    summary: row.summary,
+                    imageUrl: row.imageUrl,
+                    imageAlt: row.imageAlt,
+                    href: `https://www.gredice.com${row.publicUrl}`,
+                    rank: row.score,
+                    publishedAt: row.publishedAt,
+                    updatedAt: row.updatedAt,
+                })),
+            });
+        },
+    )
     .get('/pages', async (context) => {
         const pages = await getCmsPages({ state: 'published' });
         setCacheControl(context, cacheControlPresets.directories);

--- a/apps/api/lib/docs/openApiDocs.ts
+++ b/apps/api/lib/docs/openApiDocs.ts
@@ -481,6 +481,67 @@ export async function openApiDocs(
         },
     };
 
+    paths['/search'] = {
+        get: {
+            summary: '/search',
+            description: 'Search published directory entities.',
+            parameters: [
+                {
+                    name: 'q',
+                    in: 'query',
+                    required: true,
+                    schema: { type: 'string', minLength: 2, maxLength: 200 },
+                },
+                {
+                    name: 'category',
+                    in: 'query',
+                    required: false,
+                    schema: {
+                        oneOf: [
+                            { type: 'string' },
+                            { type: 'array', items: { type: 'string' } },
+                        ],
+                    },
+                },
+                {
+                    name: 'entityType',
+                    in: 'query',
+                    required: false,
+                    schema: {
+                        oneOf: [
+                            { type: 'string' },
+                            { type: 'array', items: { type: 'string' } },
+                        ],
+                    },
+                },
+                {
+                    name: 'limit',
+                    in: 'query',
+                    required: false,
+                    schema: { type: 'integer', minimum: 1, maximum: 50 },
+                },
+                {
+                    name: 'offset',
+                    in: 'query',
+                    required: false,
+                    schema: { type: 'integer', minimum: 0, maximum: 500 },
+                },
+            ],
+            responses: {
+                200: {
+                    description: 'Successful response',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                $ref: '#/components/schemas/directory-search-response',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
     paths['/pages/{slug}'] = {
         get: {
             summary: '/pages/{slug}',
@@ -552,6 +613,50 @@ export async function openApiDocs(
                     },
                 },
             ],
+        };
+        baseDoc.components.schemas['directory-search-result'] = {
+            type: 'object',
+            required: [
+                'entityId',
+                'entityType',
+                'category',
+                'categoryLabel',
+                'title',
+                'href',
+                'rank',
+                'publishedAt',
+                'updatedAt',
+            ],
+            properties: {
+                entityId: { type: 'number' },
+                entityType: { type: 'string' },
+                category: { type: 'string' },
+                categoryLabel: { type: 'string' },
+                title: { type: 'string' },
+                summary: { type: ['string', 'null'] },
+                imageUrl: { type: ['string', 'null'] },
+                imageAlt: { type: ['string', 'null'] },
+                href: { type: 'string', format: 'uri' },
+                rank: { type: 'number' },
+                publishedAt: { type: 'string', format: 'date-time' },
+                updatedAt: { type: 'string', format: 'date-time' },
+            },
+        };
+        baseDoc.components.schemas['directory-search-response'] = {
+            type: 'object',
+            required: ['query', 'limit', 'offset', 'count', 'results'],
+            properties: {
+                query: { type: 'string' },
+                limit: { type: 'number' },
+                offset: { type: 'number' },
+                count: { type: 'number' },
+                results: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/components/schemas/directory-search-result',
+                    },
+                },
+            },
         };
     }
 

--- a/apps/api/lib/docs/openApiDocs.ts
+++ b/apps/api/lib/docs/openApiDocs.ts
@@ -638,7 +638,7 @@ export async function openApiDocs(
                 imageAlt: { type: ['string', 'null'] },
                 href: { type: 'string', format: 'uri' },
                 rank: { type: 'number' },
-                publishedAt: { type: 'string', format: 'date-time' },
+                publishedAt: { type: ['string', 'null'], format: 'date-time' },
                 updatedAt: { type: 'string', format: 'date-time' },
             },
         };


### PR DESCRIPTION
### Motivation
- Provide a public, cache-aware directory search endpoint so web clients can query published directory entities through an FTS-backed API.
- Keep search execution SQL/FTS-backed by delegating to `@gredice/storage` and avoid broad in-memory filtering at the route layer.
- Publish an OpenAPI contract for the new search surface so `@gredice/directory-types` and `@gredice/client` can generate and consume typed clients.

### Description
- Added a new `GET /api/directories/search` route in `apps/api/app/api/[...route]/directoriesRoutes.ts` with query validation for `q`, `category`, `entityType`, `limit`, and `offset` using `hono-openapi` + `zod`.
- Wired the route to `searchDirectoryEntities` from `@gredice/storage`, normalized `category=operation` to `operations`, and returned shaped results including canonical `https://www.gredice.com` `href`s, category labels, summary/image fields, and ranking metadata while applying the existing `directories` cache-control preset.
- Extended OpenAPI generation in `apps/api/lib/docs/openApiDocs.ts` to include the `/search` path and added `directory-search-result` and `directory-search-response` schemas for deterministic type generation.
- Fixed route typing around query-array handling to satisfy TypeScript and keep the public API types narrow and safe.

### Testing
- Ran `pnpm lint --filter api` which completed successfully.
- Ran `pnpm build --filter api` which completed successfully after addressing a TypeScript array-typing issue in the new route.
- An earlier combined `pnpm test --filter api` invocation failed during the build step before the typing fix, but the final targeted `build` completed cleanly after the fix.
- Attempted to regenerate `@gredice/directory-types` and run the OpenAPI unit spec with `node --experimental-strip-types --test ./lib/docs/openApiDocs.node.spec.ts`, but those runs failed in this environment due to module/runtime constraints (a `server-only` import guard and module resolution when running the docs generation script); the OpenAPI source is updated and ready for deterministic regeneration in a local environment where the standard `regenerate` flow can run end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0748736c832f9a10a57a518c1064)