### PR TITLE
Enable raised-bed AI feature by default

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -24,7 +24,7 @@ export const addressDistanceVerificationFlag = flag<boolean>({
 export const raisedBedImageAIFlag = flag<boolean>({
     key: 'raisedBedImageAI',
     description: 'Enable AI analysis of raised-bed images.',
-    decide: () => false,
+    decide: () => true,
     options: booleanOptions,
 });
 


### PR DESCRIPTION
### Motivation
- Turn on AI analysis for raised-bed images by default so the garden app provides AI insights without requiring manual flag enabling.

### Description
- Change the default decision for `raisedBedImageAIFlag` from `false` to `true` in `apps/garden/app/flags.ts` so the feature is enabled by default.

### Testing
- Ran `pnpm lint --filter garden` which completed successfully (the run emitted a Node engine warning about `>=24` vs the environment `v22.22.2`, but lint finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b3e33910832f915c5bd50b002cae)