### PR TITLE
Fix render-safe refresh token validation in app and farm

### DIFF
--- a/apps/app/lib/auth/auth.ts
+++ b/apps/app/lib/auth/auth.ts
@@ -106,7 +106,10 @@ async function authFromToken(token: string, roles: string[]) {
 
 export async function auth(...args: Parameters<typeof baseAuth>) {
     const [roles] = args;
-    const accessToken = await refreshSessionIfNeeded();
+    const accessToken = await refreshSessionIfNeeded({
+        // auth() is used during Server Component rendering, where cookies are read-only.
+        persistCookies: false,
+    });
     if (accessToken) {
         return await authFromToken(accessToken, roles);
     }

--- a/apps/app/lib/auth/sessionRefresh.ts
+++ b/apps/app/lib/auth/sessionRefresh.ts
@@ -1,4 +1,4 @@
-import { doUseRefreshToken } from '@gredice/storage';
+import { doUseRefreshToken, getRefreshTokenUserId } from '@gredice/storage';
 import { cookies } from 'next/headers';
 import { createJwt, setCookie, verifyJwt } from './baseAuth';
 import {
@@ -8,6 +8,10 @@ import {
 } from './refreshCookies';
 import { accessTokenExpiry } from './sessionConfig';
 
+type RefreshSessionOptions = {
+    persistCookies?: boolean;
+};
+
 async function isAccessTokenValid(token: string) {
     const { result, error } = await verifyJwt(token);
     if (error || !result?.payload?.sub) {
@@ -16,7 +20,9 @@ async function isAccessTokenValid(token: string) {
     return true;
 }
 
-export async function refreshSessionIfNeeded() {
+export async function refreshSessionIfNeeded({
+    persistCookies = true,
+}: RefreshSessionOptions = {}) {
     const accessToken = (await cookies()).get('gredice_session')?.value;
     if (accessToken && (await isAccessTokenValid(accessToken))) {
         return accessToken;
@@ -27,18 +33,20 @@ export async function refreshSessionIfNeeded() {
         return null;
     }
 
-    const refreshed = await doUseRefreshToken(refreshToken);
+    const refreshed = persistCookies
+        ? await doUseRefreshToken(refreshToken)
+        : await getRefreshTokenUserId(refreshToken);
     if (!refreshed) {
-        await clearRefreshCookie();
+        if (persistCookies) {
+            await clearRefreshCookie();
+        }
         return null;
     }
 
     const newAccessToken = await createJwt(refreshed.userId, accessTokenExpiry);
-    try {
+    if (persistCookies) {
         await setCookie(newAccessToken);
         await setRefreshCookie(refreshToken);
-    } catch {
-        // Cookies are read-only in some server render paths; ignore and rely on access token.
     }
     return newAccessToken;
 }

--- a/apps/farm/lib/auth/auth.ts
+++ b/apps/farm/lib/auth/auth.ts
@@ -107,7 +107,10 @@ async function authFromToken(token: string, roles: string[]) {
 
 export async function auth(...args: Parameters<typeof baseAuth>) {
     const [roles] = args;
-    const accessToken = await refreshSessionIfNeeded();
+    const accessToken = await refreshSessionIfNeeded({
+        // auth() is used during Server Component rendering, where cookies are read-only.
+        persistCookies: false,
+    });
     if (accessToken) {
         return await authFromToken(accessToken, roles);
     }

--- a/apps/farm/lib/auth/sessionRefresh.ts
+++ b/apps/farm/lib/auth/sessionRefresh.ts
@@ -1,4 +1,4 @@
-import { doUseRefreshToken } from '@gredice/storage';
+import { doUseRefreshToken, getRefreshTokenUserId } from '@gredice/storage';
 import { cookies } from 'next/headers';
 import { createJwt, setCookie, verifyJwt } from './baseAuth';
 import {
@@ -8,6 +8,10 @@ import {
 } from './refreshCookies';
 import { accessTokenExpiry } from './sessionConfig';
 
+type RefreshSessionOptions = {
+    persistCookies?: boolean;
+};
+
 async function isAccessTokenValid(token: string) {
     const { result, error } = await verifyJwt(token);
     if (error || !result?.payload?.sub) {
@@ -16,7 +20,9 @@ async function isAccessTokenValid(token: string) {
     return true;
 }
 
-export async function refreshSessionIfNeeded() {
+export async function refreshSessionIfNeeded({
+    persistCookies = true,
+}: RefreshSessionOptions = {}) {
     const accessToken = (await cookies()).get('gredice_session')?.value;
     if (accessToken && (await isAccessTokenValid(accessToken))) {
         return accessToken;
@@ -27,18 +33,20 @@ export async function refreshSessionIfNeeded() {
         return null;
     }
 
-    const refreshed = await doUseRefreshToken(refreshToken);
+    const refreshed = persistCookies
+        ? await doUseRefreshToken(refreshToken)
+        : await getRefreshTokenUserId(refreshToken);
     if (!refreshed) {
-        await clearRefreshCookie();
+        if (persistCookies) {
+            await clearRefreshCookie();
+        }
         return null;
     }
 
     const newAccessToken = await createJwt(refreshed.userId, accessTokenExpiry);
-    try {
+    if (persistCookies) {
         await setCookie(newAccessToken);
         await setRefreshCookie(refreshToken);
-    } catch {
-        // Cookies are read-only in some server render paths; ignore and rely on access token.
     }
     return newAccessToken;
 }

--- a/packages/storage/src/repositories/refreshTokensRepo.ts
+++ b/packages/storage/src/repositories/refreshTokensRepo.ts
@@ -48,7 +48,10 @@ export async function createRefreshToken(userId: string) {
     return token;
 }
 
-export async function doUseRefreshToken(token: string) {
+async function findRefreshTokenRecord(
+    token: string,
+    { deleteExpired }: { deleteExpired: boolean },
+) {
     const parsed = parseRefreshToken(token);
     if (!parsed) {
         console.warn('Invalid refresh token format received');
@@ -65,9 +68,11 @@ export async function doUseRefreshToken(token: string) {
     // Use a 1-second buffer to prevent edge cases where token expires during processing
     const expiryBuffer = 1000;
     if (record.expiresAt.getTime() <= Date.now() + expiryBuffer) {
-        await storage()
-            .delete(refreshTokens)
-            .where(eq(refreshTokens.id, record.id));
+        if (deleteExpired) {
+            await storage()
+                .delete(refreshTokens)
+                .where(eq(refreshTokens.id, record.id));
+        }
         return null;
     }
 
@@ -76,6 +81,30 @@ export async function doUseRefreshToken(token: string) {
             'Invalid refresh token hash attempt for token ID:',
             parsed.tokenId,
         );
+        return null;
+    }
+
+    return record;
+}
+
+export async function getRefreshTokenUserId(token: string) {
+    const record = await findRefreshTokenRecord(token, {
+        deleteExpired: false,
+    });
+    if (!record) {
+        return null;
+    }
+
+    return {
+        userId: record.userId,
+    };
+}
+
+export async function doUseRefreshToken(token: string) {
+    const record = await findRefreshTokenRecord(token, {
+        deleteExpired: true,
+    });
+    if (!record) {
         return null;
     }
 

--- a/packages/storage/tests/refreshTokensRepo.node.spec.ts
+++ b/packages/storage/tests/refreshTokensRepo.node.spec.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    createRefreshToken,
+    doUseRefreshToken,
+    getRefreshTokenUserId,
+    refreshTokens,
+    storage,
+    users,
+} from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+test('getRefreshTokenUserId validates refresh token without marking it used', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    await storage().insert(users).values({
+        id: userId,
+        userName: 'refresh-token@example.com',
+        role: 'admin',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const token = await createRefreshToken(userId);
+    const [tokenId] = token.split('.');
+    assert.ok(tokenId);
+
+    const previousLastUsedAt = new Date(Date.now() - 60_000);
+    await storage()
+        .update(refreshTokens)
+        .set({ lastUsedAt: previousLastUsedAt })
+        .where(eq(refreshTokens.id, tokenId));
+
+    const readOnlyResult = await getRefreshTokenUserId(token);
+    assert.deepEqual(readOnlyResult, { userId });
+
+    const afterReadOnly = await storage().query.refreshTokens.findFirst({
+        where: eq(refreshTokens.id, tokenId),
+    });
+    assert.equal(
+        afterReadOnly?.lastUsedAt.getTime(),
+        previousLastUsedAt.getTime(),
+    );
+
+    const useResult = await doUseRefreshToken(token);
+    assert.deepEqual(useResult, { userId });
+
+    const afterUse = await storage().query.refreshTokens.findFirst({
+        where: eq(refreshTokens.id, tokenId),
+    });
+    assert.ok(afterUse);
+    assert.ok(afterUse.lastUsedAt.getTime() > previousLastUsedAt.getTime());
+});


### PR DESCRIPTION
## Summary
- Split refresh-token validation from refresh-token usage so Server Component auth paths no longer mutate cookies or update refresh-token state.
- Keep cookie persistence inside route-handler flows, where Next.js allows cookie writes and clears.
- Add storage coverage to prove read-only refresh validation does not touch `lastUsedAt`.

## Testing
- `pnpm lint --filter app`
- `pnpm lint --filter farm`
- `pnpm lint --filter @gredice/storage`
- `pnpm --filter app test:unit`
- `pnpm test --filter @gredice/storage`
- `pnpm build --filter app --filter farm`
- `pnpm test --filter farm`