### PR TITLE
Increase admin page content background mix to 90%

### DIFF
--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -128,7 +128,7 @@ svg.lucide {
     color-scheme: light;
     --admin-page-content-background: color-mix(
         in srgb,
-        hsl(var(--background)) 40%,
+        hsl(var(--background)) 90%,
         hsl(var(--muted))
     );
     scrollbar-width: thin;
@@ -139,7 +139,7 @@ svg.lucide {
 .dark {
     --admin-page-content-background: color-mix(
         in srgb,
-        hsl(var(--background)) 40%,
+        hsl(var(--background)) 90%,
         hsl(var(--muted))
     );
 }


### PR DESCRIPTION
## Summary
- Updated `--admin-page-content-background` in `apps/app/app/globals.css` from a 40% background mix to 90%
- Applied the change in both light and dark theme definitions so the admin page surface reads more consistently

## Testing
- Lint and formatting passed for `app`