### PR TITLE
[Search] Add plant sort matching to /biljke search results

### DIFF
--- a/apps/www/app/biljke/PlantsGallery.tsx
+++ b/apps/www/app/biljke/PlantsGallery.tsx
@@ -5,6 +5,7 @@ import { orderBy } from '@signalco/js';
 import { Gallery } from '@signalco/ui/Gallery';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useClientSearchParam } from '../../hooks/useClientSearchParam';
+import type { PlantSortData } from '../../lib/plants/getPlantSortsData';
 import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
 import { PlantsGalleryItem } from './PlantsGalleryItem';
 
@@ -12,10 +13,12 @@ export function PlantsGallery({
     initialSearch = '',
     initialSeedTimeFilter = '',
     plants,
+    sorts,
 }: {
     initialSearch?: string;
     initialSeedTimeFilter?: string;
     plants: (PlantData & { isRecommended?: boolean })[] | undefined;
+    sorts: PlantSortData[] | undefined;
 }) {
     const [search] = useClientSearchParam('pretraga', initialSearch);
     const [seedTimeFilter] = useClientSearchParam(
@@ -24,6 +27,18 @@ export function PlantsGallery({
     );
     const normalizedSearch = normalizeSearchText(search);
     const onlySeedTimePlants = seedTimeFilter === '1';
+    const normalizedSortNamesByPlantId = (sorts ?? []).reduce((acc, sort) => {
+        const plantId = sort.information.plant?.id;
+        const sortName = sort.information.name;
+        if (!plantId || !sortName) {
+            return acc;
+        }
+
+        const normalized = normalizeSearchText(sortName);
+        const existing = acc.get(plantId) ?? [];
+        acc.set(plantId, [...existing, normalized]);
+        return acc;
+    }, new Map<number, string[]>());
     const filteredPlants = orderBy(plants ?? [], (a, b) =>
         a.information.name.localeCompare(b.information.name),
     )
@@ -33,9 +48,26 @@ export function PlantsGallery({
                 !normalizedSearch ||
                 normalizeSearchText(plant.information.name).includes(
                     normalizedSearch,
-                ),
+                ) ||
+                (normalizedSortNamesByPlantId
+                    .get(plant.id)
+                    ?.some((sortName) => sortName.includes(normalizedSearch)) ??
+                    false),
         )
-        .map((plant) => ({ ...plant, id: plant.id.toString() }));
+        .map((plant) => {
+            const matchingSortName = (sorts ?? []).find(
+                (sort) =>
+                    sort.information.plant?.id === plant.id &&
+                    normalizeSearchText(sort.information.name).includes(
+                        normalizedSearch,
+                    ),
+            )?.information.name;
+            return {
+                ...plant,
+                id: plant.id.toString(),
+                matchingSortName,
+            };
+        });
 
     return (
         <>

--- a/apps/www/app/biljke/PlantsGallery.tsx
+++ b/apps/www/app/biljke/PlantsGallery.tsx
@@ -55,13 +55,15 @@ export function PlantsGallery({
                     false),
         )
         .map((plant) => {
-            const matchingSortName = (sorts ?? []).find(
-                (sort) =>
-                    sort.information.plant?.id === plant.id &&
-                    normalizeSearchText(sort.information.name).includes(
-                        normalizedSearch,
-                    ),
-            )?.information.name;
+            const matchingSortName = normalizedSearch
+                ? (sorts ?? []).find(
+                      (sort) =>
+                          sort.information.plant?.id === plant.id &&
+                          normalizeSearchText(sort.information.name).includes(
+                              normalizedSearch,
+                          ),
+                  )?.information.name
+                : undefined;
             return {
                 ...plant,
                 id: plant.id.toString(),

--- a/apps/www/app/biljke/PlantsGalleryItem.tsx
+++ b/apps/www/app/biljke/PlantsGalleryItem.tsx
@@ -16,10 +16,12 @@ export type PlantsGalleryItemProps = Pick<
 > &
     Partial<Pick<PlantData, 'prices'>> & {
         isRecommended?: boolean;
+        matchingSortName?: string;
     };
 
 export function PlantsGalleryItem(props: PlantsGalleryItemProps) {
-    const { information, prices, attributes, isRecommended } = props;
+    const { information, prices, attributes, isRecommended, matchingSortName } =
+        props;
     return (
         <ItemCard
             label={
@@ -40,6 +42,11 @@ export function PlantsGalleryItem(props: PlantsGalleryItemProps) {
                     <Typography level="body2" className="self-end">
                         {prices?.perPlant?.toFixed(2) ?? 'Nepoznato'}€
                     </Typography>
+                    {matchingSortName && (
+                        <Typography level="body3" secondary>
+                            Sorta: {matchingSortName}
+                        </Typography>
+                    )}
                 </Stack>
             }
             href={KnownPages.Plant(information.name)}

--- a/apps/www/app/biljke/page.tsx
+++ b/apps/www/app/biljke/page.tsx
@@ -17,6 +17,7 @@ import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { PageHeader } from '../../components/shared/PageHeader';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
+import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { KnownPages } from '../../src/KnownPages';
 import { merchantReturnPolicy } from '../../src/merchantReturnPolicy';
@@ -45,7 +46,10 @@ export default async function PlantsPage({
         ? (seedTimeFilter[0] ?? '')
         : (seedTimeFilter ?? '');
     const isSeedTimeFilterEnabled = seedTimeFilterValue === '1';
-    const entities = await getPlantsData();
+    const [entities, sorts] = await Promise.all([
+        getPlantsData(),
+        getPlantSortsData(),
+    ]);
     const isCanonicalView = !search && !isSeedTimeFilterEnabled;
     const sortedEntities = orderBy(entities ?? [], (a, b) =>
         a.information.name.localeCompare(b.information.name),
@@ -139,6 +143,7 @@ export default async function PlantsPage({
                     <TabsContent value="popis" className="mt-2">
                         <PlantsGallery
                             plants={entities}
+                            sorts={sorts}
                             initialSearch={search}
                             initialSeedTimeFilter={seedTimeFilterValue}
                         />


### PR DESCRIPTION
### Motivation
- When searching on `/biljke` the UI should include plants that have sorts matching the query and surface which sort matched on the plant card.

### Description
- Fetch plant sorts in parallel with plants by calling `getPlantSortsData` from the `/biljke` page and pass `sorts` into `PlantsGallery`.
- Extend `PlantsGallery` filtering to match the normalized `pretraga` query against both plant names and normalized sort names and attach a `matchingSortName` to the resulting plant item when a sort matched.
- Render the matching sort label in `PlantsGalleryItem` by showing `Sorta: <name>` when `matchingSortName` is present.

### Testing
- Ran `pnpm lint --filter www` which passed after automatic fixes. 
- Ran `pnpm build --filter www` which failed in this environment due to `next/font` being unable to fetch the Google Font `Montserrat` from `https://fonts.googleapis.com`, unrelated to the search logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d098a720c832fbc1ca4b8485f6f54)