### PR TITLE
Implement referral prize updates and polish referral UIs

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -2,6 +2,7 @@ import { tz } from '@date-fns/tz';
 import { sendEmail } from '@gredice/email/acs';
 import {
     acceptAccountInvitation,
+    accounts as accountRecords,
     cancelAccountInvitation,
     createAccountInvitation,
     createEvent,
@@ -20,10 +21,14 @@ import {
     getSunflowersHistory,
     getUser,
     knownEventTypes,
+    sql,
+    storage,
+    events as storedEvents,
     updateAccountTimeZone,
 } from '@gredice/storage';
 import AccountDeleteConfirmationTemplate from '@gredice/transactional/emails/Account/delete-confirmation';
 import { addDays, differenceInCalendarDays, startOfDay } from 'date-fns';
+import { asc, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { setCookie as honoSetCookie } from 'hono/cookie';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
@@ -43,6 +48,8 @@ import { getPostHogClient } from '../../../lib/posthog-server';
 
 const dailyRewards = [5, 10, 15, 20, 25, 50];
 const DAILY_REWARD_TIME_ZONE = 'Europe/Zagreb';
+const GARDEN_APP_URL =
+    process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
 
 function rewardForDay(day: number) {
     return dailyRewards[Math.min(day, dailyRewards.length) - 1] ?? 0;
@@ -52,6 +59,12 @@ function getEmailDomain(email: string) {
     const normalizedEmail = email.trim().toLowerCase();
     const [, domain] = normalizedEmail.split('@');
     return domain ?? 'unknown';
+}
+
+function getReferralLink(code: string) {
+    const url = new URL(GARDEN_APP_URL);
+    url.searchParams.set('ref', code);
+    return url.toString();
 }
 
 async function getDailyRewardState(accountId: string) {
@@ -182,12 +195,67 @@ async function getDailyRewardState(accountId: string) {
 const REFERRAL_REWARD = 10000;
 const REFERRAL_EVENT_TYPE = 'account.referral.v1';
 
+class ReferralCodeAlreadyExistsError extends Error {}
+
 function normalizeReferralCode(code: string) {
     return code
         .trim()
         .toLowerCase()
         .replace(/[^a-z0-9_-]/g, '')
         .slice(0, 32);
+}
+
+function codeFromCodeSetEventData(data: unknown) {
+    if (!data || typeof data !== 'object') {
+        return null;
+    }
+    if (!('action' in data) || data.action !== 'code_set') {
+        return null;
+    }
+    if (!('code' in data) || typeof data.code !== 'string') {
+        return null;
+    }
+    return normalizeReferralCode(data.code);
+}
+
+async function getReferralCodeOwnerAccountId(
+    code: string,
+    db: Pick<ReturnType<typeof storage>, 'select'>,
+) {
+    const [accounts, events] = await Promise.all([
+        db.select({ id: accountRecords.id }).from(accountRecords),
+        db
+            .select({
+                aggregateId: storedEvents.aggregateId,
+                data: storedEvents.data,
+            })
+            .from(storedEvents)
+            .where(eq(storedEvents.type, REFERRAL_EVENT_TYPE))
+            .orderBy(asc(storedEvents.createdAt), asc(storedEvents.id)),
+    ]);
+
+    const currentCodes = new Map<string, string>();
+    for (const account of accounts) {
+        currentCodes.set(
+            account.id,
+            normalizeReferralCode(account.id.slice(0, 12)),
+        );
+    }
+
+    for (const event of events) {
+        const eventCode = codeFromCodeSetEventData(event.data);
+        if (eventCode) {
+            currentCodes.set(event.aggregateId, eventCode);
+        }
+    }
+
+    for (const [accountId, currentCode] of currentCodes) {
+        if (currentCode === code) {
+            return accountId;
+        }
+    }
+
+    return null;
 }
 
 async function hasActiveRaisedBed(accountId: string) {
@@ -332,7 +400,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 usedReferralCode,
                 referredAccounts,
                 rewardAmount: REFERRAL_REWARD,
-                referralLink: `https://www.gredice.com/preporuke?ref=${encodeURIComponent(myCode)}`,
+                referralLink: getReferralLink(myCode),
             });
         },
     )
@@ -350,12 +418,38 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     400,
                 );
             }
-            await createEvent({
-                type: REFERRAL_EVENT_TYPE,
-                version: 1,
-                aggregateId: accountId,
-                data: { action: 'code_set', code },
-            });
+
+            try {
+                await storage().transaction(async (tx) => {
+                    await tx.execute(
+                        sql`select pg_advisory_xact_lock(hashtext(${`referral-code:${code}`}));`,
+                    );
+
+                    const ownerAccountId = await getReferralCodeOwnerAccountId(
+                        code,
+                        tx,
+                    );
+                    if (ownerAccountId && ownerAccountId !== accountId) {
+                        throw new ReferralCodeAlreadyExistsError();
+                    }
+
+                    await tx.insert(storedEvents).values({
+                        type: REFERRAL_EVENT_TYPE,
+                        version: 1,
+                        aggregateId: accountId,
+                        data: { action: 'code_set', code },
+                    });
+                });
+            } catch (error) {
+                if (error instanceof ReferralCodeAlreadyExistsError) {
+                    return context.json(
+                        { error: 'Kod preporuke je već zauzet' },
+                        409,
+                    );
+                }
+                throw error;
+            }
+
             return context.json({ code });
         },
     )
@@ -367,12 +461,6 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const body = await context.req.json<{ code?: string }>();
             const code = normalizeReferralCode(body.code ?? '');
             if (!code) return context.json({ error: 'Neispravan kod' }, 400);
-            if (await hasActiveRaisedBed(accountId)) {
-                return context.json(
-                    { error: 'Kod se ne može unijeti nakon aktivne gredice' },
-                    400,
-                );
-            }
 
             const myEvents = await getEvents(
                 REFERRAL_EVENT_TYPE,

--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -231,6 +231,24 @@ async function mockNotificationSettingsApi(
     return recorded;
 }
 
+test('notification tabs size to their labels', async ({ mount, page }) => {
+    await mockNotificationSettingsApi(page);
+    await mount(<NotificationsTabStory />);
+
+    const tabList = page.getByRole('tablist');
+    const widths = await tabList.evaluate((element) => {
+        const listRect = element.getBoundingClientRect();
+        const parentRect = element.parentElement?.getBoundingClientRect();
+
+        return {
+            list: listRect.width,
+            parent: parentRect?.width ?? 0,
+        };
+    });
+
+    expect(widths.list).toBeLessThan(widths.parent * 0.75);
+});
+
 test('notification settings shows loading, status, and empty device states', async ({
     mount,
     page,

--- a/apps/www/app/preporuke/page.tsx
+++ b/apps/www/app/preporuke/page.tsx
@@ -1,41 +1,256 @@
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Container } from '@gredice/ui/Container';
+import { PageHeader } from '@gredice/ui/PageHeader';
+import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
+import Image from 'next/image';
+import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
+import { formatPrice } from '../../lib/formatPrice';
+import { KnownPages } from '../../src/KnownPages';
+
+const referralReward = 10000;
+const sunflowerEuroRate = 1000;
+const combinedReferralReward = referralReward * 2;
+const combinedRewardValue = combinedReferralReward / sunflowerEuroRate;
+const formattedReferralReward = new Intl.NumberFormat('hr-HR').format(
+    referralReward,
+);
+const formattedCombinedReferralReward = new Intl.NumberFormat('hr-HR').format(
+    combinedReferralReward,
+);
 
 export const metadata: Metadata = {
     title: 'Preporuke',
-    description: 'Program preporuka i pravila za dijeljenje koda preporuke.',
+    description:
+        'Program preporuka za Gredice: podijeli kod, iskoristi kod i saznaj pravila za 10.000 🌻 nagradu.',
     keywords: [
         'Gredice',
         'program preporuka',
         'kod preporuke',
-        'suncokreti',
         'nagrade',
+        'vrt aplikacija',
     ],
 };
+
+const referralFlows = [
+    {
+        title: 'Daješ preporuku',
+        ctaLabel: 'Otvori i podijeli kod',
+        steps: [
+            {
+                title: 'Uredi i kopiraj svoj kod',
+                rule: 'Kod možeš mijenjati dok račun nema aktivnu gredicu, a dva računa ne mogu imati isti kod.',
+            },
+            {
+                title: 'Podijeli kod ili poveznicu',
+                rule: 'Isti kod može iskoristiti više različitih računa.',
+            },
+            {
+                title: 'Dobivaš nagradu',
+                rule: 'Kada pozvani račun ispuni uvjet aktivne gredice, tvoj račun dobiva 10.000 🌻.',
+            },
+        ],
+    },
+    {
+        title: 'Primaš preporuku',
+        ctaLabel: 'Otvori i unesi kod',
+        steps: [
+            {
+                title: 'Unesi kod prijatelja',
+                rule: 'Kod možeš iskoristiti i ako račun već ima aktivnu gredicu.',
+            },
+            {
+                title: 'Iskoristi samo jedan kod',
+                rule: 'Svaki račun može iskoristiti samo jedan kod preporuke; nakon toga ne možeš iskoristiti drugi.',
+            },
+            {
+                title: 'Dobivaš nagradu',
+                rule: 'Kada tvoj račun ispuni uvjet aktivne gredice, dobivaš 10.000 🌻.',
+            },
+        ],
+    },
+];
+
 export default function ReferralsLandingPage() {
     return (
-        <main className="container py-10">
-            <Stack spacing={6}>
-                <Typography level="h2" component="h1">
-                    💮 Gredice program preporuka
-                </Typography>
-                <Typography>
-                    Podijeli svoj kod preporuke i zaradi{' '}
-                    <strong>10.000 suncokreta</strong> kada novi račun ispuni
-                    uvjet aktivne gredice.
-                </Typography>
-                <Typography>
-                    Pravila: kod je vezan uz račun (ne korisnika), kod se može
-                    mijenjati dok račun nema aktivnu gredicu, nakon prve aktivne
-                    gredice kod se zaključava.
-                </Typography>
-                <Typography>
-                    Nagrađivanje se obrađuje kada novi račun ima barem jednu
-                    aktivnu gredicu. Broj dijeljenja koda preporuke nije
-                    ograničen.
-                </Typography>
+        <Container maxWidth="md">
+            <Stack spacing={10}>
+                <PageHeader
+                    header="Preporuke"
+                    subHeader={`Podijeli svoj kod, pozovi nekoga u Gredice i zaradi ${formattedReferralReward} 🌻 kada pozvani račun ispuni uvjet aktivne gredice.`}
+                    padded
+                    visual={
+                        <Image
+                            src="https://cdn.gredice.com/sunflower-gift-sunflowers.webp"
+                            alt="Poklon sa suncokretima"
+                            width={192}
+                            height={192}
+                            priority
+                        />
+                    }
+                />
+
+                <StyledHtml>
+                    <p>
+                        Program preporuka je jednostavan: podijeli svoj kod s
+                        osobom koja želi koristiti Gredice. Ta osoba može
+                        unijeti tvoj kod u aplikaciji, a nagrada se povezuje s
+                        oba računa kada pozvani račun ispuni uvjet aktivne
+                        gredice.
+                    </p>
+                    <p>
+                        Kodovi nisu jednokratne pozivnice. Isti kod možeš
+                        dijeliti više puta, a različiti računi ga mogu
+                        iskoristiti neovisno jedan o drugome.
+                    </p>
+                </StyledHtml>
+
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>🎁 Nagrada</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Typography level="h3" component="p">
+                                {formattedReferralReward} 🌻
+                            </Typography>
+                            <Typography level="body2" secondary>
+                                Toliko dobiva račun koji je podijelio kod, a još
+                                toliko dobiva račun koji kod iskoristi.
+                            </Typography>
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>💶 Vrijednost</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Typography level="h3" component="p">
+                                {formatPrice(combinedRewardValue)}
+                            </Typography>
+                            <Typography level="body2" secondary>
+                                Svaki račun dobiva {formattedReferralReward} 🌻.
+                                Zajedno je to {formattedCombinedReferralReward}{' '}
+                                🌻 prema pravilu 1.000 🌻 = 1 €.
+                            </Typography>
+                        </CardContent>
+                    </Card>
+                    <Card className="flex h-full flex-col">
+                        <CardHeader>
+                            <CardTitle>⚡ Brzi pristup</CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex flex-1 flex-col gap-4">
+                            <Typography level="body2" secondary>
+                                U pregledu preporuka možeš kopirati svoj kod,
+                                podijeliti poveznicu ili unijeti kod prijatelja.
+                            </Typography>
+                            <Button
+                                className="mt-auto w-fit"
+                                href={KnownPages.GardenReferrals}
+                                size="sm"
+                            >
+                                Otvori pregled
+                            </Button>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <Stack spacing={4}>
+                    <Stack spacing={2}>
+                        <Typography level="h3" component="h2">
+                            Kako funkcioniraju preporuke
+                        </Typography>
+                        <Typography
+                            level="body2"
+                            secondary
+                            className="max-w-3xl"
+                        >
+                            Odaberi tok koji odgovara tvojoj situaciji: podijeli
+                            svoj kod ili unesi kod prijatelja. Nagrada se
+                            dodjeljuje kada preporučeni račun ispuni uvjet
+                            aktivne gredice.
+                        </Typography>
+                    </Stack>
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                        {referralFlows.map((flow) => (
+                            <Stack
+                                spacing={3}
+                                key={flow.title}
+                                className="h-full"
+                            >
+                                <Typography level="h5" component="h3">
+                                    {flow.title}
+                                </Typography>
+                                <Stack spacing={3}>
+                                    {flow.steps.map((step, index) => (
+                                        <div
+                                            className="rounded-lg border bg-card p-4 text-card-foreground"
+                                            key={step.title}
+                                        >
+                                            <Row spacing={3} alignItems="start">
+                                                <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                                                    {index + 1}
+                                                </span>
+                                                <Stack spacing={1}>
+                                                    <Typography
+                                                        level="body1"
+                                                        semiBold
+                                                    >
+                                                        {step.title}
+                                                    </Typography>
+                                                    <Typography
+                                                        level="body3"
+                                                        secondary
+                                                    >
+                                                        {step.rule}
+                                                    </Typography>
+                                                </Stack>
+                                            </Row>
+                                        </div>
+                                    ))}
+                                </Stack>
+                                <Button
+                                    className="mt-auto w-fit self-center"
+                                    href={KnownPages.GardenReferrals}
+                                    size="sm"
+                                >
+                                    {flow.ctaLabel}
+                                </Button>
+                            </Stack>
+                        ))}
+                    </div>
+                </Stack>
+
+                <StyledHtml>
+                    <h2>Kako podijeliti ili iskoristiti kod?</h2>
+                    <p>
+                        Otvori pregled preporuka u aplikaciji. Tamo možeš
+                        kopirati samo kod, kopirati punu poveznicu za dijeljenje
+                        ili promijeniti svoj kod ako tvoj račun još nema aktivnu
+                        gredicu.
+                    </p>
+                    <p>
+                        Ako želiš iskoristiti kod prijatelja, unesi ga u istom
+                        pregledu. Nakon što jedan kod iskoristiš, više ne možeš
+                        iskoristiti drugi kod na istom računu.
+                    </p>
+                    <p>
+                        Više o vrijednosti i korištenju 🌻 pročitaj na{' '}
+                        <a href={KnownPages.Sunflowers}>stranici o 🌻</a>.
+                    </p>
+                </StyledHtml>
+
+                <Row spacing={4} className="mt-4">
+                    <Typography level="body1">
+                        Jesu li pravila preporuka jasna ili nešto nedostaje?
+                    </Typography>
+                    <FeedbackModal topic="www/referrals" />
+                </Row>
             </Stack>
-        </main>
+        </Container>
     );
 }

--- a/apps/www/src/KnownPages.ts
+++ b/apps/www/src/KnownPages.ts
@@ -30,6 +30,7 @@ export const KnownPages = {
     Contact: '/kontakt',
     Pricing: '/cjenik',
     Refunds: '/povrati-i-povrat-novca',
+    Referrals: '/preporuke',
 
     LegalPrivacy: '/legalno/politika-privatnosti',
     LegalTerms: '/legalno/uvjeti-koristenja',
@@ -40,6 +41,7 @@ export const KnownPages = {
     LegalOccasions: PublicDirectoryPaths.LegalOccasions as Route,
 
     GardenApp: 'https://vrt.gredice.com',
+    GardenReferrals: 'https://vrt.gredice.com/?pregled=preporuke',
     Status: 'https://status.gredice.com',
     GoogleMapsGrediceHQ: 'https://maps.app.goo.gl/hJbidDQzhHWGCZwS6',
 } as const;

--- a/packages/game/src/knownPages.ts
+++ b/packages/game/src/knownPages.ts
@@ -13,6 +13,7 @@ export const KnownPages = {
     GrediceBlock: (alias: string) =>
         `https://www.gredice.com/blokovi/${slugify(alias)}`,
     GrediceSunflowers: 'https://www.gredice.com/suncokreti',
+    GrediceReferrals: 'https://www.gredice.com/preporuke',
     GrediceContact: 'https://www.gredice.com/kontakt',
     GrediceDeliverySlots: 'https://www.gredice.com/dostava/termini',
     AdventRules2025:

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -483,7 +483,7 @@ export function NotificationsTab() {
                 }}
                 className="flex flex-col"
             >
-                <TabsList className="grid w-full grid-cols-2 border">
+                <TabsList className="w-fit self-center border">
                     <TabsTrigger value="notifications">Obavijesti</TabsTrigger>
                     <TabsTrigger value="settings">Postavke</TabsTrigger>
                 </TabsList>

--- a/packages/game/src/modals/components/ReferralsTab.tsx
+++ b/packages/game/src/modals/components/ReferralsTab.tsx
@@ -1,73 +1,329 @@
 import { clientAuthenticated } from '@gredice/client';
+import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
+import { Card, CardActions, CardContent } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
+import { Check, Copy, Edit, ExternalLink, Info } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { useReferrals } from '../../hooks/useReferrals';
+import { KnownPages } from '../../knownPages';
+
+async function errorMessageFromResponse(response: Response) {
+    const payload: unknown = await response.json().catch(() => null);
+    if (payload && typeof payload === 'object' && 'error' in payload) {
+        const error = payload.error;
+        if (typeof error === 'string') {
+            return error;
+        }
+    }
+    return 'Kod nije spremljen';
+}
+
+type CopyState = 'idle' | 'copied';
 
 export function ReferralsTab() {
     const { data, refetch } = useReferrals();
-    const [myCode, setMyCode] = useState('');
     const [useCode, setUseCode] = useState('');
+    const [changeCodeOpen, setChangeCodeOpen] = useState(false);
+    const [newCode, setNewCode] = useState('');
+    const [codeCopyState, setCodeCopyState] = useState<CopyState>('idle');
+    const [linkCopyState, setLinkCopyState] = useState<CopyState>('idle');
+    const [changeCodeError, setChangeCodeError] = useState<string | null>(null);
+    const [isChangingCode, setIsChangingCode] = useState(false);
+    const [isUsingCode, setIsUsingCode] = useState(false);
+    const referralCode = data?.myCode ?? '';
+    const referralLink = data?.referralLink ?? '';
+    const referredAccounts = data?.referredAccounts ?? [];
+    const trimmedUseCode = useCode.trim();
+
+    async function copyTextToClipboard(
+        value: string,
+        setCopyState: (state: CopyState) => void,
+    ) {
+        if (
+            !value ||
+            typeof navigator === 'undefined' ||
+            !navigator.clipboard
+        ) {
+            return;
+        }
+        try {
+            await navigator.clipboard.writeText(value);
+            setCopyState('copied');
+            window.setTimeout(() => setCopyState('idle'), 1800);
+        } catch {
+            setCopyState('idle');
+        }
+    }
+
+    function openChangeCodeModal() {
+        setNewCode(referralCode);
+        setChangeCodeError(null);
+        setChangeCodeOpen(true);
+    }
+
+    async function changeReferralCode() {
+        setIsChangingCode(true);
+        setChangeCodeError(null);
+        try {
+            const response =
+                await clientAuthenticated().api.accounts.current.referrals.code.$post(
+                    { json: { code: newCode } },
+                );
+            if (!response.ok) {
+                setChangeCodeError(await errorMessageFromResponse(response));
+                return;
+            }
+            await refetch();
+            setChangeCodeOpen(false);
+        } finally {
+            setIsChangingCode(false);
+        }
+    }
+
+    async function redeemReferralCode() {
+        if (!trimmedUseCode) {
+            return;
+        }
+
+        setIsUsingCode(true);
+        try {
+            await clientAuthenticated().api.accounts.current.referrals.use.$post(
+                {
+                    json: { code: trimmedUseCode },
+                },
+            );
+            await refetch();
+        } finally {
+            setIsUsingCode(false);
+        }
+    }
 
     return (
-        <Stack spacing={4}>
-            <div className="text-sm">
-                💮 Nagrada preporuke: {data?.rewardAmount ?? 10000} suncokreta
-            </div>
-            <div>
-                <div className="text-xs">Kod za preporuku računa</div>
-                <div className="font-bold">{data?.myCode}</div>
-                <div className="text-xs">
-                    Poveznica za preporuku:{' '}
-                    {typeof window !== 'undefined'
-                        ? `${window.location.origin}?ref=${data?.myCode ?? ''}`
-                        : ''}
-                </div>
-                <Input
-                    value={myCode}
-                    onChange={(e) => setMyCode(e.target.value)}
-                    placeholder="Promijeni moj kod"
-                />
-                <Button
-                    onClick={async () => {
-                        await clientAuthenticated().api.accounts.current.referrals.code.$post(
-                            { json: { code: myCode } },
-                        );
-                        await refetch();
-                    }}
+        <Stack spacing={8}>
+            <Typography level="h4" className="hidden md:block">
+                💮 Preporuke
+            </Typography>
+            <Stack spacing={2}>
+                <Alert
+                    color="info"
+                    startDecorator={<Info className="size-4" />}
                 >
-                    Spremi kod
-                </Button>
-            </div>
-            <div>
-                <div className="text-xs">Iskoristi kod za preporuku</div>
-                <Input
-                    value={useCode}
-                    onChange={(e) => setUseCode(e.target.value)}
-                    placeholder="Unesi kod"
-                />
-                <Button
-                    onClick={async () => {
-                        await clientAuthenticated().api.accounts.current.referrals.use.$post(
-                            { json: { code: useCode } },
-                        );
-                        await refetch();
-                    }}
+                    <Typography level="body2">
+                        Podijeli svoj kod i zaradi{' '}
+                        <strong>{data?.rewardAmount ?? 10000} 🌻</strong> kada
+                        novi račun ispuni uvjet aktivne gredice. Kod se može
+                        iskoristiti jednom po računu, a isti kod može
+                        iskoristiti više različitih računa.{' '}
+                        <Button
+                            className="inline-flex text-blue-950 dark:text-blue-100"
+                            endDecorator={
+                                <ExternalLink
+                                    aria-hidden
+                                    className="size-3.5"
+                                />
+                            }
+                            href={KnownPages.GrediceReferrals}
+                            rel="noreferrer"
+                            size="sm"
+                            target="_blank"
+                            variant="link"
+                        >
+                            Saznaj više
+                        </Button>
+                    </Typography>
+                </Alert>
+                <Card>
+                    <CardContent noHeader className="space-y-3">
+                        <div className="text-sm font-semibold">
+                            Podijeli svoj kod
+                        </div>
+                        <div>
+                            <div className="flex max-w-md items-end gap-2">
+                                <Input
+                                    className="font-medium"
+                                    endDecorator={
+                                        <IconButton
+                                            className="mr-1"
+                                            disabled={!referralCode}
+                                            onClick={() =>
+                                                copyTextToClipboard(
+                                                    referralCode,
+                                                    setCodeCopyState,
+                                                )
+                                            }
+                                            size="sm"
+                                            title="Kopiraj kod"
+                                            type="button"
+                                            variant="plain"
+                                        >
+                                            {codeCopyState === 'copied' ? (
+                                                <Check
+                                                    aria-hidden
+                                                    className="size-4"
+                                                />
+                                            ) : (
+                                                <Copy
+                                                    aria-hidden
+                                                    className="size-4"
+                                                />
+                                            )}
+                                        </IconButton>
+                                    }
+                                    fullWidth
+                                    label="Kod za preporuku računa"
+                                    readOnly
+                                    value={referralCode}
+                                />
+                                <IconButton
+                                    disabled={!referralCode}
+                                    onClick={openChangeCodeModal}
+                                    title="Promijeni kod"
+                                    type="button"
+                                    variant="plain"
+                                >
+                                    <Edit aria-hidden className="size-4" />
+                                </IconButton>
+                            </div>
+                        </div>
+                        <Input
+                            aria-label="Poveznica za preporuku"
+                            className="font-medium"
+                            endDecorator={
+                                <IconButton
+                                    className="mr-1"
+                                    disabled={!referralLink}
+                                    onClick={() =>
+                                        copyTextToClipboard(
+                                            referralLink,
+                                            setLinkCopyState,
+                                        )
+                                    }
+                                    size="sm"
+                                    title="Kopiraj poveznicu"
+                                    type="button"
+                                    variant="plain"
+                                >
+                                    {linkCopyState === 'copied' ? (
+                                        <Check aria-hidden className="size-4" />
+                                    ) : (
+                                        <Copy aria-hidden className="size-4" />
+                                    )}
+                                </IconButton>
+                            }
+                            fullWidth
+                            label="Poveznica za preporuku"
+                            readOnly
+                            value={referralLink}
+                        />
+                    </CardContent>
+                </Card>
+                <Modal
+                    onOpenChange={setChangeCodeOpen}
+                    open={changeCodeOpen}
+                    title="Promijeni kod preporuke"
                 >
-                    Primijeni kod
-                </Button>
-            </div>
-            <div>
-                <div className="text-xs">Preporučeni računi</div>
-                <ul>
-                    {data?.referredAccounts?.map((u) => (
-                        <li key={u.accountId}>
-                            {u.accountId} {u.rewarded ? '✅' : '⏳'}
-                        </li>
-                    ))}
-                </ul>
-            </div>
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            void changeReferralCode();
+                        }}
+                    >
+                        <Stack spacing={3}>
+                            <div className="text-base font-semibold">
+                                Promijeni kod preporuke
+                            </div>
+                            <Input
+                                autoFocus
+                                fullWidth
+                                label="Novi kod"
+                                onChange={(event) =>
+                                    setNewCode(event.target.value)
+                                }
+                                value={newCode}
+                            />
+                            {changeCodeError ? (
+                                <div className="text-sm text-destructive">
+                                    {changeCodeError}
+                                </div>
+                            ) : null}
+                            <div className="flex justify-end gap-2">
+                                <Button
+                                    onClick={() => setChangeCodeOpen(false)}
+                                    type="button"
+                                    variant="outlined"
+                                >
+                                    Odustani
+                                </Button>
+                                <Button loading={isChangingCode} type="submit">
+                                    Spremi kod
+                                </Button>
+                            </div>
+                        </Stack>
+                    </form>
+                </Modal>
+                <Card>
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            void redeemReferralCode();
+                        }}
+                    >
+                        <CardContent noHeader>
+                            <Stack spacing={6}>
+                                <Stack spacing={2}>
+                                    <div className="text-sm font-semibold">
+                                        Iskoristi kod preporuke
+                                    </div>
+                                    <Input
+                                        fullWidth
+                                        label="Kod za preporuku"
+                                        value={useCode}
+                                        onChange={(e) =>
+                                            setUseCode(e.target.value)
+                                        }
+                                        placeholder="Unesi kod"
+                                        disabled={isUsingCode}
+                                    />
+                                </Stack>
+                                <CardActions className="justify-end">
+                                    <Button
+                                        disabled={
+                                            !trimmedUseCode || isUsingCode
+                                        }
+                                        loading={isUsingCode}
+                                        size="sm"
+                                        type="submit"
+                                        variant="solid"
+                                    >
+                                        Primijeni kod
+                                    </Button>
+                                </CardActions>
+                            </Stack>
+                        </CardContent>
+                    </form>
+                </Card>
+                {referredAccounts.length > 0 ? (
+                    <Card>
+                        <CardContent noHeader className="space-y-3">
+                            <div className="text-sm font-semibold">
+                                Preporučeni računi
+                            </div>
+                            <ul className="space-y-1 text-sm">
+                                {referredAccounts.map((u) => (
+                                    <li key={u.accountId}>
+                                        {u.accountId} {u.rewarded ? '✅' : '⏳'}
+                                    </li>
+                                ))}
+                            </ul>
+                        </CardContent>
+                    </Card>
+                ) : null}
+            </Stack>
         </Stack>
     );
 }


### PR DESCRIPTION
## Summary
- Allow referral redemption even when an account already has an active raised bed, while keeping the one-code-per-account restriction.
- Keep referral codes globally unique across accounts and switch referral sharing links to the garden app URL.
- Refresh the public `/preporuke` page with clearer referral guidance, centered CTA buttons, and updated header imagery.
- Clean up the garden referrals/notifications UI so empty lists stay hidden and tab lists size to their content.

## Testing
- `pnpm lint --filter www`
- `pnpm build --filter www`
- `pnpm lint --filter @gredice/game`
- `pnpm test --filter @gredice/game`
- `pnpm build --filter garden --force`
- Focused Playwright checks for `/preporuke` and garden notifications passed
- `git diff --check`