### PR TITLE
Implement scoped garden box inventory persistence

### DIFF
--- a/apps/api/app/api/[...route]/inventoryRoutes.ts
+++ b/apps/api/app/api/[...route]/inventoryRoutes.ts
@@ -1,55 +1,218 @@
 import {
     type EntityStandardized,
     getEntitiesFormatted,
+    getGarden,
+    getGardenBlock,
+    getGardenBoxBlocksForAccount,
+    getGardenBoxInventory,
     getInventory,
+    type InventoryItem,
+    type InventoryItemInput,
+    setGardenBoxInventory,
 } from '@gredice/storage';
 import { Hono } from 'hono';
-import { describeRoute } from 'hono-openapi';
+import { describeRoute, validator as zValidator } from 'hono-openapi';
+import { z } from 'zod';
+import { authSecurity } from '../../../lib/docs/security';
 import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
 
-const app = new Hono<{ Variables: AuthVariables }>().get(
-    '/',
-    describeRoute({ description: 'Get account inventory' }),
-    authValidator(['user', 'admin']),
-    async (context) => {
-        const { accountId } = context.get('authContext');
-        const inventory = await getInventory(accountId);
+const gardenBoxInventoryParamsSchema = z.object({
+    gardenId: z.coerce.number().int().positive(),
+    blockId: z.string().trim().min(1).max(128),
+});
 
-        const entityTypeNames = Array.from(
-            new Set(inventory.map((item) => item.entityTypeName)),
-        );
-        const entitiesData = await Promise.all(
-            entityTypeNames.map(getEntitiesFormatted<EntityStandardized>),
-        );
-        const entitiesByType = entityTypeNames.reduce(
-            (acc, type, index) => {
-                acc[type] = entitiesData[index] ?? [];
-                return acc;
-            },
-            {} as Record<string, EntityStandardized[]>,
-        );
+const inventoryItemSchema = z.object({
+    entityTypeName: z.string().trim().min(1).max(100),
+    entityId: z.string().trim().min(1).max(100),
+    amount: z.number().int().min(0).max(1000),
+});
 
-        return context.json({
-            items: inventory.map((item) => {
-                const entity = (entitiesByType[item.entityTypeName] ?? []).find(
-                    (entity) =>
-                        (entity as { id?: string | number }).id?.toString() ===
-                        item.entityId,
-                );
+const gardenBoxInventoryBodySchema = z.object({
+    items: z.array(inventoryItemSchema).max(100),
+});
 
-                return {
-                    ...item,
-                    name:
-                        entity?.information?.name ?? entity?.information?.label,
-                    image: (entity as { image?: { cover?: { url?: string } } })
-                        ?.image?.cover?.url,
-                };
-            }),
-        });
-    },
-);
+type EnrichedInventoryItem = InventoryItem & {
+    name?: string;
+    image?: string;
+};
+
+async function enrichInventoryItems(
+    inventories: InventoryItem[][],
+): Promise<EnrichedInventoryItem[][]> {
+    const allItems = inventories.flat();
+    const entityTypeNames = Array.from(
+        new Set(allItems.map((item) => item.entityTypeName)),
+    );
+    if (entityTypeNames.length === 0) {
+        return inventories.map(() => []);
+    }
+
+    const entitiesData = await Promise.all(
+        entityTypeNames.map(getEntitiesFormatted<EntityStandardized>),
+    );
+    const entitiesByType = entityTypeNames.reduce(
+        (acc, type, index) => {
+            acc[type] = entitiesData[index] ?? [];
+            return acc;
+        },
+        {} as Record<string, EntityStandardized[]>,
+    );
+
+    return inventories.map((inventory) =>
+        inventory.map((item) => {
+            const entity = (entitiesByType[item.entityTypeName] ?? []).find(
+                (entity) =>
+                    (entity as { id?: string | number }).id?.toString() ===
+                    item.entityId,
+            );
+
+            return {
+                ...item,
+                name: entity?.information?.name ?? entity?.information?.label,
+                image: (entity as { image?: { cover?: { url?: string } } })
+                    ?.image?.cover?.url,
+            };
+        }),
+    );
+}
+
+async function getGardenBoxForAccount(
+    accountId: string,
+    gardenId: number,
+    blockId: string,
+) {
+    const [garden, block] = await Promise.all([
+        getGarden(gardenId),
+        getGardenBlock(gardenId, blockId),
+    ]);
+
+    if (
+        !garden ||
+        garden.accountId !== accountId ||
+        block?.name !== 'GardenBox'
+    ) {
+        return null;
+    }
+
+    return {
+        blockId: block.id,
+        gardenId,
+        gardenName: garden.name,
+    };
+}
+
+const app = new Hono<{ Variables: AuthVariables }>()
+    .get(
+        '/',
+        describeRoute({
+            description:
+                'Get account inventory and inventory stored in garden boxes for the current account.',
+            security: authSecurity,
+            tags: ['Inventory'],
+        }),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const inventory = await getInventory(accountId);
+            const gardenBoxes = await getGardenBoxBlocksForAccount(accountId);
+            const gardenBoxInventories = await Promise.all(
+                gardenBoxes.map((gardenBox) =>
+                    getGardenBoxInventory(
+                        accountId,
+                        gardenBox.gardenId,
+                        gardenBox.blockId,
+                    ),
+                ),
+            );
+            const [items, ...gardenBoxItems] = await enrichInventoryItems([
+                inventory,
+                ...gardenBoxInventories,
+            ]);
+
+            return context.json({
+                items,
+                gardenBoxes: gardenBoxes.map((gardenBox, index) => ({
+                    ...gardenBox,
+                    items: gardenBoxItems[index] ?? [],
+                })),
+            });
+        },
+    )
+    .get(
+        '/garden-boxes/:gardenId/:blockId',
+        describeRoute({
+            description:
+                'Get inventory stored in one garden box owned by the current account.',
+            security: authSecurity,
+            tags: ['Inventory'],
+        }),
+        authValidator(['user', 'admin']),
+        zValidator('param', gardenBoxInventoryParamsSchema),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const { gardenId, blockId } = context.req.valid('param');
+            const gardenBox = await getGardenBoxForAccount(
+                accountId,
+                gardenId,
+                blockId,
+            );
+            if (!gardenBox) {
+                return context.json({ error: 'Garden box not found' }, 404);
+            }
+
+            const inventory = await getGardenBoxInventory(
+                accountId,
+                gardenId,
+                blockId,
+            );
+            const [items] = await enrichInventoryItems([inventory]);
+
+            return context.json({
+                ...gardenBox,
+                items,
+            });
+        },
+    )
+    .put(
+        '/garden-boxes/:gardenId/:blockId',
+        describeRoute({
+            description:
+                'Replace the inventory contents stored in one garden box owned by the current account.',
+            security: authSecurity,
+            tags: ['Inventory'],
+        }),
+        authValidator(['user', 'admin']),
+        zValidator('param', gardenBoxInventoryParamsSchema),
+        zValidator('json', gardenBoxInventoryBodySchema),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const { gardenId, blockId } = context.req.valid('param');
+            const { items } = context.req.valid('json');
+            const gardenBox = await getGardenBoxForAccount(
+                accountId,
+                gardenId,
+                blockId,
+            );
+            if (!gardenBox) {
+                return context.json({ error: 'Garden box not found' }, 404);
+            }
+
+            const inventory = await setGardenBoxInventory(
+                accountId,
+                gardenId,
+                blockId,
+                items satisfies InventoryItemInput[],
+            );
+            const [enrichedItems] = await enrichInventoryItems([inventory]);
+
+            return context.json({
+                ...gardenBox,
+                items: enrichedItems,
+            });
+        },
+    );
 
 export default app;

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -58,8 +58,9 @@ export function getEvents(
     aggregateIds: string[],
     offset: number = 0,
     limit: number = 1000,
+    db: DatabaseClient = storage(),
 ) {
-    return storage().query.events.findMany({
+    return db.query.events.findMany({
         where: and(
             inArray(events.aggregateId, aggregateIds),
             Array.isArray(type)

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1070,6 +1070,28 @@ export async function getGardenBlocks(gardenId: number) {
     });
 }
 
+export async function getGardenBoxBlocksForAccount(accountId: string) {
+    return storage()
+        .select({
+            blockId: gardenBlocks.id,
+            gardenId: gardenBlocks.gardenId,
+            gardenName: gardens.name,
+            createdAt: gardenBlocks.createdAt,
+            updatedAt: gardenBlocks.updatedAt,
+        })
+        .from(gardenBlocks)
+        .innerJoin(gardens, eq(gardenBlocks.gardenId, gardens.id))
+        .where(
+            and(
+                eq(gardens.accountId, accountId),
+                eq(gardens.isDeleted, false),
+                eq(gardenBlocks.name, 'GardenBox'),
+                eq(gardenBlocks.isDeleted, false),
+            ),
+        )
+        .orderBy(asc(gardens.createdAt), asc(gardenBlocks.createdAt));
+}
+
 export async function getGardenBlock(gardenId: number, blockId: string) {
     return (
         (await storage().query.gardenBlocks.findFirst({

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -29,6 +29,8 @@ export type InventoryItem = {
     updatedAt: Date;
 };
 
+export type InventoryItemInput = Omit<InventoryItemEventPayload, 'source'>;
+
 export async function addInventoryItem(
     accountId: string,
     payload: InventoryItemEventPayload,
@@ -41,6 +43,65 @@ export async function addInventoryItem(
         ),
         db,
     );
+}
+
+function getGardenBoxInventoryAggregateId({
+    accountId,
+    gardenId,
+    blockId,
+}: {
+    accountId: string;
+    gardenId: number;
+    blockId: string;
+}) {
+    return `${INVENTORY_PREFIX}${accountId}:gardenBox:${gardenId.toString()}:${blockId}`;
+}
+
+function inventoryItemKey(
+    item: Pick<InventoryItem, 'entityTypeName' | 'entityId'>,
+) {
+    return `${item.entityTypeName}-${item.entityId}`;
+}
+
+async function getInventoryForAggregateIds(aggregateIds: string[]) {
+    if (aggregateIds.length === 0) {
+        return [];
+    }
+
+    const inventoryEvents = await getEvents(
+        [knownEventTypes.inventory.add, knownEventTypes.inventory.consume],
+        aggregateIds,
+        0,
+        5000,
+    );
+
+    const totals = new Map<string, InventoryItem>();
+
+    for (const event of inventoryEvents) {
+        const data = event.data as InventoryItemEventPayload | null;
+        if (!data) continue;
+
+        const key = inventoryItemKey(data);
+        const existing = totals.get(key) ?? {
+            entityTypeName: data.entityTypeName,
+            entityId: data.entityId,
+            amount: 0,
+            updatedAt: event.createdAt,
+        };
+
+        const delta =
+            event.type === knownEventTypes.inventory.consume
+                ? -data.amount
+                : data.amount;
+
+        totals.set(key, {
+            ...existing,
+            amount: existing.amount + delta,
+            updatedAt: event.createdAt,
+        });
+    }
+
+    return Array.from(totals.values()).filter((item) => item.amount > 0);
 }
 
 export async function consumeInventoryItem(
@@ -70,41 +131,141 @@ export async function consumeInventoryItem(
 }
 
 export async function getInventory(accountId: string) {
-    const aggregateId = getInventoryAggregateId(accountId);
-    const inventoryEvents = await getEvents(
-        [knownEventTypes.inventory.add, knownEventTypes.inventory.consume],
-        [aggregateId],
-        0,
-        5000,
+    return getInventoryForAggregateIds([getInventoryAggregateId(accountId)]);
+}
+
+export async function getGardenBoxInventory(
+    accountId: string,
+    gardenId: number,
+    blockId: string,
+) {
+    return getInventoryForAggregateIds([
+        getGardenBoxInventoryAggregateId({ accountId, gardenId, blockId }),
+    ]);
+}
+
+export async function addGardenBoxInventoryItem(
+    accountId: string,
+    gardenId: number,
+    blockId: string,
+    payload: InventoryItemEventPayload,
+    db: DatabaseClient = storage(),
+) {
+    await createEvent(
+        knownEvents.inventory.addedV1(
+            getGardenBoxInventoryAggregateId({ accountId, gardenId, blockId }),
+            payload,
+        ),
+        db,
     );
+}
 
-    const totals = new Map<string, InventoryItem>();
+export async function consumeGardenBoxInventoryItem(
+    accountId: string,
+    gardenId: number,
+    blockId: string,
+    payload: InventoryItemEventPayload,
+    db: DatabaseClient = storage(),
+) {
+    const inventory = await getGardenBoxInventory(accountId, gardenId, blockId);
+    const currentAmount =
+        inventory.find(
+            (item) =>
+                item.entityTypeName === payload.entityTypeName &&
+                item.entityId === payload.entityId,
+        )?.amount ?? 0;
 
-    for (const event of inventoryEvents) {
-        const data = event.data as InventoryItemEventPayload | null;
-        if (!data) continue;
+    if (currentAmount < payload.amount) {
+        throw new Error('Nedovoljno predmeta u vrtnoj kutiji');
+    }
 
-        const key = `${data.entityTypeName}-${data.entityId}`;
-        const existing = totals.get(key) ?? {
-            entityTypeName: data.entityTypeName,
-            entityId: data.entityId,
-            amount: 0,
-            updatedAt: event.createdAt,
-        };
+    await createEvent(
+        knownEvents.inventory.consumedV1(
+            getGardenBoxInventoryAggregateId({ accountId, gardenId, blockId }),
+            payload,
+        ),
+        db,
+    );
+}
 
-        const delta =
-            event.type === knownEventTypes.inventory.consume
-                ? -data.amount
-                : data.amount;
+export async function setGardenBoxInventory(
+    accountId: string,
+    gardenId: number,
+    blockId: string,
+    items: InventoryItemInput[],
+) {
+    const currentInventory = await getGardenBoxInventory(
+        accountId,
+        gardenId,
+        blockId,
+    );
+    const requestedTotals = new Map<string, InventoryItemInput>();
 
-        totals.set(key, {
-            ...existing,
-            amount: existing.amount + delta,
-            updatedAt: event.createdAt,
+    for (const item of items) {
+        if (item.amount <= 0) {
+            continue;
+        }
+
+        const key = inventoryItemKey(item);
+        const existing = requestedTotals.get(key);
+        requestedTotals.set(key, {
+            entityTypeName: item.entityTypeName,
+            entityId: item.entityId,
+            amount: (existing?.amount ?? 0) + item.amount,
         });
     }
 
-    return Array.from(totals.values()).filter((item) => item.amount > 0);
+    const currentTotals = new Map(
+        currentInventory.map((item) => [inventoryItemKey(item), item]),
+    );
+    const inventoryKeys = new Set([
+        ...currentTotals.keys(),
+        ...requestedTotals.keys(),
+    ]);
+
+    await storage().transaction(async (tx) => {
+        for (const key of inventoryKeys) {
+            const current = currentTotals.get(key);
+            const requested = requestedTotals.get(key);
+            const currentAmount = current?.amount ?? 0;
+            const requestedAmount = requested?.amount ?? 0;
+            const delta = requestedAmount - currentAmount;
+
+            if (delta > 0 && requested) {
+                await addGardenBoxInventoryItem(
+                    accountId,
+                    gardenId,
+                    blockId,
+                    {
+                        entityTypeName: requested.entityTypeName,
+                        entityId: requested.entityId,
+                        amount: delta,
+                        source: 'gardenBox:set',
+                    },
+                    tx,
+                );
+            } else if (delta < 0 && current) {
+                await createEvent(
+                    knownEvents.inventory.consumedV1(
+                        getGardenBoxInventoryAggregateId({
+                            accountId,
+                            gardenId,
+                            blockId,
+                        }),
+                        {
+                            entityTypeName: current.entityTypeName,
+                            entityId: current.entityId,
+                            amount: Math.abs(delta),
+                            source: 'gardenBox:set',
+                        },
+                    ),
+                    tx,
+                );
+            }
+        }
+    });
+
+    return getGardenBoxInventory(accountId, gardenId, blockId);
 }
 
 export async function getLastInventoryUpdate(accountId: string) {

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte } from 'drizzle-orm';
+import { and, eq, gte, sql } from 'drizzle-orm';
 import { events } from '../schema';
 import { storage } from '../storage';
 import { createEvent, getEvents, knownEvents, knownEventTypes } from './events';
@@ -63,7 +63,10 @@ function inventoryItemKey(
     return `${item.entityTypeName}-${item.entityId}`;
 }
 
-async function getInventoryForAggregateIds(aggregateIds: string[]) {
+async function getInventoryForAggregateIds(
+    aggregateIds: string[],
+    db: DatabaseClient = storage(),
+) {
     if (aggregateIds.length === 0) {
         return [];
     }
@@ -73,6 +76,7 @@ async function getInventoryForAggregateIds(aggregateIds: string[]) {
         aggregateIds,
         0,
         5000,
+        db,
     );
 
     const totals = new Map<string, InventoryItem>();
@@ -194,11 +198,11 @@ export async function setGardenBoxInventory(
     blockId: string,
     items: InventoryItemInput[],
 ) {
-    const currentInventory = await getGardenBoxInventory(
+    const aggregateId = getGardenBoxInventoryAggregateId({
         accountId,
         gardenId,
         blockId,
-    );
+    });
     const requestedTotals = new Map<string, InventoryItemInput>();
 
     for (const item of items) {
@@ -215,15 +219,23 @@ export async function setGardenBoxInventory(
         });
     }
 
-    const currentTotals = new Map(
-        currentInventory.map((item) => [inventoryItemKey(item), item]),
-    );
-    const inventoryKeys = new Set([
-        ...currentTotals.keys(),
-        ...requestedTotals.keys(),
-    ]);
-
     await storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${aggregateId}));`,
+        );
+
+        const currentInventory = await getInventoryForAggregateIds(
+            [aggregateId],
+            tx,
+        );
+        const currentTotals = new Map(
+            currentInventory.map((item) => [inventoryItemKey(item), item]),
+        );
+        const inventoryKeys = new Set([
+            ...currentTotals.keys(),
+            ...requestedTotals.keys(),
+        ]);
+
         for (const key of inventoryKeys) {
             const current = currentTotals.get(key);
             const requested = requestedTotals.get(key);

--- a/packages/storage/tests/inventoryRepo.node.spec.ts
+++ b/packages/storage/tests/inventoryRepo.node.spec.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    addInventoryItem,
+    createAccount,
+    createGardenBlock,
+    getGardenBoxBlocksForAccount,
+    getGardenBoxInventory,
+    getInventory,
+    setGardenBoxInventory,
+} from '@gredice/storage';
+import { createTestGarden, ensureFarmId } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+function itemSummary(
+    items: Array<{
+        entityTypeName: string;
+        entityId: string;
+        amount: number;
+    }>,
+) {
+    return items
+        .map((item) => ({
+            entityTypeName: item.entityTypeName,
+            entityId: item.entityId,
+            amount: item.amount,
+        }))
+        .sort((a, b) =>
+            `${a.entityTypeName}-${a.entityId}`.localeCompare(
+                `${b.entityTypeName}-${b.entityId}`,
+            ),
+        );
+}
+
+test('garden box inventory is scoped per box and separate from account inventory', async () => {
+    createTestDb();
+
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const firstBoxId = await createGardenBlock(gardenId, 'GardenBox');
+    const secondBoxId = await createGardenBlock(gardenId, 'GardenBox');
+
+    await addInventoryItem(accountId, {
+        entityTypeName: 'plantSort',
+        entityId: '101',
+        amount: 5,
+    });
+    await setGardenBoxInventory(accountId, gardenId, firstBoxId, [
+        { entityTypeName: 'plantSort', entityId: '101', amount: 2 },
+        { entityTypeName: 'operation', entityId: '7', amount: 1 },
+    ]);
+    await setGardenBoxInventory(accountId, gardenId, secondBoxId, [
+        { entityTypeName: 'plantSort', entityId: '101', amount: 4 },
+    ]);
+
+    assert.deepEqual(itemSummary(await getInventory(accountId)), [
+        { entityTypeName: 'plantSort', entityId: '101', amount: 5 },
+    ]);
+    assert.deepEqual(
+        itemSummary(
+            await getGardenBoxInventory(accountId, gardenId, firstBoxId),
+        ),
+        [
+            { entityTypeName: 'operation', entityId: '7', amount: 1 },
+            { entityTypeName: 'plantSort', entityId: '101', amount: 2 },
+        ],
+    );
+    assert.deepEqual(
+        itemSummary(
+            await getGardenBoxInventory(accountId, gardenId, secondBoxId),
+        ),
+        [{ entityTypeName: 'plantSort', entityId: '101', amount: 4 }],
+    );
+});
+
+test('setGardenBoxInventory replaces contents and collapses duplicate items', async () => {
+    createTestDb();
+
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const boxId = await createGardenBlock(gardenId, 'GardenBox');
+
+    await setGardenBoxInventory(accountId, gardenId, boxId, [
+        { entityTypeName: 'plantSort', entityId: '101', amount: 5 },
+        { entityTypeName: 'operation', entityId: '7', amount: 2 },
+    ]);
+    await setGardenBoxInventory(accountId, gardenId, boxId, [
+        { entityTypeName: 'plantSort', entityId: '101', amount: 1 },
+        { entityTypeName: 'plantSort', entityId: '101', amount: 2 },
+        { entityTypeName: 'operation', entityId: '7', amount: 0 },
+    ]);
+
+    assert.deepEqual(
+        itemSummary(await getGardenBoxInventory(accountId, gardenId, boxId)),
+        [{ entityTypeName: 'plantSort', entityId: '101', amount: 3 }],
+    );
+});
+
+test('getGardenBoxBlocksForAccount returns active GardenBox blocks for only that account', async () => {
+    createTestDb();
+
+    const accountId = await createAccount();
+    const otherAccountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const otherGardenId = await createTestGarden({
+        accountId: otherAccountId,
+        farmId,
+    });
+    const boxId = await createGardenBlock(gardenId, 'GardenBox');
+    await createGardenBlock(gardenId, 'Bucket');
+    await createGardenBlock(otherGardenId, 'GardenBox');
+
+    const boxes = await getGardenBoxBlocksForAccount(accountId);
+    assert.deepEqual(
+        boxes.map((box) => ({
+            blockId: box.blockId,
+            gardenId: box.gardenId,
+        })),
+        [{ blockId: boxId, gardenId }],
+    );
+});


### PR DESCRIPTION
## Summary
- Add per-garden-box inventory storage scoped by account, garden, and box block ID
- Extend the inventory API to list, fetch, and replace inventory for individual garden boxes
- Return all garden boxes with their stored contents from the main inventory endpoint
- Add storage tests covering box scoping, replace semantics, duplicate collapsing, and account isolation

## Testing
- `pnpm test --filter @gredice/storage`
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter api`
- `pnpm build --filter api`
- `pnpm build --filter garden`
- `pnpm typecheck --filter @gredice/game`