### PR TITLE
[Sunflowers] Render HUD above checkout modal backdrop

### DIFF
--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -191,7 +191,7 @@ function SunflowersAmount() {
 
 export function SunflowersHud() {
     return (
-        <HudCard position="floating" open className="static">
+        <HudCard position="floating" open className="static z-[55]">
             <SunflowersAmount />
         </HudCard>
     );


### PR DESCRIPTION
### Motivation
- Ensure the sunflower HUD remains visible above checkout/payment modal backdrops so users can see their sunflower balance while choosing payment options without obscuring primary modal actions.

### Description
- Add an explicit `z-[55]` class to the `HudCard` in `packages/game/src/hud/SunflowersHud.tsx` to raise the HUD stacking context above modal backdrops.

### Testing
- Ran `pnpm lint --filter @gredice/game` which passed, and ran `pnpm build --filter @gredice/game` (Turbo reported no build tasks for this package), and both commands completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d115a7d34832f8ea489e694f49ca7)