### PR TITLE
Fix pnpm dev shutdown to clean up child processes

### DIFF
--- a/scripts/app-registry.test.mjs
+++ b/scripts/app-registry.test.mjs
@@ -398,7 +398,11 @@ describe('app registry worktree ports', () => {
     });
 
     it('treats zombie-only process groups as stopped', () => {
+        assert.equal(processStatesIncludeLiveProcess(''), false);
+        assert.equal(processStatesIncludeLiveProcess('   '), false);
+        assert.equal(processStatesIncludeLiveProcess('Z'), false);
         assert.equal(processStatesIncludeLiveProcess('Z\nZ+\n'), false);
+        assert.equal(processStatesIncludeLiveProcess('S'), true);
         assert.equal(processStatesIncludeLiveProcess('Z\nS\n'), true);
     });
 });

--- a/scripts/app-registry.test.mjs
+++ b/scripts/app-registry.test.mjs
@@ -21,6 +21,7 @@ import {
 } from './app-registry.ts';
 import {
     childProcessTreeOptions,
+    processStatesIncludeLiveProcess,
     terminateChildProcessTree,
 } from './process-tree.mjs';
 
@@ -394,5 +395,10 @@ describe('app registry worktree ports', () => {
             child.kill('SIGKILL');
             rmSync(tempDir, { recursive: true, force: true });
         }
+    });
+
+    it('treats zombie-only process groups as stopped', () => {
+        assert.equal(processStatesIncludeLiveProcess('Z\nZ+\n'), false);
+        assert.equal(processStatesIncludeLiveProcess('Z\nS\n'), true);
     });
 });

--- a/scripts/app-registry.test.mjs
+++ b/scripts/app-registry.test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import {
+    chmodSync,
+    existsSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -12,6 +19,10 @@ import {
     getWorktreeProxyHttpsPort,
     getWorktreeSlug,
 } from './app-registry.ts';
+import {
+    childProcessTreeOptions,
+    terminateChildProcessTree,
+} from './process-tree.mjs';
 
 function withEnv(updates, callback) {
     const previousValues = new Map();
@@ -78,6 +89,141 @@ function runAppCommandForTest(command, env = {}) {
     }
 }
 
+async function delay(milliseconds) {
+    await new Promise((resolve) => {
+        setTimeout(resolve, milliseconds);
+    });
+}
+
+async function waitForFile(filePath, timeoutMs = 5000) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() <= deadline) {
+        if (existsSync(filePath)) {
+            return true;
+        }
+
+        await delay(50);
+    }
+
+    return existsSync(filePath);
+}
+
+async function waitForChildExit(child, timeoutMs = 5000) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return { code: child.exitCode, signal: child.signalCode };
+    }
+
+    return await new Promise((resolvePromise, rejectPromise) => {
+        const timeout = setTimeout(() => {
+            rejectPromise(new Error(`Timed out waiting for child ${child.pid}`));
+        }, timeoutMs);
+
+        child.once('exit', (code, signal) => {
+            clearTimeout(timeout);
+            resolvePromise({ code, signal });
+        });
+        child.once('error', (error) => {
+            clearTimeout(timeout);
+            rejectPromise(error);
+        });
+    });
+}
+
+function spawnRunAppCommand(command, env = {}) {
+    const binDir = mkdtempSync(resolve(tmpdir(), 'gredice-app-command-'));
+    const nextPath = resolve(binDir, 'next');
+    const repoRoot = resolve(import.meta.dirname, '..');
+    const childEnv = {
+        ...process.env,
+        ...env,
+        PATH: `${binDir}${delimiter}${process.env.PATH}`,
+    };
+    writeFileSync(
+        nextPath,
+        [
+            '#!/usr/bin/env node',
+            "import { writeFileSync } from 'node:fs';",
+            'const readyPath = process.env.GREDICE_TEST_READY_PATH;',
+            'const signalPath = process.env.GREDICE_TEST_SIGNAL_PATH;',
+            'process.on("SIGINT", () => {',
+            '    writeFileSync(signalPath, "SIGINT");',
+            '    process.exit(0);',
+            '});',
+            'process.on("SIGTERM", () => {',
+            '    writeFileSync(signalPath, "SIGTERM");',
+            '    process.exit(0);',
+            '});',
+            'writeFileSync(readyPath, "ready");',
+            'setInterval(() => {}, 1000);',
+        ].join('\n'),
+    );
+    chmodSync(nextPath, 0o755);
+
+    const child = spawn(
+        process.execPath,
+        [
+            '--experimental-strip-types',
+            resolve(import.meta.dirname, 'run-app-command.mjs'),
+            command,
+        ],
+        {
+            cwd: resolve(repoRoot, 'apps', 'app'),
+            env: childEnv,
+            stdio: 'ignore',
+        },
+    );
+
+    return { binDir, child };
+}
+
+function spawnDevWithProxy(env = {}) {
+    const binDir = mkdtempSync(resolve(tmpdir(), 'gredice-dev-proxy-'));
+    const turboPath = resolve(binDir, 'turbo');
+    const repoRoot = resolve(import.meta.dirname, '..');
+    const childEnv = {
+        ...process.env,
+        ...env,
+        PATH: `${binDir}${delimiter}${process.env.PATH}`,
+        SKIP_DEV_PROXY: '1',
+    };
+    writeFileSync(
+        turboPath,
+        [
+            '#!/usr/bin/env node',
+            "import { writeFileSync } from 'node:fs';",
+            'const readyPath = process.env.GREDICE_TEST_READY_PATH;',
+            'const signalPath = process.env.GREDICE_TEST_SIGNAL_PATH;',
+            'process.on("SIGINT", () => {',
+            '    writeFileSync(signalPath, "SIGINT");',
+            '    process.exit(0);',
+            '});',
+            'process.on("SIGTERM", () => {',
+            '    writeFileSync(signalPath, "SIGTERM");',
+            '    process.exit(0);',
+            '});',
+            'writeFileSync(readyPath, process.argv.slice(2).join(" "));',
+            'setInterval(() => {}, 1000);',
+        ].join('\n'),
+    );
+    chmodSync(turboPath, 0o755);
+
+    const child = spawn(
+        process.execPath,
+        [
+            '--experimental-strip-types',
+            resolve(import.meta.dirname, 'dev-with-proxy.mjs'),
+        ],
+        {
+            cwd: repoRoot,
+            env: childEnv,
+            stdio: 'ignore',
+        },
+    );
+
+    return { binDir, child };
+}
+
 describe('app registry worktree ports', () => {
     it('derives app dev ports from the worktree offset', () => {
         withEnv({ GREDICE_PORT_OFFSET: '12' }, () => {
@@ -135,5 +281,118 @@ describe('app registry worktree ports', () => {
         const output = JSON.parse(result.stdout);
         assert.deepEqual(output.args, ['start', '-p', '3003']);
         assert.equal(output.apiHost, 'http://localhost:13005');
+    });
+
+    it('forwards SIGINT to the app command and exits with the interrupt code', async () => {
+        const tempDir = mkdtempSync(resolve(tmpdir(), 'gredice-app-signal-'));
+        const readyPath = resolve(tempDir, 'ready');
+        const signalPath = resolve(tempDir, 'signal');
+        const { binDir, child } = spawnRunAppCommand('dev', {
+            GREDICE_TEST_READY_PATH: readyPath,
+            GREDICE_TEST_SIGNAL_PATH: signalPath,
+        });
+
+        try {
+            assert.equal(await waitForFile(readyPath), true);
+            child.kill('SIGINT');
+            const result = await waitForChildExit(child);
+
+            assert.equal(result.code, 130);
+            assert.equal(await waitForFile(signalPath), true);
+            assert.equal(readFileSync(signalPath, 'utf8'), 'SIGINT');
+        } finally {
+            child.kill('SIGKILL');
+            rmSync(binDir, { recursive: true, force: true });
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('forwards SIGINT from the dev wrapper to Turbo and exits with the interrupt code', async () => {
+        const tempDir = mkdtempSync(resolve(tmpdir(), 'gredice-dev-signal-'));
+        const readyPath = resolve(tempDir, 'ready');
+        const signalPath = resolve(tempDir, 'signal');
+        const { binDir, child } = spawnDevWithProxy({
+            GREDICE_TEST_READY_PATH: readyPath,
+            GREDICE_TEST_SIGNAL_PATH: signalPath,
+        });
+
+        try {
+            assert.equal(await waitForFile(readyPath), true);
+            assert.match(readFileSync(readyPath, 'utf8'), /^dev(?: |$)/);
+
+            child.kill('SIGINT');
+            const result = await waitForChildExit(child);
+
+            assert.equal(result.code, 130);
+            assert.equal(await waitForFile(signalPath), true);
+            assert.equal(readFileSync(signalPath, 'utf8'), 'SIGINT');
+        } finally {
+            child.kill('SIGKILL');
+            rmSync(binDir, { recursive: true, force: true });
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('terminates grandchildren in the spawned process group', async (context) => {
+        if (process.platform === 'win32') {
+            context.skip('POSIX process-group cleanup is not used on Windows.');
+            return;
+        }
+
+        const tempDir = mkdtempSync(resolve(tmpdir(), 'gredice-process-tree-'));
+        const childScriptPath = resolve(tempDir, 'child.mjs');
+        const descendantScriptPath = resolve(tempDir, 'descendant.mjs');
+        const readyPath = resolve(tempDir, 'ready');
+        const signalPath = resolve(tempDir, 'signal');
+
+        writeFileSync(
+            descendantScriptPath,
+            [
+                "import { writeFileSync } from 'node:fs';",
+                'const [readyPath, signalPath] = process.argv.slice(2);',
+                'process.on("SIGTERM", () => {',
+                '    writeFileSync(signalPath, "SIGTERM");',
+                '    process.exit(0);',
+                '});',
+                'writeFileSync(readyPath, String(process.pid));',
+                'setInterval(() => {}, 1000);',
+            ].join('\n'),
+        );
+        writeFileSync(
+            childScriptPath,
+            [
+                "import { spawn } from 'node:child_process';",
+                'const [descendantScriptPath, readyPath, signalPath] = process.argv.slice(2);',
+                'spawn(process.execPath, [descendantScriptPath, readyPath, signalPath], {',
+                "    stdio: 'ignore',",
+                '});',
+                'setInterval(() => {}, 1000);',
+            ].join('\n'),
+        );
+
+        const child = spawn(
+            process.execPath,
+            [childScriptPath, descendantScriptPath, readyPath, signalPath],
+            {
+                stdio: 'ignore',
+                ...childProcessTreeOptions(),
+            },
+        );
+
+        try {
+            assert.equal(await waitForFile(readyPath), true);
+            assert.equal(
+                await terminateChildProcessTree(child, {
+                    signal: 'SIGTERM',
+                    gracefulTimeoutMs: 2000,
+                }),
+                true,
+            );
+            assert.equal(await waitForFile(signalPath), true);
+            assert.equal(readFileSync(signalPath, 'utf8'), 'SIGTERM');
+        } finally {
+            child.kill('SIGKILL');
+            rmSync(tempDir, { recursive: true, force: true });
+        }
     });
 });

--- a/scripts/dev-with-proxy.mjs
+++ b/scripts/dev-with-proxy.mjs
@@ -14,6 +14,13 @@ import {
     getWorktreeProxyHttpsPort,
     getWorktreeSlug,
 } from './app-registry.ts';
+import {
+    childProcessTreeOptions,
+    shutdownSignals,
+    signalExitCode,
+    terminateChildProcessTree,
+    waitForChildProcessTreeExit,
+} from './process-tree.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
@@ -286,15 +293,6 @@ function parseEnvFlag(value) {
     }
 
     return true;
-}
-
-function signalExitCode(signal) {
-    const signalNumber = signalNumbers?.[signal];
-    if (typeof signalNumber === 'number') {
-        return 128 + signalNumber;
-    }
-
-    return 1;
 }
 
 async function delay(milliseconds) {
@@ -1138,36 +1136,64 @@ async function runTurboDev() {
             stdio: 'inherit',
             env: process.env,
             shell: process.platform === 'win32',
+            ...childProcessTreeOptions(),
+        });
+        let shutdownPromise = null;
+        let shutdownError = null;
+        let requestedSignal = null;
+        const signalHandlers = shutdownSignals.map((signal) => {
+            const handler = () => {
+                requestedSignal ??= signal;
+                shutdownPromise ??= terminateChildProcessTree(
+                    turboProcess,
+                    {
+                        signal,
+                        gracefulTimeoutMs: 12000,
+                    },
+                ).catch((error) => {
+                    shutdownError = error;
+                    return false;
+                });
+            };
+            process.on(signal, handler);
+            return [signal, handler];
         });
 
-        const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
-        const forwardSignal = (signal) => {
-            turboProcess.kill(signal);
+        const removeSignalHandlers = () => {
+            for (const [signal, handler] of signalHandlers) {
+                process.off(signal, handler);
+            }
         };
 
-        for (const signal of signals) {
-            process.on(signal, forwardSignal);
-        }
-
         turboProcess.on('error', (error) => {
-            for (const signal of signals) {
-                process.off(signal, forwardSignal);
-            }
+            removeSignalHandlers();
 
             reject(error);
         });
 
         turboProcess.on('exit', (code, signal) => {
-            for (const signal of signals) {
-                process.off(signal, forwardSignal);
-            }
+            void (async () => {
+                removeSignalHandlers();
 
-            if (signal) {
-                resolve(signalExitCode(signal));
-                return;
-            }
+                if (shutdownPromise) {
+                    await shutdownPromise;
+                    if (shutdownError) {
+                        throw shutdownError;
+                    }
+                } else if (signal) {
+                    await waitForChildProcessTreeExit(turboProcess, {
+                        timeoutMs: 2000,
+                    });
+                }
 
-            resolve(code ?? 0);
+                const exitSignal = signal ?? requestedSignal;
+                if (exitSignal) {
+                    resolve(signalExitCode(exitSignal, signalNumbers));
+                    return;
+                }
+
+                resolve(code ?? 0);
+            })().catch(reject);
         });
     });
 }

--- a/scripts/process-tree.mjs
+++ b/scripts/process-tree.mjs
@@ -27,6 +27,15 @@ function isMissingProcessError(error) {
     return error?.code === 'ESRCH';
 }
 
+export function processStatesIncludeLiveProcess(processStates) {
+    const states = processStates
+        .split('\n')
+        .map((state) => state.trim())
+        .filter(Boolean);
+
+    return states.some((state) => !state.startsWith('Z'));
+}
+
 export function signalChildProcessTree(child, signal) {
     if (!child?.pid) {
         return false;
@@ -65,6 +74,19 @@ function forceKillChildProcessTree(child) {
     return signalChildProcessTree(child, 'SIGKILL');
 }
 
+function processGroupHasLiveProcesses(processGroupId) {
+    const result = spawnSync('ps', ['-o', 'state=', '-g', String(processGroupId)], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    if (result.error || result.status !== 0) {
+        return true;
+    }
+
+    return processStatesIncludeLiveProcess(result.stdout);
+}
+
 function isChildProcessTreeRunning(child) {
     if (!child?.pid) {
         return false;
@@ -76,7 +98,6 @@ function isChildProcessTreeRunning(child) {
 
     try {
         process.kill(-child.pid, 0);
-        return true;
     } catch (error) {
         if (isMissingProcessError(error)) {
             return false;
@@ -84,6 +105,8 @@ function isChildProcessTreeRunning(child) {
 
         throw error;
     }
+
+    return processGroupHasLiveProcesses(child.pid);
 }
 
 export async function waitForChildProcessTreeExit(

--- a/scripts/process-tree.mjs
+++ b/scripts/process-tree.mjs
@@ -36,6 +36,17 @@ export function processStatesIncludeLiveProcess(processStates) {
     return states.some((state) => !state.startsWith('Z'));
 }
 
+let hasWarnedAboutProcessGroupProbe = false;
+
+function warnAboutProcessGroupProbeFailure(message) {
+    if (hasWarnedAboutProcessGroupProbe) {
+        return;
+    }
+
+    hasWarnedAboutProcessGroupProbe = true;
+    console.warn(message);
+}
+
 export function signalChildProcessTree(child, signal) {
     if (!child?.pid) {
         return false;
@@ -75,12 +86,31 @@ function forceKillChildProcessTree(child) {
 }
 
 function processGroupHasLiveProcesses(processGroupId) {
+    if (!Number.isSafeInteger(processGroupId) || processGroupId <= 0) {
+        return false;
+    }
+
     const result = spawnSync('ps', ['-o', 'state=', '-g', String(processGroupId)], {
         encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    if (result.error || result.status !== 0) {
+    if (result.error) {
+        warnAboutProcessGroupProbeFailure(
+            `Unable to inspect process group ${processGroupId}: ${result.error.message}`,
+        );
+        return true;
+    }
+
+    if (result.status !== 0) {
+        const errorOutput = result.stderr.trim();
+        if (!errorOutput) {
+            return false;
+        }
+
+        warnAboutProcessGroupProbeFailure(
+            `Unable to inspect process group ${processGroupId}: ps exited with status ${result.status}: ${errorOutput}`,
+        );
         return true;
     }
 

--- a/scripts/process-tree.mjs
+++ b/scripts/process-tree.mjs
@@ -1,0 +1,140 @@
+import { spawnSync } from 'node:child_process';
+
+export const shutdownSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
+
+export const supportsProcessGroups = process.platform !== 'win32';
+
+export function childProcessTreeOptions() {
+    return supportsProcessGroups ? { detached: true } : {};
+}
+
+export function signalExitCode(signal, signalNumbers) {
+    const signalNumber = signalNumbers?.[signal];
+    if (typeof signalNumber === 'number') {
+        return 128 + signalNumber;
+    }
+
+    return 1;
+}
+
+function delay(milliseconds) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, milliseconds);
+    });
+}
+
+function isMissingProcessError(error) {
+    return error?.code === 'ESRCH';
+}
+
+export function signalChildProcessTree(child, signal) {
+    if (!child?.pid) {
+        return false;
+    }
+
+    try {
+        if (supportsProcessGroups) {
+            process.kill(-child.pid, signal);
+            return true;
+        }
+
+        return child.kill(signal);
+    } catch (error) {
+        if (isMissingProcessError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function forceKillChildProcessTree(child) {
+    if (!child?.pid) {
+        return false;
+    }
+
+    if (process.platform === 'win32') {
+        const result = spawnSync(
+            'taskkill',
+            ['/pid', String(child.pid), '/t', '/f'],
+            { stdio: 'ignore' },
+        );
+        return result.status === 0;
+    }
+
+    return signalChildProcessTree(child, 'SIGKILL');
+}
+
+function isChildProcessTreeRunning(child) {
+    if (!child?.pid) {
+        return false;
+    }
+
+    if (!supportsProcessGroups) {
+        return child.exitCode === null && child.signalCode === null;
+    }
+
+    try {
+        process.kill(-child.pid, 0);
+        return true;
+    } catch (error) {
+        if (isMissingProcessError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+export async function waitForChildProcessTreeExit(
+    child,
+    { timeoutMs = 5000, intervalMs = 100 } = {},
+) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() <= deadline) {
+        if (!isChildProcessTreeRunning(child)) {
+            return true;
+        }
+
+        await delay(intervalMs);
+    }
+
+    return !isChildProcessTreeRunning(child);
+}
+
+export async function terminateChildProcessTree(
+    child,
+    {
+        signal = 'SIGTERM',
+        gracefulTimeoutMs = 8000,
+        terminateTimeoutMs = 2000,
+    } = {},
+) {
+    const signaled = signalChildProcessTree(child, signal);
+    if (!signaled) {
+        return true;
+    }
+
+    if (
+        await waitForChildProcessTreeExit(child, {
+            timeoutMs: gracefulTimeoutMs,
+        })
+    ) {
+        return true;
+    }
+
+    if (signal !== 'SIGTERM') {
+        signalChildProcessTree(child, 'SIGTERM');
+        if (
+            await waitForChildProcessTreeExit(child, {
+                timeoutMs: terminateTimeoutMs,
+            })
+        ) {
+            return true;
+        }
+    }
+
+    forceKillChildProcessTree(child);
+    return await waitForChildProcessTreeExit(child, { timeoutMs: 1000 });
+}

--- a/scripts/run-app-command.mjs
+++ b/scripts/run-app-command.mjs
@@ -11,6 +11,13 @@ import {
     getAppStartPort,
     localAppHostnameUrl,
 } from './app-registry.ts';
+import {
+    childProcessTreeOptions,
+    shutdownSignals,
+    signalExitCode,
+    terminateChildProcessTree,
+    waitForChildProcessTreeExit,
+} from './process-tree.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
@@ -92,15 +99,6 @@ function applyLocalServiceEnv() {
     );
 }
 
-function signalExitCode(signal) {
-    const signalNumber = signalNumbers?.[signal];
-    if (typeof signalNumber === 'number') {
-        return 128 + signalNumber;
-    }
-
-    return 1;
-}
-
 try {
     applyLocalServiceEnv();
     const appCommand = commandForApp();
@@ -108,20 +106,37 @@ try {
     const child = spawn(spawnOptions.command, spawnOptions.args, {
         stdio: 'inherit',
         env: process.env,
+        ...childProcessTreeOptions(),
     });
-    const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
-    const forwardSignal = (signal) => {
-        child.kill(signal);
+    let shutdownPromise = null;
+    let shutdownError = null;
+    let requestedSignal = null;
+    const signalHandlers = shutdownSignals.map((signal) => {
+        const handler = () => {
+            requestedSignal ??= signal;
+            shutdownPromise ??= terminateChildProcessTree(
+                child,
+                {
+                    signal,
+                    gracefulTimeoutMs: 8000,
+                },
+            ).catch((error) => {
+                shutdownError = error;
+                return false;
+            });
+        };
+        process.on(signal, handler);
+        return [signal, handler];
+    });
+
+    const removeSignalHandlers = () => {
+        for (const [signal, handler] of signalHandlers) {
+            process.off(signal, handler);
+        }
     };
 
-    for (const signal of signals) {
-        process.on(signal, forwardSignal);
-    }
-
     child.on('error', (error) => {
-        for (const signal of signals) {
-            process.off(signal, forwardSignal);
-        }
+        removeSignalHandlers();
 
         if (error?.code === 'ENOENT') {
             console.error(
@@ -137,16 +152,34 @@ try {
     });
 
     child.on('exit', (code, signal) => {
-        for (const signalName of signals) {
-            process.off(signalName, forwardSignal);
-        }
+        void (async () => {
+            removeSignalHandlers();
 
-        if (signal) {
-            process.exit(signalExitCode(signal));
-            return;
-        }
+            if (shutdownPromise) {
+                await shutdownPromise;
+                if (shutdownError) {
+                    throw shutdownError;
+                }
+            } else if (signal) {
+                await waitForChildProcessTreeExit(child, { timeoutMs: 2000 });
+            }
 
-        process.exit(code ?? 0);
+            const exitSignal = signal ?? requestedSignal;
+            if (exitSignal) {
+                process.exit(signalExitCode(exitSignal, signalNumbers));
+                return;
+            }
+
+            process.exit(code ?? 0);
+        })().catch((error) => {
+            if (error?.message) {
+                console.error(error.message);
+            } else {
+                console.error(error);
+            }
+
+            process.exit(1);
+        });
     });
 } catch (error) {
     if (error?.message) {


### PR DESCRIPTION
## Summary
- Added shared child-process tree utilities for signal forwarding and cleanup.
- Updated `pnpm dev` and app dev wrappers to terminate whole process trees instead of leaving Next/Turbo descendants behind.
- Added regression tests covering Ctrl-C forwarding and grandchild cleanup.

## Testing
- `node --experimental-strip-types --test scripts/app-registry.test.mjs`
- `node --check` on the updated Node scripts
- `git diff --check`