### PR TITLE
Add greenhouse seedling HUD flow for raised beds

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -93,6 +93,39 @@ function plantedGrowingWithRecommendedOperationsScenario(): RaisedBedScenario {
     };
 }
 
+function greenhouseSeedlingScenario(): RaisedBedScenario {
+    return {
+        fields: [
+            {
+                positionIndex: 0,
+                plantSortId: testSorts.tomato.id,
+                plantStatus: 'sprouted',
+                sowingLocation: 'greenhouse',
+                plantSowDate: '2026-05-01T00:00:00.000Z',
+                plantGrowthDate: '2026-05-10T00:00:00.000Z',
+            },
+        ],
+        operations: [
+            buildOperation({
+                id: 402,
+                name: 'mock-seedling-check',
+                label: 'Kontrola sadnice',
+                stageName: 'maintenance',
+                stageLabel: 'Održavanje',
+                relativeDays: 2,
+            }),
+            buildOperation({
+                id: 593,
+                name: 'seedlingTranslanting',
+                label: 'Presađivanje sadnice',
+                stageName: 'planting',
+                stageLabel: 'Sadnja',
+                relativeDays: 14,
+            }),
+        ],
+    };
+}
+
 function plantedGrowingWithOperationHistoryScenario(): RaisedBedScenario {
     const wateringOperation = buildOperation({
         id: 301,
@@ -457,6 +490,53 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
 
         await expect(page.locator('svg circle').first()).toBeVisible();
         await expect(page.locator('[data-field-icon-stack]')).toHaveCount(0);
+    });
+
+    test('greenhouse seedling field shows two-stage progress, diary, standard operations, and transplant action', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={greenhouseSeedlingScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await expect(
+            page.locator('[data-greenhouse-seedling-visual]').first(),
+        ).toBeVisible();
+        await expect(page.locator('[data-field-icon-stack]')).toBeVisible();
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await expect(
+            dialog.getByRole('heading', {
+                name: /Sadnica u stakleniku "Cherry rajčica"/,
+            }),
+        ).toBeVisible();
+        await expect(
+            dialog.locator('[data-greenhouse-seedling-progress] svg'),
+        ).toHaveCount(2);
+        await expect(dialog.getByText('Sadnica je u stakleniku')).toBeVisible();
+        await expect(
+            dialog.getByRole('button', { name: 'Klijanje: 9 dana' }),
+        ).toBeVisible();
+        await expect(
+            dialog.getByRole('button', {
+                name: /Presađivanje: \d+ dana/,
+            }),
+        ).toBeVisible();
+        await expect(
+            dialog.getByRole('tab', { name: /Dnevnik/ }),
+        ).toBeVisible();
+        await expect(
+            dialog.getByRole('button', { name: /Kontrola sadnice/ }),
+        ).toBeVisible();
+        await expect(
+            dialog.locator('[data-greenhouse-transplant-action]'),
+        ).toContainText('Presađivanje sadnice');
     });
 
     test('ready-to-harvest field shows the sprout status badge', async ({

--- a/apps/garden/tests/raisedBedFieldHudScenarios.ts
+++ b/apps/garden/tests/raisedBedFieldHudScenarios.ts
@@ -142,6 +142,7 @@ export type FieldConfig = {
     plantHarvestedDate?: string;
     plantDeadDate?: string;
     plantRemovedDate?: string;
+    sowingLocation?: 'direct' | 'greenhouse';
     toBeRemoved?: boolean;
     active?: boolean;
     stoppedDate?: string;
@@ -193,6 +194,7 @@ export function buildField(config: FieldConfig, id: number) {
         plantDeadDate: config.plantDeadDate,
         plantHarvestedDate: config.plantHarvestedDate,
         plantRemovedDate: config.plantRemovedDate,
+        sowingLocation: config.sowingLocation ?? 'direct',
         plantCycles: [],
         assignedUserId: null,
         assignedUserIds: [],

--- a/packages/game/src/hud/raisedBed/GreenhouseSeedlingPlantVisual.tsx
+++ b/packages/game/src/hud/raisedBed/GreenhouseSeedlingPlantVisual.tsx
@@ -1,0 +1,42 @@
+import type { PlantSortData } from '@gredice/client';
+import { Home } from '@gredice/ui/icons';
+import { PlantOrSortImage } from '@gredice/ui/plants';
+import { cx } from '@gredice/ui/utils';
+
+export function GreenhouseSeedlingPlantVisual({
+    className,
+    imageSize,
+    plantSort,
+}: {
+    className?: string;
+    imageSize: number;
+    plantSort: PlantSortData;
+}) {
+    return (
+        <span
+            className={cx(
+                'relative inline-flex items-center justify-center rounded-full',
+                className,
+            )}
+            data-greenhouse-seedling-visual
+        >
+            <span
+                className="absolute -inset-1 rounded-full border border-emerald-500/70 bg-emerald-50/70 dark:bg-emerald-950/50"
+                aria-hidden="true"
+            />
+            <PlantOrSortImage
+                plantSort={plantSort}
+                className="relative z-10 rounded-full"
+                width={imageSize}
+                height={imageSize}
+            />
+            <span
+                className="absolute -right-1 -top-1 z-20 inline-flex size-5 items-center justify-center rounded-full border border-white bg-emerald-600 text-white shadow-sm"
+                title="Staklenik"
+            >
+                <Home className="size-3.5" aria-hidden="true" />
+                <span className="sr-only">Staklenik</span>
+            </span>
+        </span>
+    );
+}

--- a/packages/game/src/hud/raisedBed/GreenhouseSeedlingProgress.tsx
+++ b/packages/game/src/hud/raisedBed/GreenhouseSeedlingProgress.tsx
@@ -1,0 +1,176 @@
+import { Chip } from '@gredice/ui/Chip';
+import { Home } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { ReactNode } from 'react';
+import type { RaisedBedFieldPlantHistoryEntry } from '../../utils/raisedBedFields';
+import type { GreenhouseSeedlingProgressData } from './greenhouseSeedlings';
+import type { PlantLifecycleAttributes } from './PlantLifecycleProgress';
+import { PlantStageSection } from './PlantStageSection';
+
+const greenhouseStageDescriptions = {
+    germination:
+        'Klijanje je razdoblje od sijanja do trenutka kada sjeme proklija i sadnica krene rasti.',
+    replanting:
+        'Razdoblje nakon klijanja u kojem sadnica ostaje u stakleniku i priprema se za presađivanje na otvoreno.',
+} as const;
+
+export function GreenhouseSeedlingProgress({
+    field,
+    lifecycleData,
+    plantAttributes,
+    plantDetailsUrl,
+    statusTrigger,
+}: {
+    field: RaisedBedFieldPlantHistoryEntry;
+    lifecycleData: GreenhouseSeedlingProgressData;
+    plantAttributes: PlantLifecycleAttributes | null | undefined;
+    plantDetailsUrl?: string;
+    statusTrigger: ReactNode;
+}) {
+    const plantScheduledDate = field.plantScheduledDate
+        ? new Date(field.plantScheduledDate)
+        : null;
+    const shouldShowPlantScheduledDate =
+        Boolean(plantScheduledDate) &&
+        !field.plantSowDate &&
+        (!field.plantStatus ||
+            field.plantStatus === 'new' ||
+            field.plantStatus === 'planned');
+
+    const germinatingDaysDayPlural =
+        lifecycleData.germinatingDays === 1 ? 'dan' : 'dana';
+    const seedlingDaysDayPlural =
+        lifecycleData.seedlingDays === 1 ? 'dan' : 'dana';
+    const seedlingEndDate = field.plantReadyDate
+        ? new Date(field.plantReadyDate)
+        : lifecycleData.expectedReplantingDate;
+    const segments =
+        field.toBeRemoved || field.plantDeadDate
+            ? [
+                  {
+                      value: 100,
+                      percentage: 100,
+                      color: 'stroke-red-500',
+                      trackColor: 'stroke-red-50 dark:stroke-red-50/80',
+                      borderColor: 'stroke-red-500',
+                  },
+              ]
+            : [
+                  {
+                      value: lifecycleData.germinationValue,
+                      percentage: lifecycleData.germinationPercentage,
+                      color: 'stroke-yellow-500',
+                      trackColor: 'stroke-yellow-200 dark:stroke-yellow-50',
+                      pulse: !field.plantGrowthDate,
+                      borderColor: 'stroke-yellow-500',
+                  },
+                  {
+                      value: lifecycleData.seedlingValue,
+                      percentage: lifecycleData.seedlingPercentage,
+                      color: 'stroke-emerald-500',
+                      trackColor: 'stroke-emerald-200 dark:stroke-emerald-50',
+                      pulse:
+                          Boolean(field.plantGrowthDate) &&
+                          lifecycleData.seedlingValue < 100,
+                      borderColor: 'stroke-emerald-500',
+                  },
+              ];
+
+    return (
+        <>
+            {shouldShowPlantScheduledDate && (
+                <Row spacing={4}>
+                    <Typography level="body2">Planirani datum</Typography>
+                    <div className="flex items-start">
+                        <Chip>
+                            {plantScheduledDate?.toLocaleDateString('hr-HR') ||
+                                'Nepoznato'}
+                        </Chip>
+                    </div>
+                </Row>
+            )}
+            <Row
+                spacing={2}
+                alignItems="center"
+                className="rounded-md border border-emerald-200 bg-emerald-50/70 px-3 py-2 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-50"
+            >
+                <Home className="size-4 shrink-0" aria-hidden="true" />
+                <Typography level="body2" semiBold>
+                    Sadnica je u stakleniku
+                </Typography>
+            </Row>
+            <Row spacing={4}>
+                <div data-greenhouse-seedling-progress>
+                    <SegmentedCircularProgress
+                        size={140}
+                        strokeWidth={3}
+                        segments={segments}
+                    >
+                        {statusTrigger}
+                    </SegmentedCircularProgress>
+                </div>
+                <Stack spacing={1.5}>
+                    <PlantStageSection
+                        label="Klijanje"
+                        legendColorClass="bg-yellow-500"
+                        legendBorderColorClass="border-yellow-500"
+                        legendPulse={
+                            Boolean(field.plantSowDate) &&
+                            !field.plantGrowthDate
+                        }
+                        legendFilled={Boolean(field.plantGrowthDate)}
+                        windowMin={plantAttributes?.germinationWindowMin}
+                        windowMax={plantAttributes?.germinationWindowMax}
+                        startDate={
+                            field.plantSowDate
+                                ? new Date(field.plantSowDate)
+                                : null
+                        }
+                        endDate={
+                            field.plantGrowthDate
+                                ? new Date(field.plantGrowthDate)
+                                : field.stoppedDate
+                                  ? new Date(field.stoppedDate)
+                                  : null
+                        }
+                        daysCount={lifecycleData.germinatingDays}
+                        dayPlural={germinatingDaysDayPlural}
+                        fallbackText="Nije posijano"
+                        stageDescription={
+                            greenhouseStageDescriptions.germination
+                        }
+                        plantDetailsUrl={plantDetailsUrl}
+                    />
+                    <PlantStageSection
+                        label="Presađivanje"
+                        legendColorClass="bg-emerald-500"
+                        legendBorderColorClass="border-emerald-500"
+                        legendPulse={
+                            Boolean(field.plantGrowthDate) &&
+                            lifecycleData.seedlingValue < 100
+                        }
+                        legendFilled={lifecycleData.seedlingValue >= 100}
+                        windowMin={lifecycleData.replantingWindowDays}
+                        windowMax={lifecycleData.replantingWindowDays}
+                        startDate={
+                            field.plantGrowthDate
+                                ? new Date(field.plantGrowthDate)
+                                : null
+                        }
+                        endDate={seedlingEndDate}
+                        daysCount={lifecycleData.seedlingDays}
+                        dayPlural={seedlingDaysDayPlural}
+                        fallbackText="Nije proklijalo"
+                        stageDescription={
+                            greenhouseStageDescriptions.replanting
+                        }
+                        plantDetailsUrl={plantDetailsUrl}
+                    />
+                </Stack>
+            </Row>
+        </>
+    );
+}

--- a/packages/game/src/hud/raisedBed/GreenhouseSeedlingTransplantAction.tsx
+++ b/packages/game/src/hud/raisedBed/GreenhouseSeedlingTransplantAction.tsx
@@ -1,0 +1,89 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Card, CardOverflow } from '@gredice/ui/Card';
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useMemo } from 'react';
+import { useOperations } from '../../hooks/useOperations';
+import { useShoppingCart } from '../../hooks/useShoppingCart';
+import { isSeedlingTransplantingOperation } from './greenhouseSeedlings';
+import { OperationsListItem } from './shared/OperationsListItem';
+
+export function GreenhouseSeedlingTransplantAction({
+    gardenId,
+    raisedBedId,
+    positionIndex,
+}: {
+    gardenId: number;
+    raisedBedId: number;
+    positionIndex: number;
+}) {
+    const { data: operations, isError, isLoading } = useOperations();
+    const { data: cart } = useShoppingCart();
+    const transplantOperation = useMemo(
+        () => operations?.find(isSeedlingTransplantingOperation),
+        [operations],
+    );
+    const inShoppingCart = Boolean(
+        transplantOperation &&
+            cart?.items.some(
+                (item) =>
+                    item.entityTypeName === 'operation' &&
+                    item.status === 'new' &&
+                    item.gardenId === gardenId &&
+                    item.raisedBedId === raisedBedId &&
+                    item.positionIndex === positionIndex &&
+                    Number(item.entityId) === transplantOperation.id,
+            ),
+    );
+
+    if (isLoading) {
+        return (
+            <Stack spacing={1} data-greenhouse-transplant-action>
+                <Typography
+                    level="body3"
+                    className="leading-tight font-semibold uppercase"
+                    component="h2"
+                >
+                    Presađivanje
+                </Typography>
+                <Skeleton className="h-24 w-full rounded-md" />
+            </Stack>
+        );
+    }
+
+    if (isError) {
+        return (
+            <Alert color="danger" data-greenhouse-transplant-action>
+                Greška prilikom učitavanja radnje presađivanja.
+            </Alert>
+        );
+    }
+
+    if (!transplantOperation) {
+        return null;
+    }
+
+    return (
+        <Stack spacing={1} data-greenhouse-transplant-action>
+            <Typography
+                level="body3"
+                className="leading-tight font-semibold uppercase"
+                component="h2"
+            >
+                Presađivanje
+            </Typography>
+            <Card className="border-emerald-500/60 bg-emerald-50/70 dark:bg-emerald-950/30">
+                <CardOverflow>
+                    <OperationsListItem
+                        operation={transplantOperation}
+                        gardenId={gardenId}
+                        raisedBedId={raisedBedId}
+                        positionIndex={positionIndex}
+                        inShoppingCart={inShoppingCart}
+                    />
+                </CardOverflow>
+            </Card>
+        </Stack>
+    );
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -1,9 +1,14 @@
 import {
+    plantFieldStatusLabel,
+    userAllowedPlantStatusTransitions,
+} from '@gredice/js/plants';
+import {
     Book,
     Check,
     ExternalLink,
     Hammer,
     History,
+    Home,
     MoreHorizontal,
     Sprout,
     Warning,
@@ -27,6 +32,14 @@ import {
     findRaisedBedOccupiedField,
     type RaisedBedFieldPlantHistoryEntry,
 } from '../../utils/raisedBedFields';
+import { GreenhouseSeedlingPlantVisual } from './GreenhouseSeedlingPlantVisual';
+import { GreenhouseSeedlingProgress } from './GreenhouseSeedlingProgress';
+import { GreenhouseSeedlingTransplantAction } from './GreenhouseSeedlingTransplantAction';
+import {
+    isGreenhouseSeedlingField,
+    useGreenhouseSeedlingProgressData,
+} from './greenhouseSeedlings';
+import { plantFieldStatusEmoji } from './PlantFieldStatusEmoji';
 import { RaisedBedFieldIconStack } from './RaisedBedFieldIconStack';
 import { RaisedBedFieldItemButton } from './RaisedBedFieldItemButton';
 import {
@@ -35,7 +48,9 @@ import {
 } from './RaisedBedFieldLifecycleTab';
 import { RaisedBedFieldOperationsTab } from './RaisedBedFieldOperationsTab';
 import { RaisedBedFieldPlantHistoryModal } from './RaisedBedFieldPlantHistoryModal';
+import { RaisedBedFieldStatusChange } from './RaisedBedFieldStatusChange';
 import { RaisedBedOperationHistoryList } from './RaisedBedOperationHistoryList';
+import { RecommendationsCard } from './RecommendationsCard';
 import {
     parseScheduledSowingDateValue,
     ScheduledSowingDateBadge,
@@ -75,6 +90,12 @@ export function RaisedBedFieldItemPlanted({
     const plantSortId = field?.plantSortId;
     const { data: plantSort, isLoading: isPlantSortLoading } =
         usePlantSort(plantSortId);
+    const lifecycleData = useRaisedBedFieldLifecycleData(
+        raisedBedId,
+        positionIndex,
+        isHistorical,
+        fieldOverride,
+    );
     const {
         germinationValue,
         germinationPercentage,
@@ -82,12 +103,14 @@ export function RaisedBedFieldItemPlanted({
         growthPercentage,
         harvestValue,
         harvestPercentage,
-    } = useRaisedBedFieldLifecycleData(
-        raisedBedId,
-        positionIndex,
-        isHistorical,
-        fieldOverride,
+    } = lifecycleData;
+    const plantAttributes = plantSort?.information.plant.attributes;
+    const greenhouseSeedlingLifecycleData = useGreenhouseSeedlingProgressData(
+        field,
+        plantAttributes,
     );
+    const isGreenhouseSeedling =
+        !isHistorical && isGreenhouseSeedlingField(field);
     const isHarvested = field?.plantHarvestedDate;
     const [internalOpen, setInternalOpen] = useState(false);
     const [activeTab, setActiveTab] =
@@ -186,22 +209,30 @@ export function RaisedBedFieldItemPlanted({
         plantSort.information.name,
     );
     const title = `${isHistorical ? 'Prethodna biljka' : 'Biljka'} "${plantSort.information.name}"`;
+    const modalTitle = isGreenhouseSeedling
+        ? `Sadnica u stakleniku "${plantSort.information.name}"`
+        : title;
     const fieldBadge = isHistorical
         ? {
               className: 'bg-muted',
               icon: <History className="size-4 text-muted-foreground" />,
           }
-        : harvestValue && !isHarvested
+        : isGreenhouseSeedling
           ? {
-                className: 'bg-blue-600',
-                icon: <Sprout className="size-4 text-white" />,
+                className: 'bg-emerald-600',
+                icon: <Home className="size-4 text-white" />,
             }
-          : isHarvested
+          : harvestValue && !isHarvested
             ? {
-                  className: 'bg-green-600',
-                  icon: <Check className="size-4 text-white" />,
+                  className: 'bg-blue-600',
+                  icon: <Sprout className="size-4 text-white" />,
               }
-            : null;
+            : isHarvested
+              ? {
+                    className: 'bg-green-600',
+                    icon: <Check className="size-4 text-white" />,
+                }
+              : null;
     const scheduledSowingDate = parseScheduledSowingDateValue(
         field.plantScheduledDate,
     );
@@ -216,6 +247,50 @@ export function RaisedBedFieldItemPlanted({
     const shouldShowIndicatorStack =
         triggerVariant === 'field' &&
         (Boolean(fieldBadge) || plantHistory.length > 0);
+    const greenhouseRecommendationStatus =
+        isGreenhouseSeedling &&
+        (field.plantStatus === 'pendingVerification' ||
+            field.plantStatus === 'sowed' ||
+            field.plantStatus === 'sprouted')
+            ? field.plantStatus
+            : undefined;
+    const localizedStatus = plantFieldStatusLabel(
+        field.plantStatus ?? undefined,
+    );
+    const canChangeStatus = Boolean(
+        field.plantStatus &&
+            userAllowedPlantStatusTransitions[field.plantStatus]?.length,
+    );
+    const statusContent = (
+        <>
+            <span className="text-2xl leading-none" aria-hidden="true">
+                {plantFieldStatusEmoji(field.plantStatus ?? undefined)}
+            </span>
+            <Typography level="body1" className="text-center" semiBold>
+                {localizedStatus.shortLabel}
+            </Typography>
+        </>
+    );
+    const statusTrigger = field.active ? (
+        <button
+            type="button"
+            className="border bg-card rounded-full shrink-0 size-[100px] aspect-square shadow flex flex-col gap-1 items-center justify-center pointer-events-auto transition-colors hover:bg-accent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2"
+            aria-label={
+                canChangeStatus
+                    ? `Promijeni stanje biljke: ${localizedStatus.shortLabel}`
+                    : `Stanje biljke: ${localizedStatus.shortLabel}`
+            }
+        >
+            {statusContent}
+        </button>
+    ) : (
+        <Stack
+            alignItems="center"
+            className="border bg-card rounded-full shrink-0 size-[100px] aspect-square shadow flex items-center justify-center"
+        >
+            {statusContent}
+        </Stack>
+    );
     const avatarTrigger = (
         <button
             type="button"
@@ -234,19 +309,48 @@ export function RaisedBedFieldItemPlanted({
             />
         </button>
     );
+    const greenhouseSeedlingSegments = [
+        {
+            value: greenhouseSeedlingLifecycleData.germinationValue,
+            percentage: greenhouseSeedlingLifecycleData.germinationPercentage,
+            color: 'stroke-yellow-500',
+            trackColor: 'stroke-yellow-50 dark:stroke-yellow-50/80',
+            pulse: !field.plantGrowthDate,
+            borderColor: 'stroke-yellow-500',
+        },
+        {
+            value: greenhouseSeedlingLifecycleData.seedlingValue,
+            percentage: greenhouseSeedlingLifecycleData.seedlingPercentage,
+            color: 'stroke-emerald-500',
+            trackColor: 'stroke-emerald-50 dark:stroke-emerald-50/80',
+            pulse:
+                Boolean(field.plantGrowthDate) &&
+                greenhouseSeedlingLifecycleData.seedlingValue < 100,
+            borderColor: 'stroke-emerald-500',
+        },
+    ];
     const fieldTrigger = (
         <RaisedBedFieldItemButton positionIndex={positionIndex}>
             <SegmentedCircularProgress
                 size={70}
                 strokeWidth={4}
-                segments={segments}
+                segments={
+                    isGreenhouseSeedling ? greenhouseSeedlingSegments : segments
+                }
             >
-                <PlantOrSortImage
-                    plantSort={plantSort}
-                    className="absolute top-1/2 start-1/2 transform -translate-y-1/2 -translate-x-1/2"
-                    width={52}
-                    height={52}
-                />
+                {isGreenhouseSeedling ? (
+                    <GreenhouseSeedlingPlantVisual
+                        plantSort={plantSort}
+                        imageSize={52}
+                    />
+                ) : (
+                    <PlantOrSortImage
+                        plantSort={plantSort}
+                        className="absolute top-1/2 start-1/2 transform -translate-y-1/2 -translate-x-1/2"
+                        width={52}
+                        height={52}
+                    />
+                )}
             </SegmentedCircularProgress>
             {shouldShowScheduledSowingDate && scheduledSowingDate && (
                 <ScheduledSowingDateBadge date={scheduledSowingDate} />
@@ -319,17 +423,24 @@ export function RaisedBedFieldItemPlanted({
                 }
                 onOpenChange?.(nextOpen);
             }}
-            title={title}
+            title={modalTitle}
             className="max-w-xl overflow-x-hidden md:border-tertiary md:border-b-4"
             trigger={trigger ?? undefined}
         >
             <Stack spacing={4} className="min-w-0 max-w-full">
                 <Row spacing={4}>
-                    <PlantOrSortImage
-                        plantSort={plantSort}
-                        width={60}
-                        height={60}
-                    />
+                    {isGreenhouseSeedling ? (
+                        <GreenhouseSeedlingPlantVisual
+                            plantSort={plantSort}
+                            imageSize={60}
+                        />
+                    ) : (
+                        <PlantOrSortImage
+                            plantSort={plantSort}
+                            width={60}
+                            height={60}
+                        />
+                    )}
                     <Stack spacing={1} className="min-w-0 flex-1">
                         <Typography
                             level="h4"
@@ -420,13 +531,67 @@ export function RaisedBedFieldItemPlanted({
                         )}
                     </TabsContent>
                     <TabsContent value="lifecycle">
-                        <RaisedBedFieldLifecycleTab
-                            raisedBedId={raisedBedId}
-                            positionIndex={positionIndex}
-                            fieldOverride={fieldOverride}
-                            includeInactive={isHistorical}
-                            onShowOperations={() => setActiveTab('operations')}
-                        />
+                        <Stack spacing={4}>
+                            {isGreenhouseSeedling ? (
+                                <GreenhouseSeedlingProgress
+                                    field={field}
+                                    plantAttributes={plantAttributes}
+                                    lifecycleData={
+                                        greenhouseSeedlingLifecycleData
+                                    }
+                                    plantDetailsUrl={plantDetailsUrl}
+                                    statusTrigger={
+                                        field.active ? (
+                                            <RaisedBedFieldStatusChange
+                                                raisedBedId={raisedBedId}
+                                                positionIndex={positionIndex}
+                                                currentStatus={
+                                                    field.plantStatus ??
+                                                    undefined
+                                                }
+                                                trigger={statusTrigger}
+                                            />
+                                        ) : (
+                                            statusTrigger
+                                        )
+                                    }
+                                />
+                            ) : (
+                                <RaisedBedFieldLifecycleTab
+                                    raisedBedId={raisedBedId}
+                                    positionIndex={positionIndex}
+                                    fieldOverride={fieldOverride}
+                                    includeInactive={isHistorical}
+                                    onShowOperations={() =>
+                                        setActiveTab('operations')
+                                    }
+                                />
+                            )}
+                            {isGreenhouseSeedling && garden && (
+                                <GreenhouseSeedlingTransplantAction
+                                    gardenId={garden.id}
+                                    raisedBedId={raisedBedId}
+                                    positionIndex={positionIndex}
+                                />
+                            )}
+                            {isGreenhouseSeedling &&
+                                garden &&
+                                greenhouseRecommendationStatus &&
+                                typeof field.plantSortId === 'number' && (
+                                    <RecommendationsCard
+                                        onShowOperations={() =>
+                                            setActiveTab('operations')
+                                        }
+                                        gardenId={garden.id}
+                                        raisedBedId={raisedBedId}
+                                        positionIndex={positionIndex}
+                                        plantStatus={
+                                            greenhouseRecommendationStatus
+                                        }
+                                        plantSortId={field.plantSortId}
+                                    />
+                                )}
+                        </Stack>
                     </TabsContent>
                 </Tabs>
                 <button

--- a/packages/game/src/hud/raisedBed/greenhouseSeedlings.ts
+++ b/packages/game/src/hud/raisedBed/greenhouseSeedlings.ts
@@ -1,0 +1,175 @@
+import type { OperationData } from '@gredice/client';
+import { useOperations } from '../../hooks/useOperations';
+import { useSnapshotTime } from '../../hooks/useSnapshotTime';
+import type { RaisedBedFieldPlantHistoryEntry } from '../../utils/raisedBedFields';
+import type { PlantLifecycleAttributes } from './PlantLifecycleProgress';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const FALLBACK_GREENHOUSE_REPLANTING_DAYS = 21;
+
+export const SEEDLING_TRANSPLANTING_OPERATION_ID = 593;
+export const SEEDLING_TRANSPLANTING_OPERATION_NAMES = [
+    'seedlingTranslanting',
+    'seedlingTransplanting',
+];
+
+export type GreenhouseSeedlingProgressData = {
+    germinationValue: number;
+    germinationPercentage: number;
+    germinatingDays: number;
+    seedlingValue: number;
+    seedlingPercentage: number;
+    seedlingDays: number;
+    replantingWindowDays: number;
+    expectedReplantingDate: Date | null;
+};
+
+const greenhouseSeedlingStatuses = new Set([
+    'pendingVerification',
+    'sowed',
+    'sprouted',
+]);
+
+export function isGreenhouseSeedlingField(
+    field: RaisedBedFieldPlantHistoryEntry | null | undefined,
+) {
+    return Boolean(
+        field &&
+            field.active !== false &&
+            field.sowingLocation === 'greenhouse' &&
+            greenhouseSeedlingStatuses.has(field.plantStatus ?? '') &&
+            !field.plantDeadDate &&
+            !field.plantHarvestedDate &&
+            !field.plantRemovedDate,
+    );
+}
+
+export function isSeedlingTransplantingOperation(operation: OperationData) {
+    return (
+        operation.id === SEEDLING_TRANSPLANTING_OPERATION_ID ||
+        SEEDLING_TRANSPLANTING_OPERATION_NAMES.includes(
+            operation.information.name,
+        )
+    );
+}
+
+export function getGreenhouseSeedlingReplantingWindowDays(
+    transplantOperation: OperationData | null | undefined,
+) {
+    const relativeDays = transplantOperation?.attributes.relativeDays;
+    return typeof relativeDays === 'number' && relativeDays > 0
+        ? Math.ceil(relativeDays)
+        : FALLBACK_GREENHOUSE_REPLANTING_DAYS;
+}
+
+export function useGreenhouseSeedlingProgressData(
+    field: RaisedBedFieldPlantHistoryEntry | null | undefined,
+    plantAttributes: PlantLifecycleAttributes | null | undefined,
+) {
+    const { data: operations } = useOperations();
+    const now = useSnapshotTime();
+    const transplantOperation = operations?.find(
+        isSeedlingTransplantingOperation,
+    );
+
+    return getGreenhouseSeedlingProgressData({
+        field,
+        now,
+        plantAttributes,
+        transplantOperation,
+    });
+}
+
+export function getGreenhouseSeedlingProgressData({
+    field,
+    plantAttributes,
+    transplantOperation,
+    now = new Date(),
+}: {
+    field: RaisedBedFieldPlantHistoryEntry | null | undefined;
+    plantAttributes: PlantLifecycleAttributes | null | undefined;
+    transplantOperation?: OperationData | null;
+    now?: Date;
+}): GreenhouseSeedlingProgressData {
+    const replantingWindowDays =
+        getGreenhouseSeedlingReplantingWindowDays(transplantOperation);
+    const result: GreenhouseSeedlingProgressData = {
+        germinationValue: 0,
+        germinationPercentage: 50,
+        germinatingDays: 0,
+        seedlingValue: 0,
+        seedlingPercentage: 50,
+        seedlingDays: 0,
+        replantingWindowDays,
+        expectedReplantingDate: null,
+    };
+
+    const germinationWindowDays = plantAttributes?.germinationWindowMax ?? 0;
+    const totalWindowDays = germinationWindowDays + replantingWindowDays;
+    if (totalWindowDays > 0) {
+        const germinationPercentage =
+            germinationWindowDays > 0
+                ? (germinationWindowDays / totalWindowDays) * 100
+                : 50;
+        result.germinationPercentage = Math.max(
+            20,
+            Math.min(80, germinationPercentage),
+        );
+        result.seedlingPercentage = 100 - result.germinationPercentage;
+    }
+
+    if (!field) {
+        return result;
+    }
+
+    const targetDateNow = getDateTime(field.stoppedDate) ?? now.getTime();
+    const plantSowTime = getDateTime(field.plantSowDate);
+    const plantGrowthTime = getDateTime(field.plantGrowthDate);
+    const plantReadyTime = getDateTime(field.plantReadyDate);
+
+    result.germinationValue = plantGrowthTime
+        ? 100
+        : plantSowTime
+          ? Math.min(
+                100,
+                ((targetDateNow - plantSowTime) /
+                    ((germinationWindowDays || 1) * MS_PER_DAY)) *
+                    100,
+            )
+          : 0;
+    result.germinatingDays = plantSowTime
+        ? daysBetween(plantSowTime, plantGrowthTime ?? targetDateNow)
+        : 0;
+
+    result.seedlingValue = plantReadyTime
+        ? 100
+        : plantGrowthTime
+          ? Math.min(
+                100,
+                ((targetDateNow - plantGrowthTime) /
+                    (replantingWindowDays * MS_PER_DAY)) *
+                    100,
+            )
+          : 0;
+    result.seedlingDays = plantGrowthTime
+        ? daysBetween(plantGrowthTime, plantReadyTime ?? targetDateNow)
+        : 0;
+    result.expectedReplantingDate = plantGrowthTime
+        ? new Date(plantGrowthTime + replantingWindowDays * MS_PER_DAY)
+        : null;
+
+    return result;
+}
+
+function getDateTime(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const time = new Date(value).getTime();
+    return Number.isNaN(time) ? null : time;
+}
+
+function daysBetween(startTime: number, endTime: number) {
+    return Math.max(0, Math.round((endTime - startTime) / MS_PER_DAY));
+}

--- a/packages/game/src/utils/raisedBedFields.ts
+++ b/packages/game/src/utils/raisedBedFields.ts
@@ -10,6 +10,7 @@ type RaisedBedFieldPlantLifecycleLike = {
     plantScheduledDate?: Date | string | null;
     plantSowDate?: Date | string | null;
     plantStatus?: string | null;
+    sowingLocation?: 'direct' | 'greenhouse' | null;
     startedAt?: Date | string | null;
     stoppedDate?: Date | string | null;
     toBeRemoved?: boolean | null;


### PR DESCRIPTION
## Summary
- Adds a greenhouse-seedling branch to the raised-bed field HUD with dedicated visual treatment, progress ring, and modal content.
- Shows greenhouse-specific lifecycle stages, diary context, and a transplant action sourced from the available operations list.
- Extends raised-bed HUD test scenarios to cover greenhouse sowing state and the new UI behavior.

## Testing
- Added/updated raised-bed HUD test coverage for the greenhouse seedling scenario.
- Not run (not requested).