### PR TITLE
Stub www auth probe in Playwright tests

### DIFF
--- a/apps/www/tests/a11y.spec.ts
+++ b/apps/www/tests/a11y.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import AxeBuilder from '@axe-core/playwright';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const FALLBACK_ROUTES = ['/', '/recepti'];
 

--- a/apps/www/tests/fixtures.ts
+++ b/apps/www/tests/fixtures.ts
@@ -1,0 +1,22 @@
+import { test as base, expect } from '@playwright/test';
+
+export type { Locator } from '@playwright/test';
+
+export const test = base.extend({
+    page: async ({ page }, use) => {
+        await page.route(
+            '**/api/gredice/api/auth/current-claims**',
+            async (route) => {
+                await route.fulfill({
+                    body: 'null',
+                    contentType: 'application/json',
+                    status: 200,
+                });
+            },
+        );
+
+        await use(page);
+    },
+});
+
+export { expect };

--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test('has title', async ({ page }) => {
     await page.goto('/');

--- a/apps/www/tests/search.spec.ts
+++ b/apps/www/tests/search.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, test } from '@playwright/test';
+import { expect, type Locator, test } from './fixtures';
 
 async function typeSearch(locator: Locator, value: string) {
     await locator.click();

--- a/apps/www/tests/titlesPresent.spec.ts
+++ b/apps/www/tests/titlesPresent.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('titles present', () => {
     const pages = JSON.parse(

--- a/apps/www/tests/visual.spec.ts
+++ b/apps/www/tests/visual.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { test } from '@playwright/test';
 import { vizzlyScreenshot } from '@vizzly-testing/cli/client';
+import { test } from './fixtures';
 
 const FALLBACK_ROUTES = ['/'];
 


### PR DESCRIPTION
## Summary
- Add a shared Playwright test fixture for `www` that intercepts the `/api/gredice/api/auth/current-claims` request and returns a signed-out response.
- Update the `www` smoke, a11y, title, search, and visual specs to use the fixture so they no longer depend on a local API server being available on the dev proxy port.
- This removes the `ECONNREFUSED` noise caused by `www` proxying auth traffic to the missing API process during test runs.

## Testing
- `pnpm lint --filter www` passed.
- `pnpm --filter www exec tsc --noEmit` passed.
- Playwright and `next build` were blocked locally by macOS native binary/code-signature issues in `@rollup/rollup-darwin-arm64` and `@next/swc-darwin-arm64`, so the browser run could not complete in this environment.