### PR TITLE
Include plant alternative names in farm plant search

### DIFF
--- a/apps/farm/app/plants/PlantsHandbook.spec.tsx
+++ b/apps/farm/app/plants/PlantsHandbook.spec.tsx
@@ -1,0 +1,54 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { expect, test } from '@playwright/experimental-ct-react';
+import { PlantsHandbook } from './PlantsHandbook';
+
+const tomatoPlant = {
+    id: 1,
+    information: {
+        name: 'Rajčica',
+        label: 'Rajčica',
+        alternativeName: ['Paradajz', 'Pomidor'],
+    },
+} satisfies EntityStandardized;
+
+const tomatoSort = {
+    id: 101,
+    information: {
+        name: 'Cherry rajčica',
+        plant: tomatoPlant,
+    },
+} satisfies EntityStandardized;
+
+const basilSort = {
+    id: 102,
+    information: {
+        name: 'Genovese bosiljak',
+        plant: {
+            id: 2,
+            information: {
+                name: 'Bosiljak',
+                alternativeName: ['Bazilikum'],
+            },
+        },
+    },
+} satisfies EntityStandardized;
+
+test('plant handbook search includes parent plant alternative names', async ({
+    mount,
+    page,
+}) => {
+    await mount(<PlantsHandbook plantSortsData={[tomatoSort, basilSort]} />);
+
+    const searchInput = page.getByPlaceholder('Pretraži biljke');
+    await searchInput.click();
+    await searchInput.pressSequentially('paradajz');
+
+    await expect(searchInput).toBeFocused();
+    await expect(searchInput).toHaveValue('paradajz');
+    await expect(
+        page.getByRole('button', { name: /Cherry rajčica/ }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: /Genovese bosiljak/ }),
+    ).toHaveCount(0);
+});

--- a/apps/farm/app/plants/PlantsHandbook.tsx
+++ b/apps/farm/app/plants/PlantsHandbook.tsx
@@ -153,20 +153,33 @@ function getPlantSortLabel(plantSort: EntityStandardized) {
     );
 }
 
+function normalizePlantSearchText(value: string | null | undefined) {
+    return (value ?? '')
+        .replace(/[Đđ]/g, 'd')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLocaleLowerCase('hr-HR')
+        .trim();
+}
+
 function getPlantSortSearchText(plantSort: EntityStandardized) {
+    const plantInformation = plantSort.information?.plant?.information;
+
     return [
         plantSort.information?.label,
         plantSort.information?.name,
         plantSort.information?.shortDescription,
         plantSort.information?.description,
-        plantSort.information?.plant?.information?.label,
-        plantSort.information?.plant?.information?.name,
-        plantSort.information?.plant?.information?.shortDescription,
-        plantSort.information?.plant?.information?.description,
+        ...(plantSort.information?.alternativeName ?? []),
+        plantInformation?.label,
+        plantInformation?.name,
+        plantInformation?.shortDescription,
+        plantInformation?.description,
+        ...(plantInformation?.alternativeName ?? []),
     ]
         .filter((value) => typeof value === 'string')
-        .join(' ')
-        .toLocaleLowerCase('hr-HR');
+        .map((value) => normalizePlantSearchText(value))
+        .join(' ');
 }
 
 export function PlantsHandbook({ plantSortsData }: PlantsHandbookProps) {
@@ -174,7 +187,7 @@ export function PlantsHandbook({ plantSortsData }: PlantsHandbookProps) {
     const [selectedPlantSortId, setSelectedPlantSortId] = useState<
         number | null
     >(null);
-    const normalizedQuery = query.trim().toLocaleLowerCase('hr-HR');
+    const normalizedQuery = normalizePlantSearchText(query);
     const sortedPlantSorts = useMemo(
         () =>
             [...plantSortsData].sort((left, right) =>


### PR DESCRIPTION
## Summary
- Include plant sort and parent plant alternative names in the farm plants handbook search text.
- Normalize farm plant search text with the same Croatian diacritic handling used by plant/global search behavior.
- Add a Playwright component regression test for searching tomato by `paradajz`.

## Validation
- `pnpm lint --filter farm`
- `pnpm build --filter farm`
- `pnpm test --filter farm`

Note: the full farm test run logs existing local API/JWT environment warnings, but all assertions passed.