### PR TITLE
fix(ui): keep SelectItems open when interacting with search input

### DIFF
--- a/packages/ui/src/SelectItems/SelectItems.tsx
+++ b/packages/ui/src/SelectItems/SelectItems.tsx
@@ -264,8 +264,14 @@ export function SelectItems<T extends string>({
                                         ref={searchInputRef}
                                         aria-label={searchPlaceholder}
                                         className="min-w-0 flex-1 bg-transparent px-2 py-1 text-sm outline-hidden placeholder:text-muted-foreground"
+                                        onClick={(event) =>
+                                            event.stopPropagation()
+                                        }
                                         onChange={handleSearchChange}
                                         onKeyDown={handleSearchKeyDown}
+                                        onPointerDown={(event) =>
+                                            event.stopPropagation()
+                                        }
                                         placeholder={searchPlaceholder}
                                         type="search"
                                         value={searchQuery}


### PR DESCRIPTION
### Motivation
- The `SelectItems` popover closed immediately after tapping the search input (notably on touch/mobile) because input events propagated and were interpreted as interactions that should close the select.

### Description
- Stop `click` and `pointerdown` event propagation on the search `input` in `packages/ui/src/SelectItems/SelectItems.tsx` so tapping the search box does not trigger the select to close.

### Testing
- Ran `pnpm lint --filter @gredice/ui`, which completed successfully (Biome fixed one file); the run included a non-blocking engine warning that the container Node version is `v22.22.2` while the repo expects `>=24`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1441bc1128832f9423d40ac2af5a35)