### PR TITLE
Use soft styling for item shop detail buttons

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -24,3 +24,36 @@ test('edit mode item picker stays centered on tablet layouts', async ({
         TABLET_VIEWPORT.width,
     );
 });
+
+test('item picker price buttons use the soft surface', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    const priceButton = page
+        .locator('button')
+        .filter({ hasText: '10' })
+        .first();
+    await expect(priceButton).toBeVisible();
+    await expect(priceButton).toHaveClass(/bg-primary\/10/u);
+});
+
+test('item details place button keeps the soft color treatment', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Stool' }).click();
+
+    const placeButton = page.getByRole('button', { name: /Postavi.*10/u });
+    await expect(placeButton).toBeVisible();
+    await expect(placeButton).toHaveClass(/bg-primary\/10/u);
+
+    const pricePill = placeButton.locator('div').filter({ hasText: '10' });
+    await expect(pricePill).toHaveClass(/bg-primary\/15/u);
+});

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -127,12 +127,13 @@ function PlaceEntityButton({
                 )}
                 onClick={placeEntity}
                 size={simple ? 'sm' : 'md'}
+                variant="soft"
                 disabled={!block.prices.sunflowers || placeBlock.isPending}
                 endDecorator={
                     <Row
                         className={cx(
                             !simple &&
-                                'rounded-full p-1 gap border bg-muted w-fit pr-2',
+                                'rounded-full p-1 gap border border-primary/15 bg-primary/15 text-primary w-fit pr-2',
                             !block.prices.sunflowers && 'pl-2',
                         )}
                     >


### PR DESCRIPTION
## Summary
- Switched item shop placement buttons to the shared `soft` button variant.
- Updated the detail popover price pill to use the same soft primary color treatment instead of the muted/white capsule.
- Added component tests covering both the item picker buttons and the item detail popover button styling.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm test --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm build --filter garden`
- `pnpm --filter garden exec playwright test tests/items-hud.spec.tsx`