### PR TITLE
Omogući odabir vrtne kutije i vraćanje blokova iz inventara u vrt

### DIFF
--- a/apps/api/app/api/[...route]/inventoryRoutes.ts
+++ b/apps/api/app/api/[...route]/inventoryRoutes.ts
@@ -1,19 +1,27 @@
 import {
+    consumeGardenBoxInventoryItem,
+    createGardenBlock,
+    createGardenStack,
     type EntityStandardized,
     getEntitiesFormatted,
     getGarden,
     getGardenBlock,
+    getGardenBlocks,
     getGardenBoxBlocksForAccount,
     getGardenBoxInventory,
     getInventory,
     type InventoryItem,
     type InventoryItemInput,
     setGardenBoxInventory,
+    storage,
+    updateGardenStack,
 } from '@gredice/storage';
 import { Hono } from 'hono';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
+import { getBlockData } from '../../../lib/blocks/blockDataService';
 import { authSecurity } from '../../../lib/docs/security';
+import { resolveGardenBlockPlacement } from '../../../lib/garden/blockPlacementService';
 import {
     type AuthVariables,
     authValidator,
@@ -23,6 +31,11 @@ const gardenBoxInventoryParamsSchema = z.object({
     gardenId: z.coerce.number().int().positive(),
     blockId: z.string().trim().min(1).max(128),
 });
+
+const gardenBoxInventoryBlockPlacementParamsSchema =
+    gardenBoxInventoryParamsSchema.extend({
+        entityId: z.string().trim().min(1).max(100),
+    });
 
 const inventoryItemSchema = z.object({
     entityTypeName: z.string().trim().min(1).max(100),
@@ -212,6 +225,153 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 ...gardenBox,
                 items: enrichedItems,
             });
+        },
+    )
+    .post(
+        '/garden-boxes/:gardenId/:blockId/items/block/:entityId/place',
+        describeRoute({
+            description:
+                'Place one block from a garden box inventory into the garden using standard block placement rules.',
+            security: authSecurity,
+            tags: ['Inventory'],
+        }),
+        authValidator(['user', 'admin']),
+        zValidator('param', gardenBoxInventoryBlockPlacementParamsSchema),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const { gardenId, blockId, entityId } = context.req.valid('param');
+            const [garden, gardenBoxBlock, gardenBlocks, blockData] =
+                await Promise.all([
+                    getGarden(gardenId),
+                    getGardenBlock(gardenId, blockId),
+                    getGardenBlocks(gardenId),
+                    getBlockData(),
+                ]);
+
+            if (
+                !garden ||
+                garden.accountId !== accountId ||
+                gardenBoxBlock?.name !== 'GardenBox'
+            ) {
+                return context.json({ error: 'Garden box not found' }, 404);
+            }
+
+            const block = blockData.find(
+                (candidate) => candidate.id.toString() === entityId,
+            );
+            const blockName = block?.information?.name;
+            if (!block || !blockName) {
+                return context.json({ error: 'Block not found' }, 404);
+            }
+
+            if (blockName === 'GardenBox') {
+                return context.json(
+                    {
+                        error: 'Garden boxes cannot be placed from garden boxes',
+                    },
+                    400,
+                );
+            }
+
+            if (blockName === 'Raised_Bed') {
+                return context.json(
+                    { error: 'Raised beds cannot be placed from garden boxes' },
+                    400,
+                );
+            }
+
+            const blockNameById = new Map(
+                gardenBlocks.map((gardenBlock) => [
+                    gardenBlock.id,
+                    gardenBlock.name,
+                ]),
+            );
+            const blockDataByName = new Map<
+                string,
+                (typeof blockData)[number]
+            >();
+            for (const candidate of blockData) {
+                const candidateName = candidate.information?.name;
+                if (candidateName) {
+                    blockDataByName.set(candidateName, candidate);
+                }
+            }
+
+            const placement = resolveGardenBlockPlacement({
+                blockName,
+                stacks: garden.stacks,
+                blockNameById,
+                blockDataByName,
+            });
+            if (!placement.valid) {
+                return context.json({ error: placement.error }, 400);
+            }
+
+            const { x, y, existingBlocks } = placement.placement;
+            const hasTargetStack = garden.stacks.some(
+                (stack) => stack.positionX === x && stack.positionY === y,
+            );
+
+            try {
+                const placedBlockId = await storage().transaction(
+                    async (tx) => {
+                        await consumeGardenBoxInventoryItem(
+                            accountId,
+                            gardenId,
+                            blockId,
+                            {
+                                entityTypeName: 'block',
+                                entityId,
+                                amount: 1,
+                                source: 'gardenBox:place',
+                            },
+                            tx,
+                        );
+
+                        if (!hasTargetStack) {
+                            await createGardenStack(gardenId, { x, y }, tx);
+                        }
+
+                        const createdBlockId = await createGardenBlock(
+                            gardenId,
+                            blockName,
+                            tx,
+                        );
+                        await updateGardenStack(
+                            gardenId,
+                            {
+                                x,
+                                y,
+                                blocks: [...existingBlocks, createdBlockId],
+                            },
+                            tx,
+                        );
+
+                        return createdBlockId;
+                    },
+                );
+
+                return context.json({
+                    id: placedBlockId,
+                    position: { x, y },
+                    item: {
+                        entityTypeName: 'block',
+                        entityId,
+                        amount: 1,
+                    },
+                });
+            } catch (error) {
+                const errorMessage =
+                    error instanceof Error
+                        ? error.message
+                        : 'Failed to place block';
+                const status =
+                    errorMessage === 'Nedovoljno predmeta u vrtnoj kutiji'
+                        ? 400
+                        : 500;
+
+                return context.json({ error: errorMessage }, status);
+            }
         },
     );
 

--- a/apps/garden/tests/InventoryHudStory.tsx
+++ b/apps/garden/tests/InventoryHudStory.tsx
@@ -1,0 +1,60 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import { InventoryHud } from '../../../packages/game/src/hud/InventoryHud';
+
+function createInventoryHudQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(['inventory'], {
+        items: [],
+        gardenBoxes: [
+            {
+                blockId: 'garden-box-1',
+                gardenId: 1,
+                gardenName: 'Test garden',
+                items: [
+                    {
+                        amount: 2,
+                        entityId: '1',
+                        entityTypeName: 'block',
+                        name: 'Bucket',
+                    },
+                ],
+            },
+        ],
+    });
+    queryClient.setQueryData(['operations'], []);
+
+    return queryClient;
+}
+
+function InventoryHudTestProviders({
+    children,
+    searchParams,
+}: PropsWithChildren<{ searchParams?: string }>) {
+    const queryClient = useMemo(() => createInventoryHudQueryClient(), []);
+
+    return (
+        <NuqsTestingAdapter hasMemory searchParams={searchParams}>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                {children}
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+export function InventoryHudGardenBoxesOpenStory() {
+    return (
+        <InventoryHudTestProviders searchParams="ruksak=true&ruksak-kartica=gardenBoxes">
+            <div className="relative h-screen w-screen p-8">
+                <InventoryHud />
+            </div>
+        </InventoryHudTestProviders>
+    );
+}

--- a/apps/garden/tests/inventory-hud.spec.tsx
+++ b/apps/garden/tests/inventory-hud.spec.tsx
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { InventoryHudGardenBoxesOpenStory } from './InventoryHudStory';
+
+test('inventory can open directly on garden boxes tab', async ({
+    mount,
+    page,
+}) => {
+    await mount(<InventoryHudGardenBoxesOpenStory />);
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(
+        page.getByRole('tab', { name: /Kutije\s+1/u }),
+    ).toHaveAttribute('data-state', 'active');
+    await expect(page.getByText('Vrtna kutija 1')).toBeVisible();
+    await expect(page.getByRole('img', { name: 'Bucket' })).toBeVisible();
+    await expect(page.getByText(/Predmeti u ruksaku koje možeš/u)).toBeHidden();
+});
+
+test('garden box block item can be placed back into the garden', async ({
+    mount,
+    page,
+}) => {
+    let placeRequestCount = 0;
+    await page.route('**/api/gredice/**', async (route) => {
+        const url = new URL(route.request().url());
+        const method = route.request().method();
+
+        if (
+            method === 'POST' &&
+            url.pathname.endsWith(
+                '/api/inventory/garden-boxes/1/garden-box-1/items/block/1/place',
+            )
+        ) {
+            placeRequestCount += 1;
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    id: 'placed-block-1',
+                    position: { x: 0, y: 0 },
+                    item: {
+                        amount: 1,
+                        entityId: '1',
+                        entityTypeName: 'block',
+                    },
+                }),
+            });
+            return;
+        }
+
+        if (method === 'GET' && url.pathname.endsWith('/api/inventory')) {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    items: [],
+                    gardenBoxes: [
+                        {
+                            blockId: 'garden-box-1',
+                            gardenId: 1,
+                            gardenName: 'Test garden',
+                            items: [
+                                {
+                                    amount: 1,
+                                    entityId: '1',
+                                    entityTypeName: 'block',
+                                    name: 'Bucket',
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            });
+            return;
+        }
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+        });
+    });
+
+    await mount(<InventoryHudGardenBoxesOpenStory />);
+
+    await page.getByRole('button', { name: 'Bucket' }).click();
+
+    await expect(page.getByText(/Dodaj ovaj blok natrag u vrt/u)).toBeVisible();
+    await expect(page.getByText(/bez trošenja suncokreta/u)).toBeVisible();
+
+    await page.getByRole('button', { name: 'Dodaj u vrt' }).click();
+
+    await expect.poll(() => placeRequestCount).toBe(1);
+    await expect(page.getByRole('dialog', { name: 'Bucket' })).toBeHidden();
+});

--- a/packages/game/src/controls/GardenBoxSelectableGroup.tsx
+++ b/packages/game/src/controls/GardenBoxSelectableGroup.tsx
@@ -1,0 +1,50 @@
+import type { PropsWithChildren } from 'react';
+import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import type { Block } from '../types/Block';
+import {
+    gardenBoxesInventoryTab,
+    useBackpackInventoryParams,
+} from '../useUrlState';
+import { useHoveredBlockStore } from './useHoveredBlockStore';
+
+export function GardenBoxSelectableGroup({
+    children,
+    block,
+}: PropsWithChildren<{ block: Block }>) {
+    const { track } = useGameAnalytics();
+    const hovered = useHoveredBlockStore();
+    const [, setBackpackInventoryParams] = useBackpackInventoryParams();
+
+    function handleSelected() {
+        track('game_garden_box_inventory_opened', {
+            block_id: block.id,
+        });
+        setBackpackInventoryParams({
+            ruksak: true,
+            'ruksak-kartica': gardenBoxesInventoryTab,
+        });
+        hovered.setHoveredBlock(null);
+    }
+
+    return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
+        <group
+            onPointerEnter={(event) => {
+                event.stopPropagation();
+                hovered.setHoveredBlock(block);
+            }}
+            onPointerLeave={(event) => {
+                if (hovered.hoveredBlock === block) {
+                    event.stopPropagation();
+                    hovered.setHoveredBlock(null);
+                }
+            }}
+            onClick={(event) => {
+                event.stopPropagation();
+                handleSelected();
+            }}
+        >
+            {children}
+        </group>
+    );
+}

--- a/packages/game/src/controls/SelectableGroup.tsx
+++ b/packages/game/src/controls/SelectableGroup.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from 'react';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import type { Block } from '../types/Block';
 import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
+import { GardenBoxSelectableGroup } from './GardenBoxSelectableGroup';
 import { GiftBoxSelectableGroup } from './GiftBoxSelectableGroup';
 import { RaisedBedSelectableGroup } from './RaisedBedSelectableGroup';
 
@@ -16,6 +17,14 @@ export function SelectableGroup({
             <GiftBoxSelectableGroup block={block}>
                 {children}
             </GiftBoxSelectableGroup>
+        );
+    }
+
+    if (block.name === 'GardenBox') {
+        return (
+            <GardenBoxSelectableGroup block={block}>
+                {children}
+            </GardenBoxSelectableGroup>
         );
     }
 

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -55,11 +55,12 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
                 rotation={lidRotation as unknown as [number, number, number]}
             >
                 <mesh
-                    castShadow
                     receiveShadow
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                     material={materials['Material.Planks']}
-                />
+                >
+                    <HoverOutline hovered={hovered} variant="outlines" />
+                </mesh>
                 <SnowOverlay
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                     {...snowPresets.giftBox}

--- a/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
@@ -1,0 +1,142 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { inventoryQueryKey } from './useInventory';
+
+const mutationKey = ['inventory', 'gardenBoxPlaceBlock'];
+
+type InventoryItemData = {
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+    name?: string;
+    image?: string;
+};
+
+type GardenBoxInventoryData = {
+    blockId: string;
+    gardenId: number;
+    gardenName?: string | null;
+    items: InventoryItemData[];
+};
+
+type InventoryData = {
+    items: InventoryItemData[];
+    gardenBoxes?: GardenBoxInventoryData[];
+};
+
+export type GardenBoxPlaceBlockArgs = {
+    gardenId: number;
+    gardenBoxBlockId: string;
+    entityId: string;
+};
+
+function decrementGardenBoxInventoryItem(
+    inventory: InventoryData,
+    args: GardenBoxPlaceBlockArgs,
+): InventoryData {
+    return {
+        ...inventory,
+        gardenBoxes: inventory.gardenBoxes?.map((gardenBox) => {
+            const isTargetGardenBox =
+                gardenBox.gardenId === args.gardenId &&
+                gardenBox.blockId === args.gardenBoxBlockId;
+
+            if (!isTargetGardenBox) {
+                return gardenBox;
+            }
+
+            return {
+                ...gardenBox,
+                items: gardenBox.items.flatMap((item) => {
+                    const isTargetItem =
+                        item.entityTypeName === 'block' &&
+                        item.entityId === args.entityId;
+                    if (!isTargetItem) {
+                        return [item];
+                    }
+
+                    const nextAmount = item.amount - 1;
+                    return nextAmount > 0
+                        ? [{ ...item, amount: nextAmount }]
+                        : [];
+                }),
+            };
+        }),
+    };
+}
+
+async function getGardenBoxPlaceBlockError(response: Response) {
+    const errorBody = await response.json().catch(() => null);
+    if (
+        errorBody &&
+        typeof errorBody === 'object' &&
+        'error' in errorBody &&
+        typeof errorBody.error === 'string'
+    ) {
+        return errorBody.error;
+    }
+
+    return 'Failed to place block from garden box';
+}
+
+export function useGardenBoxPlaceBlock() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationKey,
+        mutationFn: async ({
+            entityId,
+            gardenBoxBlockId,
+            gardenId,
+        }: GardenBoxPlaceBlockArgs) => {
+            const response = await clientAuthenticated().api.inventory[
+                'garden-boxes'
+            ][':gardenId'][':blockId'].items.block[':entityId'].place.$post({
+                param: {
+                    gardenId: gardenId.toString(),
+                    blockId: gardenBoxBlockId,
+                    entityId,
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(await getGardenBoxPlaceBlockError(response));
+            }
+
+            return await response.json();
+        },
+        onMutate: async (args) => {
+            await queryClient.cancelQueries({ queryKey: inventoryQueryKey });
+            const previousInventory =
+                queryClient.getQueryData<InventoryData>(inventoryQueryKey);
+
+            if (previousInventory) {
+                queryClient.setQueryData(
+                    inventoryQueryKey,
+                    decrementGardenBoxInventoryItem(previousInventory, args),
+                );
+            }
+
+            return { previousInventory };
+        },
+        onError: (error, _variables, context) => {
+            console.error('Error placing block from garden box', error);
+            if (context?.previousInventory) {
+                queryClient.setQueryData(
+                    inventoryQueryKey,
+                    context.previousInventory,
+                );
+            }
+        },
+        onSettled: async () => {
+            if (queryClient.isMutating({ mutationKey }) === 1) {
+                await queryClient.invalidateQueries({
+                    queryKey: inventoryQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: ['gardens', 'current'],
+                });
+            }
+        },
+    });
+}

--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -1,7 +1,9 @@
 import type { OperationData, PlantSortData } from '@gredice/client';
 import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { BlockImage } from '@gredice/ui/BlockImage';
+import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
+import { Add } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { PlantOrSortImage } from '@gredice/ui/plants';
@@ -12,10 +14,15 @@ import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { useMemo, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { useGardenBoxPlaceBlock } from '../hooks/useGardenBoxPlaceBlock';
 import { useInventory } from '../hooks/useInventory';
 import { useOperations } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
-import { useBackpackOpenParam } from '../useUrlState';
+import {
+    normalizeBackpackTab,
+    useBackpackOpenParam,
+    useBackpackTabParam,
+} from '../useUrlState';
 import { HudCard } from './components/HudCard';
 
 const GRID_SIZE = 24; // 3x4 grid
@@ -40,6 +47,12 @@ type InventoryData = {
     gardenBoxes?: GardenBoxInventoryData[];
 };
 
+type SelectedInventoryItem = {
+    item: InventoryItemData;
+    source: 'backpack' | 'gardenBox';
+    gardenBox?: GardenBoxInventoryData;
+};
+
 function inventoryItemKey(
     item: Pick<InventoryItemData, 'entityTypeName' | 'entityId'>,
 ) {
@@ -48,6 +61,15 @@ function inventoryItemKey(
 
 function inventoryItemTotal(items: InventoryItemData[]) {
     return items.reduce((sum, item) => sum + item.amount, 0);
+}
+
+function resolveBlockImageName(item?: InventoryItemData) {
+    if (!item || item.entityTypeName !== 'block') {
+        return null;
+    }
+
+    const blockName = item.name ?? item.entityId;
+    return /^\d+$/u.test(blockName) ? null : blockName;
 }
 
 function InventoryItemCell({
@@ -68,11 +90,13 @@ function InventoryItemCell({
         );
     }
 
+    const blockImageName = resolveBlockImageName(item);
+
     return (
         <button
             type="button"
             onClick={onClick}
-            className="aspect-square rounded-lg border p-0.5 relative transition-all bg-card hover:bg-primary/10"
+            className="aspect-square overflow-hidden rounded-lg border bg-card p-0.5 relative transition-all hover:bg-primary/10"
         >
             {sortData ? (
                 <PlantOrSortImage
@@ -85,9 +109,22 @@ function InventoryItemCell({
                 <div className="flex items-center justify-center h-full w-full rounded-md bg-card">
                     <OperationImage operation={operationData} size={48} />
                 </div>
+            ) : blockImageName ? (
+                <div className="flex items-center justify-center h-full w-full rounded-md bg-muted/40">
+                    <BlockImage
+                        blockName={blockImageName}
+                        alt={item.name ?? blockImageName}
+                        width={64}
+                        height={64}
+                        className="size-full object-contain p-2"
+                    />
+                </div>
             ) : (
-                <div className="flex items-center justify-center h-full w-full rounded-md bg-muted">
-                    <Typography level="body2" className="text-center">
+                <div className="flex items-center justify-center h-full w-full rounded-md bg-muted px-1">
+                    <Typography
+                        level="body3"
+                        className="line-clamp-2 max-w-full break-all text-center text-xs leading-tight"
+                    >
                         {item.name ?? item.entityTypeName}
                     </Typography>
                 </div>
@@ -157,17 +194,25 @@ function InventoryItemsGrid({
 
 function InventoryItemModal({
     item,
+    source,
+    gardenBox,
     sortData,
     operationData,
     open,
     onClose,
 }: {
     item: InventoryItemData;
+    source: SelectedInventoryItem['source'];
+    gardenBox?: GardenBoxInventoryData;
     sortData?: PlantSortData;
     operationData?: OperationData;
     open: boolean;
     onClose: () => void;
 }) {
+    const placeGardenBoxBlock = useGardenBoxPlaceBlock();
+    const blockImageName = resolveBlockImageName(item);
+    const isGardenBoxBlock =
+        source === 'gardenBox' && item.entityTypeName === 'block';
     const displayName =
         sortData?.information?.name ??
         operationData?.information?.label ??
@@ -177,7 +222,27 @@ function InventoryItemModal({
     const description =
         sortData?.information?.shortDescription ??
         sortData?.information?.plant?.information?.description ??
-        operationData?.information?.shortDescription;
+        operationData?.information?.shortDescription ??
+        (isGardenBoxBlock
+            ? 'Dodaj ovaj blok natrag u vrt. Postavit će se na prvo slobodno mjesto, bez trošenja suncokreta.'
+            : undefined);
+    const placeGardenBoxBlockError =
+        placeGardenBoxBlock.error instanceof Error
+            ? placeGardenBoxBlock.error.message
+            : null;
+
+    async function handlePlaceGardenBoxBlock() {
+        if (!gardenBox) {
+            return;
+        }
+
+        await placeGardenBoxBlock.mutateAsync({
+            gardenId: gardenBox.gardenId,
+            gardenBoxBlockId: gardenBox.blockId,
+            entityId: item.entityId,
+        });
+        onClose();
+    }
 
     return (
         <Modal
@@ -199,6 +264,16 @@ function InventoryItemModal({
                             <OperationImage
                                 operation={operationData}
                                 size={64}
+                            />
+                        </div>
+                    ) : blockImageName ? (
+                        <div className="size-20 rounded-lg border shrink-0 flex items-center justify-center bg-muted/40">
+                            <BlockImage
+                                blockName={blockImageName}
+                                alt={displayName}
+                                width={72}
+                                height={72}
+                                className="size-full object-contain p-2"
                             />
                         </div>
                     ) : (
@@ -235,6 +310,20 @@ function InventoryItemModal({
                                     ruksaka&quot;
                                 </Typography>
                             </>
+                        ) : isGardenBoxBlock ? (
+                            <>
+                                <Typography level="body3">
+                                    1. Klikni &quot;Dodaj u vrt&quot;
+                                </Typography>
+                                <Typography level="body3">
+                                    2. Blok će se postaviti na prvo slobodno
+                                    mjesto
+                                </Typography>
+                                <Typography level="body3">
+                                    3. Iz vrtne kutije uklonit će se jedan
+                                    predmet
+                                </Typography>
+                            </>
                         ) : (
                             <>
                                 <Typography level="body3">
@@ -250,6 +339,31 @@ function InventoryItemModal({
                             </>
                         )}
                     </Stack>
+                    {isGardenBoxBlock && (
+                        <Stack spacing={1}>
+                            <Button
+                                type="button"
+                                variant="soft"
+                                color="primary"
+                                startDecorator={<Add className="size-4" />}
+                                loading={placeGardenBoxBlock.isPending}
+                                disabled={
+                                    !gardenBox || placeGardenBoxBlock.isPending
+                                }
+                                onClick={handlePlaceGardenBoxBlock}
+                            >
+                                Dodaj u vrt
+                            </Button>
+                            {placeGardenBoxBlockError && (
+                                <Typography
+                                    level="body3"
+                                    className="text-red-600"
+                                >
+                                    {placeGardenBoxBlockError}
+                                </Typography>
+                            )}
+                        </Stack>
+                    )}
                 </Stack>
             </Stack>
         </Modal>
@@ -313,9 +427,10 @@ export function InventoryHud() {
     const { data: operations } = useOperations();
     const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useBackpackOpenParam();
-    const [selectedItem, setSelectedItem] = useState<InventoryItemData | null>(
-        null,
-    );
+    const [backpackTabParam, setBackpackTabParam] = useBackpackTabParam();
+    const backpackTab = normalizeBackpackTab(backpackTabParam);
+    const [selectedItem, setSelectedItem] =
+        useState<SelectedInventoryItem | null>(null);
 
     const inventoryData = inventory as InventoryData | null | undefined;
     const items = inventoryData?.items ?? [];
@@ -370,23 +485,28 @@ export function InventoryHud() {
     );
 
     const selectedSortData =
-        selectedItem?.entityTypeName === 'plantSort'
-            ? sortData?.find((s) => s.id === Number(selectedItem.entityId))
+        selectedItem?.item.entityTypeName === 'plantSort'
+            ? sortData?.find((s) => s.id === Number(selectedItem.item.entityId))
             : undefined;
     const selectedOperationData = selectedItem
-        ? operationLookup.get(inventoryItemKey(selectedItem))
+        ? operationLookup.get(inventoryItemKey(selectedItem.item))
         : undefined;
 
     const handleItemClick = (
         item: InventoryItemData,
         source: 'backpack' | 'gardenBox',
+        gardenBox?: GardenBoxInventoryData,
     ) => {
         track('game_inventory_item_opened', {
             entity_id: item.entityId,
             entity_type: item.entityTypeName,
             source,
         });
-        setSelectedItem(item);
+        setSelectedItem({
+            item,
+            source,
+            gardenBox,
+        });
     };
 
     const handleOpenChange = (open: boolean) => {
@@ -397,6 +517,9 @@ export function InventoryHud() {
         }
         setIsOpen(open);
         if (!open) setSelectedItem(null);
+    };
+    const handleTabChange = (value: string) => {
+        setBackpackTabParam(normalizeBackpackTab(value));
     };
 
     const tabCountClassName =
@@ -437,7 +560,11 @@ export function InventoryHud() {
                             Inventar
                         </Typography>
                     </Row>
-                    <Tabs defaultValue="backpack" className="flex flex-col">
+                    <Tabs
+                        value={backpackTab}
+                        onValueChange={handleTabChange}
+                        className="flex flex-col"
+                    >
                         <TabsList className="grid grid-cols-2 border">
                             <TabsTrigger value="backpack">
                                 <Row spacing={2} alignItems="center">
@@ -519,6 +646,7 @@ export function InventoryHud() {
                                                 handleItemClick(
                                                     item,
                                                     'gardenBox',
+                                                    gardenBox,
                                                 )
                                             }
                                         />
@@ -532,7 +660,9 @@ export function InventoryHud() {
 
             {selectedItem && (
                 <InventoryItemModal
-                    item={selectedItem}
+                    item={selectedItem.item}
+                    source={selectedItem.source}
+                    gardenBox={selectedItem.gardenBox}
                     sortData={selectedSortData}
                     operationData={selectedOperationData}
                     open={Boolean(selectedItem)}

--- a/packages/game/src/useUrlState.tsx
+++ b/packages/game/src/useUrlState.tsx
@@ -4,6 +4,7 @@ import {
     parseAsInteger,
     parseAsString,
     useQueryState,
+    useQueryStates,
 } from 'nuqs';
 
 // Game mode parameter (Croatian: "uredivanje" = editing)
@@ -20,6 +21,31 @@ export function useShoppingCartOpenParam() {
 // Backpack/Inventory modal parameter (Croatian: "ruksak" = backpack)
 export function useBackpackOpenParam() {
     return useQueryState('ruksak', parseAsBoolean.withDefault(false));
+}
+
+export const backpackInventoryTab = 'backpack';
+export const gardenBoxesInventoryTab = 'gardenBoxes';
+const backpackInventoryParamParsers = {
+    ruksak: parseAsBoolean.withDefault(false),
+    'ruksak-kartica': parseAsString.withDefault(backpackInventoryTab),
+};
+
+// Backpack/Inventory tab parameter (Croatian: "ruksak-kartica" = backpack tab)
+export function useBackpackTabParam() {
+    return useQueryState(
+        'ruksak-kartica',
+        parseAsString.withDefault(backpackInventoryTab),
+    );
+}
+
+export function normalizeBackpackTab(value: string | null | undefined) {
+    return value === gardenBoxesInventoryTab
+        ? gardenBoxesInventoryTab
+        : backpackInventoryTab;
+}
+
+export function useBackpackInventoryParams() {
+    return useQueryStates(backpackInventoryParamParsers);
 }
 
 // Raised bed closeup parameter (Croatian: "gredica" = raised bed)
@@ -42,6 +68,7 @@ export const urlStateSerializer = createSerializer({
     uredivanje: parseAsBoolean,
     kosarica: parseAsBoolean,
     ruksak: parseAsBoolean,
+    'ruksak-kartica': parseAsString,
     gredica: parseAsString,
     'poklon-kutija': parseAsString,
     vrt: parseAsInteger,

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -113,7 +113,10 @@ export async function consumeInventoryItem(
     payload: InventoryItemEventPayload,
     db: DatabaseClient = storage(),
 ) {
-    const inventory = await getInventory(accountId);
+    const inventory = await getInventoryForAggregateIds(
+        [getInventoryAggregateId(accountId)],
+        db,
+    );
     const currentAmount =
         inventory.find(
             (item) =>
@@ -171,7 +174,10 @@ export async function consumeGardenBoxInventoryItem(
     payload: InventoryItemEventPayload,
     db: DatabaseClient = storage(),
 ) {
-    const inventory = await getGardenBoxInventory(accountId, gardenId, blockId);
+    const inventory = await getInventoryForAggregateIds(
+        [getGardenBoxInventoryAggregateId({ accountId, gardenId, blockId })],
+        db,
+    );
     const currentAmount =
         inventory.find(
             (item) =>


### PR DESCRIPTION
## Sažetak
- Dodan hover/select tretman za vrtne kutije u normalnom modu, uz otvaranje inventara na kartici `Kutije` pri kliku.
- U inventaru vrtne kutije blokovi sada prikazuju preview slike i imaju posebno opisno stanje s akcijom `Dodaj u vrt`.
- Dodan je API i UI tok za vraćanje jednog bloka iz vrtne kutije natrag u vrt, koristeći isto pravilo pozicioniranja kao pri kupnji, ali bez trošenja suncokreta.
- Uklonjen je problem sa sjenama na vrhu vrtne kutije podešavanjem renderiranja poklopca.

## Testiranje
- Pokriveno novim Playwright CT testom za otvaranje inventara na kartici vrtnih kutija i za akciju vraćanja bloka u vrt.
- Provedeni su lint, typecheck, Node testovi i buildovi za pogođene pakete/aplikacije; svi su prošli.