### PR TITLE
Fix select input backgrounds in the app globally

### DIFF
--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -13,11 +13,9 @@
     }
 }
 
-@layer components {
-    button[role="combobox"][aria-autocomplete="none"].border,
-    select:not([aria-hidden="true"]) {
-        background-color: hsl(var(--background));
-    }
+button[role="combobox"][aria-autocomplete="none"].border,
+select:not([aria-hidden="true"]) {
+    background-color: hsl(var(--background));
 }
 
 *::-webkit-scrollbar {

--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -13,6 +13,13 @@
     }
 }
 
+@layer components {
+    button[role="combobox"][aria-autocomplete="none"].border,
+    select:not([aria-hidden="true"]) {
+        background-color: hsl(var(--background));
+    }
+}
+
 *::-webkit-scrollbar {
     width: 8px;
     height: 8px;


### PR DESCRIPTION
## Summary
- Add a global app-level background override for outlined combobox triggers and native selects.
- Keep select controls aligned with regular inputs so they render with the active surface color in light and dark themes.

## Testing
- Lint passed for `app`.
- Build check surfaced an existing Tailwind layer placement issue, which was corrected during the change.
- Not run (not requested): full UI verification in browser.