### PR TITLE
Import Typography in admin communication emails page

### DIFF
--- a/apps/app/app/admin/communication/emails/page.tsx
+++ b/apps/app/app/admin/communication/emails/page.tsx
@@ -9,6 +9,7 @@ import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
+import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../lib/auth/auth';


### PR DESCRIPTION
## Summary
- Added the missing `Typography` import to the admin communication emails list page.
- This fixes the server-rendered `ReferenceError: Typography is not defined` on `/admin/communication/emails`.

## Testing
- `pnpm lint --filter app`
- `pnpm build --filter app`
- `pnpm test --filter app`