### PR TITLE
Show active sowing tasks in operations HUD

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -139,6 +139,37 @@ function createQueryClient() {
         },
     });
     const garden = buildGarden();
+    const pendingOperationPage = {
+        pages: [
+            {
+                items: [
+                    {
+                        id: 601,
+                        entityId: 999_001,
+                        raisedBedId: TEST_RAISED_BED_ID,
+                        raisedBedFieldId: 1,
+                        status: 'planned',
+                        createdAt: now,
+                        scheduledDate: '2026-05-22T00:00:00.000Z',
+                        scheduledAt: '2026-05-22T00:00:00.000Z',
+                        completedAt: null,
+                        verifiedAt: null,
+                        canceledAt: null,
+                        targetLabel: 'Polje 1 • Raised Bed 1',
+                        statusHistory: [
+                            {
+                                status: 'planned',
+                                changedAt: now,
+                            },
+                        ],
+                    },
+                ],
+                nextCursor: null,
+                total: 1,
+            },
+        ],
+        pageParams: [0],
+    };
     const emptyOperationPage = {
         pages: [{ items: [], nextCursor: null, total: 0 }],
         pageParams: [0],
@@ -173,7 +204,7 @@ function createQueryClient() {
     });
     queryClient.setQueryData(
         ['garden-operations', TEST_GARDEN_ID, false, 10],
-        emptyOperationPage,
+        pendingOperationPage,
     );
     queryClient.setQueryData(
         ['garden-operations', TEST_GARDEN_ID, true, 20],

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -27,6 +27,9 @@ test.describe('Garden operations HUD', () => {
         ).toBeVisible();
         await expect(page.getByText('Zakazano: sutra')).toBeVisible();
         await expect(page.getByText('U košari').last()).toBeVisible();
+
+        await expect(page.getByText('Sadnja')).toBeVisible();
+        await expect(page.getByText('Polje 1 • Raised Bed 1')).toBeVisible();
         await expect(page.getByText('Nema nedovršenih radnji.')).toHaveCount(0);
     });
 });

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -395,6 +395,24 @@ function OperationDates({ operation }: { operation: GardenOperationItem }) {
     );
 }
 
+function getActiveOperationName({
+    operation,
+    operationName,
+}: {
+    operation: GardenOperationItem;
+    operationName?: string;
+}) {
+    if (operationName) {
+        return operationName;
+    }
+
+    if (operation.raisedBedFieldId != null) {
+        return plantingOperationLabel;
+    }
+
+    return `Radnja #${operation.id}`;
+}
+
 function OperationCard({
     operation,
     operationName,
@@ -404,6 +422,11 @@ function OperationCard({
     operationName?: string;
     operationData?: OperationData;
 }) {
+    const resolvedOperationName = getActiveOperationName({
+        operation,
+        operationName,
+    });
+
     return (
         <div className="rounded-xl border p-3">
             <Row spacing={3} alignItems="start">
@@ -419,7 +442,7 @@ function OperationCard({
                 <Stack spacing={1.5} className="min-w-0 flex-1">
                     <Stack spacing={0.5}>
                         <Typography level="body2" semiBold noWrap>
-                            {operationName ?? `Radnja #${operation.id}`}
+                            {resolvedOperationName}
                         </Typography>
                         <Typography level="body3" secondary>
                             {operation.targetLabel}


### PR DESCRIPTION
### Motivation
- Active sowing tasks (operations tied to a raised-bed field) were rendered with a generic numeric label and could be overlooked in the operations HUD when no operation metadata is available. This change makes those field-level tasks identifiable as sowing in the HUD.

### Description
- Add a `getActiveOperationName` helper to `packages/game/src/hud/GardenOperationsHud.tsx` and use it in `OperationCard` to render `Sadnja` when `operation.raisedBedFieldId` is present and no `operationName` exists.
- Seed the HUD story `apps/garden/tests/GardenOperationsHudStory.tsx` with a pending field-level operation so the sowing path is exercised in story/test data.
- Extend the Playwright component test `apps/garden/tests/garden-operations-hud.spec.tsx` to assert that `Sadnja` and the corresponding `Polje 1 • Raised Bed 1` target label are visible.
- Files changed: `packages/game/src/hud/GardenOperationsHud.tsx`, `apps/garden/tests/GardenOperationsHudStory.tsx`, `apps/garden/tests/garden-operations-hud.spec.tsx`.

### Testing
- Lint: ran `pnpm lint --filter @gredice/game` and it passed.
- Component test: attempted `pnpm --filter garden test -- garden-operations-hud.spec.tsx` but Playwright `webServer` failed to start because no production `.next` build is present in this environment, so the Playwright run did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1063885904832fb0a3da1da6aca76c)