### PR TITLE
Persist the admin desktop nav collapse state

### DIFF
--- a/apps/app/components/admin/navigation/DesktopNavProvider.tsx
+++ b/apps/app/components/admin/navigation/DesktopNavProvider.tsx
@@ -5,6 +5,7 @@ import {
     type PropsWithChildren,
     useCallback,
     useContext,
+    useLayoutEffect,
     useMemo,
     useState,
 } from 'react';
@@ -19,15 +20,63 @@ const DesktopNavContext = createContext<DesktopNavContextValue | undefined>(
     undefined,
 );
 
+const desktopNavExpandedStorageKey = 'gredice:admin:desktop-nav-expanded';
+
+function readStoredDesktopNavExpanded() {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    try {
+        const value = window.localStorage.getItem(desktopNavExpandedStorageKey);
+        if (value === 'true') {
+            return true;
+        }
+        if (value === 'false') {
+            return false;
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+function writeStoredDesktopNavExpanded(isExpanded: boolean) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(
+            desktopNavExpandedStorageKey,
+            String(isExpanded),
+        );
+    } catch {
+        // Ignore unavailable localStorage, for example private browsing quotas.
+    }
+}
+
 export function DesktopNavProvider({ children }: PropsWithChildren) {
     const [isExpanded, setIsExpanded] = useState(true);
+
+    useLayoutEffect(() => {
+        const storedExpanded = readStoredDesktopNavExpanded();
+        if (storedExpanded !== null) {
+            setIsExpanded(storedExpanded);
+        }
+    }, []);
 
     const setExpanded = useCallback((expanded: boolean) => {
         setIsExpanded(expanded);
     }, []);
 
     const toggle = useCallback(() => {
-        setIsExpanded((current) => !current);
+        setIsExpanded((current) => {
+            const nextExpanded = !current;
+            writeStoredDesktopNavExpanded(nextExpanded);
+            return nextExpanded;
+        });
     }, []);
 
     const value = useMemo(


### PR DESCRIPTION
## Summary
- Store the `apps/app` admin desktop nav expanded state in `localStorage`
- Restore the saved state when the admin shell mounts so route changes no longer reopen the nav
- Keep CMS editor auto-collapse behavior from overwriting the saved user preference

## Testing
- `pnpm lint --filter app`
- `pnpm build --filter app`
- `pnpm test --filter app`
- Targeted TypeScript check for `DesktopNavProvider.tsx`