### PR TITLE
[codex] Darken moonless game nights

### DIFF
--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -15,6 +15,7 @@ import {
     type GameQualityProfile,
     resolveGameQualityProfile,
 } from './gameQuality';
+import { getMoonlitNightScales } from './moonlight';
 import { Drops } from './Rain/Drops';
 import Snow from './Snow/Snow';
 import { Stars } from './Stars';
@@ -308,6 +309,12 @@ function useEnvironmentElements({
         colors: { background, sunTemperature, hemisphereSkyColor },
         intensities: { sun: sunIntensity },
     } = environmentState(location, currentTime, timeOfDay);
+    const sceneDate = timeOfDayToDate(currentTime, timeOfDay);
+    const moonlitNightScales = getMoonlitNightScales({
+        date: sceneDate,
+        location,
+        timeOfDay,
+    });
 
     // Directional light
     const directionalLightColor = useRef<Color>(new Color());
@@ -328,9 +335,10 @@ function useEnvironmentElements({
     // Ambient light
     const ambientIntensityOffset = 1;
     const ambientLightIntensity =
-        sunIntensity *
+        (sunIntensity *
             (2 + Math.max(0, -(weather?.cloudy ?? 0) - (weather?.foggy ?? 0))) +
-        ambientIntensityOffset;
+            ambientIntensityOffset) *
+        moonlitNightScales.lightScale;
 
     // Background color
     const backgroundColor = useRef<Color>(new Color());
@@ -339,6 +347,13 @@ function useEnvironmentElements({
         background[1] / 255,
         background[2] / 255,
         'srgb',
+    );
+    const moonlitBackground = { h: 0, s: 0, l: 0 };
+    backgroundColor.current.getHSL(moonlitBackground);
+    backgroundColor.current.setHSL(
+        moonlitBackground.h,
+        moonlitBackground.s,
+        moonlitBackground.l * moonlitNightScales.skyScale,
     );
 
     // Set background color based on weather
@@ -369,7 +384,8 @@ function useEnvironmentElements({
         (backgroundColor.current.b / 255) * 0.5,
         'srgb',
     );
-    const hemisphereIntensity = sunIntensity * 2 + 3;
+    const hemisphereIntensity =
+        (sunIntensity * 2 + 3) * moonlitNightScales.lightScale;
 
     return {
         background: backgroundColor.current,

--- a/packages/game/src/scene/moonlight.ts
+++ b/packages/game/src/scene/moonlight.ts
@@ -1,0 +1,102 @@
+import SunCalc from 'suncalc';
+
+const MOONLESS_NIGHT_LIGHT_SCALE = 0.32;
+const MOONLESS_NIGHT_SKY_SCALE = 0.6;
+
+const NIGHT_VISIBILITY = {
+    dawnFadeStart: 0.2,
+    dayStart: 0.25,
+    duskStart: 0.75,
+    nightStart: 0.8,
+};
+
+const MOON_HORIZON_FADE = {
+    start: -0.05,
+    end: 0.18,
+};
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function smoothstep(edge0: number, edge1: number, value: number) {
+    const t = clamp01((value - edge0) / (edge1 - edge0));
+    return t * t * (3 - 2 * t);
+}
+
+function mix(from: number, to: number, amount: number) {
+    return from + (to - from) * amount;
+}
+
+export function getNightAmount(timeOfDay: number) {
+    const dawnAmount =
+        1 -
+        smoothstep(
+            NIGHT_VISIBILITY.dawnFadeStart,
+            NIGHT_VISIBILITY.dayStart,
+            timeOfDay,
+        );
+    const duskAmount = smoothstep(
+        NIGHT_VISIBILITY.duskStart,
+        NIGHT_VISIBILITY.nightStart,
+        timeOfDay,
+    );
+    return Math.max(dawnAmount, duskAmount);
+}
+
+export function resolveMoonlitNightScales({
+    moonlight,
+    timeOfDay,
+}: {
+    moonlight: number;
+    timeOfDay: number;
+}) {
+    const nightAmount = getNightAmount(timeOfDay);
+    const visibleMoonlight = clamp01(moonlight);
+    const moonNightLightScale =
+        MOONLESS_NIGHT_LIGHT_SCALE +
+        (1 - MOONLESS_NIGHT_LIGHT_SCALE) * visibleMoonlight;
+    const moonNightSkyScale =
+        MOONLESS_NIGHT_SKY_SCALE +
+        (1 - MOONLESS_NIGHT_SKY_SCALE) * visibleMoonlight;
+
+    return {
+        lightScale: mix(1, moonNightLightScale, nightAmount),
+        nightAmount,
+        skyScale: mix(1, moonNightSkyScale, nightAmount),
+        visibleMoonlight,
+    };
+}
+
+export function getVisibleMoonlight({
+    date,
+    location,
+}: {
+    date: Date;
+    location: { lat: number; lon: number };
+}) {
+    const illumination = SunCalc.getMoonIllumination(date);
+    const position = SunCalc.getMoonPosition(date, location.lat, location.lon);
+    const horizonVisibility = smoothstep(
+        MOON_HORIZON_FADE.start,
+        MOON_HORIZON_FADE.end,
+        position.altitude,
+    );
+
+    return clamp01(illumination.fraction) * horizonVisibility;
+}
+
+export function getMoonlitNightScales({
+    date,
+    location,
+    timeOfDay,
+}: {
+    date: Date;
+    location: { lat: number; lon: number };
+    timeOfDay: number;
+}) {
+    return resolveMoonlitNightScales({
+        moonlight: getVisibleMoonlight({ date, location }),
+        timeOfDay,
+    });
+}

--- a/packages/game/src/scene/moonlight.unit.ts
+++ b/packages/game/src/scene/moonlight.unit.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getNightAmount, resolveMoonlitNightScales } from './moonlight';
+
+function round(value: number) {
+    return Number(value.toFixed(6));
+}
+
+test('moonlit night scales darken low-moon nights', () => {
+    const moonless = resolveMoonlitNightScales({
+        moonlight: 0,
+        timeOfDay: 0,
+    });
+    const fullMoon = resolveMoonlitNightScales({
+        moonlight: 1,
+        timeOfDay: 0,
+    });
+
+    assert.ok(moonless.lightScale < fullMoon.lightScale);
+    assert.ok(moonless.skyScale < fullMoon.skyScale);
+    assert.equal(round(fullMoon.lightScale), 1);
+    assert.equal(round(fullMoon.skyScale), 1);
+});
+
+test('moonlit night scales leave daylight unchanged', () => {
+    const moonlessDay = resolveMoonlitNightScales({
+        moonlight: 0,
+        timeOfDay: 0.5,
+    });
+    const fullMoonDay = resolveMoonlitNightScales({
+        moonlight: 1,
+        timeOfDay: 0.5,
+    });
+
+    assert.equal(round(moonlessDay.lightScale), 1);
+    assert.equal(round(moonlessDay.skyScale), 1);
+    assert.equal(round(fullMoonDay.lightScale), 1);
+    assert.equal(round(fullMoonDay.skyScale), 1);
+});
+
+test('night amount blends through dusk', () => {
+    assert.equal(round(getNightAmount(0.75)), 0);
+    assert.equal(round(getNightAmount(0.8)), 1);
+
+    const twilight = getNightAmount(0.775);
+    assert.ok(twilight > 0);
+    assert.ok(twilight < 1);
+});
+
+test('moonlit night scales clamp moonlight input', () => {
+    const belowRange = resolveMoonlitNightScales({
+        moonlight: -1,
+        timeOfDay: 0,
+    });
+    const zero = resolveMoonlitNightScales({
+        moonlight: 0,
+        timeOfDay: 0,
+    });
+    const aboveRange = resolveMoonlitNightScales({
+        moonlight: 2,
+        timeOfDay: 0,
+    });
+    const one = resolveMoonlitNightScales({
+        moonlight: 1,
+        timeOfDay: 0,
+    });
+
+    assert.equal(round(belowRange.lightScale), round(zero.lightScale));
+    assert.equal(round(aboveRange.lightScale), round(one.lightScale));
+});


### PR DESCRIPTION
## What changed
- Added moonlight-aware night scaling for the game scene.
- Nights now get darker when the visible moonlight is low, based on moon illumination and moon altitude.
- Applied the scale to ambient light, hemisphere light, and sky background while leaving daytime unchanged.
- Added focused unit coverage for the moonlight/night blending curve.

## Why
The existing scene kept a fixed night light floor, so crescent or moonless nights looked nearly as bright as full-moon nights. This makes night brightness track the moon more naturally.

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm lint --filter @gredice/game`
- `pnpm build --filter garden --force`
- `pnpm build --filter www --force`
- Earlier full `garden` test run passed: `pnpm test --filter garden`
- Earlier visual smoke verified the Garden debug scene rendered nonblank canvas pixels on desktop and mobile.

## Known unrelated issue
- Earlier `pnpm test --filter www` completed with 564 passing tests and 1 failing existing axe color-contrast issue in the public footer on `/biljke/timijan/sorte/timijan`.