### PR TITLE
Move entity details into a persisted right-side panel

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesContext.ts
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesContext.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+type EntityDetailsPropertiesContextValue = {
+    isOpen: boolean;
+    toggle: () => void;
+};
+
+export const EntityDetailsPropertiesContext =
+    createContext<EntityDetailsPropertiesContextValue | null>(null);
+
+export function useEntityDetailsProperties() {
+    const context = useContext(EntityDetailsPropertiesContext);
+
+    if (!context) {
+        throw new Error(
+            'useEntityDetailsProperties must be used inside EntityDetailsPropertiesProvider',
+        );
+    }
+
+    return context;
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesLayout.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesLayout.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { cx } from '@signalco/ui-primitives/cx';
+import type { ReactNode } from 'react';
+import { useEntityDetailsProperties } from './EntityDetailsPropertiesContext';
+
+export function EntityDetailsPropertiesLayout({
+    children,
+    properties,
+}: {
+    children: ReactNode;
+    properties: ReactNode;
+}) {
+    const { isOpen } = useEntityDetailsProperties();
+
+    return (
+        <div
+            className={cx(
+                'relative grid min-w-0 gap-3',
+                isOpen && 'lg:grid-cols-[minmax(0,1fr)_20rem]',
+            )}
+        >
+            <div className="min-w-0">{children}</div>
+            <aside
+                id="entity-details-properties-panel"
+                aria-label="Detalji zapisa"
+                aria-hidden={!isOpen}
+                className={cx(
+                    'fixed bottom-3 right-3 top-20 z-40 w-[min(22rem,calc(100vw-1.5rem))] transition-transform duration-200 lg:sticky lg:bottom-auto lg:right-auto lg:top-4 lg:z-10 lg:w-80 lg:self-start',
+                    isOpen
+                        ? 'translate-x-0'
+                        : 'pointer-events-none translate-x-[calc(100%+1rem)] lg:hidden',
+                )}
+            >
+                {isOpen ? properties : null}
+            </aside>
+        </div>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesPanel.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesPanel.tsx
@@ -1,0 +1,22 @@
+import { Stack } from '@signalco/ui-primitives/Stack';
+import { Typography } from '@signalco/ui-primitives/Typography';
+import type { ReactNode } from 'react';
+
+export function EntityDetailsPropertiesPanel({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    return (
+        <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border bg-background shadow-2xl lg:max-h-[calc(100vh-6rem)] lg:shadow-sm">
+            <div className="shrink-0 border-b px-4 py-3">
+                <Typography level="h5" semiBold>
+                    Detalji
+                </Typography>
+            </div>
+            <div className="min-h-0 grow overflow-y-auto p-3">
+                <Stack spacing={2}>{children}</Stack>
+            </div>
+        </section>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesProvider.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesProvider.tsx
@@ -57,6 +57,10 @@ export function EntityDetailsPropertiesProvider({
         }
 
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented) {
+                return;
+            }
+
             if (event.key === 'Escape') {
                 setIsOpen(false);
             }

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesProvider.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesProvider.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import {
+    type PropsWithChildren,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import { EntityDetailsPropertiesContext } from './EntityDetailsPropertiesContext';
+
+const entityDetailsPropertiesStorageKey =
+    'gredice.entityDetails.propertiesPanel';
+
+export function EntityDetailsPropertiesProvider({
+    children,
+}: PropsWithChildren) {
+    const [isOpen, setIsOpen] = useState(true);
+    const [hasLoadedPreference, setHasLoadedPreference] = useState(false);
+
+    useEffect(() => {
+        try {
+            const storedValue = window.localStorage.getItem(
+                entityDetailsPropertiesStorageKey,
+            );
+
+            if (storedValue === 'closed') {
+                setIsOpen(false);
+            } else if (storedValue === 'open') {
+                setIsOpen(true);
+            }
+        } catch {
+            // Local storage is an enhancement; keep the default open state.
+        } finally {
+            setHasLoadedPreference(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!hasLoadedPreference) {
+            return;
+        }
+
+        try {
+            window.localStorage.setItem(
+                entityDetailsPropertiesStorageKey,
+                isOpen ? 'open' : 'closed',
+            );
+        } catch {
+            // Ignore persistence failures and leave the panel usable.
+        }
+    }, [hasLoadedPreference, isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setIsOpen(false);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [isOpen]);
+
+    const toggle = useCallback(() => {
+        setIsOpen((current) => !current);
+    }, []);
+
+    const contextValue = useMemo(
+        () => ({
+            isOpen,
+            toggle,
+        }),
+        [isOpen, toggle],
+    );
+
+    return (
+        <EntityDetailsPropertiesContext.Provider value={contextValue}>
+            {children}
+        </EntityDetailsPropertiesContext.Provider>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesToggle.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertiesToggle.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { PanelRightClose } from '@signalco/ui-icons';
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { useEntityDetailsProperties } from './EntityDetailsPropertiesContext';
+
+export function EntityDetailsPropertiesToggle() {
+    const { isOpen, toggle } = useEntityDetailsProperties();
+
+    return (
+        <IconButton
+            variant="plain"
+            onClick={toggle}
+            title={isOpen ? 'Sakrij detalje' : 'Prikaži detalje'}
+            aria-controls="entity-details-properties-panel"
+            aria-pressed={isOpen}
+            className="rounded-md text-muted-foreground hover:text-foreground"
+        >
+            <PanelRightClose
+                className={`size-5 transition-transform ${
+                    isOpen ? '' : 'rotate-180'
+                }`}
+            />
+        </IconButton>
+    );
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertyList.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertyList.tsx
@@ -1,0 +1,69 @@
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { cx } from '@signalco/ui-primitives/cx';
+import type { ReactNode } from 'react';
+
+export type EntityDetailsPropertyListItem = {
+    id: string;
+    label: string;
+    value: Date | boolean | string | number | ReactNode | null | undefined;
+    mono?: boolean;
+    visual?: ReactNode;
+};
+
+export function EntityDetailsPropertyList({
+    items,
+}: {
+    items: EntityDetailsPropertyListItem[];
+}) {
+    return (
+        <dl className="overflow-hidden rounded-lg border bg-background">
+            {items.map((item) => (
+                <div
+                    key={item.id}
+                    className="grid grid-cols-[minmax(6rem,0.85fr)_minmax(0,1.15fr)] gap-3 border-b px-3 py-2.5 text-sm last:border-b-0"
+                >
+                    <dt className="min-w-0 truncate text-muted-foreground">
+                        {item.label}
+                    </dt>
+                    <dd className="flex min-w-0 items-center gap-2 text-foreground">
+                        {item.visual && (
+                            <span className="shrink-0 text-muted-foreground">
+                                {item.visual}
+                            </span>
+                        )}
+                        <span
+                            className={cx(
+                                'min-w-0',
+                                isCompactValue(item.value) && 'truncate',
+                                item.mono && 'font-mono',
+                            )}
+                            title={
+                                isCompactValue(item.value)
+                                    ? String(item.value)
+                                    : undefined
+                            }
+                        >
+                            {renderPropertyValue(item.value)}
+                        </span>
+                    </dd>
+                </div>
+            ))}
+        </dl>
+    );
+}
+
+function renderPropertyValue(value: EntityDetailsPropertyListItem['value']) {
+    if (value instanceof Date) {
+        return <LocalDateTime>{value}</LocalDateTime>;
+    }
+
+    if (typeof value === 'boolean') {
+        return value ? 'Da' : 'Ne';
+    }
+
+    return value ?? '-';
+}
+
+function isCompactValue(value: EntityDetailsPropertyListItem['value']) {
+    return typeof value === 'string' || typeof value === 'number';
+}

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityLinksPanel.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityLinksPanel.tsx
@@ -36,11 +36,16 @@ export function EntityLinksPanel({ entityId }: { entityId: number }) {
         }
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
+                event.preventDefault();
+                event.stopPropagation();
                 setOpen(false);
             }
         };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
+        window.addEventListener('keydown', handleKeyDown, { capture: true });
+        return () =>
+            window.removeEventListener('keydown', handleKeyDown, {
+                capture: true,
+            });
     }, [open]);
 
     async function fetchLinks() {

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -13,6 +13,7 @@ import {
 import { getEntityCompleteness } from '@gredice/storage/entityCompleteness';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
+import { Calendar, Code } from '@signalco/ui-icons';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { revalidatePath } from 'next/cache';
@@ -32,8 +33,17 @@ import { auth } from '../../../../../lib/auth/auth';
 import { entityDisplayName } from '../../../../../src/entities/entityAttributes';
 import { KnownPages } from '../../../../../src/KnownPages';
 import { handleEntityDelete } from '../../../../(actions)/entityActions';
+import { AttributeDataTypeIcon } from '../attribute-definitions/AttributeDataTypes';
 import { AttributeCategoryDetails } from './AttributeCategoryDetails';
 import { EntityActions } from './EntityActions';
+import { EntityDetailsPropertiesLayout } from './EntityDetailsPropertiesLayout';
+import { EntityDetailsPropertiesPanel } from './EntityDetailsPropertiesPanel';
+import { EntityDetailsPropertiesProvider } from './EntityDetailsPropertiesProvider';
+import { EntityDetailsPropertiesToggle } from './EntityDetailsPropertiesToggle';
+import {
+    EntityDetailsPropertyList,
+    type EntityDetailsPropertyListItem,
+} from './EntityDetailsPropertyList';
 import { EntityDetailsSaveIndicator } from './EntityDetailsSaveIndicator';
 import { EntityDetailsSaveProvider } from './EntityDetailsSaveProvider';
 import { EntityDetailsStickyHeader } from './EntityDetailsStickyHeader';
@@ -209,188 +219,237 @@ export default async function EntityDetailsPage(props: {
             (definition) => definition.category,
         ),
     );
+    const propertyItems: EntityDetailsPropertyListItem[] = [
+        {
+            id: 'slug',
+            label: 'Slug',
+            value: slugify(entityTitle),
+            mono: true,
+            visual: <Code className="size-4" aria-hidden />,
+        },
+        {
+            id: 'created-at',
+            label: 'Datum kreiranja',
+            value: entity.createdAt,
+            visual: <Calendar className="size-4" aria-hidden />,
+        },
+        {
+            id: 'updated-at',
+            label: 'Datum zadnje izmjene',
+            value: entity.updatedAt,
+            visual: <Calendar className="size-4" aria-hidden />,
+        },
+        {
+            id: 'published-at',
+            label: 'Datum objave',
+            value: entity.publishedAt,
+            visual: <Calendar className="size-4" aria-hidden />,
+        },
+        ...displayDefinitions.map((d) => {
+            const value = entity.attributes.find(
+                (a) => a.attributeDefinitionId === d.id,
+            )?.value;
+            const dataTypeIcon = (
+                <AttributeDataTypeIcon
+                    key={`attribute-${d.id}-icon`}
+                    dataType={d.dataType}
+                    className="size-4"
+                    aria-hidden
+                />
+            );
+
+            if (!value) {
+                return {
+                    id: `attribute-${d.id}`,
+                    label: d.label,
+                    value: '-',
+                    visual: dataTypeIcon,
+                };
+            }
+
+            if (d.dataType === 'image') {
+                const imageUrl = imageAttributeValue(value);
+
+                return {
+                    id: `attribute-${d.id}`,
+                    label: d.label,
+                    value: imageUrl ? (
+                        <ImageViewer
+                            key={`attribute-${d.id}-image`}
+                            src={imageUrl}
+                            alt={d.label}
+                            previewWidth={40}
+                            previewHeight={40}
+                        />
+                    ) : (
+                        '-'
+                    ),
+                    visual: imageUrl ? undefined : dataTypeIcon,
+                };
+            }
+
+            if (d.dataType === 'barcode') {
+                return {
+                    id: `attribute-${d.id}`,
+                    label: d.label,
+                    value: (
+                        <BarcodeValue
+                            key={`attribute-${d.id}-barcode`}
+                            value={value}
+                        />
+                    ),
+                };
+            }
+
+            if (d.dataType.startsWith('ref:')) {
+                return {
+                    id: `attribute-${d.id}`,
+                    label: d.label,
+                    value: refLabelsByDefinitionId[d.id]?.[value] ?? value,
+                    visual: dataTypeIcon,
+                };
+            }
+
+            return {
+                id: `attribute-${d.id}`,
+                label: d.label,
+                value: formatAttributeValueWithUnit(value, d.unit),
+                visual: dataTypeIcon,
+            };
+        }),
+    ];
+    const propertiesPanel = (
+        <EntityDetailsPropertiesPanel>
+            <EntityDetailsPropertyList items={propertyItems} />
+            {inventoryConfig && (
+                <EntityInventoryCard
+                    inventoryConfigId={inventoryConfig.id}
+                    inventoryLowCountThreshold={
+                        inventoryConfig.lowCountThreshold
+                    }
+                    entityInventoryItem={entityInventoryItem}
+                    upsertInventoryAction={upsertInventoryAction}
+                />
+            )}
+        </EntityDetailsPropertiesPanel>
+    );
 
     return (
         <EntityDetailsSaveProvider>
-            <AdminPageTitle title={entityTitle} />
-            <AdminPageHeader
-                breadcrumbs={
-                    <Row spacing={2} className="min-w-0">
-                        <div className="min-w-0">
-                            <AdminDirectoryBreadcrumbs
-                                entityTypeName={params.entityType}
-                                entityTypeLabel={entity.entityType.label}
-                                items={[
-                                    {
-                                        label: entityDisplayName(entity),
-                                    },
-                                ]}
-                            />
-                        </div>
-                        <div className="w-20 shrink-0">
-                            <EntityAttributeProgress
-                                entity={entity}
-                                definitions={attributeDefinitions}
-                            />
-                        </div>
-                    </Row>
-                }
-                actions={
-                    <Row className="items-center" spacing={1}>
-                        <EntityDetailsSaveIndicator />
-                        <EntityLinksPanel entityId={entityId} />
-                        <EntityActions
-                            entity={entity}
-                            entityType={params.entityType}
-                            importAction={importAction}
-                            deleteAction={entityDeleteBound}
-                        />
-                    </Row>
-                }
-                heading={entityDisplayName(entity)}
-            />
-            <div className="mb-3">
-                <FieldSet className="max-w-sm">
-                    <Field name="Slug" value={slugify(entityTitle)} />
-                </FieldSet>
-            </div>
-            <Tabs defaultValue={attributeCategories.at(0)?.name}>
-                <EntityDetailsStickyHeader
-                    tabs={
-                        <TabsList>
-                            {[
-                                ...attributeCategories,
-                                { name: 'history', label: 'Povijest' },
-                            ].map((category) => (
-                                <TabsTrigger
-                                    key={category.name}
-                                    value={category.name}
-                                >
-                                    <Row spacing={1} className="items-center">
-                                        <span>{category.label}</span>
-                                        {categoriesWithMissingRequiredAttributes.has(
-                                            category.name,
-                                        ) && (
-                                            <>
-                                                <span
-                                                    className="size-2 rounded-full bg-red-500"
-                                                    aria-hidden
-                                                />
-                                                <span className="sr-only">
-                                                    Nedostaju obavezni atributi
-                                                </span>
-                                            </>
-                                        )}
-                                    </Row>
-                                </TabsTrigger>
-                            ))}
-                        </TabsList>
+            <EntityDetailsPropertiesProvider>
+                <AdminPageTitle title={entityTitle} />
+                <AdminPageHeader
+                    breadcrumbs={
+                        <Row spacing={2} className="min-w-0">
+                            <div className="min-w-0">
+                                <AdminDirectoryBreadcrumbs
+                                    entityTypeName={params.entityType}
+                                    entityTypeLabel={entity.entityType.label}
+                                    items={[
+                                        {
+                                            label: entityDisplayName(entity),
+                                        },
+                                    ]}
+                                />
+                            </div>
+                            <div className="w-20 shrink-0">
+                                <EntityAttributeProgress
+                                    entity={entity}
+                                    definitions={attributeDefinitions}
+                                />
+                            </div>
+                        </Row>
                     }
-                />
-                <Stack spacing={2}>
-                    <Stack spacing={2}>
-                        {inventoryConfig && (
-                            <EntityInventoryCard
-                                inventoryConfigId={inventoryConfig.id}
-                                inventoryLowCountThreshold={
-                                    inventoryConfig.lowCountThreshold
-                                }
-                                entityInventoryItem={entityInventoryItem}
-                                upsertInventoryAction={upsertInventoryAction}
-                            />
-                        )}
-                        <FieldSet>
-                            <Field
-                                name="Datum kreiranja"
-                                value={entity.createdAt}
-                            />
-                            <Field
-                                name="Datum zadnje izmjene"
-                                value={entity.updatedAt}
-                            />
-                            <Field
-                                name="Datum objave"
-                                value={entity.publishedAt}
-                            />
-                            {displayDefinitions.map((d) => (
-                                <Field
-                                    key={d.id}
-                                    name={d.label}
-                                    value={(() => {
-                                        const value = entity.attributes.find(
-                                            (a) =>
-                                                a.attributeDefinitionId ===
-                                                d.id,
-                                        )?.value;
-                                        if (!value) {
-                                            return '-';
-                                        }
-
-                                        if (d.dataType === 'image') {
-                                            const imageUrl =
-                                                imageAttributeValue(value);
-                                            if (imageUrl) {
-                                                return (
-                                                    <ImageViewer
-                                                        src={imageUrl}
-                                                        alt={d.label}
-                                                        previewWidth={40}
-                                                        previewHeight={40}
-                                                    />
-                                                );
-                                            }
-                                        }
-
-                                        if (d.dataType === 'barcode') {
-                                            return (
-                                                <BarcodeValue value={value} />
-                                            );
-                                        }
-
-                                        if (d.dataType.startsWith('ref:')) {
-                                            return (
-                                                refLabelsByDefinitionId[d.id]?.[
-                                                    value
-                                                ] ?? value
-                                            );
-                                        }
-
-                                        return formatAttributeValueWithUnit(
-                                            value,
-                                            d.unit,
-                                        );
-                                    })()}
-                                />
-                            ))}
-                        </FieldSet>
-                    </Stack>
-                    {[
-                        ...attributeCategories,
-                        { name: 'history', label: 'Povijest' },
-                    ].map((category) => (
-                        <TabsContent value={category.name} key={category.name}>
-                            <AttributeCategoryDetails
+                    actions={
+                        <Row className="items-center" spacing={1}>
+                            <EntityDetailsSaveIndicator />
+                            <EntityLinksPanel entityId={entityId} />
+                            <EntityDetailsPropertiesToggle />
+                            <EntityActions
                                 entity={entity}
-                                category={category}
-                                attributeDefinitions={attributeDefinitions}
+                                entityType={params.entityType}
+                                importAction={importAction}
+                                deleteAction={entityDeleteBound}
                             />
-                        </TabsContent>
-                    ))}
+                        </Row>
+                    }
+                    heading={entityDisplayName(entity)}
+                />
+                <EntityDetailsPropertiesLayout properties={propertiesPanel}>
+                    <Tabs defaultValue={attributeCategories.at(0)?.name}>
+                        <EntityDetailsStickyHeader
+                            tabs={
+                                <TabsList>
+                                    {[
+                                        ...attributeCategories,
+                                        { name: 'history', label: 'Povijest' },
+                                    ].map((category) => (
+                                        <TabsTrigger
+                                            key={category.name}
+                                            value={category.name}
+                                        >
+                                            <Row
+                                                spacing={1}
+                                                className="items-center"
+                                            >
+                                                <span>{category.label}</span>
+                                                {categoriesWithMissingRequiredAttributes.has(
+                                                    category.name,
+                                                ) && (
+                                                    <>
+                                                        <span
+                                                            className="size-2 rounded-full bg-red-500"
+                                                            aria-hidden
+                                                        />
+                                                        <span className="sr-only">
+                                                            Nedostaju obavezni
+                                                            atributi
+                                                        </span>
+                                                    </>
+                                                )}
+                                            </Row>
+                                        </TabsTrigger>
+                                    ))}
+                                </TabsList>
+                            }
+                        />
+                        <Stack spacing={2}>
+                            {attributeCategories.map((category) => (
+                                <TabsContent
+                                    value={category.name}
+                                    key={category.name}
+                                >
+                                    <AttributeCategoryDetails
+                                        entity={entity}
+                                        category={category}
+                                        attributeDefinitions={
+                                            attributeDefinitions
+                                        }
+                                    />
+                                </TabsContent>
+                            ))}
 
-                    <TabsContent value="history" key="history">
-                        <FieldSet>
-                            {revisions.length === 0 ? (
-                                <Field name="Povijest" value="Nema promjena" />
-                            ) : (
-                                <HistoryRevisionListClient
-                                    revisions={revisions}
-                                    attributeDefinitions={attributeDefinitions}
-                                />
-                            )}
-                        </FieldSet>
-                    </TabsContent>
-                </Stack>
-            </Tabs>
+                            <TabsContent value="history" key="history">
+                                <FieldSet>
+                                    {revisions.length === 0 ? (
+                                        <Field
+                                            name="Povijest"
+                                            value="Nema promjena"
+                                        />
+                                    ) : (
+                                        <HistoryRevisionListClient
+                                            revisions={revisions}
+                                            attributeDefinitions={
+                                                attributeDefinitions
+                                            }
+                                        />
+                                    )}
+                                </FieldSet>
+                            </TabsContent>
+                        </Stack>
+                    </Tabs>
+                </EntityDetailsPropertiesLayout>
+            </EntityDetailsPropertiesProvider>
         </EntityDetailsSaveProvider>
     );
 }


### PR DESCRIPTION
## Summary
- Moved the entity details that used to sit at the top of the page into a right-side properties panel on desktop.
- Added a mobile-friendly slide-out panel that overlays the content, with a toggle button in the header.
- Persisted the panel open/closed state in `localStorage`, with the panel open by default on first visit.
- Kept the existing value rendering for images, barcodes, references, and dates, and added small visual cues where available.

## Testing
- `pnpm lint --filter app` passed.
- `pnpm test --filter app` passed.
- `pnpm build --filter app` passed.
- Browser smoke check could not fully render the admin entity page because this worktree does not have `POSTGRES_URL` set.