### PR TITLE
[game] Close quick notifications popper when a notification is opened

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -25,6 +25,7 @@ import { Row } from '@gredice/ui/Row';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useCurrentUser } from '../hooks/useCurrentUser';
@@ -38,7 +39,11 @@ import { GardenAccountMenuItems } from './GardenAccountMenuItems';
 import { GardenOperationsHud } from './GardenOperationsHud';
 import { NotificationList } from './NotificationList';
 
-function NotificationsCard() {
+function NotificationsCard({
+    onNotificationSelected,
+}: {
+    onNotificationSelected: () => void;
+}) {
     const [, setProfileModalOpen] = useSearchParam('pregled');
     const markAllNotificationsRead = useMarkAllNotificationsRead();
     const { track } = useGameAnalytics();
@@ -70,7 +75,10 @@ function NotificationsCard() {
             </Row>
             <Divider />
             <div className="overflow-y-auto max-h-[50vh]">
-                <NotificationList short />
+                <NotificationList
+                    short
+                    onNotificationSelected={onNotificationSelected}
+                />
             </div>
             <Divider />
             <Stack>
@@ -178,6 +186,7 @@ function ProfileCard() {
 
 export function AccountHud() {
     const { track } = useGameAnalytics();
+    const [isNotificationsOpen, setNotificationsOpen] = useState(false);
     const { data: currentUser } = useCurrentUser();
     const { data: currentGarden, isLoading } = useCurrentGarden();
     const { data: notifications } = useNotifications(currentUser?.id, false);
@@ -242,6 +251,8 @@ export function AccountHud() {
                         className="w-[min(24rem,calc(100vw-1rem))] overflow-hidden border-tertiary border-b-4"
                         side="bottom"
                         sideOffset={12}
+                        open={isNotificationsOpen}
+                        onOpenChange={setNotificationsOpen}
                         trigger={
                             <Button
                                 className="relative rounded-full p-0 aspect-square"
@@ -262,7 +273,11 @@ export function AccountHud() {
                             </Button>
                         }
                     >
-                        <NotificationsCard />
+                        <NotificationsCard
+                            onNotificationSelected={() =>
+                                setNotificationsOpen(false)
+                            }
+                        />
                     </Popper>
                 </div>
             </Row>

--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -25,6 +25,7 @@ import { NoNotificationsPlaceholder } from '../shared-ui/NoNotificationsPlacehol
 interface NotificationProps {
     read?: boolean;
     short?: boolean;
+    onNotificationSelected?: () => void;
 }
 
 type NotificationListItemProps = {
@@ -39,9 +40,13 @@ type NotificationListItemProps = {
         timestamp: Date;
         raisedBedId: number | null;
     };
+    onNotificationSelected?: () => void;
 };
 
-function NotificationListItem({ notification }: NotificationListItemProps) {
+function NotificationListItem({
+    notification,
+    onNotificationSelected,
+}: NotificationListItemProps) {
     const router = useRouter();
     const { id, header, content, linkUrl, readAt, timestamp, raisedBedId } =
         notification;
@@ -107,6 +112,8 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
         if (computedLinkUrl !== '#') {
             router.push(computedLinkUrl as Route);
         }
+
+        onNotificationSelected?.();
     }
 
     return (
@@ -184,7 +191,11 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
     );
 }
 
-export function NotificationList({ read, short }: NotificationProps) {
+export function NotificationList({
+    onNotificationSelected,
+    read,
+    short,
+}: NotificationProps) {
     const { data: currentUser } = useCurrentUser();
     const { data: notifications, error } = useNotifications(
         currentUser?.id,
@@ -228,6 +239,7 @@ export function NotificationList({ read, short }: NotificationProps) {
                 <NotificationListItem
                     key={notification.id}
                     notification={notification}
+                    onNotificationSelected={onNotificationSelected}
                 />
             ))}
         </List>


### PR DESCRIPTION
### Motivation
- Improve UX so selecting a notification from the quick notifications popper both marks it read and closes the popper, preventing the list from remaining open after navigation.
- Provide a lightweight hook for callers to react when a notification is opened so the containing UI can control visibility.

### Description
- Added an optional `onNotificationSelected?: () => void` prop to `NotificationList` and forwarded it to each `NotificationListItem` so callers can be notified when an item is opened. (modified `packages/game/src/hud/NotificationList.tsx`).
- Call `onNotificationSelected` at the end of the notification selection flow in `NotificationListItem` after marking as read and performing navigation. (modified `packages/game/src/hud/NotificationList.tsx`).
- Made the quick notifications `Popper` in `AccountHud` controlled with local `isNotificationsOpen` state and `onOpenChange`, and wired `onNotificationSelected` to close the popper when an item is opened. (modified `packages/game/src/hud/AccountHud.tsx`).
- Updated `NotificationsCard` to accept and forward the `onNotificationSelected` callback to the short `NotificationList` view. (modified `packages/game/src/hud/AccountHud.tsx`).

### Testing
- Ran `pnpm lint --filter @gredice/game`, which completed successfully; environment reported an engine warning due to Node version (local Node < 24) but the lint task passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b3107d6c832fb04dad8d8070b4fe)