### PR TITLE
Disable PostHog in local development

### DIFF
--- a/apps/api/app/layout.tsx
+++ b/apps/api/app/layout.tsx
@@ -21,8 +21,10 @@ export default function RootLayout({
     children: ReactNode;
 }>) {
     const postHogApiKey =
-        process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-        process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+        process.env.NODE_ENV === 'development'
+            ? undefined
+            : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+              process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
     const postHogApiHost = '/ingest';
     const postHogUiHost =
         process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/api/lib/posthog-server.ts
+++ b/apps/api/lib/posthog-server.ts
@@ -21,8 +21,10 @@ const postHogConsoleForwardingKey = Symbol.for(
 );
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogServerHost =
     process.env.POSTHOG_SERVER_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/api/proxy.ts
+++ b/apps/api/proxy.ts
@@ -14,8 +14,10 @@ import {
 } from './lib/posthog-server';
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogProxyHost =
     process.env.POSTHOG_PROXY_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_HOST?.replace(

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -32,8 +32,10 @@ export default function RootLayout({
     children: ReactNode;
 }>) {
     const postHogApiKey =
-        process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-        process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+        process.env.NODE_ENV === 'development'
+            ? undefined
+            : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+              process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
     const postHogApiHost = '/ingest';
     const postHogUiHost =
         process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/app/lib/posthog-server.ts
+++ b/apps/app/lib/posthog-server.ts
@@ -21,8 +21,10 @@ const postHogConsoleForwardingKey = Symbol.for(
 );
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogServerHost =
     process.env.POSTHOG_SERVER_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -14,8 +14,10 @@ import {
 } from './lib/posthog-server';
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogProxyHost =
     process.env.POSTHOG_PROXY_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_HOST?.replace(

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -27,8 +27,10 @@ export default function RootLayout({
 }>) {
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
     const postHogApiKey =
-        process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-        process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+        process.env.NODE_ENV === 'development'
+            ? undefined
+            : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+              process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
     const postHogApiHost = '/ingest';
     const postHogUiHost =
         process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/farm/lib/posthog-server.ts
+++ b/apps/farm/lib/posthog-server.ts
@@ -21,8 +21,10 @@ const postHogConsoleForwardingKey = Symbol.for(
 );
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogServerHost =
     process.env.POSTHOG_SERVER_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/farm/proxy.ts
+++ b/apps/farm/proxy.ts
@@ -14,8 +14,10 @@ import {
 } from './lib/posthog-server';
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogProxyHost =
     process.env.POSTHOG_PROXY_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_HOST?.replace(

--- a/apps/garden/app/layout.tsx
+++ b/apps/garden/app/layout.tsx
@@ -29,8 +29,10 @@ export default function RootLayout({
 }>) {
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
     const postHogApiKey =
-        process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-        process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+        process.env.NODE_ENV === 'development'
+            ? undefined
+            : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+              process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
     const postHogApiHost = '/ingest';
     const postHogUiHost =
         process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/garden/lib/posthog-server.ts
+++ b/apps/garden/lib/posthog-server.ts
@@ -21,8 +21,10 @@ const postHogConsoleForwardingKey = Symbol.for(
 );
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogServerHost =
     process.env.POSTHOG_SERVER_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/garden/proxy.ts
+++ b/apps/garden/proxy.ts
@@ -14,8 +14,10 @@ import {
 } from './lib/posthog-server';
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogProxyHost =
     process.env.POSTHOG_PROXY_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_HOST?.replace(

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -73,8 +73,10 @@ export default async function RootLayout({
 }>) {
     const shouldInjectToolbar = process.env.NODE_ENV === 'development';
     const postHogApiKey =
-        process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-        process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+        process.env.NODE_ENV === 'development'
+            ? undefined
+            : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+              process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
     const postHogApiHost = '/ingest';
     const postHogUiHost =
         process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/www/lib/posthog-server.ts
+++ b/apps/www/lib/posthog-server.ts
@@ -21,8 +21,10 @@ const postHogConsoleForwardingKey = Symbol.for(
 );
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogServerHost =
     process.env.POSTHOG_SERVER_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_UI_HOST ??

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -16,8 +16,10 @@ import {
 import { toPageAlias } from './src/pageAliases';
 
 const postHogApiKey =
-    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    process.env.NODE_ENV === 'development'
+        ? undefined
+        : (process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+          process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN);
 const postHogProxyHost =
     process.env.POSTHOG_PROXY_HOST ??
     process.env.NEXT_PUBLIC_POSTHOG_HOST?.replace(


### PR DESCRIPTION
## Summary
- Disable PostHog initialization in `NODE_ENV=development` across all five apps.
- This covers the browser provider, pageview tracking, server captures, request proxying, and log forwarding, so local dev stays quiet even if PostHog env vars are present.

## Testing
- `pnpm lint --filter app --filter www --filter garden --filter farm --filter api`
- `pnpm build --filter app --filter www --filter garden --filter farm --filter api`
- `pnpm --filter api run test:node`
- `pnpm --filter app run test:unit`
- Verified the PostHog helpers return disabled behavior in development with a local runtime sanity check
- Full `pnpm test --filter app --filter www --filter garden --filter farm --filter api` was attempted, but the API Playwright suite requires `POSTGRES_URL` and failed before the remaining suites could finish