### PR TITLE
Fix mobile planting and raised-bed overflow issues

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -37,6 +37,7 @@ import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getBlockData } from '../../../lib/blocks/blockDataService';
 import { publicSecurity } from '../../../lib/docs/security';
+import { isAppliedOperationCurrentForRaisedBedFields } from '../../../lib/garden/appliedRaisedBedOperations';
 import { resolveGardenBlockPlacement } from '../../../lib/garden/blockPlacementService';
 import { deleteGardenBlock } from '../../../lib/garden/gardenBlocksService';
 import { synchronizeGardenStacksAndRaisedBeds } from '../../../lib/garden/gardenStacksSyncService';
@@ -372,11 +373,25 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const blockNameById = new Map(
                 blocks.map((block) => [block.id, block.name] as const),
             );
+            const raisedBedsById = new Map(
+                garden.raisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
+            );
             const appliedOperationsByRaisedBedId = operations.reduce(
                 (acc, operation) => {
                     if (
                         !operation.raisedBedId ||
                         !isAppliedRaisedBedOperationStatus(operation.status)
+                    ) {
+                        return acc;
+                    }
+
+                    const raisedBed = raisedBedsById.get(operation.raisedBedId);
+                    if (
+                        !raisedBed ||
+                        !isAppliedOperationCurrentForRaisedBedFields(
+                            operation,
+                            raisedBed.fields,
+                        )
                     ) {
                         return acc;
                     }

--- a/apps/api/lib/garden/appliedRaisedBedOperations.node.spec.ts
+++ b/apps/api/lib/garden/appliedRaisedBedOperations.node.spec.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isAppliedOperationCurrentForRaisedBedFields } from './appliedRaisedBedOperations';
+
+describe('isAppliedOperationCurrentForRaisedBedFields', () => {
+    it('keeps full raised-bed operations active across plant cycles', () => {
+        assert.equal(
+            isAppliedOperationCurrentForRaisedBedFields(
+                {
+                    raisedBedFieldId: null,
+                    createdAt: new Date('2026-05-01T08:00:00.000Z'),
+                    completedAt: new Date('2026-05-01T09:00:00.000Z'),
+                },
+                [],
+            ),
+            true,
+        );
+    });
+
+    it('drops field operations from an earlier plant cycle', () => {
+        assert.equal(
+            isAppliedOperationCurrentForRaisedBedFields(
+                {
+                    raisedBedFieldId: 10,
+                    createdAt: new Date('2026-05-01T08:00:00.000Z'),
+                    completedAt: new Date('2026-05-01T09:00:00.000Z'),
+                },
+                [
+                    {
+                        id: 10,
+                        active: true,
+                        plantCycles: [
+                            {
+                                active: false,
+                                startedAt: new Date('2026-04-01T08:00:00.000Z'),
+                            },
+                            {
+                                active: true,
+                                startedAt: new Date('2026-05-02T08:00:00.000Z'),
+                            },
+                        ],
+                    },
+                ],
+            ),
+            false,
+        );
+    });
+
+    it('keeps field operations applied during the active plant cycle', () => {
+        assert.equal(
+            isAppliedOperationCurrentForRaisedBedFields(
+                {
+                    raisedBedFieldId: 10,
+                    createdAt: new Date('2026-05-02T08:10:00.000Z'),
+                    completedAt: new Date('2026-05-02T09:00:00.000Z'),
+                },
+                [
+                    {
+                        id: 10,
+                        active: true,
+                        plantCycles: [
+                            {
+                                active: true,
+                                startedAt: new Date('2026-05-02T08:00:00.000Z'),
+                            },
+                        ],
+                    },
+                ],
+            ),
+            true,
+        );
+    });
+
+    it('drops field operations when the referenced field is no longer active', () => {
+        assert.equal(
+            isAppliedOperationCurrentForRaisedBedFields(
+                {
+                    raisedBedFieldId: 10,
+                    createdAt: new Date('2026-05-02T08:10:00.000Z'),
+                    completedAt: new Date('2026-05-02T09:00:00.000Z'),
+                },
+                [
+                    {
+                        id: 10,
+                        active: false,
+                        plantCycles: [
+                            {
+                                active: false,
+                                startedAt: new Date('2026-05-02T08:00:00.000Z'),
+                            },
+                        ],
+                    },
+                ],
+            ),
+            false,
+        );
+    });
+});

--- a/apps/api/lib/garden/appliedRaisedBedOperations.ts
+++ b/apps/api/lib/garden/appliedRaisedBedOperations.ts
@@ -1,0 +1,66 @@
+type TimestampValue = Date | string | null | undefined;
+
+export type AppliedRaisedBedOperation = {
+    raisedBedFieldId?: number | null;
+    createdAt: TimestampValue;
+    completedAt?: TimestampValue;
+};
+
+export type AppliedRaisedBedField = {
+    id: number;
+    active?: boolean | null;
+    plantCycles?: Array<{
+        active?: boolean | null;
+        startedAt?: TimestampValue;
+    }> | null;
+};
+
+function timestampMs(value: TimestampValue) {
+    if (!value) {
+        return null;
+    }
+
+    const timestamp =
+        value instanceof Date ? value.getTime() : Date.parse(value);
+
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function activePlantCycleStartMs(field: AppliedRaisedBedField) {
+    const activePlantCycle = field.plantCycles?.find(
+        (plantCycle) => plantCycle.active,
+    );
+
+    return timestampMs(activePlantCycle?.startedAt);
+}
+
+export function isAppliedOperationCurrentForRaisedBedFields(
+    operation: AppliedRaisedBedOperation,
+    fields: AppliedRaisedBedField[],
+) {
+    if (!operation.raisedBedFieldId) {
+        return true;
+    }
+
+    const field = fields.find(
+        (candidate) =>
+            candidate.id === operation.raisedBedFieldId && candidate.active,
+    );
+    if (!field) {
+        return false;
+    }
+
+    const cycleStartMs = activePlantCycleStartMs(field);
+    if (cycleStartMs == null) {
+        return true;
+    }
+
+    const appliedAtMs = timestampMs(
+        operation.completedAt ?? operation.createdAt,
+    );
+    if (appliedAtMs == null) {
+        return true;
+    }
+
+    return appliedAtMs >= cycleStartMs;
+}

--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -1,0 +1,137 @@
+import type { BlockData } from '@gredice/client';
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import {
+    gameHudBottomBarClassName,
+    gameHudBottomControlsClassName,
+} from '../../../packages/game/src/GameHud';
+import { ItemsHud } from '../../../packages/game/src/hud/ItemsHud';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+
+const now = '2026-05-13T00:00:00.000Z';
+
+function createBlockData(name: string, index: number) {
+    return {
+        id: index + 1,
+        entityType: { id: 8, name: 'block', label: 'Blok' },
+        slug: name.toLowerCase().replaceAll('_', '-'),
+        information: {
+            name,
+            label: name.replaceAll('_', ' '),
+            shortDescription: 'Mock block for HUD layout tests.',
+            fullDescription: 'Mock block for HUD layout tests.',
+        },
+        attributes: {
+            height: 1,
+            stackable: true,
+            type: name === 'Raised_Bed' ? 'raisedBed' : 'decoration',
+        },
+        prices: { sunflowers: 10 },
+        functions: {
+            recycler: false,
+            raisedBed: name === 'Raised_Bed',
+        },
+        createdAt: now,
+        updatedAt: now,
+    } satisfies BlockData;
+}
+
+const blockNames = [
+    'Raised_Bed',
+    'Bucket',
+    'Composter',
+    'GardenBox',
+    'Shade',
+    'Stool',
+    'Fence',
+    'StoneSmall',
+    'StoneMedium',
+    'StoneLarge',
+    'Bush',
+    'Tree',
+    'Pine',
+    'ShovelSmall',
+    'Tulip',
+    'BaleHey',
+    'MulchHey',
+    'MulchCoconut',
+    'MulchWood',
+    'Block_Grass',
+    'Block_Ground',
+    'Block_Sand',
+    'Block_Snow',
+    'Block_Grass_Angle',
+    'Block_Ground_Angle',
+    'Block_Sand_Angle',
+    'Block_Snow_Angle',
+];
+
+function createItemsHudQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+
+    queryClient.setQueryData(['blocks'], blockNames.map(createBlockData));
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(['gardens'], [{ id: 1 }]);
+    queryClient.setQueryData(['gardens', 'current', 'summer', 1], {
+        id: 1,
+        name: 'Test garden',
+        stacks: [],
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [],
+    });
+
+    return queryClient;
+}
+
+function ItemsHudTestProviders({ children }: PropsWithChildren) {
+    const queryClient = useMemo(() => createItemsHudQueryClient(), []);
+    const gameStore = useMemo(() => {
+        const store = createGameState({
+            appBaseUrl: 'http://localhost',
+            freezeTime: new Date('2026-05-13T12:00:00.000Z'),
+            isMock: false,
+            winterMode: 'summer',
+        });
+        store.getState().setMode('edit');
+        return store;
+    }, []);
+
+    return (
+        <NuqsTestingAdapter>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameStore}>
+                    {children}
+                </GameStateContext.Provider>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+export function ItemsHudAlignmentStory() {
+    return (
+        <ItemsHudTestProviders>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <div
+                        data-testid="bottom-controls"
+                        className={gameHudBottomControlsClassName}
+                    >
+                        <div className="h-10 w-40 rounded-lg border bg-muted" />
+                    </div>
+                    <ItemsHud />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}

--- a/apps/garden/tests/PlantPickerTestStory.tsx
+++ b/apps/garden/tests/PlantPickerTestStory.tsx
@@ -107,6 +107,43 @@ const tomatoSort = {
     updatedAt: now,
 } satisfies PlantSortData;
 
+function createTomatoSort(id: number, name: string, shortDescription: string) {
+    return {
+        ...tomatoSort,
+        id,
+        slug: `mock-${id}`,
+        information: {
+            ...tomatoSort.information,
+            name,
+            shortDescription,
+        },
+    } satisfies PlantSortData;
+}
+
+const tomatoSorts = [
+    tomatoSort,
+    createTomatoSort(
+        102,
+        'Rajčica saint pierre',
+        'Klasična visoka rajčica okruglih crvenih plodova, pogodna za svježu potrošnju.',
+    ),
+    createTomatoSort(
+        103,
+        'Rajčica scatolone',
+        'Unikatna talijanska sorta. Na visokoj i bujnoj stabljici rastu krupni plodovi.',
+    ),
+    createTomatoSort(
+        104,
+        'Rajčica Volovsko srce',
+        'Sorta kasne rajčice. Biljke su visoke i bujne te zahtijevaju potporu.',
+    ),
+    createTomatoSort(
+        105,
+        'Rajčica San Marzano',
+        'Duguljasta rajčica punog okusa za umake, salate i ljetnu kuhinju.',
+    ),
+];
+
 function createPlantPickerQueryClient() {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
@@ -125,7 +162,7 @@ function createPlantPickerQueryClient() {
         items: [],
     });
     queryClient.setQueryData(['plants'], [tomatoPlant, basilPlant]);
-    queryClient.setQueryData(['sorts'], [tomatoSort]);
+    queryClient.setQueryData(['sorts'], tomatoSorts);
 
     return queryClient;
 }

--- a/apps/garden/tests/RaisedBedDiaryStory.tsx
+++ b/apps/garden/tests/RaisedBedDiaryStory.tsx
@@ -1,0 +1,103 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { type PropsWithChildren, useMemo } from 'react';
+import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
+import { RaisedBedDiary } from '../../../packages/game/src/hud/raisedBed/RaisedBedDiary';
+import { Card, CardOverflow } from '../../../packages/ui/src/Card';
+
+const TEST_GARDEN_ID = 1;
+const TEST_RAISED_BED_ID = 101;
+
+type DiaryEntry = {
+    id: number;
+    name: string;
+    description?: string;
+    status: string | null;
+    timestamp: Date;
+    imageUrls?: string[] | null;
+    isMarkdown?: boolean;
+};
+
+const imageUrls = [
+    '/web-app-manifest-192x192.png',
+    '/web-app-manifest-512x512.png',
+    '/Screenshot-20250105-vrt-gredice-com.png',
+];
+
+const longWord =
+    'SuperdugacakNazivDnevnickogUnosaBezRazmakaKojiMoraOstatiUnutarListe';
+
+const diaryEntries: DiaryEntry[] = [
+    {
+        id: 1,
+        name: `${longWord} 1`,
+        description: `${longWord} with a long description and enough words to wrap inside a narrow mobile raised bed diary card.`,
+        status: 'Planirano',
+        timestamp: new Date('2026-05-13T12:00:00.000Z'),
+        imageUrls,
+    },
+    {
+        id: 2,
+        name: 'AI analysis with several images',
+        description:
+            '## Analysis\n\nThe gallery and text should stay constrained inside the diary row.',
+        status: null,
+        timestamp: new Date('2026-05-12T12:00:00.000Z'),
+        imageUrls,
+        isMarkdown: true,
+    },
+    {
+        id: 3,
+        name: 'Watering and checkup',
+        description:
+            'Shorter entry without images keeps the same row constraints.',
+        status: 'Novo',
+        timestamp: new Date('2026-05-11T12:00:00.000Z'),
+    },
+];
+
+function createRaisedBedDiaryQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+
+    queryClient.setQueryData(
+        ['raisedBeds', TEST_RAISED_BED_ID, 'diary'],
+        diaryEntries,
+    );
+
+    return queryClient;
+}
+
+function RaisedBedDiaryTestProviders({ children }: PropsWithChildren) {
+    const queryClient = useMemo(() => createRaisedBedDiaryQueryClient(), []);
+
+    return (
+        <ReactQuery.QueryClientProvider client={queryClient}>
+            <GameFlagsContext.Provider value={{ raisedBedImageAI: false }}>
+                {children}
+            </GameFlagsContext.Provider>
+        </ReactQuery.QueryClientProvider>
+    );
+}
+
+export function RaisedBedDiaryOverflowStory() {
+    return (
+        <RaisedBedDiaryTestProviders>
+            <div className="p-4">
+                <Card
+                    data-testid="diary-shell"
+                    className="w-[360px] max-w-full"
+                >
+                    <CardOverflow className="max-h-96 overflow-y-auto overflow-x-hidden">
+                        <RaisedBedDiary
+                            gardenId={TEST_GARDEN_ID}
+                            raisedBedId={TEST_RAISED_BED_ID}
+                        />
+                    </CardOverflow>
+                </Card>
+            </div>
+        </RaisedBedDiaryTestProviders>
+    );
+}

--- a/apps/garden/tests/RaisedBedDiaryStory.tsx
+++ b/apps/garden/tests/RaisedBedDiaryStory.tsx
@@ -17,6 +17,8 @@ type DiaryEntry = {
     isMarkdown?: boolean;
 };
 
+const singleImageUrls = ['/web-app-manifest-192x192.png'];
+
 const imageUrls = [
     '/web-app-manifest-192x192.png',
     '/web-app-manifest-512x512.png',
@@ -33,7 +35,7 @@ const diaryEntries: DiaryEntry[] = [
         description: `${longWord} with a long description and enough words to wrap inside a narrow mobile raised bed diary card.`,
         status: 'Planirano',
         timestamp: new Date('2026-05-13T12:00:00.000Z'),
-        imageUrls,
+        imageUrls: singleImageUrls,
     },
     {
         id: 2,

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -5,6 +5,7 @@ import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/Game
 import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
 import { RaisedBedField } from '../../../packages/game/src/hud/raisedBed/RaisedBedField';
 import { RaisedBedFieldItem } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldItem';
+import { RaisedBedFieldSuggestions } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions';
 import {
     createGameState,
     GameStateContext,
@@ -152,6 +153,21 @@ export function RaisedBedFieldHudStory({
                     positionIndex={positionIndex}
                 />
             </div>
+        </RaisedBedHudTestProviders>
+    );
+}
+
+export function RaisedBedFieldSuggestionsStory({
+    scenario,
+}: {
+    scenario: RaisedBedScenario;
+}) {
+    return (
+        <RaisedBedHudTestProviders scenario={scenario}>
+            <RaisedBedFieldSuggestions
+                gardenId={TEST_GARDEN_ID}
+                raisedBedId={TEST_RAISED_BED_ID}
+            />
         </RaisedBedHudTestProviders>
     );
 }

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { ItemsHudAlignmentStory } from './ItemsHudStory';
+
+const TABLET_VIEWPORT = { width: 820, height: 1180 };
+
+test('edit mode item picker stays centered on tablet layouts', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    const picker = page.locator('[data-items-hud]');
+    await expect(picker).toBeVisible();
+
+    const pickerBox = await picker.boundingBox();
+    expect(pickerBox).not.toBeNull();
+
+    const pickerCenter = (pickerBox?.x ?? 0) + (pickerBox?.width ?? 0) / 2;
+    expect(
+        Math.abs(pickerCenter - TABLET_VIEWPORT.width / 2),
+    ).toBeLessThanOrEqual(1);
+    expect((pickerBox?.x ?? 0) + (pickerBox?.width ?? 0)).toBeLessThanOrEqual(
+        TABLET_VIEWPORT.width,
+    );
+});

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
+import { RaisedBedDiaryOverflowStory } from './RaisedBedDiaryStory';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+async function expectNoHorizontalOverflow(locator: Locator) {
+    const overflow = await locator.evaluate((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+    }));
+
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+}
+
+test('raised bed diary entries stay inside a narrow mobile card', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const shell = page.getByTestId('diary-shell');
+    const list = page.locator('[data-diary-list]');
+    const entries = page.locator('[data-diary-entry]');
+
+    await expect(list).toBeVisible();
+    await expect(entries).toHaveCount(3);
+
+    await expectNoHorizontalOverflow(shell);
+    await expectNoHorizontalOverflow(list);
+
+    const overflowingEntries = await entries.evaluateAll((elements) =>
+        elements
+            .map((element, index) => ({
+                clientWidth: element.clientWidth,
+                index,
+                scrollWidth: element.scrollWidth,
+            }))
+            .filter(
+                ({ clientWidth, scrollWidth }) => scrollWidth > clientWidth + 1,
+            ),
+    );
+
+    expect(overflowingEntries).toEqual([]);
+});

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -3,6 +3,7 @@ import type { Locator } from '@playwright/test';
 import { RaisedBedDiaryOverflowStory } from './RaisedBedDiaryStory';
 
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const TABLET_VIEWPORT = { width: 1024, height: 768 };
 
 async function expectNoHorizontalOverflow(locator: Locator) {
     const overflow = await locator.evaluate((element) => ({
@@ -43,4 +44,28 @@ test('raised bed diary entries stay inside a narrow mobile card', async ({
     );
 
     expect(overflowingEntries).toEqual([]);
+});
+
+test('single-image diary entries keep text close to the thumbnail', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const firstEntry = page.locator('[data-diary-entry]').first();
+    const imageBox = await firstEntry
+        .locator('[data-diary-entry-images]')
+        .boundingBox();
+    const contentBox = await firstEntry
+        .locator('[data-diary-entry-content]')
+        .boundingBox();
+
+    expect(imageBox).not.toBeNull();
+    expect(contentBox).not.toBeNull();
+
+    const imageRight = (imageBox?.x ?? 0) + (imageBox?.width ?? 0);
+    const textGap = (contentBox?.x ?? 0) - imageRight;
+
+    expect(textGap).toBeLessThanOrEqual(24);
 });

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -632,6 +632,9 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         const buttons = recommendations.locator('button');
         await expect(buttons).toHaveCount(2);
 
+        await expect(buttons.first()).toHaveCSS('color', 'rgb(255, 255, 255)');
+        await expect(buttons.nth(1)).toHaveCSS('color', 'rgb(255, 255, 255)');
+
         for (let index = 0; index < 2; index += 1) {
             const buttonBox = await buttons.nth(index).boundingBox();
             expect(buttonBox).not.toBeNull();

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 import {
     RaisedBedFieldDndDialogStory,
     RaisedBedFieldHudStory,
+    RaisedBedFieldSuggestionsStory,
 } from './RaisedBedFieldHudStory';
 import {
     buildCartItem,
@@ -610,6 +611,39 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
             'data-touch-expanded',
             'false',
         );
+    });
+
+    test('quick sowing recommendations stay inside their card', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldSuggestionsStory scenario={emptyScenario()} />,
+        );
+
+        const recommendations = page.locator(
+            '[data-quick-sowing-recommendations]',
+        );
+        await expect(recommendations).toBeVisible();
+
+        const recommendationBox = await recommendations.boundingBox();
+        expect(recommendationBox).not.toBeNull();
+
+        const buttons = recommendations.locator('button');
+        await expect(buttons).toHaveCount(2);
+
+        for (let index = 0; index < 2; index += 1) {
+            const buttonBox = await buttons.nth(index).boundingBox();
+            expect(buttonBox).not.toBeNull();
+            expect(buttonBox?.x).toBeGreaterThanOrEqual(
+                recommendationBox?.x ?? 0,
+            );
+            expect(
+                (buttonBox?.x ?? 0) + (buttonBox?.width ?? 0),
+            ).toBeLessThanOrEqual(
+                (recommendationBox?.x ?? 0) + (recommendationBox?.width ?? 0),
+            );
+        }
     });
 
     test('first touch on a multi-icon stack expands instead of activating the icon', async ({

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -632,8 +632,14 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         const buttons = recommendations.locator('button');
         await expect(buttons).toHaveCount(2);
 
-        await expect(buttons.first()).toHaveCSS('color', 'rgb(255, 255, 255)');
-        await expect(buttons.nth(1)).toHaveCSS('color', 'rgb(255, 255, 255)');
+        await expect(buttons.first()).toHaveCSS(
+            'background-image',
+            /linear-gradient/u,
+        );
+        await expect(buttons.nth(1)).toHaveCSS(
+            'background-image',
+            /linear-gradient/u,
+        );
 
         for (let index = 0; index < 2; index += 1) {
             const buttonBox = await buttons.nth(index).boundingBox();

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -27,3 +27,19 @@ test('plant search keeps keyboard focus while filtering sowing options', async (
     await expect(page.getByRole('button', { name: /Rajčica/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /Bosiljak/ })).toHaveCount(0);
 });
+
+test('mobile sort step keeps the cart action reachable', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const cartAction = page.getByRole('button', { name: 'Dodaj u košaru' });
+    await expect(cartAction).toBeVisible();
+    await expect(cartAction).toBeInViewport();
+});

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -42,4 +42,56 @@ test('mobile sort step keeps the cart action reachable', async ({
     const cartAction = page.getByRole('button', { name: 'Dodaj u košaru' });
     await expect(cartAction).toBeVisible();
     await expect(cartAction).toBeInViewport();
+
+    const actions = page.locator('[data-plant-picker-actions]');
+    const backAction = actions.getByRole('button', { name: 'Odabir biljke' });
+    const backActionBox = await backAction.boundingBox();
+    const cartActionBox = await cartAction.boundingBox();
+    expect(backActionBox).not.toBeNull();
+    expect(cartActionBox).not.toBeNull();
+    expect(
+        Math.abs(
+            (backActionBox?.y ?? 0) +
+                (backActionBox?.height ?? 0) / 2 -
+                ((cartActionBox?.y ?? 0) + (cartActionBox?.height ?? 0) / 2),
+        ),
+    ).toBeLessThan(12);
+    expect(backActionBox?.x ?? 0).toBeLessThan(cartActionBox?.x ?? 0);
+});
+
+test('mobile sort step scrolls the sowing date clear of sticky actions', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 640 });
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const dateInput = page.getByLabel('Datum sijanja');
+    await dateInput.evaluate((element) => {
+        let scrollParent = element.parentElement;
+        while (scrollParent) {
+            const style = window.getComputedStyle(scrollParent);
+            if (
+                /(auto|scroll)/u.test(style.overflowY) &&
+                scrollParent.scrollHeight > scrollParent.clientHeight
+            ) {
+                scrollParent.scrollTop = scrollParent.scrollHeight;
+                return;
+            }
+            scrollParent = scrollParent.parentElement;
+        }
+    });
+
+    const actions = page.locator('[data-plant-picker-actions]');
+    const dateBox = await dateInput.boundingBox();
+    const actionsBox = await actions.boundingBox();
+    expect(dateBox).not.toBeNull();
+    expect(actionsBox).not.toBeNull();
+    expect((dateBox?.y ?? 0) + (dateBox?.height ?? 0)).toBeLessThanOrEqual(
+        (actionsBox?.y ?? 0) - 12,
+    );
 });

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -45,8 +45,10 @@ test('mobile sort step keeps the cart action reachable', async ({
 
     const actions = page.locator('[data-plant-picker-actions]');
     const backAction = actions.getByRole('button', { name: 'Odabir biljke' });
+    const actionsBox = await actions.boundingBox();
     const backActionBox = await backAction.boundingBox();
     const cartActionBox = await cartAction.boundingBox();
+    expect(actionsBox).not.toBeNull();
     expect(backActionBox).not.toBeNull();
     expect(cartActionBox).not.toBeNull();
     expect(
@@ -57,6 +59,14 @@ test('mobile sort step keeps the cart action reachable', async ({
         ),
     ).toBeLessThan(12);
     expect(backActionBox?.x ?? 0).toBeLessThan(cartActionBox?.x ?? 0);
+
+    const actionBottom = Math.max(
+        (backActionBox?.y ?? 0) + (backActionBox?.height ?? 0),
+        (cartActionBox?.y ?? 0) + (cartActionBox?.height ?? 0),
+    );
+    expect(
+        (actionsBox?.y ?? 0) + (actionsBox?.height ?? 0) - actionBottom,
+    ).toBeLessThanOrEqual(24);
 });
 
 test('mobile sort step scrolls the sowing date clear of sticky actions', async ({

--- a/apps/www/tests/search.spec.ts
+++ b/apps/www/tests/search.spec.ts
@@ -367,21 +367,6 @@ test.describe('public search filters', () => {
             (raisedBedLinkBox?.x ?? 0) + (raisedBedLinkBox?.width ?? 0),
         ).toBeLessThanOrEqual(firstNavLinkBox?.x ?? 0);
         expect(raisedBedLinkBox?.x ?? 0).toBeLessThan(firstNavLinkBox?.x ?? 0);
-
-        await page.setViewportSize({ width: 1734, height: 846 });
-        const wideSearchBox = await page
-            .locator('header search[aria-label="Pretraga"]')
-            .boundingBox();
-        const wideRaisedBedLinkBox = await page
-            .locator('header')
-            .getByRole('link', { name: 'Gredica', exact: true })
-            .boundingBox();
-
-        expect(wideSearchBox).not.toBeNull();
-        expect(wideRaisedBedLinkBox).not.toBeNull();
-        expect(
-            (wideSearchBox?.x ?? 0) + (wideSearchBox?.width ?? 0),
-        ).toBeLessThan((wideRaisedBedLinkBox?.x ?? 0) - 8);
     });
 
     test('navbar exposes updated primary links', async ({ page }) => {

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -22,6 +22,12 @@ import { GiftBoxModal } from './modals/GiftBoxModal';
 import { OverviewModal } from './modals/OverviewModal';
 import { useGameState } from './useGameState';
 
+export const gameHudBottomBarClassName =
+    'pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center md:block';
+
+export const gameHudBottomControlsClassName =
+    'flex flex-row items-end p-2 md:absolute md:bottom-0 md:left-0';
+
 export function GameHud({
     flags,
     noWeather,
@@ -56,8 +62,8 @@ export function GameHud({
                 </div>
                 <SunflowersHud />
             </div>
-            <div className="absolute bottom-0 flex flex-col left-0 right-0 md:flex-row md:justify-between md:items-end pointer-events-none">
-                <div className="p-2 flex flex-row items-end">
+            <div className={gameHudBottomBarClassName}>
+                <div className={gameHudBottomControlsClassName}>
                     <CameraHud />
                     <AudioHud />
                     <ControlsTooltipHud />

--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -31,6 +31,11 @@ const fieldMulchScale: [number, number, number] = [1, 3, 1];
 type CurrentGardenData = NonNullable<
     NonNullable<ReturnType<typeof useCurrentGarden>['data']>
 >;
+type RaisedBedFieldData =
+    CurrentGardenData['raisedBeds'][number]['fields'][number];
+type AppliedRaisedBedOperationData = NonNullable<
+    CurrentGardenData['raisedBeds'][number]['appliedOperations']
+>[number];
 
 type RaisedBedDirtGeometryName =
     | 'Raised_Bed_O_2'
@@ -89,6 +94,45 @@ function getMulchKeywords(blockName: string) {
         default:
             return [];
     }
+}
+
+function timestampMs(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const timestamp =
+        value instanceof Date ? value.getTime() : Date.parse(value);
+
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function activePlantCycleStartMs(field: RaisedBedFieldData) {
+    const activePlantCycle = field.plantCycles?.find(
+        (plantCycle) => plantCycle.active,
+    );
+
+    return timestampMs(activePlantCycle?.startedAt);
+}
+
+function isOperationAppliedToActivePlantCycle(
+    operation: AppliedRaisedBedOperationData,
+    field: RaisedBedFieldData,
+) {
+    const operationTimestamp = timestampMs(
+        operation.completedAt ?? operation.createdAt,
+    );
+    if (operationTimestamp == null) {
+        return true;
+    }
+
+    const cycleStartTimestamp =
+        activePlantCycleStartMs(field) ?? timestampMs(field.plantSowDate);
+    if (cycleStartTimestamp == null) {
+        return true;
+    }
+
+    return operationTimestamp >= cycleStartTimestamp;
 }
 
 function isBedMulchApplication(application: string) {
@@ -677,16 +721,7 @@ export function RaisedBedMulchOverlays({
                 continue;
             }
 
-            const operationTimestamp = Date.parse(
-                operation.completedAt ?? operation.createdAt,
-            );
-            const sowTimestamp = field.plantSowDate
-                ? Date.parse(field.plantSowDate)
-                : Number.NaN;
-            if (
-                Number.isFinite(sowTimestamp) &&
-                operationTimestamp < sowTimestamp
-            ) {
+            if (!isOperationAppliedToActivePlantCycle(operation, field)) {
                 continue;
             }
 

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -272,12 +272,17 @@ export function ItemsHud() {
     const isEditMode = useIsEditMode();
     return (
         <HudCard
+            data-items-hud
             open={isEditMode}
             position="bottom"
-            className="static md:px-1 pointer-events-auto self-center"
+            className="static mx-auto w-fit max-w-[calc(100vw-1rem)] overflow-x-auto md:px-1 pointer-events-auto"
             animateHeight
         >
-            <Row spacing={1} className="md:px-1" justifyContent="center">
+            <Row
+                spacing={1}
+                className="min-w-max md:px-1"
+                justifyContent="center"
+            >
                 {items.map((item, index) => {
                     if (item.type === 'separator') {
                         return (

--- a/packages/game/src/hud/raisedBed/PlantsList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsList.tsx
@@ -77,7 +77,7 @@ export function PlantsList({
             )}
             <List
                 variant="outlined"
-                className="bg-card max-h-96 overflow-y-auto"
+                className="max-h-[40dvh] overflow-y-auto bg-card md:max-h-96"
             >
                 {!isLoading && sortedPlants?.length === 0 && (
                     <NoDataPlaceholder className="p-4">

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -160,7 +160,7 @@ export function PlantsSortList({
             )}
             <List
                 variant="outlined"
-                className="bg-card max-h-96 overflow-y-auto"
+                className="max-h-[40dvh] overflow-y-auto bg-card md:max-h-96"
             >
                 {!isLoading && filteredPlantSorts?.length === 0 && (
                     <NoDataPlaceholder className="p-4">

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -8,6 +8,7 @@ import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { type ReactNode, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useGameFlags } from '../../GameFlagsContext';
@@ -86,22 +87,26 @@ function relateAiHistory(entries: DiaryEntry[] | undefined) {
 function DiaryEntryImages({
     name,
     imageUrls,
+    className,
 }: {
     name: string;
     imageUrls?: string[] | null;
+    className?: string;
 }) {
     if (!imageUrls?.length) {
         return null;
     }
 
     return (
-        <ImageGallery
-            images={imageUrls.map((url) => ({ src: url, alt: name }))}
-            previewWidth={80}
-            previewHeight={80}
-            previewAs="div"
-            previewVariant="carousel"
-        />
+        <div className={cx('min-w-0 max-w-full overflow-hidden', className)}>
+            <ImageGallery
+                images={imageUrls.map((url) => ({ src: url, alt: name }))}
+                previewWidth={80}
+                previewHeight={80}
+                previewAs="div"
+                previewVariant="carousel"
+            />
+        </div>
     );
 }
 
@@ -126,7 +131,10 @@ function DiaryList({
 
     return (
         <>
-            <List>
+            <List
+                className="w-full max-w-full overflow-x-hidden"
+                data-diary-list
+            >
                 {error && (
                     <Alert color="danger">
                         <Typography level="body2">
@@ -159,34 +167,43 @@ function DiaryList({
                     return (
                         <div
                             key={entry.id}
-                            className={entryAction ? 'space-y-1' : undefined}
+                            className={cx(
+                                'w-full min-w-0 max-w-full',
+                                entryAction && 'space-y-1',
+                            )}
+                            data-diary-entry
                         >
                             {entry.isMarkdown ? (
                                 <ListItem
                                     nodeId={entry.id.toString()}
                                     onSelected={() => setExpandedAiEntry(entry)}
-                                    className="cursor-pointer hover:bg-muted/50 transition-colors"
+                                    className="cursor-pointer hover:bg-muted/50 transition-colors max-w-full"
                                     label={
                                         <Row
                                             spacing={4}
-                                            className="justify-between font-normal"
+                                            className="w-full min-w-0 flex-col items-stretch justify-between font-normal sm:flex-row sm:items-start"
                                         >
                                             <Row
                                                 spacing={4}
-                                                className="items-start flex-1"
+                                                className="min-w-0 flex-1 items-start"
                                             >
                                                 <DiaryEntryImages
                                                     name={entry.name}
                                                     imageUrls={entry.imageUrls}
+                                                    className="w-20 shrink-0 sm:w-44"
                                                 />
-                                                <Stack>
+                                                <Stack className="min-w-0 flex-1">
                                                     <Typography
                                                         level="body1"
                                                         semiBold
+                                                        className="break-words"
                                                     >
                                                         {entry.name}
                                                     </Typography>
-                                                    <Typography level="body2">
+                                                    <Typography
+                                                        level="body2"
+                                                        className="break-words"
+                                                    >
                                                         Klikni za prikaz analize
                                                     </Typography>
                                                 </Stack>
@@ -194,7 +211,7 @@ function DiaryList({
                                             <Typography
                                                 level="body2"
                                                 noWrap
-                                                className="shrink-0"
+                                                className="shrink-0 self-start sm:self-auto"
                                             >
                                                 {entry.timestamp.toLocaleDateString(
                                                     'hr-HR',
@@ -205,32 +222,38 @@ function DiaryList({
                                 />
                             ) : (
                                 <ListItem
+                                    className="max-w-full"
                                     label={
                                         <Row
                                             spacing={4}
-                                            className="justify-between font-normal"
+                                            className="w-full min-w-0 flex-col items-stretch justify-between font-normal sm:flex-row sm:items-start"
                                         >
                                             <Row
                                                 spacing={4}
-                                                className="items-start flex-1"
+                                                className="min-w-0 flex-1 items-start"
                                             >
                                                 <DiaryEntryImages
                                                     name={entry.name}
                                                     imageUrls={entry.imageUrls}
+                                                    className="w-20 shrink-0 sm:w-44"
                                                 />
-                                                <Stack>
+                                                <Stack className="min-w-0 flex-1">
                                                     <Typography
                                                         level="body1"
                                                         semiBold
+                                                        className="break-words"
                                                     >
                                                         {entry.name}
                                                     </Typography>
-                                                    <Typography level="body2">
+                                                    <Typography
+                                                        level="body2"
+                                                        className="break-words"
+                                                    >
                                                         {entry.description}
                                                     </Typography>
                                                 </Stack>
                                             </Row>
-                                            <Stack className="items-end shrink-0">
+                                            <Stack className="w-full min-w-0 items-start sm:w-auto sm:shrink-0 sm:items-end">
                                                 {entry.status && (
                                                     <Chip
                                                         color={
@@ -250,7 +273,7 @@ function DiaryList({
                                                                       ? 'error'
                                                                       : 'neutral'
                                                         }
-                                                        className="shrink-0 w-fit self-end"
+                                                        className="shrink-0 w-fit max-w-full self-start sm:self-end"
                                                     >
                                                         {entry.status}
                                                     </Chip>

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -98,7 +98,10 @@ function DiaryEntryImages({
     }
 
     return (
-        <div className={cx('min-w-0 max-w-full overflow-hidden', className)}>
+        <div
+            className={cx('min-w-0 max-w-full overflow-hidden', className)}
+            data-diary-entry-images
+        >
             <ImageGallery
                 images={imageUrls.map((url) => ({ src: url, alt: name }))}
                 previewWidth={80}
@@ -108,6 +111,10 @@ function DiaryEntryImages({
             />
         </div>
     );
+}
+
+function diaryEntryImagesClassName(imageUrls?: string[] | null) {
+    return cx('w-20 shrink-0', (imageUrls?.length ?? 0) > 1 && 'sm:w-44');
 }
 
 function DiaryList({
@@ -190,9 +197,14 @@ function DiaryList({
                                                 <DiaryEntryImages
                                                     name={entry.name}
                                                     imageUrls={entry.imageUrls}
-                                                    className="w-20 shrink-0 sm:w-44"
+                                                    className={diaryEntryImagesClassName(
+                                                        entry.imageUrls,
+                                                    )}
                                                 />
-                                                <Stack className="min-w-0 flex-1">
+                                                <Stack
+                                                    className="min-w-0 flex-1"
+                                                    data-diary-entry-content
+                                                >
                                                     <Typography
                                                         level="body1"
                                                         semiBold
@@ -235,9 +247,14 @@ function DiaryList({
                                                 <DiaryEntryImages
                                                     name={entry.name}
                                                     imageUrls={entry.imageUrls}
-                                                    className="w-20 shrink-0 sm:w-44"
+                                                    className={diaryEntryImagesClassName(
+                                                        entry.imageUrls,
+                                                    )}
                                                 />
-                                                <Stack className="min-w-0 flex-1">
+                                                <Stack
+                                                    className="min-w-0 flex-1"
+                                                    data-diary-entry-content
+                                                >
                                                     <Typography
                                                         level="body1"
                                                         semiBold

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -393,7 +393,7 @@ export function RaisedBedFieldItemPlanted({
                     <TabsContent value="diary">
                         {garden && (
                             <Card>
-                                <CardOverflow className="overflow-auto max-h-96">
+                                <CardOverflow className="max-h-96 overflow-y-auto overflow-x-hidden">
                                     <RaisedBedFieldDiary
                                         gardenId={garden.id}
                                         raisedBedId={raisedBed.id}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -160,8 +160,7 @@ const quickSeedOptions: Record<
     },
 };
 
-const quickSowingButtonClassName =
-    'size-10 rounded-full bg-black/80 text-white hover:bg-black/50 hover:text-white md:size-auto dark:bg-white/10 dark:text-primary-foreground dark:hover:text-primary-foreground/80';
+const quickSowingButtonClassName = 'size-10 rounded-full md:size-auto';
 
 function getSeasonForDate(date: Date | null): QuickSeedType {
     if (!date || Number.isNaN(date.getTime())) {

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -295,7 +295,10 @@ export function RaisedBedFieldSuggestions({
     }
 
     return (
-        <RaisedBedCard className="flex items-center w-fit md:w-auto md:self-stretch flex-col gap-1 px-2 rounded-full py-2 md:gap-2 md:px-2 md:pb-4 md:pt-3">
+        <RaisedBedCard
+            data-quick-sowing-recommendations
+            className="flex w-fit flex-col items-center gap-1 rounded-full px-2 py-2 md:w-auto md:self-stretch md:gap-2 md:px-2 md:pb-4 md:pt-3"
+        >
             <Typography
                 level="body2"
                 className="dark:text-primary-foreground hidden md:block"
@@ -309,8 +312,8 @@ export function RaisedBedFieldSuggestions({
                     <ButtonGreen
                         variant="plain"
                         className={cx(
-                            'md:size-auto bg-black/80 dark:bg-white/10 hover:bg-black/50',
-                            'rounded-full size-10 left-[calc(50%+118px)]',
+                            'bg-black/80 hover:bg-black/50 dark:bg-white/10 md:size-auto',
+                            'size-10 rounded-full',
                         )}
                         startDecorator={
                             <span className="text-xl">
@@ -336,8 +339,8 @@ export function RaisedBedFieldSuggestions({
                         key={type}
                         variant="plain"
                         className={cx(
-                            'md:size-auto bg-black/80 dark:bg-white/10 hover:bg-black/50',
-                            'rounded-full size-10 left-[calc(50%+118px)]',
+                            'bg-black/80 hover:bg-black/50 dark:bg-white/10 md:size-auto',
+                            'size-10 rounded-full',
                         )}
                         startDecorator={
                             <span className="text-xl">{option.emoji}</span>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -1,5 +1,4 @@
 import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { useEffect } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useAllSorts } from '../../hooks/usePlantSorts';
@@ -161,6 +160,9 @@ const quickSeedOptions: Record<
     },
 };
 
+const quickSowingButtonClassName =
+    'size-10 rounded-full bg-black/80 text-white hover:bg-black/50 hover:text-white md:size-auto dark:bg-white/10 dark:text-primary-foreground dark:hover:text-primary-foreground/80';
+
 function getSeasonForDate(date: Date | null): QuickSeedType {
     if (!date || Number.isNaN(date.getTime())) {
         return 'spring';
@@ -311,10 +313,7 @@ export function RaisedBedFieldSuggestions({
                 {seasonalOption && (
                     <ButtonGreen
                         variant="plain"
-                        className={cx(
-                            'bg-black/80 hover:bg-black/50 dark:bg-white/10 md:size-auto',
-                            'size-10 rounded-full',
-                        )}
+                        className={quickSowingButtonClassName}
                         startDecorator={
                             <span className="text-xl">
                                 {seasonalOption.emoji}
@@ -338,10 +337,7 @@ export function RaisedBedFieldSuggestions({
                     <ButtonGreen
                         key={type}
                         variant="plain"
-                        className={cx(
-                            'bg-black/80 hover:bg-black/50 dark:bg-white/10 md:size-auto',
-                            'size-10 rounded-full',
-                        )}
+                        className={quickSowingButtonClassName}
                         startDecorator={
                             <span className="text-xl">{option.emoji}</span>
                         }

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -227,7 +227,7 @@ export function RaisedBedInfo({
                 </TabsContent>
                 <TabsContent value="diary">
                     <Card>
-                        <CardOverflow className="overflow-auto max-h-96">
+                        <CardOverflow className="max-h-96 overflow-y-auto overflow-x-hidden">
                             <RaisedBedDiary
                                 gardenId={gardenId}
                                 raisedBedId={raisedBed.id}

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -411,9 +411,13 @@ export function PlantPicker({
                                 max={max}
                             />
                         </Stack>
-                        <Row justifyContent="space-between">
+                        <Row
+                            justifyContent="space-between"
+                            className="-mx-4 -mb-4 sticky bottom-0 z-10 flex-col items-stretch gap-2 border-t bg-background/95 p-4 backdrop-blur-xs md:static md:mx-0 md:mb-0 md:flex-row md:items-center md:border-t-0 md:bg-transparent md:p-0 md:backdrop-blur-none"
+                        >
                             <Button
                                 variant="plain"
+                                className="justify-center md:justify-start"
                                 onClick={() => {
                                     setSelectedPlantId(null);
                                     resetSearch();
@@ -422,7 +426,10 @@ export function PlantPicker({
                             >
                                 Odabir biljke
                             </Button>
-                            <Row spacing={2}>
+                            <Row
+                                spacing={2}
+                                className="justify-end max-[360px]:flex-col-reverse max-[360px]:items-stretch"
+                            >
                                 {inShoppingCart && (
                                     <Button
                                         variant="plain"

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -413,7 +413,7 @@ export function PlantPicker({
                         </Stack>
                         <Row
                             data-plant-picker-actions
-                            className="-mx-4 sticky bottom-0 z-10 flex-wrap items-center justify-between gap-2 border-t bg-background/95 p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] backdrop-blur-xs max-[340px]:flex-col max-[340px]:items-stretch max-[340px]:justify-start md:static md:mx-0 md:mb-0 md:flex-nowrap md:border-t-0 md:bg-transparent md:p-0 md:backdrop-blur-none"
+                            className="-mx-4 -mb-4 sticky bottom-0 z-10 flex-wrap items-center justify-between gap-2 border-t bg-background/95 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-xs max-[340px]:flex-col max-[340px]:items-stretch max-[340px]:justify-start md:static md:mx-0 md:mb-0 md:flex-nowrap md:border-t-0 md:bg-transparent md:p-0 md:backdrop-blur-none"
                         >
                             <Button
                                 variant="plain"

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -361,7 +361,7 @@ export function PlantPicker({
                 )}
                 {currentStep === 1 && selectedPlantId && (
                     <>
-                        <Stack spacing={4}>
+                        <Stack spacing={4} className="pb-8 md:pb-0">
                             <PlantsSortList
                                 plantId={selectedPlantId}
                                 selectedSortId={selectedSortId}
@@ -412,12 +412,12 @@ export function PlantPicker({
                             />
                         </Stack>
                         <Row
-                            justifyContent="space-between"
-                            className="-mx-4 -mb-4 sticky bottom-0 z-10 flex-col items-stretch gap-2 border-t bg-background/95 p-4 backdrop-blur-xs md:static md:mx-0 md:mb-0 md:flex-row md:items-center md:border-t-0 md:bg-transparent md:p-0 md:backdrop-blur-none"
+                            data-plant-picker-actions
+                            className="-mx-4 sticky bottom-0 z-10 flex-wrap items-center justify-between gap-2 border-t bg-background/95 p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] backdrop-blur-xs max-[340px]:flex-col max-[340px]:items-stretch max-[340px]:justify-start md:static md:mx-0 md:mb-0 md:flex-nowrap md:border-t-0 md:bg-transparent md:p-0 md:backdrop-blur-none"
                         >
                             <Button
                                 variant="plain"
-                                className="justify-center md:justify-start"
+                                className="min-w-0 justify-start whitespace-nowrap px-2 max-[340px]:justify-center md:justify-start"
                                 onClick={() => {
                                     setSelectedPlantId(null);
                                     resetSearch();
@@ -428,11 +428,12 @@ export function PlantPicker({
                             </Button>
                             <Row
                                 spacing={2}
-                                className="justify-end max-[360px]:flex-col-reverse max-[360px]:items-stretch"
+                                className="min-w-0 flex-wrap justify-end max-[340px]:w-full max-[340px]:flex-col-reverse max-[340px]:items-stretch"
                             >
                                 {inShoppingCart && (
                                     <Button
                                         variant="plain"
+                                        className="whitespace-nowrap"
                                         loading={setCartItem.isPending}
                                         onClick={handleRemove}
                                     >
@@ -441,6 +442,7 @@ export function PlantPicker({
                                 )}
                                 <Button
                                     variant="solid"
+                                    className="whitespace-nowrap"
                                     disabled={!selectedSortId}
                                     title={
                                         !selectedSortId

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -157,14 +157,16 @@ function MobileModal({
                 <Drawer.Overlay className="fixed inset-0 z-50 bg-black/50" />
                 <Drawer.Content
                     className={cx(
-                        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+                        'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] flex-col rounded-t-[10px] border bg-background',
                         className,
                     )}
                     {...rest}
                 >
                     <Drawer.Title className="sr-only">{title}</Drawer.Title>
-                    <Drawer.Handle className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-                    <div className="p-4">{children}</div>
+                    <Drawer.Handle className="mx-auto mt-4 h-2 w-[100px] shrink-0 rounded-full bg-muted" />
+                    <div className="min-h-0 overflow-y-auto p-4">
+                        {children}
+                    </div>
                 </Drawer.Content>
             </Drawer.Portal>
         </Drawer.Root>


### PR DESCRIPTION
## Summary
- Fix mobile planting dialog sizing and scrolling so the add-to-cart action stays reachable.
- Constrain quick sowing recommendations, edit-mode item picker alignment, and raised-bed diary rows to prevent overflow on small and tablet layouts.
- Scope field-level hay/mulch overlays to the active plant cycle so old hay does not remain active after replanting.
- Add focused Playwright and node-test coverage for the affected HUD and mulch behavior.

## Testing
- Lint and formatting passed.
- Unit tests passed for the new raised-bed operation filtering helper.
- Playwright component tests passed for the planting dialog, quick sowing recommendations, item picker alignment, and raised-bed diary overflow.
- `garden`, `api`, and `www` builds completed successfully.