### PR TITLE
Popravi globalnu pretragu i prikaz kalendara biljaka

### DIFF
--- a/apps/api/app/api/mcp/directories/route.ts
+++ b/apps/api/app/api/mcp/directories/route.ts
@@ -1,4 +1,7 @@
-import { getEntitiesFormatted } from '@gredice/storage';
+import {
+    getEntitiesFormatted,
+    normalizeDirectorySearchText,
+} from '@gredice/storage';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -329,6 +332,7 @@ type EntityStandardized = {
     information?: {
         name?: string;
         label?: string;
+        alternativeName?: string[];
         shortDescription?: string;
         description?: string;
         plant?: EntityStandardized;
@@ -447,15 +451,16 @@ async function handleGetPlant(input: z.infer<typeof GetPlantSchema>) {
 
     const allPlants = await getDirectoryEntities<EntityStandardized>('plant');
 
-    // Search for plant by name (case-insensitive, partial match)
-    const searchName = input.plantName.toLowerCase();
+    const searchName = normalizeDirectorySearchText(input.plantName);
     plant =
-        allPlants.find(
-            (p) =>
-                p.information?.name?.toLowerCase().includes(searchName) ||
-                p.information?.label?.toLowerCase().includes(searchName) ||
-                p.information?.name?.toLowerCase() === searchName ||
-                p.information?.label?.toLowerCase() === searchName,
+        allPlants.find((p) =>
+            [
+                p.information?.name,
+                p.information?.label,
+                ...(p.information?.alternativeName ?? []),
+            ].some((value) =>
+                normalizeDirectorySearchText(value).includes(searchName),
+            ),
         ) || null;
 
     if (!plant) {

--- a/apps/api/app/api/mcp/directories/tools/call/execute.ts
+++ b/apps/api/app/api/mcp/directories/tools/call/execute.ts
@@ -1,4 +1,7 @@
-import { getEntitiesFormatted } from '@gredice/storage';
+import {
+    getEntitiesFormatted,
+    normalizeDirectorySearchText,
+} from '@gredice/storage';
 import { z } from 'zod';
 import { handleSearchEntities } from '../../searchEntities';
 
@@ -7,6 +10,7 @@ type EntityStandardized = {
     information?: {
         name?: string;
         label?: string;
+        alternativeName?: string[];
         shortDescription?: string;
         description?: string;
         plant?: EntityStandardized;
@@ -71,6 +75,14 @@ function entityName(entity: EntityStandardized): string {
         entity.information?.label ||
         `Entity ${entity.id}`
     );
+}
+
+function entityMatchesPlantSearch(entity: EntityStandardized, term: string) {
+    return [
+        entity.information?.name,
+        entity.information?.label,
+        ...(entity.information?.alternativeName ?? []),
+    ].some((value) => normalizeDirectorySearchText(value).includes(term));
 }
 
 function extractPlantName(entity: EntityStandardized): string {
@@ -203,9 +215,9 @@ async function handleGetPlant(
         signal,
     );
     signal?.throwIfAborted();
-    const term = input.plantName.toLowerCase();
+    const term = normalizeDirectorySearchText(input.plantName);
     const plant = allPlants.find((item) =>
-        entityName(item).toLowerCase().includes(term),
+        entityMatchesPlantSearch(item, term),
     );
 
     if (!plant) {

--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -43,6 +43,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * /search
+         * @description Search published directory entities.
+         */
+        get: {
+            parameters: {
+                query: {
+                    q: string;
+                    category?: string | string[];
+                    entityType?: string | string[];
+                    limit?: number;
+                    offset?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["directory-search-response"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/pages/{slug}": {
         parameters: {
             query?: never;
@@ -666,6 +711,31 @@ export interface components {
         "page-detail": components["schemas"]["page-summary"] & {
             content: components["schemas"]["section-data"][];
         };
+        "directory-search-result": {
+            entityId: number;
+            entityType: string;
+            category: string;
+            categoryLabel: string;
+            title: string;
+            summary?: string | null;
+            imageUrl?: string | null;
+            imageAlt?: string | null;
+            visualKey?: string | null;
+            /** Format: uri */
+            href: string;
+            rank: number;
+            /** Format: date-time */
+            publishedAt: string | null;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        "directory-search-response": {
+            query: string;
+            limit: number;
+            offset: number;
+            count: number;
+            results: components["schemas"]["directory-search-result"][];
+        };
         "entity-plant": {
             id: number;
             entityType: {
@@ -677,30 +747,10 @@ export interface components {
                 label: string;
             };
             slug: string;
-            calendar: {
-                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                sowing?: {
-                    start: number;
-                    end: number;
-                }[];
-                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                planting?: {
-                    start: number;
-                    end: number;
-                }[];
-                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                harvest: {
-                    start: number;
-                    end: number;
-                }[];
-                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                propagating?: {
-                    start: number;
-                    end: number;
-                }[];
-            };
             information: {
                 name: string;
+                /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                alternativeName?: string[];
                 latinName: string;
                 origin: string;
                 verified?: boolean;
@@ -839,40 +889,62 @@ export interface components {
                     };
                 }[];
             };
+            calendar: {
+                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                propagating?: {
+                    start: number;
+                    end: number;
+                }[];
+                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                planting?: {
+                    start: number;
+                    end: number;
+                }[];
+                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                sowing?: {
+                    start: number;
+                    end: number;
+                }[];
+                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                harvest: {
+                    start: number;
+                    end: number;
+                }[];
+            };
             attributes: {
-                /** @description (u gramima) */
-                yieldMin: number;
+                /** @description (u danima) */
+                harvestWindowMin: number;
                 /** @description (u gramima) */
                 yieldMax: number;
                 /** @description (u danima) */
-                harvestWindowMin: number;
-                /** @description (u danima) */
-                harvestWindowMax: number;
-                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                soil: string;
-                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                light: number;
-                /** @description (u centimetrima) */
-                seedingDepth: number;
-                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                nutrients: string;
-                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                water: string;
+                germinationWindowMax: number;
                 /** @description (u centimetrima) */
                 seedingDistance: number;
-                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                germinationType: string;
+                /** @description (u centimetrima) */
+                seedingDepth: number;
                 /** @description (u stupnjevima °C) */
                 gernimationTemperature: number;
+                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                germinationType: string;
+                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                soil: string;
                 germinationWindowMin: number;
-                /** @description (u danima) */
-                germinationWindowMax: number;
                 /** @description (u danima) */
                 growthWindowMin: number;
                 /** @description (u danima) */
                 growthWindowMax: number;
+                /** @description (u gramima) */
+                yieldMin: number;
+                /** @description (u danima) */
+                harvestWindowMax: number;
                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                 yieldType: string;
+                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                light: number;
+                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                nutrients: string;
+                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                water: string;
                 /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                 cleanHarvest: boolean;
             };
@@ -905,30 +977,10 @@ export interface components {
             information: {
                 plant: {
                     id: number;
-                    calendar: {
-                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        sowing?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        planting?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        harvest: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        propagating?: {
-                            start: number;
-                            end: number;
-                        }[];
-                    };
                     information: {
                         name: string;
+                        /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                        alternativeName?: string[];
                         latinName: string;
                         origin: string;
                         verified?: boolean;
@@ -1067,40 +1119,62 @@ export interface components {
                             };
                         }[];
                     };
+                    calendar: {
+                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        propagating?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        planting?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        sowing?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        harvest: {
+                            start: number;
+                            end: number;
+                        }[];
+                    };
                     attributes: {
-                        /** @description (u gramima) */
-                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMin: number;
                         /** @description (u gramima) */
                         yieldMax: number;
                         /** @description (u danima) */
-                        harvestWindowMin: number;
-                        /** @description (u danima) */
-                        harvestWindowMax: number;
-                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                        soil: string;
-                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                        light: number;
-                        /** @description (u centimetrima) */
-                        seedingDepth: number;
-                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                        nutrients: string;
-                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                        water: string;
+                        germinationWindowMax: number;
                         /** @description (u centimetrima) */
                         seedingDistance: number;
-                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                        germinationType: string;
+                        /** @description (u centimetrima) */
+                        seedingDepth: number;
                         /** @description (u stupnjevima °C) */
                         gernimationTemperature: number;
+                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                        germinationType: string;
+                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                        soil: string;
                         germinationWindowMin: number;
-                        /** @description (u danima) */
-                        germinationWindowMax: number;
                         /** @description (u danima) */
                         growthWindowMin: number;
                         /** @description (u danima) */
                         growthWindowMax: number;
+                        /** @description (u gramima) */
+                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMax: number;
                         /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                         yieldType: string;
+                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                        light: number;
+                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                        nutrients: string;
+                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                        water: string;
                         /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                         cleanHarvest: boolean;
                     };
@@ -1193,30 +1267,10 @@ export interface components {
                 name: string;
                 plant: {
                     id: number;
-                    calendar: {
-                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        sowing?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        planting?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        harvest: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        propagating?: {
-                            start: number;
-                            end: number;
-                        }[];
-                    };
                     information: {
                         name: string;
+                        /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                        alternativeName?: string[];
                         latinName: string;
                         origin: string;
                         verified?: boolean;
@@ -1355,40 +1409,62 @@ export interface components {
                             };
                         }[];
                     };
+                    calendar: {
+                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        propagating?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        planting?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        sowing?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        harvest: {
+                            start: number;
+                            end: number;
+                        }[];
+                    };
                     attributes: {
-                        /** @description (u gramima) */
-                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMin: number;
                         /** @description (u gramima) */
                         yieldMax: number;
                         /** @description (u danima) */
-                        harvestWindowMin: number;
-                        /** @description (u danima) */
-                        harvestWindowMax: number;
-                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                        soil: string;
-                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                        light: number;
-                        /** @description (u centimetrima) */
-                        seedingDepth: number;
-                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                        nutrients: string;
-                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                        water: string;
+                        germinationWindowMax: number;
                         /** @description (u centimetrima) */
                         seedingDistance: number;
-                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                        germinationType: string;
+                        /** @description (u centimetrima) */
+                        seedingDepth: number;
                         /** @description (u stupnjevima °C) */
                         gernimationTemperature: number;
+                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                        germinationType: string;
+                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                        soil: string;
                         germinationWindowMin: number;
-                        /** @description (u danima) */
-                        germinationWindowMax: number;
                         /** @description (u danima) */
                         growthWindowMin: number;
                         /** @description (u danima) */
                         growthWindowMax: number;
+                        /** @description (u gramima) */
+                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMax: number;
                         /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                         yieldType: string;
+                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                        light: number;
+                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                        nutrients: string;
+                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                        water: string;
                         /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                         cleanHarvest: boolean;
                     };
@@ -1408,30 +1484,10 @@ export interface components {
                     information: {
                         plant: {
                             id: number;
-                            calendar: {
-                                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                sowing?: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                planting?: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                harvest: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                propagating?: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                            };
                             information: {
                                 name: string;
+                                /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                                alternativeName?: string[];
                                 latinName: string;
                                 origin: string;
                                 verified?: boolean;
@@ -1570,40 +1626,62 @@ export interface components {
                                     };
                                 }[];
                             };
+                            calendar: {
+                                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                propagating?: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                planting?: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                sowing?: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                harvest: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                            };
                             attributes: {
-                                /** @description (u gramima) */
-                                yieldMin: number;
+                                /** @description (u danima) */
+                                harvestWindowMin: number;
                                 /** @description (u gramima) */
                                 yieldMax: number;
                                 /** @description (u danima) */
-                                harvestWindowMin: number;
-                                /** @description (u danima) */
-                                harvestWindowMax: number;
-                                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                                soil: string;
-                                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                                light: number;
-                                /** @description (u centimetrima) */
-                                seedingDepth: number;
-                                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                                nutrients: string;
-                                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                                water: string;
+                                germinationWindowMax: number;
                                 /** @description (u centimetrima) */
                                 seedingDistance: number;
-                                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                                germinationType: string;
+                                /** @description (u centimetrima) */
+                                seedingDepth: number;
                                 /** @description (u stupnjevima °C) */
                                 gernimationTemperature: number;
+                                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                                germinationType: string;
+                                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                                soil: string;
                                 germinationWindowMin: number;
-                                /** @description (u danima) */
-                                germinationWindowMax: number;
                                 /** @description (u danima) */
                                 growthWindowMin: number;
                                 /** @description (u danima) */
                                 growthWindowMax: number;
+                                /** @description (u gramima) */
+                                yieldMin: number;
+                                /** @description (u danima) */
+                                harvestWindowMax: number;
                                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                                 yieldType: string;
+                                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                                light: number;
+                                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                                nutrients: string;
+                                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                                water: string;
                                 /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                                 cleanHarvest: boolean;
                             };

--- a/apps/api/playwright.config.ts
+++ b/apps/api/playwright.config.ts
@@ -35,7 +35,9 @@ export const config: PlaywrightTestConfig = {
         },
     ],
     webServer: {
-        command: 'pnpm start',
+        command: 'node ../../scripts/run-app-command.mjs start',
+        env: { GREDICE_DETACH_CHILD_PROCESS: 'false' },
+        gracefulShutdown: { signal: 'SIGTERM', timeout: 5000 },
         url: getPlaywrightBaseUrl(app),
         reuseExistingServer: shouldReusePlaywrightServer(),
     },

--- a/apps/app/playwright.config.ts
+++ b/apps/app/playwright.config.ts
@@ -37,7 +37,9 @@ export const config: PlaywrightTestConfig = {
         },
     ],
     webServer: {
-        command: 'pnpm start',
+        command: 'node ../../scripts/run-app-command.mjs start',
+        env: { GREDICE_DETACH_CHILD_PROCESS: 'false' },
+        gracefulShutdown: { signal: 'SIGTERM', timeout: 5000 },
         url: getPlaywrightBaseUrl(app),
         reuseExistingServer: shouldReusePlaywrightServer(),
     },

--- a/apps/farm/playwright.config.ts
+++ b/apps/farm/playwright.config.ts
@@ -37,7 +37,9 @@ export const config: PlaywrightTestConfig = {
         },
     ],
     webServer: {
-        command: 'pnpm start',
+        command: 'node ../../scripts/run-app-command.mjs start',
+        env: { GREDICE_DETACH_CHILD_PROCESS: 'false' },
+        gracefulShutdown: { signal: 'SIGTERM', timeout: 5000 },
         url: getPlaywrightBaseUrl(app),
         reuseExistingServer: shouldReusePlaywrightServer(),
     },

--- a/apps/garden/playwright.config.ts
+++ b/apps/garden/playwright.config.ts
@@ -67,7 +67,9 @@ export const config: PlaywrightTestConfig = {
         },
     ],
     webServer: {
-        command: 'pnpm start',
+        command: 'node ../../scripts/run-app-command.mjs start',
+        env: { GREDICE_DETACH_CHILD_PROCESS: 'false' },
+        gracefulShutdown: { signal: 'SIGTERM', timeout: 5000 },
         url: getPlaywrightBaseUrl(app),
         reuseExistingServer: shouldReusePlaywrightServer(),
     },

--- a/apps/garden/tests/PlantPickerTestStory.tsx
+++ b/apps/garden/tests/PlantPickerTestStory.tsx
@@ -18,6 +18,7 @@ const tomatoPlant = {
     },
     information: {
         name: 'Rajčica',
+        alternativeName: ['Paradajz', 'Pomidor'],
         latinName: 'Solanum lycopersicum',
         origin: 'Mock',
         description: 'Mock plant for sowing picker tests.',
@@ -72,6 +73,7 @@ const basilPlant = {
     information: {
         ...tomatoPlant.information,
         name: 'Bosiljak',
+        alternativeName: ['Bazilikum'],
         latinName: 'Ocimum basilicum',
     },
     isRecommended: false,

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -18,4 +18,12 @@ test('plant search keeps keyboard focus while filtering sowing options', async (
     await expect(page.getByRole('button', { name: /Rajčica/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /Bosiljak/ })).toHaveCount(0);
     await expect(page).not.toHaveURL(/pretraga=/u);
+
+    await searchInput.fill('');
+    await searchInput.pressSequentially('paradajz');
+
+    await expect(searchInput).toBeFocused();
+    await expect(searchInput).toHaveValue('paradajz');
+    await expect(page.getByRole('button', { name: /Rajčica/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Bosiljak/ })).toHaveCount(0);
 });

--- a/apps/www/app/biljke/PlantsCalendar.tsx
+++ b/apps/www/app/biljke/PlantsCalendar.tsx
@@ -6,10 +6,12 @@ import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
-import { type CSSProperties, Fragment } from 'react';
+import { Fragment } from 'react';
 import { useClientSearchParam } from '../../hooks/useClientSearchParam';
+import { plantMatchesSearch } from '../../lib/plants/plantSearch';
 import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
 import { KnownPages } from '../../src/KnownPages';
+import { getCalendarRangePosition } from './calendarRangePosition';
 
 const calendarMonths = [
     'I',
@@ -65,13 +67,7 @@ export function PlantsCalendar({
         a.information.name.localeCompare(b.information.name),
     )
         .filter((plant) => !onlySeedTimePlants || plant.isRecommended)
-        .filter(
-            (plant) =>
-                !normalizedSearch ||
-                normalizeSearchText(plant.information.name).includes(
-                    normalizedSearch,
-                ),
-        )
+        .filter((plant) => plantMatchesSearch(plant, normalizedSearch))
         .map((plant) => ({ ...plant, id: plant.id.toString() }));
 
     const currentDate = new Date();
@@ -100,130 +96,97 @@ export function PlantsCalendar({
                     </Typography>
                 </div>
             )}
-            {Object.keys(calendarActivityTypes).map((activityTypeName) => {
-                const activityType =
-                    calendarActivityTypes[
-                        activityTypeName as keyof typeof calendarActivityTypes
-                    ];
-                return filteredPlants
-                    .filter(
-                        (p) =>
-                            p.calendar &&
-                            Object.keys(p.calendar).some(
-                                (a) => a === activityTypeName,
-                            ),
-                    )
-                    .map((plant, plantIndex) => {
-                        const activities = plant.calendar;
-                        if (!activities) return null;
+            {Object.entries(calendarActivityTypes).map(
+                ([activityTypeName, activityType]) => {
+                    return filteredPlants
+                        .filter(
+                            (p) =>
+                                p.calendar &&
+                                Object.keys(p.calendar).some(
+                                    (a) => a === activityTypeName,
+                                ),
+                        )
+                        .map((plant, plantIndex) => {
+                            const activities = plant.calendar;
+                            if (!activities) return null;
 
-                        return (
-                            <Fragment key={`${plant.id}-${activityTypeName}`}>
-                                <Link
-                                    href={KnownPages.Plant(
-                                        plant.information.name,
-                                    )}
-                                    prefetch
+                            return (
+                                <Fragment
+                                    key={`${plant.id}-${activityTypeName}`}
                                 >
-                                    <Row
-                                        justifyContent="space-between"
-                                        spacing={2}
-                                        className="mx-2"
+                                    <Link
+                                        href={KnownPages.Plant(
+                                            plant.information.name,
+                                        )}
+                                        prefetch
                                     >
-                                        <Row spacing={2}>
-                                            <PlantOrSortImage
-                                                plant={plant}
-                                                width={20}
-                                                height={20}
-                                            />
-                                            <Typography level="body2">
-                                                {plant.information.name}
-                                            </Typography>
-                                        </Row>
-                                        <Row>
-                                            {plantIndex === 0 && (
-                                                <Typography
-                                                    level="body2"
-                                                    title={activityType.name}
-                                                    className="whitespace-nowrap"
-                                                >
-                                                    {activityType.name}
-                                                </Typography>
-                                            )}
-                                            <div
-                                                className={`size-4 rounded-full inline-block ml-2 ${activityType.color}`}
-                                            ></div>
-                                        </Row>
-                                    </Row>
-                                </Link>
-                                {calendarMonths.map((monthName, index) => {
-                                    const month = index + 1;
-                                    const currentActivities =
-                                        activities[
-                                            activityTypeName as keyof typeof calendarActivityTypes
-                                        ];
-                                    if (!currentActivities) return null;
-                                    const currentMonthActivities =
-                                        currentActivities.filter(
-                                            (a) =>
-                                                month >=
-                                                    Math.floor(a.start ?? 0) &&
-                                                month <= Math.floor(a.end ?? 0),
-                                        );
-                                    const minStart = Math.min(
-                                        ...currentMonthActivities.map(
-                                            (a) => (a.start ?? 0) % 1,
-                                        ),
-                                    );
-                                    const maxEnd = Math.max(
-                                        ...currentMonthActivities.map(
-                                            (a) => (a.end ?? 0) % 1,
-                                        ),
-                                    );
-                                    const isActivityActive =
-                                        currentMonthActivities.length > 0;
-                                    const isActivityStart =
-                                        currentActivities.some(
-                                            (a) =>
-                                                month ===
-                                                Math.floor(a.start ?? 0),
-                                        );
-                                    const isActivityEnd =
-                                        currentActivities.some(
-                                            (a) =>
-                                                month ===
-                                                Math.floor(a.end ?? 0),
-                                        );
-
-                                    return (
-                                        <div
-                                            key={monthName}
-                                            className="relative border-l"
+                                        <Row
+                                            justifyContent="space-between"
+                                            spacing={2}
+                                            className="mx-2"
                                         >
-                                            {isActivityActive && (
+                                            <Row spacing={2}>
+                                                <PlantOrSortImage
+                                                    plant={plant}
+                                                    width={20}
+                                                    height={20}
+                                                />
+                                                <Typography level="body2">
+                                                    {plant.information.name}
+                                                </Typography>
+                                            </Row>
+                                            <Row>
+                                                {plantIndex === 0 && (
+                                                    <Typography
+                                                        level="body2"
+                                                        title={
+                                                            activityType.name
+                                                        }
+                                                        className="whitespace-nowrap"
+                                                    >
+                                                        {activityType.name}
+                                                    </Typography>
+                                                )}
                                                 <div
-                                                    className={`absolute inset-y-1 left-[--activity-left] -ml-[1px] right-[--activity-right] ${activityType.color} ${isActivityStart ? 'rounded-l-full' : ''} ${isActivityEnd ? 'rounded-r-full' : ''}`}
-                                                    style={
-                                                        {
-                                                            '--activity-left':
-                                                                isActivityStart
-                                                                    ? `${minStart * 100}%`
-                                                                    : '0px',
-                                                            '--activity-right':
-                                                                isActivityEnd
-                                                                    ? `${Math.min(75, (1 - maxEnd) * 100)}%`
-                                                                    : '0px',
-                                                        } as CSSProperties
-                                                    }
+                                                    className={`size-4 rounded-full inline-block ml-2 ${activityType.color}`}
                                                 ></div>
-                                            )}
-                                        </div>
-                                    );
-                                })}
-                            </Fragment>
-                        );
-                    });
-            })}
+                                            </Row>
+                                        </Row>
+                                    </Link>
+                                    {calendarMonths.map((monthName, index) => {
+                                        const month = index + 1;
+                                        const currentActivities =
+                                            activities[
+                                                activityTypeName as keyof typeof calendarActivityTypes
+                                            ];
+                                        const position =
+                                            getCalendarRangePosition(
+                                                currentActivities,
+                                                month,
+                                            );
+
+                                        return (
+                                            <div
+                                                key={monthName}
+                                                className="relative border-l"
+                                            >
+                                                {position && (
+                                                    <div
+                                                        className={`absolute inset-y-1 -ml-[1px] ${activityType.color} ${position.isStart ? 'rounded-l-full' : ''} ${position.isEnd ? 'rounded-r-full' : ''}`}
+                                                        style={{
+                                                            left: position.left,
+                                                            right: position.right,
+                                                        }}
+                                                    ></div>
+                                                )}
+                                            </div>
+                                        );
+                                    })}
+                                </Fragment>
+                            );
+                        });
+                },
+            )}
             <div className="grid grid-cols-subgrid [grid-column:2/-1] relative">
                 <div
                     className="absolute bottom-0 w-0.5 bg-red-600"

--- a/apps/www/app/biljke/PlantsGallery.tsx
+++ b/apps/www/app/biljke/PlantsGallery.tsx
@@ -6,6 +6,10 @@ import { Gallery } from '@gredice/ui/Gallery';
 import { Typography } from '@gredice/ui/Typography';
 import { useClientSearchParam } from '../../hooks/useClientSearchParam';
 import type { PlantSortData } from '../../lib/plants/getPlantSortsData';
+import {
+    matchingPlantAlternativeName,
+    plantMatchesSearch,
+} from '../../lib/plants/plantSearch';
 import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
 import { PlantsGalleryItem } from './PlantsGalleryItem';
 
@@ -45,10 +49,7 @@ export function PlantsGallery({
         .filter((plant) => !onlySeedTimePlants || plant.isRecommended)
         .filter(
             (plant) =>
-                !normalizedSearch ||
-                normalizeSearchText(plant.information.name).includes(
-                    normalizedSearch,
-                ) ||
+                plantMatchesSearch(plant, normalizedSearch) ||
                 (normalizedSortNamesByPlantId
                     .get(plant.id)
                     ?.some((sortName) => sortName.includes(normalizedSearch)) ??
@@ -67,6 +68,10 @@ export function PlantsGallery({
             return {
                 ...plant,
                 id: plant.id.toString(),
+                matchingAlternativeName: matchingPlantAlternativeName(
+                    plant,
+                    normalizedSearch,
+                ),
                 matchingSortName,
             };
         });

--- a/apps/www/app/biljke/PlantsGalleryItem.tsx
+++ b/apps/www/app/biljke/PlantsGalleryItem.tsx
@@ -16,12 +16,19 @@ export type PlantsGalleryItemProps = Pick<
 > &
     Partial<Pick<PlantData, 'prices'>> & {
         isRecommended?: boolean;
+        matchingAlternativeName?: string;
         matchingSortName?: string;
     };
 
 export function PlantsGalleryItem(props: PlantsGalleryItemProps) {
-    const { information, prices, attributes, isRecommended, matchingSortName } =
-        props;
+    const {
+        information,
+        prices,
+        attributes,
+        isRecommended,
+        matchingAlternativeName,
+        matchingSortName,
+    } = props;
     return (
         <ItemCard
             label={
@@ -45,6 +52,11 @@ export function PlantsGalleryItem(props: PlantsGalleryItemProps) {
                     {matchingSortName && (
                         <Typography level="body3" secondary>
                             Sorta: {matchingSortName}
+                        </Typography>
+                    )}
+                    {matchingAlternativeName && (
+                        <Typography level="body3" secondary>
+                            Poznato i kao: {matchingAlternativeName}
                         </Typography>
                     )}
                 </Stack>

--- a/apps/www/app/biljke/[alias]/PlantGrowthCalendar.tsx
+++ b/apps/www/app/biljke/[alias]/PlantGrowthCalendar.tsx
@@ -1,7 +1,7 @@
 import type { PlantData } from '@gredice/client';
 import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
-import { type CSSProperties, Fragment } from 'react';
+import { Fragment } from 'react';
 
 const plantCalendarMonths = [
     'I',
@@ -167,19 +167,15 @@ export function PlantGrowthCalendar({
                                     >
                                         {isActivityActive && (
                                             <div
-                                                className={`absolute inset-y-1 left-[--activity-left] -ml-[1px] right-[--activity-right] ${window.color} ${isActivityStart ? 'rounded-l-full' : ''} ${isActivityEnd ? 'rounded-r-full' : ''}`}
-                                                style={
-                                                    {
-                                                        '--activity-left':
-                                                            isActivityStart
-                                                                ? `${Math.min(75, minStart * 100)}%`
-                                                                : '0px',
-                                                        '--activity-right':
-                                                            isActivityEnd
-                                                                ? `${Math.min(75, (1 - maxEnd) * 100)}%`
-                                                                : '0px',
-                                                    } as CSSProperties
-                                                }
+                                                className={`absolute inset-y-1 -ml-[1px] ${window.color} ${isActivityStart ? 'rounded-l-full' : ''} ${isActivityEnd ? 'rounded-r-full' : ''}`}
+                                                style={{
+                                                    left: isActivityStart
+                                                        ? `${Math.min(75, minStart * 100)}%`
+                                                        : '0px',
+                                                    right: isActivityEnd
+                                                        ? `${Math.min(75, (1 - maxEnd) * 100)}%`
+                                                        : '0px',
+                                                }}
                                             ></div>
                                         )}
                                     </div>

--- a/apps/www/app/biljke/[alias]/PlantYearCalendar.tsx
+++ b/apps/www/app/biljke/[alias]/PlantYearCalendar.tsx
@@ -1,7 +1,8 @@
 import type { PlantData } from '@gredice/client';
 import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
-import { type CSSProperties, Fragment } from 'react';
+import { Fragment } from 'react';
+import { getCalendarRangePosition } from '../calendarRangePosition';
 
 const plantCalendarMonths = [
     'I',
@@ -63,96 +64,65 @@ export function PlantYearCalendar({ activities, now }: PlantYearCalendarProps) {
                         {month}
                     </Typography>
                 ))}
-                {Object.keys(calendarActivityTypes).map((activityTypeName) => {
-                    const activityType =
-                        calendarActivityTypes[
-                            activityTypeName as keyof typeof calendarActivityTypes
-                        ];
-                    if (
-                        !Object.keys(activities).some(
-                            (a) => a === activityTypeName,
+                {Object.entries(calendarActivityTypes).map(
+                    ([activityTypeName, activityType]) => {
+                        if (
+                            !Object.keys(activities).some(
+                                (a) => a === activityTypeName,
+                            )
                         )
-                    )
-                        return null;
+                            return null;
 
-                    return (
-                        <Fragment key={activityTypeName}>
-                            <Row
-                                justifyContent="space-between"
-                                spacing={2}
-                                className="mx-2 min-w-0 overflow-hidden"
-                            >
-                                <Typography
-                                    level="body2"
-                                    title={activityType.name}
-                                    className="min-w-0 truncate whitespace-nowrap"
+                        return (
+                            <Fragment key={activityTypeName}>
+                                <Row
+                                    justifyContent="space-between"
+                                    spacing={2}
+                                    className="mx-2 min-w-0 overflow-hidden"
                                 >
-                                    {activityType.name}
-                                </Typography>
-                                <div
-                                    className={`size-4 rounded-full inline-block ml-2 ${activityType.color}`}
-                                ></div>
-                            </Row>
-                            {plantCalendarMonths.map((monthName, index) => {
-                                const month = index + 1;
-                                const currentActivities =
-                                    activities[
-                                        activityTypeName as keyof typeof calendarActivityTypes
-                                    ];
-                                if (!currentActivities) return null;
-                                const currentMonthActivities =
-                                    currentActivities.filter(
-                                        (a) =>
-                                            month >= Math.floor(a.start ?? 0) &&
-                                            month <= Math.floor(a.end ?? 0),
-                                    );
-                                const minStart = Math.min(
-                                    ...currentMonthActivities.map(
-                                        (a) => (a.start ?? 0) % 1,
-                                    ),
-                                );
-                                const maxEnd = Math.max(
-                                    ...currentMonthActivities.map(
-                                        (a) => (a.end ?? 0) % 1,
-                                    ),
-                                );
-                                const isActivityActive =
-                                    currentMonthActivities.length > 0;
-                                const isActivityStart = currentActivities.some(
-                                    (a) => month === Math.floor(a.start ?? 0),
-                                );
-                                const isActivityEnd = currentActivities.some(
-                                    (a) => month === Math.floor(a.end ?? 0),
-                                );
-
-                                return (
-                                    <div
-                                        key={monthName}
-                                        className="relative border-l"
+                                    <Typography
+                                        level="body2"
+                                        title={activityType.name}
+                                        className="min-w-0 truncate whitespace-nowrap"
                                     >
-                                        {isActivityActive && (
-                                            <div
-                                                className={`absolute inset-y-1 left-[--activity-left] -ml-[1px] right-[--activity-right] ${activityType.color} ${isActivityStart ? 'rounded-l-full' : ''} ${isActivityEnd ? 'rounded-r-full' : ''}`}
-                                                style={
-                                                    {
-                                                        '--activity-left':
-                                                            isActivityStart
-                                                                ? `${minStart * 100}%`
-                                                                : '0px',
-                                                        '--activity-right':
-                                                            isActivityEnd
-                                                                ? `${Math.min(75, (1 - maxEnd) * 100)}%`
-                                                                : '0px',
-                                                    } as CSSProperties
-                                                }
-                                            ></div>
-                                        )}
-                                    </div>
-                                );
-                            })}
-                        </Fragment>
-                    );
-                })}
+                                        {activityType.name}
+                                    </Typography>
+                                    <div
+                                        className={`size-4 rounded-full inline-block ml-2 ${activityType.color}`}
+                                    ></div>
+                                </Row>
+                                {plantCalendarMonths.map((monthName, index) => {
+                                    const month = index + 1;
+                                    const currentActivities =
+                                        activities[
+                                            activityTypeName as keyof typeof calendarActivityTypes
+                                        ];
+                                    const position = getCalendarRangePosition(
+                                        currentActivities,
+                                        month,
+                                    );
+
+                                    return (
+                                        <div
+                                            key={monthName}
+                                            className="relative border-l"
+                                        >
+                                            {position && (
+                                                <div
+                                                    className={`absolute inset-y-1 -ml-[1px] ${activityType.color} ${position.isStart ? 'rounded-l-full' : ''} ${position.isEnd ? 'rounded-r-full' : ''}`}
+                                                    style={{
+                                                        left: position.left,
+                                                        right: position.right,
+                                                    }}
+                                                ></div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </Fragment>
+                        );
+                    },
+                )}
                 <div className="grid grid-cols-subgrid [grid-column:2/-1] relative">
                     <div
                         className="absolute bottom-0 w-0.5 bg-red-600"

--- a/apps/www/app/biljke/calendarRangePosition.ts
+++ b/apps/www/app/biljke/calendarRangePosition.ts
@@ -1,0 +1,95 @@
+export type CalendarRangeInput = {
+    start?: number | string | null;
+    end?: number | string | null;
+};
+
+export type CalendarRangePosition = {
+    isStart: boolean;
+    isEnd: boolean;
+    left: string;
+    right: string;
+};
+
+type MonthBoundary = {
+    month: number;
+    fraction: number;
+};
+
+type NormalizedCalendarRange = {
+    start: MonthBoundary;
+    end: MonthBoundary;
+};
+
+function parseMonthBoundary(value: number | string | null | undefined) {
+    if (typeof value !== 'number' && typeof value !== 'string') {
+        return null;
+    }
+
+    const parsed =
+        typeof value === 'number' ? value : Number.parseFloat(value.trim());
+
+    if (!Number.isFinite(parsed)) {
+        return null;
+    }
+
+    const flooredMonth = Math.floor(parsed);
+
+    return {
+        month: Math.min(12, Math.max(1, flooredMonth)),
+        fraction: Math.min(0.99, Math.max(0, parsed - flooredMonth)),
+    };
+}
+
+function normalizeRange(
+    range: CalendarRangeInput,
+): NormalizedCalendarRange | null {
+    const start = parseMonthBoundary(range.start);
+    const end = parseMonthBoundary(range.end ?? range.start);
+
+    if (!start || !end) {
+        return null;
+    }
+
+    return { start, end };
+}
+
+function isMonthInRange(range: NormalizedCalendarRange, month: number) {
+    if (range.start.month <= range.end.month) {
+        return month >= range.start.month && month <= range.end.month;
+    }
+
+    return month >= range.start.month || month <= range.end.month;
+}
+
+export function getCalendarRangePosition(
+    ranges: readonly CalendarRangeInput[] | undefined,
+    month: number,
+): CalendarRangePosition | null {
+    const activeRanges =
+        ranges
+            ?.map(normalizeRange)
+            .filter(
+                (range): range is NormalizedCalendarRange =>
+                    range !== null && isMonthInRange(range, month),
+            ) ?? [];
+
+    if (!activeRanges.length) {
+        return null;
+    }
+
+    const isStart = activeRanges.some((range) => range.start.month === month);
+    const isEnd = activeRanges.some((range) => range.end.month === month);
+    const minStartFraction = Math.min(
+        ...activeRanges.map((range) => range.start.fraction),
+    );
+    const maxEndFraction = Math.max(
+        ...activeRanges.map((range) => range.end.fraction),
+    );
+
+    return {
+        isStart,
+        isEnd,
+        left: isStart ? `${minStartFraction * 100}%` : '0px',
+        right: isEnd ? `${Math.min(75, (1 - maxEndFraction) * 100)}%` : '0px',
+    };
+}

--- a/apps/www/app/blokovi/PlantBlockGallery.tsx
+++ b/apps/www/app/blokovi/PlantBlockGallery.tsx
@@ -7,6 +7,7 @@ import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import { ItemCard } from '../../components/shared/ItemCard';
 import { useClientSearchParam } from '../../hooks/useClientSearchParam';
+import { plantMatchesSearch } from '../../lib/plants/plantSearch';
 import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
 import { KnownPages } from '../../src/KnownPages';
 import { PlantBlockImage } from './PlantBlockImage';
@@ -44,13 +45,7 @@ export function PlantBlockGallery({
         .filter((plant) =>
             plantNamesWithLSystem.has(plant.information.name.toLowerCase()),
         )
-        .filter(
-            (plant) =>
-                !normalizedSearch ||
-                normalizeSearchText(plant.information.name).includes(
-                    normalizedSearch,
-                ),
-        )
+        .filter((plant) => plantMatchesSearch(plant, normalizedSearch))
         .map((plant) => ({ ...plant, id: plant.id.toString() }));
 
     if (filteredPlants.length === 0) {

--- a/apps/www/app/preporuke/page.tsx
+++ b/apps/www/app/preporuke/page.tsx
@@ -22,11 +22,11 @@ const formattedReferralReward = new Intl.NumberFormat('hr-HR').format(
 const formattedCombinedReferralReward = new Intl.NumberFormat('hr-HR').format(
     combinedReferralReward,
 );
+const referralMetadataDescription = `Program preporuka za Gredice: podijeli ili iskoristi kod i saznaj kako jedna preporuka donosi ukupno ${formattedCombinedReferralReward} 🌻 nagrade.`;
 
 export const metadata: Metadata = {
     title: 'Preporuke',
-    description:
-        'Program preporuka za Gredice: podijeli kod, iskoristi kod i saznaj pravila za 10.000 🌻 nagradu.',
+    description: referralMetadataDescription,
     keywords: [
         'Gredice',
         'program preporuka',
@@ -34,6 +34,11 @@ export const metadata: Metadata = {
         'nagrade',
         'vrt aplikacija',
     ],
+    openGraph: {
+        title: 'Preporuke',
+        description: referralMetadataDescription,
+        url: KnownPages.Referrals,
+    },
 };
 
 const referralFlows = [
@@ -81,7 +86,7 @@ export default function ReferralsLandingPage() {
             <Stack spacing={10}>
                 <PageHeader
                     header="Preporuke"
-                    subHeader={`Podijeli svoj kod, pozovi nekoga u Gredice i zaradi ${formattedReferralReward} 🌻 kada pozvani račun ispuni uvjet aktivne gredice.`}
+                    subHeader={`Podijeli svoj kod, pozovi nekoga u Gredice i zajedno ostvarite ukupno ${formattedCombinedReferralReward} 🌻 kada pozvani račun ispuni uvjet aktivne gredice.`}
                     padded
                     visual={
                         <Image

--- a/apps/www/app/pretraga/SearchInteractive.tsx
+++ b/apps/www/app/pretraga/SearchInteractive.tsx
@@ -1,14 +1,13 @@
 'use client';
 
+import { Markdown } from '@gredice/ui/Markdown';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { usePostHog } from '@posthog/next';
 import type { Route } from 'next';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { DirectorySearchResultVisual } from '../../components/search/DirectorySearchResultVisual';
-import { SearchCategoryFilters } from '../../components/search/SearchCategoryFilters';
 import {
     type SearchCategoryValue,
     searchPageHref,
@@ -54,10 +53,6 @@ export function SearchInteractive({
     hasNextPage: boolean;
 }) {
     const posthog = usePostHog();
-    const router = useRouter();
-    const pathname = usePathname();
-    const params = useSearchParams();
-    const previousCategory = useRef(selectedCategory);
     const emitted = useRef<string | null>(null);
 
     useEffect(() => {
@@ -81,25 +76,6 @@ export function SearchInteractive({
         }
     }, [page, posthog, query, results.length, selectedCategory]);
 
-    const navigateCategory = (nextCategory: SearchCategoryValue) => {
-        if (previousCategory.current !== nextCategory) {
-            posthog?.capture('public_search_category_filter_changed', {
-                category: nextCategory,
-                previousCategory: previousCategory.current,
-                queryLength: query.trim().length,
-            });
-        }
-        previousCategory.current = nextCategory;
-        const nextParams = new URLSearchParams(params.toString());
-        if (nextCategory === 'all') nextParams.delete('kategorija');
-        else nextParams.set('kategorija', nextCategory);
-        nextParams.delete('stranica');
-        const nextHref = (
-            nextParams.toString() ? `${pathname}?${nextParams}` : pathname
-        ) as Route;
-        router.replace(nextHref);
-    };
-
     const previousHref =
         page > 1
             ? searchPageHref({
@@ -118,52 +94,56 @@ export function SearchInteractive({
 
     return (
         <>
-            <SearchCategoryFilters
-                activeCategory={selectedCategory}
-                onSelect={navigateCategory}
-                className="px-0 py-0"
-                withBorder={false}
-            />
-            <Stack spacing={4}>
-                {results.map((result, index) => (
-                    <a
-                        key={`${result.entityType}-${result.entityId}`}
-                        href={localHref(result.href)}
-                        className="flex gap-3 rounded-lg border border-border/70 bg-card p-3 outline-hidden transition-colors hover:bg-muted/60 focus-visible:bg-muted/60"
-                        onClick={() =>
-                            posthog?.capture('public_search_result_clicked', {
-                                category: selectedCategory,
-                                href: result.href,
-                                page,
-                                rank: (page - 1) * searchPageLimit + index + 1,
-                                queryLength: query.trim().length,
-                            })
-                        }
-                    >
-                        <DirectorySearchResultVisual
-                            result={result}
-                            imageSize={56}
-                            className="size-14 rounded-lg"
-                            iconClassName="size-6"
-                        />
-                        <span className="min-w-0 flex-1">
-                            <span className="flex items-center gap-2">
-                                <span className="truncate text-base font-medium">
-                                    {result.title}
-                                </span>
-                                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                                    {result.categoryLabel}
-                                </span>
-                            </span>
-                            {result.summary ? (
-                                <span className="mt-1 line-clamp-2 block text-sm text-muted-foreground">
-                                    {result.summary}
-                                </span>
-                            ) : null}
-                        </span>
-                    </a>
-                ))}
-            </Stack>
+            {results.length > 0 ? (
+                <Stack spacing={2}>
+                    {results.map((result, index) => (
+                        <a
+                            key={`${result.entityType}-${result.entityId}`}
+                            href={localHref(result.href)}
+                            className="group flex gap-3 rounded-lg border border-border/70 bg-card p-3 outline-hidden transition-colors hover:bg-muted/60 focus-visible:bg-muted/60"
+                            onClick={() =>
+                                posthog?.capture(
+                                    'public_search_result_clicked',
+                                    {
+                                        category: selectedCategory,
+                                        href: result.href,
+                                        page,
+                                        rank:
+                                            (page - 1) * searchPageLimit +
+                                            index +
+                                            1,
+                                        queryLength: query.trim().length,
+                                    },
+                                )
+                            }
+                        >
+                            <DirectorySearchResultVisual
+                                result={result}
+                                imageSize={56}
+                                className="size-14 rounded-lg"
+                                iconClassName="size-6"
+                            />
+                            <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                    <span className="truncate text-base font-medium">
+                                        {result.title}
+                                    </span>
+                                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                                        {result.categoryLabel}
+                                    </span>
+                                </div>
+                                {result.summary ? (
+                                    <div className="relative mt-1 max-h-28 overflow-hidden after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-8 after:bg-gradient-to-b after:from-transparent after:to-card group-hover:after:to-muted group-focus-visible:after:to-muted">
+                                        <Markdown className="text-sm text-muted-foreground prose-headings:my-1 prose-headings:text-sm prose-headings:font-medium prose-headings:text-muted-foreground prose-li:my-0 prose-ol:my-1 prose-p:my-1 prose-strong:text-muted-foreground prose-ul:my-1">
+                                            {result.summary}
+                                        </Markdown>
+                                    </div>
+                                ) : null}
+                            </div>
+                        </a>
+                    ))}
+                </Stack>
+            ) : null}
             {previousHref || nextHref ? (
                 <nav
                     className="flex items-center justify-between gap-3"

--- a/apps/www/app/pretraga/SearchPageControls.tsx
+++ b/apps/www/app/pretraga/SearchPageControls.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { usePostHog } from '@posthog/next';
+import type { Route } from 'next';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRef } from 'react';
+import { SearchCategoryFilters } from '../../components/search/SearchCategoryFilters';
+import type { SearchCategoryValue } from '../../components/search/searchCategories';
+import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
+
+export function SearchPageControls({
+    query,
+    selectedCategory,
+}: {
+    query: string;
+    selectedCategory: SearchCategoryValue;
+}) {
+    const posthog = usePostHog();
+    const router = useRouter();
+    const pathname = usePathname();
+    const params = useSearchParams();
+    const previousCategory = useRef(selectedCategory);
+
+    const navigateCategory = (nextCategory: SearchCategoryValue) => {
+        if (previousCategory.current !== nextCategory) {
+            posthog?.capture('public_search_category_filter_changed', {
+                category: nextCategory,
+                previousCategory: previousCategory.current,
+                queryLength: query.trim().length,
+            });
+        }
+        previousCategory.current = nextCategory;
+
+        const nextParams = new URLSearchParams(params.toString());
+        if (nextCategory === 'all') {
+            nextParams.delete('kategorija');
+        } else {
+            nextParams.set('kategorija', nextCategory);
+        }
+        nextParams.delete('stranica');
+
+        const nextHref = (
+            nextParams.toString() ? `${pathname}?${nextParams}` : pathname
+        ) as Route;
+        router.replace(nextHref);
+    };
+
+    return (
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center">
+            <PageFilterInputNoSSR
+                searchParamName="pretraga"
+                fieldName="global-search"
+                initialValue={query}
+                className="w-full min-w-0 xl:w-[42rem] xl:flex-none"
+                navigateOnChange
+                placeholder="Pretraga..."
+                resetSearchParamNamesOnChange={['stranica']}
+            />
+            <SearchCategoryFilters
+                activeCategory={selectedCategory}
+                onSelect={navigateCategory}
+                className="min-w-0 px-0 py-0 xl:shrink-0"
+                withBorder={false}
+            />
+        </div>
+    );
+}

--- a/apps/www/app/pretraga/page.tsx
+++ b/apps/www/app/pretraga/page.tsx
@@ -1,6 +1,7 @@
 import { type components, directoriesClient } from '@gredice/client';
 import { Card } from '@gredice/ui/Card';
 import { Search, Warning } from '@gredice/ui/icons';
+import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -9,14 +10,17 @@ import {
     searchCategoryParam,
     searchPageLimit,
 } from '../../components/search/searchCategories';
-import { PageFilterInputNoSSR } from '../../components/shared/PageFilterInputNoSSR';
 import { SearchInteractive } from './SearchInteractive';
+import { SearchPageControls } from './SearchPageControls';
 
 export const revalidate = 300;
 
+const pageDescription =
+    'Pronađi biljke, sorte, radnje, blokove i sjeme na Gredice webu.';
+
 export const metadata = {
     title: 'Pretraga',
-    description: 'Pretraži javni sadržaj na Gredice webu.',
+    description: pageDescription,
     robots: {
         index: false,
         follow: true,
@@ -89,49 +93,49 @@ export default async function SearchPage({
     const hasNextPage = results.length === searchPageLimit;
 
     return (
-        <Stack spacing={8} className="py-4">
-            <Typography level="h1">Pretraga</Typography>
-            <PageFilterInputNoSSR
-                searchParamName="pretraga"
-                fieldName="global-search"
-                initialValue={query}
-                className="w-full"
-                navigateOnChange
-                placeholder="Pretraga..."
-                resetSearchParamNamesOnChange={['stranica']}
-            />
+        <Stack spacing={5} className="py-4">
+            <PageHeader header="Pretraga" subHeader={pageDescription} padded />
 
-            {error ? (
-                <Card className="p-4">
-                    <Row spacing={4} alignItems="center">
-                        <Warning className="size-5 text-orange-500" />
-                        <Typography>{error}</Typography>
-                    </Row>
-                </Card>
-            ) : null}
+            <Stack spacing={3}>
+                <SearchPageControls
+                    query={query}
+                    selectedCategory={selectedCategory}
+                />
 
-            <SearchInteractive
-                query={query}
-                selectedCategory={selectedCategory}
-                results={trimmedQuery.length >= 2 ? results : []}
-                page={page}
-                hasNextPage={trimmedQuery.length >= 2 && hasNextPage}
-            />
+                {error ? (
+                    <Card className="p-4">
+                        <Row spacing={4} alignItems="center">
+                            <Warning className="size-5 text-orange-500" />
+                            <Typography>{error}</Typography>
+                        </Row>
+                    </Card>
+                ) : null}
 
-            {!trimmedQuery ? (
-                <Card className="p-6 text-center">
-                    <Search className="mx-auto mb-2 size-8 text-muted-foreground" />
-                    <Typography>Upiši pojam za pretragu.</Typography>
-                </Card>
-            ) : trimmedQuery.length < 2 ? (
-                <Card className="p-6 text-center">
-                    <Typography>Upiši barem 2 znaka za pretragu.</Typography>
-                </Card>
-            ) : results.length === 0 && !error ? (
-                <Card className="p-6 text-center">
-                    <Typography>Nema rezultata za zadani pojam.</Typography>
-                </Card>
-            ) : null}
+                <SearchInteractive
+                    query={query}
+                    selectedCategory={selectedCategory}
+                    results={trimmedQuery.length >= 2 ? results : []}
+                    page={page}
+                    hasNextPage={trimmedQuery.length >= 2 && hasNextPage}
+                />
+
+                {!trimmedQuery ? (
+                    <Card className="p-6 text-center">
+                        <Search className="mx-auto mb-2 size-8 text-muted-foreground" />
+                        <Typography>Upiši pojam za pretragu.</Typography>
+                    </Card>
+                ) : trimmedQuery.length < 2 ? (
+                    <Card className="p-6 text-center">
+                        <Typography>
+                            Upiši barem 2 znaka za pretragu.
+                        </Typography>
+                    </Card>
+                ) : results.length === 0 && !error ? (
+                    <Card className="p-6 text-center">
+                        <Typography>Nema rezultata za zadani pojam.</Typography>
+                    </Card>
+                ) : null}
+            </Stack>
         </Stack>
     );
 }

--- a/apps/www/components/NavSearch.tsx
+++ b/apps/www/components/NavSearch.tsx
@@ -328,7 +328,7 @@ export function NavSearch({ className }: NavSearchProps) {
         <div ref={rootRef} className={cx('relative', className)}>
             <search aria-label="Pretraga" className="hidden xl:block">
                 <form onSubmit={handleSubmit}>
-                    <div className="flex h-10 w-64 items-center rounded-full border border-muted-foreground/20 bg-background pl-3 pr-2 shadow-[0_2px_10px_rgba(38,31,24,0.10)] ring-offset-background transition-[background-color,border-color,box-shadow] duration-200 hover:border-muted-foreground/30 hover:bg-card hover:shadow-[0_8px_24px_rgba(38,31,24,0.16)] focus-within:border-primary/40 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 2xl:w-72">
+                    <div className="flex h-10 w-52 items-center rounded-full border border-muted-foreground/20 bg-background pl-3 pr-2 shadow-[0_2px_10px_rgba(38,31,24,0.10)] ring-offset-background transition-[background-color,border-color,box-shadow] duration-200 hover:border-muted-foreground/30 hover:bg-card hover:shadow-[0_8px_24px_rgba(38,31,24,0.16)] focus-within:border-primary/40 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 2xl:w-72">
                         <Search className="size-4 shrink-0 text-muted-foreground" />
                         <input
                             ref={desktopInputRef}
@@ -382,7 +382,7 @@ export function NavSearch({ className }: NavSearchProps) {
 
             {isOpen ? (
                 <div
-                    className="fixed left-3 right-3 top-20 z-50 overflow-hidden rounded-xl border border-border/70 bg-background shadow-2xl ring-1 ring-black/5 xl:absolute xl:left-auto xl:right-0 xl:top-12 xl:w-[28rem]"
+                    className="fixed left-3 right-3 top-20 z-50 overflow-hidden rounded-xl border border-muted-foreground/20 bg-popover text-popover-foreground shadow-[0_24px_70px_rgba(38,31,24,0.22)] ring-1 ring-muted-foreground/10 dark:border-muted-foreground/30 dark:bg-card dark:text-card-foreground dark:shadow-[0_28px_80px_rgba(0,0,0,0.65)] dark:ring-white/10 xl:absolute xl:left-auto xl:right-0 xl:top-12 xl:w-[28rem]"
                     role="dialog"
                     aria-label="Pretraga"
                 >

--- a/apps/www/lib/plants/plantSearch.ts
+++ b/apps/www/lib/plants/plantSearch.ts
@@ -1,0 +1,37 @@
+import { normalizeSearchText } from '../search/normalizeSearchText';
+
+export type PlantSearchable = {
+    information: {
+        name?: string | null;
+        label?: string | null;
+        alternativeName?: string[] | null;
+    };
+};
+
+export function plantMatchesSearch(
+    plant: PlantSearchable,
+    normalizedSearch: string,
+) {
+    if (!normalizedSearch) {
+        return true;
+    }
+
+    return [
+        plant.information.name,
+        plant.information.label,
+        ...(plant.information.alternativeName ?? []),
+    ].some((value) => normalizeSearchText(value).includes(normalizedSearch));
+}
+
+export function matchingPlantAlternativeName(
+    plant: PlantSearchable,
+    normalizedSearch: string,
+) {
+    if (!normalizedSearch) {
+        return undefined;
+    }
+
+    return plant.information.alternativeName?.find((name) =>
+        normalizeSearchText(name).includes(normalizedSearch),
+    );
+}

--- a/apps/www/playwright.config.ts
+++ b/apps/www/playwright.config.ts
@@ -37,7 +37,9 @@ export const config: PlaywrightTestConfig = {
         },
     ],
     webServer: {
-        command: 'pnpm start',
+        command: 'node ../../scripts/run-app-command.mjs start',
+        env: { GREDICE_DETACH_CHILD_PROCESS: 'false' },
+        gracefulShutdown: { signal: 'SIGTERM', timeout: 5000 },
         url: getPlaywrightBaseUrl(app),
         reuseExistingServer: shouldReusePlaywrightServer(),
     },

--- a/packages/directory-types/src/v1.d.ts
+++ b/packages/directory-types/src/v1.d.ts
@@ -747,30 +747,10 @@ export interface components {
                 label: string;
             };
             slug: string;
-            calendar: {
-                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                sowing?: {
-                    start: number;
-                    end: number;
-                }[];
-                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                planting?: {
-                    start: number;
-                    end: number;
-                }[];
-                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                harvest: {
-                    start: number;
-                    end: number;
-                }[];
-                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                propagating?: {
-                    start: number;
-                    end: number;
-                }[];
-            };
             information: {
                 name: string;
+                /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                alternativeName?: string[];
                 latinName: string;
                 origin: string;
                 verified?: boolean;
@@ -909,40 +889,62 @@ export interface components {
                     };
                 }[];
             };
+            calendar: {
+                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                propagating?: {
+                    start: number;
+                    end: number;
+                }[];
+                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                planting?: {
+                    start: number;
+                    end: number;
+                }[];
+                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                sowing?: {
+                    start: number;
+                    end: number;
+                }[];
+                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                harvest: {
+                    start: number;
+                    end: number;
+                }[];
+            };
             attributes: {
-                /** @description (u gramima) */
-                yieldMin: number;
+                /** @description (u danima) */
+                harvestWindowMin: number;
                 /** @description (u gramima) */
                 yieldMax: number;
                 /** @description (u danima) */
-                harvestWindowMin: number;
-                /** @description (u danima) */
-                harvestWindowMax: number;
-                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                soil: string;
-                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                light: number;
-                /** @description (u centimetrima) */
-                seedingDepth: number;
-                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                nutrients: string;
-                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                water: string;
+                germinationWindowMax: number;
                 /** @description (u centimetrima) */
                 seedingDistance: number;
-                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                germinationType: string;
+                /** @description (u centimetrima) */
+                seedingDepth: number;
                 /** @description (u stupnjevima °C) */
                 gernimationTemperature: number;
+                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                germinationType: string;
+                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                soil: string;
                 germinationWindowMin: number;
-                /** @description (u danima) */
-                germinationWindowMax: number;
                 /** @description (u danima) */
                 growthWindowMin: number;
                 /** @description (u danima) */
                 growthWindowMax: number;
+                /** @description (u gramima) */
+                yieldMin: number;
+                /** @description (u danima) */
+                harvestWindowMax: number;
                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                 yieldType: string;
+                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                light: number;
+                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                nutrients: string;
+                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                water: string;
                 /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                 cleanHarvest: boolean;
             };
@@ -975,30 +977,10 @@ export interface components {
             information: {
                 plant: {
                     id: number;
-                    calendar: {
-                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        sowing?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        planting?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        harvest: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        propagating?: {
-                            start: number;
-                            end: number;
-                        }[];
-                    };
                     information: {
                         name: string;
+                        /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                        alternativeName?: string[];
                         latinName: string;
                         origin: string;
                         verified?: boolean;
@@ -1137,40 +1119,62 @@ export interface components {
                             };
                         }[];
                     };
+                    calendar: {
+                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        propagating?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        planting?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        sowing?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        harvest: {
+                            start: number;
+                            end: number;
+                        }[];
+                    };
                     attributes: {
-                        /** @description (u gramima) */
-                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMin: number;
                         /** @description (u gramima) */
                         yieldMax: number;
                         /** @description (u danima) */
-                        harvestWindowMin: number;
-                        /** @description (u danima) */
-                        harvestWindowMax: number;
-                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                        soil: string;
-                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                        light: number;
-                        /** @description (u centimetrima) */
-                        seedingDepth: number;
-                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                        nutrients: string;
-                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                        water: string;
+                        germinationWindowMax: number;
                         /** @description (u centimetrima) */
                         seedingDistance: number;
-                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                        germinationType: string;
+                        /** @description (u centimetrima) */
+                        seedingDepth: number;
                         /** @description (u stupnjevima °C) */
                         gernimationTemperature: number;
+                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                        germinationType: string;
+                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                        soil: string;
                         germinationWindowMin: number;
-                        /** @description (u danima) */
-                        germinationWindowMax: number;
                         /** @description (u danima) */
                         growthWindowMin: number;
                         /** @description (u danima) */
                         growthWindowMax: number;
+                        /** @description (u gramima) */
+                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMax: number;
                         /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                         yieldType: string;
+                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                        light: number;
+                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                        nutrients: string;
+                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                        water: string;
                         /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                         cleanHarvest: boolean;
                     };
@@ -1263,30 +1267,10 @@ export interface components {
                 name: string;
                 plant: {
                     id: number;
-                    calendar: {
-                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        sowing?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        planting?: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        harvest: {
-                            start: number;
-                            end: number;
-                        }[];
-                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                        propagating?: {
-                            start: number;
-                            end: number;
-                        }[];
-                    };
                     information: {
                         name: string;
+                        /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                        alternativeName?: string[];
                         latinName: string;
                         origin: string;
                         verified?: boolean;
@@ -1425,40 +1409,62 @@ export interface components {
                             };
                         }[];
                     };
+                    calendar: {
+                        /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        propagating?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        planting?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        sowing?: {
+                            start: number;
+                            end: number;
+                        }[];
+                        /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                        harvest: {
+                            start: number;
+                            end: number;
+                        }[];
+                    };
                     attributes: {
-                        /** @description (u gramima) */
-                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMin: number;
                         /** @description (u gramima) */
                         yieldMax: number;
                         /** @description (u danima) */
-                        harvestWindowMin: number;
-                        /** @description (u danima) */
-                        harvestWindowMax: number;
-                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                        soil: string;
-                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                        light: number;
-                        /** @description (u centimetrima) */
-                        seedingDepth: number;
-                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                        nutrients: string;
-                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                        water: string;
+                        germinationWindowMax: number;
                         /** @description (u centimetrima) */
                         seedingDistance: number;
-                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                        germinationType: string;
+                        /** @description (u centimetrima) */
+                        seedingDepth: number;
                         /** @description (u stupnjevima °C) */
                         gernimationTemperature: number;
+                        /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                        germinationType: string;
+                        /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                        soil: string;
                         germinationWindowMin: number;
-                        /** @description (u danima) */
-                        germinationWindowMax: number;
                         /** @description (u danima) */
                         growthWindowMin: number;
                         /** @description (u danima) */
                         growthWindowMax: number;
+                        /** @description (u gramima) */
+                        yieldMin: number;
+                        /** @description (u danima) */
+                        harvestWindowMax: number;
                         /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                         yieldType: string;
+                        /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                        light: number;
+                        /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                        nutrients: string;
+                        /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                        water: string;
                         /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                         cleanHarvest: boolean;
                     };
@@ -1478,30 +1484,10 @@ export interface components {
                     information: {
                         plant: {
                             id: number;
-                            calendar: {
-                                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                sowing?: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                planting?: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                harvest: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
-                                propagating?: {
-                                    start: number;
-                                    end: number;
-                                }[];
-                            };
                             information: {
                                 name: string;
+                                /** @description (alternativni nazivi za biljku, iz naroda, druga nariječja) */
+                                alternativeName?: string[];
                                 latinName: string;
                                 origin: string;
                                 verified?: boolean;
@@ -1640,40 +1626,62 @@ export interface components {
                                     };
                                 }[];
                             };
+                            calendar: {
+                                /** @description vrijeme sijanja u zatvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                propagating?: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                                /** @description vrijeme presađivanja na otvoreno (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                planting?: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                                /** @description vrijeme sijanja na otvorenom (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                sowing?: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                                /** @description (upisati mjesec pocetka i kraja; npr. 1.5 naznacava sredinu siječnja) */
+                                harvest: {
+                                    start: number;
+                                    end: number;
+                                }[];
+                            };
                             attributes: {
-                                /** @description (u gramima) */
-                                yieldMin: number;
+                                /** @description (u danima) */
+                                harvestWindowMin: number;
                                 /** @description (u gramima) */
                                 yieldMax: number;
                                 /** @description (u danima) */
-                                harvestWindowMin: number;
-                                /** @description (u danima) */
-                                harvestWindowMax: number;
-                                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
-                                soil: string;
-                                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
-                                light: number;
-                                /** @description (u centimetrima) */
-                                seedingDepth: number;
-                                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
-                                nutrients: string;
-                                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
-                                water: string;
+                                germinationWindowMax: number;
                                 /** @description (u centimetrima) */
                                 seedingDistance: number;
-                                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
-                                germinationType: string;
+                                /** @description (u centimetrima) */
+                                seedingDepth: number;
                                 /** @description (u stupnjevima °C) */
                                 gernimationTemperature: number;
+                                /** @description (Klijanje pod svijetlosti, Klijanje u mraku) */
+                                germinationType: string;
+                                /** @description (Lagano (pješčano), Srednje (ilovasto), Teško (glineno)) */
+                                soil: string;
                                 germinationWindowMin: number;
-                                /** @description (u danima) */
-                                germinationWindowMax: number;
                                 /** @description (u danima) */
                                 growthWindowMin: number;
                                 /** @description (u danima) */
                                 growthWindowMax: number;
+                                /** @description (u gramima) */
+                                yieldMin: number;
+                                /** @description (u danima) */
+                                harvestWindowMax: number;
                                 /** @description ('perPlant' ako je mjera po biljci ili 'perField' ako je mjera za jedno polje gredice) */
                                 yieldType: string;
+                                /** @description (od 0 do 1 gdje 0 označava potpuni hlad a 1 direktno sunce) */
+                                light: number;
+                                /** @description (Niske potrebe, Srednje potrebe, Visoke potrebe) */
+                                nutrients: string;
+                                /** @description (Suho tlo, Vlažno tlo, Mokro tlo) */
+                                water: string;
                                 /** @description (da li je polje čisto nakon branja biljke; u suprotnom je pokrebna radnja uklanjanja biljke) */
                                 cleanHarvest: boolean;
                             };

--- a/packages/game/src/hud/raisedBed/PlantsList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsList.tsx
@@ -18,6 +18,33 @@ import { usePlants } from '../../hooks/usePlants';
 import { KnownPages } from '../../knownPages';
 import { PlantListItemSkeleton } from './PlantListItemSkeleton';
 
+type PlantSearchable = {
+    information: {
+        name?: string | null;
+        label?: string | null;
+        alternativeName?: string[] | null;
+    };
+};
+
+function normalizePlantSearchText(value: string | null | undefined) {
+    return (value ?? '')
+        .replace(/[Đđ]/g, 'd')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLocaleLowerCase('hr-HR')
+        .trim();
+}
+
+function plantMatchesSearch(plant: PlantSearchable, normalizedSearch: string) {
+    return [
+        plant.information.name,
+        plant.information.label,
+        ...(plant.information.alternativeName ?? []),
+    ].some((value) =>
+        normalizePlantSearchText(value).includes(normalizedSearch),
+    );
+}
+
 export function PlantsList({
     onChange,
     search,
@@ -27,14 +54,12 @@ export function PlantsList({
 }) {
     const { track } = useGameAnalytics();
     const { data: plants, isLoading, isError } = usePlants();
-    const normalizedSearch = search.trim().toLowerCase();
+    const normalizedSearch = normalizePlantSearchText(search);
     // Filter plants based on search query
     const filteredPlants =
         normalizedSearch.length > 0
             ? plants?.filter((plant) =>
-                  plant.information.name
-                      .toLowerCase()
-                      .includes(normalizedSearch),
+                  plantMatchesSearch(plant, normalizedSearch),
               )
             : plants;
 

--- a/packages/storage/src/@types/EntityStandardized.ts
+++ b/packages/storage/src/@types/EntityStandardized.ts
@@ -8,6 +8,7 @@ export type EntityStandardized = {
     information?: {
         name?: string;
         label?: string;
+        alternativeName?: string[];
         shortDescription?: string;
         description?: string;
         instructions?: string;

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -475,7 +475,7 @@ async function buildEntitySearchDocumentValues(
     const category = publicSearchCategoryForDirectoryEntityType(
         entity.entityTypeName,
     );
-    if (!category || entity.state !== 'published' || !entity.publishedAt) {
+    if (!category || entity.state !== 'published') {
         return null;
     }
 
@@ -528,7 +528,6 @@ export async function refreshEntitySearchDocument(entityId: number) {
             id: true,
             entityTypeName: true,
             state: true,
-            publishedAt: true,
             isDeleted: true,
         },
     });
@@ -537,7 +536,6 @@ export async function refreshEntitySearchDocument(entityId: number) {
         !entityState ||
         entityState.isDeleted ||
         entityState.state !== 'published' ||
-        !entityState.publishedAt ||
         !publicSearchCategoryForDirectoryEntityType(entityState.entityTypeName)
     ) {
         await storage()

--- a/packages/storage/tests/entitySearchRepo.node.spec.ts
+++ b/packages/storage/tests/entitySearchRepo.node.spec.ts
@@ -5,13 +5,16 @@ import {
     createAttributeDefinition,
     createEntity,
     deleteEntity,
+    entities,
     normalizeDirectorySearchText,
     rebuildDirectorySearchIndex,
     searchDirectoryEntities,
+    storage,
     updateEntity,
     upsertAttributeValue,
     upsertEntityType,
 } from '@gredice/storage';
+import { eq } from 'drizzle-orm';
 import { createTestDb } from './testDb';
 
 const ensuredEntityTypes = new Set<string>();
@@ -142,6 +145,92 @@ test('directory entity search normalizes Croatian diacritics and ranks title mat
         normalizeDirectorySearchText('Čišćenje gredice'),
         'ciscenje gredice',
     );
+});
+
+test('directory entity search includes legacy published plants without publishedAt', async () => {
+    createTestDb();
+    const kupusId = await createSearchableEntity({
+        entityTypeName: 'plant',
+        entityTypeLabel: 'Plant',
+        title: 'Kupus',
+        state: 'draft',
+    });
+    const cesnjakId = await createSearchableEntity({
+        entityTypeName: 'plant',
+        entityTypeLabel: 'Plant',
+        title: 'Češnjak',
+        state: 'draft',
+    });
+
+    await storage()
+        .update(entities)
+        .set({ state: 'published', publishedAt: null })
+        .where(eq(entities.id, kupusId));
+    await storage()
+        .update(entities)
+        .set({ state: 'published', publishedAt: null })
+        .where(eq(entities.id, cesnjakId));
+    await rebuildDirectorySearchIndex();
+
+    const kupusRows = await searchDirectoryEntities({
+        query: 'kupus',
+        entityTypeNames: ['plant'],
+    });
+    const cesnjakRows = await searchDirectoryEntities({
+        query: 'cesnjak',
+        entityTypeNames: ['plant'],
+    });
+    const diacriticCesnjakRows = await searchDirectoryEntities({
+        query: 'češnjak',
+        entityTypeNames: ['plant'],
+    });
+
+    assert.equal(kupusRows[0]?.entityId, kupusId);
+    assert.equal(kupusRows[0]?.publishedAt, null);
+    assert.equal(cesnjakRows[0]?.entityId, cesnjakId);
+    assert.equal(diacriticCesnjakRows[0]?.entityId, cesnjakId);
+});
+
+test('directory entity search includes multiple plant alternative names', async () => {
+    createTestDb();
+    const kupusId = await createSearchableEntity({
+        entityTypeName: 'plant',
+        entityTypeLabel: 'Plant',
+        title: 'Kupus',
+    });
+    const alternativeNameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'alternativeName',
+        label: 'Alternative name',
+        entityTypeName: 'plant',
+        dataType: 'text',
+        multiple: true,
+    });
+
+    await upsertAttributeValue({
+        attributeDefinitionId: alternativeNameDefinitionId,
+        entityTypeName: 'plant',
+        entityId: kupusId,
+        value: 'Zelje',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: alternativeNameDefinitionId,
+        entityTypeName: 'plant',
+        entityId: kupusId,
+        value: 'Kapus',
+    });
+
+    const zeljeRows = await searchDirectoryEntities({
+        query: 'zelje',
+        entityTypeNames: ['plant'],
+    });
+    const kapusRows = await searchDirectoryEntities({
+        query: 'kapus',
+        entityTypeNames: ['plant'],
+    });
+
+    assert.equal(zeljeRows[0]?.entityId, kupusId);
+    assert.equal(kapusRows[0]?.entityId, kupusId);
 });
 
 test('directory entity search finds published operations without diacritics', async () => {

--- a/scripts/app-registry.test.mjs
+++ b/scripts/app-registry.test.mjs
@@ -22,6 +22,7 @@ import {
 import {
     childProcessTreeOptions,
     processStatesIncludeLiveProcess,
+    shouldDetachChildProcessTree,
     terminateChildProcessTree,
 } from './process-tree.mjs';
 
@@ -271,6 +272,13 @@ describe('app registry worktree ports', () => {
         assert.equal(getWorktreeSlug('Feature/ABC thing'), 'feature-abc-thing');
     });
 
+    it('can keep app commands in the parent process group for Playwright teardown', () => {
+        withEnv({ GREDICE_DETACH_CHILD_PROCESS: 'false' }, () => {
+            assert.equal(shouldDetachChildProcessTree(), false);
+            assert.deepEqual(childProcessTreeOptions(), {});
+        });
+    });
+
     it('points local API calls at the app dev port for dev commands', () => {
         const result = runAppCommandForTest('dev', {
             GREDICE_PORT_OFFSET: '12',
@@ -320,6 +328,31 @@ describe('app registry worktree ports', () => {
         const readyPath = resolve(tempDir, 'ready');
         const signalPath = resolve(tempDir, 'signal');
         const { binDir, child } = spawnRunAppCommand('dev', {
+            GREDICE_TEST_READY_PATH: readyPath,
+            GREDICE_TEST_SIGNAL_PATH: signalPath,
+        });
+
+        try {
+            assert.equal(await waitForFile(readyPath), true);
+            child.kill('SIGINT');
+            const result = await waitForChildExit(child);
+
+            assert.equal(result.code, 130);
+            assert.equal(await waitForFile(signalPath), true);
+            assert.equal(readFileSync(signalPath, 'utf8'), 'SIGINT');
+        } finally {
+            child.kill('SIGKILL');
+            rmSync(binDir, { recursive: true, force: true });
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('forwards SIGINT to a non-detached app command', async () => {
+        const tempDir = mkdtempSync(resolve(tmpdir(), 'gredice-app-signal-'));
+        const readyPath = resolve(tempDir, 'ready');
+        const signalPath = resolve(tempDir, 'signal');
+        const { binDir, child } = spawnRunAppCommand('dev', {
+            GREDICE_DETACH_CHILD_PROCESS: 'false',
             GREDICE_TEST_READY_PATH: readyPath,
             GREDICE_TEST_SIGNAL_PATH: signalPath,
         });

--- a/scripts/process-tree.mjs
+++ b/scripts/process-tree.mjs
@@ -4,8 +4,32 @@ export const shutdownSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
 
 export const supportsProcessGroups = process.platform !== 'win32';
 
+export function shouldDetachChildProcessTree() {
+    if (!supportsProcessGroups) {
+        return false;
+    }
+
+    const detachOverride = process.env.GREDICE_DETACH_CHILD_PROCESS?.trim();
+    if (!detachOverride) {
+        return true;
+    }
+
+    const normalizedOverride = detachOverride.toLowerCase();
+    if (['0', 'false', 'no', 'off'].includes(normalizedOverride)) {
+        return false;
+    }
+
+    if (['1', 'true', 'yes', 'on'].includes(normalizedOverride)) {
+        return true;
+    }
+
+    throw new Error(
+        `Invalid GREDICE_DETACH_CHILD_PROCESS value: ${detachOverride}`,
+    );
+}
+
 export function childProcessTreeOptions() {
-    return supportsProcessGroups ? { detached: true } : {};
+    return shouldDetachChildProcessTree() ? { detached: true } : {};
 }
 
 export function signalExitCode(signal, signalNumbers) {
@@ -53,7 +77,7 @@ export function signalChildProcessTree(child, signal) {
     }
 
     try {
-        if (supportsProcessGroups) {
+        if (shouldDetachChildProcessTree()) {
             process.kill(-child.pid, signal);
             return true;
         }
@@ -122,7 +146,7 @@ function isChildProcessTreeRunning(child) {
         return false;
     }
 
-    if (!supportsProcessGroups) {
+    if (!shouldDetachChildProcessTree()) {
         return child.exitCode === null && child.signalCode === null;
     }
 


### PR DESCRIPTION
## Sažetak
- Ispravlja globalnu pretragu tako da `published` biljke budu dostupne i kad nedostaje `publishedAt`, uključujući slučajeve s dijakriticima kao `Kupus` i `Češnjak`.
- Uređuje stranicu pretrage s boljim rasporedom, `PageHeader` uvodom, Markdown prikazom opisa rezultata i kompaktnijim rezultatima.
- Poboljšava navbar pretragu i kontrast popovera u tamnom načinu.
- Ažurira prikaz kalendara i povezanih galerija/komponenti za stabilniji prikaz i testiranje.

## Testing
- Dodani regresijski testovi za repo pretrage biljaka i postojeći Playwright scenariji za pretragu.
- Lokalno provjereno s Playwrightom za `www` pretragu; svi povezani Chromium testovi su prošli.
- Build i provjera formatiranja za pogođeni `www` workspace su prošli.