### PR TITLE
[Search] Add directory search index invalidation + rebuild workflow

### DIFF
--- a/docs/search-indexing.md
+++ b/docs/search-indexing.md
@@ -1,0 +1,39 @@
+# Directory search indexing operations
+
+This guide documents how `@gredice/storage` keeps `entity_search_documents` in sync with directory entity mutations.
+
+## Automatic refresh path
+
+The following repository mutations trigger `refreshImpactedEntitySearchDocuments`:
+
+- `updateEntity` and `deleteEntity` in `entitiesRepo.ts`.
+- `upsertAttributeValue` and `deleteAttributeValue` in `attributeValuesRepo.ts`.
+
+The refresh flow is safe and idempotent:
+
+1. Recompute the source entity search document.
+2. Recompute dependent entity documents when parent public URL dependencies change:
+   - `plant` changes refresh linked `plantSort` and `seed` documents.
+   - `plantSort` changes refresh linked `seed` documents.
+3. Remove documents automatically when entities are unpublished/deleted/non-public.
+
+Failures log operational context (`entityId`, error object) without logging attribute values.
+
+## Full rebuild / backfill
+
+Use `rebuildDirectorySearchIndex()` from `entitySearchRepo` for deployment backfills and maintenance:
+
+- Refreshes all currently published, non-deleted entities.
+- Deletes stale rows for entities that are no longer published or were deleted.
+- Returns `{ refreshedCount }`.
+- Empty datasets are a successful no-op (`refreshedCount: 0`).
+
+Example (from repo root):
+
+```bash
+pnpm --filter @gredice/storage exec tsx -e "import { rebuildDirectorySearchIndex } from './src/repositories/entitySearchRepo.ts'; rebuildDirectorySearchIndex().then((r) => { console.log(r); process.exit(0); });"
+```
+
+## Revalidation coordination
+
+Search documents are consumed by the directories API search endpoint. Existing `Cache-Control` and `www` revalidation endpoints continue to govern HTTP/page cache lifetimes. Index updates now happen during mutation writes so API search reads fresh indexed rows without waiting for a periodic job.

--- a/packages/storage/src/repositories/attributeValuesRepo.ts
+++ b/packages/storage/src/repositories/attributeValuesRepo.ts
@@ -19,10 +19,10 @@ async function refreshEntitySearchDocumentAfterMutation(
         return;
     }
     try {
-        const { refreshEntitySearchDocument } = await import(
+        const { refreshImpactedEntitySearchDocuments } = await import(
             './entitySearchRepo'
         );
-        await refreshEntitySearchDocument(entityId);
+        await refreshImpactedEntitySearchDocuments(entityId);
     } catch (error) {
         console.error('Failed to refresh entity search document', {
             entityId,

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -26,10 +26,10 @@ const entityCacheTtl = 60 * 60; // 1 hour
 
 async function refreshEntitySearchDocumentAfterMutation(entityId: number) {
     try {
-        const { refreshEntitySearchDocument } = await import(
+        const { refreshImpactedEntitySearchDocuments } = await import(
             './entitySearchRepo'
         );
-        await refreshEntitySearchDocument(entityId);
+        await refreshImpactedEntitySearchDocuments(entityId);
     } catch (error) {
         console.error('Failed to refresh entity search document', {
             entityId,

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -431,8 +431,8 @@ export async function refreshEntitySearchDocuments(entityIds: number[]) {
     }
 }
 
-async function relatedEntityIdsForPublicUrl(entity: EntitySearchSource) {
-    if (entity.entityTypeName === 'plant') {
+async function relatedEntityIdsForPublicUrl(entityTypeName: string) {
+    if (entityTypeName === 'plant') {
         const rows = await storage()
             .select({ id: entities.id })
             .from(entities)
@@ -445,7 +445,7 @@ async function relatedEntityIdsForPublicUrl(entity: EntitySearchSource) {
         return rows.map((row) => row.id);
     }
 
-    if (entity.entityTypeName === 'plantSort') {
+    if (entityTypeName === 'plantSort') {
         const rows = await storage()
             .select({ id: entities.id })
             .from(entities)
@@ -463,13 +463,21 @@ async function relatedEntityIdsForPublicUrl(entity: EntitySearchSource) {
 
 export async function refreshImpactedEntitySearchDocuments(entityId: number) {
     const sourceEntity = await getEntityRaw(entityId);
-    if (!sourceEntity) {
-        await refreshEntitySearchDocument(entityId);
-        return [entityId];
-    }
+    const sourceEntityState = sourceEntity
+        ? null
+        : await storage().query.entities.findFirst({
+              where: eq(entities.id, entityId),
+              columns: {
+                  entityTypeName: true,
+              },
+          });
+    const sourceEntityTypeName =
+        sourceEntity?.entityTypeName ?? sourceEntityState?.entityTypeName;
 
     const impacted = new Set<number>([entityId]);
-    const relatedIds = await relatedEntityIdsForPublicUrl(sourceEntity);
+    const relatedIds = sourceEntityTypeName
+        ? await relatedEntityIdsForPublicUrl(sourceEntityTypeName)
+        : [];
 
     if (relatedIds.length > 0) {
         const references = await storage().query.attributeValues.findMany({

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -5,6 +5,7 @@ import {
 } from '@gredice/directory-types';
 import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
+    attributeValues,
     entities,
     entitySearchDocuments,
     type SelectAttributeDefinition,
@@ -430,6 +431,91 @@ export async function refreshEntitySearchDocuments(entityIds: number[]) {
     }
 }
 
+async function relatedEntityIdsForPublicUrl(entity: EntitySearchSource) {
+    if (entity.entityTypeName === 'plant') {
+        const rows = await storage()
+            .select({ id: entities.id })
+            .from(entities)
+            .where(
+                and(
+                    eq(entities.isDeleted, false),
+                    inArray(entities.entityTypeName, ['plantSort', 'seed']),
+                ),
+            );
+        return rows.map((row) => row.id);
+    }
+
+    if (entity.entityTypeName === 'plantSort') {
+        const rows = await storage()
+            .select({ id: entities.id })
+            .from(entities)
+            .where(
+                and(
+                    eq(entities.isDeleted, false),
+                    eq(entities.entityTypeName, 'seed'),
+                ),
+            );
+        return rows.map((row) => row.id);
+    }
+
+    return [];
+}
+
+export async function refreshImpactedEntitySearchDocuments(entityId: number) {
+    const sourceEntity = await getEntityRaw(entityId);
+    if (!sourceEntity) {
+        await refreshEntitySearchDocument(entityId);
+        return [entityId];
+    }
+
+    const impacted = new Set<number>([entityId]);
+    const relatedIds = await relatedEntityIdsForPublicUrl(sourceEntity);
+
+    if (relatedIds.length > 0) {
+        const references = await storage().query.attributeValues.findMany({
+            where: and(
+                eq(attributeValues.isDeleted, false),
+                inArray(attributeValues.entityId, relatedIds),
+                inArray(attributeValues.value, [String(entityId)]),
+            ),
+            columns: {
+                entityId: true,
+            },
+        });
+
+        for (const reference of references) {
+            impacted.add(reference.entityId);
+        }
+    }
+
+    await refreshEntitySearchDocuments(Array.from(impacted));
+    return Array.from(impacted);
+}
+
+export async function rebuildDirectorySearchIndex() {
+    const publishedRows = await storage()
+        .select({ id: entities.id })
+        .from(entities)
+        .where(
+            and(eq(entities.isDeleted, false), eq(entities.state, 'published')),
+        );
+
+    const publishedIds = publishedRows.map((row) => row.id);
+    if (publishedIds.length > 0) {
+        await refreshEntitySearchDocuments(publishedIds);
+    }
+
+    await storage()
+        .delete(entitySearchDocuments)
+        .where(sql`${entitySearchDocuments.entityId} NOT IN (
+            select ${entities.id} from ${entities}
+            where ${entities.isDeleted} = false and ${entities.state} = 'published'
+        )`);
+
+    return {
+        refreshedCount: publishedIds.length,
+    };
+}
 export async function searchDirectoryEntities({
     query,
     entityTypeNames,

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -463,7 +463,7 @@ async function relatedEntityIdsForPublicUrl(entityTypeName: string) {
 
 export async function refreshImpactedEntitySearchDocuments(entityId: number) {
     const sourceEntity = await getEntityRaw(entityId);
-    const sourceEntityState = sourceEntity
+    const deletedEntityInfo = sourceEntity
         ? null
         : await storage().query.entities.findFirst({
               where: eq(entities.id, entityId),
@@ -472,7 +472,7 @@ export async function refreshImpactedEntitySearchDocuments(entityId: number) {
               },
           });
     const sourceEntityTypeName =
-        sourceEntity?.entityTypeName ?? sourceEntityState?.entityTypeName;
+        sourceEntity?.entityTypeName ?? deletedEntityInfo?.entityTypeName;
 
     const impacted = new Set<number>([entityId]);
     const relatedIds = sourceEntityTypeName

--- a/packages/storage/tests/entitySearchRepo.node.spec.ts
+++ b/packages/storage/tests/entitySearchRepo.node.spec.ts
@@ -271,6 +271,15 @@ test('directory entity search returns canonical seed URLs through plant sort dat
     assert.equal(rows[0]?.publicCategory, 'seeds');
     assert.equal(rows[0]?.publicCategoryLabel, 'Sjeme');
     assert.equal(rows[0]?.publicUrl, '/biljke/rajcica/sorte/cherry-rajcica');
+
+    await deleteEntity(sortId);
+
+    const refreshedRows = await searchDirectoryEntities({
+        query: token,
+        entityTypeNames: ['seed'],
+    });
+    assert.equal(refreshedRows[0]?.entityId, seedId);
+    assert.equal(refreshedRows[0]?.publicUrl, '/biljke/rajcica');
 });
 
 test('directory entity search falls back to plant URLs for seeds without plant sort data', async () => {
@@ -462,6 +471,66 @@ test('directory entity search excludes draft, unpublished, and deleted entities'
     );
     assert.deepEqual(
         await searchDirectoryEntities({ query: deletedToken }),
+        [],
+    );
+});
+
+test('directory entity search removes dependent plant sort documents after parent deletion', async () => {
+    createTestDb();
+    const token = uniqueToken('deletedparent');
+    const plantId = await createSearchableEntity({
+        entityTypeName: 'plant',
+        entityTypeLabel: 'Plant',
+        title: `Parent plant ${token}`,
+    });
+    await ensurePublicEntityType('plantSort', 'Sorta biljke');
+
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Name',
+        entityTypeName: 'plantSort',
+        dataType: 'text',
+    });
+    const plantDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'plant',
+        label: 'Plant',
+        entityTypeName: 'plantSort',
+        dataType: 'ref:plant',
+    });
+    const sortId = await createEntity('plantSort');
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName: 'plantSort',
+        entityId: sortId,
+        value: `Dependent sort ${token}`,
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: plantDefinitionId,
+        entityTypeName: 'plantSort',
+        entityId: sortId,
+        value: String(plantId),
+    });
+    await updateEntity({ id: sortId, state: 'published' });
+
+    assert.equal(
+        (
+            await searchDirectoryEntities({
+                query: token,
+                entityTypeNames: ['plantSort'],
+            })
+        )[0]?.entityId,
+        sortId,
+    );
+
+    await deleteEntity(plantId);
+
+    assert.deepEqual(
+        await searchDirectoryEntities({
+            query: token,
+            entityTypeNames: ['plantSort'],
+        }),
         [],
     );
 });

--- a/packages/storage/tests/entitySearchRepo.node.spec.ts
+++ b/packages/storage/tests/entitySearchRepo.node.spec.ts
@@ -6,6 +6,7 @@ import {
     createEntity,
     deleteEntity,
     normalizeDirectorySearchText,
+    rebuildDirectorySearchIndex,
     searchDirectoryEntities,
     updateEntity,
     upsertAttributeValue,
@@ -474,4 +475,23 @@ test('directory entity search returns an empty result set for no matches', async
     });
 
     assert.deepEqual(rows, []);
+});
+
+test('rebuildDirectorySearchIndex is idempotent and supports empty no-op runs', async () => {
+    createTestDb();
+    const empty = await rebuildDirectorySearchIndex();
+    assert.ok(empty.refreshedCount >= 0);
+
+    await createSearchableEntity({
+        entityTypeName: 'plant',
+        entityTypeLabel: 'Plant',
+        title: `Rebuild ${uniqueToken('plant')}`,
+        description: 'Opis',
+    });
+
+    const first = await rebuildDirectorySearchIndex();
+    const second = await rebuildDirectorySearchIndex();
+
+    assert.ok(first.refreshedCount >= 1);
+    assert.equal(second.refreshedCount, first.refreshedCount);
 });


### PR DESCRIPTION
### Motivation
- Ensure PostgreSQL-backed directory search documents stay current when entities, attributes, publication state, or public URLs change so search does not serve stale or draft content.
- Provide a safe operational path to backfill or rebuild the search index for published entities and to remove stale rows after deletions or unpublishes.

### Description
- Switched mutation-time refresh hooks in `entitiesRepo` and `attributeValuesRepo` to call `refreshImpactedEntitySearchDocuments` so mutations refresh both the source entity and any dependent entities whose public URL may change.
- Added `relatedEntityIdsForPublicUrl`, `refreshImpactedEntitySearchDocuments(entityId)`, and `rebuildDirectorySearchIndex()` to `packages/storage/src/repositories/entitySearchRepo.ts` to compute impacted IDs, refresh documents, and perform idempotent full backfills and stale-row cleanup.
- Updated exports and tests surface by adding `rebuildDirectorySearchIndex()` to the test imports and adding tests in `packages/storage/tests/entitySearchRepo.node.spec.ts` that verify idempotency and empty/no-op behavior.
- Added operational documentation `docs/search-indexing.md` describing the automatic refresh path, rebuild command, and coordination with existing cache/revalidation endpoints.

### Testing
- Ran the storage unit tests for the modified file with `pnpm --filter @gredice/storage test -- entitySearchRepo.node.spec.ts` and the test suite passed (new rebuild/idempotency tests included).
- Ran linter with `pnpm --filter @gredice/storage lint`, which succeeded after automatic fixes.
- Built the package with `pnpm build --filter @gredice/storage`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a2abdb6b8832fa4ee72c3e5b0e25f)