### PR TITLE
Add dedicated drag handles for attribute reordering

### DIFF
--- a/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
+++ b/apps/app/components/admin/directories/AttributeDefinitionsListClient.tsx
@@ -46,6 +46,7 @@ import { KnownPages } from '../../../src/KnownPages';
 import { NoDataPlaceholder } from '../../shared/placeholders/NoDataPlaceholder';
 import { CreateAttributeDefinitionButton } from '../buttons/CreateAttributeDefinitionButton';
 import { CreateAttributeDefinitionCategoryButton } from '../buttons/CreateAttributeDefinitionCategoryButton';
+import { SortableDragHandle } from './SortableDragHandle';
 import { TableAttributeOrderSection } from './TableAttributeOrderSection';
 
 function AttributeDataTypeIcon({
@@ -110,6 +111,7 @@ function AttributeDefinitionCard({
                 attributeDefinition.id,
             )}
             onClick={handleClick}
+            className="block"
         >
             <Card>
                 <Row spacing={1}>
@@ -162,6 +164,7 @@ function AttributeDefinitionCategoryCard({
                 attributeDefinitionCategory.id,
             )}
             onClick={handleClick}
+            className="block"
         >
             <Card>
                 <Row spacing={1} justifyContent="space-between">
@@ -196,11 +199,26 @@ function SortableCategory({
         transition,
     };
     return (
-        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-            <AttributeDefinitionCategoryCard
-                attributeDefinitionCategory={category}
-                isDragging={isDragging || preventClick}
+        <div
+            ref={setNodeRef}
+            style={style}
+            className="flex items-stretch gap-1"
+        >
+            <SortableDragHandle
+                {...attributes}
+                {...listeners}
+                aria-label="Promijeni poredak kategorije"
+                title="Promijeni poredak kategorije"
+                className={
+                    isDragging ? 'cursor-grabbing bg-muted text-foreground' : ''
+                }
             />
+            <div className="min-w-0 flex-1">
+                <AttributeDefinitionCategoryCard
+                    attributeDefinitionCategory={category}
+                    isDragging={isDragging || preventClick}
+                />
+            </div>
         </div>
     );
 }
@@ -225,11 +243,26 @@ function SortableAttributeDefinition({
         transition,
     };
     return (
-        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-            <AttributeDefinitionCard
-                attributeDefinition={attribute}
-                isDragging={isDragging || preventClick}
+        <div
+            ref={setNodeRef}
+            style={style}
+            className="flex items-stretch gap-1"
+        >
+            <SortableDragHandle
+                {...attributes}
+                {...listeners}
+                aria-label="Promijeni poredak atributa"
+                title="Promijeni poredak atributa"
+                className={
+                    isDragging ? 'cursor-grabbing bg-muted text-foreground' : ''
+                }
             />
+            <div className="min-w-0 flex-1">
+                <AttributeDefinitionCard
+                    attributeDefinition={attribute}
+                    isDragging={isDragging || preventClick}
+                />
+            </div>
         </div>
     );
 }

--- a/apps/app/components/admin/directories/SortableDragHandle.tsx
+++ b/apps/app/components/admin/directories/SortableDragHandle.tsx
@@ -1,0 +1,37 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+export function SortableDragHandle({
+    className,
+    title = 'Promijeni poredak',
+    'aria-label': ariaLabel = 'Promijeni poredak',
+    ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+    const classNames = [
+        'flex min-h-12 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-md border border-transparent text-muted-foreground/60 outline-none transition-colors hover:border-border hover:bg-muted/70 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:cursor-grabbing',
+        className,
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button
+            {...rest}
+            type="button"
+            title={title}
+            aria-label={ariaLabel}
+            className={classNames}
+        >
+            <span
+                className="grid grid-cols-2 gap-x-0.5 gap-y-1"
+                aria-hidden="true"
+            >
+                <span className="size-1 rounded-full bg-current" />
+                <span className="size-1 rounded-full bg-current" />
+                <span className="size-1 rounded-full bg-current" />
+                <span className="size-1 rounded-full bg-current" />
+                <span className="size-1 rounded-full bg-current" />
+                <span className="size-1 rounded-full bg-current" />
+            </span>
+        </button>
+    );
+}

--- a/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
+++ b/apps/app/components/admin/directories/TableAttributeOrderSection.tsx
@@ -29,6 +29,7 @@ import type { CSSProperties, MouseEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { reorderAttributeDefinition } from '../../../app/(actions)/definitionActions';
 import { KnownPages } from '../../../src/KnownPages';
+import { SortableDragHandle } from './SortableDragHandle';
 
 function SortableTableAttributeRow({
     attribute,
@@ -61,13 +62,27 @@ function SortableTableAttributeRow({
     };
 
     return (
-        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+        <div
+            ref={setNodeRef}
+            style={style}
+            className="flex items-stretch gap-1"
+        >
+            <SortableDragHandle
+                {...attributes}
+                {...listeners}
+                aria-label="Promijeni poredak atributa u tablici"
+                title="Promijeni poredak atributa u tablici"
+                className={
+                    isDragging ? 'cursor-grabbing bg-muted text-foreground' : ''
+                }
+            />
             <Link
                 href={KnownPages.DirectoryEntityTypeAttributeDefinition(
                     attribute.entityTypeName,
                     attribute.id,
                 )}
                 onClick={handleClick}
+                className="min-w-0 flex-1"
             >
                 <Card>
                     <Row spacing={1} justifyContent="space-between">


### PR DESCRIPTION
## Summary
- Added a compact left-side drag handle for attribute definition and category reordering in the admin directory view.
- Moved dnd-kit listeners off the full cards so clicks open attribute details without triggering reorder.
- Reused the same handle pattern for the table display-order section.

## Testing
- `pnpm lint --filter app` passed.
- `pnpm build --filter app` passed.
- `pnpm test --filter app` passed.