### PR TITLE
Refine entity details panel visuals and reference interactions

### DIFF
--- a/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertyList.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/EntityDetailsPropertyList.tsx
@@ -16,21 +16,21 @@ export function EntityDetailsPropertyList({
     items: EntityDetailsPropertyListItem[];
 }) {
     return (
-        <dl className="overflow-hidden rounded-lg border bg-background">
+        <dl className="space-y-1">
             {items.map((item) => (
                 <div
                     key={item.id}
-                    className="grid grid-cols-[minmax(6rem,0.85fr)_minmax(0,1.15fr)] gap-3 border-b px-3 py-2.5 text-sm last:border-b-0"
+                    className="grid grid-cols-[minmax(6rem,0.85fr)_minmax(0,1.15fr)] gap-3 px-3 py-2 text-sm"
                 >
-                    <dt className="min-w-0 truncate text-muted-foreground">
-                        {item.label}
-                    </dt>
-                    <dd className="flex min-w-0 items-center gap-2 text-foreground">
+                    <dt className="flex min-w-0 items-center gap-2 text-muted-foreground">
                         {item.visual && (
-                            <span className="shrink-0 text-muted-foreground">
+                            <span className="shrink-0" aria-hidden>
                                 {item.visual}
                             </span>
                         )}
+                        <span className="min-w-0 truncate">{item.label}</span>
+                    </dt>
+                    <dd className="flex min-w-0 items-center gap-2 text-foreground">
                         <span
                             className={cx(
                                 'min-w-0',
@@ -58,7 +58,7 @@ function renderPropertyValue(value: EntityDetailsPropertyListItem['value']) {
     }
 
     if (typeof value === 'boolean') {
-        return value ? 'Da' : 'Ne';
+        return renderBooleanValueToggle(value);
     }
 
     return value ?? '-';
@@ -66,4 +66,27 @@ function renderPropertyValue(value: EntityDetailsPropertyListItem['value']) {
 
 function isCompactValue(value: EntityDetailsPropertyListItem['value']) {
     return typeof value === 'string' || typeof value === 'number';
+}
+
+function renderBooleanValueToggle(value: boolean) {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={value}
+            disabled
+            className={cx(
+                'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:cursor-default disabled:opacity-100',
+                value ? 'bg-primary' : 'bg-muted',
+            )}
+        >
+            <span
+                className={cx(
+                    'inline-block size-4 rounded-full bg-background shadow-sm transition-transform',
+                    value ? 'translate-x-4' : 'translate-x-0.5',
+                )}
+            />
+            <span className="sr-only">{value ? 'Da' : 'Ne'}</span>
+        </button>
+    );
 }

--- a/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
+++ b/apps/app/app/admin/directories/[entityType]/[entityId]/page.tsx
@@ -6,6 +6,7 @@ import {
     getEntitiesRaw,
     getEntityRaw,
     getEntityRevisions,
+    getEntityTypeByName,
     getInventoryConfigByEntityTypeName,
     getInventoryItemsByConfig,
     updateInventoryItem,
@@ -13,13 +14,15 @@ import {
 import { getEntityCompleteness } from '@gredice/storage/entityCompleteness';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
-import { Calendar, Code } from '@signalco/ui-icons';
+import { Calendar, Code, ExternalLink } from '@signalco/ui-icons';
 import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { revalidatePath } from 'next/cache';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { importEntityData } from '../../../../../app/admin/directories/(actions)/importEntityData';
 import { EntityAttributeProgress } from '../../../../../components/admin/directories/EntityAttributeProgress';
+import { EntityTypeIcon } from '../../../../../components/admin/directories/EntityTypeIcon';
 import {
     AdminDirectoryBreadcrumbs,
     AdminPageHeader,
@@ -84,6 +87,25 @@ function getEntityLabel(
                 attribute.attributeDefinition.name === 'name',
         )?.value
     );
+}
+
+function refEntityTypeName(dataType: string) {
+    return dataType.startsWith('ref:') ? dataType.substring(4) : null;
+}
+
+function booleanAttributeValue(value: string) {
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+        return false;
+    }
+    return null;
+}
+
+function entityIdFromReferenceValue(value: string) {
+    const entityId = Number(value);
+    return Number.isInteger(entityId) && entityId > 0 ? entityId : null;
 }
 
 export default async function EntityDetailsPage(props: {
@@ -183,23 +205,37 @@ export default async function EntityDetailsPage(props: {
     );
     const refEntityTypes = Array.from(
         new Set(
-            refDefinitions.map(
-                (definition) => definition.dataType.split(':')[1],
-            ),
+            refDefinitions
+                .map((definition) => refEntityTypeName(definition.dataType))
+                .filter((name): name is string => Boolean(name)),
         ),
     );
     const refEntitiesByType = await Promise.all(
-        refEntityTypes.map(async (refEntityTypeName) => ({
-            refEntityTypeName,
-            entities: await getEntitiesRaw(refEntityTypeName, 'published'),
-        })),
+        refEntityTypes.map(async (refEntityType) => {
+            const [entities, entityType] = await Promise.all([
+                getEntitiesRaw(refEntityType, 'published'),
+                getEntityTypeByName(refEntityType),
+            ]);
+
+            return {
+                refEntityTypeName: refEntityType,
+                entityType,
+                entities,
+            };
+        }),
+    );
+    const refEntityTypesByName = Object.fromEntries(
+        refEntitiesByType.map((entry) => [
+            entry.refEntityTypeName,
+            entry.entityType,
+        ]),
     );
     const refLabelsByDefinitionId = Object.fromEntries(
         refDefinitions.map((definition) => {
-            const refEntityTypeName = definition.dataType.split(':')[1];
+            const refTypeName = refEntityTypeName(definition.dataType);
             const refEntities =
                 refEntitiesByType.find(
-                    (entry) => entry.refEntityTypeName === refEntityTypeName,
+                    (entry) => entry.refEntityTypeName === refTypeName,
                 )?.entities ?? [];
             return [
                 definition.id,
@@ -249,7 +285,14 @@ export default async function EntityDetailsPage(props: {
             const value = entity.attributes.find(
                 (a) => a.attributeDefinitionId === d.id,
             )?.value;
-            const dataTypeIcon = (
+            const refTypeName = refEntityTypeName(d.dataType);
+            const dataTypeIcon = refTypeName ? (
+                <EntityTypeIcon
+                    key={`attribute-${d.id}-icon`}
+                    icon={refEntityTypesByName[refTypeName]?.icon}
+                    className="size-4"
+                />
+            ) : (
                 <AttributeDataTypeIcon
                     key={`attribute-${d.id}-icon`}
                     dataType={d.dataType}
@@ -284,7 +327,7 @@ export default async function EntityDetailsPage(props: {
                     ) : (
                         '-'
                     ),
-                    visual: imageUrl ? undefined : dataTypeIcon,
+                    visual: dataTypeIcon,
                 };
             }
 
@@ -298,14 +341,48 @@ export default async function EntityDetailsPage(props: {
                             value={value}
                         />
                     ),
+                    visual: dataTypeIcon,
                 };
             }
 
-            if (d.dataType.startsWith('ref:')) {
+            if (d.dataType === 'boolean') {
                 return {
                     id: `attribute-${d.id}`,
                     label: d.label,
-                    value: refLabelsByDefinitionId[d.id]?.[value] ?? value,
+                    value:
+                        booleanAttributeValue(value) ??
+                        formatAttributeValueWithUnit(value, d.unit),
+                    visual: dataTypeIcon,
+                };
+            }
+
+            if (refTypeName) {
+                const refEntityId = entityIdFromReferenceValue(value);
+                const refEntityLabel =
+                    refLabelsByDefinitionId[d.id]?.[value] ?? value;
+
+                return {
+                    id: `attribute-${d.id}`,
+                    label: d.label,
+                    value: refEntityId ? (
+                        <Link
+                            href={KnownPages.DirectoryEntity(
+                                refTypeName,
+                                refEntityId,
+                            )}
+                            className="inline-flex min-w-0 items-center gap-1.5 text-primary hover:underline"
+                        >
+                            <span className="min-w-0 truncate">
+                                {refEntityLabel}
+                            </span>
+                            <ExternalLink
+                                className="size-3.5 shrink-0"
+                                aria-hidden
+                            />
+                        </Link>
+                    ) : (
+                        refEntityLabel
+                    ),
                     visual: dataTypeIcon,
                 };
             }


### PR DESCRIPTION
## Summary
- Removed the bordered item styling from the entity details list and moved data-type icons to the label column.
- Rendered boolean values as read-only switch controls instead of text labels.
- Added navigable reference links with an `ExternalLink` icon and used the referenced entity type icon when available.

## Testing
- `pnpm lint --filter app`
- `pnpm test --filter app`
- `pnpm build --filter app`
- `git diff --check`
- Extra `tsc --noEmit` validation was attempted; it still fails on unrelated existing app-wide type errors, but the changed details files were not implicated in the narrowed output.