### PR TITLE
Fix login modal width, social button styling, and tab alignment

### DIFF
--- a/apps/app/components/admin/navigation/LoginDialog.tsx
+++ b/apps/app/components/admin/navigation/LoginDialog.tsx
@@ -105,7 +105,7 @@ export function LoginDialog() {
                     <Typography level="h4" component="p">
                         Prijava
                     </Typography>
-                    <form action={submitAction}>
+                    <form action={submitAction} className="w-full">
                         <Stack spacing={8}>
                             <Stack spacing={2}>
                                 <Input
@@ -114,18 +114,21 @@ export function LoginDialog() {
                                     placeholder="email@email.com"
                                     type="email"
                                     autoComplete="email"
+                                    fullWidth
                                 />
                                 <Input
                                     name="password"
                                     label="Zaporka"
                                     type="password"
                                     autoComplete="current-password"
+                                    fullWidth
                                 />
                             </Stack>
                             <Button
                                 type="submit"
                                 loading={isPending}
                                 variant="solid"
+                                fullWidth
                             >
                                 Prijavi se
                             </Button>

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -142,7 +142,7 @@ export function LoginDialog() {
                             svojom farmom.
                         </Typography>
                     </Stack>
-                    <form action={submitAction} className="space-y-4">
+                    <form action={submitAction} className="w-full space-y-4">
                         <Stack spacing={6}>
                             <Stack spacing={2}>
                                 <Input
@@ -151,6 +151,7 @@ export function LoginDialog() {
                                     placeholder="ime@primjer.com"
                                     type="email"
                                     autoComplete="email"
+                                    fullWidth
                                     required
                                 />
                                 <Input
@@ -158,6 +159,7 @@ export function LoginDialog() {
                                     label="Zaporka"
                                     type="password"
                                     autoComplete="current-password"
+                                    fullWidth
                                     required
                                 />
                             </Stack>

--- a/apps/garden/components/auth/EmailPasswordForm.tsx
+++ b/apps/garden/components/auth/EmailPasswordForm.tsx
@@ -39,12 +39,13 @@ export function EmailPasswordForm({
     };
 
     return (
-        <form onSubmit={handleSubmit} className="gap-6 flex flex-col">
+        <form onSubmit={handleSubmit} className="flex w-full flex-col gap-6">
             <Stack spacing={2}>
                 <Input
                     id="email"
                     type="email"
                     label="Email"
+                    fullWidth
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     required
@@ -53,6 +54,7 @@ export function EmailPasswordForm({
                     id="password"
                     type="password"
                     label="Zaporka"
+                    fullWidth
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     required
@@ -63,6 +65,7 @@ export function EmailPasswordForm({
                             id="repeatPassword"
                             type="password"
                             label="Ponovi zaporku"
+                            fullWidth
                             value={repeatPassword}
                             onChange={(e) => setRepeatPassword(e.target.value)}
                             required

--- a/packages/game/src/modals/components/FacebookLoginButton.tsx
+++ b/packages/game/src/modals/components/FacebookLoginButton.tsx
@@ -1,16 +1,21 @@
 import { Button, type ButtonProps } from '@gredice/ui/Button';
 import { CompanyFacebook } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
 
-export function FacebookLoginButton({ ...props }: ButtonProps) {
+export function FacebookLoginButton({ className, ...props }: ButtonProps) {
     return (
         <Button
             type="button"
+            color="neutral"
             variant="outlined"
-            className="bg-white dark:bg-blue-900"
+            className={cx(
+                'border-transparent bg-[#1877F2] text-white hover:bg-[#166FE5] dark:border-transparent dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800',
+                className,
+            )}
             fullWidth
             {...props}
         >
-            <CompanyFacebook className="mr-2" />
+            <CompanyFacebook className="size-4 shrink-0" />
             Poveži Facebook račun
         </Button>
     );

--- a/packages/game/src/modals/components/GoogleLoginButton.tsx
+++ b/packages/game/src/modals/components/GoogleLoginButton.tsx
@@ -1,16 +1,21 @@
 import { Button, type ButtonProps } from '@gredice/ui/Button';
+import { cx } from '@gredice/ui/utils';
 import { CompanyGoogle } from './CompanyGoogle';
 
-export function GoogleLoginButton({ ...props }: ButtonProps) {
+export function GoogleLoginButton({ className, ...props }: ButtonProps) {
     return (
         <Button
             type="button"
+            color="neutral"
             variant="outlined"
-            className="bg-white dark:bg-black"
+            className={cx(
+                'bg-white text-black hover:bg-white/90 dark:text-black dark:hover:bg-white/80',
+                className,
+            )}
             fullWidth
             {...props}
         >
-            <CompanyGoogle className="mr-2 h-4 w-4" />
+            <CompanyGoogle className="h-4 w-4 shrink-0" />
             Poveži Google račun
         </Button>
     );

--- a/packages/ui/src/Tabs/Tabs.tsx
+++ b/packages/ui/src/Tabs/Tabs.tsx
@@ -7,7 +7,7 @@ import type {
     CSSProperties,
     ForwardedRef,
 } from 'react';
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useLayoutEffect, useState } from 'react';
 
 function cx(...classes: Array<string | false | null | undefined>) {
     return classes.filter(Boolean).join(' ');
@@ -69,7 +69,7 @@ export const TabsList = forwardRef<
         [ref],
     );
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (!listElement || typeof window === 'undefined') {
             return;
         }
@@ -89,21 +89,11 @@ export const TabsList = forwardRef<
                 return;
             }
 
-            const listRect = tabsListElement.getBoundingClientRect();
-            const activeRect = activeTrigger.getBoundingClientRect();
             const nextIndicator = {
-                height: activeRect.height,
-                left:
-                    activeRect.left -
-                    listRect.left +
-                    tabsListElement.scrollLeft -
-                    tabsListElement.clientLeft,
-                top:
-                    activeRect.top -
-                    listRect.top +
-                    tabsListElement.scrollTop -
-                    tabsListElement.clientTop,
-                width: activeRect.width,
+                height: activeTrigger.offsetHeight,
+                left: activeTrigger.offsetLeft - tabsListElement.scrollLeft,
+                top: activeTrigger.offsetTop - tabsListElement.scrollTop,
+                width: activeTrigger.offsetWidth,
             };
 
             setIndicator((current) =>

--- a/packages/ui/src/auth/FacebookLoginButton.tsx
+++ b/packages/ui/src/auth/FacebookLoginButton.tsx
@@ -1,15 +1,21 @@
 import { Button, type ButtonProps } from '../Button';
 import { Chip } from '../Chip';
+import { cx } from '../utils';
 
 export function FacebookLoginButton({
+    className,
     lastUsed,
     ...props
 }: ButtonProps & { lastUsed?: boolean }) {
     return (
         <Button
             type="button"
+            color="neutral"
             variant="outlined"
-            className="bg-white dark:bg-blue-900 dark:hover:bg-blue-800"
+            className={cx(
+                'border-transparent bg-[#1877F2] text-white hover:bg-[#166FE5] dark:border-transparent dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800',
+                className,
+            )}
             fullWidth
             endDecorator={
                 lastUsed && (
@@ -24,7 +30,7 @@ export function FacebookLoginButton({
             {...props}
         >
             <svg
-                className="mr-2 h-4 w-4 text-[#1877F2] dark:text-white"
+                className="h-4 w-4 shrink-0 text-white"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"

--- a/packages/ui/src/auth/GoogleLoginButton.tsx
+++ b/packages/ui/src/auth/GoogleLoginButton.tsx
@@ -1,15 +1,21 @@
 import { Button, type ButtonProps } from '../Button';
 import { Chip } from '../Chip';
+import { cx } from '../utils';
 
 export function GoogleLoginButton({
+    className,
     lastUsed,
     ...props
 }: ButtonProps & { lastUsed?: boolean }) {
     return (
         <Button
             type="button"
+            color="neutral"
             variant="outlined"
-            className="bg-white dark:text-black dark:hover:bg-white/80"
+            className={cx(
+                'bg-white text-black hover:bg-white/90 dark:text-black dark:hover:bg-white/80',
+                className,
+            )}
             fullWidth
             endDecorator={
                 lastUsed && (
@@ -23,7 +29,7 @@ export function GoogleLoginButton({
             }
             {...props}
         >
-            <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+            <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24">
                 <title>Google</title>
                 <path
                     fill="#4285F4"


### PR DESCRIPTION
## Summary
- Make login form fields and submit controls full width across garden, farm, and admin login modals.
- Fix shared Facebook and Google auth button styling so the Facebook button no longer shows an outlined border and both buttons keep consistent icon alignment.
- Stabilize the shared tabs indicator measurement so the active tab is aligned correctly on first render.

## Testing
- `pnpm lint --filter @gredice/ui --filter garden --filter farm --filter app`
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/ui --filter garden --filter farm --filter app`
- `pnpm build --filter garden --filter farm --filter app`
- `pnpm build --filter www`
- `pnpm test --filter @gredice/game`
- Local browser check of the garden login modal confirmed full-width inputs, corrected social button styling, and aligned tabs on initial load and after switching tabs.