### PR TITLE
Add branded tabs component and replace Signalco tabs usage

### DIFF
--- a/apps/app/app/admin/communication/notifications/NotificationComposerClient.tsx
+++ b/apps/app/app/admin/communication/notifications/NotificationComposerClient.tsx
@@ -1,10 +1,10 @@
 'use client';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
 import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import { Input } from '@signalco/ui-primitives/Input';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Tabs } from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useActionState, useState, useTransition } from 'react';
 import {
@@ -133,17 +133,30 @@ export function NotificationComposerClient() {
             </Card>
             <Card className="p-4">
                 <Typography level="h6">Preview</Typography>
-                <Tabs
-                    items={[
-                        { id: 'in-app', label: 'In-app' },
-                        { id: 'push', label: 'Push' },
-                        { id: 'email', label: 'Email' },
-                    ]}
-                >
-                    <Typography>
-                        Payload preview shown with browser fallback behavior for
-                        rich push fields.
-                    </Typography>
+                <Tabs defaultValue="in-app">
+                    <TabsList>
+                        <TabsTrigger value="in-app">In-app</TabsTrigger>
+                        <TabsTrigger value="push">Push</TabsTrigger>
+                        <TabsTrigger value="email">Email</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="in-app">
+                        <Typography>
+                            Payload preview shown with browser fallback behavior
+                            for rich push fields.
+                        </Typography>
+                    </TabsContent>
+                    <TabsContent value="push">
+                        <Typography>
+                            Push notification preview uses the same campaign
+                            payload.
+                        </Typography>
+                    </TabsContent>
+                    <TabsContent value="email">
+                        <Typography>
+                            Email preview uses campaign fields when email
+                            delivery is enabled.
+                        </Typography>
+                    </TabsContent>
                 </Tabs>
             </Card>
             <Card className="p-4">

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -12,14 +12,9 @@ import {
 } from '@gredice/storage';
 import { getEntityCompleteness } from '@gredice/storage/entityCompleteness';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { revalidatePath } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -6,17 +6,12 @@ import {
     GoogleLoginButton,
     useLastLoginProvider,
 } from '@gredice/ui/auth';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { usePostHog } from '@posthog/next';
 import { Alert } from '@signalco/ui/Alert';
 import { Divider } from '@signalco/ui-primitives/Divider';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';

--- a/apps/storybook/stories/packages/ui/Tabs.stories.tsx
+++ b/apps/storybook/stories/packages/ui/Tabs.stories.tsx
@@ -1,0 +1,125 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Navigation/Tabs',
+    component: Tabs,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Tabs switch between sibling views with Gredice control styling and Radix keyboard behavior.',
+            },
+        },
+    },
+    args: {
+        defaultValue: 'overview',
+    },
+    render: (args) => (
+        <Tabs {...args} className="w-full max-w-xl">
+            <TabsList>
+                <TabsTrigger value="overview">Pregled</TabsTrigger>
+                <TabsTrigger value="calendar">Kalendar</TabsTrigger>
+                <TabsTrigger value="history">Povijest</TabsTrigger>
+            </TabsList>
+            <TabsContent value="overview">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Trenutno stanje gredice, zadnje radnje i korisni sazetak.
+                </div>
+            </TabsContent>
+            <TabsContent value="calendar">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Kalendar sjetve, zalijevanja i planiranih radnji.
+                </div>
+            </TabsContent>
+            <TabsContent value="history">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Povijest promjena i biljeske korisnika.
+                </div>
+            </TabsContent>
+        </Tabs>
+    ),
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FullWidth: Story = {
+    render: (args) => (
+        <Tabs {...args} className="w-full max-w-xl">
+            <TabsList className="grid w-full grid-cols-3">
+                <TabsTrigger value="overview">Pregled</TabsTrigger>
+                <TabsTrigger value="calendar">Kalendar</TabsTrigger>
+                <TabsTrigger value="history">Povijest</TabsTrigger>
+            </TabsList>
+            <TabsContent value="overview">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Kompaktna navigacija za panele koji zauzimaju cijelu sirinu.
+                </div>
+            </TabsContent>
+            <TabsContent value="calendar">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Sadrzaj ostaje poravnat ispod liste tabova.
+                </div>
+            </TabsContent>
+            <TabsContent value="history">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Aktivni tab koristi povrsinu kartice bez skakanja layouta.
+                </div>
+            </TabsContent>
+        </Tabs>
+    ),
+};
+
+export const Disabled: Story = {
+    render: (args) => (
+        <Tabs {...args} className="w-full max-w-xl">
+            <TabsList>
+                <TabsTrigger value="overview">Pregled</TabsTrigger>
+                <TabsTrigger value="calendar">Kalendar</TabsTrigger>
+                <TabsTrigger value="history" disabled>
+                    Povijest
+                </TabsTrigger>
+            </TabsList>
+            <TabsContent value="overview">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Nedostupni tab ostaje vidljiv, ali nije interaktivan.
+                </div>
+            </TabsContent>
+            <TabsContent value="calendar">
+                <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                    Tipkovnica preskace onemogucene tabove.
+                </div>
+            </TabsContent>
+        </Tabs>
+    ),
+};
+
+export const LongLabels: Story = {
+    render: (args) => (
+        <div className="w-72">
+            <Tabs {...args}>
+                <TabsList className="grid w-full grid-cols-2">
+                    <TabsTrigger value="overview">
+                        Pregled dostupnosti
+                    </TabsTrigger>
+                    <TabsTrigger value="calendar">Kalendar sijanja</TabsTrigger>
+                </TabsList>
+                <TabsContent value="overview">
+                    <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                        Ogranicena sirina provjerava da tekst ostaje uredan.
+                    </div>
+                </TabsContent>
+                <TabsContent value="calendar">
+                    <div className="rounded-lg border border-border bg-card p-4 text-sm text-card-foreground shadow-sm">
+                        Dugi nazivi ostaju centrirani u triggerima.
+                    </div>
+                </TabsContent>
+            </Tabs>
+        </div>
+    ),
+};

--- a/apps/www/app/biljke/[alias]/PlantCalendarPicker.tsx
+++ b/apps/www/app/biljke/[alias]/PlantCalendarPicker.tsx
@@ -1,14 +1,9 @@
 import type { PlantData, PlantSortData } from '@gredice/client';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { NoDataPlaceholder } from '@signalco/ui/NoDataPlaceholder';
 import { Calendar, Sprout } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { PlantGrowthCalendar } from './PlantGrowthCalendar';

--- a/apps/www/app/biljke/page.tsx
+++ b/apps/www/app/biljke/page.tsx
@@ -1,14 +1,9 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { orderBy } from '@signalco/js';
 import { Calendar, LayoutGrid } from '@signalco/ui-icons';
 import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -100,31 +95,36 @@ export default async function PlantsPage({
                 <Tabs value={view} defaultValue="popis" className="w-full">
                     <div className="mt-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                         <TabsList className="grid grid-cols-2 w-fit border">
-                            <Link
-                                href={`?pregled=popis${search ? `&pretraga=${search}` : ''}${isSeedTimeFilterEnabled ? '&vrijemeZaSijanje=1' : ''}`}
-                                prefetch
+                            <TabsTrigger
+                                value="popis"
+                                className="w-full"
+                                asChild
                             >
-                                <TabsTrigger value="popis" className="w-full">
+                                <Link
+                                    href={`?pregled=popis${search ? `&pretraga=${search}` : ''}${isSeedTimeFilterEnabled ? '&vrijemeZaSijanje=1' : ''}`}
+                                    prefetch
+                                >
                                     <Row spacing={1} className="cursor-default">
                                         <LayoutGrid className="size-5" />
                                         <span>Popis</span>
                                     </Row>
-                                </TabsTrigger>
-                            </Link>
-                            <Link
-                                href={`?pregled=kalendar${search ? `&pretraga=${search}` : ''}${isSeedTimeFilterEnabled ? '&vrijemeZaSijanje=1' : ''}`}
-                                prefetch
+                                </Link>
+                            </TabsTrigger>
+                            <TabsTrigger
+                                value="kalendar"
+                                className="w-full"
+                                asChild
                             >
-                                <TabsTrigger
-                                    value="kalendar"
-                                    className="w-full"
+                                <Link
+                                    href={`?pregled=kalendar${search ? `&pretraga=${search}` : ''}${isSeedTimeFilterEnabled ? '&vrijemeZaSijanje=1' : ''}`}
+                                    prefetch
                                 >
                                     <Row spacing={1} className="cursor-default">
                                         <Calendar className="size-5" />
                                         <span>Kalendar</span>
                                     </Row>
-                                </TabsTrigger>
-                            </Link>
+                                </Link>
+                            </TabsTrigger>
                         </TabsList>
                         <Suspense>
                             <PlantsSeedTimeFilterToggle

--- a/apps/www/app/recepti/[slug]/NutritionDisplay.tsx
+++ b/apps/www/app/recepti/[slug]/NutritionDisplay.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { Tabs, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Alert } from '@signalco/ui/Alert';
 import { Card, CardContent } from '@signalco/ui-primitives/Card';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Tabs, TabsList, TabsTrigger } from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
 import type { Recipe } from '../../../lib/recipes/getRecipesData';

--- a/packages/game/src/generators/plant/editor/components/PlantControl.tsx
+++ b/packages/game/src/generators/plant/editor/components/PlantControl.tsx
@@ -1,13 +1,8 @@
 'use client';
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Edit, Leaf, Redo, Settings, Sprout, Undo } from '@signalco/ui-icons';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { PlantControlsProps } from '../@types/plant-generator';
 import { ExportDialog } from './ExportDialog';

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,5 +1,6 @@
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import {
     Book,
     Check,
@@ -15,12 +16,6 @@ import { Link } from '@signalco/ui-primitives/Link';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { type ReactElement, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -1,4 +1,5 @@
 import { BlockImage } from '@gredice/ui/BlockImage';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Alert } from '@signalco/ui/Alert';
 import { EditableInput } from '@signalco/ui/EditableInput';
 import { ModalConfirm } from '@signalco/ui/ModalConfirm';
@@ -14,12 +15,6 @@ import { Card, CardOverflow } from '@signalco/ui-primitives/Card';
 import { cx } from '@signalco/ui-primitives/cx';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
 import { useAbandonRaisedBed } from '../../hooks/useAbandonRaisedBed';

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -1,3 +1,4 @@
+import { Tabs, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import {
     Check,
     Down,
@@ -16,7 +17,6 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Skeleton } from '@signalco/ui-primitives/Skeleton';
 import { Spinner } from '@signalco/ui-primitives/Spinner';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import { Tabs, TabsList, TabsTrigger } from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useState } from 'react';
 import {

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -1,4 +1,5 @@
 import { clientAuthenticated } from '@gredice/client';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Approved, Close, Empty, Megaphone } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Card } from '@signalco/ui-primitives/Card';
@@ -7,12 +8,6 @@ import { Input } from '@signalco/ui-primitives/Input';
 import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -1,3 +1,4 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Alert } from '@signalco/ui/Alert';
 import { NoDataPlaceholder } from '@signalco/ui/NoDataPlaceholder';
 import {
@@ -14,12 +15,6 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { SelectItems } from '@signalco/ui-primitives/SelectItems';
 import { Skeleton } from '@signalco/ui-primitives/Skeleton';
 import { Stack } from '@signalco/ui-primitives/Stack';
-import {
-    Tabs,
-    TabsContent,
-    TabsList,
-    TabsTrigger,
-} from '@signalco/ui-primitives/Tabs';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useEffect, useState } from 'react';
 import type { useCheckout } from '../../hooks/useCheckout';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@gredice/client": "workspace:*",
         "@gredice/js": "workspace:*",
+        "@radix-ui/react-tabs": "1.1.13",
         "@signalco/hooks": "0.2.1",
         "@signalco/js": "0.1.0",
         "@signalco/ui": "0.2.10",

--- a/packages/ui/src/Tabs/Tabs.tsx
+++ b/packages/ui/src/Tabs/Tabs.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import type { ComponentPropsWithoutRef, ComponentRef } from 'react';
+import { forwardRef } from 'react';
+
+function cx(...classes: Array<string | false | null | undefined>) {
+    return classes.filter(Boolean).join(' ');
+}
+
+export type TabsProps = ComponentPropsWithoutRef<typeof TabsPrimitive.Root>;
+
+export const Tabs = TabsPrimitive.Root;
+
+export type TabsListProps = ComponentPropsWithoutRef<typeof TabsPrimitive.List>;
+
+export const TabsList = forwardRef<
+    ComponentRef<typeof TabsPrimitive.List>,
+    TabsListProps
+>(function TabsList({ className, ...props }, ref) {
+    return (
+        <TabsPrimitive.List
+            ref={ref}
+            className={cx(
+                'inline-flex min-h-10 items-center justify-center gap-1 rounded-lg border border-border bg-muted/80 p-1 text-muted-foreground shadow-sm',
+                className,
+            )}
+            {...props}
+        />
+    );
+});
+
+export type TabsTriggerProps = ComponentPropsWithoutRef<
+    typeof TabsPrimitive.Trigger
+>;
+
+export const TabsTrigger = forwardRef<
+    ComponentRef<typeof TabsPrimitive.Trigger>,
+    TabsTriggerProps
+>(function TabsTrigger({ className, ...props }, ref) {
+    return (
+        <TabsPrimitive.Trigger
+            ref={ref}
+            className={cx(
+                'inline-flex min-h-8 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium leading-none text-muted-foreground transition-colors',
+                'hover:bg-background/70 hover:text-foreground',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                'disabled:pointer-events-none disabled:opacity-50',
+                'data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+                className,
+            )}
+            {...props}
+        />
+    );
+});
+
+export type TabsContentProps = ComponentPropsWithoutRef<
+    typeof TabsPrimitive.Content
+>;
+
+export const TabsContent = forwardRef<
+    ComponentRef<typeof TabsPrimitive.Content>,
+    TabsContentProps
+>(function TabsContent({ className, ...props }, ref) {
+    return (
+        <TabsPrimitive.Content
+            ref={ref}
+            className={cx(
+                'mt-2 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                className,
+            )}
+            {...props}
+        />
+    );
+});

--- a/packages/ui/src/Tabs/index.ts
+++ b/packages/ui/src/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './Tabs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,13 +156,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -467,13 +467,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -579,7 +579,7 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -588,7 +588,7 @@ importers:
         version: 0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -615,7 +615,7 @@ importers:
         version: 19.1.0-rc.3
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
       postcss:
         specifier: 8.5.14
         version: 8.5.14
@@ -685,13 +685,13 @@ importers:
         version: link:../../packages/ui
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-themes-minimal-app':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -788,7 +788,7 @@ importers:
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -840,13 +840,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -1060,7 +1060,7 @@ importers:
         version: 6.198.0
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.15
@@ -1118,13 +1118,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-themes-minimal':
         specifier: 0.1.3
         version: 0.1.3(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -1428,6 +1428,9 @@ importers:
       '@gredice/js':
         specifier: workspace:*
         version: link:../js
+      '@radix-ui/react-tabs':
+        specifier: 1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/hooks':
         specifier: 0.2.1
         version: 0.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1436,13 +1439,13 @@ importers:
         version: 0.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui':
         specifier: 0.2.10
-        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@signalco/ui-icons':
         specifier: 0.2.2
         version: 0.2.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@signalco/ui-primitives':
         specifier: 0.6.5
-        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+        version: 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       motion:
         specifier: 12.38.0
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1451,7 +1454,7 @@ importers:
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -4016,6 +4019,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-toggle-group@1.1.11':
@@ -9753,7 +9769,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9840,7 +9856,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9853,7 +9869,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11964,6 +11980,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -12762,7 +12794,7 @@ snapshots:
 
   '@signalco/auth-client@0.3.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(@tanstack/react-query@5.100.10(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       '@tanstack/react-query': 5.100.10(react@19.2.6)
       next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       react: 19.2.6
@@ -12802,7 +12834,7 @@ snapshots:
 
   '@signalco/cms-core@0.1.1(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -12830,7 +12862,7 @@ snapshots:
 
   '@signalco/ui-notifications@0.2.0(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -12842,7 +12874,7 @@ snapshots:
       tailwindcss: 3.4.19(tsx@4.22.0)(yaml@2.9.0)
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
 
-  '@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))':
+  '@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))':
     dependencies:
       next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       react: 19.2.6
@@ -12870,7 +12902,15 @@ snapshots:
 
   '@signalco/ui@0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))':
     dependencies:
-      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      tailwindcss: 3.4.19(tsx@4.22.0)(yaml@2.9.0)
+      tailwindcss-animate: 1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
+
+  '@signalco/ui@0.2.10(@signalco/ui-primitives@0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))':
+    dependencies:
+      '@signalco/ui-primitives': 0.6.5(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0)))(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tailwindcss: 3.4.19(tsx@4.22.0)(yaml@2.9.0)
@@ -13443,7 +13483,7 @@ snapshots:
   '@typespec/ts-http-runtime@0.3.2':
     dependencies:
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -13723,6 +13763,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -13873,7 +13919,7 @@ snapshots:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -13905,7 +13951,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -14389,7 +14435,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -14610,7 +14656,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -14685,7 +14731,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -14726,7 +14772,7 @@ snapshots:
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
 
   foreground-child@3.3.1:
     dependencies:
@@ -15067,7 +15113,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -15079,16 +15125,16 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 7.1.4
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -15930,7 +15976,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -16118,7 +16164,7 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  nuqs@2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6):
+  nuqs@2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.6
@@ -16909,7 +16955,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -16959,7 +17005,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -17065,7 +17111,7 @@ snapshots:
     dependencies:
       axios: 1.16.1(debug@4.4.3)
       axios-ntlm: 1.4.6(debug@4.4.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       follow-redirects: 1.16.0(debug@4.4.3)
       formidable: 3.5.4
       sax: 1.6.0
@@ -17089,7 +17135,7 @@ snapshots:
 
   socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -17099,7 +17145,7 @@ snapshots:
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -17108,7 +17154,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       engine.io: 6.6.7
       socket.io-adapter: 2.5.6
       socket.io-parser: 4.2.6
@@ -17655,7 +17701,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@8.0.13(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.4.2)(sass@1.99.0)(tsx@4.22.0)(yaml@2.9.0)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@6.0.3)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Added a shared `@gredice/ui` Tabs component built on Radix Tabs with Gredice styling and better vertical alignment.
- Added Storybook coverage for default, full-width, disabled, and long-label states.
- Replaced all direct `@signalco/ui-primitives/Tabs` usage across app, garden, www, and game surfaces with the new shared component.
- Converted the remaining Signalco `items`-based tabs usage to the compound API and updated linked tab triggers to use `asChild` where needed.

## Testing
- Lint and formatting passed for the affected workspaces.
- `@gredice/game` tests passed.
- Built `storybook`, `garden`, `app`, and `www` successfully.
- Verified the new Tabs story in Storybook and confirmed the tab labels are vertically centered and do not overflow in constrained widths.