### PR TITLE
Add plant page content anchor links

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -29,6 +29,24 @@ export function PlantPageHeader({
     const { totalPlants } = calculatePlantsPerField(
         plant.attributes?.seedingDistance,
     );
+    const contentLinks = informationSections
+        .filter((section) => section.avaialble)
+        .map((section) => ({
+            href: `#${slug(section.header)}`,
+            label: section.header,
+        }));
+    if ((plant.information.tip?.length ?? 0) > 0) {
+        contentLinks.push({
+            href: `#${slug('Savjeti')}`,
+            label: 'Savjeti',
+        });
+    }
+    if (!sort) {
+        contentLinks.push({
+            href: `#${slug('Sorte')}`,
+            label: 'Sorte',
+        });
+    }
 
     const baseLatinName = plant.information.latinName
         ? `lat. ${plant.information.latinName}`
@@ -99,23 +117,19 @@ export function PlantPageHeader({
                             Trenutno nije dostupna za sjetvu
                         </Typography>
                     )}
-                    {informationSections.some(
-                        (section) => section.avaialble,
-                    ) && (
+                    {contentLinks.length > 0 && (
                         <Stack spacing={2}>
                             <Typography level="body2">Sadržaj</Typography>
                             <Row spacing={2} className="flex-wrap">
-                                {informationSections
-                                    .filter((section) => section.avaialble)
-                                    .map((section) => (
-                                        <Chip
-                                            key={section.id}
-                                            color="neutral"
-                                            href={`#${slug(section.header)}`}
-                                        >
-                                            {section.header}
-                                        </Chip>
-                                    ))}
+                                {contentLinks.map((link) => (
+                                    <Chip
+                                        key={link.href}
+                                        color="neutral"
+                                        href={link.href}
+                                    >
+                                        {link.label}
+                                    </Chip>
+                                ))}
                             </Row>
                         </Stack>
                     )}

--- a/apps/www/app/biljke/[alias]/PlantSortsList.tsx
+++ b/apps/www/app/biljke/[alias]/PlantSortsList.tsx
@@ -24,7 +24,7 @@ async function PlantSortsListContent({
     if (!sorts.length) {
         return (
             <Stack spacing={4}>
-                <Typography level="h2" className="text-2xl">
+                <Typography level="h2" className="text-2xl" id={slug('Sorte')}>
                     Sorte
                 </Typography>
                 <Typography level="body2" className="text-gray-500 italic">

--- a/apps/www/app/biljke/[alias]/PlantTips.tsx
+++ b/apps/www/app/biljke/[alias]/PlantTips.tsx
@@ -1,4 +1,5 @@
 import type { PlantData } from '@gredice/client';
+import { slug } from '@gredice/js/slug';
 import { Accordion } from '@gredice/ui/Accordion';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -14,7 +15,7 @@ export function PlantTips({
 }) {
     return (
         <Stack spacing={4}>
-            <Typography level="h2" className="text-2xl">
+            <Typography level="h2" className="text-2xl" id={slug('Savjeti')}>
                 Savjeti
             </Typography>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- Add on-page `Savjeti` and `Sorte` quick links to the plant page content summary.
- Add on-page `Savjeti` quick links to plant sort page summaries when tips are rendered.
- Anchor the `Savjeti` heading and both populated and empty `Sorte` section headings.

## Validation
- `pnpm lint --filter www` passed.
- `pnpm build --filter www` passed.
- `pnpm test --filter www` ran the full sitemap Playwright suite: 557 passed, 4 failed on existing shared color-contrast issues in nav/footer/breadcrumb surfaces, including unrelated `/legalno/politika-privatnosti` and `/radnje/odrzavajuca-rezidba` routes.