### PR TITLE
Prevent raised-bed drag while HUD dialog/drawer is open

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -62,6 +62,7 @@ export function RaisedBedField({
     );
     const moveSequenceRef = useRef(0);
     const [dropAnimationDisabled, setDropAnimationDisabled] = useState(false);
+    const [isHudDialogOpen, setIsHudDialogOpen] = useState(false);
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
 
     const sensors = useSensors(
@@ -90,6 +91,28 @@ export function RaisedBedField({
 
         return () => window.clearTimeout(timeoutId);
     }, [dropAnimationDisabled]);
+
+    useEffect(() => {
+        function syncDialogState() {
+            const openDialog = document.querySelector(
+                '[role="dialog"][data-state="open"], [data-vaul-drawer][data-state="open"]',
+            );
+            setIsHudDialogOpen(Boolean(openDialog));
+        }
+
+        syncDialogState();
+        const observer = new MutationObserver(() => {
+            syncDialogState();
+        });
+        observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['data-state'],
+            childList: true,
+            subtree: true,
+        });
+
+        return () => observer.disconnect();
+    }, []);
 
     // Determine which positions have cart items (draggable)
     const baseCartItemsByPosition = useMemo(() => {
@@ -254,7 +277,7 @@ export function RaisedBedField({
             <div></div>
             <DndContext
                 id={`raised-bed-field-${gardenId}-${raisedBedId}`}
-                sensors={sensors}
+                sensors={isHudDialogOpen ? [] : sensors}
                 collisionDetection={closestCenter}
                 onDragEnd={handleDragEnd}
             >


### PR DESCRIPTION
### Motivation
- Avoid accidental dragging of raised-bed fields when a closeup modal/drawer is open and the user swipes to dismiss it.

### Description
- Suspend DnD sensors for the raised-bed grid when a HUD dialog or vaul drawer is detected open by introducing `isHudDialogOpen` and passing `[]` as `sensors` to `DndContext` while open. 
- Detect open dialogs/drawers by querying `'[role="dialog"][data-state="open"], [data-vaul-drawer][data-state="open"]'` and keep state in sync with a `MutationObserver` watching `data-state` changes on `document.body`.
- Implemented changes in `packages/game/src/hud/raisedBed/RaisedBedField.tsx` by adding the new state, observer logic, and conditional `sensors` wiring.

### Testing
- Ran `pnpm lint --filter @gredice/game` and lint checks passed (note: environment reported a Node engine warning `>=24` vs current `v22.22.2` but the lint task completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a19bd3534832f89d55d1c6f2dcaa0)