### PR TITLE
Dodaj paginaciju i ograniči visinu tablice događaja na računu

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/AccountEventsCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/AccountEventsCard.tsx
@@ -1,12 +1,26 @@
-import { getAccount, getEvents, knownEventTypes } from '@gredice/storage';
-import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
+import { getAccount, getLatestEvents, knownEventTypes } from '@gredice/storage';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { ArrowLeft, ArrowRight } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import type { ReactNode } from 'react';
 import { EventsTable } from '../../../../components/shared/events/EventsTable';
+import { KnownPages } from '../../../../src/KnownPages';
 
 interface AccountEventsCardProps {
     accountId: string;
+    searchParams?: AccountEventsSearchParams;
 }
+
+type AccountEventsSearchParams = Record<string, string | string[] | undefined>;
 
 const ACCOUNT_EVENT_TYPE_LABELS: Record<string, string> = {
     [knownEventTypes.accounts.create]: 'Račun stvoren',
@@ -16,10 +30,53 @@ const ACCOUNT_EVENT_TYPE_LABELS: Record<string, string> = {
 };
 
 const ACCOUNT_EVENT_TYPES = Object.values(knownEventTypes.accounts);
+const ACCOUNT_EVENTS_PAGE_PARAM = 'eventsPage';
+const ACCOUNT_EVENTS_PAGE_SIZE = 25;
+const ACCOUNT_EVENTS_SECTION_ID = 'account-events';
 
-type AccountEvent = Awaited<ReturnType<typeof getEvents>>[number];
+type AccountEvent = Awaited<ReturnType<typeof getLatestEvents>>[number];
 
 type AccountUserLabels = Map<string, string>;
+
+function getAccountEventsPage(searchParams?: AccountEventsSearchParams) {
+    const pageValue =
+        typeof searchParams?.[ACCOUNT_EVENTS_PAGE_PARAM] === 'string'
+            ? searchParams[ACCOUNT_EVENTS_PAGE_PARAM]
+            : undefined;
+    const pageNumber = pageValue ? Number(pageValue) : 1;
+
+    return Number.isInteger(pageNumber) && pageNumber > 0 ? pageNumber : 1;
+}
+
+function buildAccountEventsPageHref(
+    accountId: string,
+    page: number,
+    searchParams?: AccountEventsSearchParams,
+) {
+    const params = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(searchParams ?? {})) {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                params.append(key, item);
+            }
+            continue;
+        }
+
+        if (typeof value === 'string') {
+            params.set(key, value);
+        }
+    }
+
+    if (page > 1) {
+        params.set(ACCOUNT_EVENTS_PAGE_PARAM, page.toString());
+    } else {
+        params.delete(ACCOUNT_EVENTS_PAGE_PARAM);
+    }
+
+    const query = params.toString();
+    return `${KnownPages.Account(accountId)}${query ? `?${query}` : ''}#${ACCOUNT_EVENTS_SECTION_ID}`;
+}
 
 function renderEventDetails(
     event: AccountEvent,
@@ -77,9 +134,19 @@ function renderEventDetails(
     return null;
 }
 
-export async function AccountEventsCard({ accountId }: AccountEventsCardProps) {
-    const [events, account] = await Promise.all([
-        getEvents(ACCOUNT_EVENT_TYPES, [accountId], 0, 10000),
+export async function AccountEventsCard({
+    accountId,
+    searchParams,
+}: AccountEventsCardProps) {
+    const currentPage = getAccountEventsPage(searchParams);
+    const offset = (currentPage - 1) * ACCOUNT_EVENTS_PAGE_SIZE;
+    const [eventsPage, account] = await Promise.all([
+        getLatestEvents(
+            ACCOUNT_EVENT_TYPES,
+            [accountId],
+            offset,
+            ACCOUNT_EVENTS_PAGE_SIZE + 1,
+        ),
         getAccount(accountId),
     ]);
 
@@ -88,23 +155,22 @@ export async function AccountEventsCard({ accountId }: AccountEventsCardProps) {
         if (!accountUser.user) {
             continue;
         }
-        const { id, userName, email } = accountUser.user;
-        userLabels.set(id, userName ?? email ?? id);
+        const { id, userName, displayName } = accountUser.user;
+        userLabels.set(id, userName ?? displayName ?? id);
     }
 
-    const sortedEvents = [...events].sort(
-        (first, second) =>
-            second.createdAt.getTime() - first.createdAt.getTime(),
-    );
+    const hasNextPage = eventsPage.length > ACCOUNT_EVENTS_PAGE_SIZE;
+    const events = eventsPage.slice(0, ACCOUNT_EVENTS_PAGE_SIZE);
+    const hasPagination = currentPage > 1 || hasNextPage;
 
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Događaji</CardTitle>
+                <CardTitle id={ACCOUNT_EVENTS_SECTION_ID}>Događaji</CardTitle>
             </CardHeader>
-            <CardOverflow className="overflow-auto">
+            <CardOverflow className="mb-0 max-h-96 overflow-auto">
                 <EventsTable
-                    events={sortedEvents}
+                    events={events}
                     renderType={(event) =>
                         ACCOUNT_EVENT_TYPE_LABELS[event.type] ?? event.type
                     }
@@ -114,6 +180,49 @@ export async function AccountEventsCard({ accountId }: AccountEventsCardProps) {
                     labels={{ details: 'Detalji' }}
                 />
             </CardOverflow>
+            {hasPagination && (
+                <CardContent className="pt-2">
+                    <Row
+                        spacing={3}
+                        className="items-center justify-center flex-wrap"
+                    >
+                        {currentPage > 1 && (
+                            <Chip
+                                href={buildAccountEventsPageHref(
+                                    accountId,
+                                    currentPage - 1,
+                                    searchParams,
+                                )}
+                                startDecorator={
+                                    <ArrowLeft className="size-4" />
+                                }
+                            >
+                                Prethodna
+                            </Chip>
+                        )}
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Stranica {currentPage}
+                        </Typography>
+                        {hasNextPage && (
+                            <Chip
+                                href={buildAccountEventsPageHref(
+                                    accountId,
+                                    currentPage + 1,
+                                    searchParams,
+                                )}
+                                startDecorator={
+                                    <ArrowRight className="size-4" />
+                                }
+                            >
+                                Sljedeća
+                            </Chip>
+                        )}
+                    </Row>
+                </CardContent>
+            )}
         </Card>
     );
 }

--- a/apps/app/app/admin/accounts/[accountId]/page.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/page.tsx
@@ -34,12 +34,19 @@ import { RaisedBedsTableCard } from './RaisedBedsTableCard';
 
 export const dynamic = 'force-dynamic';
 
+type AccountPageSearchParams = Record<string, string | string[] | undefined>;
+
 export default async function AccountPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ accountId: string }>;
+    searchParams: Promise<AccountPageSearchParams>;
 }) {
-    const { accountId } = await params;
+    const [{ accountId }, resolvedSearchParams] = await Promise.all([
+        params,
+        searchParams,
+    ]);
     await auth(['admin']);
 
     const actionBound = sendDeleteAccountEmail.bind(null, accountId);
@@ -111,7 +118,10 @@ export default async function AccountPage({
                         <AccountAchievementsCard accountId={accountId} />
                         <AccountTransactionsCard accountId={accountId} />
                         <RaisedBedsTableCard accountId={accountId} />
-                        <AccountEventsCard accountId={accountId} />
+                        <AccountEventsCard
+                            accountId={accountId}
+                            searchParams={resolvedSearchParams}
+                        />
                         <NotificationsTableCard accountId={accountId} scroll />
                         <AccountInventoryCard accountId={accountId} />
                         <AccountShoppingCartsCard accountId={accountId} />

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -14,6 +14,7 @@ export {
     getAiAnalysisTotals,
     getEvents,
     getLastBirthdayRewardEvent,
+    getLatestEvents,
     getPlantPlaceEventsCount,
     getPlantUpdateEvents,
     getSunflowersDailyTotals,

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -73,6 +73,26 @@ export function getEvents(
     });
 }
 
+export function getLatestEvents(
+    type: string | string[],
+    aggregateIds: string[],
+    offset: number = 0,
+    limit: number = 1000,
+    db: DatabaseClient = storage(),
+) {
+    return db.query.events.findMany({
+        where: and(
+            inArray(events.aggregateId, aggregateIds),
+            Array.isArray(type)
+                ? inArray(events.type, type)
+                : eq(events.type, type),
+        ),
+        orderBy: [desc(events.createdAt), desc(events.id)],
+        offset,
+        limit,
+    });
+}
+
 export async function getPlantUpdateEvents(filter?: {
     status?: string;
     from?: Date;

--- a/packages/storage/tests/eventsRepo.node.spec.ts
+++ b/packages/storage/tests/eventsRepo.node.spec.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     createEvent,
     getEvents,
+    getLatestEvents,
     knownEvents,
     knownEventTypes,
 } from '@gredice/storage';
@@ -32,4 +33,46 @@ test('getEvents returns empty for unknown aggregate', async () => {
     ]);
     assert.ok(Array.isArray(events));
     assert.strictEqual(events.length, 0);
+});
+
+test('getLatestEvents returns newest events first and paginates', async () => {
+    createTestDb();
+    const aggregateId = 'agg-latest';
+    const eventDates = [
+        new Date('2026-01-01T12:00:00.000Z'),
+        new Date('2026-01-02T12:00:00.000Z'),
+        new Date('2026-01-03T12:00:00.000Z'),
+    ];
+
+    for (const [index, createdAt] of eventDates.entries()) {
+        await createEvent({
+            ...knownEvents.accounts.sunflowersEarnedV1(aggregateId, {
+                amount: index + 1,
+                reason: `test-${index + 1}`,
+            }),
+            createdAt,
+        });
+    }
+
+    const firstPage = await getLatestEvents(
+        knownEventTypes.accounts.earnSunflowers,
+        [aggregateId],
+        0,
+        2,
+    );
+    assert.deepStrictEqual(
+        firstPage.map((event) => event.createdAt.toISOString()),
+        ['2026-01-03T12:00:00.000Z', '2026-01-02T12:00:00.000Z'],
+    );
+
+    const secondPage = await getLatestEvents(
+        knownEventTypes.accounts.earnSunflowers,
+        [aggregateId],
+        2,
+        1,
+    );
+    assert.deepStrictEqual(
+        secondPage.map((event) => event.createdAt.toISOString()),
+        ['2026-01-01T12:00:00.000Z'],
+    );
 });


### PR DESCRIPTION
## Sažetak
- Ograničen je prikaz kartice `Događaji` na računu s `max-h-96` i unutarnjim scrollom kako cijela stranica ne bi postala predugačka.
- Događaji se sada dohvaćaju i prikazuju po stranicama, s navigacijom `Prethodna` / `Sljedeća` kroz `eventsPage` query parametar.
- Dodan je storage helper za newest-first dohvat događaja te test koji pokriva paginaciju.

## Testiranje
- `pnpm lint --filter app`
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage`
- `pnpm build --filter app`
- `pnpm test --filter app`