### PR TITLE
Show referral codes in account details

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -1,8 +1,8 @@
 import { tz } from '@date-fns/tz';
 import { sendEmail } from '@gredice/email/acs';
 import {
+    ACCOUNT_REFERRAL_EVENT_TYPE,
     acceptAccountInvitation,
-    accounts as accountRecords,
     cancelAccountInvitation,
     createAccountInvitation,
     createEvent,
@@ -14,13 +14,15 @@ import {
     getAccountInvitationByToken,
     getAccountInvitations,
     getAccountInvitationsByEmail,
+    getAccountReferralDetails,
     getAccountUsers,
-    getEvents,
     getRaisedBeds,
+    getReferralCodeOwnerAccountId,
     getSunflowers,
     getSunflowersHistory,
     getUser,
     knownEventTypes,
+    normalizeReferralCode,
     sql,
     storage,
     events as storedEvents,
@@ -28,7 +30,6 @@ import {
 } from '@gredice/storage';
 import AccountDeleteConfirmationTemplate from '@gredice/transactional/emails/Account/delete-confirmation';
 import { addDays, differenceInCalendarDays, startOfDay } from 'date-fns';
-import { asc, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { setCookie as honoSetCookie } from 'hono/cookie';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
@@ -193,70 +194,8 @@ async function getDailyRewardState(accountId: string) {
 }
 
 const REFERRAL_REWARD = 10000;
-const REFERRAL_EVENT_TYPE = 'account.referral.v1';
 
 class ReferralCodeAlreadyExistsError extends Error {}
-
-function normalizeReferralCode(code: string) {
-    return code
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9_-]/g, '')
-        .slice(0, 32);
-}
-
-function codeFromCodeSetEventData(data: unknown) {
-    if (!data || typeof data !== 'object') {
-        return null;
-    }
-    if (!('action' in data) || data.action !== 'code_set') {
-        return null;
-    }
-    if (!('code' in data) || typeof data.code !== 'string') {
-        return null;
-    }
-    return normalizeReferralCode(data.code);
-}
-
-async function getReferralCodeOwnerAccountId(
-    code: string,
-    db: Pick<ReturnType<typeof storage>, 'select'>,
-) {
-    const [accounts, events] = await Promise.all([
-        db.select({ id: accountRecords.id }).from(accountRecords),
-        db
-            .select({
-                aggregateId: storedEvents.aggregateId,
-                data: storedEvents.data,
-            })
-            .from(storedEvents)
-            .where(eq(storedEvents.type, REFERRAL_EVENT_TYPE))
-            .orderBy(asc(storedEvents.createdAt), asc(storedEvents.id)),
-    ]);
-
-    const currentCodes = new Map<string, string>();
-    for (const account of accounts) {
-        currentCodes.set(
-            account.id,
-            normalizeReferralCode(account.id.slice(0, 12)),
-        );
-    }
-
-    for (const event of events) {
-        const eventCode = codeFromCodeSetEventData(event.data);
-        if (eventCode) {
-            currentCodes.set(event.aggregateId, eventCode);
-        }
-    }
-
-    for (const [accountId, currentCode] of currentCodes) {
-        if (currentCode === code) {
-            return accountId;
-        }
-    }
-
-    return null;
-}
 
 async function hasActiveRaisedBed(accountId: string) {
     const gardens = await getAccountGardens(accountId);
@@ -352,48 +291,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
         authValidator(['user', 'admin']),
         async (context) => {
             const { accountId } = context.get('authContext');
-            const events = await getEvents(
-                REFERRAL_EVENT_TYPE,
-                [accountId],
-                0,
-                1000,
-            );
-
-            let myCode = '';
-            let usedReferralCode: string | null = null;
-            const referredAccounts: Array<{
-                accountId: string;
-                rewarded: boolean;
-            }> = [];
-
-            for (const event of events) {
-                const data = event.data as Record<string, unknown> | null;
-                if (
-                    data?.action === 'code_set' &&
-                    typeof data.code === 'string'
-                ) {
-                    myCode = data.code;
-                }
-                if (
-                    data?.action === 'used_code' &&
-                    typeof data.code === 'string'
-                ) {
-                    usedReferralCode = data.code;
-                }
-                if (
-                    data?.action === 'referred_account' &&
-                    typeof data.referredAccountId === 'string'
-                ) {
-                    referredAccounts.push({
-                        accountId: data.referredAccountId,
-                        rewarded: data.rewarded === true,
-                    });
-                }
-            }
-
-            if (!myCode) {
-                myCode = normalizeReferralCode(accountId.slice(0, 12));
-            }
+            const { myCode, usedReferralCode, referredAccounts } =
+                await getAccountReferralDetails(accountId);
 
             return context.json({
                 myCode,
@@ -434,7 +333,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     }
 
                     await tx.insert(storedEvents).values({
-                        type: REFERRAL_EVENT_TYPE,
+                        type: ACCOUNT_REFERRAL_EVENT_TYPE,
                         version: 1,
                         aggregateId: accountId,
                         data: { action: 'code_set', code },
@@ -462,19 +361,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const code = normalizeReferralCode(body.code ?? '');
             if (!code) return context.json({ error: 'Neispravan kod' }, 400);
 
-            const myEvents = await getEvents(
-                REFERRAL_EVENT_TYPE,
-                [accountId],
-                0,
-                1000,
-            );
-            if (
-                myEvents.some(
-                    (e) =>
-                        (e.data as Record<string, unknown> | null)?.action ===
-                        'used_code',
-                )
-            ) {
+            const { usedReferralCode } =
+                await getAccountReferralDetails(accountId);
+            if (usedReferralCode) {
                 return context.json(
                     { error: 'Referral kod je već iskorišten' },
                     400,
@@ -482,7 +371,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }
 
             await createEvent({
-                type: REFERRAL_EVENT_TYPE,
+                type: ACCOUNT_REFERRAL_EVENT_TYPE,
                 version: 1,
                 aggregateId: accountId,
                 data: { action: 'used_code', code },

--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -1,9 +1,11 @@
+import { getAccountReferralDetails } from '@gredice/storage';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Button } from '@gredice/ui/Button';
 import { Delete } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import Link from 'next/link';
 import {
     EntityDetailsPanelCard,
     EntityDetailsPropertiesLayout,
@@ -43,9 +45,40 @@ export default async function AccountPage({
     await auth(['admin']);
 
     const actionBound = sendDeleteAccountEmail.bind(null, accountId);
-    const currentTimeZone = await getAccountTimeZone(accountId);
+    const [currentTimeZone, referralDetails] = await Promise.all([
+        getAccountTimeZone(accountId),
+        getAccountReferralDetails(accountId, {
+            includeUsedReferralSource: true,
+        }),
+    ]);
+    const usedReferralCodeValue =
+        referralDetails.usedReferralCode &&
+        referralDetails.usedReferralSourceAccountId ? (
+            <Link
+                href={KnownPages.Account(
+                    referralDetails.usedReferralSourceAccountId,
+                )}
+                title={`Izvorni račun: ${referralDetails.usedReferralSourceAccountId}`}
+            >
+                {referralDetails.usedReferralCode}
+            </Link>
+        ) : (
+            referralDetails.usedReferralCode
+        );
     const propertyItems: EntityDetailsPropertyListItem[] = [
         { id: 'account-id', label: 'ID računa', value: accountId, mono: true },
+        {
+            id: 'own-referral-code',
+            label: 'Vlastiti kod preporuke',
+            value: referralDetails.myCode,
+            mono: true,
+        },
+        {
+            id: 'used-referral-code',
+            label: 'Korišteni kod preporuke',
+            value: usedReferralCodeValue,
+            mono: true,
+        },
         {
             id: 'time-zone',
             label: 'Vremenska zona',

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -1,7 +1,13 @@
 import 'server-only';
 import { randomUUID } from 'node:crypto';
-import { asc, desc, eq } from 'drizzle-orm';
-import { accounts, accountUsers, ensureAccountAchievement, storage } from '..';
+import { and, asc, desc, eq, lte } from 'drizzle-orm';
+import {
+    accounts,
+    accountUsers,
+    ensureAccountAchievement,
+    storage,
+    events as storedEvents,
+} from '..';
 import {
     createEvent,
     getEvents,
@@ -9,9 +15,94 @@ import {
     knownEventTypes,
 } from './eventsRepo';
 
+type DatabaseClient = ReturnType<typeof storage>;
+
 interface SunflowerEventData {
     amount: number;
     reason?: string;
+}
+
+export const ACCOUNT_REFERRAL_EVENT_TYPE = 'account.referral.v1';
+
+export type AccountReferralDetails = {
+    myCode: string;
+    usedReferralCode: string | null;
+    usedReferralSourceAccountId: string | null;
+    referredAccounts: Array<{
+        accountId: string;
+        rewarded: boolean;
+    }>;
+};
+
+type AccountReferralEventData =
+    | {
+          action: 'code_set';
+          code: string;
+      }
+    | {
+          action: 'used_code';
+          code: string;
+      }
+    | {
+          action: 'referred_account';
+          referredAccountId: string;
+          rewarded: boolean;
+      };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object';
+}
+
+export function normalizeReferralCode(code: string) {
+    return code
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '')
+        .slice(0, 32);
+}
+
+function getDefaultReferralCode(accountId: string) {
+    return normalizeReferralCode(accountId.slice(0, 12));
+}
+
+function parseAccountReferralEventData(
+    data: unknown,
+): AccountReferralEventData | null {
+    if (!isRecord(data) || typeof data.action !== 'string') {
+        return null;
+    }
+
+    if (data.action === 'code_set' && typeof data.code === 'string') {
+        return {
+            action: 'code_set',
+            code: normalizeReferralCode(data.code),
+        };
+    }
+
+    if (data.action === 'used_code' && typeof data.code === 'string') {
+        return {
+            action: 'used_code',
+            code: normalizeReferralCode(data.code),
+        };
+    }
+
+    if (
+        data.action === 'referred_account' &&
+        typeof data.referredAccountId === 'string'
+    ) {
+        return {
+            action: 'referred_account',
+            referredAccountId: data.referredAccountId,
+            rewarded: data.rewarded === true,
+        };
+    }
+
+    return null;
+}
+
+function codeFromReferralCodeSetEventData(data: unknown) {
+    const eventData = parseAccountReferralEventData(data);
+    return eventData?.action === 'code_set' ? eventData.code : null;
 }
 
 function parseSunflowerEventData(data: unknown): SunflowerEventData {
@@ -72,6 +163,133 @@ export function getAccountUsers(accountId: string) {
         },
         orderBy: asc(accountUsers.createdAt),
     });
+}
+
+export async function getReferralCodeOwnerAccountId(
+    code: string,
+    db: Pick<DatabaseClient, 'select'> = storage(),
+) {
+    return findReferralCodeOwnerAccountId(code, db);
+}
+
+async function findReferralCodeOwnerAccountId(
+    code: string,
+    db: Pick<DatabaseClient, 'select'>,
+    at?: Date,
+) {
+    const normalizedCode = normalizeReferralCode(code);
+    if (!normalizedCode) {
+        return null;
+    }
+
+    const [accountRows, referralEvents] = await Promise.all([
+        db
+            .select({ id: accounts.id, createdAt: accounts.createdAt })
+            .from(accounts),
+        db
+            .select({
+                aggregateId: storedEvents.aggregateId,
+                data: storedEvents.data,
+            })
+            .from(storedEvents)
+            .where(
+                at
+                    ? and(
+                          eq(storedEvents.type, ACCOUNT_REFERRAL_EVENT_TYPE),
+                          lte(storedEvents.createdAt, at),
+                      )
+                    : eq(storedEvents.type, ACCOUNT_REFERRAL_EVENT_TYPE),
+            )
+            .orderBy(asc(storedEvents.createdAt), asc(storedEvents.id)),
+    ]);
+
+    const currentCodes = new Map<string, string>();
+    for (const account of accountRows) {
+        if (at && account.createdAt.getTime() > at.getTime()) {
+            continue;
+        }
+        currentCodes.set(account.id, getDefaultReferralCode(account.id));
+    }
+
+    for (const event of referralEvents) {
+        const eventCode = codeFromReferralCodeSetEventData(event.data);
+        if (eventCode) {
+            currentCodes.set(event.aggregateId, eventCode);
+        }
+    }
+
+    for (const [accountId, currentCode] of currentCodes) {
+        if (currentCode === normalizedCode) {
+            return accountId;
+        }
+    }
+
+    return null;
+}
+
+export async function getAccountReferralDetails(
+    accountId: string,
+    options: {
+        includeUsedReferralSource?: boolean;
+        db?: DatabaseClient;
+    } = {},
+): Promise<AccountReferralDetails> {
+    const db = options.db ?? storage();
+    const referralEvents = await getEvents(
+        ACCOUNT_REFERRAL_EVENT_TYPE,
+        [accountId],
+        0,
+        1000,
+        db,
+    );
+
+    let myCode = '';
+    let usedReferralCode: string | null = null;
+    let usedReferralCodeUsedAt: Date | undefined;
+    const referredAccounts: AccountReferralDetails['referredAccounts'] = [];
+
+    for (const event of referralEvents) {
+        const data = parseAccountReferralEventData(event.data);
+        if (!data) {
+            continue;
+        }
+
+        if (data.action === 'code_set') {
+            myCode = data.code;
+        }
+
+        if (data.action === 'used_code') {
+            usedReferralCode = data.code;
+            usedReferralCodeUsedAt = event.createdAt;
+        }
+
+        if (data.action === 'referred_account') {
+            referredAccounts.push({
+                accountId: data.referredAccountId,
+                rewarded: data.rewarded,
+            });
+        }
+    }
+
+    if (!myCode) {
+        myCode = getDefaultReferralCode(accountId);
+    }
+
+    const usedReferralSourceAccountId =
+        options.includeUsedReferralSource && usedReferralCode
+            ? await findReferralCodeOwnerAccountId(
+                  usedReferralCode,
+                  db,
+                  usedReferralCodeUsedAt,
+              )
+            : null;
+
+    return {
+        myCode,
+        usedReferralCode,
+        usedReferralSourceAccountId,
+        referredAccounts,
+    };
 }
 
 export async function createAccount(timeZone?: string) {

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    ACCOUNT_REFERRAL_EVENT_TYPE,
     assignStripeCustomerId,
+    createEvent,
     earnSunflowers,
     getAccount,
+    getAccountReferralDetails,
     getAccounts,
     getAccountUsers,
+    getReferralCodeOwnerAccountId,
     getSunflowers,
     getSunflowersHistory,
     spendSunflowers,
@@ -51,6 +55,82 @@ test('getAccountUsers returns empty array for new account', async () => {
     const users = await getAccountUsers(accountId);
     assert.ok(Array.isArray(users));
     assert.strictEqual(users.length, 0);
+});
+
+test('getAccountReferralDetails returns default own code', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const details = await getAccountReferralDetails(accountId);
+    assert.strictEqual(details.myCode, accountId.slice(0, 12));
+    assert.strictEqual(details.usedReferralCode, null);
+    assert.strictEqual(details.usedReferralSourceAccountId, null);
+    assert.deepStrictEqual(details.referredAccounts, []);
+});
+
+test('getAccountReferralDetails resolves used referral source account', async () => {
+    createTestDb();
+    const sourceAccountId = await createTestAccount();
+    const referredAccountId = await createTestAccount();
+    const sourceCode = `source-code-${sourceAccountId.slice(0, 8)}`;
+
+    await createEvent({
+        type: ACCOUNT_REFERRAL_EVENT_TYPE,
+        version: 1,
+        aggregateId: sourceAccountId,
+        data: { action: 'code_set', code: sourceCode },
+    });
+    await createEvent({
+        type: ACCOUNT_REFERRAL_EVENT_TYPE,
+        version: 1,
+        aggregateId: referredAccountId,
+        data: { action: 'used_code', code: sourceCode },
+    });
+
+    const details = await getAccountReferralDetails(referredAccountId, {
+        includeUsedReferralSource: true,
+    });
+    assert.strictEqual(details.usedReferralCode, sourceCode);
+    assert.strictEqual(details.usedReferralSourceAccountId, sourceAccountId);
+    assert.strictEqual(
+        await getReferralCodeOwnerAccountId(sourceCode),
+        sourceAccountId,
+    );
+});
+
+test('getAccountReferralDetails resolves used referral source at time of use', async () => {
+    createTestDb();
+    const sourceAccountId = await createTestAccount();
+    const referredAccountId = await createTestAccount();
+    const sourceCode = `source-code-${sourceAccountId.slice(0, 8)}`;
+
+    await createEvent({
+        type: ACCOUNT_REFERRAL_EVENT_TYPE,
+        version: 1,
+        aggregateId: sourceAccountId,
+        createdAt: new Date('2030-01-01T00:00:00.000Z'),
+        data: { action: 'code_set', code: sourceCode },
+    });
+    await createEvent({
+        type: ACCOUNT_REFERRAL_EVENT_TYPE,
+        version: 1,
+        aggregateId: referredAccountId,
+        createdAt: new Date('2030-01-02T00:00:00.000Z'),
+        data: { action: 'used_code', code: sourceCode },
+    });
+    await createEvent({
+        type: ACCOUNT_REFERRAL_EVENT_TYPE,
+        version: 1,
+        aggregateId: sourceAccountId,
+        createdAt: new Date('2030-01-03T00:00:00.000Z'),
+        data: { action: 'code_set', code: 'new-source-code' },
+    });
+
+    const details = await getAccountReferralDetails(referredAccountId, {
+        includeUsedReferralSource: true,
+    });
+    assert.strictEqual(details.usedReferralCode, sourceCode);
+    assert.strictEqual(details.usedReferralSourceAccountId, sourceAccountId);
+    assert.strictEqual(await getReferralCodeOwnerAccountId(sourceCode), null);
 });
 
 test('getSunflowers returns initial sunflowers after registration', async () => {


### PR DESCRIPTION
## Summary
- Adds referral code summary helpers in shared storage so the API and admin UI read the same referral state.
- Shows the account’s own referral code and the used referral code on the admin account details page.
- Links the used referral code to the source account when it can be resolved.
- Reuses the shared referral helper in the account referral API routes.

## Testing
- `pnpm lint --filter app`
- `pnpm lint --filter api`
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage`
- `pnpm build --filter app --force`
- `pnpm build --filter api --force`