### PR TITLE
Adjust sunflower HUD / cart modal stacking and add Modal overlayClassName

### DIFF
--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -311,7 +311,8 @@ export function ShoppingCartHud() {
                         setIsOpen(open);
                     }}
                     title="Košara"
-                    className="border-tertiary border-b-4 md:max-w-2xl"
+                    className="z-[46] border-tertiary border-b-4 md:max-w-2xl"
+                    overlayClassName="z-[46]"
                     trigger={
                         <Button
                             title="Košara"

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -215,7 +215,7 @@ function SunflowersAmount() {
 
 export function SunflowersHud() {
     return (
-        <HudCard position="floating" open className="static z-[55]">
+        <HudCard position="floating" open className="static z-[48]">
             <SunflowersAmount />
         </HudCard>
     );

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -21,6 +21,7 @@ export type ModalProps = Omit<HTMLAttributes<HTMLDivElement>, 'title'> & {
     disableMobile?: boolean;
     mobileOverride?: boolean;
     dismissible?: boolean;
+    overlayClassName?: string;
 };
 
 export function Modal({
@@ -32,6 +33,7 @@ export function Modal({
     mobileOverride,
     disableMobile,
     onOpenChange,
+    overlayClassName,
     open,
     title,
     trigger,
@@ -47,6 +49,7 @@ export function Modal({
                 dismissible={dismissible}
                 modal={modal}
                 onOpenChange={onOpenChange}
+                overlayClassName={overlayClassName}
                 open={open}
                 title={title}
                 trigger={trigger}
@@ -64,6 +67,7 @@ export function Modal({
             hideClose={hideClose}
             modal={modal}
             onOpenChange={onOpenChange}
+            overlayClassName={overlayClassName}
             open={open}
             title={title}
             trigger={trigger}
@@ -81,6 +85,7 @@ function DesktopModal({
     hideClose,
     modal,
     onOpenChange,
+    overlayClassName,
     open,
     title,
     trigger,
@@ -104,7 +109,12 @@ function DesktopModal({
                 </DialogPrimitive.Trigger>
             ) : null}
             <DialogPrimitive.Portal>
-                <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+                <DialogPrimitive.Overlay
+                    className={cx(
+                        'fixed inset-0 z-50 bg-background/80 backdrop-blur-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+                        overlayClassName,
+                    )}
+                />
                 <DialogPrimitive.Content
                     aria-describedby={undefined}
                     className={cx(
@@ -137,6 +147,7 @@ function MobileModal({
     dismissible = true,
     modal,
     onOpenChange,
+    overlayClassName,
     open,
     title,
     trigger,
@@ -154,7 +165,12 @@ function MobileModal({
                 <Drawer.Trigger asChild>{trigger}</Drawer.Trigger>
             ) : null}
             <Drawer.Portal>
-                <Drawer.Overlay className="fixed inset-0 z-50 bg-black/50" />
+                <Drawer.Overlay
+                    className={cx(
+                        'fixed inset-0 z-50 bg-black/50',
+                        overlayClassName,
+                    )}
+                />
                 <Drawer.Content
                     className={cx(
                         'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] flex-col rounded-t-[10px] border bg-background',


### PR DESCRIPTION
### Motivation
- Users reported the sunflower HUD appearing above an image viewer and blocking the close control, so modal stacking needed to be adjusted.
- The goal was to keep the sunflower HUD visible above the shopping cart modal (so users can see sunflower state while the cart is open) but ensure it remains below other global modals like image viewers.

### Description
- Added an optional `overlayClassName` prop to the shared `Modal` component and threaded it into both desktop (`DialogPrimitive.Overlay`) and mobile (`Drawer.Overlay`) overlays so individual modals can tune overlay stacking without changing global defaults (`packages/ui/src/Modal/Modal.tsx`).
- Lowered the sunflower HUD z-index from `z-[55]` to `z-[48]` so it no longer sits above general-purpose modals (`packages/game/src/hud/SunflowersHud.tsx`).
- Set the shopping cart modal content and its overlay to `z-[46]` so the sunflower HUD remains above the cart but below other modals (`packages/game/src/hud/ShoppingCartHud.tsx`).

### Testing
- Ran `pnpm lint --filter @gredice/game` which completed successfully (biome checks passed) with only an environment engine warning about Node version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140dbb7080832f8a9eeb2713820699)