### PR TITLE
Fix sunflower payment HUD and cart interactions

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -1,8 +1,9 @@
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { type PropsWithChildren, useMemo } from 'react';
+import { type PropsWithChildren, useMemo, useState } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
+import { RaisedBedField } from '../../../packages/game/src/hud/raisedBed/RaisedBedField';
 import { RaisedBedFieldItem } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldItem';
 import {
     createGameState,
@@ -149,6 +150,36 @@ export function RaisedBedFieldHudStory({
                     isCartPending={false}
                     raisedBedId={TEST_RAISED_BED_ID}
                     positionIndex={positionIndex}
+                />
+            </div>
+        </RaisedBedHudTestProviders>
+    );
+}
+
+export function RaisedBedFieldDndDialogStory({
+    scenario,
+}: {
+    scenario: RaisedBedScenario;
+}) {
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+    return (
+        <RaisedBedHudTestProviders scenario={scenario}>
+            <button
+                type="button"
+                onClick={() => setIsDialogOpen((open) => !open)}
+            >
+                Toggle dialog
+            </button>
+            {isDialogOpen && (
+                <div role="dialog" data-state="open">
+                    Test dialog
+                </div>
+            )}
+            <div className="size-60">
+                <RaisedBedField
+                    gardenId={TEST_GARDEN_ID}
+                    raisedBedId={TEST_RAISED_BED_ID}
                 />
             </div>
         </RaisedBedHudTestProviders>

--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -1,0 +1,141 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
+import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
+import { useShoppingCart } from '../../../packages/game/src/hooks/useShoppingCart';
+import { ShoppingCartItem } from '../../../packages/game/src/hud/components/shopping-cart/ShoppingCartItem';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+
+const now = '2026-05-21T00:00:00.000Z';
+
+const cartItem = {
+    id: 1,
+    cartId: 1,
+    entityId: 'operation-1',
+    entityTypeName: 'operation',
+    gardenId: null,
+    raisedBedId: null,
+    positionIndex: null,
+    additionalData: null,
+    amount: 1,
+    currency: 'eur',
+    status: 'new',
+    isDeleted: false,
+    createdAt: now,
+    updatedAt: now,
+    shopData: {
+        name: 'Zalijevanje',
+        description: 'Mock operation.',
+        image: '',
+        price: 2.5,
+    },
+    entityData: {
+        id: 1,
+        entityType: { id: 10, name: 'operation', label: 'Radnje' },
+        slug: 'mock-watering',
+        information: {
+            name: 'watering',
+            label: 'Zalijevanje',
+            shortDescription: 'Mock operation.',
+        },
+    },
+} as unknown as ShoppingCartItemData;
+
+function createOptimisticToggleQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(['accounts', 'current'], {
+        id: 'test-account',
+        name: 'Test Account',
+        sunflowers: {
+            amount: 8000,
+            history: [],
+        },
+    });
+    queryClient.setQueryData(['gardens'], [{ id: 1 }]);
+    queryClient.setQueryData(['gardens', 'current', 'summer', 1], {
+        id: 1,
+        name: 'Test garden',
+        stacks: [],
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [],
+    });
+    queryClient.setQueryData(['inventory'], { items: [] });
+    queryClient.setQueryData(['shopping-cart'], {
+        allowPurchase: true,
+        hasDeliverableItems: false,
+        id: 1,
+        items: [cartItem],
+        notes: [],
+        total: 2.5,
+        totalSunflowers: 0,
+    });
+
+    return queryClient;
+}
+
+function ShoppingCartOptimisticToggleProviders({
+    children,
+}: PropsWithChildren) {
+    const queryClient = useMemo(() => createOptimisticToggleQueryClient(), []);
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date('2026-05-21T12:00:00.000Z'),
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
+
+    return (
+        <NuqsTestingAdapter>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameStore}>
+                    <GameAnalyticsProvider capture={() => undefined}>
+                        {children}
+                    </GameAnalyticsProvider>
+                </GameStateContext.Provider>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+function ShoppingCartOptimisticTogglePanel() {
+    const { data: cart } = useShoppingCart();
+    const item = cart?.items[0];
+
+    if (!cart || !item) {
+        return null;
+    }
+
+    return (
+        <div className="w-[32rem] p-8">
+            <ShoppingCartItem item={item} />
+            <div data-testid="optimistic-cart-total">
+                {cart.total.toFixed(2)} €
+            </div>
+            <div data-testid="optimistic-cart-sunflowers">
+                {cart.totalSunflowers}
+            </div>
+        </div>
+    );
+}
+
+export function ShoppingCartOptimisticToggleStory() {
+    return (
+        <ShoppingCartOptimisticToggleProviders>
+            <ShoppingCartOptimisticTogglePanel />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}

--- a/apps/garden/tests/SunflowersHudStory.tsx
+++ b/apps/garden/tests/SunflowersHudStory.tsx
@@ -1,0 +1,105 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { type PropsWithChildren, useMemo } from 'react';
+import { SunflowersHud } from '../../../packages/game/src/hud/SunflowersHud';
+import { SunflowersList } from '../../../packages/game/src/shared-ui/sunflowers/SunflowersList';
+
+function createSunflowersHudQueryClient({
+    accountSunflowers,
+    cartSunflowers,
+}: {
+    accountSunflowers: number;
+    cartSunflowers: number;
+}) {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(['accounts', 'current'], {
+        id: 'test-account',
+        name: 'Test Account',
+        sunflowers: {
+            amount: accountSunflowers,
+            history: [],
+        },
+    });
+    queryClient.setQueryData(['accounts', 'current', 'sunflowers', 'daily'], {
+        current: { amount: 0, day: 1 },
+        next: { amount: 1, day: 2 },
+    });
+    queryClient.setQueryData(['shopping-cart'], {
+        allowPurchase: true,
+        hasDeliverableItems: false,
+        id: 1,
+        items: [],
+        notes: [],
+        total: 0,
+        totalSunflowers: cartSunflowers,
+    });
+
+    return queryClient;
+}
+
+function SunflowersHudTestProviders({
+    accountSunflowers,
+    cartSunflowers,
+    children,
+}: PropsWithChildren<{
+    accountSunflowers: number;
+    cartSunflowers: number;
+}>) {
+    const queryClient = useMemo(
+        () =>
+            createSunflowersHudQueryClient({
+                accountSunflowers,
+                cartSunflowers,
+            }),
+        [accountSunflowers, cartSunflowers],
+    );
+
+    return (
+        <ReactQuery.QueryClientProvider client={queryClient}>
+            {children}
+        </ReactQuery.QueryClientProvider>
+    );
+}
+
+export function SunflowersHudStory({
+    accountSunflowers = 9034,
+    cartSunflowers = 10470,
+}: {
+    accountSunflowers?: number;
+    cartSunflowers?: number;
+}) {
+    return (
+        <div className="min-h-96 p-12">
+            <SunflowersHudTestProviders
+                accountSunflowers={accountSunflowers}
+                cartSunflowers={cartSunflowers}
+            >
+                <SunflowersHud />
+            </SunflowersHudTestProviders>
+        </div>
+    );
+}
+
+export function SunflowersPendingDetailsStory({
+    accountSunflowers = 9034,
+    cartSunflowers = 10470,
+}: {
+    accountSunflowers?: number;
+    cartSunflowers?: number;
+}) {
+    return (
+        <div className="w-80 p-4">
+            <SunflowersHudTestProviders
+                accountSunflowers={accountSunflowers}
+                cartSunflowers={cartSunflowers}
+            >
+                <SunflowersList limit={5} pendingSunflowers={cartSunflowers} />
+            </SunflowersHudTestProviders>
+        </div>
+    );
+}

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1,6 +1,9 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
-import { RaisedBedFieldHudStory } from './RaisedBedFieldHudStory';
+import {
+    RaisedBedFieldDndDialogStory,
+    RaisedBedFieldHudStory,
+} from './RaisedBedFieldHudStory';
 import {
     buildCartItem,
     buildOperation,
@@ -220,6 +223,32 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(stack).toHaveAttribute('data-touch-expanded', 'false');
         const fieldButton = page.getByRole('button').first();
         await expect(fieldButton).toContainText('20');
+    });
+
+    test('opening a HUD dialog keeps drag sensors stable', async ({
+        mount,
+        page,
+    }) => {
+        const dragSensorErrors: string[] = [];
+        page.on('console', (message) => {
+            if (
+                message.type() === 'error' &&
+                message
+                    .text()
+                    .includes(
+                        'The final argument passed to useEffect changed size between renders',
+                    )
+            ) {
+                dragSensorErrors.push(message.text());
+            }
+        });
+
+        await mount(<RaisedBedFieldDndDialogStory scenario={cartScenario()} />);
+        await page.getByRole('button', { name: 'Toggle dialog' }).click();
+
+        await expect(page.getByRole('dialog')).toBeVisible();
+        await page.waitForTimeout(100);
+        expect(dragSensorErrors).toEqual([]);
     });
 
     test('planted growing field renders lifecycle progress and no indicator stack', async ({

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { ShoppingCartOptimisticToggleStory } from './ShoppingCartOptimisticToggleStory';
+
+test('shopping cart payment toggle updates before the server responds', async ({
+    mount,
+    page,
+}) => {
+    let releasePost: (() => void) | undefined;
+    let markPostStarted: (() => void) | undefined;
+    const postStarted = new Promise<void>((resolve) => {
+        markPostStarted = resolve;
+    });
+
+    await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+        if (route.request().method() !== 'POST') {
+            await route.fallback();
+            return;
+        }
+
+        markPostStarted?.();
+        await new Promise<void>((resolve) => {
+            releasePost = resolve;
+        });
+        await route.fulfill({
+            body: JSON.stringify({ success: true }),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+
+    await mount(<ShoppingCartOptimisticToggleStory />);
+
+    const paymentSwitch = page.getByRole('switch');
+    await expect(paymentSwitch).toHaveAttribute('aria-checked', 'false');
+    await expect(page.getByTestId('optimistic-cart-total')).toContainText(
+        '2.50 €',
+    );
+
+    await paymentSwitch.click();
+    await postStarted;
+
+    await expect(paymentSwitch).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByText('2.500')).toBeVisible();
+    await expect(page.getByTestId('optimistic-cart-total')).toContainText(
+        '0.00 €',
+    );
+    await expect(page.getByTestId('optimistic-cart-sunflowers')).toContainText(
+        '2500',
+    );
+
+    releasePost?.();
+});

--- a/apps/garden/tests/sunflower-payment-transfer.spec.tsx
+++ b/apps/garden/tests/sunflower-payment-transfer.spec.tsx
@@ -68,4 +68,13 @@ test.describe('sunflower payment transfer', () => {
             page.locator('[data-sunflower-transfer-layer]'),
         ).toHaveCount(0);
     });
+
+    test('shows sunflower prices without cents', async ({ mount, page }) => {
+        await mount(
+            <SunflowerPaymentTransferStory initialIsSunflower={true} />,
+        );
+
+        await expect(page.getByText('2.500')).toBeVisible();
+        await expect(page.getByText('2500.00')).toHaveCount(0);
+    });
 });

--- a/apps/garden/tests/sunflowers-hud.spec.tsx
+++ b/apps/garden/tests/sunflowers-hud.spec.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import {
+    SunflowersHudStory,
+    SunflowersPendingDetailsStory,
+} from './SunflowersHudStory';
+
+test.describe('Sunflowers HUD', () => {
+    test('deducts sunflower cart total and shows the cart indicator', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SunflowersHudStory />);
+
+        const hud = page.locator('[data-sunflowers-hud-target]');
+        await expect(hud).toContainText(/[\u2212-]1\.436/u);
+        await expect(
+            page.locator('[data-sunflowers-cart-indicator]'),
+        ).toBeVisible();
+    });
+
+    test('shows pending cart amount in sunflower details', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SunflowersPendingDetailsStory />);
+
+        await expect(page.getByText('U košari')).toBeVisible();
+        await expect(page.getByText(/[\u2212-]10\.470/u)).toBeVisible();
+    });
+});

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -30,24 +30,28 @@ export function GameHud({
     noWeather?: boolean;
 }) {
     const isCloseup = useGameState((state) => state.view) === 'closeup';
+    const closeupHiddenHudClassName = cx(
+        'empty:hidden',
+        isCloseup && 'hidden md:block',
+    );
 
     return (
         <>
             <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
-                <ShoppingCartHud />
                 <AccountHud />
-                <div className={cx(isCloseup && 'hidden md:block')}>
+                <ShoppingCartHud />
+                <div className={closeupHiddenHudClassName}>
                     <GameModeHud />
                 </div>
-                <div className={cx(isCloseup && 'hidden md:block')}>
+                <div className={closeupHiddenHudClassName}>
                     <AdventHud />
                 </div>
-                <div className={cx(isCloseup && 'hidden md:block')}>
+                <div className={closeupHiddenHudClassName}>
                     <InventoryHud />
                 </div>
             </div>
             <div className="absolute top-2 right-2 flex items-end flex-col-reverse md:flex-row gap-1 md:gap-2">
-                <div className={cx(isCloseup && 'hidden md:block')}>
+                <div className={closeupHiddenHudClassName}>
                     <WeatherHud noWeather={noWeather} />
                 </div>
                 <SunflowersHud />

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -34,6 +34,7 @@ export function GameHud({
     return (
         <>
             <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
+                <ShoppingCartHud />
                 <AccountHud />
                 <div className={cx(isCloseup && 'hidden md:block')}>
                     <GameModeHud />
@@ -43,9 +44,6 @@ export function GameHud({
                 </div>
                 <div className={cx(isCloseup && 'hidden md:block')}>
                     <InventoryHud />
-                </div>
-                <div className={cx(isCloseup && 'hidden md:block')}>
-                    <ShoppingCartHud />
                 </div>
             </div>
             <div className="absolute top-2 right-2 flex items-end flex-col-reverse md:flex-row gap-1 md:gap-2">

--- a/packages/game/src/hooks/useSetShoppingCartItem.ts
+++ b/packages/game/src/hooks/useSetShoppingCartItem.ts
@@ -1,23 +1,158 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useShoppingCart, useShoppingCartQueryKey } from './useShoppingCart';
+import { getEffectiveEurPrice } from '../utils/sunflowerPricing';
+import {
+    currentAccountKeys,
+    type useCurrentAccount,
+} from './useCurrentAccount';
+import {
+    type ShoppingCartData,
+    useShoppingCart,
+    useShoppingCartQueryKey,
+} from './useShoppingCart';
+
+type SetShoppingCartItemInput = {
+    id?: number;
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+    gardenId?: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+    additionalData?: string | null;
+    currency?: string | null;
+    forceCreate?: boolean;
+};
+
+type CurrentAccountData = ReturnType<typeof useCurrentAccount>['data'];
+
+function cartItemPrice(item: ShoppingCartData['items'][number]) {
+    return getEffectiveEurPrice({
+        price: item.shopData.price,
+        discountPrice: item.shopData.discountPrice,
+    });
+}
+
+function isInsufficientSunflowersNote(note: string) {
+    return note.startsWith('Nedovoljno suncokreta.');
+}
+
+function recalculateCartTotals(
+    cart: ShoppingCartData,
+    account: CurrentAccountData,
+) {
+    const total = cart.items
+        .filter((item) => item.status !== 'paid' && item.currency === 'eur')
+        .reduce((sum, item) => sum + cartItemPrice(item), 0);
+    const totalSunflowers = Math.round(
+        cart.items
+            .filter(
+                (item) =>
+                    item.status !== 'paid' && item.currency === 'sunflower',
+            )
+            .reduce((sum, item) => sum + cartItemPrice(item), 0) * 1000,
+    );
+    const notes = cart.notes ?? [];
+    const notesWithoutSunflowerBalance = notes.filter(
+        (note) => !isInsufficientSunflowersNote(note),
+    );
+    const accountSunflowers = account?.sunflowers.amount;
+
+    if (typeof accountSunflowers !== 'number') {
+        return {
+            ...cart,
+            total,
+            totalSunflowers,
+        };
+    }
+
+    const hasEnoughSunflowers = totalSunflowers <= accountSunflowers;
+    const cartInfoAllowsPurchase =
+        cart.allowPurchase ||
+        (notes.some(isInsufficientSunflowersNote) &&
+            notesWithoutSunflowerBalance.length === 0);
+
+    return {
+        ...cart,
+        total,
+        totalSunflowers,
+        notes: hasEnoughSunflowers
+            ? notesWithoutSunflowerBalance
+            : [
+                  ...notesWithoutSunflowerBalance,
+                  `Nedovoljno suncokreta. Potrebno je ${totalSunflowers} 🌻, a imaš samo ${accountSunflowers} 🌻.`,
+              ],
+        allowPurchase: cartInfoAllowsPurchase && hasEnoughSunflowers,
+    };
+}
+
+function applyOptimisticShoppingCartItem(
+    cart: ShoppingCartData,
+    item: SetShoppingCartItemInput,
+    account: CurrentAccountData,
+) {
+    if (item.id == null) {
+        return cart;
+    }
+
+    let updatedExistingItem = false;
+    const nextItems = cart.items.flatMap((cartItem) => {
+        if (cartItem.id !== item.id) {
+            return [cartItem];
+        }
+
+        updatedExistingItem = true;
+
+        if (item.amount <= 0) {
+            return [];
+        }
+
+        return [
+            {
+                ...cartItem,
+                amount: item.amount,
+                additionalData:
+                    item.additionalData !== undefined
+                        ? item.additionalData
+                        : cartItem.additionalData,
+                currency:
+                    item.currency !== undefined && item.currency !== null
+                        ? item.currency
+                        : cartItem.currency,
+                gardenId:
+                    item.gardenId !== undefined
+                        ? item.gardenId
+                        : cartItem.gardenId,
+                raisedBedId:
+                    item.raisedBedId !== undefined
+                        ? item.raisedBedId
+                        : cartItem.raisedBedId,
+                positionIndex:
+                    item.positionIndex !== undefined
+                        ? item.positionIndex
+                        : cartItem.positionIndex,
+            },
+        ];
+    });
+
+    if (!updatedExistingItem) {
+        return cart;
+    }
+
+    return recalculateCartTotals(
+        {
+            ...cart,
+            items: nextItems,
+        },
+        account,
+    );
+}
 
 export function useSetShoppingCartItem() {
     const queryClient = useQueryClient();
     const { data: cart } = useShoppingCart();
     return useMutation({
-        mutationFn: async (item: {
-            id?: number;
-            entityTypeName: string;
-            entityId: string;
-            amount: number;
-            gardenId?: number;
-            raisedBedId?: number;
-            positionIndex?: number;
-            additionalData?: string | null;
-            currency?: string | null;
-            forceCreate?: boolean;
-        }) => {
+        mutationFn: async (item: SetShoppingCartItemInput) => {
             if (!cart) {
                 throw new Error('Shopping cart is not available');
             }
@@ -32,6 +167,41 @@ export function useSetShoppingCartItem() {
             });
             if (response.status !== 200) {
                 throw new Error('Failed to set shopping cart item');
+            }
+        },
+        onMutate: async (item) => {
+            await queryClient.cancelQueries({
+                queryKey: useShoppingCartQueryKey,
+            });
+
+            const previousCart =
+                queryClient.getQueryData<ShoppingCartData | null>(
+                    useShoppingCartQueryKey,
+                );
+            const currentAccount =
+                queryClient.getQueryData<CurrentAccountData>(
+                    currentAccountKeys,
+                );
+
+            if (previousCart) {
+                queryClient.setQueryData<ShoppingCartData | null>(
+                    useShoppingCartQueryKey,
+                    applyOptimisticShoppingCartItem(
+                        previousCart,
+                        item,
+                        currentAccount,
+                    ),
+                );
+            }
+
+            return { previousCart };
+        },
+        onError: (_error, _item, context) => {
+            if (context?.previousCart) {
+                queryClient.setQueryData(
+                    useShoppingCartQueryKey,
+                    context.previousCart,
+                );
             }
         },
         onSettled: () => {

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -1,5 +1,5 @@
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
-import { Check } from '@signalco/ui-icons';
+import { Check, Navigate } from '@signalco/ui-icons';
 import { cx } from '@signalco/ui-primitives/cx';
 import { Modal } from '@signalco/ui-primitives/Modal';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -104,7 +104,12 @@ export function RaisedBedFieldHud(_props: {
                         modal={false}
                         className="md:border-tertiary md:border-b-4"
                         trigger={
-                            <ButtonGreen fullWidth>
+                            <ButtonGreen
+                                fullWidth
+                                endDecorator={
+                                    <Navigate className="size-4 shrink-0" />
+                                }
+                            >
                                 <Row spacing={1}>
                                     <RaisedBedIcon
                                         physicalId={raisedBed.physicalId}

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -26,11 +26,13 @@ import {
     DeliveryStep,
 } from '../shared-ui/delivery/DeliveryStep';
 import { useShoppingCartOpenParam } from '../useUrlState';
-import { calculateSunflowerAmountFromPrices } from '../utils/sunflowerPricing';
+import {
+    calculateSunflowerAmountFromPrices,
+    formatSunflowers,
+} from '../utils/sunflowerPricing';
 import { HudCard } from './components/HudCard';
 import { ButtonConfirmPayment } from './components/shopping-cart/ButtonConfirmPayment';
 import { ShoppingCartItem } from './components/shopping-cart/ShoppingCartItem';
-import { SunflowerCheckoutBalance } from './components/shopping-cart/SunflowerCheckoutBalance';
 
 export function ShoppingCart() {
     const { data: account } = useCurrentAccount();
@@ -181,7 +183,6 @@ export function ShoppingCart() {
                             ))}
                     </Stack>
                     <Stack className="border-t mt-4 pt-2" spacing={1}>
-                        <SunflowerCheckoutBalance cart={cart} />
                         <Row
                             justifyContent="space-between"
                             alignItems="start"
@@ -195,7 +196,9 @@ export function ShoppingCart() {
                                 {(cart?.totalSunflowers ?? 0) > 0 && (
                                     <Typography level="body1" bold>
                                         {(cart?.totalSunflowers ?? 0) > 0
-                                            ? `${cart?.totalSunflowers ?? 0}`
+                                            ? formatSunflowers(
+                                                  cart?.totalSunflowers ?? 0,
+                                              )
                                             : '0'}{' '}
                                         <span className={'text-lg'}>🌻</span>
                                     </Typography>

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -1,5 +1,9 @@
 import { useSearchParam } from '@signalco/hooks/useSearchParam';
-import { Info, Navigate } from '@signalco/ui-icons';
+import {
+    Info,
+    Navigate,
+    ShoppingCart as ShoppingCartIcon,
+} from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import { Divider } from '@signalco/ui-primitives/Divider';
 import { IconButton } from '@signalco/ui-primitives/IconButton';
@@ -10,8 +14,10 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import Image from 'next/image';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
 import { useDailyReward } from '../hooks/useDailyReward';
+import { useShoppingCart } from '../hooks/useShoppingCart';
 import { KnownPages } from '../knownPages';
 import { SunflowersList } from '../shared-ui/sunflowers/SunflowersList';
+import { formatSunflowers } from '../utils/sunflowerPricing';
 import { HudCard } from './components/HudCard';
 
 function DailyRewardInfo() {
@@ -106,7 +112,7 @@ export function SunflowersInfoTooltipContent() {
     );
 }
 
-function SunflowersCard() {
+function SunflowersCard({ pendingSunflowers }: { pendingSunflowers: number }) {
     const [, setProfileModalOpen] = useSearchParam('pregled');
 
     return (
@@ -132,7 +138,7 @@ function SunflowersCard() {
             <Divider />
             <DailyRewardInfo />
             <Divider />
-            <SunflowersList limit={5} />
+            <SunflowersList limit={5} pendingSunflowers={pendingSunflowers} />
             <Divider />
             <Stack>
                 <Button
@@ -151,7 +157,13 @@ function SunflowersCard() {
 
 function SunflowersAmount() {
     const { data: account, isLoading } = useCurrentAccount();
+    const { data: cart } = useShoppingCart();
     const sunflowerCount = account?.sunflowers.amount;
+    const pendingSunflowers = cart?.totalSunflowers ?? 0;
+    const displayedSunflowerCount =
+        typeof sunflowerCount === 'number'
+            ? sunflowerCount - pendingSunflowers
+            : undefined;
 
     if (isLoading) {
         return null;
@@ -176,15 +188,27 @@ function SunflowersAmount() {
                             height={24}
                         />
                     }
-                    className="rounded-full px-2 md:min-w-20 justify-between pr-4"
+                    className="relative rounded-full px-2 md:min-w-20 justify-between pr-4"
                 >
                     <Typography level="body2" className="text-base pl-0.5">
-                        {sunflowerCount}
+                        {typeof displayedSunflowerCount === 'number'
+                            ? formatSunflowers(displayedSunflowerCount)
+                            : sunflowerCount}
                     </Typography>
+                    {pendingSunflowers > 0 && (
+                        <span
+                            aria-hidden="true"
+                            title={`U košari: ${formatSunflowers(pendingSunflowers)} 🌻`}
+                            data-sunflowers-cart-indicator
+                            className="pointer-events-none absolute -right-1 -top-1 flex size-6 items-center justify-center rounded-full border border-background bg-neutral-100 text-neutral-900 shadow-sm"
+                        >
+                            <ShoppingCartIcon className="size-[18px] shrink-0" />
+                        </span>
+                    )}
                 </Button>
             }
         >
-            <SunflowersCard />
+            <SunflowersCard pendingSunflowers={pendingSunflowers} />
         </Popper>
     );
 }

--- a/packages/game/src/hud/components/shopping-cart/ButtonConfirmPayment.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ButtonConfirmPayment.tsx
@@ -3,6 +3,7 @@ import { Info, Navigate } from '@signalco/ui-icons';
 import { Button } from '@signalco/ui-primitives/Button';
 import type { useCheckout } from '../../../hooks/useCheckout';
 import type { useShoppingCart } from '../../../hooks/useShoppingCart';
+import { formatSunflowers } from '../../../utils/sunflowerPricing';
 import { SunflowerCheckoutBalance } from './SunflowerCheckoutBalance';
 
 type ButtonConfirmPaymentProps = {
@@ -23,7 +24,7 @@ export function ButtonConfirmPayment({
             {cart?.totalSunflowers ? (
                 <ModalConfirm
                     title="Potvrdi plaćanje"
-                    header={`Potvrđuješ plaćanje ${cart?.totalSunflowers ?? 0} 🌻 i ${cart?.total.toFixed(2) ?? 0} €?`}
+                    header={`Potvrđuješ plaćanje ${formatSunflowers(cart?.totalSunflowers ?? 0)} 🌻 i ${cart?.total.toFixed(2) ?? 0} €?`}
                     onConfirm={onConfirm}
                     trigger={
                         <Button

--- a/packages/game/src/hud/components/shopping-cart/ButtonPricePickPaymentMethod.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ButtonPricePickPaymentMethod.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import { useSunflowerTransferAnimation } from '../../../indicators/SunflowerTransfer/useSunflowerTransferAnimation';
 import {
     calculateSunflowerAmountFromPrices,
+    formatSunflowers,
     getEffectiveEurPrice,
 } from '../../../utils/sunflowerPricing';
 
@@ -35,6 +36,9 @@ export function ButtonPricePickPaymentMethod({
         discountPrice,
     });
     const displayPrice = isSunflower ? requiredSunflowers : effectivePrice;
+    const formattedDisplayPrice = isSunflower
+        ? formatSunflowers(displayPrice)
+        : displayPrice.toFixed(2);
     const canAffordSunflowers =
         availableSunflowers !== undefined
             ? availableSunflowers >= requiredSunflowers
@@ -57,7 +61,7 @@ export function ButtonPricePickPaymentMethod({
         <Row spacing={1}>
             {/* Price Display */}
             <Typography level="body1" semiBold>
-                {displayPrice.toFixed(2)}
+                {formattedDisplayPrice}
             </Typography>
 
             {/* Custom Switch */}
@@ -78,8 +82,8 @@ export function ButtonPricePickPaymentMethod({
                 aria-checked={isSunflower}
                 aria-label={
                     isSunflower
-                        ? `Plaćanje suncokretima, ${requiredSunflowers.toLocaleString('hr-HR')} suncokreta`
-                        : `Plaćanje eurima, prebaci na ${requiredSunflowers.toLocaleString('hr-HR')} suncokreta`
+                        ? `Plaćanje suncokretima, ${formatSunflowers(requiredSunflowers)} suncokreta`
+                        : `Plaćanje eurima, prebaci na ${formatSunflowers(requiredSunflowers)} suncokreta`
                 }
                 title={
                     isToggleDisabled && !isSunflower

--- a/packages/game/src/hud/components/shopping-cart/SunflowerCheckoutBalance.tsx
+++ b/packages/game/src/hud/components/shopping-cart/SunflowerCheckoutBalance.tsx
@@ -1,6 +1,7 @@
 import { Row } from '@signalco/ui-primitives/Row';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import type { useShoppingCart } from '../../../hooks/useShoppingCart';
+import { formatSunflowers } from '../../../utils/sunflowerPricing';
 
 export function SunflowerCheckoutBalance({
     cart,
@@ -20,8 +21,4 @@ export function SunflowerCheckoutBalance({
             </Row>
         </div>
     );
-}
-
-function formatSunflowers(value: number) {
-    return value.toLocaleString('hr-HR');
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -219,6 +219,8 @@ export function RaisedBedField({
     );
 
     function handleDragEnd(event: DragEndEvent) {
+        if (isHudDialogOpen) return;
+
         const { active, over } = event;
         if (!over || active.id === over.id) return;
 
@@ -277,7 +279,7 @@ export function RaisedBedField({
             <div></div>
             <DndContext
                 id={`raised-bed-field-${gardenId}-${raisedBedId}`}
-                sensors={isHudDialogOpen ? [] : sensors}
+                sensors={sensors}
                 collisionDetection={closestCenter}
                 onDragEnd={handleDragEnd}
             >
@@ -320,7 +322,9 @@ export function RaisedBedField({
                                     const isPlanted =
                                         plantedPositions.has(positionIndex);
                                     const isDragDisabled =
-                                        !isInCart || isPlanted;
+                                        isHudDialogOpen ||
+                                        !isInCart ||
+                                        isPlanted;
 
                                     return (
                                         <div

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -198,7 +198,7 @@ export function RaisedBedFieldItemEmpty({
                                 }
                                 onKeyDown={(event) => event.stopPropagation()}
                             >
-                                <ShoppingCart className="size-[18px] stroke-tertiary" />
+                                <ShoppingCart className="size-[18px] text-foreground dark:text-[hsl(28_47.4%_11.2%)]" />
                             </button>
                         }
                         {...plantPickerProps}

--- a/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
+++ b/packages/game/src/shared-ui/sunflowers/SunflowersList.tsx
@@ -1,6 +1,6 @@
 import { getAchievementDefinition } from '@gredice/js/achievements';
 import { BlockImage } from '@gredice/ui/BlockImage';
-import { Empty } from '@signalco/ui-icons';
+import { Empty, ShoppingCart as ShoppingCartIcon } from '@signalco/ui-icons';
 import { List } from '@signalco/ui-primitives/List';
 import { ListItem } from '@signalco/ui-primitives/ListItem';
 import { Row } from '@signalco/ui-primitives/Row';
@@ -8,6 +8,7 @@ import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import Image from 'next/image';
 import { useCurrentAccount } from '../../hooks/useCurrentAccount';
+import { formatSunflowers } from '../../utils/sunflowerPricing';
 import { NoSunflowersPlaceholder } from './NoSunflowersPlaceholder';
 
 function sunflowerReasonToDescription(reason: string) {
@@ -118,10 +119,18 @@ function sunflowerReasonToDescription(reason: string) {
     return { icon: <Empty className="size-10" />, label: 'Nepoznato' };
 }
 
-export function SunflowersList({ limit }: { limit?: number }) {
+export function SunflowersList({
+    limit,
+    pendingSunflowers = 0,
+}: {
+    limit?: number;
+    pendingSunflowers?: number;
+}) {
     const { data: account } = useCurrentAccount();
-    const history = account?.sunflowers.history;
-    if (!history?.length) {
+    const history = account?.sunflowers.history ?? [];
+    const hasPendingSunflowers = pendingSunflowers > 0;
+
+    if (!history.length && !hasPendingSunflowers) {
         return (
             <div className="px-2 py-4">
                 <NoSunflowersPlaceholder />
@@ -159,10 +168,37 @@ export function SunflowersList({ limit }: { limit?: number }) {
         (typeof history)[0] & { count: number; totalAmount: number }
     >());
     const historyGroupedArray = Array.from(historyGrouped.values());
-    const actualLimit = limit ?? historyGroupedArray.length;
+    const actualLimit =
+        typeof limit === 'number' && hasPendingSunflowers
+            ? Math.max(limit - 1, 0)
+            : (limit ?? historyGroupedArray.length);
 
     return (
         <List>
+            {hasPendingSunflowers && (
+                <ListItem
+                    label={
+                        <Row spacing={1} justifyContent="space-between">
+                            <Row spacing={2}>
+                                <div className="size-10 flex items-center justify-center rounded-full bg-yellow-100 text-yellow-800">
+                                    <ShoppingCartIcon className="size-5 shrink-0" />
+                                </div>
+                                <Stack>
+                                    <Typography level="body2">
+                                        U košari
+                                    </Typography>
+                                    <Typography level="body3">
+                                        Privremeno rezervirano
+                                    </Typography>
+                                </Stack>
+                            </Row>
+                            <Typography color="danger">
+                                {formatSunflowers(-pendingSunflowers)}
+                            </Typography>
+                        </Row>
+                    }
+                />
+            )}
             {historyGroupedArray.slice(0, actualLimit).map((event) => {
                 const description = sunflowerReasonToDescription(
                     typeof event.reason === 'string' ? event.reason : '',
@@ -204,8 +240,8 @@ export function SunflowersList({ limit }: { limit?: number }) {
                                     }
                                 >
                                     {event.totalAmount > 0
-                                        ? `+${event.totalAmount}`
-                                        : event.totalAmount}
+                                        ? `+${formatSunflowers(event.totalAmount)}`
+                                        : formatSunflowers(event.totalAmount)}
                                 </Typography>
                             </Row>
                         }

--- a/packages/game/src/utils/sunflowerPricing.ts
+++ b/packages/game/src/utils/sunflowerPricing.ts
@@ -22,3 +22,9 @@ export function calculateSunflowerAmountFromPrices({
     const effectivePrice = getEffectiveEurPrice({ price, discountPrice });
     return Math.round(effectivePrice * 1000);
 }
+
+export function formatSunflowers(value: number) {
+    return value.toLocaleString('hr-HR', {
+        maximumFractionDigits: 0,
+    });
+}


### PR DESCRIPTION
## Summary
- Remove duplicate sunflower payment totals and format sunflower amounts as whole numbers
- Make sunflower cart deductions visible in the HUD and surface the temporary `U košari` balance breakdown
- Add optimistic shopping-cart currency updates so the UI changes immediately without waiting for the server
- Move the cart HUD to the top of the stack and add clearer navigation affordances on clickable raised-bed items
- Fix the dnd sensor warning by keeping the sensor array stable while dialogs are open

## Testing
- Added and updated Playwright component coverage for sunflower HUD, optimistic cart toggling, and raised-bed HUD behavior
- Ran lint, typecheck, and targeted Playwright checks locally; all passed