### PR TITLE
[Checkout] Persist sunflower deductions only after successful payment

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -479,6 +479,17 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
     }
 
     const uniqueAffectedCartIds = Array.from(new Set(affectedCartIds));
+
+    if (accountId && session.amountTotal) {
+        await createTransaction({
+            accountId,
+            amount: session.amountTotal,
+            stripePaymentId: session.paymentId ?? session.id,
+            status: 'completed',
+            currency: 'eur',
+        });
+    }
+
     if (accountId && uniqueAffectedCartIds.length > 0) {
         for (const cartId of uniqueAffectedCartIds) {
             await processNonStripeCartItems(
@@ -491,18 +502,7 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
     }
 
     // Update all affected carts to mark them as paid if all items are paid
-    await Promise.all([
-        ...uniqueAffectedCartIds.map(markCartPaidIfAllItemsPaid),
-        accountId && session.amountTotal
-            ? createTransaction({
-                  accountId,
-                  amount: session.amountTotal,
-                  stripePaymentId: session.paymentId ?? session.id,
-                  status: 'completed',
-                  currency: 'eur',
-              })
-            : undefined,
-    ]);
+    await Promise.all(uniqueAffectedCartIds.map(markCartPaidIfAllItemsPaid));
 
     await notifyPurchase({
         accountId,


### PR DESCRIPTION
### Motivation
- Prevent sunflower balance deductions and inventory processing from running before the Stripe payment is persisted to the system to avoid inconsistent state if payment processing/recording fails. 
- Ensure non-Stripe items (sunflower-priced items and inventory consumption) are only processed once a completed transaction exists for the session. 

### Description
- Moved the `createTransaction` call to persist the completed Stripe transaction ahead of invoking `processNonStripeCartItems` in `processCheckoutSession`.
- Kept non-Stripe processing by calling `processNonStripeCartItems` for each affected cart after persisting the transaction.
- Simplified the final reconciliation to `await Promise.all(uniqueAffectedCartIds.map(markCartPaidIfAllItemsPaid))` after item processing.
- Modified file: `apps/api/lib/stripe/processCheckoutSession.ts`.

### Testing
- Ran `pnpm lint --filter api` which executed `biome check --write` and completed successfully (repo engine warning due to local Node version vs `>=24`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0fc9fa88832f9a8b040f9288d645)