### PR TITLE
Remove top spacing above the landing game scene

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -239,7 +239,7 @@ function StepsSection() {
 export default function Home() {
     return (
         <Stack>
-            <div className="relative pt-3 pb-4 md:pt-6">
+            <div className="relative pb-4">
                 <Container
                     maxWidth="xl"
                     className="relative px-2 sm:px-4 [--landing-card-radius:calc(var(--landing-frame-radius)*0.625)] [--landing-frame-radius:1.5rem] md:[--landing-frame-radius:2rem]"


### PR DESCRIPTION
## Summary
- Remove the homepage wrapper’s top padding so the landing game scene sits flush beneath the header.
- Keep the existing bottom spacing intact.

## Testing
- Lint and build for `www` passed.
- Browser measurement confirmed the frame now starts at the main content boundary with no top gap.