### PR TITLE
[Basket] Show transient hub during add-to-basket animations

### DIFF
--- a/packages/game/src/hooks/useShoppingCartTransientHub.ts
+++ b/packages/game/src/hooks/useShoppingCartTransientHub.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+const HUB_HIDE_DELAY_MS = 3000;
+
+let transientVisible = false;
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+const listeners = new Set<(visible: boolean) => void>();
+
+function notify() {
+    for (const listener of listeners) {
+        listener(transientVisible);
+    }
+}
+
+export function showShoppingCartTransientHub() {
+    transientVisible = true;
+    if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+    }
+    notify();
+}
+
+export function scheduleHideShoppingCartTransientHub() {
+    if (hideTimer) {
+        clearTimeout(hideTimer);
+    }
+
+    hideTimer = setTimeout(() => {
+        transientVisible = false;
+        hideTimer = null;
+        notify();
+    }, HUB_HIDE_DELAY_MS);
+}
+
+export function useShoppingCartTransientHub(isShoppingCartOpen: boolean) {
+    const [visible, setVisible] = useState(transientVisible);
+
+    useEffect(() => {
+        listeners.add(setVisible);
+        return () => {
+            listeners.delete(setVisible);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (isShoppingCartOpen && transientVisible) {
+            transientVisible = false;
+            if (hideTimer) {
+                clearTimeout(hideTimer);
+                hideTimer = null;
+            }
+            notify();
+        }
+    }, [isShoppingCartOpen]);
+
+    return visible;
+}

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -20,6 +20,7 @@ import { isCompleteDeliverySelection, useCheckout } from '../hooks/useCheckout';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
 import { useShoppingCart } from '../hooks/useShoppingCart';
 import { useShoppingCartDelete } from '../hooks/useShoppingCartDelete';
+import { useShoppingCartTransientHub } from '../hooks/useShoppingCartTransientHub';
 import {
     type DeliverySelectionData,
     DeliveryStep,
@@ -286,8 +287,9 @@ export function ShoppingCartHud() {
     const { data: cart } = useShoppingCart();
     const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useShoppingCartOpenParam();
+    const showTransientHub = useShoppingCartTransientHub(isOpen);
 
-    if (!cart?.items.length) {
+    if (!cart?.items.length && !showTransientHub) {
         return null;
     }
 
@@ -299,8 +301,8 @@ export function ShoppingCartHud() {
                     onOpenChange={(open) => {
                         if (open) {
                             track('game_cart_opened', {
-                                item_count: cart.items.length,
-                                total: cart.total,
+                                item_count: cart?.items.length ?? 0,
+                                total: cart?.total ?? 0,
                             });
                         }
                         setIsOpen(open);
@@ -319,7 +321,7 @@ export function ShoppingCartHud() {
                                 semiBold
                                 className="text-foreground"
                             >
-                                {(cart.total ?? 0).toFixed(2)} €
+                                {(cart?.total ?? 0).toFixed(2)} €
                             </Typography>
                             {Boolean(cart?.items.length) && (
                                 <div className="absolute -right-2 -top-2">

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -211,22 +211,25 @@ export function PlantPicker({
         });
         showShoppingCartTransientHub();
         setFlyToShoppingCart(true);
-        await setCartItem.mutateAsync({
-            entityTypeName: 'plantSort',
-            entityId: selectedSortId?.toString(),
-            amount: 1,
-            gardenId,
-            raisedBedId,
-            positionIndex,
-            additionalData: JSON.stringify({
-                scheduledDate: plantOptions?.scheduledDate?.toISOString(),
-            }),
-            currency: useInventoryItem ? 'inventory' : 'eur',
-        });
-        await new Promise((resolve) => setTimeout(resolve, 800)); // Wait for animation to finish
-        scheduleHideShoppingCartTransientHub();
-        setOpen(false);
-        setFlyToShoppingCart(false);
+        try {
+            await setCartItem.mutateAsync({
+                entityTypeName: 'plantSort',
+                entityId: selectedSortId?.toString(),
+                amount: 1,
+                gardenId,
+                raisedBedId,
+                positionIndex,
+                additionalData: JSON.stringify({
+                    scheduledDate: plantOptions?.scheduledDate?.toISOString(),
+                }),
+                currency: useInventoryItem ? 'inventory' : 'eur',
+            });
+            await new Promise((resolve) => setTimeout(resolve, 800)); // Wait for animation to finish
+        } finally {
+            scheduleHideShoppingCartTransientHub();
+            setOpen(false);
+            setFlyToShoppingCart(false);
+        }
     }
 
     function handleOpenChange(open: boolean) {

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -25,6 +25,10 @@ import {
     type ShoppingCartItemData,
     useShoppingCart,
 } from '../../hooks/useShoppingCart';
+import {
+    scheduleHideShoppingCartTransientHub,
+    showShoppingCartTransientHub,
+} from '../../hooks/useShoppingCartTransientHub';
 import { PlantsList } from './PlantsList';
 import { PlantsSortList } from './PlantsSortList';
 
@@ -205,6 +209,7 @@ export function PlantPicker({
             sort_id: selectedSortId,
             use_inventory: useInventoryItem,
         });
+        showShoppingCartTransientHub();
         setFlyToShoppingCart(true);
         await setCartItem.mutateAsync({
             entityTypeName: 'plantSort',
@@ -219,6 +224,7 @@ export function PlantPicker({
             currency: useInventoryItem ? 'inventory' : 'eur',
         });
         await new Promise((resolve) => setTimeout(resolve, 800)); // Wait for animation to finish
+        scheduleHideShoppingCartTransientHub();
         setOpen(false);
         setFlyToShoppingCart(false);
     }


### PR DESCRIPTION
### Motivation
- Make the basket hub appear as a visible destination before an item flies into it so add-to-basket feedback is clear even from close-up views. 
- Ensure the transient hub auto-hides after the fly animation and that repeated additions reset/extend the hide timer to avoid races. 

### Description
- Added a shared controller hook `useShoppingCartTransientHub` with `showShoppingCartTransientHub()` and `scheduleHideShoppingCartTransientHub()` to manage a global transient visibility state and timer. 
- Triggered `showShoppingCartTransientHub()` before the fly-to-basket animation and `scheduleHideShoppingCartTransientHub()` after the animation in `PlantPicker` (`packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx`). 
- Updated `ShoppingCartHud` (`packages/game/src/hud/ShoppingCartHud.tsx`) to render when the transient visibility is active even if the cart is otherwise empty so the hub is clickable from close-up contexts. 
- Key files: `packages/game/src/hooks/useShoppingCartTransientHub.ts`, `packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx`, and `packages/game/src/hud/ShoppingCartHud.tsx`.

### Testing
- Ran lint for the game package with `pnpm lint --filter @gredice/game`, which passed. 
- Ran unit tests with `pnpm test --filter @gredice/game`, which passed. 
- Ran package build check with `pnpm build --filter @gredice/game`, which completed (package had no build tasks to run). 
- Attempted broader builds with `pnpm build --filter garden --filter www`; `garden` compiled successfully but `www` failed due to a network/font fetch error (Google Fonts `Montserrat`) in the environment, unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d09c71fc8832fbe5fda5437a08410)