### PR TITLE
[Analytics] Add push delivery event recording and notification delivery summaries

### DIFF
--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -11,8 +11,8 @@ import {
     type NotificationCampaignAudience,
     type NotificationCampaignDeliveryMetadata,
     notificationCampaigns,
-    notificationDeliveryEvents,
     notificationDeliveryAttempts,
+    notificationDeliveryEvents,
     notificationEmailLog,
     notifications,
     notificationUserChannelPreferences,
@@ -740,6 +740,24 @@ export async function recordNotificationDeliveryEvent({
     metadata?: Record<string, unknown>;
     occurredAt?: Date;
 }) {
+    const attempt = await storage()
+        .select({
+            notificationId: notificationDeliveryAttempts.notificationId,
+        })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.id, deliveryAttemptId))
+        .limit(1);
+
+    if (!attempt[0]) {
+        throw new Error('Delivery attempt not found.');
+    }
+
+    if (attempt[0].notificationId !== notificationId) {
+        throw new Error(
+            'Delivery attempt does not belong to the provided notification.',
+        );
+    }
+
     const result = await storage()
         .insert(notificationDeliveryEvents)
         .values({
@@ -763,7 +781,12 @@ export async function getNotificationDeliverySummary(
             pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId,
         })
         .from(notificationDeliveryAttempts)
-        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+        .where(
+            and(
+                eq(notificationDeliveryAttempts.notificationId, notificationId),
+                eq(notificationDeliveryAttempts.channel, 'push'),
+            ),
+        );
 
     const events = await storage()
         .select({
@@ -790,7 +813,8 @@ export async function getNotificationDeliverySummary(
         sent: attempts.filter((attempt) => attempt.status === 'sent').length,
         accepted: attempts.filter((attempt) => attempt.status === 'accepted')
             .length,
-        failed: attempts.filter((attempt) => attempt.status === 'failed').length,
+        failed: attempts.filter((attempt) => attempt.status === 'failed')
+            .length,
         retried,
         invalidated: 0,
         opened: 0,

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -11,6 +11,7 @@ import {
     type NotificationCampaignAudience,
     type NotificationCampaignDeliveryMetadata,
     notificationCampaigns,
+    notificationDeliveryEvents,
     notificationDeliveryAttempts,
     notificationEmailLog,
     notifications,
@@ -47,6 +48,21 @@ export type NotificationCampaignAudiencePreview = {
     gardenCount: number;
     explicitRecipientCount: number;
     unmatchedRecipientCount: number;
+};
+
+export type NotificationDeliveryEventType =
+    (typeof notificationDeliveryEvents.$inferSelect)['type'];
+
+export type NotificationDeliveryRollup = {
+    sent: number;
+    accepted: number;
+    failed: number;
+    retried: number;
+    invalidated: number;
+    opened: number;
+    dismissed: number;
+    clicked: number;
+    unsubscribed: number;
 };
 
 export type CreateNotificationCampaignInput = Omit<
@@ -709,6 +725,89 @@ export async function routeNotificationDelivery(notificationId: string) {
     }
 
     return decisions;
+}
+
+export async function recordNotificationDeliveryEvent({
+    notificationId,
+    deliveryAttemptId,
+    type,
+    metadata,
+    occurredAt,
+}: {
+    notificationId: string;
+    deliveryAttemptId: number;
+    type: NotificationDeliveryEventType;
+    metadata?: Record<string, unknown>;
+    occurredAt?: Date;
+}) {
+    const result = await storage()
+        .insert(notificationDeliveryEvents)
+        .values({
+            notificationId,
+            deliveryAttemptId,
+            type,
+            metadata: metadata ?? {},
+            occurredAt: occurredAt ?? new Date(),
+        })
+        .returning();
+    return result[0];
+}
+
+export async function getNotificationDeliverySummary(
+    notificationId: string,
+): Promise<NotificationDeliveryRollup> {
+    const attempts = await storage()
+        .select({
+            id: notificationDeliveryAttempts.id,
+            status: notificationDeliveryAttempts.status,
+            pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId,
+        })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+
+    const events = await storage()
+        .select({
+            type: notificationDeliveryEvents.type,
+            deliveryAttemptId: notificationDeliveryEvents.deliveryAttemptId,
+        })
+        .from(notificationDeliveryEvents)
+        .where(eq(notificationDeliveryEvents.notificationId, notificationId));
+
+    const attemptsBySubscription = new Map<string, number>();
+    for (const attempt of attempts) {
+        if (!attempt.pushSubscriptionId) continue;
+        attemptsBySubscription.set(
+            attempt.pushSubscriptionId,
+            (attemptsBySubscription.get(attempt.pushSubscriptionId) ?? 0) + 1,
+        );
+    }
+
+    const retried = Array.from(attemptsBySubscription.values()).filter(
+        (count) => count > 1,
+    ).length;
+
+    const rollup: NotificationDeliveryRollup = {
+        sent: attempts.filter((attempt) => attempt.status === 'sent').length,
+        accepted: attempts.filter((attempt) => attempt.status === 'accepted')
+            .length,
+        failed: attempts.filter((attempt) => attempt.status === 'failed').length,
+        retried,
+        invalidated: 0,
+        opened: 0,
+        dismissed: 0,
+        clicked: 0,
+        unsubscribed: 0,
+    };
+
+    for (const event of events) {
+        if (event.type === 'opened') rollup.opened += 1;
+        if (event.type === 'dismissed') rollup.dismissed += 1;
+        if (event.type === 'clicked') rollup.clicked += 1;
+        if (event.type === 'failed') rollup.invalidated += 1;
+        if (event.type === 'unsubscribed') rollup.unsubscribed += 1;
+    }
+
+    return rollup;
 }
 
 export function getNotificationsByUser(

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -10,10 +10,13 @@ import {
     enqueuePushDeliveryAttemptsForNotification,
     gardens,
     getNotificationCampaign,
+    getNotificationDeliverySummary,
     getNotificationsByAccount,
     getUser,
     notifications,
+    notificationDeliveryAttempts,
     previewNotificationCampaignAudience,
+    recordNotificationDeliveryEvent,
     routeNotificationDelivery,
     storage,
 } from '@gredice/storage';
@@ -34,6 +37,7 @@ test('createNotification and getNotificationsByAccount basic usage', async () =>
         content: 'Test notification',
         timestamp: new Date(),
     });
+
     const notifications = await getNotificationsByAccount(
         accountId,
         false,
@@ -253,4 +257,98 @@ test('explicit notification campaign audience excludes deleted gardens', async (
     assert.equal(preview.userCount, 0);
     assert.equal(preview.gardenCount, 0);
     assert.equal(preview.unmatchedRecipientCount, 1);
+});
+
+test('notification delivery summary tracks attempts and engagement events', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userName = `delivery-summary-${randomUUID()}@example.com`;
+    const userId = await createUserWithPassword(userName, 'password');
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+
+    const notificationId = await createNotification({
+        accountId,
+        userId,
+        header: 'Push analytics',
+        content: 'Track delivery analytics',
+        category: 'general',
+        timestamp: new Date(),
+    });
+    const sub1Id = randomUUID();
+    const sub2Id = randomUUID();
+    await storage().execute(
+        `insert into web_push_subscriptions (id, account_id, user_id, endpoint, p256dh, auth, enabled)
+         values ('${sub1Id}', '${accountId}', '${userId}', 'https://example.com/${sub1Id}', 'k', 'a', true),
+                ('${sub2Id}', '${accountId}', '${userId}', 'https://example.com/${sub2Id}', 'k', 'a', true)`,
+    );
+
+    const attemptRows = await storage()
+        .insert(notificationDeliveryAttempts)
+        .values([
+            {
+                notificationId,
+                userId,
+                accountId,
+                channel: 'push',
+                status: 'accepted',
+                pushSubscriptionId: sub1Id,
+            },
+            {
+                notificationId,
+                userId,
+                accountId,
+                channel: 'push',
+                status: 'failed',
+                pushSubscriptionId: sub1Id,
+            },
+            {
+                notificationId,
+                userId,
+                accountId,
+                channel: 'push',
+                status: 'sent',
+                pushSubscriptionId: sub2Id,
+            },
+        ])
+        .returning({ id: notificationDeliveryAttempts.id });
+
+    await recordNotificationDeliveryEvent({
+        notificationId,
+        deliveryAttemptId: attemptRows[0].id,
+        type: 'opened',
+    });
+    await recordNotificationDeliveryEvent({
+        notificationId,
+        deliveryAttemptId: attemptRows[0].id,
+        type: 'clicked',
+    });
+    await recordNotificationDeliveryEvent({
+        notificationId,
+        deliveryAttemptId: attemptRows[1].id,
+        type: 'failed',
+    });
+    await recordNotificationDeliveryEvent({
+        notificationId,
+        deliveryAttemptId: attemptRows[2].id,
+        type: 'dismissed',
+    });
+    await recordNotificationDeliveryEvent({
+        notificationId,
+        deliveryAttemptId: attemptRows[2].id,
+        type: 'unsubscribed',
+    });
+
+    const summary = await getNotificationDeliverySummary(notificationId);
+    assert.equal(summary.sent, 1);
+    assert.equal(summary.accepted, 1);
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.retried, 1);
+    assert.equal(summary.opened, 1);
+    assert.equal(summary.clicked, 1);
+    assert.equal(summary.dismissed, 1);
+    assert.equal(summary.invalidated, 1);
+    assert.equal(summary.unsubscribed, 1);
 });

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -13,8 +13,8 @@ import {
     getNotificationDeliverySummary,
     getNotificationsByAccount,
     getUser,
-    notifications,
     notificationDeliveryAttempts,
+    notifications,
     previewNotificationCampaignAudience,
     recordNotificationDeliveryEvent,
     routeNotificationDelivery,
@@ -285,6 +285,17 @@ test('notification delivery summary tracks attempts and engagement events', asyn
                 ('${sub2Id}', '${accountId}', '${userId}', 'https://example.com/${sub2Id}', 'k', 'a', true)`,
     );
 
+    const emailAttempt = await storage()
+        .insert(notificationDeliveryAttempts)
+        .values({
+            notificationId,
+            userId,
+            accountId,
+            channel: 'email',
+            status: 'failed',
+        })
+        .returning({ id: notificationDeliveryAttempts.id });
+
     const attemptRows = await storage()
         .insert(notificationDeliveryAttempts)
         .values([
@@ -351,4 +362,63 @@ test('notification delivery summary tracks attempts and engagement events', asyn
     assert.equal(summary.dismissed, 1);
     assert.equal(summary.invalidated, 1);
     assert.equal(summary.unsubscribed, 1);
+    assert.notEqual(emailAttempt[0].id, attemptRows[0].id);
+});
+
+test('recordNotificationDeliveryEvent rejects mismatched notification and attempt ids', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const firstUserName = `delivery-event-first-${randomUUID()}@example.com`;
+    const firstUserId = await createUserWithPassword(firstUserName, 'password');
+    const firstUser = await getUser(firstUserId);
+    assert.ok(firstUser);
+    const firstAccountId = firstUser.accounts[0]?.accountId;
+    assert.ok(firstAccountId);
+
+    const secondUserName = `delivery-event-second-${randomUUID()}@example.com`;
+    const secondUserId = await createUserWithPassword(
+        secondUserName,
+        'password',
+    );
+    const secondUser = await getUser(secondUserId);
+    assert.ok(secondUser);
+    const secondAccountId = secondUser.accounts[0]?.accountId;
+    assert.ok(secondAccountId);
+
+    const firstNotificationId = await createNotification({
+        accountId: firstAccountId,
+        userId: firstUserId,
+        header: 'First',
+        content: 'First notification',
+        category: 'general',
+        timestamp: new Date(),
+    });
+    const secondNotificationId = await createNotification({
+        accountId: secondAccountId,
+        userId: secondUserId,
+        header: 'Second',
+        content: 'Second notification',
+        category: 'general',
+        timestamp: new Date(),
+    });
+
+    const secondAttempt = await storage()
+        .insert(notificationDeliveryAttempts)
+        .values({
+            notificationId: secondNotificationId,
+            userId: secondUserId,
+            accountId: secondAccountId,
+            channel: 'push',
+            status: 'accepted',
+        })
+        .returning({ id: notificationDeliveryAttempts.id });
+
+    await assert.rejects(
+        recordNotificationDeliveryEvent({
+            notificationId: firstNotificationId,
+            deliveryAttemptId: secondAttempt[0].id,
+            type: 'opened',
+        }),
+        /does not belong to the provided notification/u,
+    );
 });


### PR DESCRIPTION
### Motivation
- Expose push delivery health and user engagement (delivery attempts, provider responses, opens, clicks, dismissals, unsubscribes) for campaign and notification observability.
- Keep analytics safe by avoiding storage of push endpoint secrets and relying on attempt/event ids and metadata.

### Description
- Added storage-layer helpers in `packages/storage/src/repositories/notificationsRepo.ts`: `recordNotificationDeliveryEvent(...)` to persist events into the `notification_delivery_events` table and `getNotificationDeliverySummary(notificationId)` to return aggregated counts (sent, accepted, failed, retried, invalidated, opened, dismissed, clicked, unsubscribed).
- Introduced types `NotificationDeliveryEventType` and `NotificationDeliveryRollup` to model event kinds and rollup output.
- Updated the storage tests in `packages/storage/tests/notificationsRepo.node.spec.ts` to cover attempt aggregation and engagement/unsubscribe event recording and to assert expected rollup counts.

### Testing
- Ran the storage unit test file with `pnpm test --filter @gredice/storage -- notificationsRepo.node.spec.ts` and verified the suite passed (all tests in that spec succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3005a5dc832fa79e294a9d9c6523)