### PR TITLE
[Storybook] Fix shared UI styling and foundation primitive coverage

### DIFF
--- a/apps/storybook/stories/packages/ui/CorePrimitives.stories.tsx
+++ b/apps/storybook/stories/packages/ui/CorePrimitives.stories.tsx
@@ -62,6 +62,26 @@ const meta = {
                             <Search className="size-4" />
                         </IconButton>
                     </Row>
+                    <Row spacing={3} className="flex-wrap">
+                        <Button size="xs">Extra small</Button>
+                        <Button size="sm">Small</Button>
+                        <Button size="md">Medium</Button>
+                        <Button size="lg">Large</Button>
+                    </Row>
+                    <Row spacing={3} className="flex-wrap">
+                        <IconButton aria-label="Search extra small" size="xs">
+                            <Search className="size-3.5" />
+                        </IconButton>
+                        <IconButton aria-label="Search small" size="sm">
+                            <Search className="size-4" />
+                        </IconButton>
+                        <IconButton aria-label="Search medium" size="md">
+                            <Search className="size-4" />
+                        </IconButton>
+                        <IconButton aria-label="Search large" size="lg">
+                            <Search className="size-5" />
+                        </IconButton>
+                    </Row>
                     <Link className="text-primary underline" href="/">
                         Next link primitive
                     </Link>
@@ -76,6 +96,15 @@ const meta = {
                         placeholder="Find a plant"
                     />
                     <Row spacing={4} className="flex-wrap">
+                        <Chip color="neutral" size="sm">
+                            Small
+                        </Chip>
+                        <Chip color="neutral" size="md">
+                            Medium
+                        </Chip>
+                        <Chip color="neutral" size="lg">
+                            Large
+                        </Chip>
                         <Chip color="success">Ready</Chip>
                         <Chip color="warning">Needs review</Chip>
                         <Chip color="info" startDecorator={<Check />}>

--- a/apps/storybook/stories/packages/ui/primitives/Avatar.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Avatar.stories.tsx
@@ -1,0 +1,59 @@
+import { Avatar } from '@gredice/ui/Avatar';
+import { Row } from '@gredice/ui/Row';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Avatar',
+    component: Avatar,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Avatar renders either initials or an image in the shared circular identity primitive.',
+            },
+        },
+    },
+    args: {
+        children: 'AG',
+    },
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+    render: () => (
+        <Row spacing={3}>
+            <Avatar size="sm">SM</Avatar>
+            <Avatar size="md">MD</Avatar>
+            <Avatar size="lg">LG</Avatar>
+        </Row>
+    ),
+};
+
+export const Image: Story = {
+    args: {
+        alt: 'Farmer avatar',
+        src: 'https://cdn.gredice.com/avatars/farmer-female.png',
+    },
+};
+
+export const Group: Story = {
+    render: () => (
+        <Row spacing={0}>
+            <Avatar className="ring-2 ring-background" size="sm">
+                AK
+            </Avatar>
+            <Avatar className="-ml-2 ring-2 ring-background" size="sm">
+                MK
+            </Avatar>
+            <Avatar className="-ml-2 ring-2 ring-background" size="sm">
+                PT
+            </Avatar>
+        </Row>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Button.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Button.stories.tsx
@@ -1,0 +1,129 @@
+import { Button } from '@gredice/ui/Button';
+import { Check, Edit, Navigate, Warning } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Button',
+    component: Button,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Button is the shared action primitive for form submits, links, compact admin actions, and public calls to action.',
+            },
+        },
+    },
+    args: {
+        children: 'Spremi promjenu',
+    },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Button>Solid</Button>
+            <Button variant="soft">Soft</Button>
+            <Button variant="outlined">Outlined</Button>
+            <Button variant="plain">Plain</Button>
+            <Button href="/" variant="link">
+                Link
+            </Button>
+        </Row>
+    ),
+};
+
+export const Sizes: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Button size="xs">Extra small</Button>
+            <Button size="sm">Small</Button>
+            <Button size="md">Medium</Button>
+            <Button size="lg">Large</Button>
+        </Row>
+    ),
+};
+
+export const Colors: Story = {
+    render: () => (
+        <Stack spacing={3}>
+            <Row className="flex-wrap" spacing={3}>
+                <Button color="primary">Primary</Button>
+                <Button color="secondary">Secondary</Button>
+                <Button color="neutral">Neutral</Button>
+            </Row>
+            <Row className="flex-wrap" spacing={3}>
+                <Button color="success" variant="soft">
+                    Success
+                </Button>
+                <Button color="warning" variant="soft">
+                    Warning
+                </Button>
+                <Button color="danger" variant="soft">
+                    Danger
+                </Button>
+                <Button color="info" variant="soft">
+                    Info
+                </Button>
+            </Row>
+        </Stack>
+    ),
+};
+
+export const Decorators: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Button startDecorator={<Check className="size-4" />}>
+                Potvrdi
+            </Button>
+            <Button
+                endDecorator={<Navigate className="size-4" />}
+                href="/"
+                variant="outlined"
+            >
+                Otvori zapis
+            </Button>
+            <Button
+                color="warning"
+                startDecorator={<Warning className="size-4" />}
+                variant="soft"
+            >
+                Provjeri
+            </Button>
+        </Row>
+    ),
+};
+
+export const LoadingAndDisabled: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Button loading>Sinkronizacija</Button>
+            <Button disabled variant="outlined">
+                Nedostupno
+            </Button>
+            <Button
+                disabled
+                startDecorator={<Edit className="size-4" />}
+                variant="plain"
+            >
+                Zakljucano
+            </Button>
+        </Row>
+    ),
+};
+
+export const FullWidth: Story = {
+    render: () => (
+        <div className="w-80">
+            <Button fullWidth>Spremi postavke</Button>
+        </div>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Chip.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Chip.stories.tsx
@@ -1,0 +1,104 @@
+import { Chip } from '@gredice/ui/Chip';
+import { Check, Warning } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Chip',
+    component: Chip,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Chip displays compact status, filters, counts, and inline links with size, color, and variant coverage.',
+            },
+        },
+    },
+    args: {
+        children: 'Spremno',
+    },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Chip size="sm">Small</Chip>
+            <Chip size="md">Medium</Chip>
+            <Chip size="lg">Large</Chip>
+        </Row>
+    ),
+};
+
+export const Variants: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Chip variant="solid">Solid</Chip>
+            <Chip variant="soft">Soft</Chip>
+            <Chip variant="outlined">Outlined</Chip>
+            <Chip variant="plain">Plain</Chip>
+        </Row>
+    ),
+};
+
+export const Colors: Story = {
+    render: () => (
+        <Stack spacing={3}>
+            <Row className="flex-wrap" spacing={3}>
+                <Chip color="primary">Primary</Chip>
+                <Chip color="secondary">Secondary</Chip>
+                <Chip color="neutral">Neutral</Chip>
+            </Row>
+            <Row className="flex-wrap" spacing={3}>
+                <Chip color="success" variant="soft">
+                    Success
+                </Chip>
+                <Chip color="warning" variant="soft">
+                    Warning
+                </Chip>
+                <Chip color="error" variant="soft">
+                    Error
+                </Chip>
+                <Chip color="info" variant="soft">
+                    Info
+                </Chip>
+            </Row>
+        </Stack>
+    ),
+};
+
+export const Decorators: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Chip color="success" startDecorator={<Check />}>
+                Sinkronizirano
+            </Chip>
+            <Chip color="warning" startDecorator={<Warning />} variant="soft">
+                Potrebna provjera
+            </Chip>
+        </Row>
+    ),
+};
+
+export const Interactive: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Chip href="/" variant="outlined">
+                Link chip
+            </Chip>
+            <Chip onClick={() => undefined} variant="soft">
+                Button chip
+            </Chip>
+            <Chip disabled onClick={() => undefined}>
+                Disabled chip
+            </Chip>
+        </Row>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Container.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Container.stories.tsx
@@ -1,0 +1,72 @@
+import { Container } from '@gredice/ui/Container';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Container',
+    component: Container,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Container constrains page and section width while preserving the shared horizontal padding behavior.',
+            },
+        },
+    },
+    args: {
+        maxWidth: 'md',
+    },
+    render: (args) => (
+        <Container {...args}>
+            <div className="rounded-md border bg-card p-4">
+                <Typography level="body2">
+                    Constrained content inside a shared container.
+                </Typography>
+            </div>
+        </Container>
+    ),
+} satisfies Meta<typeof Container>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const MaxWidths: Story = {
+    render: () => (
+        <Stack className="w-[52rem]" spacing={3}>
+            <Container maxWidth="xs">
+                <div className="rounded-md border bg-card p-3 text-sm">xs</div>
+            </Container>
+            <Container maxWidth="sm">
+                <div className="rounded-md border bg-card p-3 text-sm">sm</div>
+            </Container>
+            <Container maxWidth="md">
+                <div className="rounded-md border bg-card p-3 text-sm">md</div>
+            </Container>
+            <Container maxWidth="lg">
+                <div className="rounded-md border bg-card p-3 text-sm">lg</div>
+            </Container>
+            <Container maxWidth={false}>
+                <div className="rounded-md border bg-card p-3 text-sm">
+                    full width
+                </div>
+            </Container>
+        </Stack>
+    ),
+};
+
+export const WithoutPadding: Story = {
+    args: {
+        padded: false,
+    },
+};
+
+export const NotCentered: Story = {
+    args: {
+        centered: false,
+    },
+};

--- a/apps/storybook/stories/packages/ui/primitives/Divider.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Divider.stories.tsx
@@ -1,0 +1,58 @@
+import { Divider } from '@gredice/ui/Divider';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Divider',
+    component: Divider,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Divider separates dense content groups with horizontal or vertical orientation.',
+            },
+        },
+    },
+    render: (args) => (
+        <Stack className="w-80" spacing={3}>
+            <Typography level="body2">Prva grupa</Typography>
+            <Divider {...args} />
+            <Typography level="body2">Druga grupa</Typography>
+        </Stack>
+    ),
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Vertical: Story = {
+    render: () => (
+        <Row className="h-16" spacing={4}>
+            <Typography level="body2">Lijevo</Typography>
+            <Divider flex orientation="vertical" />
+            <Typography level="body2">Desno</Typography>
+        </Row>
+    ),
+};
+
+export const InPanel: Story = {
+    render: () => (
+        <div className="w-80 rounded-lg border bg-card p-4">
+            <Stack spacing={3}>
+                <Typography level="body2" semiBold>
+                    Dnevni pregled
+                </Typography>
+                <Divider />
+                <Typography level="body3" secondary>
+                    Separator keeps compact metadata readable.
+                </Typography>
+            </Stack>
+        </div>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/IconButton.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/IconButton.stories.tsx
@@ -1,0 +1,122 @@
+import { IconButton } from '@gredice/ui/IconButton';
+import { MoreHorizontal, Search, Settings } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/IconButton',
+    component: IconButton,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'IconButton preserves Button sizing, variants, and disabled behavior for square icon-only controls.',
+            },
+        },
+    },
+    args: {
+        'aria-label': 'Pretraga',
+        children: <Search className="size-4" />,
+    },
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <IconButton aria-label="Plain search">
+                <Search className="size-4" />
+            </IconButton>
+            <IconButton aria-label="Soft settings" variant="soft">
+                <Settings className="size-4" />
+            </IconButton>
+            <IconButton aria-label="Solid settings" variant="solid">
+                <Settings className="size-4" />
+            </IconButton>
+            <IconButton aria-label="Outlined options" variant="outlined">
+                <MoreHorizontal className="size-4" />
+            </IconButton>
+        </Row>
+    ),
+};
+
+export const Sizes: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <IconButton aria-label="Search extra small" size="xs">
+                <Search className="size-3.5" />
+            </IconButton>
+            <IconButton aria-label="Search small" size="sm">
+                <Search className="size-4" />
+            </IconButton>
+            <IconButton aria-label="Search medium" size="md">
+                <Search className="size-4" />
+            </IconButton>
+            <IconButton aria-label="Search large" size="lg">
+                <Search className="size-5" />
+            </IconButton>
+        </Row>
+    ),
+};
+
+export const Colors: Story = {
+    render: () => (
+        <Stack spacing={3}>
+            <Row className="flex-wrap" spacing={3}>
+                <IconButton aria-label="Primary action" color="primary">
+                    <Search className="size-4" />
+                </IconButton>
+                <IconButton aria-label="Secondary action" color="secondary">
+                    <Search className="size-4" />
+                </IconButton>
+                <IconButton aria-label="Neutral action" color="neutral">
+                    <Search className="size-4" />
+                </IconButton>
+            </Row>
+            <Row className="flex-wrap" spacing={3}>
+                <IconButton
+                    aria-label="Success action"
+                    color="success"
+                    variant="soft"
+                >
+                    <Settings className="size-4" />
+                </IconButton>
+                <IconButton
+                    aria-label="Warning action"
+                    color="warning"
+                    variant="soft"
+                >
+                    <Settings className="size-4" />
+                </IconButton>
+                <IconButton
+                    aria-label="Danger action"
+                    color="danger"
+                    variant="soft"
+                >
+                    <Settings className="size-4" />
+                </IconButton>
+                <IconButton
+                    aria-label="Info action"
+                    color="info"
+                    variant="soft"
+                >
+                    <Settings className="size-4" />
+                </IconButton>
+            </Row>
+        </Stack>
+    ),
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+        variant: 'outlined',
+    },
+};

--- a/apps/storybook/stories/packages/ui/primitives/Input.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Input.stories.tsx
@@ -1,0 +1,85 @@
+import { Input } from '@gredice/ui/Input';
+import { Search, Settings } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Input',
+    component: Input,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Input provides label, helper text, decorators, width, and visual variants for compact data entry.',
+            },
+        },
+    },
+    args: {
+        label: 'Pretraga',
+        placeholder: 'Pronadi biljku',
+    },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+    render: () => (
+        <Stack spacing={4}>
+            <Input label="Outlined" placeholder="Zadani stil" />
+            <Input label="Soft" placeholder="Tiha povrsina" variant="soft" />
+            <Input label="Plain" placeholder="Bez okvira" variant="plain" />
+        </Stack>
+    ),
+};
+
+export const Decorators: Story = {
+    args: {
+        endDecorator: <Search className="mr-3 size-4" />,
+        helperText: 'Dekoratori se koriste za ikone, prefikse i status.',
+        label: 'Radnja',
+        placeholder: 'Pretrazi radnje',
+        startDecorator: <Settings className="ml-3 size-4" />,
+    },
+};
+
+export const States: Story = {
+    render: () => (
+        <Stack spacing={4}>
+            <Input
+                defaultValue="Jutarnji pregled"
+                helperText="Spremljena vrijednost."
+                label="Popunjeno"
+            />
+            <Input disabled label="Nedostupno" placeholder="Zakljucano polje" />
+            <Input readOnly defaultValue="Samo citanje" label="Read only" />
+        </Stack>
+    ),
+};
+
+export const FullWidth: Story = {
+    render: () => (
+        <div className="w-96">
+            <Input
+                fullWidth
+                helperText="Full width input fills the available panel width."
+                label="Naziv prikaza"
+                placeholder="Npr. tjedni plan"
+            />
+        </div>
+    ),
+};
+
+export const InlinePair: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Input placeholder="Ime" />
+            <Input placeholder="Prezime" />
+        </Row>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Link.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Link.stories.tsx
@@ -1,0 +1,76 @@
+import { Link } from '@gredice/ui/Link';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Link',
+    component: Link,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Link is the shared Next.js link primitive used when a surface owns its text and visual treatment.',
+            },
+        },
+    },
+    args: {
+        children: 'Otvori katalog',
+        className: 'text-primary underline underline-offset-4',
+        href: '/',
+    },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const InlineText: Story = {
+    render: () => (
+        <Typography className="max-w-md">
+            Pregledaj dostupne biljke u{' '}
+            <Link
+                className="text-primary underline underline-offset-4"
+                href="/"
+            >
+                katalogu
+            </Link>{' '}
+            prije izrade plana sadnje.
+        </Typography>
+    ),
+};
+
+export const NavigationList: Story = {
+    render: () => (
+        <Stack spacing={2}>
+            <Link
+                className="text-primary underline underline-offset-4"
+                href="/"
+            >
+                Biljke
+            </Link>
+            <Link
+                className="text-primary underline underline-offset-4"
+                href="/"
+            >
+                Radnje
+            </Link>
+            <Link
+                className="text-primary underline underline-offset-4"
+                href="/"
+            >
+                Dostava
+            </Link>
+        </Stack>
+    ),
+};
+
+export const Muted: Story = {
+    args: {
+        children: 'Pogledaj detalje',
+        className: 'text-muted-foreground underline underline-offset-4',
+    },
+};

--- a/apps/storybook/stories/packages/ui/primitives/Progress.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Progress.stories.tsx
@@ -1,0 +1,74 @@
+import { Progress } from '@gredice/ui/Progress';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Progress',
+    component: Progress,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Progress shows bounded completion values for capacity, sync, and operation status bars.',
+            },
+        },
+    },
+    args: {
+        'aria-label': 'Napredak sinkronizacije',
+        value: 68,
+    },
+    render: (args) => (
+        <div className="w-80">
+            <Progress {...args} />
+        </div>
+    ),
+} satisfies Meta<typeof Progress>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Values: Story = {
+    render: () => (
+        <Stack className="w-80" spacing={4}>
+            <Progress aria-label="Cetvrtina" value={25} />
+            <Progress aria-label="Polovica" value={50} />
+            <Progress aria-label="Skoro dovrseno" value={88} />
+        </Stack>
+    ),
+};
+
+export const BoundedValues: Story = {
+    render: () => (
+        <Stack className="w-80" spacing={4}>
+            <Stack spacing={2}>
+                <Typography level="body3" secondary>
+                    Negative values clamp to empty.
+                </Typography>
+                <Progress aria-label="Negativna vrijednost" value={-20} />
+            </Stack>
+            <Stack spacing={2}>
+                <Typography level="body3" secondary>
+                    Values above 100 clamp to full.
+                </Typography>
+                <Progress aria-label="Prevelika vrijednost" value={140} />
+            </Stack>
+        </Stack>
+    ),
+};
+
+export const CustomTrack: Story = {
+    render: () => (
+        <div className="w-80">
+            <Progress
+                aria-label="Status berbe"
+                trackClassName="bg-green-600"
+                value={72}
+            />
+        </div>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Row.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Row.stories.tsx
@@ -1,0 +1,85 @@
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+function SampleBox({ children }: { children: string }) {
+    return (
+        <div className="rounded-md border bg-card px-3 py-2 text-sm">
+            {children}
+        </div>
+    );
+}
+
+const meta = {
+    title: 'packages/ui/Foundation/Row',
+    component: Row,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Row provides horizontal flex layout with token-based spacing and alignment shortcuts.',
+            },
+        },
+    },
+    render: (args) => (
+        <Row {...args} spacing={3}>
+            <SampleBox>Prvi</SampleBox>
+            <SampleBox>Drugi</SampleBox>
+            <SampleBox>Treci</SampleBox>
+        </Row>
+    ),
+} satisfies Meta<typeof Row>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Spacing: Story = {
+    render: () => (
+        <Stack spacing={4}>
+            <Row spacing={1}>
+                <SampleBox>1</SampleBox>
+                <SampleBox>1</SampleBox>
+            </Row>
+            <Row spacing={3}>
+                <SampleBox>3</SampleBox>
+                <SampleBox>3</SampleBox>
+            </Row>
+            <Row spacing={6}>
+                <SampleBox>6</SampleBox>
+                <SampleBox>6</SampleBox>
+            </Row>
+        </Stack>
+    ),
+};
+
+export const Alignment: Story = {
+    render: () => (
+        <Row
+            alignItems="end"
+            className="h-28 rounded-md border p-3"
+            spacing={3}
+        >
+            <SampleBox>Kratko</SampleBox>
+            <div className="rounded-md border bg-card px-3 py-8 text-sm">
+                Visoko
+            </div>
+            <Typography level="body2">Poravnato dolje</Typography>
+        </Row>
+    ),
+};
+
+export const Wrapped: Story = {
+    render: () => (
+        <Row className="w-72 flex-wrap" spacing={2}>
+            <SampleBox>Dostava</SampleBox>
+            <SampleBox>Berba</SampleBox>
+            <SampleBox>Sadnja</SampleBox>
+            <SampleBox>Zalijevanje</SampleBox>
+        </Row>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Skeleton.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Skeleton.stories.tsx
@@ -1,0 +1,65 @@
+import { Avatar } from '@gredice/ui/Avatar';
+import { Row } from '@gredice/ui/Row';
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Skeleton',
+    component: Skeleton,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Skeleton provides the shared muted loading placeholder for rows, cards, and text blocks.',
+            },
+        },
+    },
+    args: {
+        className: 'h-5 w-48',
+    },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TextRows: Story = {
+    render: () => (
+        <Stack spacing={2}>
+            <Skeleton className="h-4 w-72" />
+            <Skeleton className="h-4 w-64" />
+            <Skeleton className="h-4 w-48" />
+        </Stack>
+    ),
+};
+
+export const AvatarRow: Story = {
+    render: () => (
+        <Row spacing={3}>
+            <Avatar size="md"> </Avatar>
+            <Stack spacing={2}>
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-28" />
+            </Stack>
+        </Row>
+    ),
+};
+
+export const CardPlaceholder: Story = {
+    render: () => (
+        <div className="w-80 rounded-lg border bg-card p-4">
+            <Stack spacing={4}>
+                <Skeleton className="h-36 w-full" />
+                <Stack spacing={2}>
+                    <Skeleton className="h-5 w-44" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-3/4" />
+                </Stack>
+            </Stack>
+        </div>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Spinner.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Spinner.stories.tsx
@@ -1,0 +1,58 @@
+import { Row } from '@gredice/ui/Row';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Spinner',
+    component: Spinner,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Spinner is the shared inline loading indicator used in buttons, rows, and compact async states.',
+            },
+        },
+    },
+    args: {
+        loadingLabel: 'Ucitavanje',
+    },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+    render: () => (
+        <Row spacing={4}>
+            <Spinner className="size-3" loadingLabel="Malo ucitavanje" />
+            <Spinner className="size-4" loadingLabel="Srednje ucitavanje" />
+            <Spinner className="size-5" loadingLabel="Veliko ucitavanje" />
+        </Row>
+    ),
+};
+
+export const InlineState: Story = {
+    render: () => (
+        <Row spacing={3}>
+            <Spinner loadingLabel="Sinkronizacija" />
+            <Typography level="body2">Sinkronizacija u tijeku</Typography>
+        </Row>
+    ),
+};
+
+export const NotLoading: Story = {
+    render: () => (
+        <Stack spacing={2}>
+            <Spinner loading={false} loadingLabel="Skriveno ucitavanje" />
+            <Typography level="body2" secondary>
+                The component renders nothing when loading is false.
+            </Typography>
+        </Stack>
+    ),
+};

--- a/apps/storybook/stories/packages/ui/primitives/Stack.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Stack.stories.tsx
@@ -1,0 +1,80 @@
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+function SampleBox({ children }: { children: string }) {
+    return (
+        <div className="rounded-md border bg-card px-3 py-2 text-sm">
+            {children}
+        </div>
+    );
+}
+
+const meta = {
+    title: 'packages/ui/Foundation/Stack',
+    component: Stack,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Stack provides vertical flex layout with token-based spacing and simple alignment controls.',
+            },
+        },
+    },
+    render: (args) => (
+        <Stack {...args} spacing={3}>
+            <SampleBox>Prvi red</SampleBox>
+            <SampleBox>Drugi red</SampleBox>
+            <SampleBox>Treci red</SampleBox>
+        </Stack>
+    ),
+} satisfies Meta<typeof Stack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Spacing: Story = {
+    render: () => (
+        <div className="grid gap-6 md:grid-cols-3">
+            <Stack spacing={1}>
+                <Typography level="body3" secondary>
+                    spacing 1
+                </Typography>
+                <SampleBox>A</SampleBox>
+                <SampleBox>B</SampleBox>
+            </Stack>
+            <Stack spacing={3}>
+                <Typography level="body3" secondary>
+                    spacing 3
+                </Typography>
+                <SampleBox>A</SampleBox>
+                <SampleBox>B</SampleBox>
+            </Stack>
+            <Stack spacing={6}>
+                <Typography level="body3" secondary>
+                    spacing 6
+                </Typography>
+                <SampleBox>A</SampleBox>
+                <SampleBox>B</SampleBox>
+            </Stack>
+        </div>
+    ),
+};
+
+export const Centered: Story = {
+    args: {
+        alignItems: 'center',
+        className: 'w-80 rounded-md border p-4',
+    },
+};
+
+export const SpaceBetween: Story = {
+    args: {
+        className: 'h-64 rounded-md border p-4',
+        justifyContent: 'space-between',
+    },
+};

--- a/apps/storybook/stories/packages/ui/primitives/Typography.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Typography.stories.tsx
@@ -1,0 +1,78 @@
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Foundation/Typography',
+    component: Typography,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Typography standardizes semantic headings, compact body text, emphasis, and status text across Gredice surfaces.',
+            },
+        },
+    },
+    args: {
+        children: 'Pregled aktivnih gredica',
+    },
+} satisfies Meta<typeof Typography>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Levels: Story = {
+    render: () => (
+        <Stack spacing={3}>
+            <Typography level="h1">Heading 1</Typography>
+            <Typography level="h2">Heading 2</Typography>
+            <Typography level="h3">Heading 3</Typography>
+            <Typography level="h4">Heading 4</Typography>
+            <Typography level="h5">Heading 5</Typography>
+            <Typography level="h6">Heading 6</Typography>
+            <Typography level="body1">Body 1 content</Typography>
+            <Typography level="body2">Body 2 supporting content</Typography>
+            <Typography level="body3">Body 3 compact metadata</Typography>
+        </Stack>
+    ),
+};
+
+export const Emphasis: Story = {
+    render: () => (
+        <Stack spacing={2}>
+            <Typography semiBold>Medium emphasis</Typography>
+            <Typography bold>Bold emphasis</Typography>
+            <Typography thin>Light emphasis</Typography>
+            <Typography uppercase>Uppercase label</Typography>
+            <Typography mono>operations.queue.status</Typography>
+        </Stack>
+    ),
+};
+
+export const Tone: Story = {
+    render: () => (
+        <Stack spacing={2}>
+            <Typography>Default foreground</Typography>
+            <Typography secondary>Secondary foreground</Typography>
+            <Typography tertiary>Tertiary foreground</Typography>
+            <Typography color="success">Success text</Typography>
+            <Typography color="warning">Warning text</Typography>
+            <Typography color="danger">Danger text</Typography>
+            <Typography color="info">Info text</Typography>
+        </Stack>
+    ),
+};
+
+export const NoWrap: Story = {
+    render: () => (
+        <div className="w-72 rounded-md border bg-card p-3">
+            <Typography noWrap>
+                Dugi naziv zapisa ostaje u jednom retku i zavrsava elipsom.
+            </Typography>
+        </div>
+    ),
+};

--- a/apps/storybook/styles.css
+++ b/apps/storybook/styles.css
@@ -28,12 +28,86 @@
     --tertiary-foreground: 28 20% 40%;
     --accent: 28 40% 90.1%;
     --accent-foreground: 28 47.4% 11.2%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 210 40% 98%;
     --ring: 28 20.2% 65.1%;
+    --radius: 0.5rem;
+    --light-display: visible;
+    --dark-display: none;
     --bg-selection: hsl(137, 40%, 24%);
     --text-selection: #fff;
     scrollbar-width: thin;
     scrollbar-color: color-mix(in srgb, currentColor 20%, transparent)
         transparent;
+}
+
+.dark {
+    --hue: 212;
+
+    --background: var(--hue) 16% 19%;
+    --foreground: var(--hue) 47% 92%;
+
+    --muted: var(--hue) 16% 10%;
+    --muted-foreground: var(--hue) 16% 98%;
+
+    --popover: var(--hue) 16% 19%;
+    --popover-foreground: var(--hue) 47% 89%;
+
+    --card: var(--hue) 16% 10%;
+    --card-transparent: var(--hue) 0% 0%;
+    --card-foreground: var(--hue) 17% 92%;
+
+    --border: var(--hue) 16% 25%;
+    --input: var(--hue) 31% 9%;
+
+    --primary: var(--hue) 16% 98%;
+    --primary-foreground: var(--hue) 40% 20%;
+
+    --secondary: var(--hue) 47% 25%;
+    --secondary-foreground: var(--hue) 10% 86%;
+
+    --tertiary: var(--hue) 16% 10%;
+    --tertiary-foreground: var(--hue) 10% 86%;
+
+    --accent: var(--hue) 20% 25%;
+    --accent-foreground: var(--hue) 47% 92%;
+
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 210 40% 98%;
+
+    --ring: var(--hue) 20% 65%;
+
+    --radius: 0.5rem;
+
+    --light-display: none;
+    --dark-display: visible;
+
+    --bg-selection: hsl(137, 40%, 90%);
+    --text-selection: #000;
+}
+
+@layer base {
+    * {
+        border-color: hsl(var(--border));
+    }
+
+    body {
+        background-color: hsl(var(--background));
+        color: hsl(var(--foreground));
+        font-feature-settings:
+            "rlig" 1,
+            "calt" 1;
+    }
+
+    button,
+    [role="button"] {
+        cursor: auto;
+    }
+
+    ::selection {
+        background: var(--bg-selection);
+        color: var(--text-selection);
+    }
 }
 
 html,
@@ -46,6 +120,18 @@ body,
 body {
     background: hsl(var(--background));
     color: hsl(var(--foreground));
+}
+
+.image--light {
+    display: var(--light-display);
+}
+
+.image--dark {
+    display: var(--dark-display);
+}
+
+svg.lucide {
+    stroke-width: 1.75px;
 }
 
 *::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

- Add focused Storybook stories for foundational `@gredice/ui` primitives: Button, IconButton, Typography, Input, Link, Chip, Avatar, Progress, Spinner, Skeleton, Container, Row, Stack, and Divider.
- Expand the core primitives showcase with missing Button, IconButton, and Chip size variants.
- Align Storybook global CSS with app/shared UI base behavior so bare borders, radius tokens, dark tokens, image light/dark helpers, selection colors, button cursor behavior, and lucide stroke widths match in-app rendering.

## Root Cause

Storybook defined the Gredice color tokens but did not include several shared base CSS rules used by the apps. Components that rely on base `border` color, `--radius`, or lucide icon defaults could render differently in Storybook than in actual app surfaces.

## Validation

- `pnpm lint --filter storybook`
- `pnpm build --filter storybook`
- `pnpm test --filter storybook`
- Browser smoke checks against local Storybook for Button, IconButton, CorePrimitives, Accordion, Card, Avatar, List, GentleSlide, and dark-mode Accordion border token behavior.