### PR TITLE
Rank exact global search matches above prefix-only hits

### DIFF
--- a/docs/search-public-contract.md
+++ b/docs/search-public-contract.md
@@ -142,6 +142,7 @@ These can be promoted once GRE-365 (canonical URL resolution) defines linkabilit
   - highest: title/name-like fields
   - medium: subtitle/taxonomy-like fields (e.g. latin name)
   - lower: long description/body fields
+  - exact token matches rank ahead of prefix-only matches, including alternative-name matches
 - **No results behavior:** return empty `results` with preserved query metadata and category facets.
 
 ## Reuse guarantees for non-www consumers

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -17,6 +17,7 @@ import { getEntityRaw } from './entitiesRepo';
 const minSearchQueryLength = 2;
 const defaultSearchLimit = 20;
 const maxSearchLimit = 50;
+const exactSearchMatchBoost = 10;
 
 type EntitySearchSource = NonNullable<Awaited<ReturnType<typeof getEntityRaw>>>;
 
@@ -713,12 +714,17 @@ export async function searchDirectoryEntities({
     const prefixTsQuery = prefixQueryText
         ? sql`to_tsquery('simple', ${prefixQueryText})`
         : null;
+    const exactRank = sql<number>`ts_rank_cd(${entitySearchDocuments.searchVector}, ${exactTsQuery})`;
+    const exactMatchBoost = prefixTsQuery
+        ? sql<number>`case when ${entitySearchDocuments.searchVector} @@ ${exactTsQuery} then ${exactSearchMatchBoost} else 0 end`
+        : sql<number>`0`;
     const score = prefixTsQuery
         ? sql<number>`
-            ts_rank_cd(${entitySearchDocuments.searchVector}, ${exactTsQuery}) +
+            ${exactMatchBoost} +
+            ${exactRank} +
             (ts_rank_cd(${entitySearchDocuments.searchVector}, ${prefixTsQuery}) * 0.5)
         `
-        : sql<number>`ts_rank_cd(${entitySearchDocuments.searchVector}, ${exactTsQuery})`;
+        : exactRank;
     const conditions = [
         eq(entitySearchDocuments.state, 'published'),
         prefixTsQuery

--- a/packages/storage/tests/entitySearchRepo.node.spec.ts
+++ b/packages/storage/tests/entitySearchRepo.node.spec.ts
@@ -198,6 +198,11 @@ test('directory entity search includes multiple plant alternative names', async 
         entityTypeLabel: 'Plant',
         title: 'Kupus',
     });
+    const titlePrefixMatchId = await createSearchableEntity({
+        entityTypeName: 'plant',
+        entityTypeLabel: 'Plant',
+        title: 'Zeljeznica',
+    });
     const alternativeNameDefinitionId = await createAttributeDefinition({
         category: 'information',
         name: 'alternativeName',
@@ -231,6 +236,11 @@ test('directory entity search includes multiple plant alternative names', async 
 
     assert.equal(zeljeRows[0]?.entityId, kupusId);
     assert.equal(kapusRows[0]?.entityId, kupusId);
+    assert.ok(zeljeRows.some((row) => row.entityId === titlePrefixMatchId));
+    assert.ok(
+        zeljeRows.findIndex((row) => row.entityId === kupusId) <
+            zeljeRows.findIndex((row) => row.entityId === titlePrefixMatchId),
+    );
 });
 
 test('directory entity search finds published operations without diacritics', async () => {


### PR DESCRIPTION
## Summary
- Boost exact token matches in directory search so full matches outrank prefix-only results.
- Keep the existing FTS weighting, but add an explicit priority bump for exact matches, including alternative-name hits.
- Extend the storage search test coverage to verify `zelje` ranks above a partial title match.

## Testing
- `pnpm test --filter @gredice/storage` passed
- `pnpm lint --filter @gredice/storage` passed
- `pnpm build --filter api` passed