### PR TITLE
Make Codex Cloud Playwright setup tolerate apt mirror failures

### DIFF
--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -178,6 +178,8 @@ Recommended Codex maintenance script:
 
 Override the setup-time Node.js installer with `GREDICE_CODEX_NODE_VERSION=<major-or-full-version>` only when the Codex base image does not already provide Node.js `>=24` and a specific release is required.
 
+`./scripts/codex-cloud-setup.sh` installs the `www` Playwright Chromium browser. By default it tries `playwright install --with-deps chromium`, then falls back to browser-only `playwright install chromium` if Codex Cloud's Ubuntu package mirror or apt proxy is unavailable. Set `GREDICE_CODEX_PLAYWRIGHT_WITH_DEPS=browser-only` to skip apt entirely, or `GREDICE_CODEX_PLAYWRIGHT_WITH_DEPS=required` when a task must fail fast unless OS-level Playwright dependencies install successfully.
+
 Recommended Codex environment variables:
 
 ```bash

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -16,8 +16,26 @@ pnpm install --frozen-lockfile
 codex_log "Creating safe local env files from checked-in examples."
 codex_copy_example_env_files
 
-codex_log "Installing Chromium for the www Playwright workspace."
-pnpm --filter www exec playwright install --with-deps chromium
+case "${GREDICE_CODEX_PLAYWRIGHT_WITH_DEPS:-auto}" in
+  0 | false | no | browser-only)
+    codex_log "Installing Chromium for the www Playwright workspace without apt-managed OS dependencies."
+    pnpm --filter www exec playwright install chromium
+    ;;
+  1 | true | yes | required)
+    codex_log "Installing Chromium for the www Playwright workspace with apt-managed OS dependencies."
+    pnpm --filter www exec playwright install --with-deps chromium
+    ;;
+  auto | '')
+    codex_log "Installing Chromium for the www Playwright workspace with apt-managed OS dependencies when available."
+    if ! pnpm --filter www exec playwright install --with-deps chromium; then
+      codex_log "Playwright OS dependency install failed; retrying Chromium browser-only install."
+      pnpm --filter www exec playwright install chromium
+    fi
+    ;;
+  *)
+    codex_die "GREDICE_CODEX_PLAYWRIGHT_WITH_DEPS must be auto, required, true, false, yes, no, 1, 0, or browser-only."
+    ;;
+esac
 
 codex_log "Validating CI path filters."
 pnpm lint:ci-filters


### PR DESCRIPTION
## Summary
- Updated the Codex Cloud setup script to fall back from `playwright install --with-deps chromium` to browser-only Chromium installation when Ubuntu apt/package fetching fails.
- Added `GREDICE_CODEX_PLAYWRIGHT_WITH_DEPS` to force browser-only or required-with-deps behavior when a task needs one mode explicitly.
- Documented the setup behavior and override in `WORKSPACE.md`.

## Testing
- `bash -n scripts/codex-cloud-setup.sh scripts/codex-cloud-common.sh`
- `git diff --check`