### PR TITLE
Fix chip text alignment in transaction tables and shared Chip primitive

### DIFF
--- a/apps/app/app/admin/transactions/TransactionsTable.tsx
+++ b/apps/app/app/admin/transactions/TransactionsTable.tsx
@@ -85,14 +85,14 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                             )}
                             <Table.Cell>
                                 <Chip color="info" className="w-fit">
-                                    <Typography noWrap>
+                                    <Typography component="span" noWrap>
                                         {transaction.status}
                                     </Typography>
                                 </Chip>
                             </Table.Cell>
                             <Table.Cell>
                                 <Chip color="success" className="w-fit">
-                                    <Typography noWrap>
+                                    <Typography component="span" noWrap>
                                         €{(transaction.amount / 100).toFixed(2)}
                                     </Typography>
                                 </Chip>
@@ -101,13 +101,13 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                                 <Row spacing={2}>
                                     {hasNoInvoices ? (
                                         <Chip color="error" className="w-fit">
-                                            <Typography noWrap>
+                                            <Typography component="span" noWrap>
                                                 Bez ponuda
                                             </Typography>
                                         </Chip>
                                     ) : (
                                         <Chip color="success" className="w-fit">
-                                            <Typography noWrap>
+                                            <Typography component="span" noWrap>
                                                 📋 {invoiceCount} ponuda
                                             </Typography>
                                         </Chip>

--- a/apps/app/components/admin/tables/TransactionsTable.tsx
+++ b/apps/app/components/admin/tables/TransactionsTable.tsx
@@ -85,14 +85,14 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                             )}
                             <Table.Cell>
                                 <Chip color="info" className="w-fit">
-                                    <Typography noWrap>
+                                    <Typography component="span" noWrap>
                                         {transaction.status}
                                     </Typography>
                                 </Chip>
                             </Table.Cell>
                             <Table.Cell>
                                 <Chip color="success" className="w-fit">
-                                    <Typography noWrap>
+                                    <Typography component="span" noWrap>
                                         €{(transaction.amount / 100).toFixed(2)}
                                     </Typography>
                                 </Chip>
@@ -101,13 +101,13 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                                 <Row spacing={2}>
                                     {hasNoInvoices ? (
                                         <Chip color="error" className="w-fit">
-                                            <Typography noWrap>
+                                            <Typography component="span" noWrap>
                                                 Bez ponuda
                                             </Typography>
                                         </Chip>
                                     ) : (
                                         <Chip color="success" className="w-fit">
-                                            <Typography noWrap>
+                                            <Typography component="span" noWrap>
                                                 📋 {invoiceCount} ponuda
                                             </Typography>
                                         </Chip>

--- a/apps/storybook/stories/packages/ui/primitives/Chip.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Chip.stories.tsx
@@ -1,7 +1,8 @@
 import { Chip } from '@gredice/ui/Chip';
-import { Check, Warning } from '@gredice/ui/icons';
+import { Check, ExternalLink, Warning } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
@@ -82,6 +83,36 @@ export const Decorators: Story = {
             </Chip>
             <Chip color="warning" startDecorator={<Warning />} variant="soft">
                 Potrebna provjera
+            </Chip>
+        </Row>
+    ),
+};
+
+export const ContentAlignment: Story = {
+    render: () => (
+        <Row className="flex-wrap" spacing={3}>
+            <Chip color="info">
+                <Typography component="span" noWrap>
+                    completed
+                </Typography>
+            </Chip>
+            <Chip color="success">
+                <Typography component="span" noWrap>
+                    €12.70
+                </Typography>
+            </Chip>
+            <Chip color="error">
+                <Typography component="span" noWrap>
+                    Bez ponuda
+                </Typography>
+            </Chip>
+            <Chip color="success">
+                <Typography component="span" noWrap>
+                    1 ponuda
+                </Typography>
+            </Chip>
+            <Chip color="neutral" startDecorator={<ExternalLink />}>
+                Stripe
             </Chip>
         </Row>
     ),

--- a/packages/ui/src/Chip/Chip.tsx
+++ b/packages/ui/src/Chip/Chip.tsx
@@ -29,9 +29,9 @@ export type ChipProps = PropsWithChildren<{
 }>;
 
 const sizeClassNames = {
-    sm: 'min-h-6 px-1.5 py-0.5 text-xs leading-none',
-    md: 'min-h-7 px-2 py-1 text-sm leading-none',
-    lg: 'min-h-8 px-3 py-1 text-sm leading-none',
+    sm: 'min-h-6 px-1.5 py-0.5 text-xs',
+    md: 'min-h-7 px-2 py-1 text-sm',
+    lg: 'min-h-8 px-3 py-1 text-sm',
 };
 
 const decoratorSizeClassNames = {


### PR DESCRIPTION
## Summary
- Removed `leading-none` from the shared `Chip` size styles so chip text uses the normal line height while keeping the same compact chip height.
- Updated transaction table chip labels to render `Typography` as `span` inside chips, which avoids block-level text wrappers inside inline-flex pills.
- Added a Storybook Chip alignment example that mirrors the transaction-table chip content and decorator patterns.

## Testing
- Lint and formatting checks passed for the touched files.
- `@gredice/ui` typecheck passed.
- Storybook build passed.
- `app` build passed.
- `app` unit tests passed.
- Verified the Chip alignment story in the browser and confirmed the chip text is vertically centered.