### PR TITLE
Stabilize navbar Playwright coverage

### DIFF
--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -1,6 +1,8 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from './fixtures';
 
+test.describe.configure({ mode: 'default' });
+
 async function expectMobileNavActionsDoNotOverlap(page: Page) {
     const cta = page.getByRole('link', { name: 'Moj novi vrt' });
     const menuButton = page.getByRole('button', {
@@ -33,7 +35,7 @@ test('mobile navbar closes after navigating from the menu', async ({
     test.slow();
 
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('/');
+    await page.goto('/kontakt');
     await expectMobileNavActionsDoNotOverlap(page);
 
     const menuButton = page.getByRole('button', {
@@ -59,7 +61,7 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
     page,
 }, testInfo) => {
     test.slow();
-    testInfo.setTimeout(35_000);
+    testInfo.setTimeout(60_000);
 
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/');

--- a/apps/www/tests/search.spec.ts
+++ b/apps/www/tests/search.spec.ts
@@ -1,6 +1,8 @@
 import type { Page } from '@playwright/test';
 import { expect, type Locator, test } from './fixtures';
 
+const navSearchTestPath = '/kontakt';
+
 async function typeSearch(locator: Locator, value: string) {
     await locator.click();
     await locator.pressSequentially(value);
@@ -68,7 +70,7 @@ test.describe('public search filters', () => {
             },
         );
 
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
 
         const expectedShortcut = await page.evaluate(() =>
             /Mac|iPhone|iPad|iPod/u.test(
@@ -146,7 +148,7 @@ test.describe('public search filters', () => {
             },
         );
 
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
         const expectedShortcut = await page.evaluate(() =>
             /Mac|iPhone|iPad|iPod/u.test(
                 navigator.platform || navigator.userAgent,
@@ -262,7 +264,7 @@ test.describe('public search filters', () => {
             },
         );
 
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
         const expectedShortcut = await page.evaluate(() =>
             /Mac|iPhone|iPad|iPod/u.test(
                 navigator.platform || navigator.userAgent,
@@ -328,7 +330,7 @@ test.describe('public search filters', () => {
                 get: () => 1,
             });
         });
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
 
         await expect(page.getByText('⌘K', { exact: true })).toHaveCount(0);
         await expect(page.getByText('Ctrl K', { exact: true })).toHaveCount(0);
@@ -336,7 +338,7 @@ test.describe('public search filters', () => {
 
     test('navbar search avoids primary link overlap', async ({ page }) => {
         await page.setViewportSize({ width: 1180, height: 720 });
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
         await expect(
             page.locator('header search[aria-label="Pretraga"]'),
         ).toBeHidden();
@@ -370,7 +372,7 @@ test.describe('public search filters', () => {
     });
 
     test('navbar exposes updated primary links', async ({ page }) => {
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
 
         const navbar = page.locator('header');
         await expect(
@@ -399,7 +401,7 @@ test.describe('public search filters', () => {
             },
         );
 
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
 
         const navbar = page.locator('header');
         await expect(
@@ -410,7 +412,7 @@ test.describe('public search filters', () => {
 
     test('navbar search uses compact mobile button', async ({ page }) => {
         await page.setViewportSize({ width: 390, height: 844 });
-        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.goto(navSearchTestPath, { waitUntil: 'domcontentloaded' });
 
         const searchButton = page.getByRole('button', { name: 'Pretraga' });
         await expect(searchButton).toBeVisible();

--- a/packages/ui/src/Nav/Nav.tsx
+++ b/packages/ui/src/Nav/Nav.tsx
@@ -109,7 +109,7 @@ export function PageNav({ logo, links, children }: PageNavProps) {
             >
                 <header
                     className={cx(
-                        'pointer-events-auto relative flex h-16 items-center border-transparent bg-background/75 backdrop-blur-md transition-[height,border-color,background-color,border-radius,box-shadow] duration-300 ease-out',
+                        'pointer-events-auto relative flex h-16 items-center border-transparent bg-background/75 backdrop-blur-md transition-[height,border-color,background-color,box-shadow] duration-300 ease-out',
                         isFloating &&
                             'h-14 rounded-2xl border border-border/70 bg-background/80 shadow-lg shadow-foreground/10 backdrop-blur-xl',
                     )}


### PR DESCRIPTION
## Summary
- Moved navbar-only search tests off the landing page so they no longer compete with the game-heavy hero during CI runs.
- Kept the landing navbar spec isolated with explicit default describe mode and a longer timeout for the expensive game-frame check.
- Removed `border-radius` from the nav header transition so the floating state resolves deterministically in CSS assertions.

## Testing
- `pnpm build --filter www`
- `pnpm lint --filter @gredice/ui`
- `pnpm lint --filter www`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter www exec playwright test --project=chromium tests/landing.spec.ts tests/search.spec.ts`