### PR TITLE
Implement garden box hover lid animation

### DIFF
--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -318,6 +318,8 @@ export function PickableGroup({
             return {
                 blockId: placement.blockId,
                 blockName: placement.blockName,
+                blockUnderId: blockUnder?.id ?? null,
+                blockUnderName: blockUnder?.name ?? null,
                 destination,
                 destinationIndex: destinationBlocks.length,
                 hoverHeight,
@@ -466,6 +468,10 @@ export function PickableGroup({
             sourceHoverHeight,
             attachedHoverHeight,
         );
+        const hoveredGardenBoxBlockId =
+            placementPreviews.find(
+                (preview) => preview.blockUnderName === 'GardenBox',
+            )?.blockUnderId ?? null;
         const heightsMismatch =
             attachedPlacement !== null &&
             Math.abs(sourceHoverHeight - attachedHoverHeight) > 0.0001;
@@ -598,6 +604,7 @@ export function PickableGroup({
             setActiveDragPreview({
                 sourceBlockId: block.id,
                 attachedBlockId: attachedPlacement?.candidateBlock.id ?? null,
+                hoveredGardenBoxBlockId,
                 relative: {
                     x: relative.x,
                     z: relative.z,

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -1,13 +1,17 @@
-import { animated } from '@react-spring/three';
+import { animated, useSpring } from '@react-spring/three';
 import { useHoveredBlockStore } from '../../controls/useHoveredBlockStore';
 import { RainWetOverlay } from '../../rain/RainWetOverlay';
 import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
+import { useGameState } from '../../useGameState';
 import { useStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { HoverOutline } from './HoverOutline';
 import { useAnimatedEntityRotation } from './useAnimatedEntityRotation';
+
+const lidClosedRotation = 0;
+const lidOpenRotation = -Math.PI / 2;
 
 type GardenBoxProps = EntityInstanceProps & {
     bodyColor: string;
@@ -34,6 +38,18 @@ export function GardenBox({
     const currentStackHeight = useStackHeight(stack, block);
     const hovered =
         useHoveredBlockStore((state) => state.hoveredBlock) === block;
+    const isLidOpen = useGameState(
+        (state) =>
+            state.activeDragPreview?.hoveredGardenBoxBlockId === block.id,
+    );
+    const { rotation: lidRotation } = useSpring({
+        config: {
+            mass: 0.18,
+            tension: 260,
+            friction: 18,
+        },
+        rotation: [isLidOpen ? lidOpenRotation : lidClosedRotation, 0, 0],
+    });
 
     return (
         <animated.group
@@ -57,7 +73,10 @@ export function GardenBox({
                 {...snowPresets.giftBox}
             />
             <RainWetOverlay geometry={nodes.GardenBox_Body_Planks.geometry} />
-            <group position={[0, 0.6, -0.38]}>
+            <animated.group
+                position={[0, 0.6, -0.38]}
+                rotation={lidRotation as unknown as [number, number, number]}
+            >
                 <mesh
                     castShadow
                     receiveShadow
@@ -76,7 +95,7 @@ export function GardenBox({
                 <RainWetOverlay
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                 />
-            </group>
+            </animated.group>
         </animated.group>
     );
 }

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -89,6 +89,7 @@ export type WinterMode = 'summer' | 'winter' | 'holiday';
 export type ActiveDragPreview = {
     sourceBlockId: string;
     attachedBlockId: string | null;
+    hoveredGardenBoxBlockId: string | null;
     relative: {
         x: number;
         z: number;


### PR DESCRIPTION
## Summary
- Added drag-preview context for the block currently hovered over a `GardenBox`
- Animated the garden box lid open while an item is hovered above it and close when the interaction ends
- Kept the change scoped to the existing garden/game entity runtime

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm lint --filter www`
- `pnpm build --filter garden --filter www`
- `pnpm test --filter garden`
- Local browser smoke check on the garden debug entity scene