### PR TITLE
Localize ModalConfirm default action labels to Croatian

### DIFF
--- a/packages/ui/src/ModalConfirm/ModalConfirm.tsx
+++ b/packages/ui/src/ModalConfirm/ModalConfirm.tsx
@@ -42,10 +42,10 @@ export type ModalConfirmProps = ModalConfirmBaseProps &
     (ModalConfirmNoPromptProps | ModalConfirmPromptProps);
 
 export function ModalConfirm({
-    cancelLabel = 'Cancel',
+    cancelLabel = 'Odustani',
     children,
     className,
-    confirmLabel = 'Confirm',
+    confirmLabel = 'Potvrdi',
     disableMobile: _disableMobile,
     dismissible: _dismissible,
     expectedConfirm,


### PR DESCRIPTION
### Motivation
- Make the default action labels for the confirmation modal localized to Croatian so dialogs are presented in the app's target language.

### Description
- Updated default labels in `packages/ui/src/ModalConfirm/ModalConfirm.tsx` by changing `cancelLabel` from `Cancel` to `Odustani` and `confirmLabel` from `Confirm` to `Potvrdi`.

### Testing
- Ran `pnpm lint --filter @gredice/ui`, `pnpm test --filter @gredice/ui`, and `pnpm build --filter @gredice/ui`; all commands completed successfully (the test and build runs had no tasks configured for this package).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140f28d278832f9a571d18cd5fde2e)