### PR TITLE
Fix dashboard operations graph layout and user breakdown

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -359,7 +359,11 @@ export function AdminDashboardClient({
             </Stack>
             <Stack spacing={2}>
                 <DashboardDivider>Radnje</DashboardDivider>
-                <OperationsDurationCard data={initialOperationsDurationData} />
+                <div className="w-full lg:max-w-2xl">
+                    <OperationsDurationCard
+                        data={initialOperationsDurationData}
+                    />
+                </div>
             </Stack>
             <Stack spacing={2}>
                 <DashboardDivider>Zapisi</DashboardDivider>

--- a/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
+++ b/apps/app/components/admin/dashboard/OperationsDurationCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardOverflow } from '@gredice/ui/Card';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
 import {
     Bar,
     BarChart,
@@ -17,24 +18,31 @@ import {
 export type OperationsDurationPoint = {
     date: string;
     operationsMinutes: number;
+    plannedMinutes: number;
     sowingMinutes: number;
     totalMinutes: number;
     byUser: {
         userId: string;
         userName: string;
+        userAvatarUrl: string | null;
         operationsMinutes: number;
+        plannedMinutes: number;
     }[];
 };
 
 export type OperationsDurationData = {
     totalMinutes: number;
     operationsMinutes: number;
+    plannedMinutes: number;
     sowingMinutes: number;
     byUser: {
         userId: string;
         userName: string;
+        userAvatarUrl: string | null;
         operationsMinutes: number;
+        plannedMinutes: number;
         operationsCount: number;
+        plannedCount: number;
     }[];
     daily: OperationsDurationPoint[];
 };
@@ -54,6 +62,21 @@ const USER_BAR_COLORS = [
     'hsl(199 89% 48% / 0.8)',
     'hsl(32 95% 44% / 0.8)',
 ];
+
+function getUserBarColor(index: number) {
+    return (
+        USER_BAR_COLORS[index % USER_BAR_COLORS.length] ??
+        'hsl(var(--primary) / 0.8)'
+    );
+}
+
+function getCompletedDataKey(userId: string) {
+    return `completed-${userId}`;
+}
+
+function getPlannedDataKey(userId: string) {
+    return `planned-${userId}`;
+}
 
 function formatTotalDuration(totalMinutes: number) {
     const hours = Math.floor(totalMinutes / 60);
@@ -93,19 +116,25 @@ export function OperationsDurationCard({
     const userSegments = data.byUser.map((user, index) => ({
         userId: user.userId,
         userName: user.userName,
-        color: USER_BAR_COLORS[index % USER_BAR_COLORS.length],
+        userAvatarUrl: user.userAvatarUrl,
+        completedDataKey: getCompletedDataKey(user.userId),
+        plannedDataKey: getPlannedDataKey(user.userId),
+        color: getUserBarColor(index),
     }));
     const chartData = data.daily.map((day) => {
-        const valuesByUser = Object.fromEntries(
-            day.byUser.map((user) => [user.userId, user.operationsMinutes]),
-        );
-
-        return {
-            ...valuesByUser,
+        const valuesByUser: Record<string, string | number> = {
             date: day.date,
             label: formatDateLabel(day.date),
             sowingMinutes: day.sowingMinutes,
         };
+
+        for (const user of day.byUser) {
+            valuesByUser[getCompletedDataKey(user.userId)] =
+                user.operationsMinutes;
+            valuesByUser[getPlannedDataKey(user.userId)] = user.plannedMinutes;
+        }
+
+        return valuesByUser;
     });
     const maxVisibleLabels = 10;
     const labelStep = Math.max(
@@ -135,6 +164,15 @@ export function OperationsDurationCard({
                                 </Typography>
                             </Row>
                             <Row spacing={1} className="items-center">
+                                <span className="h-2 w-2 rounded-xs border border-primary/70" />
+                                <Typography level="body3">
+                                    Planirano{' '}
+                                    {formatTooltipDuration(
+                                        data.plannedMinutes ?? 0,
+                                    )}
+                                </Typography>
+                            </Row>
+                            <Row spacing={1} className="items-center">
                                 <span className="h-2 w-2 rounded-xs bg-emerald-500/60" />
                                 <Typography level="body3">
                                     Sijanje{' '}
@@ -142,12 +180,6 @@ export function OperationsDurationCard({
                                 </Typography>
                             </Row>
                         </Row>
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground"
-                        >
-                            Prikazane su samo završene radnje
-                        </Typography>
                     </Stack>
                     {chartData.length === 0 ? (
                         <Typography
@@ -210,12 +242,6 @@ export function OperationsDurationCard({
                                         cursor={{
                                             fill: 'hsl(var(--primary) / 0.08)',
                                         }}
-                                        contentStyle={{
-                                            border: '1px solid hsl(var(--border))',
-                                            borderRadius: '0.5rem',
-                                            backgroundColor:
-                                                'hsl(var(--background))',
-                                        }}
                                         content={({
                                             active,
                                             payload,
@@ -269,7 +295,7 @@ export function OperationsDurationCard({
                                             return (
                                                 <Stack
                                                     spacing={1}
-                                                    className="text-xs"
+                                                    className="rounded-md border border-border bg-card p-2 text-xs text-card-foreground shadow-md"
                                                 >
                                                     <Typography level="body2">
                                                         {label}
@@ -330,16 +356,28 @@ export function OperationsDurationCard({
                                     {userSegments.map((user) => (
                                         <Bar
                                             key={user.userId}
-                                            dataKey={user.userId}
-                                            stackId="duration"
+                                            dataKey={user.completedDataKey}
+                                            stackId="completedDuration"
                                             fill={user.color}
                                             radius={[4, 4, 0, 0]}
-                                            name={user.userName}
+                                            name={`${user.userName} završeno`}
+                                        />
+                                    ))}
+                                    {userSegments.map((user) => (
+                                        <Bar
+                                            key={`${user.userId}-planned`}
+                                            dataKey={user.plannedDataKey}
+                                            stackId="plannedDuration"
+                                            fill="transparent"
+                                            stroke={user.color}
+                                            strokeWidth={2}
+                                            radius={[4, 4, 0, 0]}
+                                            name={`${user.userName} planirano`}
                                         />
                                     ))}
                                     <Bar
                                         dataKey="sowingMinutes"
-                                        stackId="duration"
+                                        stackId="completedDuration"
                                         fill="hsl(142 71% 45% / 0.65)"
                                         name="Sijanje"
                                     />
@@ -350,33 +388,67 @@ export function OperationsDurationCard({
                     {data.byUser.length > 0 ? (
                         <Stack spacing={3} className="pt-2">
                             <Typography level="body3" className="font-medium">
-                                Po korisniku (dodijeljene radnje)
+                                Po korisniku
                             </Typography>
-                            <Stack spacing={2}>
-                                {data.byUser.map((user) => (
-                                    <Row
-                                        key={user.userId}
-                                        className="items-center justify-between gap-3 rounded-md border border-border/40 px-2 py-1.5"
-                                    >
-                                        <Stack spacing={0}>
-                                            <Typography level="body3" semiBold>
-                                                {user.userName}
-                                            </Typography>
+                            <div className="flex flex-wrap gap-2">
+                                {data.byUser.map((user, index) => {
+                                    const segmentColor =
+                                        userSegments[index]?.color ??
+                                        getUserBarColor(index);
+
+                                    return (
+                                        <Row
+                                            key={user.userId}
+                                            className="min-w-[14rem] items-center gap-2 rounded-md border border-border/40 px-2 py-1.5"
+                                        >
+                                            <span
+                                                className="size-2.5 shrink-0 rounded-full"
+                                                style={{
+                                                    backgroundColor:
+                                                        segmentColor,
+                                                }}
+                                            />
+                                            <UserAvatar
+                                                size="sm"
+                                                avatarUrl={user.userAvatarUrl}
+                                                displayName={user.userName}
+                                            />
+                                            <Stack
+                                                spacing={0}
+                                                className="min-w-0"
+                                            >
+                                                <Typography
+                                                    level="body3"
+                                                    semiBold
+                                                    className="truncate"
+                                                >
+                                                    {user.userName}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-muted-foreground"
+                                                >
+                                                    Završeno:{' '}
+                                                    {user.operationsCount} ·
+                                                    Nezavršeno:{' '}
+                                                    {user.plannedCount ?? 0}
+                                                </Typography>
+                                            </Stack>
                                             <Typography
                                                 level="body3"
-                                                className="text-muted-foreground"
+                                                semiBold
+                                                className="ml-auto whitespace-nowrap"
                                             >
-                                                Radnji: {user.operationsCount}
+                                                {formatTooltipDuration(
+                                                    user.operationsMinutes +
+                                                        (user.plannedMinutes ??
+                                                            0),
+                                                )}
                                             </Typography>
-                                        </Stack>
-                                        <Typography level="body3" semiBold>
-                                            {formatTooltipDuration(
-                                                user.operationsMinutes,
-                                            )}
-                                        </Typography>
-                                    </Row>
-                                ))}
-                            </Stack>
+                                        </Row>
+                                    );
+                                })}
+                            </div>
                         </Stack>
                     ) : null}
                 </Stack>

--- a/apps/app/components/admin/dashboard/actions.ts
+++ b/apps/app/components/admin/dashboard/actions.ts
@@ -20,26 +20,51 @@ import type { EntityStandardized } from '../../../lib/@types/EntityStandardized'
 type OperationsDurationPoint = {
     date: string;
     operationsMinutes: number;
+    plannedMinutes: number;
     sowingMinutes: number;
     totalMinutes: number;
     byUser: {
         userId: string;
         userName: string;
+        userAvatarUrl: string | null;
         operationsMinutes: number;
+        plannedMinutes: number;
     }[];
 };
 
 type OperationsDurationData = {
     totalMinutes: number;
     operationsMinutes: number;
+    plannedMinutes: number;
     sowingMinutes: number;
     byUser: {
         userId: string;
         userName: string;
+        userAvatarUrl: string | null;
         operationsMinutes: number;
+        plannedMinutes: number;
         operationsCount: number;
+        plannedCount: number;
     }[];
     daily: OperationsDurationPoint[];
+};
+
+type OperationUserStats = {
+    userId: string;
+    userName: string;
+    userAvatarUrl: string | null;
+    operationsMinutes: number;
+    plannedMinutes: number;
+    operationsCount: number;
+    plannedCount: number;
+};
+
+type DailyOperationUserStats = {
+    userId: string;
+    userName: string;
+    userAvatarUrl: string | null;
+    operationsMinutes: number;
+    plannedMinutes: number;
 };
 
 type DateRange = {
@@ -64,6 +89,11 @@ const WEEKDAY_LABELS = [
     'Subota',
 ];
 const PLANT_SOWING_DURATION_MINUTES = 5;
+const UNASSIGNED_USER = {
+    userId: 'unassigned',
+    userName: 'Nedodijeljeno',
+    userAvatarUrl: null,
+};
 
 function toDateKey(date: Date) {
     const year = date.getFullYear();
@@ -85,7 +115,7 @@ function analyticsCacheKey(
     from?: string,
     to?: string,
 ) {
-    return `dashboard:admin:analytics:days:${cacheKeyPart(days)}:from:${cacheKeyPart(from)}:to:${cacheKeyPart(to)}:v1`;
+    return `dashboard:admin:analytics:days:${cacheKeyPart(days)}:from:${cacheKeyPart(from)}:to:${cacheKeyPart(to)}:v2`;
 }
 
 function parseDuration(value: unknown) {
@@ -140,31 +170,21 @@ function addDurationToUsers({
     durationMinutes,
     userId,
     userName,
+    userAvatarUrl,
     operationsByUser,
     dailyOperationsByUser,
     includeInDailyTotals = true,
+    kind = 'completed',
 }: {
     date: string;
     durationMinutes: number;
     userId: string;
     userName: string;
-    operationsByUser: Map<
-        string,
-        {
-            userId: string;
-            userName: string;
-            operationsMinutes: number;
-            operationsCount: number;
-        }
-    >;
-    dailyOperationsByUser: Map<
-        string,
-        Map<
-            string,
-            { userId: string; userName: string; operationsMinutes: number }
-        >
-    >;
+    userAvatarUrl: string | null;
+    operationsByUser: Map<string, OperationUserStats>;
+    dailyOperationsByUser: Map<string, Map<string, DailyOperationUserStats>>;
     includeInDailyTotals?: boolean;
+    kind?: 'completed' | 'planned';
 }) {
     if (includeInDailyTotals) {
         const dateUserStats = dailyOperationsByUser.get(date) ?? new Map();
@@ -173,10 +193,16 @@ function addDurationToUsers({
             dateUserStats.set(userId, {
                 userId,
                 userName,
-                operationsMinutes: durationMinutes,
+                userAvatarUrl,
+                operationsMinutes: kind === 'completed' ? durationMinutes : 0,
+                plannedMinutes: kind === 'planned' ? durationMinutes : 0,
             });
         } else {
-            existingDailyStats.operationsMinutes += durationMinutes;
+            if (kind === 'completed') {
+                existingDailyStats.operationsMinutes += durationMinutes;
+            } else {
+                existingDailyStats.plannedMinutes += durationMinutes;
+            }
         }
         dailyOperationsByUser.set(date, dateUserStats);
     }
@@ -186,19 +212,28 @@ function addDurationToUsers({
         operationsByUser.set(userId, {
             userId,
             userName,
-            operationsMinutes: durationMinutes,
-            operationsCount: 1,
+            userAvatarUrl,
+            operationsMinutes: kind === 'completed' ? durationMinutes : 0,
+            plannedMinutes: kind === 'planned' ? durationMinutes : 0,
+            operationsCount: kind === 'completed' ? 1 : 0,
+            plannedCount: kind === 'planned' ? 1 : 0,
         });
         return;
     }
 
-    existingUserStats.operationsMinutes += durationMinutes;
-    existingUserStats.operationsCount += 1;
+    if (kind === 'completed') {
+        existingUserStats.operationsMinutes += durationMinutes;
+        existingUserStats.operationsCount += 1;
+    } else {
+        existingUserStats.plannedMinutes += durationMinutes;
+        existingUserStats.plannedCount += 1;
+    }
 }
 
 function createDurationBuckets(startDate: Date, days: number) {
     const dateKeys: string[] = [];
     const operationsTotals = new Map<string, number>();
+    const plannedTotals = new Map<string, number>();
     const sowingTotals = new Map<string, number>();
     for (let i = 0; i < days; i += 1) {
         const current = new Date(startDate);
@@ -206,12 +241,14 @@ function createDurationBuckets(startDate: Date, days: number) {
         const key = toDateKey(current);
         dateKeys.push(key);
         operationsTotals.set(key, 0);
+        plannedTotals.set(key, 0);
         sowingTotals.set(key, 0);
     }
 
     return {
         dateKeys,
         operationsTotals,
+        plannedTotals,
         sowingTotals,
     };
 }
@@ -219,32 +256,62 @@ function createDurationBuckets(startDate: Date, days: number) {
 function formatOperationsDurationData(
     dateKeys: string[],
     operationsTotals: Map<string, number>,
+    plannedTotals: Map<string, number>,
     sowingTotals: Map<string, number>,
 ): OperationsDurationData {
     const daily = dateKeys.map((date) => ({
         date,
         operationsMinutes: operationsTotals.get(date) ?? 0,
+        plannedMinutes: plannedTotals.get(date) ?? 0,
         sowingMinutes: sowingTotals.get(date) ?? 0,
         totalMinutes:
-            (operationsTotals.get(date) ?? 0) + (sowingTotals.get(date) ?? 0),
+            (operationsTotals.get(date) ?? 0) +
+            (plannedTotals.get(date) ?? 0) +
+            (sowingTotals.get(date) ?? 0),
         byUser: [],
     }));
     const operationsMinutes = daily.reduce(
         (total, day) => total + day.operationsMinutes,
         0,
     );
+    const plannedMinutes = daily.reduce(
+        (total, day) => total + day.plannedMinutes,
+        0,
+    );
     const sowingMinutes = daily.reduce(
         (total, day) => total + day.sowingMinutes,
         0,
     );
-    const totalMinutes = operationsMinutes + sowingMinutes;
+    const totalMinutes = operationsMinutes + plannedMinutes + sowingMinutes;
 
     return {
         totalMinutes,
         operationsMinutes,
+        plannedMinutes,
         sowingMinutes,
         byUser: [],
         daily,
+    };
+}
+
+function getOperationUser(operation: {
+    assignedUser?: {
+        id: string;
+        userName: string;
+        displayName: string | null;
+        avatarUrl: string | null;
+    } | null;
+}) {
+    if (!operation.assignedUser) {
+        return UNASSIGNED_USER;
+    }
+
+    return {
+        userId: operation.assignedUser.id,
+        userName:
+            operation.assignedUser.displayName ??
+            operation.assignedUser.userName,
+        userAvatarUrl: operation.assignedUser.avatarUrl,
     };
 }
 
@@ -335,6 +402,7 @@ async function getAnalyticsDataUncached(
         analyticsResult,
         entityTypes,
         operationsList,
+        plannedOperationsList,
         operationsData,
         weekdayRegistrationsRaw,
         aiTotals,
@@ -346,6 +414,9 @@ async function getAnalyticsDataUncached(
         getAllOperations({
             completedFrom: startDate,
             completedTo: endDate,
+        }),
+        getAllOperations({
+            status: 'planned',
         }),
         getEntitiesFormatted<EntityStandardized>('operation'),
         getUserRegistrationsByWeekday(startDate, endDate),
@@ -372,10 +443,8 @@ async function getAnalyticsDataUncached(
         }),
     );
 
-    const { dateKeys, operationsTotals, sowingTotals } = createDurationBuckets(
-        startDate,
-        rangeDays,
-    );
+    const { dateKeys, operationsTotals, plannedTotals, sowingTotals } =
+        createDurationBuckets(startDate, rangeDays);
 
     const operationDurations = new Map<number, number>();
     for (const operation of operationsData ?? []) {
@@ -386,21 +455,10 @@ async function getAnalyticsDataUncached(
         operationDurations.set(operation.id, duration);
     }
 
-    const operationsByUser = new Map<
-        string,
-        {
-            userId: string;
-            userName: string;
-            operationsMinutes: number;
-            operationsCount: number;
-        }
-    >();
+    const operationsByUser = new Map<string, OperationUserStats>();
     const dailyOperationsByUser = new Map<
         string,
-        Map<
-            string,
-            { userId: string; userName: string; operationsMinutes: number }
-        >
+        Map<string, DailyOperationUserStats>
     >();
 
     for (const operation of operationsList) {
@@ -414,27 +472,54 @@ async function getAnalyticsDataUncached(
         }
 
         const durationMinutes = operationDurations.get(operation.entityId) ?? 0;
-        if (!durationMinutes) {
-            continue;
-        }
 
         operationsTotals.set(
             key,
             (operationsTotals.get(key) ?? 0) + durationMinutes,
         );
 
-        const userId = operation.assignedUser?.id ?? 'unassigned';
-        const userName =
-            operation.assignedUser?.displayName ??
-            operation.assignedUser?.userName ??
-            'Nedodijeljeno';
+        const user = getOperationUser(operation);
         addDurationToUsers({
             date: key,
             durationMinutes,
-            userId,
-            userName,
+            userId: user.userId,
+            userName: user.userName,
+            userAvatarUrl: user.userAvatarUrl,
             operationsByUser,
             dailyOperationsByUser,
+        });
+    }
+
+    for (const operation of plannedOperationsList) {
+        if (operation.status !== 'planned' || !operation.scheduledDate) {
+            continue;
+        }
+
+        if (
+            operation.scheduledDate < startDate ||
+            operation.scheduledDate > endDate
+        ) {
+            continue;
+        }
+
+        const key = toDateKey(operation.scheduledDate);
+        if (!plannedTotals.has(key)) {
+            continue;
+        }
+
+        const durationMinutes = operationDurations.get(operation.entityId) ?? 0;
+        plannedTotals.set(key, (plannedTotals.get(key) ?? 0) + durationMinutes);
+
+        const user = getOperationUser(operation);
+        addDurationToUsers({
+            date: key,
+            durationMinutes,
+            userId: user.userId,
+            userName: user.userName,
+            userAvatarUrl: user.userAvatarUrl,
+            operationsByUser,
+            dailyOperationsByUser,
+            kind: 'planned',
         });
     }
 
@@ -461,12 +546,13 @@ async function getAnalyticsDataUncached(
         }
 
         for (const userId of assignedUserIds) {
-            const userName = operationsByUser.get(userId)?.userName ?? userId;
+            const existingUser = operationsByUser.get(userId);
             addDurationToUsers({
                 date: key,
                 durationMinutes: PLANT_SOWING_DURATION_MINUTES,
                 userId,
-                userName,
+                userName: existingUser?.userName ?? userId,
+                userAvatarUrl: existingUser?.userAvatarUrl ?? null,
                 operationsByUser,
                 dailyOperationsByUser,
                 includeInDailyTotals: false,
@@ -477,17 +563,28 @@ async function getAnalyticsDataUncached(
     const operationsDuration = formatOperationsDurationData(
         dateKeys,
         operationsTotals,
+        plannedTotals,
         sowingTotals,
     );
 
     operationsDuration.byUser = Array.from(operationsByUser.values()).sort(
-        (a, b) => b.operationsMinutes - a.operationsMinutes,
+        (a, b) =>
+            b.operationsMinutes +
+            b.plannedMinutes -
+            (a.operationsMinutes + a.plannedMinutes),
     );
     operationsDuration.daily = operationsDuration.daily.map((day) => ({
         ...day,
         byUser: Array.from(dailyOperationsByUser.get(day.date)?.values() ?? [])
-            .filter((user) => user.operationsMinutes > 0)
-            .sort((a, b) => b.operationsMinutes - a.operationsMinutes),
+            .filter(
+                (user) => user.operationsMinutes > 0 || user.plannedMinutes > 0,
+            )
+            .sort(
+                (a, b) =>
+                    b.operationsMinutes +
+                    b.plannedMinutes -
+                    (a.operationsMinutes + a.plannedMinutes),
+            ),
     }));
 
     const weekdayRegistrations = WEEKDAY_LABELS.map((label, index) => ({


### PR DESCRIPTION
## Summary
- tightened the operations chart to the same half-width layout as registrations
- added planned-task series, unassigned task handling, and user avatars/counts to the dashboard data
- replaced the plain tooltip with a styled surface and removed the redundant completion disclaimer
- updated the user breakdown to a horizontal legend with color dots, avatars, and completed vs unfinished counts

## Testing
- `pnpm lint --filter app`
- `pnpm test --filter app`
- `pnpm build --filter app`
- `pnpm typecheck --filter app`
- local browser smoke check of the app admin entry route