### PR TITLE
Fix mobile expandable search input overlay positioning

### DIFF
--- a/apps/app/tests/expandable-search-input-mobile.spec.tsx
+++ b/apps/app/tests/expandable-search-input-mobile.spec.tsx
@@ -1,0 +1,52 @@
+import { ExpandableSearchInput } from '@gredice/ui/ExpandableSearchInput';
+import { expect, test } from '@playwright/experimental-ct-react';
+
+test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+});
+
+test('mobile expansion escapes clipped header containers', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <div>
+            <div
+                style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    height: 44,
+                    justifyContent: 'flex-end',
+                    overflow: 'hidden',
+                    position: 'relative',
+                    width: 360,
+                }}
+            >
+                <ExpandableSearchInput
+                    value=""
+                    onChange={() => undefined}
+                    placeholder="Pretraži zapise"
+                    inputClassName="min-w-60"
+                />
+            </div>
+            <div style={{ height: 120 }}>Sadržaj</div>
+        </div>,
+    );
+
+    await page.getByRole('button', { name: 'Pretraži' }).tap();
+
+    const search = page.getByPlaceholder('Pretraži zapise').last();
+    await expect(search).toBeVisible();
+
+    const box = await search.boundingBox();
+    expect(box).not.toBeNull();
+
+    if (!box) {
+        throw new Error('Expected mobile search input to have a bounding box');
+    }
+
+    expect(box.y).toBeGreaterThan(44);
+    expect(box.height).toBeGreaterThan(20);
+});

--- a/packages/ui/src/ExpandableSearchInput/ExpandableSearchInput.tsx
+++ b/packages/ui/src/ExpandableSearchInput/ExpandableSearchInput.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+import {
+    type ChangeEvent,
+    type CSSProperties,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { IconButton } from '../IconButton';
 import { Input } from '../Input';
 import { Search } from '../icons';
@@ -22,14 +30,56 @@ export function ExpandableSearchInput({
     inputClassName,
 }: ExpandableSearchInputProps) {
     const [isExpanded, setIsExpanded] = useState(Boolean(value));
+    const [portalElement, setPortalElement] = useState<HTMLElement | null>(
+        null,
+    );
+    const [mobileInputStyle, setMobileInputStyle] =
+        useState<CSSProperties | null>(null);
     const rootRef = useRef<HTMLDivElement>(null);
     const mobileInputRootRef = useRef<HTMLDivElement>(null);
 
+    const updateMobileInputPosition = useCallback(() => {
+        const rootElement = rootRef.current;
+        if (!rootElement) {
+            return;
+        }
+
+        const rect = rootElement.getBoundingClientRect();
+        const viewportPadding = 16;
+        const availableWidth = Math.max(
+            0,
+            window.innerWidth - viewportPadding * 2,
+        );
+        const inputWidth = Math.min(288, availableWidth);
+        const maxRight = window.innerWidth - viewportPadding - inputWidth;
+        const anchoredRight = window.innerWidth - rect.right;
+        const right = Math.max(
+            viewportPadding,
+            Math.min(anchoredRight, maxRight),
+        );
+        const top = Math.max(
+            viewportPadding,
+            Math.min(rect.bottom + 8, window.innerHeight - 64),
+        );
+
+        setMobileInputStyle({
+            position: 'fixed',
+            right,
+            top,
+            width: inputWidth,
+            zIndex: 50,
+        });
+    }, []);
+
     useEffect(() => {
-        if (isExpanded) {
+        setPortalElement(document.body);
+    }, []);
+
+    useEffect(() => {
+        if (isExpanded && (mobileInputStyle || !portalElement)) {
             mobileInputRootRef.current?.querySelector('input')?.focus();
         }
-    }, [isExpanded]);
+    }, [isExpanded, mobileInputStyle, portalElement]);
 
     useEffect(() => {
         if (value) {
@@ -38,10 +88,33 @@ export function ExpandableSearchInput({
     }, [value]);
 
     useEffect(() => {
+        if (!isExpanded) {
+            setMobileInputStyle(null);
+            return;
+        }
+
+        updateMobileInputPosition();
+
+        window.addEventListener('resize', updateMobileInputPosition);
+        window.addEventListener('scroll', updateMobileInputPosition, true);
+
+        return () => {
+            window.removeEventListener('resize', updateMobileInputPosition);
+            window.removeEventListener(
+                'scroll',
+                updateMobileInputPosition,
+                true,
+            );
+        };
+    }, [isExpanded, updateMobileInputPosition]);
+
+    useEffect(() => {
         const handlePointerDown = (event: PointerEvent) => {
+            const target = event.target;
             if (
-                !(event.target instanceof Node) ||
-                !rootRef.current?.contains(event.target)
+                !(target instanceof Node) ||
+                (!rootRef.current?.contains(target) &&
+                    !mobileInputRootRef.current?.contains(target))
             ) {
                 setIsExpanded(false);
             }
@@ -72,7 +145,27 @@ export function ExpandableSearchInput({
                 >
                     <Search className="size-5" />
                 </IconButton>
-                {isExpanded && (
+                {isExpanded && portalElement && mobileInputStyle
+                    ? createPortal(
+                          <div
+                              ref={mobileInputRootRef}
+                              className="md:hidden"
+                              style={mobileInputStyle}
+                          >
+                              <Input
+                                  value={value}
+                                  onChange={onChange}
+                                  placeholder={placeholder}
+                                  startDecorator={
+                                      <Search className="size-5 shrink-0 ml-3" />
+                                  }
+                                  className={cx('w-full', inputClassName)}
+                              />
+                          </div>,
+                          portalElement,
+                      )
+                    : null}
+                {isExpanded && !portalElement && (
                     <div
                         ref={mobileInputRootRef}
                         className="absolute right-0 top-full z-20 mt-2 w-[min(18rem,calc(100vw-2rem))]"


### PR DESCRIPTION
## Summary
- Render the mobile `ExpandableSearchInput` overlay in a portal so it can sit above clipped admin header/content containers.
- Position the mobile input relative to the trigger and keep it within the viewport on resize and scroll.
- Add a Playwright component test that verifies the expanded input is visible outside a clipped header wrapper on mobile.

## Testing
- `pnpm typecheck --filter @gredice/ui`
- `pnpm build --filter app`
- `pnpm --filter app exec playwright test tests/expandable-search-input-mobile.spec.tsx`
- `pnpm lint --filter @gredice/ui --filter app`