### PR TITLE
Add confirmation modal for plant status changes and make transitions reversible

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -285,7 +285,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeVisible();
     });
 
-    test('status popover explains when current state cannot change', async ({
+    test('status popover allows reverting ready state back to sprouted', async ({
         mount,
         page,
     }) => {
@@ -305,16 +305,11 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             })
             .click();
 
-        await expect(
-            page.getByText('Stanje biljke', { exact: true }),
-        ).toBeVisible();
-        await expect(page.getByText('Spremna za berbu').last()).toBeVisible();
-        await expect(
-            page.getByText('Stanje se ne može promijeniti u ovom trenutku.'),
-        ).toBeVisible();
+        await expect(page.getByText('Promijeni stanje')).toBeVisible();
+        await expect(page.getByText('Proklijala').last()).toBeVisible();
         await expect(
             page.getByRole('button', { name: 'Odaberi datum promjene' }),
-        ).toHaveCount(0);
+        ).toBeVisible();
     });
 
     test('future harvest date shows absolute harvest days', async ({

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx
@@ -6,6 +6,7 @@ import { Input } from '@gredice/ui/Input';
 import { Calendar, Navigate } from '@gredice/ui/icons';
 import { List } from '@gredice/ui/List';
 import { ListItem } from '@gredice/ui/ListItem';
+import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { Popper } from '@gredice/ui/Popper';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -41,6 +42,7 @@ export function RaisedBedFieldStatusChange({
     );
     const [open, setOpen] = useState(false);
     const [datePickerOpen, setDatePickerOpen] = useState(false);
+    const [statusToConfirm, setStatusToConfirm] = useState<string | null>(null);
     const [datePickerContainer, setDatePickerContainer] =
         useState<HTMLElement>();
     const handleDatePickerContainerRef = useCallback(
@@ -76,7 +78,12 @@ export function RaisedBedFieldStatusChange({
             timestamp,
         });
         setOpen(false);
+        setStatusToConfirm(null);
     };
+
+    const confirmedStatusInfo = statusToConfirm
+        ? plantFieldStatusLabel(statusToConfirm)
+        : null;
 
     return (
         <Popper
@@ -156,7 +163,9 @@ export function RaisedBedFieldStatusChange({
                                         updateStatusMutation.isPending ||
                                         !isDateSelected
                                     }
-                                    onSelected={handleStatusChange}
+                                    onSelected={(nextStatus) => {
+                                        setStatusToConfirm(nextStatus);
+                                    }}
                                     className="py-3 pr-4"
                                     startDecorator={
                                         <span
@@ -206,6 +215,29 @@ export function RaisedBedFieldStatusChange({
                     </Stack>
                 )}
             </Stack>
+            <ModalConfirm
+                open={Boolean(statusToConfirm)}
+                onOpenChange={(nextOpen) => {
+                    if (!nextOpen) {
+                        setStatusToConfirm(null);
+                    }
+                }}
+                title="Potvrda promjene stanja"
+                description={
+                    confirmedStatusInfo
+                        ? `Jeste li sigurni da želite promijeniti stanje biljke u "${confirmedStatusInfo.shortLabel}"?`
+                        : 'Jeste li sigurni da želite promijeniti stanje biljke?'
+                }
+                cancelLabel="Odustani"
+                confirmLabel="Promijeni stanje"
+                onConfirm={async () => {
+                    if (statusToConfirm) {
+                        await handleStatusChange(statusToConfirm);
+                    }
+                }}
+                disabled={updateStatusMutation.isPending}
+                loading={updateStatusMutation.isPending}
+            />
         </Popper>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx
@@ -222,22 +222,24 @@ export function RaisedBedFieldStatusChange({
                         setStatusToConfirm(null);
                     }
                 }}
-                title="Potvrda promjene stanja"
-                description={
-                    confirmedStatusInfo
-                        ? `Jeste li sigurni da želite promijeniti stanje biljke u "${confirmedStatusInfo.shortLabel}"?`
-                        : 'Jeste li sigurni da želite promijeniti stanje biljke?'
+                title="Potvrda promjene stanja biljke"
+                header="Potvrda promjene stanja"
+                confirmLabel={
+                    updateStatusMutation.isPending
+                        ? 'Spremam...'
+                        : 'Promijeni stanje'
                 }
                 cancelLabel="Odustani"
-                confirmLabel="Promijeni stanje"
-                onConfirm={async () => {
-                    if (statusToConfirm) {
-                        await handleStatusChange(statusToConfirm);
+                onConfirm={() => {
+                    if (statusToConfirm && !updateStatusMutation.isPending) {
+                        void handleStatusChange(statusToConfirm);
                     }
                 }}
-                disabled={updateStatusMutation.isPending}
-                loading={updateStatusMutation.isPending}
-            />
+            >
+                {confirmedStatusInfo
+                    ? `Jeste li sigurni da želite promijeniti stanje biljke u "${confirmedStatusInfo.shortLabel}"?`
+                    : 'Jeste li sigurni da želite promijeniti stanje biljke?'}
+            </ModalConfirm>
         </Popper>
     );
 }

--- a/packages/js/src/plants/plantFieldStatusTransitions.ts
+++ b/packages/js/src/plants/plantFieldStatusTransitions.ts
@@ -5,10 +5,13 @@
  * statuses the user can transition to from that state.
  *
  * Allowed transitions:
- * - sowed → sprouted
- * - sprouted → notSprouted, died, ready
+ * - sowed ↔ sprouted
+ * - sprouted ↔ notSprouted, died, ready
  */
 export const userAllowedPlantStatusTransitions: Record<string, string[]> = {
     sowed: ['sprouted'],
-    sprouted: ['notSprouted', 'died', 'ready'],
+    sprouted: ['sowed', 'notSprouted', 'died', 'ready'],
+    notSprouted: ['sprouted'],
+    died: ['sprouted'],
+    ready: ['sprouted'],
 };


### PR DESCRIPTION
### Motivation
- Prevent accidental plant lifecycle changes by requiring an explicit confirmation before applying a new status.
- Allow users to always revert to the previous lifecycle state by making forward transitions reversible in the allowed transitions map.

### Description
- Add a confirmation step in the lifecycle status picker by introducing `statusToConfirm` and showing `ModalConfirm` before calling the update mutation in `packages/game/src/hud/raisedBed/RaisedBedFieldStatusChange.tsx`.
- Change the `ListItem` selection handler to set `statusToConfirm` and invoke the mutation only after the user confirms, preserving the existing date-selection flow.
- Expand `userAllowedPlantStatusTransitions` in `packages/js/src/plants/plantFieldStatusTransitions.ts` to include reverse transitions so each forward lifecycle change can be reversed (added entries for `notSprouted`, `died`, and `ready` and added `sowed` as a target for `sprouted`).
- Update JSDoc comment in the transitions file to reflect the reversible transitions.

### Testing
- Ran `pnpm lint --filter @gredice/game --filter @gredice/js` which completed successfully and applied one automatic fix in `@gredice/game`.
- Ran `pnpm test --filter @gredice/game --filter @gredice/js` which completed successfully with tests passing for the affected packages.
- Ran `pnpm build --filter @gredice/game --filter @gredice/js` which reported no build tasks executed for these filters in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140e57438c832fbb77dae6230faaa0)