### PR TITLE
Collapse overflowing breadcrumbs into a dropdown

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -92,14 +92,20 @@ export default async function RaisedBedPage({
                                           )
                                         : undefined,
                                 },
-                                { label: 'Vrtovi' },
+                                {
+                                    label: 'Vrtovi',
+                                    href: KnownPages.Gardens,
+                                },
                                 {
                                     label: raisedBed.gardenId ?? 'Nepoznato',
                                     href: raisedBed.gardenId
                                         ? KnownPages.Garden(raisedBed.gardenId)
                                         : undefined,
                                 },
-                                { label: 'Gredice' },
+                                {
+                                    label: 'Gredice',
+                                    href: KnownPages.RaisedBeds,
+                                },
                                 { label: raisedBed?.id },
                             ]}
                         />

--- a/apps/app/components/admin/navigation/AdminDirectoryBreadcrumbs.tsx
+++ b/apps/app/components/admin/navigation/AdminDirectoryBreadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { type BreadcrumbItem, Breadcrumbs } from '@gredice/ui/Breadcrumbs';
+import { KnownPages } from '../../../src/KnownPages';
 import { AdminBreadcrumbLevelSelector } from './AdminBreadcrumbLevelSelector';
 import { AdminDirectoryCategoryBreadcrumbSelector } from './AdminDirectoryCategoryBreadcrumbSelector';
 import { AdminDirectoryEntityTypeBreadcrumbSelector } from './AdminDirectoryEntityTypeBreadcrumbSelector';
@@ -21,6 +22,8 @@ export function AdminDirectoryBreadcrumbs({
     if (entityTypeName) {
         breadcrumbs.push(
             {
+                dropdownHref: KnownPages.Directories,
+                dropdownLabel: 'Kategorije',
                 label: (
                     <AdminDirectoryCategoryBreadcrumbSelector
                         entityTypeName={entityTypeName}
@@ -28,6 +31,8 @@ export function AdminDirectoryBreadcrumbs({
                 ),
             },
             {
+                dropdownHref: KnownPages.DirectoryEntityType(entityTypeName),
+                dropdownLabel: entityTypeLabel ?? entityTypeName,
                 label: (
                     <AdminDirectoryEntityTypeBreadcrumbSelector
                         entityTypeName={entityTypeName}

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -531,7 +531,9 @@ function OperationsDashboardShowcase() {
                     items={[
                         { label: 'Admin', href: '/' },
                         { label: 'Operacije', href: '/' },
-                        { label: 'Danas' },
+                        { label: 'Raspored', href: '/' },
+                        { label: 'Danas', href: '/' },
+                        { label: 'Berba' },
                     ]}
                 />
                 <PageHeader

--- a/apps/storybook/stories/packages/ui/primitives/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Breadcrumbs.stories.tsx
@@ -51,3 +51,17 @@ export const LongLabels: Story = {
         </div>
     ),
 };
+
+export const CollapsedMiddleItems: Story = {
+    args: {
+        items: [
+            { label: 'Gredice', href: '/' },
+            { label: 'Računi', href: '/' },
+            { label: 'd5048f9f-51c2-48f4-85d5-4bed9e8e06c2', href: '/' },
+            { label: 'Vrtovi', href: '/' },
+            { label: '24', href: '/' },
+            { label: 'Gredice', href: '/' },
+            { label: '33' },
+        ],
+    },
+};

--- a/packages/ui/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui/src/Breadcrumbs/Breadcrumbs.tsx
@@ -2,8 +2,11 @@ import type { ReactNode } from 'react';
 import { Link } from '../Link';
 import { Typography } from '../Typography';
 import { cx } from '../utils';
+import { BreadcrumbsCollapsedItems } from './BreadcrumbsCollapsedItems';
 
 export type BreadcrumbItem = {
+    dropdownHref?: string;
+    dropdownLabel?: ReactNode | string | undefined;
     href?: string;
     label: ReactNode | string | undefined;
 };
@@ -65,25 +68,43 @@ export function Breadcrumbs({
     return (
         <nav aria-label="Breadcrumb" className={cx('max-w-full', className)}>
             <ol className="flex min-w-0 flex-wrap items-center gap-1">
-                {items.map((item, index) => {
-                    const key =
-                        item.href ??
-                        (typeof item.label === 'string'
-                            ? item.label
-                            : `breadcrumb-${index}`);
-
-                    return (
-                        <li
-                            className="flex min-w-0 items-center gap-1"
-                            key={key}
-                        >
-                            <BreadcrumbsItem {...item} />
-                            {index < items.length - 1 ? (
-                                <BreadcrumbsSeparator />
-                            ) : null}
+                {items.length > 3 ? (
+                    <>
+                        <li className="flex min-w-0 items-center gap-1">
+                            <BreadcrumbsItem {...items[0]} />
+                            <BreadcrumbsSeparator />
                         </li>
-                    );
-                })}
+                        <li className="flex min-w-0 items-center gap-1">
+                            <BreadcrumbsCollapsedItems
+                                items={items.slice(1, -1)}
+                            />
+                            <BreadcrumbsSeparator />
+                        </li>
+                        <li className="flex min-w-0 items-center gap-1">
+                            <BreadcrumbsItem {...items[items.length - 1]} />
+                        </li>
+                    </>
+                ) : (
+                    items.map((item, index) => {
+                        const key =
+                            item.href ??
+                            (typeof item.label === 'string'
+                                ? item.label
+                                : `breadcrumb-${index}`);
+
+                        return (
+                            <li
+                                className="flex min-w-0 items-center gap-1"
+                                key={key}
+                            >
+                                <BreadcrumbsItem {...item} />
+                                {index < items.length - 1 ? (
+                                    <BreadcrumbsSeparator />
+                                ) : null}
+                            </li>
+                        );
+                    })
+                )}
                 {endSeparator ? (
                     <li>
                         <BreadcrumbsSeparator />

--- a/packages/ui/src/Breadcrumbs/BreadcrumbsCollapsedItems.tsx
+++ b/packages/ui/src/Breadcrumbs/BreadcrumbsCollapsedItems.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { IconButton } from '../IconButton';
+import { MoreHorizontal } from '../icons';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '../Menu';
+import type { BreadcrumbItem } from './Breadcrumbs';
+
+type BreadcrumbsCollapsedItemsProps = {
+    items: BreadcrumbItem[];
+};
+
+function breadcrumbKey(item: BreadcrumbItem, index: number) {
+    const href = item.dropdownHref ?? item.href;
+    if (href) {
+        return `${href}-${index}`;
+    }
+
+    const label = item.dropdownLabel ?? item.label;
+    if (typeof label === 'string') {
+        return `${label}-${index}`;
+    }
+
+    return `collapsed-breadcrumb-${index}`;
+}
+
+function breadcrumbDropdownLabel(item: BreadcrumbItem) {
+    return item.dropdownLabel ?? item.label;
+}
+
+function breadcrumbDropdownHref(item: BreadcrumbItem) {
+    return item.dropdownHref ?? item.href;
+}
+
+export function BreadcrumbsCollapsedItems({
+    items,
+}: BreadcrumbsCollapsedItemsProps) {
+    const visibleItems = items.filter((item) => breadcrumbDropdownLabel(item));
+
+    if (!visibleItems.length) {
+        return null;
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <IconButton
+                    aria-label="Prikaži skrivene putanje"
+                    className="size-6 text-muted-foreground hover:text-foreground"
+                    size="xs"
+                    variant="plain"
+                >
+                    <MoreHorizontal aria-hidden className="size-4" />
+                </IconButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="max-w-80">
+                {visibleItems.map((item, index) => {
+                    const href = breadcrumbDropdownHref(item);
+                    const label = breadcrumbDropdownLabel(item);
+
+                    return (
+                        <DropdownMenuItem
+                            className="max-w-72"
+                            disabled={!href}
+                            href={href}
+                            key={breadcrumbKey(item, index)}
+                        >
+                            <span className="min-w-0 truncate">{label}</span>
+                        </DropdownMenuItem>
+                    );
+                })}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}


### PR DESCRIPTION
## Summary
- Collapse breadcrumb trails longer than 3 items into `first / ... / last`.
- Make the overflow button open a dropdown with the hidden middle breadcrumb destinations.
- Add explicit dropdown labels/links for admin directory breadcrumbs and the raised-bed breadcrumb trail so collapsed items still navigate correctly.
- Add Storybook coverage for the collapsed breadcrumb state.

## Testing
- `pnpm lint --filter @gredice/ui`
- `pnpm lint --filter app`
- `pnpm lint --filter storybook`
- `pnpm build --filter app`
- `pnpm build --filter storybook`
- `pnpm test --filter app`
- Browser-checked the Storybook breadcrumb story to confirm the collapsed button and dropdown render correctly.