### PR TITLE
Match garden box wood colors to shared plank material

### DIFF
--- a/packages/game/src/entities/GardenBox.tsx
+++ b/packages/game/src/entities/GardenBox.tsx
@@ -2,5 +2,5 @@ import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { GardenBox as GardenBoxBase } from './helpers/GardenBox';
 
 export function GardenBox(props: EntityInstanceProps) {
-    return <GardenBoxBase {...props} bodyColor="#8B5A2B" lidColor="#5E3A1D" />;
+    return <GardenBoxBase {...props} />;
 }

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -13,27 +13,8 @@ import { useAnimatedEntityRotation } from './useAnimatedEntityRotation';
 const lidClosedRotation = 0;
 const lidOpenRotation = -Math.PI / 2;
 
-type GardenBoxProps = EntityInstanceProps & {
-    bodyColor: string;
-    lidColor: string;
-    bodyMetalness?: number;
-    bodyRoughness?: number;
-    lidMetalness?: number;
-    lidRoughness?: number;
-};
-
-export function GardenBox({
-    stack,
-    block,
-    rotation,
-    bodyColor,
-    lidColor,
-    bodyMetalness = 0.1,
-    bodyRoughness = 0.85,
-    lidMetalness = 0.2,
-    lidRoughness = 0.75,
-}: GardenBoxProps) {
-    const { nodes } = useGameGLTF('GardenBox');
+export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
+    const { nodes, materials } = useGameGLTF('GardenBox');
     const [animatedRotation] = useAnimatedEntityRotation(rotation);
     const currentStackHeight = useStackHeight(stack, block);
     const hovered =
@@ -60,12 +41,8 @@ export function GardenBox({
                 castShadow
                 receiveShadow
                 geometry={nodes.GardenBox_Body_Planks.geometry}
+                material={materials['Material.Planks']}
             >
-                <meshStandardMaterial
-                    color={bodyColor}
-                    metalness={bodyMetalness}
-                    roughness={bodyRoughness}
-                />
                 <HoverOutline hovered={hovered} variant="outlines" />
             </mesh>
             <SnowOverlay
@@ -81,13 +58,8 @@ export function GardenBox({
                     castShadow
                     receiveShadow
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
-                >
-                    <meshStandardMaterial
-                        color={lidColor}
-                        metalness={lidMetalness}
-                        roughness={lidRoughness}
-                    />
-                </mesh>
+                    material={materials['Material.Planks']}
+                />
                 <SnowOverlay
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                     {...snowPresets.giftBox}


### PR DESCRIPTION
## Summary
- Swapped the garden box off hardcoded brown colors and onto the shared `Material.Planks` GLB material.
- Kept the same geometry, overlays, and hover behavior while aligning the box with raised beds and other wooden assets.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm test --filter @gredice/game`
- `pnpm build --filter garden --filter www`
- `pnpm --filter www exec next build`
- Local visual smoke test in the garden debug scene