### PR TITLE
Replace raised bed diary with filtered operations history

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -208,6 +208,8 @@ function serializeGardenOperation(
         completedAt: operation.completedAt?.toISOString() ?? null,
         verifiedAt: operation.verifiedAt?.toISOString() ?? null,
         canceledAt: operation.canceledAt?.toISOString() ?? null,
+        imageUrls: operation.imageUrls ?? [],
+        completionNotes: operation.completionNotes ?? null,
         targetLabel:
             (operation.raisedBedFieldId
                 ? targetsByRaisedBedFieldId.get(operation.raisedBedFieldId)
@@ -278,7 +280,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         '/:gardenId/operations',
         describeRoute({
             description:
-                'Get garden operations for timeline and history with cursor pagination',
+                'Get garden operations for timeline and history with cursor pagination and optional raised bed or field filters',
         }),
         zValidator(
             'param',
@@ -292,13 +294,22 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 cursor: z.coerce.number().int().min(0).optional(),
                 limit: z.coerce.number().int().min(1).max(50).optional(),
                 includeCompleted: queryBooleanSchema.optional(),
+                raisedBedId: z.coerce.number().int().min(1).optional(),
+                raisedBedFieldId: z.coerce.number().int().min(1).optional(),
+                positionIndex: z.coerce.number().int().min(0).optional(),
             }),
         ),
         authValidator(['user', 'admin']),
         async (context) => {
             const { gardenId } = context.req.valid('param');
-            const { cursor, limit, includeCompleted } =
-                context.req.valid('query');
+            const {
+                cursor,
+                limit,
+                includeCompleted,
+                raisedBedId,
+                raisedBedFieldId,
+                positionIndex,
+            } = context.req.valid('query');
             const gardenIdNumber = Number.parseInt(gardenId, 10);
 
             if (Number.isNaN(gardenIdNumber)) {
@@ -312,9 +323,51 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Garden not found' }, 404);
             }
 
+            const scopedRaisedBed = raisedBedId
+                ? garden.raisedBeds.find(
+                      (raisedBed) => raisedBed.id === raisedBedId,
+                  )
+                : undefined;
+
+            if (raisedBedId && !scopedRaisedBed) {
+                return context.json({ error: 'Raised bed not found' }, 404);
+            }
+
+            if (positionIndex !== undefined && !raisedBedId) {
+                return context.json(
+                    { error: 'raisedBedId is required with positionIndex' },
+                    400,
+                );
+            }
+
+            const positionFieldIds =
+                scopedRaisedBed && positionIndex !== undefined
+                    ? scopedRaisedBed.fields
+                          .filter(
+                              (field) => field.positionIndex === positionIndex,
+                          )
+                          .map((field) => field.id)
+                    : undefined;
+            const raisedBedFieldIds = raisedBedFieldId
+                ? [raisedBedFieldId]
+                : positionFieldIds;
+
+            if (
+                positionIndex !== undefined &&
+                raisedBedFieldIds?.length === 0
+            ) {
+                return context.json({
+                    items: [],
+                    nextCursor: null,
+                    total: 0,
+                });
+            }
+
             const operationsPage = await getOperationsPage({
                 accountId,
                 gardenId: gardenIdNumber,
+                raisedBedId,
+                raisedBedFieldIds,
                 cursor,
                 limit,
                 includeCompleted,

--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -3,6 +3,7 @@ import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
+import { gardenOperationsQueryKey } from '../../../packages/game/src/hooks/useGardenOperations';
 import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
 import { GardenOperationsHud } from '../../../packages/game/src/hud/GardenOperationsHud';
 import {
@@ -166,6 +167,8 @@ function createQueryClient() {
                         completedAt: null,
                         verifiedAt: null,
                         canceledAt: null,
+                        imageUrls: [],
+                        completionNotes: null,
                         targetLabel: 'Polje 1 • Raised Bed 1',
                         statusHistory: [
                             {
@@ -215,11 +218,19 @@ function createQueryClient() {
         ],
     });
     queryClient.setQueryData(
-        ['garden-operations', TEST_GARDEN_ID, false, 10],
+        gardenOperationsQueryKey({
+            gardenId: TEST_GARDEN_ID,
+            includeCompleted: false,
+            pageSize: 10,
+        }),
         pendingOperationPage,
     );
     queryClient.setQueryData(
-        ['garden-operations', TEST_GARDEN_ID, true, 20],
+        gardenOperationsQueryKey({
+            gardenId: TEST_GARDEN_ID,
+            includeCompleted: true,
+            pageSize: 20,
+        }),
         emptyOperationPage,
     );
 

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -3,6 +3,7 @@ import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo, useState } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
+import { gardenOperationsQueryKey } from '../../../packages/game/src/hooks/useGardenOperations';
 import { RaisedBedField } from '../../../packages/game/src/hud/raisedBed/RaisedBedField';
 import { RaisedBedFieldItem } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldItem';
 import { RaisedBedFieldSuggestions } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions';
@@ -71,6 +72,57 @@ function createScenarioQueryClient(scenario: RaisedBedScenario) {
     queryClient.setQueryData(['plants'], allPlants);
     queryClient.setQueryData(['sorts'], allSorts);
     queryClient.setQueryData(['operations'], scenario.operations ?? []);
+    const operationHistoryItems = scenario.operationHistoryItems ?? [];
+    queryClient.setQueryData(
+        gardenOperationsQueryKey({
+            gardenId: TEST_GARDEN_ID,
+            includeCompleted: true,
+            pageSize: 20,
+            raisedBedId: TEST_RAISED_BED_ID,
+        }),
+        {
+            pages: [
+                {
+                    items: operationHistoryItems,
+                    nextCursor: null,
+                    total: operationHistoryItems.length,
+                },
+            ],
+            pageParams: [0],
+        },
+    );
+
+    for (const field of garden.raisedBeds[0]?.fields ?? []) {
+        const fieldIds = garden.raisedBeds[0].fields
+            .filter(
+                (candidate) => candidate.positionIndex === field.positionIndex,
+            )
+            .map((candidate) => candidate.id);
+        const fieldOperationHistoryItems = operationHistoryItems.filter(
+            (operation) =>
+                operation.raisedBedFieldId !== null &&
+                fieldIds.includes(operation.raisedBedFieldId),
+        );
+        queryClient.setQueryData(
+            gardenOperationsQueryKey({
+                gardenId: TEST_GARDEN_ID,
+                includeCompleted: true,
+                pageSize: 20,
+                raisedBedId: TEST_RAISED_BED_ID,
+                positionIndex: field.positionIndex,
+            }),
+            {
+                pages: [
+                    {
+                        items: fieldOperationHistoryItems,
+                        nextCursor: null,
+                        total: fieldOperationHistoryItems.length,
+                    },
+                ],
+                pageParams: [0],
+            },
+        );
+    }
 
     return queryClient;
 }
@@ -78,12 +130,14 @@ function createScenarioQueryClient(scenario: RaisedBedScenario) {
 type ProvidersProps = PropsWithChildren<{
     scenario: RaisedBedScenario;
     enablePlantHistory?: boolean;
+    enableRaisedBedImageAI?: boolean;
 }>;
 
 function RaisedBedHudTestProviders({
     children,
     scenario,
     enablePlantHistory = true,
+    enableRaisedBedImageAI = false,
 }: ProvidersProps) {
     const queryClient = useMemo(
         () => createScenarioQueryClient(scenario),
@@ -105,7 +159,10 @@ function RaisedBedHudTestProviders({
             <ReactQuery.QueryClientProvider client={queryClient}>
                 <GameStateContext.Provider value={gameStore}>
                     <GameFlagsContext.Provider
-                        value={{ enablePlantHistoryFlag: enablePlantHistory }}
+                        value={{
+                            enablePlantHistoryFlag: enablePlantHistory,
+                            raisedBedImageAI: enableRaisedBedImageAI,
+                        }}
                     >
                         <GameAnalyticsProvider capture={() => undefined}>
                             {children}
@@ -121,11 +178,13 @@ export function RaisedBedFieldHudStory({
     scenario,
     positionIndex,
     enablePlantHistory = true,
+    enableRaisedBedImageAI = false,
     cellSize = 80,
 }: {
     scenario: RaisedBedScenario;
     positionIndex: number;
     enablePlantHistory?: boolean;
+    enableRaisedBedImageAI?: boolean;
     cellSize?: number;
 }) {
     const cartItem =
@@ -136,6 +195,7 @@ export function RaisedBedFieldHudStory({
         <RaisedBedHudTestProviders
             scenario={scenario}
             enablePlantHistory={enablePlantHistory}
+            enableRaisedBedImageAI={enableRaisedBedImageAI}
         >
             <div
                 data-testid="hud-cell"

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -31,6 +31,15 @@ test.describe('Garden operations HUD', () => {
         await expect(page.getByText('Zakazano: sutra')).toBeVisible();
         await expect(page.getByText('U košari').last()).toBeVisible();
 
+        await expect(page.getByText('Zakazano', { exact: true })).toHaveCount(
+            2,
+        );
+        await expect(page.getByText('Planirano', { exact: true })).toHaveCount(
+            0,
+        );
+        await expect(
+            page.getByText('Zakazano: 22. svibnja 2026.'),
+        ).toBeVisible();
         await expect(page.getByText('Sadnja', { exact: true })).toBeVisible();
         await expect(page.getByLabel('Polje 1 • Raised Bed 1')).toBeVisible();
         await expect(page.getByText('Sadnja: Klasični bosiljak')).toBeVisible();
@@ -38,6 +47,8 @@ test.describe('Garden operations HUD', () => {
         await expect(
             page.getByText('Zakazano: 23. svibnja 2026.'),
         ).toBeVisible();
+        await expect(page.getByLabel('Tijek radnje')).toHaveCount(0);
+        await expect(page.locator('.animate-progress')).toHaveCount(0);
         await expect(page.getByText(/^Kreirano:/)).toHaveCount(0);
         await expect(page.getByText(/Sljedeći korak/)).toHaveCount(0);
         await expect(page.getByText('Nema nedovršenih radnji.')).toHaveCount(0);
@@ -56,5 +67,9 @@ test.describe('Garden operations HUD', () => {
         await expect(dialog.getByText('Sadnja: Cherry rajčica')).toBeVisible();
         await expect(dialog.getByLabel('Polje 3 • Raised Bed 1')).toBeVisible();
         await expect(dialog.getByText('Završeno')).toBeVisible();
+        await expect(dialog.getByLabel('Tijek radnje').first()).toHaveCSS(
+            'max-width',
+            '320px',
+        );
     });
 });

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -79,6 +79,77 @@ function plantedGrowingWithRecommendedOperationsScenario(): RaisedBedScenario {
     };
 }
 
+function plantedGrowingWithOperationHistoryScenario(): RaisedBedScenario {
+    const wateringOperation = buildOperation({
+        id: 301,
+        name: 'mock-history-watering',
+        label: 'Zalijevanje',
+        stageName: 'maintenance',
+        stageLabel: 'Održavanje',
+    });
+
+    return {
+        ...plantedGrowingScenario(),
+        operations: [wateringOperation],
+        operationHistoryItems: [
+            {
+                id: 901,
+                entityId: wateringOperation.id,
+                entityTypeName: 'operation',
+                raisedBedId: 1,
+                raisedBedFieldId: 1,
+                status: 'completed',
+                createdAt: '2026-05-10T00:00:00.000Z',
+                scheduledDate: '2026-05-10T00:00:00.000Z',
+                scheduledAt: '2026-05-09T00:00:00.000Z',
+                completedAt: '2026-05-10T08:00:00.000Z',
+                verifiedAt: '2026-05-10T09:00:00.000Z',
+                canceledAt: null,
+                imageUrls: ['https://example.com/watering.jpg'],
+                completionNotes: 'Biljka je zalivena nakon pregleda tla.',
+                targetLabel: 'Polje 1 • Raised Bed 1',
+                statusHistory: [
+                    {
+                        status: 'new',
+                        changedAt: '2026-05-09T00:00:00.000Z',
+                    },
+                    {
+                        status: 'planned',
+                        changedAt: '2026-05-09T00:00:00.000Z',
+                    },
+                    {
+                        status: 'completed',
+                        changedAt: '2026-05-10T09:00:00.000Z',
+                    },
+                ],
+            },
+            {
+                id: 902,
+                entityId: wateringOperation.id,
+                entityTypeName: 'operation',
+                raisedBedId: 1,
+                raisedBedFieldId: 99,
+                status: 'completed',
+                createdAt: '2026-05-10T00:00:00.000Z',
+                scheduledDate: null,
+                scheduledAt: null,
+                completedAt: '2026-05-10T08:00:00.000Z',
+                verifiedAt: '2026-05-10T09:00:00.000Z',
+                canceledAt: null,
+                imageUrls: [],
+                completionNotes: 'Ovo je zapis za drugo polje.',
+                targetLabel: 'Polje 99 • Raised Bed 1',
+                statusHistory: [
+                    {
+                        status: 'completed',
+                        changedAt: '2026-05-10T09:00:00.000Z',
+                    },
+                ],
+            },
+        ],
+    };
+}
+
 function plantedSownWithScheduledScenario(): RaisedBedScenario {
     return {
         fields: [
@@ -506,6 +577,38 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             dialog.getByRole('tab', { name: /Radnje/ }),
         ).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('diary tab shows filtered operation history with photos and notes', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithOperationHistoryScenario()}
+                positionIndex={0}
+                enableRaisedBedImageAI
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
+
+        await expect(dialog.getByText('Zalijevanje')).toBeVisible();
+        await expect(
+            dialog.getByText('Biljka je zalivena nakon pregleda tla.'),
+        ).toBeVisible();
+        await expect(dialog.locator('[data-operation-images]')).toBeVisible();
+        await expect(
+            dialog.getByRole('button', {
+                name: /Pitaj suncokret za savjete/u,
+            }),
+        ).toBeVisible();
+        await expect(
+            dialog.getByText('Ovo je zapis za drugo polje.'),
+        ).toHaveCount(0);
     });
 
     test('lifecycle modal opens status change popover from current state', async ({

--- a/apps/garden/tests/raisedBedFieldHudScenarios.ts
+++ b/apps/garden/tests/raisedBedFieldHudScenarios.ts
@@ -1,4 +1,5 @@
 import type { OperationData, PlantData, PlantSortData } from '@gredice/client';
+import type { GardenOperationItem } from '../../../packages/game/src/hooks/useGardenOperations';
 import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
 
 const now = '2026-05-13T00:00:00.000Z';
@@ -150,6 +151,7 @@ export type RaisedBedScenario = {
     fields: FieldConfig[];
     cartItems?: ShoppingCartItemData[];
     operations?: OperationData[];
+    operationHistoryItems?: GardenOperationItem[];
     raisedBedStatus?: string;
     raisedBedAbandonReason?: string | null;
     isRaisedBedValid?: boolean;

--- a/packages/game/src/hooks/useGardenOperations.ts
+++ b/packages/game/src/hooks/useGardenOperations.ts
@@ -37,11 +37,19 @@ export type GardenOperationItem = {
     completedAt: string | null;
     verifiedAt: string | null;
     canceledAt: string | null;
+    imageUrls: string[];
+    completionNotes: string | null;
     targetLabel: string;
     statusHistory: {
         status: GardenOperationStatus;
         changedAt: string;
     }[];
+};
+
+type GardenOperationsScope = {
+    raisedBedId?: number;
+    raisedBedFieldId?: number;
+    positionIndex?: number;
 };
 
 type GardenOperationsPage = {
@@ -52,9 +60,15 @@ type GardenOperationsPage = {
 
 type GardenOperationItemResponse = Omit<
     GardenOperationItem,
-    'entityTypeName' | 'status' | 'statusHistory'
+    | 'completionNotes'
+    | 'entityTypeName'
+    | 'imageUrls'
+    | 'status'
+    | 'statusHistory'
 > & {
+    completionNotes?: string | null;
     entityTypeName?: string;
+    imageUrls?: string[] | null;
     status: string;
     statusHistory: ({
         status: string;
@@ -80,7 +94,9 @@ function parseGardenOperationItem(
 ): GardenOperationItem {
     return {
         ...item,
+        completionNotes: item.completionNotes ?? null,
         entityTypeName: item.entityTypeName ?? 'operation',
+        imageUrls: item.imageUrls ?? [],
         status: parseGardenOperationStatus(item.status),
         statusHistory: item.statusHistory.flatMap((entry) => {
             if (!entry) {
@@ -107,12 +123,14 @@ function parseGardenOperationsPage(
     };
 }
 
-async function getGardenOperationsPage(input: {
-    gardenId: number;
-    includeCompleted: boolean;
-    pageSize: number;
-    cursor: number;
-}): Promise<GardenOperationsPage> {
+async function getGardenOperationsPage(
+    input: {
+        gardenId: number;
+        includeCompleted: boolean;
+        pageSize: number;
+        cursor: number;
+    } & GardenOperationsScope,
+): Promise<GardenOperationsPage> {
     const response = await clientAuthenticated().api.gardens[
         ':gardenId'
     ].operations.$get({
@@ -123,6 +141,15 @@ async function getGardenOperationsPage(input: {
             cursor: input.cursor.toString(),
             limit: input.pageSize.toString(),
             includeCompleted: input.includeCompleted.toString(),
+            ...(input.raisedBedId !== undefined
+                ? { raisedBedId: input.raisedBedId.toString() }
+                : {}),
+            ...(input.raisedBedFieldId !== undefined
+                ? { raisedBedFieldId: input.raisedBedFieldId.toString() }
+                : {}),
+            ...(input.positionIndex !== undefined
+                ? { positionIndex: input.positionIndex.toString() }
+                : {}),
         },
     });
 
@@ -133,22 +160,50 @@ async function getGardenOperationsPage(input: {
     return parseGardenOperationsPage(await response.json());
 }
 
+export function gardenOperationsQueryKey({
+    gardenId,
+    includeCompleted,
+    pageSize,
+    raisedBedId,
+    raisedBedFieldId,
+    positionIndex,
+}: {
+    gardenId: number | undefined;
+    includeCompleted: boolean;
+    pageSize: number;
+} & GardenOperationsScope) {
+    return [
+        'garden-operations',
+        gardenId,
+        includeCompleted,
+        pageSize,
+        raisedBedId ?? null,
+        raisedBedFieldId ?? null,
+        positionIndex ?? null,
+    ] as const;
+}
+
 export function useGardenOperations({
     includeCompleted,
     pageSize = DEFAULT_PAGE_SIZE,
+    raisedBedId,
+    raisedBedFieldId,
+    positionIndex,
 }: {
     includeCompleted: boolean;
     pageSize?: number;
-}) {
+} & GardenOperationsScope) {
     const { data: currentGarden } = useCurrentGarden();
 
     return useInfiniteQuery({
-        queryKey: [
-            'garden-operations',
-            currentGarden?.id,
+        queryKey: gardenOperationsQueryKey({
+            gardenId: currentGarden?.id,
             includeCompleted,
             pageSize,
-        ],
+            raisedBedId,
+            raisedBedFieldId,
+            positionIndex,
+        }),
         queryFn: async ({ pageParam }) => {
             if (!currentGarden?.id) {
                 return {
@@ -162,6 +217,9 @@ export function useGardenOperations({
                 gardenId: currentGarden.id,
                 includeCompleted,
                 pageSize,
+                raisedBedId,
+                raisedBedFieldId,
+                positionIndex,
                 cursor: pageParam,
             });
         },

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@gredice/ui/Button';
 import { Divider } from '@gredice/ui/Divider';
 import { DotIndicator } from '@gredice/ui/DotIndicator';
+import { ImageGallery } from '@gredice/ui/ImageGallery';
 import {
     Approved,
     Calendar,
@@ -22,7 +23,13 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { type ComponentType, useCallback, useMemo, useRef } from 'react';
+import {
+    type ComponentType,
+    type ReactNode,
+    useCallback,
+    useMemo,
+    useRef,
+} from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { SegmentedProgress } from '../controls/components/SegmentedProgress';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
@@ -31,6 +38,7 @@ import {
     type GardenOperationStatus,
     useGardenOperations,
 } from '../hooks/useGardenOperations';
+import { useLiveTime } from '../hooks/useLiveTime';
 import { useOperations } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
 import {
@@ -97,7 +105,7 @@ const hiddenFromActive = new Set<GardenOperationStatus>([
     'canceled',
 ]);
 const cartOperationEntityType = 'operation' as const;
-const cartPlantSortEntityType = 'plantSort' as const;
+export const cartPlantSortEntityType = 'plantSort' as const;
 const plantingOperationLabel = 'Sadnja';
 const plantSortFallbackLabel = 'Sorta';
 const sowingCompletedStatuses = new Set([
@@ -117,6 +125,7 @@ type StatusConfig = {
     icon: ComponentType<{ className?: string }>;
     colorClass: string;
 };
+type OperationDisplayStatus = GardenOperationStatus | 'scheduled';
 
 const statusConfig: Record<GardenOperationStatus, StatusConfig> = {
     new: {
@@ -154,6 +163,11 @@ const statusConfig: Record<GardenOperationStatus, StatusConfig> = {
         icon: Close,
         colorClass: 'text-neutral-500',
     },
+};
+const scheduledStatusConfig: StatusConfig = {
+    label: 'Zakazano',
+    icon: Calendar,
+    colorClass: 'text-indigo-600',
 };
 
 function formatDate(value?: string | null) {
@@ -203,6 +217,42 @@ function getCartItemScheduledDate(item: ShoppingCartItemData) {
 function getTimestamp(value: string | Date | null | undefined) {
     const timestamp = value ? new Date(value).getTime() : 0;
     return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function getStartOfNextLocalDay(referenceDate: Date) {
+    return new Date(
+        referenceDate.getFullYear(),
+        referenceDate.getMonth(),
+        referenceDate.getDate() + 1,
+    );
+}
+
+function isScheduledForLaterDate(
+    scheduledDate: string | null | undefined,
+    referenceDate: Date,
+) {
+    if (!scheduledDate) {
+        return false;
+    }
+
+    const scheduledTimestamp = new Date(scheduledDate).getTime();
+    if (!Number.isFinite(scheduledTimestamp)) {
+        return false;
+    }
+
+    return (
+        scheduledTimestamp >= getStartOfNextLocalDay(referenceDate).getTime()
+    );
+}
+
+function isScheduledUnassignedOperation(
+    operation: GardenOperationHudItem,
+    referenceDate: Date,
+) {
+    return (
+        operation.status === 'planned' &&
+        isScheduledForLaterDate(operation.scheduledDate, referenceDate)
+    );
 }
 
 function toIsoString(value: string | Date | null | undefined) {
@@ -358,7 +408,7 @@ function getSowingEntries(
     return [field];
 }
 
-function buildSowingOperationItems(
+export function buildSowingOperationItems(
     garden: CurrentGardenData | null | undefined,
 ): GardenOperationHudItem[] {
     if (!garden) {
@@ -407,6 +457,8 @@ function buildSowingOperationItems(
                                 : null,
                         verifiedAt: status === 'completed' ? completedAt : null,
                         canceledAt,
+                        imageUrls: [],
+                        completionNotes: null,
                         targetLabel: `Polje ${field.positionIndex + 1} • ${
                             raisedBed.name
                         }`,
@@ -522,11 +574,12 @@ function StatusBadge({
     size = 'sm',
     className,
 }: {
-    status: GardenOperationStatus;
+    status: OperationDisplayStatus;
     size?: 'sm' | 'md';
     className?: string;
 }) {
-    const config = statusConfig[status];
+    const config =
+        status === 'scheduled' ? scheduledStatusConfig : statusConfig[status];
     const Icon = config.icon;
     const iconSize = size === 'md' ? 'size-4' : 'size-3.5';
     const textLevel = size === 'md' ? 'body2' : 'body3';
@@ -682,12 +735,20 @@ function buildSegments(operation: GardenOperationItem) {
 
 function OperationProgress({
     operation,
+    className,
 }: {
     operation: GardenOperationHudItem;
+    className?: string;
 }) {
     const segments = useMemo(() => buildSegments(operation), [operation]);
 
-    return <SegmentedProgress className="pb-5 pr-4" segments={segments} />;
+    return (
+        <SegmentedProgress
+            aria-label="Tijek radnje"
+            className={cx('pb-5 pr-4', className)}
+            segments={segments}
+        />
+    );
 }
 
 function OperationDates({ operation }: { operation: GardenOperationItem }) {
@@ -701,6 +762,46 @@ function OperationDates({ operation }: { operation: GardenOperationItem }) {
         <Typography level="body3" secondary>
             Zakazano: {scheduledDate}
         </Typography>
+    );
+}
+
+function OperationEvidence({ operation }: { operation: GardenOperationItem }) {
+    const imageUrls = operation.imageUrls;
+    const completionNotes = operation.completionNotes?.trim();
+
+    if (!imageUrls.length && !completionNotes) {
+        return null;
+    }
+
+    return (
+        <Stack spacing={1} className="min-w-0 max-w-full">
+            {imageUrls.length > 0 && (
+                <div
+                    className="min-w-0 max-w-full overflow-hidden"
+                    data-operation-images
+                >
+                    <ImageGallery
+                        images={imageUrls.map((url) => ({
+                            src: url,
+                            alt: operation.targetLabel,
+                        }))}
+                        previewWidth={72}
+                        previewHeight={72}
+                        previewAs="div"
+                        previewVariant="carousel"
+                    />
+                </div>
+            )}
+            {completionNotes && (
+                <Typography
+                    level="body2"
+                    className="break-words"
+                    data-operation-notes
+                >
+                    {completionNotes}
+                </Typography>
+            )}
+        </Stack>
     );
 }
 
@@ -793,18 +894,24 @@ function getActiveOperationName({
     return `Radnja #${operation.id}`;
 }
 
-function OperationCard({
+export function GardenOperationCard({
     operation,
     operationName,
     operationData,
     plantSortData,
     currentGarden,
+    referenceDate,
+    progressClassName,
+    action,
 }: {
     operation: GardenOperationHudItem;
     operationName?: string;
     operationData?: OperationData;
     plantSortData?: PlantSortData;
     currentGarden?: CurrentGardenData | null;
+    referenceDate: Date;
+    progressClassName?: string;
+    action?: ReactNode;
 }) {
     const resolvedOperationName = getActiveOperationName({
         operation,
@@ -812,6 +919,10 @@ function OperationCard({
         plantSortName: plantSortData?.information.name,
     });
     const targetDetails = getOperationTargetDetails(operation, currentGarden);
+    const isScheduledUnassigned = isScheduledUnassignedOperation(
+        operation,
+        referenceDate,
+    );
 
     return (
         <div className="rounded-xl border p-3">
@@ -844,14 +955,25 @@ function OperationCard({
                                 {resolvedOperationName}
                             </Typography>
                             <StatusBadge
-                                status={operation.status}
+                                status={
+                                    isScheduledUnassigned
+                                        ? 'scheduled'
+                                        : operation.status
+                                }
                                 className="shrink-0"
                             />
                         </Row>
                         <OperationTargetLabel targetDetails={targetDetails} />
                     </Stack>
                     <OperationDates operation={operation} />
-                    <OperationProgress operation={operation} />
+                    <OperationEvidence operation={operation} />
+                    {!isScheduledUnassigned && (
+                        <OperationProgress
+                            operation={operation}
+                            className={progressClassName}
+                        />
+                    )}
+                    {action && <div className="flex justify-end">{action}</div>}
                 </Stack>
             </Row>
         </div>
@@ -969,6 +1091,7 @@ function HistoryModal({
     plantSortById,
     currentGarden,
     listRef,
+    referenceDate,
 }: {
     trigger: React.ReactElement;
     operations: GardenOperationHudItem[];
@@ -976,6 +1099,7 @@ function HistoryModal({
     plantSortById: Map<number, PlantSortData>;
     currentGarden?: CurrentGardenData | null;
     listRef: (node: HTMLDivElement | null) => void;
+    referenceDate: Date;
 }) {
     return (
         <Modal
@@ -1003,7 +1127,7 @@ function HistoryModal({
                         </Typography>
                     ) : (
                         operations.map((operation) => (
-                            <OperationCard
+                            <GardenOperationCard
                                 key={`${operation.entityTypeName}-${operation.id}`}
                                 operation={operation}
                                 operationName={
@@ -1029,6 +1153,8 @@ function HistoryModal({
                                         : undefined
                                 }
                                 currentGarden={currentGarden}
+                                referenceDate={referenceDate}
+                                progressClassName="md:max-w-80"
                             />
                         ))
                     )}
@@ -1052,7 +1178,7 @@ function getLatestOperationChangeTime(operation: GardenOperationHudItem) {
     return latest;
 }
 
-function sortNewestFirst(operations: GardenOperationHudItem[]) {
+export function sortNewestFirst(operations: GardenOperationHudItem[]) {
     return [...operations].sort((a, b) => {
         const dateDiff =
             getLatestOperationChangeTime(b) - getLatestOperationChangeTime(a);
@@ -1073,6 +1199,7 @@ function sortScheduledSoonestFirst(operations: GardenOperationHudItem[]) {
 
 export function GardenOperationsHud() {
     const { track } = useGameAnalytics();
+    const referenceDate = useLiveTime();
     const { data: currentGarden } = useCurrentGarden();
     const { data: operationsData } = useOperations();
     const { data: cart } = useShoppingCart();
@@ -1282,7 +1409,7 @@ export function GardenOperationsHud() {
                             {cartOperations.length > 0 &&
                                 pendingOperations.length > 0 && <Divider />}
                             {pendingOperations.map((operation) => (
-                                <OperationCard
+                                <GardenOperationCard
                                     key={`${operation.entityTypeName}-${operation.id}`}
                                     operation={operation}
                                     operationName={
@@ -1310,6 +1437,7 @@ export function GardenOperationsHud() {
                                             : undefined
                                     }
                                     currentGarden={currentGarden}
+                                    referenceDate={referenceDate}
                                 />
                             ))}
                         </>
@@ -1323,6 +1451,7 @@ export function GardenOperationsHud() {
                     plantSortById={plantSortById}
                     currentGarden={currentGarden}
                     listRef={historyRef}
+                    referenceDate={referenceDate}
                     trigger={
                         <Button
                             variant="plain"

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,4 +1,3 @@
-import { Card, CardOverflow } from '@gredice/ui/Card';
 import {
     Book,
     Check,
@@ -27,7 +26,6 @@ import {
     findRaisedBedOccupiedField,
     type RaisedBedFieldPlantHistoryEntry,
 } from '../../utils/raisedBedFields';
-import { RaisedBedFieldDiary } from './RaisedBedDiary';
 import { RaisedBedFieldIconStack } from './RaisedBedFieldIconStack';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import {
@@ -36,6 +34,7 @@ import {
 } from './RaisedBedFieldLifecycleTab';
 import { RaisedBedFieldOperationsTab } from './RaisedBedFieldOperationsTab';
 import { RaisedBedFieldPlantHistoryModal } from './RaisedBedFieldPlantHistoryModal';
+import { RaisedBedOperationHistoryList } from './RaisedBedOperationHistoryList';
 
 type RaisedBedFieldTabValue = 'lifecycle' | 'diary' | 'operations';
 
@@ -392,16 +391,12 @@ export function RaisedBedFieldItemPlanted({
                     )}
                     <TabsContent value="diary">
                         {garden && (
-                            <Card>
-                                <CardOverflow className="max-h-96 overflow-y-auto overflow-x-hidden">
-                                    <RaisedBedFieldDiary
-                                        gardenId={garden.id}
-                                        raisedBedId={raisedBed.id}
-                                        positionIndex={positionIndex}
-                                        disableActions={isHistorical}
-                                    />
-                                </CardOverflow>
-                            </Card>
+                            <div className="max-h-96 overflow-y-auto overflow-x-hidden pr-1">
+                                <RaisedBedOperationHistoryList
+                                    raisedBedId={raisedBed.id}
+                                    positionIndex={positionIndex}
+                                />
+                            </div>
                         )}
                     </TabsContent>
                     <TabsContent value="lifecycle">

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -395,6 +395,7 @@ export function RaisedBedFieldItemPlanted({
                                 <RaisedBedOperationHistoryList
                                     raisedBedId={raisedBed.id}
                                     positionIndex={positionIndex}
+                                    disableActions={isHistorical}
                                 />
                             </div>
                         )}

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -1,7 +1,6 @@
 import { Alert } from '@gredice/ui/Alert';
 import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
-import { Card, CardOverflow } from '@gredice/ui/Card';
 import { EditableInput } from '@gredice/ui/EditableInput';
 import { Book, Hammer, Info, MoreHorizontal, Warning } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
@@ -19,8 +18,8 @@ import {
     RAISED_BED_STATUS_ABANDONED,
 } from '../../raisedBedConstants';
 import { useGameState } from '../../useGameState';
-import { RaisedBedDiary } from './RaisedBedDiary';
 import { RaisedBedInfoTab } from './RaisedBedInfoTab';
+import { RaisedBedOperationHistoryList } from './RaisedBedOperationHistoryList';
 import { RaisedBedOperationsTab } from './RaisedBedOperationsTab';
 
 type RaisedBedTab = 'diary' | 'operations' | 'info' | 'more';
@@ -226,14 +225,11 @@ export function RaisedBedInfo({
                     </Stack>
                 </TabsContent>
                 <TabsContent value="diary">
-                    <Card>
-                        <CardOverflow className="max-h-96 overflow-y-auto overflow-x-hidden">
-                            <RaisedBedDiary
-                                gardenId={gardenId}
-                                raisedBedId={raisedBed.id}
-                            />
-                        </CardOverflow>
-                    </Card>
+                    <div className="max-h-96 overflow-y-auto overflow-x-hidden pr-1">
+                        <RaisedBedOperationHistoryList
+                            raisedBedId={raisedBed.id}
+                        />
+                    </div>
                 </TabsContent>
                 <TabsContent value="operations">
                     <RaisedBedOperationsTab

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -80,10 +80,12 @@ export function RaisedBedOperationHistoryList({
     raisedBedId,
     positionIndex,
     raisedBedFieldId,
+    disableActions = false,
 }: {
     raisedBedId?: number;
     positionIndex?: number;
     raisedBedFieldId?: number;
+    disableActions?: boolean;
 }) {
     const referenceDate = useLiveTime();
     const flags = useGameFlags();
@@ -205,6 +207,7 @@ export function RaisedBedOperationHistoryList({
                 const actionRaisedBedId = operation.raisedBedId ?? raisedBedId;
                 const action =
                     flags.raisedBedImageAI &&
+                    !disableActions &&
                     currentGarden &&
                     actionRaisedBedId &&
                     operation.imageUrls.length > 0 ? (

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -1,0 +1,250 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { useMemo } from 'react';
+import { useGameFlags } from '../../GameFlagsContext';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import {
+    type GardenOperationItem,
+    useGardenOperations,
+} from '../../hooks/useGardenOperations';
+import { useLiveTime } from '../../hooks/useLiveTime';
+import { useOperations } from '../../hooks/useOperations';
+import { useSorts } from '../../hooks/usePlantSorts';
+import {
+    buildSowingOperationItems,
+    cartPlantSortEntityType,
+    GardenOperationCard,
+    sortNewestFirst,
+} from '../GardenOperationsHud';
+import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
+
+function buildFieldPositionById(
+    garden: ReturnType<typeof useCurrentGarden>['data'],
+) {
+    return new Map(
+        (garden?.raisedBeds ?? []).flatMap((raisedBed) =>
+            raisedBed.fields.map(
+                (field) => [field.id, field.positionIndex] as const,
+            ),
+        ),
+    );
+}
+
+function filterOperationsByTarget({
+    operations,
+    raisedBedId,
+    positionIndex,
+    raisedBedFieldId,
+    fieldPositionById,
+}: {
+    operations: GardenOperationItem[];
+    raisedBedId?: number;
+    positionIndex?: number;
+    raisedBedFieldId?: number;
+    fieldPositionById: Map<number, number>;
+}) {
+    return operations.filter((operation) => {
+        if (
+            raisedBedId !== undefined &&
+            operation.raisedBedId !== raisedBedId
+        ) {
+            return false;
+        }
+
+        if (
+            raisedBedFieldId !== undefined &&
+            operation.raisedBedFieldId !== raisedBedFieldId
+        ) {
+            return false;
+        }
+
+        if (positionIndex !== undefined) {
+            if (operation.raisedBedFieldId === null) {
+                return false;
+            }
+
+            return (
+                fieldPositionById.get(operation.raisedBedFieldId) ===
+                positionIndex
+            );
+        }
+
+        return true;
+    });
+}
+
+export function RaisedBedOperationHistoryList({
+    raisedBedId,
+    positionIndex,
+    raisedBedFieldId,
+}: {
+    raisedBedId?: number;
+    positionIndex?: number;
+    raisedBedFieldId?: number;
+}) {
+    const referenceDate = useLiveTime();
+    const flags = useGameFlags();
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: operationsData } = useOperations();
+    const fieldPositionById = useMemo(
+        () => buildFieldPositionById(currentGarden),
+        [currentGarden],
+    );
+    const history = useGardenOperations({
+        includeCompleted: true,
+        pageSize: 20,
+        raisedBedId,
+        raisedBedFieldId,
+        positionIndex,
+    });
+    const sowingOperations = useMemo(
+        () =>
+            filterOperationsByTarget({
+                operations: buildSowingOperationItems(currentGarden),
+                raisedBedId,
+                positionIndex,
+                raisedBedFieldId,
+                fieldPositionById,
+            }),
+        [
+            currentGarden,
+            fieldPositionById,
+            raisedBedId,
+            raisedBedFieldId,
+            positionIndex,
+        ],
+    );
+    const operations = useMemo(
+        () =>
+            sortNewestFirst([
+                ...(history.data?.pages.flatMap((page) => page.items) ?? []),
+                ...sowingOperations,
+            ]),
+        [history.data?.pages, sowingOperations],
+    );
+    const sowingPlantSortIds = useMemo(
+        () =>
+            Array.from(
+                new Set(
+                    operations
+                        .filter(
+                            (operation) =>
+                                operation.entityTypeName ===
+                                cartPlantSortEntityType,
+                        )
+                        .map((operation) => operation.entityId),
+                ),
+            ),
+        [operations],
+    );
+    const { data: sowingPlantSorts } = useSorts(
+        sowingPlantSortIds.length > 0 ? sowingPlantSortIds : undefined,
+    );
+    const operationDataById = useMemo(
+        () =>
+            new Map(
+                (operationsData ?? []).map((operation) => [
+                    operation.id,
+                    operation,
+                ]),
+            ),
+        [operationsData],
+    );
+    const plantSortById = useMemo(
+        () =>
+            new Map(
+                (sowingPlantSorts ?? []).map((plantSort) => [
+                    plantSort.id,
+                    plantSort,
+                ]),
+            ),
+        [sowingPlantSorts],
+    );
+
+    if (history.isError) {
+        return (
+            <Alert color="danger">
+                Došlo je do pogreške prilikom učitavanja radnji.
+            </Alert>
+        );
+    }
+
+    if (history.isLoading) {
+        return (
+            <Spinner
+                loading
+                loadingLabel="Učitavanje radnji..."
+                className="mx-auto my-8 flex items-center justify-center"
+            />
+        );
+    }
+
+    if (operations.length === 0) {
+        return (
+            <NoDataPlaceholder className="p-4">
+                Nema zabilježenih radnji.
+            </NoDataPlaceholder>
+        );
+    }
+
+    return (
+        <Stack spacing={3}>
+            {operations.map((operation) => {
+                const operationData =
+                    operation.entityTypeName === 'operation'
+                        ? operationDataById.get(operation.entityId)
+                        : undefined;
+                const plantSortData =
+                    operation.entityTypeName === cartPlantSortEntityType
+                        ? plantSortById.get(operation.entityId)
+                        : undefined;
+                const operationName = operationData?.information.label;
+                const actionRaisedBedId = operation.raisedBedId ?? raisedBedId;
+                const action =
+                    flags.raisedBedImageAI &&
+                    currentGarden &&
+                    actionRaisedBedId &&
+                    operation.imageUrls.length > 0 ? (
+                        <RaisedBedDiaryAiAction
+                            gardenId={currentGarden.id}
+                            raisedBedId={actionRaisedBedId}
+                            positionIndex={positionIndex}
+                            entryName={
+                                operationName ??
+                                plantSortData?.information.name ??
+                                operation.targetLabel
+                            }
+                            imageUrls={operation.imageUrls}
+                        />
+                    ) : undefined;
+
+                return (
+                    <GardenOperationCard
+                        key={`${operation.entityTypeName}-${operation.id}`}
+                        operation={operation}
+                        operationName={operationName}
+                        operationData={operationData}
+                        plantSortData={plantSortData}
+                        currentGarden={currentGarden}
+                        referenceDate={referenceDate}
+                        progressClassName="md:max-w-80"
+                        action={action}
+                    />
+                );
+            })}
+            {history.hasNextPage && (
+                <Button
+                    variant="plain"
+                    size="sm"
+                    loading={history.isFetchingNextPage}
+                    onClick={() => history.fetchNextPage()}
+                >
+                    Prikaži više
+                </Button>
+            )}
+        </Stack>
+    );
+}


### PR DESCRIPTION
## Summary
- Replaced the raised bed and field diary tabs with a filtered operations history view based on raised bed or field scope.
- Added support for operation images and completion notes so the history view shows richer content than the old diary.
- Backported the AI sunflower action into the new operations list for photo-based entries.
- Updated garden operations handling so later scheduled, unassigned tasks show as `Zakazano` with a date instead of a running progress indicator.
- Limited history progress width on desktop to reduce visual clutter.

## Testing
- Lint and formatting passed for `api`, `garden`, and `@gredice/game`.
- Playwright coverage passed for the Garden operations HUD and raised-bed field HUD scenarios.
- `@gredice/game` unit tests passed.
- API node tests and production builds passed for `api`, `garden`, and `www`.