### PR TITLE
Add 'view read' CTA to HUD when no unread notifications

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -42,6 +42,11 @@ function NotificationsCard() {
     const [, setProfileModalOpen] = useSearchParam('pregled');
     const markAllNotificationsRead = useMarkAllNotificationsRead();
     const { track } = useGameAnalytics();
+    const { data: currentUser } = useCurrentUser();
+    const { data: notifications } = useNotifications(currentUser?.id, false);
+    const hasUnreadNotifications = notifications?.some(
+        (notification) => !notification.readAt,
+    );
 
     const handleMarkAllNotificationsRead = () => {
         track('game_notifications_mark_all_read', {
@@ -70,7 +75,27 @@ function NotificationsCard() {
             </Row>
             <Divider />
             <div className="overflow-y-auto max-h-[50vh]">
-                <NotificationList short />
+                {hasUnreadNotifications ? (
+                    <NotificationList short unreadOnly />
+                ) : (
+                    <Stack className="p-4" spacing={2} alignItems="center">
+                        <Typography level="body3" className="text-center">
+                            Nema nepročitanih obavijesti.
+                        </Typography>
+                        <Button
+                            variant="plain"
+                            size="sm"
+                            onClick={() => {
+                                track('game_notifications_view_all_opened', {
+                                    source: 'quick_panel_no_unread',
+                                });
+                                setProfileModalOpen('obavijesti');
+                            }}
+                        >
+                            Prikaži sve pročitane
+                        </Button>
+                    </Stack>
+                )}
             </div>
             <Divider />
             <Stack>

--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -25,6 +25,7 @@ import { NoNotificationsPlaceholder } from '../shared-ui/NoNotificationsPlacehol
 interface NotificationProps {
     read?: boolean;
     short?: boolean;
+    unreadOnly?: boolean;
 }
 
 type NotificationListItemProps = {
@@ -184,7 +185,11 @@ function NotificationListItem({ notification }: NotificationListItemProps) {
     );
 }
 
-export function NotificationList({ read, short }: NotificationProps) {
+export function NotificationList({
+    read,
+    short,
+    unreadOnly,
+}: NotificationProps) {
     const { data: currentUser } = useCurrentUser();
     const { data: notifications, error } = useNotifications(
         currentUser?.id,
@@ -218,13 +223,17 @@ export function NotificationList({ read, short }: NotificationProps) {
         );
     }
 
-    if (!notifications?.length) {
+    const visibleNotifications = unreadOnly
+        ? notifications?.filter((notification) => !notification.readAt)
+        : notifications;
+
+    if (!visibleNotifications?.length) {
         return <NoNotificationsPlaceholder />;
     }
 
     return (
         <List variant="outlined" className="border-none">
-            {notifications.map((notification) => (
+            {visibleNotifications.map((notification) => (
                 <NotificationListItem
                     key={notification.id}
                     notification={notification}


### PR DESCRIPTION
### Motivation
- Give users a quick way to open the full notifications view when the HUD quick panel has no unread notifications so they can review already-read items. 

### Description
- Add an `unreadOnly?: boolean` prop to `NotificationList` and apply local filtering to show only unread items when requested in `packages/game/src/hud/NotificationList.tsx`. 
- Update the HUD `NotificationsCard` to fetch notifications, compute `hasUnreadNotifications`, and render `NotificationList short unreadOnly` when unread items exist or a compact empty-state with a small CTA button that opens the full notifications modal when none exist in `packages/game/src/hud/AccountHud.tsx`. 
- Preserve the existing full-width "Prikaži sve obavijesti" button and add a tracking event for the new compact CTA (`source: 'quick_panel_no_unread'`).

### Testing
- Ran `pnpm lint --filter @gredice/game`, which completed successfully and applied one lint fix. 
- Ran `pnpm test --filter @gredice/game`, which passed (21 tests passed, 0 failed). 
- Ran `pnpm build --filter @gredice/game`, which reported no build tasks to execute for this package. 
- Note: local environment reports Node v22 while the repo requests Node `>=24`, resulting in engine warning messages only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b3525430832fa53e1e28e9e6f74c)