### PR TITLE
Polish www floating navbar and landing game scene

### DIFF
--- a/apps/storybook/stories/packages/ui/primitives/Nav.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Nav.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    'PageNav provides the fixed public-site navigation shell with Signalco-compatible logo, links, and children props.',
+                    'PageNav provides the floating public-site navigation shell with glass treatment, mobile menu state, links, and children props.',
             },
         },
     },
@@ -23,7 +23,7 @@ const meta = {
         ],
     },
     render: (args) => (
-        <div className="min-h-48">
+        <div className="min-h-[32rem] bg-muted/30 pt-24">
             <PageNav {...args}>
                 <Typography level="body3" secondary>
                     Akcija

--- a/apps/www/app/LandingGameScene.tsx
+++ b/apps/www/app/LandingGameScene.tsx
@@ -4,7 +4,7 @@ import { GameScene } from '@gredice/game';
 import { getGardenBaseUrl } from '@gredice/js/urls';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Close, Navigate } from '@gredice/ui/icons';
+import { Close, Navigate, SquareArrowRightEnter } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { cx } from '@gredice/ui/utils';
 import type { CSSProperties } from 'react';
@@ -38,6 +38,9 @@ const winterWeather = {
 };
 
 const transitionDurationMs = 700;
+const landingCameraPosition: [x: number, y: number, z: number] = [
+    -130, 72, -120,
+];
 
 type SceneRect = {
     top: number;
@@ -202,33 +205,43 @@ export function LandingGameScene() {
                             : collapsedStyle
                         : undefined
                 }
+                data-testid="landing-game-scene"
             >
-                <GameScene
-                    key={isLoggedIn ? 'user-garden' : 'landing-mock'}
-                    appBaseUrl="https://vrt.gredice.com"
-                    spriteBaseUrl=""
-                    deferDetails
-                    zoom={
-                        interactiveMounted
-                            ? 'normal'
-                            : isMobile
-                              ? 'far'
-                              : 'normal'
-                    }
-                    hideHud={!interactiveVisible}
-                    noControls={!interactiveVisible}
-                    noSound={!interactiveVisible}
-                    mockGarden={!isLoggedIn}
-                    winterMode={winterMode}
-                    weather={
-                        isLoggedIn
-                            ? undefined
-                            : isWinter
-                              ? winterWeather
-                              : summerWeather
-                    }
-                    className="size-full"
-                />
+                <div
+                    className={cx(
+                        'absolute inset-0',
+                        !interactiveMounted && 'top-20 -bottom-20 md:inset-0',
+                    )}
+                >
+                    <GameScene
+                        key={isLoggedIn ? 'user-garden' : 'landing-mock'}
+                        appBaseUrl="https://vrt.gredice.com"
+                        spriteBaseUrl=""
+                        cameraPosition={landingCameraPosition}
+                        deferDetails
+                        quality={interactiveMounted ? undefined : 'high'}
+                        zoom={
+                            interactiveMounted
+                                ? 'normal'
+                                : isMobile
+                                  ? 'far'
+                                  : 'normal'
+                        }
+                        hideHud={!interactiveVisible}
+                        noControls={!interactiveVisible}
+                        noSound={!interactiveVisible}
+                        mockGarden={!isLoggedIn}
+                        winterMode={winterMode}
+                        weather={
+                            isLoggedIn
+                                ? undefined
+                                : isWinter
+                                  ? winterWeather
+                                  : summerWeather
+                        }
+                        className="size-full"
+                    />
+                </div>
                 {interactiveMounted && (
                     <div
                         className={cx(
@@ -286,5 +299,38 @@ export function LandingGameScene() {
                 </div>
             )}
         </>
+    );
+}
+
+export function LandingGameSignupCta() {
+    const gardenBaseUrl = getGardenBaseUrl();
+    const { data: user, isLoading } = useCurrentUser();
+
+    if (isLoading || user) {
+        return null;
+    }
+
+    return (
+        <div
+            className="mt-4 flex flex-col items-center justify-center gap-2 px-3 sm:flex-row md:mt-5"
+            data-testid="landing-game-signup-cta"
+        >
+            <NavigatingButton
+                href={gardenBaseUrl}
+                className="rounded-full bg-green-800 hover:bg-green-700 dark:bg-green-700 dark:text-white dark:hover:bg-green-600"
+                endDecorator={
+                    <SquareArrowRightEnter aria-hidden className="size-4" />
+                }
+            >
+                Započni svoj vrt
+            </NavigatingButton>
+            <NavigatingButton
+                href={gardenBaseUrl}
+                variant="outlined"
+                className="rounded-full bg-background/90 shadow-sm backdrop-blur-xs"
+            >
+                Otvori aplikaciju
+            </NavigatingButton>
+        </div>
     );
 }

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -167,22 +167,6 @@
         animation: scale-in 0.15s ease-out;
     }
 
-    header label[for="mobile-menu-toggle"] {
-        height: 2.25rem;
-        width: 2.25rem;
-        align-items: center;
-        justify-content: center;
-        border-radius: 9999px;
-        transition:
-            background-color 0.2s ease,
-            box-shadow 0.2s ease;
-    }
-
-    header label[for="mobile-menu-toggle"]:hover {
-        background-color: hsl(var(--accent));
-        box-shadow: 0 4px 14px rgba(38, 31, 24, 0.14);
-    }
-
     .site-footer .text-muted-foreground,
     .site-footer .text-tertiary-foreground {
         color: hsl(var(--foreground));
@@ -205,11 +189,6 @@
     }
 }
 
-@media (max-width: 767px) {
-    header label[for="mobile-menu-toggle"] {
-        display: inline-flex;
-    }
-}
 svg.lucide {
     stroke-width: 1.75px;
 }

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -116,7 +116,7 @@ export default async function RootLayout({
                     <PageNav
                         logo={
                             <Logotype
-                                className="w-[140px] h-[38px]"
+                                className="h-[38px] w-[128px] sm:w-[140px]"
                                 aria-label="Gredice"
                             />
                         }
@@ -144,9 +144,8 @@ export default async function RootLayout({
                             </NavLinkButton>,
                         ]}
                     >
-                        <div className="absolute bg-background/80 w-full inset-0 -z-10" />
-                        <div className="flex items-center gap-2">
-                            <NavSearch className="md:-ml-1 xl:absolute xl:left-1/2 xl:top-1/2 xl:ml-0 xl:-translate-x-1/2 xl:-translate-y-1/2" />
+                        <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+                            <NavSearch className="shrink-0 md:-ml-1 xl:absolute xl:left-1/2 xl:top-1/2 xl:ml-0 xl:-translate-x-1/2 xl:-translate-y-1/2" />
                             <NavUserButton href={KnownPages.GardenApp} />
                         </div>
                     </PageNav>

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -18,7 +18,7 @@ import { InstagramCard } from '../components/social/InstagramCard';
 import { WhatsAppCard } from '../components/social/WhatsAppCard';
 import { WinterModeToggle } from '../components/WinterModeToggle';
 import { KnownPages } from '../src/KnownPages';
-import { LandingGameScene } from './LandingGameScene';
+import { LandingGameScene, LandingGameSignupCta } from './LandingGameScene';
 import { NewsletterSignUp } from './NewsletterSignUp';
 import { PlantsShowcase } from './PlantsShowcase';
 
@@ -239,57 +239,48 @@ function StepsSection() {
 export default function Home() {
     return (
         <Stack>
-            <div className="relative">
-                <div className="relative h-[100dvh] lg:h-[700px] -mt-16 w-full overflow-hidden">
-                    <Image
-                        alt="Tvoj novi vrt u Gredice aplikaciji"
-                        className="absolute inset-0 h-full w-full object-contain opacity-0 pointer-events-none"
-                        height={1080}
-                        src="/seo-fallback.png"
-                        width={1920}
-                    />
-                    <LandingGameScene />
+            <div className="relative pt-3 pb-4 md:pt-6">
+                <Container
+                    maxWidth="xl"
+                    className="relative px-2 sm:px-4 [--landing-card-radius:calc(var(--landing-frame-radius)*0.625)] [--landing-frame-radius:1.5rem] md:[--landing-frame-radius:2rem]"
+                >
                     <div
-                        className="pointer-events-none absolute inset-x-0 bottom-0 h-24"
-                        style={{
-                            background: `linear-gradient(
-                                to bottom,
-                                hsl(var(--background) / 0) 0%,
-                                hsl(var(--background) / 0.013) 8.1%,
-                                hsl(var(--background) / 0.049) 15.5%,
-                                hsl(var(--background) / 0.104) 22.5%,
-                                hsl(var(--background) / 0.175) 29%,
-                                hsl(var(--background) / 0.259) 35.3%,
-                                hsl(var(--background) / 0.352) 41.2%,
-                                hsl(var(--background) / 0.45) 47.1%,
-                                hsl(var(--background) / 0.55) 52.9%,
-                                hsl(var(--background) / 0.648) 58.8%,
-                                hsl(var(--background) / 0.741) 64.7%,
-                                hsl(var(--background) / 0.825) 71%,
-                                hsl(var(--background) / 0.896) 77.5%,
-                                hsl(var(--background) / 0.951) 84.5%,
-                                hsl(var(--background) / 0.987) 91.9%,
-                                hsl(var(--background)) 100%
-                            )`,
-                        }}
-                    />
-                </div>
-                <Container className="absolute top-0 left-0 right-0">
-                    <div className="flex flex-col items-end sm:flex-row sm:items-start sm:justify-between gap-4 mt-4">
-                        <Card className="w-fit border-tertiary border-b-4">
-                            <CardContent noHeader className="p-6 lg:pr-10">
-                                <Stack spacing={4}>
-                                    <Typography level="h2" component="h1">
-                                        Vrt po tvom 🌱
-                                    </Typography>
-                                    <Typography level="body1">
-                                        Dobiješ povrće iz svojih gredica - nit
-                                        oro, nit kopo!
-                                    </Typography>
-                                </Stack>
-                            </CardContent>
-                        </Card>
-                        <WinterModeToggle />
+                        className="relative h-[min(540px,calc(100dvh-18rem))] min-h-[420px] w-full overflow-hidden rounded-[var(--landing-frame-radius)] border border-tertiary/70 bg-muted shadow-2xl shadow-foreground/10 md:h-[calc(100dvh-9rem)] md:max-h-[720px] lg:min-h-[560px]"
+                        data-testid="landing-game-frame"
+                    >
+                        <Image
+                            alt="Tvoj novi vrt u Gredice aplikaciji"
+                            className="absolute inset-0 h-full w-full object-contain opacity-0 pointer-events-none"
+                            height={1080}
+                            src="/seo-fallback.png"
+                            width={1920}
+                        />
+                        <LandingGameScene />
+                    </div>
+                    <LandingGameSignupCta />
+                    <div className="pointer-events-none absolute left-8 right-8 top-8 z-10 sm:left-10 sm:right-10 md:top-10 lg:left-16 lg:right-16 lg:top-12">
+                        <div className="pointer-events-auto flex flex-col items-start sm:flex-row sm:items-start sm:justify-between gap-4">
+                            <Card
+                                className="w-fit max-w-[19rem] rounded-[var(--landing-card-radius)] border-tertiary border-b-4 sm:max-w-none"
+                                data-testid="landing-hero-card"
+                            >
+                                <CardContent
+                                    noHeader
+                                    className="p-5 sm:p-6 lg:pr-10"
+                                >
+                                    <Stack spacing={4}>
+                                        <Typography level="h2" component="h1">
+                                            Vrt po tvom 🌱
+                                        </Typography>
+                                        <Typography level="body1">
+                                            Dobiješ povrće iz svojih gredica -
+                                            nit oro, nit kopo!
+                                        </Typography>
+                                    </Stack>
+                                </CardContent>
+                            </Card>
+                            <WinterModeToggle />
+                        </div>
                     </div>
                 </Container>
             </div>

--- a/apps/www/components/NavUserButton.tsx
+++ b/apps/www/components/NavUserButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { SquareArrowRightEnter } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
 import { useCurrentUser } from '../hooks/useCurrentUser';
@@ -10,19 +11,32 @@ export function NavUserButton({ href }: { href: string }) {
     return (
         <NavigatingButton
             href={href}
-            className="whitespace-nowrap bg-green-800 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600 dark:text-white rounded-full"
+            className="shrink-0 whitespace-nowrap rounded-full bg-green-800 px-3 hover:bg-green-700 dark:bg-green-700 dark:text-white dark:hover:bg-green-600 sm:px-4"
+            endDecorator={
+                <span className="hidden pl-1 sm:inline-flex">
+                    <SquareArrowRightEnter aria-hidden className="size-4" />
+                </span>
+            }
             startDecorator={
                 user ? (
-                    <UserAvatar
-                        avatarUrl={user.avatarUrl}
-                        displayName={user.displayName ?? user.userName}
-                        className="-ml-3.5 mr-1"
-                        animate
-                    />
+                    <span className="hidden sm:inline-flex">
+                        <UserAvatar
+                            avatarUrl={user.avatarUrl}
+                            displayName={user.displayName ?? user.userName}
+                            className="-ml-3.5 mr-1"
+                            animate
+                        />
+                    </span>
                 ) : undefined
             }
         >
-            {user ? 'Moj vrt' : 'Moj novi vrt'}
+            <span className="hidden sm:inline">
+                {user ? 'Moj vrt' : 'Moj novi vrt'}
+            </span>
+            <span className="sr-only sm:hidden">
+                {user ? 'Moj vrt' : 'Moj novi vrt'}
+            </span>
+            <SquareArrowRightEnter aria-hidden className="size-5 sm:hidden" />
         </NavigatingButton>
     );
 }

--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -1,6 +1,236 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from './fixtures';
+
+async function expectMobileNavActionsDoNotOverlap(page: Page) {
+    const cta = page.getByRole('link', { name: 'Moj novi vrt' });
+    const menuButton = page.getByRole('button', {
+        name: /Otvori navigaciju|Zatvori navigaciju/u,
+    });
+
+    await expect(cta).toBeVisible();
+    await expect(menuButton).toBeVisible();
+
+    const ctaBox = await cta.boundingBox();
+    const menuButtonBox = await menuButton.boundingBox();
+    expect(ctaBox).not.toBeNull();
+    expect(menuButtonBox).not.toBeNull();
+    if (!ctaBox || !menuButtonBox) {
+        throw new Error('Expected mobile nav CTA and menu button boxes.');
+    }
+
+    expect(menuButtonBox.x).toBeGreaterThanOrEqual(ctaBox.x + ctaBox.width + 4);
+    expect(ctaBox.width).toBeLessThanOrEqual(50);
+}
 
 test('has title', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle(/Gredice/);
+});
+
+test('mobile navbar closes after navigating from the menu', async ({
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await expectMobileNavActionsDoNotOverlap(page);
+
+    const menuButton = page.getByRole('button', {
+        name: 'Otvori navigaciju',
+    });
+    await menuButton.click();
+
+    const mobileNav = page.getByRole('navigation', {
+        name: 'Glavna navigacija',
+    });
+    await expect(mobileNav).toBeVisible();
+
+    await mobileNav.getByRole('link', { name: 'Česta pitanja' }).click();
+
+    await expect(page).toHaveURL(/\/cesta-pitanja/u);
+    await expect(mobileNav).toBeHidden();
+    await expect(
+        page.getByRole('button', { name: 'Otvori navigaciju' }),
+    ).toBeVisible();
+});
+
+test('navbar floats on scroll and landing game frame is rounded', async ({
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+
+    await expect(page.getByTestId('landing-game-frame')).toHaveCSS(
+        'border-radius',
+        '24px',
+    );
+    await expect(page.getByTestId('landing-hero-card')).toHaveCSS(
+        'border-radius',
+        '15px',
+    );
+    await expect(
+        page
+            .getByTestId('landing-game-frame')
+            .locator('[style*="linear-gradient"]'),
+    ).toHaveCount(0);
+
+    const frameBox = await page.getByTestId('landing-game-frame').boundingBox();
+    const heroCardBox = await page
+        .getByTestId('landing-hero-card')
+        .boundingBox();
+    expect(frameBox).not.toBeNull();
+    expect(heroCardBox).not.toBeNull();
+    if (!frameBox || !heroCardBox) {
+        throw new Error('Expected landing game frame and hero card boxes.');
+    }
+
+    expect(heroCardBox.x - frameBox.x).toBeGreaterThanOrEqual(23);
+    expect(heroCardBox.y - frameBox.y).toBeGreaterThanOrEqual(31);
+    expect(heroCardBox.width).toBeLessThan(frameBox.width - 48);
+    expect(frameBox.height).toBeLessThanOrEqual(550);
+    await expect(page.locator('canvas')).toBeVisible();
+
+    const signupCta = page.getByTestId('landing-game-signup-cta');
+    await expect(signupCta).toBeVisible();
+    await expect(
+        signupCta.getByRole('link', { name: 'Započni svoj vrt' }),
+    ).toBeVisible();
+    await expect(
+        signupCta.getByRole('link', { name: 'Otvori aplikaciju' }),
+    ).toBeVisible();
+
+    const signupCtaBox = await signupCta.boundingBox();
+    expect(signupCtaBox).not.toBeNull();
+    if (!signupCtaBox) {
+        throw new Error('Expected landing game signup CTA box.');
+    }
+
+    expect(signupCtaBox.y).toBeGreaterThanOrEqual(frameBox.y + frameBox.height);
+
+    await expect
+        .poll(() =>
+            page.evaluate(() => {
+                const profile = (
+                    window as Window & {
+                        __grediceGameProfile?: {
+                            dprCap?: number;
+                            qualityTier?: string;
+                        };
+                    }
+                ).__grediceGameProfile;
+
+                return {
+                    dprCap: profile?.dprCap,
+                    qualityTier: profile?.qualityTier,
+                };
+            }),
+        )
+        .toEqual({ dprCap: 2, qualityTier: 'high' });
+
+    const canvas = page.locator('canvas');
+    const countVisibleCanvasPixels = () =>
+        canvas.evaluate((canvasElement: HTMLCanvasElement) => {
+            const sampleCanvas = document.createElement('canvas');
+            sampleCanvas.width = 20;
+            sampleCanvas.height = 20;
+            const context = sampleCanvas.getContext('2d');
+            if (!context) {
+                return 0;
+            }
+
+            context.drawImage(canvasElement, 0, 0, 20, 20);
+            const pixels = context.getImageData(0, 0, 20, 20).data;
+            let visiblePixels = 0;
+            for (let index = 0; index < pixels.length; index += 4) {
+                const red = pixels[index] ?? 0;
+                const green = pixels[index + 1] ?? 0;
+                const blue = pixels[index + 2] ?? 0;
+                const alpha = pixels[index + 3] ?? 0;
+                if (alpha > 0 && red + green + blue > 0) {
+                    visiblePixels += 1;
+                }
+            }
+
+            return visiblePixels;
+        });
+    await expect
+        .poll(countVisibleCanvasPixels, { timeout: 10_000 })
+        .toBeGreaterThan(10);
+
+    const header = page.locator('header');
+    await page.evaluate(() => window.scrollTo(0, 160));
+    await expect(header).toHaveCSS('border-radius', '16px');
+    await expectMobileNavActionsDoNotOverlap(page);
+
+    const mobileHeaderBox = await header.boundingBox();
+    expect(mobileHeaderBox).not.toBeNull();
+    if (!mobileHeaderBox) {
+        throw new Error('Expected mobile navbar to have a bounding box.');
+    }
+
+    expect(mobileHeaderBox.x).toBeGreaterThanOrEqual(7);
+    expect(mobileHeaderBox.y).toBeGreaterThanOrEqual(7);
+});
+
+test('desktop floating navbar keeps container width', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+
+    const header = page.locator('header');
+    await page.evaluate(() => window.scrollTo(0, 160));
+    await expect(header).toHaveCSS('border-radius', '16px');
+
+    const headerBox = await header.boundingBox();
+    expect(headerBox).not.toBeNull();
+    if (!headerBox) {
+        throw new Error('Expected desktop navbar to have a bounding box.');
+    }
+
+    expect(headerBox.width).toBeLessThanOrEqual(1280);
+    expect(headerBox.x).toBeGreaterThanOrEqual(70);
+});
+
+test('logged-in landing game morphs into full screen in place', async ({
+    page,
+}) => {
+    await page.unroute('**/api/gredice/api/auth/current-claims**');
+    await page.route(
+        '**/api/gredice/api/auth/current-claims**',
+        async (route) => {
+            await route.fulfill({
+                body: JSON.stringify({
+                    id: 'test-user',
+                    userName: 'test',
+                    displayName: 'Test User',
+                    avatarUrl: null,
+                }),
+                contentType: 'application/json',
+                status: 200,
+            });
+        },
+    );
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+
+    const scene = page.getByTestId('landing-game-scene');
+    const initialBox = await scene.boundingBox();
+    expect(initialBox).not.toBeNull();
+
+    await page.getByRole('button', { name: 'Pogledaj moj vrt ovdje' }).click();
+
+    await expect(scene).toHaveCSS('border-radius', '0px', {
+        timeout: 1200,
+    });
+    await page.waitForTimeout(800);
+
+    const expandedBox = await scene.boundingBox();
+    expect(expandedBox).not.toBeNull();
+    if (!expandedBox) {
+        throw new Error('Expected expanded landing game to have a box.');
+    }
+
+    expect(expandedBox.x).toBeLessThanOrEqual(1);
+    expect(expandedBox.y).toBeLessThanOrEqual(1);
+    expect(expandedBox.width).toBeGreaterThanOrEqual(389);
+    expect(expandedBox.height).toBeGreaterThanOrEqual(843);
 });

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -39,6 +39,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     appBaseUrl?: string;
     spriteBaseUrl?: string;
     zoom?: 'far' | 'normal';
+    cameraPosition?: [x: number, y: number, z: number];
 
     // Demo purposes only
     freezeTime?: Date;
@@ -58,6 +59,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 export function GameScene({
+    cameraPosition = defaultGameCameraPosition,
     zoom = 'normal',
     noControls,
     noWeather,
@@ -110,7 +112,7 @@ export function GameScene({
         >
             <GameSceneDetailContext.Provider value={{ renderDetails }}>
                 <Scene
-                    position={defaultGameCameraPosition}
+                    position={cameraPosition}
                     quality={qualityProfile}
                     zoom={
                         zoom === 'far'

--- a/packages/ui/src/Nav/Nav.tsx
+++ b/packages/ui/src/Nav/Nav.tsx
@@ -1,10 +1,20 @@
-import type { PropsWithChildren, ReactElement, ReactNode } from 'react';
+'use client';
+
+import type {
+    MouseEvent,
+    PropsWithChildren,
+    ReactElement,
+    ReactNode,
+} from 'react';
+import { useEffect, useId, useState } from 'react';
 import { Button } from '../Button';
 import { Container } from '../Container';
-import { Menu as MenuIcon } from '../icons';
+import { IconButton } from '../IconButton';
+import { Close, Menu as MenuIcon } from '../icons';
 import { Link } from '../Link';
 import { Row } from '../Row';
 import { Stack } from '../Stack';
+import { cx } from '../utils';
 
 export type NavLinkItem = {
     href: string;
@@ -39,44 +49,133 @@ function renderNavItem(item: NavLinkItem | ReactElement, mobile = false) {
 }
 
 export function PageNav({ logo, links, children }: PageNavProps) {
+    const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+    const [isScrolled, setIsScrolled] = useState(false);
+    const menuId = useId();
+    const isFloating = isScrolled || mobileMenuOpen;
+
+    useEffect(() => {
+        let animationFrame = 0;
+
+        const updateScrolled = () => {
+            window.cancelAnimationFrame(animationFrame);
+            animationFrame = window.requestAnimationFrame(() => {
+                setIsScrolled(window.scrollY > 12);
+            });
+        };
+
+        updateScrolled();
+        window.addEventListener('scroll', updateScrolled, { passive: true });
+
+        return () => {
+            window.cancelAnimationFrame(animationFrame);
+            window.removeEventListener('scroll', updateScrolled);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!mobileMenuOpen) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setMobileMenuOpen(false);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [mobileMenuOpen]);
+
+    const closeMobileMenu = () => setMobileMenuOpen(false);
+    const handleMobileNavClick = (event: MouseEvent<HTMLElement>) => {
+        const target = event.target;
+        if (target instanceof Element && target.closest('a')) {
+            closeMobileMenu();
+        }
+    };
+
     return (
-        <div>
-            <input
-                aria-label="Toggle menu"
-                className="peer hidden"
-                id="mobile-menu-toggle"
-                type="checkbox"
-            />
-            <header className="fixed inset-x-0 top-0 z-10 flex h-16 items-center border-b border-muted/30 backdrop-blur-md transition-all peer-checked:border-border peer-checked:bg-card">
-                <Container>
-                    <Row justifyContent="space-between">
-                        <div className="flex h-full flex-col items-center">
-                            <Link href="/">{logo}</Link>
+        <div className="pointer-events-none fixed inset-x-0 top-0 z-40">
+            <Container
+                padded={false}
+                className={cx(
+                    'transition-[padding] duration-300 ease-out',
+                    isFloating
+                        ? 'px-2 pt-2 md:px-4 md:pt-3'
+                        : 'px-0 pt-0 md:px-4',
+                )}
+            >
+                <header
+                    className={cx(
+                        'pointer-events-auto relative flex h-16 items-center border-b border-muted/30 bg-background/75 backdrop-blur-md transition-[height,border-color,background-color,border-radius,box-shadow] duration-300 ease-out',
+                        isFloating &&
+                            'h-14 rounded-2xl border border-border/70 bg-background/80 shadow-lg shadow-foreground/10 backdrop-blur-xl',
+                    )}
+                >
+                    <div className="relative flex h-full w-full min-w-0 items-center justify-between gap-1 px-2 sm:gap-2 sm:px-3 md:px-4">
+                        <div className="flex h-full min-w-0 flex-1 flex-col items-start justify-center md:flex-none">
+                            <Link
+                                className="block min-w-0 [&>svg]:max-w-full"
+                                href="/"
+                                onClick={closeMobileMenu}
+                            >
+                                {logo}
+                            </Link>
                         </div>
-                        <Row spacing={0}>
+                        <Row spacing={0} className="min-w-0 shrink-0">
                             <nav className="hidden md:block">
                                 <Row spacing={0}>
                                     {links?.map((item) => renderNavItem(item))}
                                 </Row>
                             </nav>
-                            <label
-                                className="block md:hidden"
-                                htmlFor="mobile-menu-toggle"
+                            {children && (
+                                <div className="flex shrink-0 items-center gap-1 sm:gap-2 md:ml-2">
+                                    {children}
+                                </div>
+                            )}
+                            <IconButton
+                                aria-controls={menuId}
+                                aria-expanded={mobileMenuOpen}
+                                aria-label={
+                                    mobileMenuOpen
+                                        ? 'Zatvori navigaciju'
+                                        : 'Otvori navigaciju'
+                                }
+                                className="ml-1 shrink-0 rounded-full md:hidden"
+                                size="md"
+                                type="button"
+                                variant="plain"
+                                onClick={() =>
+                                    setMobileMenuOpen((current) => !current)
+                                }
                             >
-                                <MenuIcon aria-hidden className="size-6" />
-                            </label>
-                            {children && <div className="ml-2">{children}</div>}
+                                {mobileMenuOpen ? (
+                                    <Close aria-hidden className="size-5" />
+                                ) : (
+                                    <MenuIcon aria-hidden className="size-5" />
+                                )}
+                            </IconButton>
                         </Row>
-                    </Row>
-                </Container>
-            </header>
-            <nav className="hidden peer-checked:block md:hidden">
-                <div className="fixed inset-x-2 top-16 z-10 mt-2 rounded-lg border bg-card shadow-lg animate-in fade-in slide-in-from-top-2">
-                    <Stack>
-                        {links?.map((item) => renderNavItem(item, true))}
-                    </Stack>
-                </div>
-            </nav>
+                    </div>
+                </header>
+                <nav
+                    aria-label="Glavna navigacija"
+                    className={cx(
+                        'pointer-events-auto md:hidden',
+                        mobileMenuOpen ? 'block' : 'hidden',
+                    )}
+                    id={menuId}
+                    onClickCapture={handleMobileNavClick}
+                >
+                    <div className="mt-2 overflow-hidden rounded-2xl border border-border/70 bg-background/90 p-2 shadow-xl shadow-foreground/10 ring-1 ring-black/5 backdrop-blur-xl animate-in fade-in slide-in-from-top-2">
+                        <Stack spacing={1}>
+                            {links?.map((item) => renderNavItem(item, true))}
+                        </Stack>
+                    </div>
+                </nav>
+            </Container>
         </div>
     );
 }

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -129,6 +129,7 @@ export {
     Sparkles as AI,
     Sprout,
     Square as Stop,
+    SquareArrowRightEnter,
     Store,
     Sun,
     SunMoon,


### PR DESCRIPTION
## Summary
- Convert the shared nav into a mobile-friendly floating glass navbar that closes on link click / Escape and keeps desktop container width.
- Update the www landing game preview camera and rounded frame/card layout, including logged-in fullscreen morph behavior.
- Add focused Playwright coverage for nav closing, scroll morphing, game frame geometry, canvas rendering, and logged-in fullscreen behavior.

## Validation
- pnpm lint --filter @gredice/ui
- pnpm lint --filter @gredice/game
- pnpm lint --filter www
- pnpm lint --filter storybook
- pnpm lint --filter garden
- pnpm typecheck --filter @gredice/ui
- pnpm typecheck --filter @gredice/game
- pnpm typecheck --filter storybook
- pnpm test --filter @gredice/game
- pnpm build --filter garden
- pnpm build --filter www
- pnpm --filter www exec playwright test landing.spec.ts --config /private/tmp/gredice-www-playwright.config.ts --project=chromium
- git diff --check