### PR TITLE
Animate sunflower transfers between HUD and payment switch

### DIFF
--- a/apps/garden/tests/SunflowerPaymentTransferStory.tsx
+++ b/apps/garden/tests/SunflowerPaymentTransferStory.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { ButtonPricePickPaymentMethod } from '../../../packages/game/src/hud/components/shopping-cart/ButtonPricePickPaymentMethod';
+
+export function SunflowerPaymentTransferStory({
+    initialIsSunflower = false,
+}: {
+    initialIsSunflower?: boolean;
+}) {
+    const [isSunflower, setIsSunflower] = useState(initialIsSunflower);
+
+    return (
+        <div className="min-h-96 p-12">
+            <button
+                type="button"
+                data-sunflowers-hud-target
+                aria-label="Suncokreti"
+                className="fixed right-6 top-6 rounded-full border px-4 py-2"
+            >
+                8.000 🌻
+            </button>
+            <div className="mt-48 w-fit">
+                <ButtonPricePickPaymentMethod
+                    price={2.5}
+                    isSunflower={isSunflower}
+                    onChange={setIsSunflower}
+                    availableSunflowers={8000}
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/garden/tests/sunflower-payment-transfer.spec.tsx
+++ b/apps/garden/tests/sunflower-payment-transfer.spec.tsx
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { SunflowerPaymentTransferStory } from './SunflowerPaymentTransferStory';
+
+test.describe('sunflower payment transfer', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.emulateMedia({ reducedMotion: 'no-preference' });
+    });
+
+    test('animates from the HUD to the payment method when enabling sunflower payment', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SunflowerPaymentTransferStory />);
+
+        await page.getByRole('switch').click();
+
+        await expect(page.getByRole('switch')).toHaveAttribute(
+            'aria-checked',
+            'true',
+        );
+        await expect(
+            page.locator('[data-sunflower-transfer-layer]'),
+        ).toHaveCount(1);
+        await expect(
+            page.locator('[data-sunflower-transfer-particle]').first(),
+        ).toBeVisible();
+        await expect(
+            page.locator('[data-sunflower-transfer-layer]'),
+        ).toHaveCount(0, { timeout: 2000 });
+    });
+
+    test('collapses rapid reversed transfers into one active layer', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <SunflowerPaymentTransferStory initialIsSunflower={true} />,
+        );
+        const paymentSwitch = page.getByRole('switch');
+
+        await paymentSwitch.click();
+        await expect(paymentSwitch).toHaveAttribute('aria-checked', 'false');
+        await paymentSwitch.click();
+
+        await expect(paymentSwitch).toHaveAttribute('aria-checked', 'true');
+        await expect(
+            page.locator('[data-sunflower-transfer-layer]'),
+        ).toHaveCount(1);
+        await expect(
+            page.locator('[data-sunflower-transfer-layer]'),
+        ).toHaveCount(0, { timeout: 2000 });
+    });
+
+    test('skips flying particles for reduced-motion users', async ({
+        mount,
+        page,
+    }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await mount(<SunflowerPaymentTransferStory />);
+
+        await page.getByRole('switch').click();
+
+        await expect(page.getByRole('switch')).toHaveAttribute(
+            'aria-checked',
+            'true',
+        );
+        await expect(
+            page.locator('[data-sunflower-transfer-layer]'),
+        ).toHaveCount(0);
+    });
+});

--- a/packages/game/src/hud/components/shopping-cart/ButtonPricePickPaymentMethod.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ButtonPricePickPaymentMethod.tsx
@@ -1,5 +1,7 @@
 import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
+import { useRef } from 'react';
+import { useSunflowerTransferAnimation } from '../../../indicators/SunflowerTransfer/useSunflowerTransferAnimation';
 import {
     calculateSunflowerAmountFromPrices,
     getEffectiveEurPrice,
@@ -20,10 +22,8 @@ export function ButtonPricePickPaymentMethod({
     discountPrice?: number | null;
     disabled?: boolean;
 }) {
-    function handleToggle() {
-        if (isToggleDisabled) return;
-        onChange?.(!isSunflower);
-    }
+    const paymentTargetRef = useRef<HTMLButtonElement>(null);
+    const runSunflowerTransfer = useSunflowerTransferAnimation();
 
     if (price == null || price === undefined) {
         return <Typography level="body1">Nevaljan iznos</Typography>;
@@ -40,6 +40,18 @@ export function ButtonPricePickPaymentMethod({
             ? availableSunflowers >= requiredSunflowers
             : true;
     const isToggleDisabled = disabled || (!isSunflower && !canAffordSunflowers);
+    const nextIsSunflower = !isSunflower;
+
+    function handleToggle() {
+        if (isToggleDisabled) return;
+
+        runSunflowerTransfer({
+            paymentElement: paymentTargetRef.current,
+            direction: nextIsSunflower ? 'hud-to-payment' : 'payment-to-hud',
+            amount: requiredSunflowers,
+        });
+        onChange?.(nextIsSunflower);
+    }
 
     return (
         <Row spacing={1}>
@@ -50,9 +62,11 @@ export function ButtonPricePickPaymentMethod({
 
             {/* Custom Switch */}
             <button
+                ref={paymentTargetRef}
                 type="button"
                 onClick={handleToggle}
                 disabled={isToggleDisabled}
+                data-sunflower-payment-target
                 className={`relative inline-flex h-6 w-10 items-center rounded-full transition-colors focus:outline-1 focus:outline-[#2f6e40] focus:outline-offset-2 ${
                     isToggleDisabled
                         ? 'bg-gray-200 dark:bg-gray-700 cursor-not-allowed opacity-50'
@@ -62,6 +76,11 @@ export function ButtonPricePickPaymentMethod({
                 }`}
                 role="switch"
                 aria-checked={isSunflower}
+                aria-label={
+                    isSunflower
+                        ? `Plaćanje suncokretima, ${requiredSunflowers.toLocaleString('hr-HR')} suncokreta`
+                        : `Plaćanje eurima, prebaci na ${requiredSunflowers.toLocaleString('hr-HR')} suncokreta`
+                }
                 title={
                     isToggleDisabled && !isSunflower
                         ? 'Nedovoljno suncokreta'

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -172,6 +172,9 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                                     account?.sunflowers.amount ?? 0
                                 }
                                 discountPrice={item.shopData.discountPrice}
+                                disabled={
+                                    changeCurrencyShoppingCartItem.isPending
+                                }
                             />
                         </Row>
                     )}

--- a/packages/game/src/indicators/SunflowerTransfer/useSunflowerTransferAnimation.ts
+++ b/packages/game/src/indicators/SunflowerTransfer/useSunflowerTransferAnimation.ts
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type Point = {
+    x: number;
+    y: number;
+};
+
+export type SunflowerTransferDirection = 'hud-to-payment' | 'payment-to-hud';
+
+type SunflowerTransferOptions = {
+    paymentElement: HTMLElement | null;
+    direction: SunflowerTransferDirection;
+    amount?: number;
+};
+
+const HUD_TARGET_SELECTOR = '[data-sunflowers-hud-target]';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const activeTransferCleanups = new Set<() => void>();
+
+function getPrefersReducedMotion() {
+    if (
+        typeof window === 'undefined' ||
+        typeof window.matchMedia !== 'function'
+    ) {
+        return false;
+    }
+
+    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function usePrefersReducedMotion() {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+        getPrefersReducedMotion,
+    );
+
+    useEffect(() => {
+        if (
+            typeof window === 'undefined' ||
+            typeof window.matchMedia !== 'function'
+        ) {
+            return;
+        }
+
+        const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
+        const handleChange = () => {
+            setPrefersReducedMotion(mediaQueryList.matches);
+        };
+
+        setPrefersReducedMotion(mediaQueryList.matches);
+        mediaQueryList.addEventListener('change', handleChange);
+
+        return () => {
+            mediaQueryList.removeEventListener('change', handleChange);
+        };
+    }, []);
+
+    return prefersReducedMotion;
+}
+
+function clearActiveTransfers() {
+    for (const cleanup of Array.from(activeTransferCleanups)) {
+        cleanup();
+    }
+}
+
+function getElementCenter(element: HTMLElement): Point {
+    const rect = element.getBoundingClientRect();
+    return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+    };
+}
+
+function getParticleCount(amount: number) {
+    if (!Number.isFinite(amount) || amount <= 0) {
+        return 3;
+    }
+
+    return Math.min(7, Math.max(3, Math.ceil(amount / 1500)));
+}
+
+function formatSunflowersCompact(amount: number) {
+    return amount.toLocaleString('hr-HR', {
+        maximumFractionDigits: 0,
+    });
+}
+
+function createTransferLayer() {
+    const layer = document.createElement('div');
+    layer.setAttribute('aria-hidden', 'true');
+    layer.setAttribute('data-sunflower-transfer-layer', 'true');
+    layer.style.position = 'fixed';
+    layer.style.inset = '0';
+    layer.style.pointerEvents = 'none';
+    layer.style.zIndex = '1000';
+    layer.style.contain = 'layout style paint';
+    document.body.appendChild(layer);
+    return layer;
+}
+
+function createParticle({
+    amount,
+    index,
+    layer,
+    from,
+}: {
+    amount: number;
+    index: number;
+    layer: HTMLElement;
+    from: Point;
+}) {
+    const particle = document.createElement('span');
+    particle.setAttribute('data-sunflower-transfer-particle', 'true');
+    particle.textContent =
+        index === 0 && amount > 0
+            ? `${formatSunflowersCompact(amount)} 🌻`
+            : '🌻';
+    particle.style.position = 'absolute';
+    particle.style.left = `${from.x}px`;
+    particle.style.top = `${from.y}px`;
+    particle.style.display = 'inline-flex';
+    particle.style.alignItems = 'center';
+    particle.style.justifyContent = 'center';
+    particle.style.minWidth = index === 0 && amount > 0 ? '2.25rem' : '1.5rem';
+    particle.style.height = '1.5rem';
+    particle.style.padding = index === 0 && amount > 0 ? '0 0.375rem' : '0';
+    particle.style.borderRadius = '9999px';
+    particle.style.background =
+        index === 0 && amount > 0 ? 'rgba(255, 251, 235, 0.96)' : 'transparent';
+    particle.style.border =
+        index === 0 && amount > 0 ? '1px solid rgba(217, 119, 6, 0.35)' : '0';
+    particle.style.color = '#1f2937';
+    particle.style.fontSize = index === 0 && amount > 0 ? '0.75rem' : '1.25rem';
+    particle.style.fontWeight = index === 0 && amount > 0 ? '700' : '400';
+    particle.style.lineHeight = '1';
+    particle.style.filter = 'drop-shadow(0 6px 12px rgba(0, 0, 0, 0.22))';
+    particle.style.transform = 'translate3d(-50%, -50%, 0) scale(0.86)';
+    particle.style.willChange = 'transform, opacity';
+    layer.appendChild(particle);
+    return particle;
+}
+
+function animateParticle({
+    particle,
+    index,
+    particleCount,
+    from,
+    to,
+}: {
+    particle: HTMLElement;
+    index: number;
+    particleCount: number;
+    from: Point;
+    to: Point;
+}) {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const centeredIndex = index - (particleCount - 1) / 2;
+    const spreadX = centeredIndex * 9;
+    const spreadY = Math.abs(centeredIndex) * 5;
+    const arcY = Math.min(-28, dy * 0.16 - 30);
+    const midX = dx * 0.46 + centeredIndex * 14;
+    const midY = dy * 0.46 + arcY;
+    const duration = 620 + index * 42;
+    const delay = index * 34;
+
+    return particle.animate(
+        [
+            {
+                opacity: 0,
+                transform:
+                    'translate3d(-50%, -50%, 0) translate3d(0, 0, 0) scale(0.82)',
+            },
+            {
+                opacity: 1,
+                transform: `translate3d(-50%, -50%, 0) translate3d(${midX}px, ${midY}px, 0) scale(1.1)`,
+                offset: 0.4,
+            },
+            {
+                opacity: 0,
+                transform: `translate3d(-50%, -50%, 0) translate3d(${dx + spreadX}px, ${dy + spreadY}px, 0) scale(0.5)`,
+            },
+        ],
+        {
+            duration,
+            delay,
+            easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+            fill: 'forwards',
+        },
+    );
+}
+
+function startSunflowerTransfer({
+    amount,
+    from,
+    to,
+}: {
+    amount: number;
+    from: Point;
+    to: Point;
+}) {
+    clearActiveTransfers();
+
+    const layer = createTransferLayer();
+    const particleCount = getParticleCount(amount);
+    const animations: Animation[] = [];
+    let timeoutId: number | undefined;
+    let isCleanedUp = false;
+
+    const cleanup = () => {
+        if (isCleanedUp) {
+            return;
+        }
+
+        isCleanedUp = true;
+
+        if (timeoutId !== undefined) {
+            window.clearTimeout(timeoutId);
+        }
+
+        for (const animation of animations) {
+            animation.cancel();
+        }
+
+        layer.remove();
+        activeTransferCleanups.delete(cleanup);
+    };
+
+    activeTransferCleanups.add(cleanup);
+
+    for (let index = 0; index < particleCount; index += 1) {
+        const particle = createParticle({ amount, index, layer, from });
+        animations.push(
+            animateParticle({
+                particle,
+                index,
+                particleCount,
+                from,
+                to,
+            }),
+        );
+    }
+
+    const longestDuration = 620 + (particleCount - 1) * 76;
+    timeoutId = window.setTimeout(cleanup, longestDuration + 180);
+
+    void Promise.allSettled(
+        animations.map((animation) => animation.finished),
+    ).then(cleanup);
+}
+
+export function useSunflowerTransferAnimation() {
+    const prefersReducedMotion = usePrefersReducedMotion();
+
+    return useCallback(
+        ({
+            paymentElement,
+            direction,
+            amount = 0,
+        }: SunflowerTransferOptions) => {
+            if (
+                prefersReducedMotion ||
+                typeof document === 'undefined' ||
+                !paymentElement
+            ) {
+                return;
+            }
+
+            const hudElement =
+                document.querySelector<HTMLElement>(HUD_TARGET_SELECTOR);
+            if (!hudElement) {
+                return;
+            }
+
+            const sourceElement =
+                direction === 'hud-to-payment' ? hudElement : paymentElement;
+            const targetElement =
+                direction === 'hud-to-payment' ? paymentElement : hudElement;
+
+            startSunflowerTransfer({
+                amount,
+                from: getElementCenter(sourceElement),
+                to: getElementCenter(targetElement),
+            });
+        },
+        [prefersReducedMotion],
+    );
+}


### PR DESCRIPTION
## Summary
- Added a transfer animation layer that flies sunflowers between the HUD balance and the payment-method toggle in both directions.
- Kept the animation out of the modal/backdrop stack, collapsed overlapping transfers, and skipped motion for reduced-motion users.
- Wired the cart item toggle to block repeat switches while the payment mutation is pending.
- Added component coverage for forward transfer, rapid reversed transfers, and reduced-motion behavior.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm --filter @gredice/game typecheck`
- `pnpm test --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm --filter garden exec playwright test tests/sunflower-payment-transfer.spec.tsx`
- `pnpm build --filter garden`
- `pnpm lint --filter www`
- `pnpm build --filter www --force`