### PR TITLE
[codex] Add searchable select filtering

### DIFF
--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -287,6 +287,21 @@ function ControlledSelect() {
                 { value: 'today', label: 'Danas', icon: <Calendar /> },
                 { value: 'week', label: 'Tjedan', icon: <Dashboard /> },
                 {
+                    value: 'harvest',
+                    label: 'Berba',
+                    icon: <Leaf />,
+                },
+                {
+                    value: 'delivery',
+                    label: 'Dostava',
+                    icon: <Truck />,
+                },
+                {
+                    value: 'settings',
+                    label: 'Postavke',
+                    icon: <Settings />,
+                },
+                {
                     value: 'blocked',
                     label: 'Blokirano',
                     icon: <Warning />,

--- a/apps/storybook/stories/packages/ui/primitives/SelectItems.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/SelectItems.stories.tsx
@@ -63,6 +63,37 @@ export const WithIcons: Story = {
     },
 };
 
+const plantSortItems = [
+    { value: 'rajcica', label: 'Rajčica' },
+    { value: 'paprika', label: 'Paprika' },
+    { value: 'krastavac', label: 'Krastavac' },
+    { value: 'salata', label: 'Salata' },
+    { value: 'mrkva', label: 'Mrkva' },
+    { value: 'blitva', label: 'Blitva' },
+    { value: 'tikvica', label: 'Tikvica' },
+    { value: 'bosiljak', label: 'Bosiljak' },
+];
+
+export const SearchableList: Story = {
+    args: {
+        label: 'Biljka',
+        placeholder: 'Odaberi biljku',
+        items: plantSortItems,
+    },
+};
+
+export const ServerFilteredList: Story = {
+    args: {
+        label: 'Račun',
+        placeholder: 'Odaberi račun',
+        searchable: true,
+        clientSideFilter: false,
+        searchPlaceholder: 'Pretraži račune...',
+        items: plantSortItems.slice(0, 5),
+    },
+    render: (args) => <ServerFilteredSelect {...args} />,
+};
+
 export const EmptyStringValue: Story = {
     args: {
         defaultValue: '',
@@ -82,7 +113,7 @@ export const HelperText: Story = {
 
 function ControlledSelect(args: ComponentProps<typeof SelectItems>) {
     const [value, setValue] = useState<string | undefined>(
-        args.defaultValue as string | undefined,
+        defaultStringValue(args.defaultValue),
     );
 
     return (
@@ -94,4 +125,34 @@ function ControlledSelect(args: ComponentProps<typeof SelectItems>) {
             />
         </div>
     );
+}
+
+function ServerFilteredSelect(args: ComponentProps<typeof SelectItems>) {
+    const [value, setValue] = useState<string | undefined>(
+        defaultStringValue(args.defaultValue),
+    );
+    const [search, setSearch] = useState('');
+    const normalizedSearch = search.trim().toLocaleLowerCase();
+    const filteredItems = plantSortItems
+        .filter((item) =>
+            item.label.toLocaleLowerCase().includes(normalizedSearch),
+        )
+        .slice(0, 5);
+
+    return (
+        <div className="w-80">
+            <SelectItems
+                {...args}
+                items={filteredItems}
+                searchValue={search}
+                value={value}
+                onSearchValueChange={setSearch}
+                onValueChange={(nextValue) => setValue(nextValue)}
+            />
+        </div>
+    );
+}
+
+function defaultStringValue(value: unknown) {
+    return typeof value === 'string' ? value : undefined;
 }

--- a/apps/storybook/stories/packages/ui/primitives/SelectItems.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/SelectItems.stories.tsx
@@ -86,7 +86,6 @@ export const ServerFilteredList: Story = {
     args: {
         label: 'Račun',
         placeholder: 'Odaberi račun',
-        searchable: true,
         clientSideFilter: false,
         searchPlaceholder: 'Pretraži račune...',
         items: plantSortItems.slice(0, 5),

--- a/packages/ui/src/SelectItems/SelectItems.tsx
+++ b/packages/ui/src/SelectItems/SelectItems.tsx
@@ -2,16 +2,19 @@
 
 import * as SelectPrimitive from '@radix-ui/react-select';
 import type {
+    ChangeEvent,
     ComponentPropsWithoutRef,
     HTMLAttributes,
+    KeyboardEvent,
     ReactNode,
 } from 'react';
-import { useId } from 'react';
-import { Check, Down, Up } from '../icons';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Check, Down, Search, Up } from '../icons';
 import { Stack } from '../Stack';
 import { cx } from '../utils';
 
 const EMPTY_VALUE = '__gredice_select_empty__';
+const SEARCH_ITEM_THRESHOLD = 5;
 
 export type SelectItem<T extends string> = {
     value: T;
@@ -39,6 +42,15 @@ export type SelectItemsProps<T extends string> = Omit<
         helperText?: string;
         variant?: 'outlined' | 'plain';
         container?: HTMLElement;
+        /** Defaults to true when the select has more than five items. */
+        searchable?: boolean;
+        searchPlaceholder?: string;
+        searchValue?: string;
+        /** Supplying this disables client filtering unless `clientSideFilter` is true. */
+        onSearchValueChange?(value: string): void;
+        /** Set to false for paginated or server-filtered option sets. */
+        clientSideFilter?: boolean;
+        emptySearchText?: string;
     };
 
 function toSelectValue(value: string | undefined) {
@@ -57,17 +69,45 @@ function itemLabel<T extends string>(item: SelectItem<T>) {
     return item.content ?? item.label ?? item.value;
 }
 
+function itemSearchText<T extends string>(item: SelectItem<T>) {
+    return [
+        item.value,
+        item.title,
+        typeof item.label === 'string' ? item.label : undefined,
+        typeof item.content === 'string' ? item.content : undefined,
+    ]
+        .filter((part): part is string => Boolean(part))
+        .join(' ')
+        .toLocaleLowerCase();
+}
+
+function isInputEditingKey(event: KeyboardEvent<HTMLInputElement>) {
+    return (
+        event.key.length === 1 ||
+        event.key === 'Backspace' ||
+        event.key === 'Delete'
+    );
+}
+
 export function SelectItems<T extends string>({
+    clientSideFilter,
     className,
     container,
     defaultValue,
+    emptySearchText = 'Nema rezultata.',
     helperText,
     id,
     items,
     label,
     name,
+    onOpenChange,
+    onSearchValueChange,
     onValueChange,
+    open,
     placeholder,
+    searchable,
+    searchPlaceholder = 'Pretraži opcije...',
+    searchValue,
     value,
     variant = 'outlined',
     ...rest
@@ -75,6 +115,84 @@ export function SelectItems<T extends string>({
     const generatedId = useId();
     const inputId = id ?? name ?? generatedId;
     const labelId = label ? `label-${inputId}` : undefined;
+    const [internalOpen, setInternalOpen] = useState(false);
+    const [internalSearchValue, setInternalSearchValue] = useState('');
+    const searchInputRef = useRef<HTMLInputElement>(null);
+    const isOpen = open ?? internalOpen;
+    const shouldShowSearch = searchable ?? items.length > SEARCH_ITEM_THRESHOLD;
+    const shouldClientFilter = clientSideFilter ?? !onSearchValueChange;
+    const isSearchActive =
+        shouldShowSearch &&
+        (shouldClientFilter || Boolean(onSearchValueChange));
+    const searchQuery = searchValue ?? internalSearchValue;
+    const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
+    const visibleItems = useMemo(() => {
+        if (
+            !isSearchActive ||
+            !shouldClientFilter ||
+            normalizedSearchQuery.length === 0
+        ) {
+            return items;
+        }
+
+        return items.filter((item) =>
+            itemSearchText(item).includes(normalizedSearchQuery),
+        );
+    }, [isSearchActive, items, normalizedSearchQuery, shouldClientFilter]);
+
+    useEffect(() => {
+        if (!isOpen || !isSearchActive) {
+            return;
+        }
+
+        const timeoutId = setTimeout(() => {
+            searchInputRef.current?.focus();
+        }, 0);
+
+        return () => {
+            clearTimeout(timeoutId);
+        };
+    }, [isOpen, isSearchActive]);
+
+    useEffect(() => {
+        if (!isOpen && searchValue === undefined && internalSearchValue) {
+            setInternalSearchValue('');
+            onSearchValueChange?.('');
+        }
+    }, [internalSearchValue, isOpen, onSearchValueChange, searchValue]);
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        setInternalOpen(nextOpen);
+        onOpenChange?.(nextOpen);
+    };
+
+    const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const nextValue = event.target.value;
+
+        if (searchValue === undefined) {
+            setInternalSearchValue(nextValue);
+        }
+
+        onSearchValueChange?.(nextValue);
+    };
+
+    const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Escape' && searchQuery) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (searchValue === undefined) {
+                setInternalSearchValue('');
+            }
+
+            onSearchValueChange?.('');
+            return;
+        }
+
+        if (isInputEditingKey(event)) {
+            event.stopPropagation();
+        }
+    };
 
     return (
         <Stack className={className} spacing={1}>
@@ -90,9 +208,11 @@ export function SelectItems<T extends string>({
             <SelectPrimitive.Root
                 defaultValue={toSelectValue(defaultValue)}
                 name={name}
+                onOpenChange={handleOpenChange}
                 onValueChange={(nextValue) =>
                     onValueChange?.(fromSelectValue(nextValue))
                 }
+                open={open}
                 value={toSelectValue(value)}
                 {...rest}
             >
@@ -119,32 +239,61 @@ export function SelectItems<T extends string>({
                         <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
                             <Up className="size-4" />
                         </SelectPrimitive.ScrollUpButton>
+                        {isSearchActive ? (
+                            <div
+                                className="border-b p-1"
+                                onPointerDown={(event) =>
+                                    event.stopPropagation()
+                                }
+                            >
+                                <div className="flex h-9 items-center rounded-sm border border-input bg-background px-2 ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+                                    <Search className="size-4 shrink-0 text-muted-foreground" />
+                                    <input
+                                        ref={searchInputRef}
+                                        aria-label={searchPlaceholder}
+                                        className="min-w-0 flex-1 bg-transparent px-2 py-1 text-sm outline-hidden placeholder:text-muted-foreground"
+                                        onChange={handleSearchChange}
+                                        onKeyDown={handleSearchKeyDown}
+                                        placeholder={searchPlaceholder}
+                                        type="search"
+                                        value={searchQuery}
+                                    />
+                                </div>
+                            </div>
+                        ) : null}
                         <SelectPrimitive.Viewport className="h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] p-1">
-                            {items.map((item) => (
-                                <SelectPrimitive.Item
-                                    className="relative flex w-full cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
-                                    disabled={item.disabled}
-                                    key={item.value || EMPTY_VALUE}
-                                    title={item.title}
-                                    value={
-                                        toSelectValue(item.value) ?? item.value
-                                    }
-                                >
-                                    <span className="absolute left-2 flex size-3.5 items-center justify-center">
-                                        <SelectPrimitive.ItemIndicator>
-                                            <Check className="size-4" />
-                                        </SelectPrimitive.ItemIndicator>
-                                    </span>
-                                    <SelectPrimitive.ItemText>
-                                        <span className="flex items-center gap-2">
-                                            {item.icon}
-                                            <span className="line-clamp-1">
-                                                {itemLabel(item)}
-                                            </span>
+                            {visibleItems.length > 0 ? (
+                                visibleItems.map((item) => (
+                                    <SelectPrimitive.Item
+                                        className="relative flex w-full cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                                        disabled={item.disabled}
+                                        key={item.value || EMPTY_VALUE}
+                                        title={item.title}
+                                        value={
+                                            toSelectValue(item.value) ??
+                                            item.value
+                                        }
+                                    >
+                                        <span className="absolute left-2 flex size-3.5 items-center justify-center">
+                                            <SelectPrimitive.ItemIndicator>
+                                                <Check className="size-4" />
+                                            </SelectPrimitive.ItemIndicator>
                                         </span>
-                                    </SelectPrimitive.ItemText>
-                                </SelectPrimitive.Item>
-                            ))}
+                                        <SelectPrimitive.ItemText>
+                                            <span className="flex items-center gap-2">
+                                                {item.icon}
+                                                <span className="line-clamp-1">
+                                                    {itemLabel(item)}
+                                                </span>
+                                            </span>
+                                        </SelectPrimitive.ItemText>
+                                    </SelectPrimitive.Item>
+                                ))
+                            ) : (
+                                <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                                    {emptySearchText}
+                                </div>
+                            )}
                         </SelectPrimitive.Viewport>
                         <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
                             <Down className="size-4" />

--- a/packages/ui/src/SelectItems/SelectItems.tsx
+++ b/packages/ui/src/SelectItems/SelectItems.tsx
@@ -119,12 +119,16 @@ export function SelectItems<T extends string>({
     const [internalSearchValue, setInternalSearchValue] = useState('');
     const searchInputRef = useRef<HTMLInputElement>(null);
     const isOpen = open ?? internalOpen;
-    const shouldShowSearch = searchable ?? items.length > SEARCH_ITEM_THRESHOLD;
     const shouldClientFilter = clientSideFilter ?? !onSearchValueChange;
+    const searchQuery = searchValue ?? internalSearchValue;
+    const hasControlledServerSearch =
+        Boolean(onSearchValueChange) && !shouldClientFilter;
+    const shouldShowSearch =
+        searchable ??
+        (items.length > SEARCH_ITEM_THRESHOLD || hasControlledServerSearch);
     const isSearchActive =
         shouldShowSearch &&
         (shouldClientFilter || Boolean(onSearchValueChange));
-    const searchQuery = searchValue ?? internalSearchValue;
     const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
     const visibleItems = useMemo(() => {
         if (


### PR DESCRIPTION
## Summary
- Add automatic search to `SelectItems` when a select has more than five options.
- Support server-filtered or paginated option sets with controlled search props and `clientSideFilter={false}`.
- Add Storybook coverage for searchable and server-filtered select states, plus the UI showcase path.

## Validation
- `pnpm lint --filter @gredice/ui --filter storybook`
- `pnpm typecheck --filter @gredice/ui --filter storybook`
- `pnpm build --filter storybook`
- `pnpm build --filter app --filter farm --filter garden --filter www`
- Headless Storybook check verified search input autofocus, client filtering to `Rajčica`, and server-filtered search autofocus.