### PR TITLE
Add mobile debug page and Playwright tests to validate SelectItems touch/search behavior

### DIFF
--- a/apps/app/app/debug/select-items/DebugSelectItemsClient.tsx
+++ b/apps/app/app/debug/select-items/DebugSelectItemsClient.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { useState } from 'react';
+
+const items = [
+    { value: 'open', label: 'Open' },
+    { value: 'in_progress', label: 'In progress' },
+    { value: 'blocked', label: 'Blocked' },
+    { value: 'done', label: 'Done' },
+    { value: 'archived', label: 'Archived' },
+    { value: 'cancelled', label: 'Cancelled' },
+];
+
+export function DebugSelectItemsClient() {
+    const [value, setValue] = useState<string | undefined>(undefined);
+
+    return (
+        <main className="mx-auto flex w-full max-w-md flex-col gap-4 p-4">
+            <h1 className="text-xl font-semibold">SelectItems mobile debug</h1>
+            <p className="text-sm text-muted-foreground">
+                Use this page to manually validate whether SelectItems closes
+                immediately on mobile after opening.
+            </p>
+            <SelectItems
+                items={items}
+                label="Status"
+                onValueChange={setValue}
+                placeholder="Select status"
+                searchable
+                value={value}
+            />
+            <p className="text-sm" data-testid="selected-value">
+                Selected: {value ?? 'none'}
+            </p>
+        </main>
+    );
+}

--- a/apps/app/app/debug/select-items/page.tsx
+++ b/apps/app/app/debug/select-items/page.tsx
@@ -1,0 +1,5 @@
+import { DebugSelectItemsClient } from './DebugSelectItemsClient';
+
+export default function SelectItemsDebugPage() {
+    return <DebugSelectItemsClient />;
+}

--- a/apps/app/tests/select-items-mobile-debug.spec.ts
+++ b/apps/app/tests/select-items-mobile-debug.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+});
+
+test('debug page select stays open while using search on mobile touch', async ({
+    page,
+}) => {
+    await page.goto('/debug/select-items');
+
+    const trigger = page.getByRole('combobox', { name: 'Status' });
+    await trigger.tap();
+
+    const search = page.getByRole('searchbox', { name: 'Pretraži opcije...' });
+    await expect(search).toBeVisible();
+
+    await search.tap();
+    await search.fill('done');
+
+    await expect(search).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Done' })).toBeVisible();
+
+    await page.getByRole('option', { name: 'Done' }).tap();
+    await expect(page.getByTestId('selected-value')).toHaveText(
+        'Selected: done',
+    );
+});

--- a/apps/app/tests/select-items-mobile.spec.tsx
+++ b/apps/app/tests/select-items-mobile.spec.tsx
@@ -1,0 +1,48 @@
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { expect, test } from '@playwright/experimental-ct-react';
+
+const options = [
+    { value: '1', label: 'Option 1' },
+    { value: '2', label: 'Option 2' },
+    { value: '3', label: 'Option 3' },
+    { value: '4', label: 'Option 4' },
+    { value: '5', label: 'Option 5' },
+    { value: '6', label: 'Option 6' },
+];
+
+test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+});
+
+test('stays open on touch after trigger tap and search input interaction', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(
+        <SelectItems
+            items={options}
+            label="Status"
+            placeholder="Select status"
+            searchable
+        />,
+    );
+
+    const trigger = component.getByRole('combobox', { name: 'Status' });
+    await trigger.tap();
+
+    const search = page.getByRole('searchbox', {
+        name: 'Pretraži opcije...',
+    });
+
+    await expect(search).toBeVisible();
+    await page.waitForTimeout(100);
+    await expect(search).toBeVisible();
+
+    await search.tap();
+    await search.fill('Option 2');
+
+    await expect(search).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Option 2' })).toBeVisible();
+});


### PR DESCRIPTION
### Motivation

- Reproduce and validate a mobile-specific issue where `SelectItems` could close immediately after opening when interacting via touch and using the search input.

### Description

- Add a client-side debug component `DebugSelectItemsClient` that renders a sample `SelectItems` instance and displays the selected value.
- Expose the debug screen at `/debug/select-items` via `page.tsx` so the component can be manually inspected on mobile viewports.
- Add an end-to-end Playwright test `select-items-mobile-debug.spec.ts` that navigates to the debug page and verifies the select stays open while searching and selecting on touch devices.
- Add a component Playwright test `select-items-mobile.spec.tsx` that mounts `SelectItems` in a mobile viewport and verifies the searchable input keeps the overlay visible during touch interaction.

### Testing

- Ran the end-to-end test `apps/app/tests/select-items-mobile-debug.spec.ts` using Playwright with a mobile viewport and touch emulation, and it passed.
- Ran the component test `apps/app/tests/select-items-mobile.spec.tsx` with `@playwright/experimental-ct-react` in a mobile context, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140e055c28832fae48caa435a5b6ea)