### PR TITLE
Add sliding active indicator to Tabs

### DIFF
--- a/apps/storybook/stories/packages/ui/Tabs.stories.tsx
+++ b/apps/storybook/stories/packages/ui/Tabs.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    'Tabs switch between sibling views with Gredice control styling and Radix keyboard behavior.',
+                    'Tabs switch between sibling views with Gredice control styling, a sliding active indicator, and Radix keyboard behavior.',
             },
         },
     },

--- a/packages/ui/src/Tabs/Tabs.tsx
+++ b/packages/ui/src/Tabs/Tabs.tsx
@@ -1,11 +1,50 @@
 'use client';
 
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import type { ComponentPropsWithoutRef, ComponentRef } from 'react';
-import { forwardRef } from 'react';
+import type {
+    ComponentPropsWithoutRef,
+    ComponentRef,
+    CSSProperties,
+    ForwardedRef,
+} from 'react';
+import { forwardRef, useCallback, useEffect, useState } from 'react';
 
 function cx(...classes: Array<string | false | null | undefined>) {
     return classes.filter(Boolean).join(' ');
+}
+
+function setForwardedRef<T>(ref: ForwardedRef<T>, value: T | null) {
+    if (typeof ref === 'function') {
+        ref(value);
+        return;
+    }
+
+    if (ref) {
+        ref.current = value;
+    }
+}
+
+type TabsIndicator = {
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+};
+
+function areIndicatorsEqual(
+    current: TabsIndicator | null,
+    next: TabsIndicator | null,
+) {
+    if (!current || !next) {
+        return current === next;
+    }
+
+    return (
+        Math.abs(current.height - next.height) < 0.5 &&
+        Math.abs(current.left - next.left) < 0.5 &&
+        Math.abs(current.top - next.top) < 0.5 &&
+        Math.abs(current.width - next.width) < 0.5
+    );
 }
 
 export type TabsProps = ComponentPropsWithoutRef<typeof TabsPrimitive.Root>;
@@ -18,15 +57,140 @@ export const TabsList = forwardRef<
     ComponentRef<typeof TabsPrimitive.List>,
     TabsListProps
 >(function TabsList({ className, ...props }, ref) {
+    const [listElement, setListElement] = useState<ComponentRef<
+        typeof TabsPrimitive.List
+    > | null>(null);
+    const [indicator, setIndicator] = useState<TabsIndicator | null>(null);
+    const handleListRef = useCallback(
+        (node: ComponentRef<typeof TabsPrimitive.List> | null) => {
+            setListElement(node);
+            setForwardedRef(ref, node);
+        },
+        [ref],
+    );
+
+    useEffect(() => {
+        if (!listElement || typeof window === 'undefined') {
+            return;
+        }
+
+        let frameId: number | undefined;
+
+        function measureIndicator() {
+            const activeTrigger = listElement.querySelector<HTMLElement>(
+                '[role="tab"][data-state="active"]',
+            );
+
+            if (!activeTrigger) {
+                setIndicator((current) =>
+                    areIndicatorsEqual(current, null) ? current : null,
+                );
+                return;
+            }
+
+            const listRect = listElement.getBoundingClientRect();
+            const activeRect = activeTrigger.getBoundingClientRect();
+            const nextIndicator = {
+                height: activeRect.height,
+                left:
+                    activeRect.left -
+                    listRect.left +
+                    listElement.scrollLeft -
+                    listElement.clientLeft,
+                top:
+                    activeRect.top -
+                    listRect.top +
+                    listElement.scrollTop -
+                    listElement.clientTop,
+                width: activeRect.width,
+            };
+
+            setIndicator((current) =>
+                areIndicatorsEqual(current, nextIndicator)
+                    ? current
+                    : nextIndicator,
+            );
+        }
+
+        function updateIndicator() {
+            if (frameId !== undefined) {
+                window.cancelAnimationFrame(frameId);
+            }
+
+            frameId = window.requestAnimationFrame(measureIndicator);
+        }
+
+        let resizeObserver: ResizeObserver | undefined;
+
+        function observeTabs() {
+            if (resizeObserver) {
+                resizeObserver.disconnect();
+                resizeObserver.observe(listElement);
+                for (const tab of listElement.querySelectorAll<HTMLElement>(
+                    '[role="tab"]',
+                )) {
+                    resizeObserver.observe(tab);
+                }
+            }
+
+            updateIndicator();
+        }
+
+        if (typeof ResizeObserver !== 'undefined') {
+            resizeObserver = new ResizeObserver(updateIndicator);
+        }
+
+        const mutationObserver = new MutationObserver(observeTabs);
+
+        observeTabs();
+        mutationObserver.observe(listElement, {
+            attributeFilter: ['data-state', 'disabled'],
+            attributes: true,
+            childList: true,
+            subtree: true,
+        });
+        listElement.addEventListener('scroll', updateIndicator, {
+            passive: true,
+        });
+        window.addEventListener('resize', updateIndicator);
+
+        return () => {
+            if (frameId !== undefined) {
+                window.cancelAnimationFrame(frameId);
+            }
+
+            mutationObserver.disconnect();
+            resizeObserver?.disconnect();
+            listElement.removeEventListener('scroll', updateIndicator);
+            window.removeEventListener('resize', updateIndicator);
+        };
+    }, [listElement]);
+
+    const indicatorStyle: CSSProperties | undefined = indicator
+        ? {
+              height: indicator.height,
+              opacity: 1,
+              transform: `translate3d(${indicator.left}px, ${indicator.top}px, 0)`,
+              width: indicator.width,
+          }
+        : undefined;
+
     return (
         <TabsPrimitive.List
-            ref={ref}
+            ref={handleListRef}
             className={cx(
-                'inline-flex min-h-10 items-center justify-center gap-1 rounded-lg border border-border bg-muted/80 p-1 text-muted-foreground shadow-sm',
+                'relative isolate inline-flex min-h-10 items-center justify-center gap-1 rounded-lg border border-border bg-muted/80 p-1 text-muted-foreground shadow-sm',
                 className,
             )}
             {...props}
-        />
+        >
+            <span
+                aria-hidden="true"
+                className="pointer-events-none absolute left-0 top-0 z-0 rounded-md bg-background opacity-0 shadow-sm transition-[transform,width,height,opacity] duration-200 ease-out motion-reduce:transition-none"
+                style={indicatorStyle}
+            />
+            {props.children}
+        </TabsPrimitive.List>
     );
 });
 
@@ -42,11 +206,11 @@ export const TabsTrigger = forwardRef<
         <TabsPrimitive.Trigger
             ref={ref}
             className={cx(
-                'inline-flex min-h-8 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium leading-none text-muted-foreground transition-colors',
+                'relative z-10 inline-flex min-h-8 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium leading-none text-muted-foreground transition-colors',
                 'hover:bg-background/70 hover:text-foreground',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                 'disabled:pointer-events-none disabled:opacity-50',
-                'data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+                'data-[state=active]:text-foreground data-[state=active]:hover:bg-transparent',
                 className,
             )}
             {...props}

--- a/packages/ui/src/Tabs/Tabs.tsx
+++ b/packages/ui/src/Tabs/Tabs.tsx
@@ -74,10 +74,11 @@ export const TabsList = forwardRef<
             return;
         }
 
+        const tabsListElement = listElement;
         let frameId: number | undefined;
 
         function measureIndicator() {
-            const activeTrigger = listElement.querySelector<HTMLElement>(
+            const activeTrigger = tabsListElement.querySelector<HTMLElement>(
                 '[role="tab"][data-state="active"]',
             );
 
@@ -88,20 +89,20 @@ export const TabsList = forwardRef<
                 return;
             }
 
-            const listRect = listElement.getBoundingClientRect();
+            const listRect = tabsListElement.getBoundingClientRect();
             const activeRect = activeTrigger.getBoundingClientRect();
             const nextIndicator = {
                 height: activeRect.height,
                 left:
                     activeRect.left -
                     listRect.left +
-                    listElement.scrollLeft -
-                    listElement.clientLeft,
+                    tabsListElement.scrollLeft -
+                    tabsListElement.clientLeft,
                 top:
                     activeRect.top -
                     listRect.top +
-                    listElement.scrollTop -
-                    listElement.clientTop,
+                    tabsListElement.scrollTop -
+                    tabsListElement.clientTop,
                 width: activeRect.width,
             };
 
@@ -125,8 +126,8 @@ export const TabsList = forwardRef<
         function observeTabs() {
             if (resizeObserver) {
                 resizeObserver.disconnect();
-                resizeObserver.observe(listElement);
-                for (const tab of listElement.querySelectorAll<HTMLElement>(
+                resizeObserver.observe(tabsListElement);
+                for (const tab of tabsListElement.querySelectorAll<HTMLElement>(
                     '[role="tab"]',
                 )) {
                     resizeObserver.observe(tab);
@@ -143,13 +144,13 @@ export const TabsList = forwardRef<
         const mutationObserver = new MutationObserver(observeTabs);
 
         observeTabs();
-        mutationObserver.observe(listElement, {
+        mutationObserver.observe(tabsListElement, {
             attributeFilter: ['data-state', 'disabled'],
             attributes: true,
             childList: true,
             subtree: true,
         });
-        listElement.addEventListener('scroll', updateIndicator, {
+        tabsListElement.addEventListener('scroll', updateIndicator, {
             passive: true,
         });
         window.addEventListener('resize', updateIndicator);
@@ -161,7 +162,7 @@ export const TabsList = forwardRef<
 
             mutationObserver.disconnect();
             resizeObserver?.disconnect();
-            listElement.removeEventListener('scroll', updateIndicator);
+            tabsListElement.removeEventListener('scroll', updateIndicator);
             window.removeEventListener('resize', updateIndicator);
         };
     }, [listElement]);


### PR DESCRIPTION
## Summary
- Added a shared active indicator to `TabsList` so tab selection now slides between triggers instead of switching abruptly.
- Kept the public Tabs API unchanged while preserving Radix keyboard and accessibility behavior.
- Updated the Storybook docs copy to reflect the new motion.

## Testing
- `pnpm lint --filter @gredice/ui`
- `pnpm build --filter storybook`
- Verified the Storybook Tabs story in the browser and confirmed the indicator tracks the active tab when switching selections.