### PR TITLE
Build a WYSIWYG CMS page editor for admin

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -1,14 +1,39 @@
 'use client';
 
+import {
+    closestCenter,
+    DndContext,
+    type DragEndEvent,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import type { SelectCmsPage } from '@gredice/storage';
 import {
     type CmsPageSectionComponent,
+    type CmsPageSectionPreset,
     cmsPageSectionComponents,
+    cmsPageSectionPresets,
 } from '@gredice/storage/cmsPageSections';
 import { Button } from '@gredice/ui/Button';
 import { Card } from '@gredice/ui/Card';
 import { SectionsView } from '@gredice/ui/cms';
 import { Input } from '@gredice/ui/Input';
+import {
+    Add,
+    ArrowDown,
+    ArrowUp,
+    Delete,
+    Desktop,
+    Duplicate,
+    Mobile,
+    Tablet,
+} from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
@@ -23,6 +48,13 @@ import {
 } from 'react';
 import { sectionsComponentRegistry } from '../../../../components/shared/sectionsComponentRegistry';
 import type { CmsPageAutosaveState, CmsPageFormState } from './actions';
+import type {
+    CmsPageEditableSection,
+    CmsPageSectionData,
+} from './CmsPageFormTypes';
+import { CmsPageSectionFields } from './CmsPageSectionFields';
+import { CmsPageSectionLibrary } from './CmsPageSectionLibrary';
+import { CmsPageSortablePreviewSection } from './CmsPageSortablePreviewSection';
 
 type CmsPageFormProps = {
     page?: SelectCmsPage;
@@ -34,16 +66,6 @@ type CmsPageFormProps = {
     autosaveAction?: (formData: FormData) => Promise<CmsPageAutosaveState>;
 };
 
-type CmsPageSectionData = {
-    component: string;
-    [key: string]: unknown;
-};
-
-type CmsPageEditableSection = {
-    id: string;
-    data: CmsPageSectionData;
-};
-
 const cmsPageStateItems = [
     { value: 'draft', label: 'Draft' },
     {
@@ -51,12 +73,6 @@ const cmsPageStateItems = [
         label: 'Objavljeno',
     },
 ];
-
-const cmsPageSectionItems = cmsPageSectionComponents.map((component) => ({
-    value: component.component,
-    label: component.label,
-    category: component.isCustom ? 'Prilagođene' : 'Osnovne',
-}));
 
 const cmsPageSectionComponentsByName = new Map<string, CmsPageSectionComponent>(
     cmsPageSectionComponents.map((component) => [
@@ -129,6 +145,11 @@ function sectionValue(section: CmsPageEditableSection, key: string) {
     return typeof value === 'string' ? value : '';
 }
 
+function sectionListValue(section: CmsPageEditableSection, key: string) {
+    const value = section.data[key];
+    return Array.isArray(value) ? value : [];
+}
+
 function sectionLabel(component: string) {
     return cmsPageSectionComponentsByName.get(component)?.label ?? component;
 }
@@ -137,12 +158,30 @@ function sectionSummary(section: CmsPageEditableSection) {
     const fields =
         cmsPageSectionComponentsByName.get(section.data.component)?.fields ??
         [];
+
     for (const field of fields) {
+        if (
+            field.type === 'feature-list' ||
+            field.type === 'cta-list' ||
+            field.type === 'url'
+        ) {
+            continue;
+        }
+
         const value = sectionValue(section, field.key).trim();
         if (value.length > 0) {
             return value;
         }
     }
+
+    const firstFeature = sectionListValue(section, 'features').find(
+        (feature): feature is Record<string, unknown> =>
+            Boolean(feature) && typeof feature === 'object',
+    );
+    if (typeof firstFeature?.header === 'string') {
+        return firstFeature.header;
+    }
+
     return '';
 }
 
@@ -178,7 +217,7 @@ function copySection(
 ): CmsPageEditableSection {
     return {
         id,
-        data: JSON.parse(JSON.stringify(section.data)) as CmsPageSectionData,
+        data: structuredClone(section.data),
     };
 }
 
@@ -186,10 +225,15 @@ function validateSection(section: CmsPageEditableSection) {
     const fields =
         cmsPageSectionComponentsByName.get(section.data.component)?.fields ??
         [];
+
     return fields
         .filter((field) => field.required)
         .filter((field) => {
             const value = section.data[field.key];
+            if (field.type === 'feature-list' || field.type === 'cta-list') {
+                return !Array.isArray(value) || value.length === 0;
+            }
+
             return !(typeof value === 'string' && value.trim().length > 0);
         })
         .map((field) => `${field.label} je obavezno polje.`);
@@ -203,9 +247,16 @@ function sectionFieldErrors(section: CmsPageEditableSection) {
     return new Map(
         fields
             .filter((field) => field.required)
-            .filter(
-                (field) => sectionValue(section, field.key).trim().length === 0,
-            )
+            .filter((field) => {
+                if (
+                    field.type === 'feature-list' ||
+                    field.type === 'cta-list'
+                ) {
+                    return sectionListValue(section, field.key).length === 0;
+                }
+
+                return sectionValue(section, field.key).trim().length === 0;
+            })
             .map((field) => [field.key, `${field.label} je obavezno polje.`]),
     );
 }
@@ -219,10 +270,9 @@ function formatLastSavedAt(value: number | null) {
     }).format(new Date(value));
 }
 
-function updateSectionField(
+function updateSectionData(
     sectionId: string,
-    key: string,
-    value: string,
+    data: CmsPageSectionData,
     setSections: React.Dispatch<React.SetStateAction<CmsPageEditableSection[]>>,
 ) {
     setSections((current) =>
@@ -230,10 +280,7 @@ function updateSectionField(
             currentSection.id === sectionId
                 ? {
                       ...currentSection,
-                      data: {
-                          ...currentSection.data,
-                          [key]: value,
-                      },
+                      data,
                   }
                 : currentSection,
         ),
@@ -290,20 +337,15 @@ export function CmsPageForm({
     const [lastSavedAt, setLastSavedAt] = useState<number | null>(Date.now());
     const [lastSavedSnapshot, setLastSavedSnapshot] =
         useState(autosaveSnapshot);
-    const [previewSections, setPreviewSections] = useState<
-        CmsPageSectionData[]
-    >([]);
     const [selectedSectionId, setSelectedSectionId] = useState<string | null>(
         null,
     );
     const [insertAtEnd, setInsertAtEnd] = useState(false);
     const [sectionSearch, setSectionSearch] = useState('');
-    const [previewMode, setPreviewMode] = useState<'inline' | 'focused'>(
-        'inline',
-    );
     const [previewViewport, setPreviewViewport] = useState<
         'mobile' | 'tablet' | 'desktop'
     >('desktop');
+    const sensors = useSensors(useSensor(PointerSensor));
     const rawReadinessContent = useMemo(
         () => parseSections(rawContent),
         [rawContent],
@@ -387,16 +429,11 @@ export function CmsPageForm({
     ]);
 
     useEffect(() => {
-        setPreviewSections(parseSections(serializedContent).sections);
-    }, [serializedContent]);
-
-    useEffect(() => {
         if (sections.length === 0) {
             setSelectedSectionId(null);
             return;
         }
 
-        // Preserve explicit append mode instead of auto-selecting the first section.
         if (insertAtEnd && selectedSectionId === null) {
             return;
         }
@@ -425,28 +462,9 @@ export function CmsPageForm({
         insertAtEnd || selectedSectionIndex < 0
             ? undefined
             : selectedSectionIndex + 1;
-    const filteredSectionItems = useMemo(() => {
-        const query = sectionSearch.trim().toLowerCase();
-        if (!query) {
-            return cmsPageSectionItems;
-        }
-
-        return cmsPageSectionItems.filter(
-            (item) =>
-                item.label.toLowerCase().includes(query) ||
-                item.value.toLowerCase().includes(query),
-        );
-    }, [sectionSearch]);
-    const groupedSectionItems = useMemo(() => {
-        const grouped: Record<string, typeof cmsPageSectionItems> = {};
-        for (const item of filteredSectionItems) {
-            if (!grouped[item.category]) {
-                grouped[item.category] = [];
-            }
-            grouped[item.category].push(item);
-        }
-        return grouped;
-    }, [filteredSectionItems]);
+    const selectedSectionComponent = selectedSection
+        ? cmsPageSectionComponentsByName.get(selectedSection.data.component)
+        : undefined;
     const missingSectionFields = readinessSections
         .map((section, index) => ({
             section,
@@ -454,16 +472,17 @@ export function CmsPageForm({
             errors: validateSection(section),
         }))
         .filter((entry) => entry.errors.length > 0);
-    const metadataWarnings = [
-        {
-            label: 'Meta naslov',
-            value: metaTitle,
-        },
-        {
-            label: 'Meta opis',
-            value: metaDescription,
-        },
-    ].filter((entry) => entry.value.trim().length === 0);
+    const metadataIssues = [
+        ...(metaTitle.trim().length === 0 ? ['Meta naslov'] : []),
+        ...(metaDescription.trim().length === 0 ? ['Meta opis'] : []),
+        ...(metaDescription.length > 160
+            ? ['Meta opis je duži od 160 znakova']
+            : []),
+    ];
+    const publishReady =
+        missingSectionFields.length === 0 &&
+        metadataIssues.length === 0 &&
+        !contentReadinessWarning;
     const autosaveBadgeClassName =
         autosaveStatus === 'saved'
             ? 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30'
@@ -479,12 +498,12 @@ export function CmsPageForm({
               ? 'max-w-2xl'
               : 'max-w-none';
 
-    const insertSection = (component: string, index?: number) => {
+    const insertSectionData = (data: CmsPageSectionData, index?: number) => {
         const sectionId = nextSectionId.current;
         nextSectionId.current += 1;
         const id = `${newSectionIdPrefix}-${sectionId}`;
         setSections((current) => {
-            const entry = { id, data: { component } };
+            const entry = { id, data: structuredClone(data) };
             if (typeof index === 'number') {
                 const safeIndex = Math.max(0, Math.min(index, current.length));
                 return [
@@ -498,6 +517,68 @@ export function CmsPageForm({
         });
         setInsertAtEnd(false);
         setSelectedSectionId(id);
+    };
+
+    const insertSection = (component: string, index?: number) => {
+        insertSectionData({ component }, index);
+    };
+
+    const insertPreset = (preset: CmsPageSectionPreset, index?: number) => {
+        insertSectionData(preset.data, index);
+    };
+
+    const duplicateSection = (section: CmsPageEditableSection) => {
+        setSections((current) => {
+            const index = current.findIndex(
+                (candidate) => candidate.id === section.id,
+            );
+            if (index < 0) {
+                return current;
+            }
+
+            const sectionId = nextSectionId.current;
+            nextSectionId.current += 1;
+            const duplicate = copySection(
+                section,
+                `${newSectionIdPrefix}-${sectionId}`,
+            );
+            setSelectedSectionId(duplicate.id);
+            return [
+                ...current.slice(0, index + 1),
+                duplicate,
+                ...current.slice(index + 1),
+            ];
+        });
+    };
+
+    const removeSection = (sectionId: string) => {
+        setSections((current) =>
+            current.filter((section) => section.id !== sectionId),
+        );
+    };
+
+    const handleSectionDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        setSections((current) => {
+            const oldIndex = current.findIndex(
+                (section) => section.id === active.id,
+            );
+            const newIndex = current.findIndex(
+                (section) => section.id === over.id,
+            );
+
+            if (oldIndex < 0 || newIndex < 0) {
+                return current;
+            }
+
+            return arrayMove(current, oldIndex, newIndex);
+        });
+        setInsertAtEnd(false);
+        setSelectedSectionId(String(active.id));
     };
 
     return (
@@ -542,908 +623,695 @@ export function CmsPageForm({
                     </Row>
                 </Row>
             </Card>
-            <Card className="w-full">
-                <Stack spacing={8} className="p-4 md:p-6">
-                    <form
-                        id={reactId}
-                        ref={formRef}
-                        action={formAction}
-                        onChange={() =>
-                            setFormRevision((current) => current + 1)
-                        }
-                        onSubmit={(event) => {
-                            if (!rawMode) {
-                                return;
-                            }
+            <form
+                id={reactId}
+                ref={formRef}
+                action={formAction}
+                onChange={() => setFormRevision((current) => current + 1)}
+                onSubmit={(event) => {
+                    if (!rawMode) {
+                        return;
+                    }
 
-                            try {
-                                setRawContent(formatJsonContent(rawContent));
-                                setRawError(null);
-                            } catch {
-                                event.preventDefault();
-                                setRawError(
-                                    'JSON nije valjan. Ispravi sadržaj prije spremanja.',
-                                );
-                            }
-                        }}
-                    >
-                        <Stack spacing={8}>
-                            <Stack spacing={6}>
-                                {autosaveAction && (
-                                    <Card className="border-border/60 bg-muted/20 p-3">
-                                        <Stack spacing={2}>
-                                            <Typography level="body3" semiBold>
-                                                Autosave status
-                                            </Typography>
-                                            <Typography level="body3" secondary>
-                                                {autosaveMessage ??
-                                                    (autosaveStatus === 'failed'
-                                                        ? 'Spremanje nije uspjelo. Provjeri polja i pokušaj ponovno.'
-                                                        : autosaveStatus ===
-                                                            'unsaved'
-                                                          ? 'Imaš nespremljene promjene.'
-                                                          : autosaveStatus ===
-                                                              'saving'
-                                                            ? 'Promjene se spremaju...'
-                                                            : 'Sve promjene su spremljene.')}
-                                            </Typography>
-                                            <Typography level="body3" secondary>
-                                                Zadnje spremanje:{' '}
-                                                {formatLastSavedAt(
-                                                    lastSavedAt,
-                                                ) ?? 'Nije dostupno'}
-                                            </Typography>
-                                        </Stack>
-                                    </Card>
-                                )}
-                                <Input
-                                    name="title"
-                                    label="Naslov"
-                                    defaultValue={page?.title ?? ''}
-                                    required
-                                />
-                                <Input
-                                    name="slug"
-                                    label="Slug"
-                                    defaultValue={page?.slug ?? ''}
-                                    placeholder="npr. sezonski-vodic"
-                                    helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
-                                    required
-                                />
-                                <SelectItems
-                                    name="state"
-                                    label="Status"
-                                    defaultValue={page?.state ?? 'draft'}
-                                    items={cmsPageStateItems}
-                                />
-                                <Stack spacing={4}>
-                                    <Typography level="h3" semiBold>
-                                        Sadržaj stranice
-                                    </Typography>
-                                    <Typography level="body3" secondary>
-                                        Vizualni editor je zadani način rada, a
-                                        JSON editor je dostupan kao fallback.
-                                    </Typography>
-                                    <Row spacing={4}>
-                                        <Button
-                                            type="button"
-                                            variant={
-                                                !rawMode ? 'solid' : 'outlined'
-                                            }
-                                            onClick={() => setRawMode(false)}
-                                        >
-                                            Vizualni editor
-                                        </Button>
-                                        <Button
-                                            type="button"
-                                            variant={
-                                                rawMode ? 'solid' : 'outlined'
-                                            }
-                                            onClick={() => {
-                                                if (rawMode) {
-                                                    return;
-                                                }
-                                                setRawMode(true);
+                    try {
+                        setRawContent(formatJsonContent(rawContent));
+                        setRawError(null);
+                    } catch {
+                        event.preventDefault();
+                        setRawError(
+                            'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                        );
+                    }
+                }}
+            >
+                <Stack spacing={6}>
+                    {autosaveAction && (
+                        <Card className="border-border/60 bg-muted/20 p-3">
+                            <Stack spacing={2}>
+                                <Typography level="body3" semiBold>
+                                    Autosave status
+                                </Typography>
+                                <Typography level="body3" secondary>
+                                    {autosaveMessage ??
+                                        (autosaveStatus === 'failed'
+                                            ? 'Spremanje nije uspjelo. Provjeri polja i pokušaj ponovno.'
+                                            : autosaveStatus === 'unsaved'
+                                              ? 'Imaš nespremljene promjene.'
+                                              : autosaveStatus === 'saving'
+                                                ? 'Promjene se spremaju...'
+                                                : 'Sve promjene su spremljene.')}
+                                </Typography>
+                                <Typography level="body3" secondary>
+                                    Zadnje spremanje:{' '}
+                                    {formatLastSavedAt(lastSavedAt) ??
+                                        'Nije dostupno'}
+                                </Typography>
+                            </Stack>
+                        </Card>
+                    )}
+
+                    <Card className="p-4 md:p-6">
+                        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_14rem]">
+                            <Input
+                                name="title"
+                                label="Naslov"
+                                defaultValue={page?.title ?? ''}
+                                required
+                            />
+                            <Input
+                                name="slug"
+                                label="Slug"
+                                defaultValue={page?.slug ?? ''}
+                                placeholder="npr. sezonski-vodic"
+                                helperText="Slug se sprema normalizirano i ne smije zauzeti postojeću statičku rutu."
+                                required
+                            />
+                            <SelectItems
+                                name="state"
+                                label="Status"
+                                defaultValue={page?.state ?? 'draft'}
+                                items={cmsPageStateItems}
+                            />
+                        </div>
+                    </Card>
+
+                    <Stack spacing={4}>
+                        <Row
+                            spacing={4}
+                            className="flex-wrap items-center justify-between"
+                        >
+                            <Stack spacing={1}>
+                                <Typography level="h3" semiBold>
+                                    Sadržaj stranice
+                                </Typography>
+                                <Typography level="body3" secondary>
+                                    Vizualni editor sprema isti SectionData JSON
+                                    koji koristi javni www renderer.
+                                </Typography>
+                            </Stack>
+                            <Row spacing={2} className="flex-wrap">
+                                <Button
+                                    type="button"
+                                    variant={!rawMode ? 'solid' : 'outlined'}
+                                    onClick={() => setRawMode(false)}
+                                >
+                                    Vizualni editor
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant={rawMode ? 'solid' : 'outlined'}
+                                    onClick={() => {
+                                        if (rawMode) {
+                                            return;
+                                        }
+                                        setRawMode(true);
+                                        setRawError(null);
+                                        setRawContent(builderContent);
+                                    }}
+                                >
+                                    JSON fallback
+                                </Button>
+                            </Row>
+                        </Row>
+
+                        {preserveFallbackContent && (
+                            <Card className="p-3 text-sm text-amber-700">
+                                Postojeći sadržaj nije moguće prikazati u
+                                vizualnom editoru bez gubitka podataka.
+                            </Card>
+                        )}
+
+                        <input
+                            name="content"
+                            type="hidden"
+                            value={serializedContent}
+                            readOnly
+                        />
+
+                        {rawMode ? (
+                            <Card className="p-4">
+                                <label className="space-y-1">
+                                    <span className="block text-sm font-medium">
+                                        JSON sadržaj
+                                    </span>
+                                    <textarea
+                                        value={rawContent}
+                                        rows={18}
+                                        className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        onBlur={() => {
+                                            try {
+                                                setRawContent(
+                                                    formatJsonContent(
+                                                        rawContent,
+                                                    ),
+                                                );
                                                 setRawError(null);
-                                                setRawContent(builderContent);
+                                            } catch {
+                                                setRawError(
+                                                    'JSON nije valjan. Ispravi sadržaj prije spremanja.',
+                                                );
+                                            }
+                                        }}
+                                        onChange={(event) => {
+                                            setRawContent(event.target.value);
+                                            setRawError(null);
+                                        }}
+                                    />
+                                    {rawError && (
+                                        <Typography
+                                            level="body2"
+                                            className="text-red-600"
+                                        >
+                                            {rawError}
+                                        </Typography>
+                                    )}
+                                    {preserveFallbackContent && (
+                                        <Button
+                                            type="button"
+                                            variant="plain"
+                                            onClick={() => {
+                                                setRawContent(
+                                                    page?.content ?? '',
+                                                );
+                                                setRawError(null);
                                             }}
                                         >
-                                            JSON fallback
+                                            Vrati spremljeni sadržaj
                                         </Button>
-                                    </Row>
-                                    {preserveFallbackContent && (
-                                        <Card className="p-3 text-sm text-amber-700">
-                                            Postojeći sadržaj nije moguće
-                                            prikazati u vizualnom editoru bez
-                                            gubitka podataka.
-                                        </Card>
                                     )}
-                                    <input
-                                        name="content"
-                                        type="hidden"
-                                        value={serializedContent}
-                                        readOnly
-                                    />
-                                    {rawMode ? (
-                                        <label className="space-y-1">
-                                            <span className="block text-sm font-medium">
-                                                JSON sadržaj
-                                            </span>
-                                            <textarea
-                                                value={rawContent}
-                                                rows={16}
-                                                className="block w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                onBlur={() => {
-                                                    try {
-                                                        setRawContent(
-                                                            formatJsonContent(
-                                                                rawContent,
-                                                            ),
-                                                        );
-                                                        setRawError(null);
-                                                    } catch {
-                                                        setRawError(
-                                                            'JSON nije valjan. Ispravi sadržaj prije spremanja.',
-                                                        );
-                                                    }
-                                                }}
-                                                onChange={(event) => {
-                                                    setRawContent(
-                                                        event.target.value,
-                                                    );
-                                                    setRawError(null);
-                                                }}
-                                            />
-                                            {rawError && (
-                                                <Typography
-                                                    level="body2"
-                                                    className="text-red-600"
-                                                >
-                                                    {rawError}
-                                                </Typography>
-                                            )}
-                                            {preserveFallbackContent && (
-                                                <Button
-                                                    type="button"
-                                                    variant="plain"
-                                                    onClick={() => {
-                                                        setRawContent(
-                                                            page?.content ?? '',
-                                                        );
-                                                        setRawError(null);
-                                                    }}
-                                                >
-                                                    Vrati spremljeni sadržaj
-                                                </Button>
-                                            )}
-                                        </label>
-                                    ) : sections.length === 0 ? (
-                                        <Card className="p-4 text-sm text-muted-foreground">
-                                            {preserveFallbackContent
-                                                ? 'Postojeći sadržaj nije JSON niz sekcija i bit će sačuvan dok ne dodaš novu sekciju. Dodavanje nove sekcije zamijenit će ga novom strukturom sekcija.'
-                                                : 'Stranica još nema sekcija.'}
-                                        </Card>
-                                    ) : (
+                                </label>
+                            </Card>
+                        ) : (
+                            <div className="grid gap-6 xl:grid-cols-[18rem_minmax(0,1fr)_24rem]">
+                                <Stack spacing={6} className="h-fit">
+                                    <div className="rounded-lg border bg-background p-3">
+                                        <CmsPageSectionLibrary
+                                            query={sectionSearch}
+                                            components={
+                                                cmsPageSectionComponents
+                                            }
+                                            presets={cmsPageSectionPresets}
+                                            onQueryChange={setSectionSearch}
+                                            onInsertComponent={(component) =>
+                                                insertSection(
+                                                    component,
+                                                    insertionIndex,
+                                                )
+                                            }
+                                            onInsertPreset={(preset) =>
+                                                insertPreset(
+                                                    preset,
+                                                    insertionIndex,
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                    <div className="rounded-lg border bg-background p-3">
                                         <Stack spacing={4}>
-                                            {sections.map((section, index) => (
-                                                <Card
-                                                    key={section.id}
-                                                    className={`p-4 cursor-pointer ${selectedSectionId === section.id ? 'border-primary' : ''}`}
-                                                    onClick={() =>
-                                                        selectSection(
-                                                            section.id,
-                                                        )
-                                                    }
-                                                >
-                                                    <Stack spacing={4}>
-                                                        <Row
-                                                            spacing={4}
-                                                            className="items-center justify-between"
-                                                        >
-                                                            <Typography
-                                                                level="body1"
-                                                                semiBold
-                                                            >
-                                                                {index + 1}.{' '}
-                                                                {sectionLabel(
-                                                                    section.data
-                                                                        .component,
-                                                                )}
-                                                            </Typography>
-                                                            <Row spacing={2}>
-                                                                <Button
-                                                                    type="button"
-                                                                    variant="plain"
-                                                                    disabled={
-                                                                        index ===
-                                                                        0
-                                                                    }
-                                                                    onClick={() =>
-                                                                        setSections(
-                                                                            (
-                                                                                current,
-                                                                            ) =>
-                                                                                moveSection(
-                                                                                    current,
-                                                                                    section.id,
-                                                                                    -1,
-                                                                                ),
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    ↑ Gore
-                                                                </Button>
-                                                                <Button
-                                                                    type="button"
-                                                                    variant="plain"
-                                                                    disabled={
-                                                                        index ===
-                                                                        sections.length -
-                                                                            1
-                                                                    }
-                                                                    onClick={() =>
-                                                                        setSections(
-                                                                            (
-                                                                                current,
-                                                                            ) =>
-                                                                                moveSection(
-                                                                                    current,
-                                                                                    section.id,
-                                                                                    1,
-                                                                                ),
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    ↓ Dolje
-                                                                </Button>
-                                                                <Button
-                                                                    type="button"
-                                                                    variant="plain"
-                                                                    onClick={() => {
-                                                                        setSections(
-                                                                            (
-                                                                                current,
-                                                                            ) => {
-                                                                                const idx =
-                                                                                    current.findIndex(
-                                                                                        (
-                                                                                            candidate,
-                                                                                        ) =>
-                                                                                            candidate.id ===
-                                                                                            section.id,
-                                                                                    );
-                                                                                if (
-                                                                                    idx <
-                                                                                    0
-                                                                                ) {
-                                                                                    return current;
-                                                                                }
-                                                                                const sectionId =
-                                                                                    nextSectionId.current;
-                                                                                nextSectionId.current += 1;
-                                                                                const duplicate =
-                                                                                    copySection(
-                                                                                        section,
-                                                                                        `${newSectionIdPrefix}-${sectionId}`,
-                                                                                    );
-                                                                                return [
-                                                                                    ...current.slice(
-                                                                                        0,
-                                                                                        idx +
-                                                                                            1,
-                                                                                    ),
-                                                                                    duplicate,
-                                                                                    ...current.slice(
-                                                                                        idx +
-                                                                                            1,
-                                                                                    ),
-                                                                                ];
-                                                                            },
-                                                                        );
-                                                                    }}
-                                                                >
-                                                                    Dupliciraj
-                                                                </Button>
-                                                                <Button
-                                                                    type="button"
-                                                                    variant="plain"
-                                                                    color="danger"
-                                                                    onClick={() =>
-                                                                        setSections(
-                                                                            (
-                                                                                current,
-                                                                            ) =>
-                                                                                current.filter(
-                                                                                    (
-                                                                                        currentSection,
-                                                                                    ) =>
-                                                                                        currentSection.id !==
-                                                                                        section.id,
-                                                                                ),
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    Ukloni
-                                                                </Button>
-                                                            </Row>
-                                                        </Row>
-                                                        {validateSection(
-                                                            section,
-                                                        ).map((error) => (
-                                                            <Typography
-                                                                key={error}
-                                                                level="body3"
-                                                                className="text-red-600"
-                                                            >
-                                                                {error}
-                                                            </Typography>
-                                                        ))}
-                                                        {!sectionSummary(
-                                                            section,
-                                                        ) && (
-                                                            <Typography
-                                                                level="body3"
-                                                                secondary
-                                                            >
-                                                                Prazna sekcija —
-                                                                sadržaj dodaj
-                                                                kroz postavke
-                                                                polja.
-                                                            </Typography>
-                                                        )}
-                                                    </Stack>
-                                                </Card>
-                                            ))}
-                                        </Stack>
-                                    )}
-                                    {!rawMode && (
-                                        <Card className="p-3">
-                                            <Stack spacing={4}>
-                                                <Typography
-                                                    level="body2"
-                                                    semiBold
-                                                >
-                                                    Komponente
-                                                </Typography>
-                                                <Input
-                                                    label="Pretraži komponente"
-                                                    value={sectionSearch}
-                                                    onChange={(event) =>
-                                                        setSectionSearch(
-                                                            event.target.value,
-                                                        )
-                                                    }
-                                                    placeholder="npr. Heading ili Feature"
-                                                />
-                                                <Row
-                                                    spacing={2}
-                                                    className="flex-wrap"
-                                                >
-                                                    {Object.entries(
-                                                        groupedSectionItems,
-                                                    ).map(([group, items]) => (
-                                                        <Stack
-                                                            key={group}
-                                                            spacing={2}
-                                                            className="min-w-56"
-                                                        >
-                                                            <Typography
-                                                                level="body3"
-                                                                secondary
-                                                            >
-                                                                {group}
-                                                            </Typography>
-                                                            {items.map(
-                                                                (item) => (
-                                                                    <Button
-                                                                        key={
-                                                                            item.value
-                                                                        }
-                                                                        type="button"
-                                                                        variant="outlined"
-                                                                        onClick={() =>
-                                                                            insertSection(
-                                                                                item.value,
-                                                                                insertionIndex,
-                                                                            )
-                                                                        }
-                                                                    >
-                                                                        Dodaj{' '}
-                                                                        {
-                                                                            item.label
-                                                                        }
-                                                                    </Button>
-                                                                ),
-                                                            )}
-                                                        </Stack>
-                                                    ))}
-                                                </Row>
-                                            </Stack>
-                                        </Card>
-                                    )}
-                                </Stack>
-                            </Stack>
-
-                            <Stack spacing={4}>
-                                <Typography level="h3" semiBold>
-                                    Live preview
-                                </Typography>
-                                <Row spacing={4} className="flex-wrap">
-                                    <Button
-                                        type="button"
-                                        variant={
-                                            previewMode === 'inline'
-                                                ? 'solid'
-                                                : 'outlined'
-                                        }
-                                        onClick={() => setPreviewMode('inline')}
-                                    >
-                                        Inline preview
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant={
-                                            previewMode === 'focused'
-                                                ? 'solid'
-                                                : 'outlined'
-                                        }
-                                        onClick={() =>
-                                            setPreviewMode('focused')
-                                        }
-                                    >
-                                        Fokusirani preview
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant={
-                                            previewViewport === 'mobile'
-                                                ? 'solid'
-                                                : 'outlined'
-                                        }
-                                        onClick={() =>
-                                            setPreviewViewport('mobile')
-                                        }
-                                    >
-                                        Mobile
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant={
-                                            previewViewport === 'tablet'
-                                                ? 'solid'
-                                                : 'outlined'
-                                        }
-                                        onClick={() =>
-                                            setPreviewViewport('tablet')
-                                        }
-                                    >
-                                        Tablet
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant={
-                                            previewViewport === 'desktop'
-                                                ? 'solid'
-                                                : 'outlined'
-                                        }
-                                        onClick={() =>
-                                            setPreviewViewport('desktop')
-                                        }
-                                    >
-                                        Desktop
-                                    </Button>
-                                </Row>
-                                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
-                                    <Card
-                                        className={`p-4 ${previewMode === 'focused' ? 'lg:col-span-2' : ''}`}
-                                    >
-                                        <Stack spacing={4}>
-                                            {sections.map((section) => (
-                                                <Stack
-                                                    key={section.id}
-                                                    spacing={4}
-                                                    className={
-                                                        previewViewportClassName
-                                                    }
-                                                >
-                                                    <Card
-                                                        className={`p-3 cursor-pointer ${section.id === selectedSectionId ? 'border-primary' : ''}`}
-                                                        onClick={() =>
-                                                            selectSection(
-                                                                section.id,
-                                                            )
-                                                        }
-                                                    >
-                                                        <SectionsView
-                                                            sectionsData={[
-                                                                section.data,
-                                                            ]}
-                                                            componentsRegistry={
-                                                                sectionsComponentRegistry
-                                                            }
-                                                        />
-                                                    </Card>
-                                                </Stack>
-                                            ))}
-                                            {previewSections.length === 0 && (
+                                            <Typography level="h4" semiBold>
+                                                Navigator
+                                            </Typography>
+                                            {sections.length === 0 ? (
                                                 <Typography
                                                     level="body3"
                                                     secondary
                                                 >
-                                                    Nema sekcija za prikaz.
+                                                    Nema sekcija.
                                                 </Typography>
-                                            )}
-                                        </Stack>
-                                    </Card>
-                                    {previewMode === 'inline' && (
-                                        <Stack
-                                            spacing={6}
-                                            className="h-fit lg:sticky lg:top-24"
-                                        >
-                                            <Card className="p-4">
-                                                <Stack spacing={4}>
-                                                    <Typography
-                                                        level="h4"
-                                                        semiBold
-                                                    >
-                                                        Navigator sekcija
-                                                    </Typography>
-                                                    {sections.length === 0 ? (
-                                                        <Typography
-                                                            level="body3"
-                                                            secondary
+                                            ) : (
+                                                sections.map(
+                                                    (section, index) => (
+                                                        <Button
+                                                            key={`navigator-${section.id}`}
+                                                            type="button"
+                                                            variant={
+                                                                selectedSectionId ===
+                                                                section.id
+                                                                    ? 'solid'
+                                                                    : 'plain'
+                                                            }
+                                                            className="justify-start"
+                                                            onClick={() =>
+                                                                selectSection(
+                                                                    section.id,
+                                                                )
+                                                            }
                                                         >
-                                                            Dodaj prvu sekciju
-                                                            iz palete
-                                                            komponenti.
-                                                        </Typography>
-                                                    ) : (
-                                                        sections.map(
-                                                            (
-                                                                section,
-                                                                index,
-                                                            ) => (
-                                                                <Button
-                                                                    key={`navigator-${section.id}`}
-                                                                    type="button"
-                                                                    variant={
-                                                                        selectedSectionId ===
+                                                            {index + 1}.{' '}
+                                                            {sectionLabel(
+                                                                section.data
+                                                                    .component,
+                                                            )}
+                                                        </Button>
+                                                    ),
+                                                )
+                                            )}
+                                            <Button
+                                                type="button"
+                                                variant={
+                                                    insertAtEnd
+                                                        ? 'solid'
+                                                        : 'outlined'
+                                                }
+                                                startDecorator={
+                                                    <Add className="size-4" />
+                                                }
+                                                onClick={selectAppendTarget}
+                                            >
+                                                Dodaj na kraj
+                                            </Button>
+                                        </Stack>
+                                    </div>
+                                </Stack>
+
+                                <Stack spacing={4} className="min-w-0">
+                                    <Row
+                                        spacing={3}
+                                        className="flex-wrap items-center justify-between"
+                                    >
+                                        <Typography level="h4" semiBold>
+                                            Editor / preview
+                                        </Typography>
+                                        <Row spacing={2}>
+                                            <Button
+                                                type="button"
+                                                variant={
+                                                    previewViewport === 'mobile'
+                                                        ? 'solid'
+                                                        : 'outlined'
+                                                }
+                                                size="sm"
+                                                startDecorator={
+                                                    <Mobile className="size-4" />
+                                                }
+                                                onClick={() =>
+                                                    setPreviewViewport('mobile')
+                                                }
+                                            >
+                                                Mobile
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant={
+                                                    previewViewport === 'tablet'
+                                                        ? 'solid'
+                                                        : 'outlined'
+                                                }
+                                                size="sm"
+                                                startDecorator={
+                                                    <Tablet className="size-4" />
+                                                }
+                                                onClick={() =>
+                                                    setPreviewViewport('tablet')
+                                                }
+                                            >
+                                                Tablet
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant={
+                                                    previewViewport ===
+                                                    'desktop'
+                                                        ? 'solid'
+                                                        : 'outlined'
+                                                }
+                                                size="sm"
+                                                startDecorator={
+                                                    <Desktop className="size-4" />
+                                                }
+                                                onClick={() =>
+                                                    setPreviewViewport(
+                                                        'desktop',
+                                                    )
+                                                }
+                                            >
+                                                Desktop
+                                            </Button>
+                                        </Row>
+                                    </Row>
+                                    <div
+                                        className={`mx-auto w-full ${previewViewportClassName}`}
+                                    >
+                                        {sections.length === 0 ? (
+                                            <div className="min-h-96 rounded-lg border border-dashed bg-muted/20 p-8 text-center">
+                                                <Typography
+                                                    level="body2"
+                                                    secondary
+                                                >
+                                                    Stranica još nema sekcija.
+                                                </Typography>
+                                            </div>
+                                        ) : (
+                                            <DndContext
+                                                id={`cms-page-sections-${page?.id ?? 'new'}`}
+                                                sensors={sensors}
+                                                collisionDetection={
+                                                    closestCenter
+                                                }
+                                                onDragEnd={handleSectionDragEnd}
+                                            >
+                                                <SortableContext
+                                                    items={sections.map(
+                                                        (section) => section.id,
+                                                    )}
+                                                    strategy={
+                                                        verticalListSortingStrategy
+                                                    }
+                                                >
+                                                    <Stack spacing={4}>
+                                                        {sections.map(
+                                                            (section) => (
+                                                                <CmsPageSortablePreviewSection
+                                                                    key={
                                                                         section.id
-                                                                            ? 'solid'
-                                                                            : 'plain'
                                                                     }
-                                                                    className="justify-start"
-                                                                    onClick={() =>
+                                                                    id={
+                                                                        section.id
+                                                                    }
+                                                                    selected={
+                                                                        section.id ===
+                                                                        selectedSectionId
+                                                                    }
+                                                                    onSelect={() =>
                                                                         selectSection(
                                                                             section.id,
                                                                         )
                                                                     }
                                                                 >
-                                                                    {index + 1}.{' '}
-                                                                    {sectionLabel(
-                                                                        section
-                                                                            .data
-                                                                            .component,
-                                                                    )}
-                                                                </Button>
+                                                                    <SectionsView
+                                                                        sectionsData={[
+                                                                            section.data,
+                                                                        ]}
+                                                                        componentsRegistry={
+                                                                            sectionsComponentRegistry
+                                                                        }
+                                                                        debug
+                                                                    />
+                                                                </CmsPageSortablePreviewSection>
                                                             ),
-                                                        )
-                                                    )}
-                                                    <Row spacing={4}>
-                                                        <Button
-                                                            type="button"
-                                                            variant={
-                                                                insertAtEnd
-                                                                    ? 'solid'
-                                                                    : 'outlined'
-                                                            }
-                                                            onClick={
-                                                                selectAppendTarget
-                                                            }
-                                                        >
-                                                            Dodaj na kraj
-                                                        </Button>
-                                                        <Button
-                                                            type="button"
-                                                            variant="outlined"
-                                                            onClick={() =>
-                                                                insertSection(
-                                                                    cmsPageSectionItems[0]
-                                                                        ?.value ??
-                                                                        'Heading1',
-                                                                    insertionIndex,
-                                                                )
-                                                            }
-                                                        >
-                                                            Brzo dodaj sekciju
-                                                        </Button>
-                                                    </Row>
-                                                </Stack>
-                                            </Card>
-                                            <Card className="p-4">
-                                                <Stack spacing={4}>
+                                                        )}
+                                                    </Stack>
+                                                </SortableContext>
+                                            </DndContext>
+                                        )}
+                                    </div>
+                                </Stack>
+
+                                <Stack
+                                    spacing={4}
+                                    className="h-fit xl:sticky xl:top-24"
+                                >
+                                    <Card className="p-4">
+                                        <Stack spacing={4}>
+                                            <Row
+                                                spacing={2}
+                                                className="items-start justify-between"
+                                            >
+                                                <Stack spacing={1}>
                                                     <Typography
                                                         level="h4"
                                                         semiBold
                                                     >
-                                                        Postavke sekcije
+                                                        Detalji sekcije
                                                     </Typography>
-                                                    {!selectedSection ? (
+                                                    {selectedSection && (
                                                         <Typography
                                                             level="body3"
                                                             secondary
                                                         >
-                                                            Klikni sekciju u
-                                                            preview prikazu za
-                                                            uređivanje atributa.
+                                                            {
+                                                                selectedSection
+                                                                    .data
+                                                                    .component
+                                                            }
                                                         </Typography>
-                                                    ) : (
-                                                        <>
-                                                            <Typography
-                                                                level="body2"
-                                                                semiBold
-                                                            >
-                                                                {
-                                                                    selectedSection
-                                                                        .data
-                                                                        .component
-                                                                }
-                                                            </Typography>
-                                                            {(
-                                                                cmsPageSectionComponentsByName.get(
-                                                                    selectedSection
-                                                                        .data
-                                                                        .component,
-                                                                )?.fields ?? []
-                                                            ).map((field) =>
-                                                                field.type ===
-                                                                'textarea' ? (
-                                                                    <label
-                                                                        key={
-                                                                            field.key
-                                                                        }
-                                                                        className="space-y-1"
-                                                                    >
-                                                                        <span className="block text-sm font-medium">
-                                                                            {
-                                                                                field.label
-                                                                            }
-                                                                            {field.required && (
-                                                                                <span className="text-red-600">
-                                                                                    {' '}
-                                                                                    *
-                                                                                </span>
-                                                                            )}
-                                                                        </span>
-                                                                        <textarea
-                                                                            value={sectionValue(
-                                                                                selectedSection,
-                                                                                field.key,
-                                                                            )}
-                                                                            rows={
-                                                                                field.rows ??
-                                                                                4
-                                                                            }
-                                                                            className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                                                            onChange={(
-                                                                                event,
-                                                                            ) =>
-                                                                                updateSectionField(
-                                                                                    selectedSection.id,
-                                                                                    field.key,
-                                                                                    event
-                                                                                        .target
-                                                                                        .value,
-                                                                                    setSections,
-                                                                                )
-                                                                            }
-                                                                        />
-                                                                        {selectedSectionErrors.has(
-                                                                            field.key,
-                                                                        ) && (
-                                                                            <Typography
-                                                                                level="body3"
-                                                                                className="text-red-600"
-                                                                            >
-                                                                                {selectedSectionErrors.get(
-                                                                                    field.key,
-                                                                                )}
-                                                                            </Typography>
-                                                                        )}
-                                                                    </label>
-                                                                ) : (
-                                                                    <Stack
-                                                                        key={
-                                                                            field.key
-                                                                        }
-                                                                        spacing={
-                                                                            2
-                                                                        }
-                                                                    >
-                                                                        <Input
-                                                                            label={`${field.label}${field.required ? ' *' : ''}`}
-                                                                            value={sectionValue(
-                                                                                selectedSection,
-                                                                                field.key,
-                                                                            )}
-                                                                            onChange={(
-                                                                                event,
-                                                                            ) =>
-                                                                                updateSectionField(
-                                                                                    selectedSection.id,
-                                                                                    field.key,
-                                                                                    event
-                                                                                        .target
-                                                                                        .value,
-                                                                                    setSections,
-                                                                                )
-                                                                            }
-                                                                        />
-                                                                        {selectedSectionErrors.has(
-                                                                            field.key,
-                                                                        ) && (
-                                                                            <Typography
-                                                                                level="body3"
-                                                                                className="text-red-600"
-                                                                            >
-                                                                                {selectedSectionErrors.get(
-                                                                                    field.key,
-                                                                                )}
-                                                                            </Typography>
-                                                                        )}
-                                                                    </Stack>
-                                                                ),
-                                                            )}
-                                                            {selectedSectionErrors.size >
-                                                                0 && (
-                                                                <Typography
-                                                                    level="body3"
-                                                                    className="text-red-600"
-                                                                >
-                                                                    Sekcija ima
-                                                                    nepopunjena
-                                                                    obavezna
-                                                                    polja.
-                                                                </Typography>
-                                                            )}
-                                                        </>
                                                     )}
                                                 </Stack>
-                                            </Card>
-                                        </Stack>
-                                    )}
-                                </div>
-                            </Stack>
-
-                            <Stack spacing={6}>
-                                <Card className="p-4">
-                                    <Stack spacing={4}>
-                                        <Typography level="h3" semiBold>
-                                            Publish readiness
-                                        </Typography>
-                                        {missingSectionFields.length === 0 &&
-                                        metadataWarnings.length === 0 &&
-                                        !contentReadinessWarning ? (
-                                            <Typography
-                                                level="body3"
-                                                className="text-emerald-500"
-                                            >
-                                                Stranica je spremna za objavu.
-                                            </Typography>
-                                        ) : (
-                                            <Stack spacing={2}>
-                                                {contentReadinessWarning && (
-                                                    <Typography
-                                                        level="body3"
-                                                        className="text-amber-500"
-                                                    >
-                                                        {
-                                                            contentReadinessWarning
-                                                        }
-                                                    </Typography>
-                                                )}
-                                                {missingSectionFields.map(
-                                                    (entry) => (
-                                                        <Typography
-                                                            key={
-                                                                entry.section.id
+                                                {selectedSection && (
+                                                    <Row spacing={1}>
+                                                        <Button
+                                                            type="button"
+                                                            variant="plain"
+                                                            size="sm"
+                                                            disabled={
+                                                                selectedSectionIndex ===
+                                                                0
                                                             }
-                                                            level="body3"
-                                                            className="text-amber-500"
+                                                            aria-label="Pomakni sekciju gore"
+                                                            title="Pomakni sekciju gore"
+                                                            onClick={() =>
+                                                                setSections(
+                                                                    (current) =>
+                                                                        moveSection(
+                                                                            current,
+                                                                            selectedSection.id,
+                                                                            -1,
+                                                                        ),
+                                                                )
+                                                            }
                                                         >
-                                                            Sekcija{' '}
-                                                            {entry.index + 1} (
-                                                            {sectionLabel(
-                                                                entry.section
-                                                                    .data
-                                                                    .component,
-                                                            )}
-                                                            ) ima obavezna
-                                                            prazna polja.
-                                                        </Typography>
-                                                    ),
-                                                )}
-                                                {metadataWarnings.map(
-                                                    (warning) => (
-                                                        <Typography
-                                                            key={warning.label}
-                                                            level="body3"
-                                                            className="text-amber-500"
+                                                            <ArrowUp className="size-4" />
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="plain"
+                                                            size="sm"
+                                                            disabled={
+                                                                selectedSectionIndex ===
+                                                                sections.length -
+                                                                    1
+                                                            }
+                                                            aria-label="Pomakni sekciju dolje"
+                                                            title="Pomakni sekciju dolje"
+                                                            onClick={() =>
+                                                                setSections(
+                                                                    (current) =>
+                                                                        moveSection(
+                                                                            current,
+                                                                            selectedSection.id,
+                                                                            1,
+                                                                        ),
+                                                                )
+                                                            }
                                                         >
-                                                            Nedostaje:{' '}
-                                                            {warning.label}.
-                                                        </Typography>
-                                                    ),
+                                                            <ArrowDown className="size-4" />
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="plain"
+                                                            size="sm"
+                                                            aria-label="Dupliciraj sekciju"
+                                                            title="Dupliciraj sekciju"
+                                                            onClick={() =>
+                                                                duplicateSection(
+                                                                    selectedSection,
+                                                                )
+                                                            }
+                                                        >
+                                                            <Duplicate className="size-4" />
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="plain"
+                                                            color="danger"
+                                                            size="sm"
+                                                            aria-label="Ukloni sekciju"
+                                                            title="Ukloni sekciju"
+                                                            onClick={() =>
+                                                                removeSection(
+                                                                    selectedSection.id,
+                                                                )
+                                                            }
+                                                        >
+                                                            <Delete className="size-4" />
+                                                        </Button>
+                                                    </Row>
                                                 )}
-                                            </Stack>
-                                        )}
-                                    </Stack>
-                                </Card>
-                                <Card className="p-4">
-                                    <Stack spacing={4}>
-                                        <Typography level="h3" semiBold>
-                                            Metadata
-                                        </Typography>
-                                        <Input
-                                            name="metaTitle"
-                                            label="Meta naslov"
-                                            value={metaTitle}
-                                            onChange={(event) =>
-                                                setMetaTitle(event.target.value)
-                                            }
-                                        />
-                                        <Input
-                                            name="metaDescription"
-                                            label="Meta opis"
-                                            value={metaDescription}
-                                            onChange={(event) =>
-                                                setMetaDescription(
-                                                    event.target.value,
-                                                )
-                                            }
-                                        />
-                                        <Input
-                                            name="metaImageUrl"
-                                            label="Meta slika URL"
-                                            type="url"
-                                            defaultValue={
-                                                page?.metaImageUrl ?? ''
-                                            }
-                                        />
-                                        <Input
-                                            name="canonicalPath"
-                                            label="Canonical putanja"
-                                            defaultValue={
-                                                page?.canonicalPath ?? ''
-                                            }
-                                            placeholder="/primjer-stranice"
-                                        />
-                                        <label className="flex items-center gap-2 text-sm">
-                                            <input
-                                                type="checkbox"
-                                                name="noIndex"
-                                                defaultChecked={
-                                                    page?.noIndex ?? false
+                                            </Row>
+                                            {selectedSection && (
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    {selectedSectionComponent?.description ??
+                                                        sectionSummary(
+                                                            selectedSection,
+                                                        )}
+                                                </Typography>
+                                            )}
+                                            <CmsPageSectionFields
+                                                section={selectedSection}
+                                                fields={
+                                                    selectedSectionComponent?.fields ??
+                                                    []
+                                                }
+                                                fieldErrors={
+                                                    selectedSectionErrors
+                                                }
+                                                onChange={(sectionId, data) =>
+                                                    updateSectionData(
+                                                        sectionId,
+                                                        data,
+                                                        setSections,
+                                                    )
                                                 }
                                             />
-                                            Isključi iz indeksiranja (noindex)
-                                        </label>
-                                    </Stack>
-                                </Card>
-                            </Stack>
+                                        </Stack>
+                                    </Card>
 
-                            {state?.message && (
-                                <Typography
-                                    level="body2"
-                                    className="text-red-600"
-                                >
-                                    {state.message}
-                                </Typography>
-                            )}
-                        </Stack>
-                    </form>
+                                    <Card className="p-4">
+                                        <Stack spacing={4}>
+                                            <Typography level="h4" semiBold>
+                                                SEO
+                                            </Typography>
+                                            <Input
+                                                name="metaTitle"
+                                                label="Meta naslov"
+                                                value={metaTitle}
+                                                onChange={(event) =>
+                                                    setMetaTitle(
+                                                        event.target.value,
+                                                    )
+                                                }
+                                            />
+                                            <Input
+                                                name="metaDescription"
+                                                label="Meta opis"
+                                                value={metaDescription}
+                                                maxLength={160}
+                                                helperText={`${metaDescription.length}/160 znakova`}
+                                                onChange={(event) =>
+                                                    setMetaDescription(
+                                                        event.target.value,
+                                                    )
+                                                }
+                                            />
+                                            <Input
+                                                name="metaImageUrl"
+                                                label="Meta slika URL"
+                                                type="url"
+                                                defaultValue={
+                                                    page?.metaImageUrl ?? ''
+                                                }
+                                            />
+                                            <Input
+                                                name="canonicalPath"
+                                                label="Canonical putanja"
+                                                defaultValue={
+                                                    page?.canonicalPath ?? ''
+                                                }
+                                                placeholder="/primjer-stranice"
+                                            />
+                                            <label className="flex items-center gap-2 text-sm">
+                                                <input
+                                                    type="checkbox"
+                                                    name="noIndex"
+                                                    defaultChecked={
+                                                        page?.noIndex ?? false
+                                                    }
+                                                />
+                                                Isključi iz indeksiranja
+                                                (noindex)
+                                            </label>
+                                            <div className="rounded-md border bg-muted/20 p-3">
+                                                <Typography
+                                                    level="body3"
+                                                    semiBold
+                                                >
+                                                    {metaTitle ||
+                                                        page?.title ||
+                                                        'Meta naslov'}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="line-clamp-3"
+                                                    secondary
+                                                >
+                                                    {metaDescription ||
+                                                        'Meta opis za javni prikaz stranice.'}
+                                                </Typography>
+                                            </div>
+                                        </Stack>
+                                    </Card>
+
+                                    <Card className="p-4">
+                                        <Stack spacing={3}>
+                                            <Typography level="h4" semiBold>
+                                                Publish readiness
+                                            </Typography>
+                                            {publishReady ? (
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-emerald-500"
+                                                >
+                                                    Stranica je spremna za
+                                                    objavu.
+                                                </Typography>
+                                            ) : (
+                                                <Stack spacing={2}>
+                                                    {contentReadinessWarning && (
+                                                        <Typography
+                                                            level="body3"
+                                                            className="text-amber-500"
+                                                        >
+                                                            {
+                                                                contentReadinessWarning
+                                                            }
+                                                        </Typography>
+                                                    )}
+                                                    {missingSectionFields.map(
+                                                        (entry) => (
+                                                            <Typography
+                                                                key={
+                                                                    entry
+                                                                        .section
+                                                                        .id
+                                                                }
+                                                                level="body3"
+                                                                className="text-amber-500"
+                                                            >
+                                                                Sekcija{' '}
+                                                                {entry.index +
+                                                                    1}{' '}
+                                                                (
+                                                                {sectionLabel(
+                                                                    entry
+                                                                        .section
+                                                                        .data
+                                                                        .component,
+                                                                )}
+                                                                ) ima obavezna
+                                                                prazna polja.
+                                                            </Typography>
+                                                        ),
+                                                    )}
+                                                    {metadataIssues.map(
+                                                        (issue) => (
+                                                            <Typography
+                                                                key={issue}
+                                                                level="body3"
+                                                                className="text-amber-500"
+                                                            >
+                                                                {issue}
+                                                            </Typography>
+                                                        ),
+                                                    )}
+                                                </Stack>
+                                            )}
+                                        </Stack>
+                                    </Card>
+                                </Stack>
+                            </div>
+                        )}
+                    </Stack>
+
+                    {state?.message && (
+                        <Typography level="body2" className="text-red-600">
+                            {state.message}
+                        </Typography>
+                    )}
                 </Stack>
-            </Card>
+            </form>
         </Stack>
     );
 }

--- a/apps/app/app/admin/cms/pages/CmsPageFormTypes.ts
+++ b/apps/app/app/admin/cms/pages/CmsPageFormTypes.ts
@@ -1,0 +1,24 @@
+export type CmsPageCtaData = {
+    id?: string;
+    label?: string;
+    href?: string;
+    iconName?: string;
+    secondary?: boolean;
+};
+
+export type CmsPageFeatureData = {
+    id?: string;
+    header?: string;
+    description?: string;
+    ctas?: CmsPageCtaData[];
+};
+
+export type CmsPageSectionData = {
+    component: string;
+    [key: string]: unknown;
+};
+
+export type CmsPageEditableSection = {
+    id: string;
+    data: CmsPageSectionData;
+};

--- a/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
@@ -118,17 +118,20 @@ export function CmsPageSectionFields({
     fieldErrors,
     onChange,
 }: CmsPageSectionFieldsProps) {
+    const sectionId = section?.id;
+    const sectionData = section?.data;
+
     useEffect(() => {
-        if (!section) {
+        if (!sectionId || !sectionData) {
             return;
         }
 
         let changed = false;
-        const nextData: CmsPageSectionData = { ...section.data };
+        const nextData: CmsPageSectionData = { ...sectionData };
 
         for (const field of fields) {
             if (field.type === 'cta-list') {
-                const ctas = normalizeCtaValues(section.data[field.key]);
+                const ctas = normalizeCtaValues(sectionData[field.key]);
 
                 if (ctas.changed) {
                     changed = true;
@@ -137,9 +140,7 @@ export function CmsPageSectionFields({
             }
 
             if (field.type === 'feature-list') {
-                const features = normalizeFeatureValues(
-                    section.data[field.key],
-                );
+                const features = normalizeFeatureValues(sectionData[field.key]);
 
                 if (features.changed) {
                     changed = true;
@@ -149,9 +150,9 @@ export function CmsPageSectionFields({
         }
 
         if (changed) {
-            onChange(section.id, nextData);
+            onChange(sectionId, nextData);
         }
-    }, [fields, onChange, section]);
+    }, [fields, onChange, sectionData, sectionId]);
 
     if (!section) {
         return (

--- a/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
@@ -7,6 +7,7 @@ import { Add, Delete } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { useEffect } from 'react';
 import type {
     CmsPageCtaData,
     CmsPageEditableSection,
@@ -21,6 +22,12 @@ type CmsPageSectionFieldsProps = {
     onChange: (sectionId: string, data: CmsPageSectionData) => void;
 };
 
+type CmsPageCtaEditorData = CmsPageCtaData & { id: string };
+type CmsPageFeatureEditorData = Omit<CmsPageFeatureData, 'ctas'> & {
+    id: string;
+    ctas: CmsPageCtaEditorData[];
+};
+
 function textValue(value: unknown) {
     return typeof value === 'string' ? value : '';
 }
@@ -33,31 +40,68 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object';
 }
 
-function ctaValues(value: unknown): CmsPageCtaData[] {
+function normalizeCtaValues(value: unknown): {
+    items: CmsPageCtaEditorData[];
+    changed: boolean;
+} {
     if (!Array.isArray(value)) {
-        return [];
+        return { items: [], changed: false };
     }
 
-    return value.filter(isRecord).map((item) => ({
-        id: textValue(item.id),
-        label: textValue(item.label),
-        href: textValue(item.href),
-        iconName: textValue(item.iconName),
-        secondary: booleanValue(item.secondary),
-    }));
+    let changed = false;
+    const items = value.filter(isRecord).map((item) => {
+        const id = textValue(item.id);
+
+        if (!id) {
+            changed = true;
+        }
+
+        return {
+            id: id || crypto.randomUUID(),
+            label: textValue(item.label),
+            href: textValue(item.href),
+            iconName: textValue(item.iconName),
+            secondary: booleanValue(item.secondary),
+        };
+    });
+
+    return { items, changed };
 }
 
-function featureValues(value: unknown): CmsPageFeatureData[] {
+function ctaValues(value: unknown) {
+    return normalizeCtaValues(value).items;
+}
+
+function normalizeFeatureValues(value: unknown): {
+    items: CmsPageFeatureEditorData[];
+    changed: boolean;
+} {
     if (!Array.isArray(value)) {
-        return [];
+        return { items: [], changed: false };
     }
 
-    return value.filter(isRecord).map((item) => ({
-        id: textValue(item.id),
-        header: textValue(item.header),
-        description: textValue(item.description),
-        ctas: ctaValues(item.ctas),
-    }));
+    let changed = false;
+    const items = value.filter(isRecord).map((item) => {
+        const id = textValue(item.id);
+        const ctas = normalizeCtaValues(item.ctas);
+
+        if (!id || ctas.changed) {
+            changed = true;
+        }
+
+        return {
+            id: id || crypto.randomUUID(),
+            header: textValue(item.header),
+            description: textValue(item.description),
+            ctas: ctas.items,
+        };
+    });
+
+    return { items, changed };
+}
+
+function featureValues(value: unknown) {
+    return normalizeFeatureValues(value).items;
 }
 
 function replaceAt<T>(items: T[], index: number, value: T) {
@@ -74,6 +118,41 @@ export function CmsPageSectionFields({
     fieldErrors,
     onChange,
 }: CmsPageSectionFieldsProps) {
+    useEffect(() => {
+        if (!section) {
+            return;
+        }
+
+        let changed = false;
+        const nextData: CmsPageSectionData = { ...section.data };
+
+        for (const field of fields) {
+            if (field.type === 'cta-list') {
+                const ctas = normalizeCtaValues(section.data[field.key]);
+
+                if (ctas.changed) {
+                    changed = true;
+                    nextData[field.key] = ctas.items;
+                }
+            }
+
+            if (field.type === 'feature-list') {
+                const features = normalizeFeatureValues(
+                    section.data[field.key],
+                );
+
+                if (features.changed) {
+                    changed = true;
+                    nextData[field.key] = features.items;
+                }
+            }
+        }
+
+        if (changed) {
+            onChange(section.id, nextData);
+        }
+    }, [fields, onChange, section]);
+
     if (!section) {
         return (
             <Typography level="body3" secondary>
@@ -95,15 +174,15 @@ export function CmsPageSectionFields({
 
     const renderCtas = (
         key: string,
-        items: CmsPageCtaData[],
+        items: CmsPageCtaEditorData[],
         options: { allowIcon?: boolean; allowSecondary?: boolean },
-        updateItems: (items: CmsPageCtaData[]) => void,
+        updateItems: (items: CmsPageCtaEditorData[]) => void,
     ) => (
         <Stack spacing={3}>
             {items.map((cta, index) => (
                 <div
                     className="rounded-md border bg-background p-3"
-                    key={`${key}-${cta.id || cta.label || cta.href || cta.iconName}`}
+                    key={`${key}-${cta.id}`}
                 >
                     <Stack spacing={3}>
                         <Row spacing={2} className="items-start">
@@ -263,7 +342,7 @@ export function CmsPageSectionFields({
                             {items.map((feature, index) => (
                                 <div
                                     className="rounded-md border bg-background p-3"
-                                    key={`${field.key}-${feature.id || feature.header || feature.description}`}
+                                    key={`${field.key}-${feature.id}`}
                                 >
                                     <Stack spacing={3}>
                                         <Row
@@ -343,7 +422,7 @@ export function CmsPageSectionFields({
                                         )}
                                         {field.allowCtas &&
                                             renderCtas(
-                                                `${field.key}-${index}-ctas`,
+                                                `${field.key}-${feature.id}-ctas`,
                                                 feature.ctas ?? [],
                                                 { allowSecondary: true },
                                                 (nextCtas) =>

--- a/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import type { CmsPageSectionField } from '@gredice/storage/cmsPageSections';
+import { Button } from '@gredice/ui/Button';
+import { Input } from '@gredice/ui/Input';
+import { Add, Delete } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type {
+    CmsPageCtaData,
+    CmsPageEditableSection,
+    CmsPageFeatureData,
+    CmsPageSectionData,
+} from './CmsPageFormTypes';
+
+type CmsPageSectionFieldsProps = {
+    section?: CmsPageEditableSection;
+    fields: CmsPageSectionField[];
+    fieldErrors: Map<string, string>;
+    onChange: (sectionId: string, data: CmsPageSectionData) => void;
+};
+
+function textValue(value: unknown) {
+    return typeof value === 'string' ? value : '';
+}
+
+function booleanValue(value: unknown) {
+    return typeof value === 'boolean' ? value : false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object';
+}
+
+function ctaValues(value: unknown): CmsPageCtaData[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.filter(isRecord).map((item) => ({
+        id: textValue(item.id),
+        label: textValue(item.label),
+        href: textValue(item.href),
+        iconName: textValue(item.iconName),
+        secondary: booleanValue(item.secondary),
+    }));
+}
+
+function featureValues(value: unknown): CmsPageFeatureData[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.filter(isRecord).map((item) => ({
+        id: textValue(item.id),
+        header: textValue(item.header),
+        description: textValue(item.description),
+        ctas: ctaValues(item.ctas),
+    }));
+}
+
+function replaceAt<T>(items: T[], index: number, value: T) {
+    return items.map((item, itemIndex) => (itemIndex === index ? value : item));
+}
+
+function removeAt<T>(items: T[], index: number) {
+    return items.filter((_item, itemIndex) => itemIndex !== index);
+}
+
+export function CmsPageSectionFields({
+    section,
+    fields,
+    fieldErrors,
+    onChange,
+}: CmsPageSectionFieldsProps) {
+    if (!section) {
+        return (
+            <Typography level="body3" secondary>
+                Odaberi sekciju u preview prikazu.
+            </Typography>
+        );
+    }
+
+    const updateData = (data: CmsPageSectionData) => {
+        onChange(section.id, data);
+    };
+
+    const updateField = (key: string, value: unknown) => {
+        updateData({
+            ...section.data,
+            [key]: value,
+        });
+    };
+
+    const renderCtas = (
+        key: string,
+        items: CmsPageCtaData[],
+        options: { allowIcon?: boolean; allowSecondary?: boolean },
+        updateItems: (items: CmsPageCtaData[]) => void,
+    ) => (
+        <Stack spacing={3}>
+            {items.map((cta, index) => (
+                <div
+                    className="rounded-md border bg-background p-3"
+                    key={`${key}-${cta.id || cta.label || cta.href || cta.iconName}`}
+                >
+                    <Stack spacing={3}>
+                        <Row spacing={2} className="items-start">
+                            <Input
+                                fullWidth
+                                label="Label"
+                                value={cta.label ?? ''}
+                                onChange={(event) =>
+                                    updateItems(
+                                        replaceAt(items, index, {
+                                            ...cta,
+                                            label: event.target.value,
+                                        }),
+                                    )
+                                }
+                            />
+                            <Button
+                                type="button"
+                                variant="plain"
+                                color="danger"
+                                size="sm"
+                                aria-label="Ukloni poveznicu"
+                                title="Ukloni poveznicu"
+                                onClick={() =>
+                                    updateItems(removeAt(items, index))
+                                }
+                            >
+                                <Delete className="size-4" />
+                            </Button>
+                        </Row>
+                        <Input
+                            fullWidth
+                            label="Href"
+                            value={cta.href ?? ''}
+                            placeholder="/kontakt"
+                            onChange={(event) =>
+                                updateItems(
+                                    replaceAt(items, index, {
+                                        ...cta,
+                                        href: event.target.value,
+                                    }),
+                                )
+                            }
+                        />
+                        {options.allowIcon && (
+                            <Input
+                                fullWidth
+                                label="Ikona"
+                                value={cta.iconName ?? ''}
+                                placeholder="instagram, facebook, github"
+                                onChange={(event) =>
+                                    updateItems(
+                                        replaceAt(items, index, {
+                                            ...cta,
+                                            iconName: event.target.value,
+                                        }),
+                                    )
+                                }
+                            />
+                        )}
+                        {options.allowSecondary && (
+                            <label className="flex items-center gap-2 text-sm">
+                                <input
+                                    checked={Boolean(cta.secondary)}
+                                    type="checkbox"
+                                    onChange={(event) =>
+                                        updateItems(
+                                            replaceAt(items, index, {
+                                                ...cta,
+                                                secondary: event.target.checked,
+                                            }),
+                                        )
+                                    }
+                                />
+                                Sekundarni stil
+                            </label>
+                        )}
+                    </Stack>
+                </div>
+            ))}
+            <Button
+                type="button"
+                variant="outlined"
+                size="sm"
+                startDecorator={<Add className="size-4" />}
+                onClick={() =>
+                    updateItems([
+                        ...items,
+                        { id: crypto.randomUUID(), label: '', href: '' },
+                    ])
+                }
+            >
+                Dodaj poveznicu
+            </Button>
+        </Stack>
+    );
+
+    return (
+        <Stack spacing={4}>
+            {fields.map((field) => {
+                const error = fieldErrors.get(field.key);
+
+                if (field.type === 'cta-list') {
+                    const items = ctaValues(section.data[field.key]);
+
+                    return (
+                        <Stack spacing={3} key={field.key}>
+                            <Typography level="body2" semiBold>
+                                {field.label}
+                                {field.required && (
+                                    <span className="text-red-600"> *</span>
+                                )}
+                            </Typography>
+                            {field.helperText && (
+                                <Typography level="body3" secondary>
+                                    {field.helperText}
+                                </Typography>
+                            )}
+                            {renderCtas(
+                                field.key,
+                                items,
+                                {
+                                    allowIcon: field.allowIcon,
+                                    allowSecondary: field.allowSecondary,
+                                },
+                                (nextItems) =>
+                                    updateField(field.key, nextItems),
+                            )}
+                            {error && (
+                                <Typography
+                                    level="body3"
+                                    className="text-red-600"
+                                >
+                                    {error}
+                                </Typography>
+                            )}
+                        </Stack>
+                    );
+                }
+
+                if (field.type === 'feature-list') {
+                    const items = featureValues(section.data[field.key]);
+
+                    return (
+                        <Stack spacing={3} key={field.key}>
+                            <Typography level="body2" semiBold>
+                                {field.label}
+                                {field.required && (
+                                    <span className="text-red-600"> *</span>
+                                )}
+                            </Typography>
+                            {field.helperText && (
+                                <Typography level="body3" secondary>
+                                    {field.helperText}
+                                </Typography>
+                            )}
+                            {items.map((feature, index) => (
+                                <div
+                                    className="rounded-md border bg-background p-3"
+                                    key={`${field.key}-${feature.id || feature.header || feature.description}`}
+                                >
+                                    <Stack spacing={3}>
+                                        <Row
+                                            spacing={2}
+                                            className="items-start"
+                                        >
+                                            <Input
+                                                fullWidth
+                                                label={field.itemLabel}
+                                                value={feature.header ?? ''}
+                                                onChange={(event) =>
+                                                    updateField(
+                                                        field.key,
+                                                        replaceAt(
+                                                            items,
+                                                            index,
+                                                            {
+                                                                ...feature,
+                                                                header: event
+                                                                    .target
+                                                                    .value,
+                                                            },
+                                                        ),
+                                                    )
+                                                }
+                                            />
+                                            <Button
+                                                type="button"
+                                                variant="plain"
+                                                color="danger"
+                                                size="sm"
+                                                aria-label="Ukloni stavku"
+                                                title="Ukloni stavku"
+                                                onClick={() =>
+                                                    updateField(
+                                                        field.key,
+                                                        removeAt(items, index),
+                                                    )
+                                                }
+                                            >
+                                                <Delete className="size-4" />
+                                            </Button>
+                                        </Row>
+                                        {!field.allowCtas && (
+                                            <label className="space-y-1">
+                                                <span className="block text-sm font-medium">
+                                                    {field.itemLabel ===
+                                                    'Pitanje'
+                                                        ? 'Odgovor'
+                                                        : 'Opis'}
+                                                </span>
+                                                <textarea
+                                                    value={
+                                                        feature.description ??
+                                                        ''
+                                                    }
+                                                    rows={3}
+                                                    className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                    onChange={(event) =>
+                                                        updateField(
+                                                            field.key,
+                                                            replaceAt(
+                                                                items,
+                                                                index,
+                                                                {
+                                                                    ...feature,
+                                                                    description:
+                                                                        event
+                                                                            .target
+                                                                            .value,
+                                                                },
+                                                            ),
+                                                        )
+                                                    }
+                                                />
+                                            </label>
+                                        )}
+                                        {field.allowCtas &&
+                                            renderCtas(
+                                                `${field.key}-${index}-ctas`,
+                                                feature.ctas ?? [],
+                                                { allowSecondary: true },
+                                                (nextCtas) =>
+                                                    updateField(
+                                                        field.key,
+                                                        replaceAt(
+                                                            items,
+                                                            index,
+                                                            {
+                                                                ...feature,
+                                                                ctas: nextCtas,
+                                                            },
+                                                        ),
+                                                    ),
+                                            )}
+                                    </Stack>
+                                </div>
+                            ))}
+                            <Button
+                                type="button"
+                                variant="outlined"
+                                size="sm"
+                                startDecorator={<Add className="size-4" />}
+                                onClick={() =>
+                                    updateField(field.key, [
+                                        ...items,
+                                        {
+                                            id: crypto.randomUUID(),
+                                            header: '',
+                                            description: '',
+                                        },
+                                    ])
+                                }
+                            >
+                                Dodaj {field.itemLabel.toLowerCase()}
+                            </Button>
+                            {error && (
+                                <Typography
+                                    level="body3"
+                                    className="text-red-600"
+                                >
+                                    {error}
+                                </Typography>
+                            )}
+                        </Stack>
+                    );
+                }
+
+                if (field.type === 'textarea') {
+                    return (
+                        <label className="space-y-1" key={field.key}>
+                            <span className="block text-sm font-medium">
+                                {field.label}
+                                {field.required && (
+                                    <span className="text-red-600"> *</span>
+                                )}
+                            </span>
+                            <textarea
+                                value={textValue(section.data[field.key])}
+                                rows={field.rows ?? 4}
+                                placeholder={field.placeholder}
+                                className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                onChange={(event) =>
+                                    updateField(field.key, event.target.value)
+                                }
+                            />
+                            {field.helperText && (
+                                <Typography level="body3" secondary>
+                                    {field.helperText}
+                                </Typography>
+                            )}
+                            {error && (
+                                <Typography
+                                    level="body3"
+                                    className="text-red-600"
+                                >
+                                    {error}
+                                </Typography>
+                            )}
+                        </label>
+                    );
+                }
+
+                return (
+                    <Stack spacing={2} key={field.key}>
+                        <Input
+                            fullWidth
+                            label={`${field.label}${field.required ? ' *' : ''}`}
+                            placeholder={field.placeholder}
+                            type={field.type === 'url' ? 'url' : 'text'}
+                            value={textValue(section.data[field.key])}
+                            onChange={(event) =>
+                                updateField(field.key, event.target.value)
+                            }
+                        />
+                        {field.helperText && (
+                            <Typography level="body3" secondary>
+                                {field.helperText}
+                            </Typography>
+                        )}
+                        {error && (
+                            <Typography level="body3" className="text-red-600">
+                                {error}
+                            </Typography>
+                        )}
+                    </Stack>
+                );
+            })}
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageSectionFields.tsx
@@ -7,7 +7,7 @@ import { Add, Delete } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type {
     CmsPageCtaData,
     CmsPageEditableSection,
@@ -27,6 +27,21 @@ type CmsPageFeatureEditorData = Omit<CmsPageFeatureData, 'ctas'> & {
     id: string;
     ctas: CmsPageCtaEditorData[];
 };
+
+let fallbackIdCounter = 0;
+
+function createEditorId() {
+    if (
+        typeof crypto !== 'undefined' &&
+        typeof crypto.randomUUID === 'function'
+    ) {
+        return crypto.randomUUID();
+    }
+
+    fallbackIdCounter += 1;
+
+    return `cms-editor-${Date.now().toString(36)}-${fallbackIdCounter.toString(36)}`;
+}
 
 function textValue(value: unknown) {
     return typeof value === 'string' ? value : '';
@@ -57,7 +72,7 @@ function normalizeCtaValues(value: unknown): {
         }
 
         return {
-            id: id || crypto.randomUUID(),
+            id: id || createEditorId(),
             label: textValue(item.label),
             href: textValue(item.href),
             iconName: textValue(item.iconName),
@@ -90,7 +105,7 @@ function normalizeFeatureValues(value: unknown): {
         }
 
         return {
-            id: id || crypto.randomUUID(),
+            id: id || createEditorId(),
             header: textValue(item.header),
             description: textValue(item.description),
             ctas: ctas.items,
@@ -120,9 +135,16 @@ export function CmsPageSectionFields({
 }: CmsPageSectionFieldsProps) {
     const sectionId = section?.id;
     const sectionData = section?.data;
+    const normalizedSectionData = useRef<WeakSet<CmsPageSectionData>>(
+        new WeakSet(),
+    );
 
     useEffect(() => {
-        if (!sectionId || !sectionData) {
+        if (
+            !sectionId ||
+            !sectionData ||
+            normalizedSectionData.current.has(sectionData)
+        ) {
             return;
         }
 
@@ -150,8 +172,12 @@ export function CmsPageSectionFields({
         }
 
         if (changed) {
+            normalizedSectionData.current.add(nextData);
             onChange(sectionId, nextData);
+            return;
         }
+
+        normalizedSectionData.current.add(sectionData);
     }, [fields, onChange, sectionData, sectionId]);
 
     if (!section) {
@@ -272,7 +298,7 @@ export function CmsPageSectionFields({
                 onClick={() =>
                     updateItems([
                         ...items,
-                        { id: crypto.randomUUID(), label: '', href: '' },
+                        { id: createEditorId(), label: '', href: '' },
                     ])
                 }
             >
@@ -451,7 +477,7 @@ export function CmsPageSectionFields({
                                     updateField(field.key, [
                                         ...items,
                                         {
-                                            id: crypto.randomUUID(),
+                                            id: createEditorId(),
                                             header: '',
                                             description: '',
                                         },

--- a/apps/app/app/admin/cms/pages/CmsPageSectionLibrary.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageSectionLibrary.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import type {
+    CmsPageSectionComponent,
+    CmsPageSectionPreset,
+} from '@gredice/storage/cmsPageSections';
+import { Button } from '@gredice/ui/Button';
+import { Card } from '@gredice/ui/Card';
+import { Input } from '@gredice/ui/Input';
+import { Add, Search } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+
+type CmsPageSectionLibraryProps = {
+    query: string;
+    components: CmsPageSectionComponent[];
+    presets: CmsPageSectionPreset[];
+    onQueryChange: (query: string) => void;
+    onInsertComponent: (component: string) => void;
+    onInsertPreset: (preset: CmsPageSectionPreset) => void;
+};
+
+function matchesQuery(
+    query: string,
+    item: Pick<CmsPageSectionPreset, 'label' | 'description' | 'category'>,
+) {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+        return true;
+    }
+
+    return [item.label, item.description, item.category].some((value) =>
+        value.toLowerCase().includes(normalized),
+    );
+}
+
+export function CmsPageSectionLibrary({
+    query,
+    components,
+    presets,
+    onQueryChange,
+    onInsertComponent,
+    onInsertPreset,
+}: CmsPageSectionLibraryProps) {
+    const visiblePresets = presets.filter((preset) =>
+        matchesQuery(query, preset),
+    );
+    const visibleComponents = components.filter((component) =>
+        matchesQuery(query, component),
+    );
+    const groupedPresets = visiblePresets.reduce<
+        Record<string, CmsPageSectionPreset[]>
+    >((groups, preset) => {
+        if (!groups[preset.category]) {
+            groups[preset.category] = [];
+        }
+        groups[preset.category].push(preset);
+        return groups;
+    }, {});
+
+    return (
+        <Stack spacing={4}>
+            <Input
+                fullWidth
+                label="Biblioteka"
+                placeholder="Pretraži sekcije"
+                startDecorator={<Search className="ml-3 size-4 shrink-0" />}
+                value={query}
+                onChange={(event) => onQueryChange(event.target.value)}
+            />
+            <Stack spacing={3}>
+                {Object.entries(groupedPresets).map(([category, items]) => (
+                    <Stack spacing={2} key={category}>
+                        <Typography level="body3" secondary>
+                            {category}
+                        </Typography>
+                        {items.map((preset) => (
+                            <Card className="p-3" key={preset.id}>
+                                <Stack spacing={2}>
+                                    <Typography level="body2" semiBold>
+                                        {preset.label}
+                                    </Typography>
+                                    <Typography
+                                        level="body3"
+                                        className="line-clamp-2"
+                                        secondary
+                                    >
+                                        {preset.description}
+                                    </Typography>
+                                    <Button
+                                        type="button"
+                                        variant="outlined"
+                                        size="sm"
+                                        startDecorator={
+                                            <Add className="size-4" />
+                                        }
+                                        onClick={() => onInsertPreset(preset)}
+                                    >
+                                        Dodaj
+                                    </Button>
+                                </Stack>
+                            </Card>
+                        ))}
+                    </Stack>
+                ))}
+            </Stack>
+            <Stack spacing={2}>
+                <Typography level="body3" secondary>
+                    Prazne komponente
+                </Typography>
+                {visibleComponents.map((component) => (
+                    <Button
+                        key={component.component}
+                        type="button"
+                        variant="plain"
+                        className="justify-start"
+                        startDecorator={<Add className="size-4" />}
+                        onClick={() => onInsertComponent(component.component)}
+                    >
+                        {component.label}
+                    </Button>
+                ))}
+            </Stack>
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/cms/pages/CmsPageSortablePreviewSection.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageSortablePreviewSection.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Card } from '@gredice/ui/Card';
+import { Row } from '@gredice/ui/Row';
+import type { CSSProperties, ReactNode } from 'react';
+import { SortableDragHandle } from '../../../../components/admin/directories/SortableDragHandle';
+
+type CmsPageSortablePreviewSectionProps = {
+    id: string;
+    selected: boolean;
+    children: ReactNode;
+    className?: string;
+    onSelect: () => void;
+};
+
+export function CmsPageSortablePreviewSection({
+    id,
+    selected,
+    children,
+    className,
+    onSelect,
+}: CmsPageSortablePreviewSectionProps) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id });
+    const style: CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <Row
+            spacing={2}
+            className={`items-stretch ${isDragging ? 'opacity-70' : ''}`}
+            ref={setNodeRef}
+            style={style}
+        >
+            <SortableDragHandle
+                {...attributes}
+                {...listeners}
+                aria-label="Promijeni poredak sekcije"
+                title="Promijeni poredak sekcije"
+                className={
+                    isDragging ? 'cursor-grabbing bg-muted text-foreground' : ''
+                }
+            />
+            <Card
+                className={`min-w-0 flex-1 cursor-pointer overflow-hidden p-3 ${
+                    selected ? 'border-primary' : ''
+                } ${className ?? ''}`}
+                onClick={onSelect}
+            >
+                {children}
+            </Card>
+        </Row>
+    );
+}

--- a/packages/storage/src/cmsPageSections.ts
+++ b/packages/storage/src/cmsPageSections.ts
@@ -1,21 +1,67 @@
+export type CmsPageTextSectionField = {
+    key: string;
+    label: string;
+    type: 'text' | 'textarea' | 'url';
+    rows?: number;
+    required?: boolean;
+    helperText?: string;
+    placeholder?: string;
+};
+
+export type CmsPageCtaListSectionField = {
+    key: string;
+    label: string;
+    type: 'cta-list';
+    itemLabel: string;
+    required?: boolean;
+    helperText?: string;
+    allowIcon?: boolean;
+    allowSecondary?: boolean;
+};
+
+export type CmsPageFeatureListSectionField = {
+    key: string;
+    label: string;
+    type: 'feature-list';
+    itemLabel: string;
+    required?: boolean;
+    helperText?: string;
+    allowCtas?: boolean;
+};
+
+export type CmsPageSectionField =
+    | CmsPageTextSectionField
+    | CmsPageCtaListSectionField
+    | CmsPageFeatureListSectionField;
+
 export type CmsPageSectionComponent = {
     component: string;
     label: string;
-    fields: Array<{
-        key: string;
-        label: string;
-        type: 'text' | 'textarea';
-        rows?: number;
-        required?: boolean;
-    }>;
+    description: string;
+    category: string;
+    fields: CmsPageSectionField[];
     isCustom?: boolean;
+};
+
+export type CmsPageSectionPreset = {
+    id: string;
+    label: string;
+    description: string;
+    category: string;
+    data: {
+        component: string;
+        [key: string]: unknown;
+    };
 };
 
 export const cmsPageSectionComponents = [
     {
         component: 'Heading1',
         label: 'Heading1',
+        description: 'Veliki uvodni blok s naslovom, opisom i pozivima.',
+        category: 'Hero i uvod',
         fields: [
+            { key: 'tagline', label: 'Tagline', type: 'text' },
             { key: 'header', label: 'Naslov', type: 'text', required: true },
             {
                 key: 'description',
@@ -23,13 +69,30 @@ export const cmsPageSectionComponents = [
                 type: 'textarea',
                 rows: 4,
                 required: true,
+            },
+            {
+                key: 'assetUrl',
+                label: 'URL slike',
+                type: 'url',
+                helperText: 'Opcionalna slika prikazana uz sekciju.',
+            },
+            { key: 'assetAlt', label: 'Opis slike', type: 'text' },
+            {
+                key: 'ctas',
+                label: 'Pozivi na akciju',
+                type: 'cta-list',
+                itemLabel: 'CTA',
+                allowSecondary: true,
             },
         ],
     },
     {
         component: 'Feature1',
         label: 'Feature1',
+        description: 'Dvodijelni blok za opis koristi, koraka ili značajki.',
+        category: 'Sadržaj',
         fields: [
+            { key: 'tagline', label: 'Tagline', type: 'text' },
             { key: 'header', label: 'Naslov', type: 'text', required: true },
             {
                 key: 'description',
@@ -37,13 +100,36 @@ export const cmsPageSectionComponents = [
                 type: 'textarea',
                 rows: 4,
                 required: true,
+            },
+            {
+                key: 'assetUrl',
+                label: 'URL slike',
+                type: 'url',
+                helperText: 'Opcionalna slika prikazana u lijevom stupcu.',
+            },
+            { key: 'assetAlt', label: 'Opis slike', type: 'text' },
+            {
+                key: 'features',
+                label: 'Stavke',
+                type: 'feature-list',
+                itemLabel: 'Stavka',
+            },
+            {
+                key: 'ctas',
+                label: 'Pozivi na akciju',
+                type: 'cta-list',
+                itemLabel: 'CTA',
+                allowSecondary: true,
             },
         ],
     },
     {
         component: 'Faq1',
         label: 'Faq1',
+        description: 'FAQ blok s pitanjima i odgovorima.',
+        category: 'Podrška',
         fields: [
+            { key: 'tagline', label: 'Tagline', type: 'text' },
             { key: 'header', label: 'Naslov', type: 'text', required: true },
             {
                 key: 'description',
@@ -52,26 +138,378 @@ export const cmsPageSectionComponents = [
                 rows: 4,
                 required: true,
             },
+            {
+                key: 'features',
+                label: 'Pitanja i odgovori',
+                type: 'feature-list',
+                itemLabel: 'Pitanje',
+                required: true,
+            },
+            {
+                key: 'ctas',
+                label: 'Pozivi na akciju',
+                type: 'cta-list',
+                itemLabel: 'CTA',
+                allowSecondary: true,
+            },
         ],
     },
     {
         component: 'Footer1',
         label: 'Footer1',
+        description: 'Footer s grupama linkova i društvenim poveznicama.',
+        category: 'Navigacija',
         fields: [
-            { key: 'header', label: 'Naslov', type: 'text' },
-            { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+            {
+                key: 'tagline',
+                label: 'Naziv tvrtke',
+                type: 'text',
+                placeholder: 'Gredice d.o.o',
+            },
+            {
+                key: 'features',
+                label: 'Grupe linkova',
+                type: 'feature-list',
+                itemLabel: 'Grupa',
+                allowCtas: true,
+            },
+            {
+                key: 'ctas',
+                label: 'Društvene poveznice',
+                type: 'cta-list',
+                itemLabel: 'Poveznica',
+                allowIcon: true,
+            },
         ],
     },
     {
         component: 'PageHeader',
         label: 'Page header',
+        description: 'Standardno zaglavlje CMS stranice.',
+        category: 'Hero i uvod',
         isCustom: true,
         fields: [
-            { key: 'header', label: 'Naslov', type: 'text' },
+            { key: 'header', label: 'Naslov', type: 'text', required: true },
             { key: 'description', label: 'Opis', type: 'textarea', rows: 4 },
+            {
+                key: 'assetUrl',
+                label: 'URL slike',
+                type: 'url',
+                helperText: 'Opcionalna vizualna kartica u zaglavlju.',
+            },
+            { key: 'assetAlt', label: 'Opis slike', type: 'text' },
         ],
     },
 ] satisfies CmsPageSectionComponent[];
+
+export const cmsPageSectionPresets = [
+    {
+        id: 'page-header-basic',
+        label: 'Osnovno zaglavlje',
+        description: 'Naslov i uvodni opis za standardnu CMS stranicu.',
+        category: 'Struktura',
+        data: {
+            component: 'PageHeader',
+            header: 'Naslov stranice',
+            description:
+                'Kratki uvod koji objašnjava što se nalazi na stranici.',
+        },
+    },
+    {
+        id: 'page-header-visual',
+        label: 'Zaglavlje s vizualom',
+        description:
+            'Zaglavlje koje može pratiti stvarna slika ili ilustracija.',
+        category: 'Struktura',
+        data: {
+            component: 'PageHeader',
+            header: 'Suncokreti',
+            description:
+                'Sakupljaj i koristi suncokrete za uređenje vrta ili brigu o svojim biljkama.',
+            assetUrl: 'https://cdn.gredice.com/sunflower-large.svg',
+            assetAlt: 'Suncokret',
+        },
+    },
+    {
+        id: 'home-main-offer',
+        label: 'Početna - glavna ponuda',
+        description: 'Uvodni Gredice blok iz javne početne stranice.',
+        category: 'Početna',
+        data: {
+            component: 'Feature1',
+            tagline: 'Vrt po tvom',
+            header: 'Klikneš, mi sadimo - ti uživaš',
+            description:
+                'Par klikova i tvoje gredice su spremne. Odaberi povrće, mi ga posadimo, a ti ubrzo uživaš u plodovima svog novog vrta.',
+            ctas: [
+                { label: 'Složi gredicu', href: '/podignuta-gredica' },
+                {
+                    label: 'Pogledaj biljke',
+                    href: '/biljke',
+                    secondary: true,
+                },
+            ],
+        },
+    },
+    {
+        id: 'home-three-steps',
+        label: 'Početna - tri koraka',
+        description: 'Zasadi, održavaj i uberi kao uredive stavke.',
+        category: 'Početna',
+        data: {
+            component: 'Feature1',
+            tagline: 'Kako radi',
+            header: 'Odaberi, prati i uživaj u svom vrtu',
+            description:
+                'Gredice povezuju aplikaciju, lokalni OPG i stvarne vrtne radnje.',
+            features: [
+                {
+                    header: 'Zasadi',
+                    description:
+                        'Odaberi svoju kombinaciju povrća u aplikaciji i složi svoju gredicu.',
+                },
+                {
+                    header: 'Održavaj',
+                    description:
+                        'Prati stanje gredica, naruči radnje i dobivaj obavijesti o vrtu.',
+                },
+                {
+                    header: 'Uberi i uživaj',
+                    description:
+                        'Kad poželiš, zatraži branje i isporuku plodova iz svog vrta.',
+                },
+            ],
+        },
+    },
+    {
+        id: 'raised-bed-intro',
+        label: 'Podignuta gredica',
+        description: 'Uvod za stranicu o podignutim gredicama.',
+        category: 'Proizvod',
+        data: {
+            component: 'Heading1',
+            tagline: 'Modularni vrt',
+            header: 'Podignuta gredica za stvarni vrt',
+            description:
+                'Predstavi što korisnik dobiva, kako se gredica koristi i koje odluke može donijeti prije kupnje.',
+            ctas: [{ label: 'Saznaj više', href: '/podignuta-gredica' }],
+        },
+    },
+    {
+        id: 'plants-directory-intro',
+        label: 'Biljke - uvod',
+        description: 'Uvodni blok za katalog biljaka i sorti.',
+        category: 'Katalog',
+        data: {
+            component: 'Feature1',
+            tagline: 'Katalog',
+            header: 'Biljke koje možeš posaditi u gredice',
+            description:
+                'Koristi ovaj blok za uvod u biljke, sorte, sezonalnost i odluke pri sadnji.',
+            ctas: [{ label: 'Pogledaj biljke', href: '/biljke' }],
+        },
+    },
+    {
+        id: 'operations-intro',
+        label: 'Radnje - uvod',
+        description: 'Blok za objašnjenje vrtnih radnji i održavanja.',
+        category: 'Katalog',
+        data: {
+            component: 'Feature1',
+            tagline: 'Održavanje',
+            header: 'Radnje koje održavaju vrt urednim',
+            description:
+                'Objasni što korisnik može zatražiti, kada se radnje izvode i kako se prate u aplikaciji.',
+            ctas: [{ label: 'Pogledaj radnje', href: '/radnje' }],
+        },
+    },
+    {
+        id: 'support-faq',
+        label: 'FAQ blok',
+        description: 'Česta pitanja s tri početne stavke.',
+        category: 'Podrška',
+        data: {
+            component: 'Faq1',
+            tagline: 'Pitanja',
+            header: 'Česta pitanja',
+            description:
+                'Sažmi najvažnije odgovore prije nego korisnik kontaktira podršku.',
+            features: [
+                {
+                    header: 'Kako započeti?',
+                    description:
+                        'Uredi ovaj odgovor prema konkretnoj stranici i korisničkom koraku.',
+                },
+                {
+                    header: 'Što se događa nakon narudžbe?',
+                    description:
+                        'Objasni sljedeći korak, očekivanja i gdje korisnik vidi status.',
+                },
+                {
+                    header: 'Koga mogu kontaktirati?',
+                    description:
+                        'Dodaj kanal podrške koji već postoji u javnom iskustvu.',
+                },
+            ],
+        },
+    },
+    {
+        id: 'sunflowers-faq',
+        label: 'Suncokreti FAQ',
+        description: 'Postojeći FAQ uzorak za stranicu o suncokretima.',
+        category: 'Podrška',
+        data: {
+            component: 'Faq1',
+            header: 'Sve što trebaš znati o suncokretima',
+            description:
+                'Suncokreti ne dolaze samo u jednoj boji i veličini. Postoje različite vrste suncokreta, a svaka od njih ima svoje karakteristike i boje.',
+            features: [
+                {
+                    header: 'Što su suncokreti?',
+                    description:
+                        'Sakupljaj i koristi suncokrete za uređenje i dekoraciju vrta ili kupnju i brigu o svojim biljkama.',
+                },
+                {
+                    header: 'Kako skupljam suncokrete?',
+                    description:
+                        'Suncokrete dobivaš kroz aktivnost u vrtu, odrađene radnje i kupnje u aplikaciji.',
+                },
+                {
+                    header: 'Za što se mogu koristiti suncokreti?',
+                    description:
+                        'Suncokrete možeš koristiti za ukrašavanje vrta te brigu o gredicama i biljkama.',
+                },
+            ],
+        },
+    },
+    {
+        id: 'seo-content-block',
+        label: 'SEO tekstualni blok',
+        description: 'Dugi opis s podstavkama za javne sadržajne stranice.',
+        category: 'SEO',
+        data: {
+            component: 'Feature1',
+            tagline: 'Vodič',
+            header: 'Naslov koji jasno opisuje temu stranice',
+            description:
+                'Uvodni odlomak treba objasniti komu je stranica namijenjena, što korisnik može odlučiti i što je sljedeći korak.',
+            features: [
+                {
+                    header: 'Korisna odluka',
+                    description:
+                        'Dodaj konkretan kriterij koji pomaže korisniku usporediti opcije.',
+                },
+                {
+                    header: 'Praktičan sljedeći korak',
+                    description:
+                        'Poveži sadržaj sa stvarnim Gredice tokom rada ili javnom rutom.',
+                },
+            ],
+        },
+    },
+    {
+        id: 'cta-primary',
+        label: 'CTA blok',
+        description: 'Jednostavan blok za usmjeravanje na sljedeću radnju.',
+        category: 'Konverzija',
+        data: {
+            component: 'Heading1',
+            tagline: 'Sljedeći korak',
+            header: 'Spremni za planiranje vrta?',
+            description:
+                'Kratko objasni što korisnik dobiva klikom na primarni poziv.',
+            ctas: [
+                { label: 'Kreni', href: '/podignuta-gredica' },
+                { label: 'Kontakt', href: '/kontakt', secondary: true },
+            ],
+        },
+    },
+    {
+        id: 'contact-block',
+        label: 'Kontakt blok',
+        description: 'Kontakt i podrška s primarnim javnim rutama.',
+        category: 'Podrška',
+        data: {
+            component: 'Feature1',
+            tagline: 'Podrška',
+            header: 'Trebaš pomoć oko Gredica?',
+            description:
+                'Usmjeri korisnika prema kontaktu, čestim pitanjima ili relevantnom javnom sadržaju.',
+            ctas: [
+                { label: 'Kontaktiraj nas', href: '/kontakt' },
+                {
+                    label: 'Česta pitanja',
+                    href: '/cesta-pitanja',
+                    secondary: true,
+                },
+            ],
+        },
+    },
+    {
+        id: 'footer-main-links',
+        label: 'Footer linkovi',
+        description: 'Glavne javne grupe linkova iz Gredice footera.',
+        category: 'Navigacija',
+        data: {
+            component: 'Footer1',
+            tagline: 'Gredice d.o.o',
+            features: [
+                {
+                    header: 'Informacije',
+                    ctas: [
+                        { label: 'Dostava', href: '/dostava' },
+                        { label: 'Cjenik', href: '/cjenik' },
+                        { label: 'Česta pitanja', href: '/cesta-pitanja' },
+                        { label: 'Kontaktiraj nas', href: '/kontakt' },
+                    ],
+                },
+                {
+                    header: 'Aplikacija',
+                    ctas: [
+                        {
+                            label: 'Podignuta gredica',
+                            href: '/podignuta-gredica',
+                        },
+                        { label: 'Sjetva biljaka', href: '/sjetva' },
+                        { label: 'Biljke', href: '/biljke' },
+                        { label: 'Radnje', href: '/radnje' },
+                    ],
+                },
+                {
+                    header: 'Više',
+                    ctas: [
+                        {
+                            label: 'Politika privatnosti',
+                            href: '/legalno/politika-privatnosti',
+                        },
+                        {
+                            label: 'Uvjeti korištenja',
+                            href: '/legalno/uvjeti-koristenja',
+                        },
+                        { label: 'Natječaji', href: '/legalno/natjecaji' },
+                    ],
+                },
+            ],
+            ctas: [
+                {
+                    label: 'Instagram',
+                    href: 'https://gredice.link/ig',
+                    iconName: 'instagram',
+                },
+                {
+                    label: 'Facebook',
+                    href: 'https://gredice.link/fb',
+                    iconName: 'facebook',
+                },
+                {
+                    label: 'GitHub',
+                    href: 'https://github.com/gredice',
+                    iconName: 'github',
+                },
+            ],
+        },
+    },
+] satisfies CmsPageSectionPreset[];
 
 export const supportedCmsPageSectionComponents = new Set(
     cmsPageSectionComponents.map((section) => section.component),

--- a/packages/ui/src/PageHeader/PageHeaderSection.tsx
+++ b/packages/ui/src/PageHeader/PageHeaderSection.tsx
@@ -1,11 +1,31 @@
 import type { SectionData } from '../cms';
 import { PageHeader } from './PageHeader';
 
-export function PageHeaderSection({ header, description }: SectionData) {
+export function PageHeaderSection({
+    asset,
+    assetAlt,
+    assetUrl,
+    header,
+    description,
+}: SectionData) {
+    const visual =
+        asset ??
+        (assetUrl ? (
+            <div className="flex size-48 items-center justify-center overflow-hidden">
+                {/** biome-ignore lint/performance/noImgElement: CMS image URLs are remote and not known at build time. */}
+                <img
+                    alt={assetAlt ?? ''}
+                    className="h-full w-full object-cover"
+                    src={assetUrl}
+                />
+            </div>
+        ) : null);
+
     return (
         <PageHeader
             header={typeof header === 'string' ? header : ''}
             subHeader={typeof description === 'string' ? description : null}
+            visual={visual}
         />
     );
 }

--- a/packages/ui/src/cms/CmsSections.tsx
+++ b/packages/ui/src/cms/CmsSections.tsx
@@ -4,6 +4,15 @@ import { Accordion } from '../Accordion';
 import { Button } from '../Button';
 import { Container } from '../Container';
 import { Divider } from '../Divider';
+import {
+    Comment,
+    CompanyFacebook,
+    CompanyGitHub,
+    CompanyReddit,
+    CompanyX,
+    Globe,
+    Mail,
+} from '../icons';
 import { Stack } from '../Stack';
 import { Typography } from '../Typography';
 import { cx } from '../utils';
@@ -14,11 +23,14 @@ export type SectionData = {
     header?: string;
     description?: ReactNode;
     asset?: ReactNode;
+    assetUrl?: string;
+    assetAlt?: string;
     features?: SectionData[];
     ctas?: {
         label: string;
         href: string;
         icon?: ReactNode;
+        iconName?: string;
         secondary?: boolean;
     }[];
 };
@@ -113,6 +125,77 @@ function DescriptionBlock({
     );
 }
 
+function AssetBlock({
+    asset,
+    assetAlt,
+    assetUrl,
+}: Pick<SectionData, 'asset' | 'assetAlt' | 'assetUrl'>) {
+    if (asset) {
+        return <div>{asset}</div>;
+    }
+
+    if (!assetUrl) {
+        return null;
+    }
+
+    return (
+        <div className="overflow-hidden rounded-lg border bg-muted/20">
+            {/** biome-ignore lint/performance/noImgElement: CMS image URLs are remote and not known at build time. */}
+            <img
+                alt={assetAlt ?? ''}
+                className="h-auto w-full object-cover"
+                src={assetUrl}
+            />
+        </div>
+    );
+}
+
+function IconName({ name }: { name: string }) {
+    const normalized = name.trim().toLowerCase();
+
+    if (!normalized) {
+        return null;
+    }
+
+    switch (normalized) {
+        case 'facebook':
+            return <CompanyFacebook className="size-4" />;
+        case 'github':
+            return <CompanyGitHub className="size-4" />;
+        case 'instagram':
+        case 'link':
+            return <Globe className="size-4" />;
+        case 'mail':
+            return <Mail className="size-4" />;
+        case 'reddit':
+            return <CompanyReddit className="size-4" />;
+        case 'whatsapp':
+            return <Comment className="size-4" />;
+        case 'x':
+            return <CompanyX className="size-4" />;
+        default:
+            break;
+    }
+
+    return (
+        <span className="text-xs font-semibold uppercase tracking-normal">
+            {normalized.slice(0, 2)}
+        </span>
+    );
+}
+
+function ctaIcon(cta: NonNullable<SectionData['ctas']>[number]) {
+    if (cta.icon) {
+        return cta.icon;
+    }
+
+    if (!cta.iconName) {
+        return null;
+    }
+
+    return <IconName name={cta.iconName} />;
+}
+
 function Ctas({ ctas }: { ctas: SectionData['ctas'] }) {
     if (!ctas?.length) {
         return null;
@@ -125,7 +208,7 @@ function Ctas({ ctas }: { ctas: SectionData['ctas'] }) {
                     color={cta.secondary ? 'secondary' : 'primary'}
                     href={cta.href}
                     key={cta.label}
-                    startDecorator={cta.icon}
+                    startDecorator={ctaIcon(cta)}
                     variant={cta.secondary ? 'outlined' : 'solid'}
                 >
                     {cta.label}
@@ -158,9 +241,18 @@ export function SectionsView({
     debug,
     sectionsData,
 }: CmsSectionsViewProps) {
+    const sectionKeyCounts = new Map<string, number>();
+
     return (
         <div>
             {sectionsData.map((section) => {
+                const baseSectionKey = sectionKey(section) || 'section';
+                const occurrence = sectionKeyCounts.get(baseSectionKey) ?? 0;
+                sectionKeyCounts.set(baseSectionKey, occurrence + 1);
+                const key =
+                    occurrence === 0
+                        ? baseSectionKey
+                        : `${baseSectionKey}-${occurrence}`;
                 const Component = section.component
                     ? componentsRegistry[section.component]
                     : null;
@@ -168,7 +260,7 @@ export function SectionsView({
                 if (Component) {
                     return createElement(Component, {
                         ...section,
-                        key: sectionKey(section),
+                        key,
                     });
                 }
 
@@ -179,7 +271,7 @@ export function SectionsView({
                 return (
                     <div
                         className="rounded-lg border border-red-400 bg-red-100 p-4 text-red-700"
-                        key={sectionKey(section)}
+                        key={key}
                         role="alert"
                     >
                         <Typography className="text-base font-semibold">
@@ -195,6 +287,8 @@ export function SectionsView({
 
 export function Heading1({
     asset,
+    assetAlt,
+    assetUrl,
     ctas,
     description,
     header,
@@ -230,7 +324,11 @@ export function Heading1({
                     </Stack>
                     <Ctas ctas={ctas} />
                 </Stack>
-                {asset && <div>{asset}</div>}
+                <AssetBlock
+                    asset={asset}
+                    assetAlt={assetAlt}
+                    assetUrl={assetUrl}
+                />
             </Container>
         </section>
     );
@@ -238,6 +336,8 @@ export function Heading1({
 
 export function Feature1({
     asset,
+    assetAlt,
+    assetUrl,
     ctas,
     description,
     features,
@@ -254,7 +354,11 @@ export function Feature1({
                         tagline={tagline}
                     />
                     <Ctas ctas={ctas} />
-                    {asset && <div>{asset}</div>}
+                    <AssetBlock
+                        asset={asset}
+                        assetAlt={assetAlt}
+                        assetUrl={assetUrl}
+                    />
                 </Stack>
                 {features?.length ? (
                     <div className="flex flex-col gap-8">
@@ -329,7 +433,9 @@ function FooterSocialLinks({ ctas }: { ctas: SectionData['ctas'] }) {
                     href={cta.href}
                     key={cta.label}
                 >
-                    {cta.icon}
+                    {ctaIcon(cta) ?? (
+                        <span className="text-xs font-medium">{cta.label}</span>
+                    )}
                 </a>
             ))}
         </div>


### PR DESCRIPTION
## Summary
- Added a visual CMS page editor in the admin app with a searchable section library, drag-and-drop reordering, and a side panel for editing section details.
- Expanded shared CMS section definitions and renderers to support richer page content, including presets, CTA icons, assets, nested lists, and SEO-ready section metadata.
- Added page-level SEO controls, publish readiness checks, and a JSON fallback for direct payload editing.

## Testing
- Lint passed for the touched app and shared packages.
- Build passed for the admin app and public web app.
- Targeted storage and app test suites passed; browser verification confirmed the admin route compiles, with auth redirect behavior expected in the local environment.