### PR TITLE
Include raised-bed AI analysis events in admin analytics

### DIFF
--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -223,7 +223,10 @@ export async function createEvent(
 export async function getAiAnalysisEvents(filter?: { from?: Date; to?: Date }) {
     const results = await storage().query.events.findMany({
         where: and(
-            eq(events.type, knownEventTypes.raisedBedFields.aiAnalysis),
+            inArray(events.type, [
+                knownEventTypes.raisedBeds.aiAnalysis,
+                knownEventTypes.raisedBedFields.aiAnalysis,
+            ]),
             filter?.from ? gte(events.createdAt, filter.from) : undefined,
             filter?.to ? lte(events.createdAt, filter.to) : undefined,
         ),
@@ -238,7 +241,10 @@ export async function getAiAnalysisEvents(filter?: { from?: Date; to?: Date }) {
 
 export async function getAiAnalysisTotals(filter?: { from?: Date; to?: Date }) {
     const whereConditions = [
-        eq(events.type, knownEventTypes.raisedBedFields.aiAnalysis),
+        inArray(events.type, [
+            knownEventTypes.raisedBeds.aiAnalysis,
+            knownEventTypes.raisedBedFields.aiAnalysis,
+        ]),
         ...(filter?.from ? [gte(events.createdAt, filter.from)] : []),
         ...(filter?.to ? [lte(events.createdAt, filter.to)] : []),
     ];

--- a/packages/storage/tests/eventsRepo.node.spec.ts
+++ b/packages/storage/tests/eventsRepo.node.spec.ts
@@ -4,6 +4,8 @@ import test from 'node:test';
 import {
     countAiRequestEventsSince,
     createEvent,
+    getAiAnalysisEvents,
+    getAiAnalysisTotals,
     getEvents,
     getLatestEvents,
     knownEvents,
@@ -164,6 +166,68 @@ test('countAiRequestEventsSince counts account-kind events with legacy aggregate
     });
 
     assert.strictEqual(count, 2);
+});
+
+test('AI analysis analytics includes raised-bed and field events', async () => {
+    createTestDb();
+    const raisedBedAggregateId = `raised-bed-${randomUUID()}`;
+    const fieldAggregateId = `${raisedBedAggregateId}|0`;
+    const from = new Date('2036-03-01T00:00:00.000Z');
+    const to = new Date('2036-03-31T23:59:59.999Z');
+
+    await createEvent({
+        ...knownEvents.raisedBeds.aiAnalysisV1(
+            raisedBedAggregateId,
+            aiAnalysisData({
+                model: 'raised-bed-model',
+                inputTokens: 100,
+                outputTokens: 50,
+                totalTokens: 150,
+            }),
+        ),
+        createdAt: new Date('2036-03-03T12:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.raisedBedFields.aiAnalysisV1(
+            fieldAggregateId,
+            aiAnalysisData({
+                model: 'field-model',
+                inputTokens: 200,
+                outputTokens: 100,
+                totalTokens: 300,
+            }),
+        ),
+        createdAt: new Date('2036-03-04T12:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.accounts.sunflowersEarnedV1(
+            `unrelated-account-${randomUUID()}`,
+            {
+                amount: 10,
+                reason: 'unrelated',
+            },
+        ),
+        createdAt: new Date('2036-03-05T12:00:00.000Z'),
+    });
+
+    const events = await getAiAnalysisEvents({ from, to });
+
+    assert.deepStrictEqual(
+        events.map((event) => event.type),
+        [
+            knownEventTypes.raisedBedFields.aiAnalysis,
+            knownEventTypes.raisedBeds.aiAnalysis,
+        ],
+    );
+
+    const allTotals = await getAiAnalysisTotals({ from, to });
+    assert.strictEqual(allTotals.count, 2);
+
+    const filteredTotals = await getAiAnalysisTotals({
+        from: new Date('2036-03-04T00:00:00.000Z'),
+        to,
+    });
+    assert.strictEqual(filteredTotals.count, 1);
 });
 
 test('getLatestEvents can list multiple event types for an aggregate', async () => {


### PR DESCRIPTION
## Summary
- Expand AI analytics queries to count both `raisedBed.aiAnalysis` and `raisedBedField.aiAnalysis` events.
- Add regression coverage to ensure the totals and event list include both analysis sources and still respect date filters.

## Testing
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage`
- `pnpm lint --filter app`
- `pnpm build --filter app`
- `pnpm test --filter app`