### PR TITLE
Enrich raised-bed AI context and batch history fetch

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -25,6 +25,7 @@ import {
     getOperations,
     getOperationsPage,
     getRaisedBed,
+    getRaisedBedAiHistoryEntries,
     getRaisedBedDiaryEntries,
     getRaisedBedFieldDiaryEntries,
     getRaisedBedIdsByAccount,
@@ -2002,6 +2003,46 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const diaryEntries =
                 await getRaisedBedDiaryEntries(raisedBedIdNumber);
             return context.json(diaryEntries);
+        },
+    )
+    .get(
+        '/:gardenId/raised-beds/:raisedBedId/ai-history',
+        describeRoute({
+            description:
+                'Get the combined AI analysis history for a raised bed and all of its fields',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                raisedBedId: z.string(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, raisedBedId } = context.req.valid('param');
+            const gardenIdNumber = parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+            const raisedBedIdNumber = parseInt(raisedBedId, 10);
+            if (Number.isNaN(raisedBedIdNumber)) {
+                return context.json({ error: 'Invalid raised bed ID' }, 400);
+            }
+
+            const { accountId } = context.get('authContext');
+            const raisedBed = await getRaisedBed(raisedBedIdNumber);
+            if (
+                !raisedBed ||
+                raisedBed.gardenId !== gardenIdNumber ||
+                raisedBed.accountId !== accountId
+            ) {
+                return context.json({ error: 'Raised bed not found' }, 404);
+            }
+
+            const entries =
+                await getRaisedBedAiHistoryEntries(raisedBedIdNumber);
+            return context.json(entries);
         },
     )
     .post(

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -1,6 +1,22 @@
-import { getEntitiesFormatted, getOperations } from '@gredice/storage';
+import {
+    getEntitiesFormatted,
+    getOperations,
+    grediceCacheKeys,
+    grediceCached,
+} from '@gredice/storage';
 import { streamText } from 'ai';
 import { validateHostedImageUrl } from '../http/safeUrls';
+import { getBjelovarForecast } from '../weather/forecast';
+import { findClosestForecastEntry } from '../weather/weatherNowContract';
+
+const FORECAST_CACHE_TTL_SECONDS = 60 * 60;
+const RAISED_BED_FIELDS_PER_BLOCK = 9;
+const RAISED_BED_COLUMNS = 3;
+const GREENHOUSE_SEEDLING_STATUSES = new Set([
+    'pendingVerification',
+    'sowed',
+    'sprouted',
+]);
 
 const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.5';
 
@@ -58,6 +74,7 @@ function daysSince(date: Date | string | null | undefined) {
 
 type RaisedBedAnalysisTarget = {
     id: number;
+    orientation?: 'vertical' | 'horizontal' | string | null;
     fields: Array<{
         id: number;
         positionIndex: number;
@@ -68,10 +85,99 @@ type RaisedBedAnalysisTarget = {
         plantReadyDate?: Date | string | null;
         plantHarvestedDate?: Date | string | null;
         plantDeadDate?: Date | string | null;
+        plantRemovedDate?: Date | string | null;
+        sowingLocation?: 'direct' | 'greenhouse' | string | null;
         toBeRemoved?: boolean | null;
         active?: boolean | null;
     }>;
 };
+
+type WeatherDayContext = {
+    date: string;
+    minTemperatureC: number;
+    maxTemperatureC: number;
+    rainMm: number;
+    symbol: number;
+    windDirection: string | null;
+    windStrength: number;
+};
+
+type WeatherContext = {
+    location: string;
+    now: {
+        temperatureC: number | null;
+        rainMm: number;
+        symbol: number | null;
+        windDirection: string | null;
+        windStrength: number;
+    } | null;
+    forecast: WeatherDayContext[];
+};
+
+function toPositionLabel(positionIndex: number) {
+    return positionIndex + 1;
+}
+
+function isCurrentlyGreenhouseSeedling(field: {
+    sowingLocation?: 'direct' | 'greenhouse' | string | null;
+    plantStatus?: string | null;
+    plantDeadDate?: Date | string | null;
+    plantHarvestedDate?: Date | string | null;
+    plantRemovedDate?: Date | string | null;
+    active?: boolean | null;
+}) {
+    return Boolean(
+        field.active !== false &&
+            field.sowingLocation === 'greenhouse' &&
+            GREENHOUSE_SEEDLING_STATUSES.has(field.plantStatus ?? '') &&
+            !field.plantDeadDate &&
+            !field.plantHarvestedDate &&
+            !field.plantRemovedDate,
+    );
+}
+
+async function buildWeatherContext(): Promise<WeatherContext | null> {
+    try {
+        const forecast = await grediceCached(
+            grediceCacheKeys.forecastBjelovar,
+            getBjelovarForecast,
+            FORECAST_CACHE_TTL_SECONDS,
+        );
+        if (!forecast || forecast.length === 0) {
+            return null;
+        }
+
+        const closestEntry = findClosestForecastEntry(forecast, Date.now());
+
+        return {
+            location: 'Bjelovar, HR',
+            now: closestEntry
+                ? {
+                      temperatureC: closestEntry.temperature,
+                      rainMm: closestEntry.rain,
+                      symbol: closestEntry.symbol,
+                      windDirection: closestEntry.windDirection,
+                      windStrength: closestEntry.windStrength,
+                  }
+                : null,
+            forecast: forecast.slice(0, 5).map((day) => ({
+                date: day.date,
+                minTemperatureC: day.minTemp,
+                maxTemperatureC: day.maxTemp,
+                rainMm: day.rain,
+                symbol: day.symbol,
+                windDirection: day.windDirection,
+                windStrength: day.windStrength,
+            })),
+        };
+    } catch (error) {
+        console.warn(
+            'Failed to load weather context for AI analysis:',
+            error,
+        );
+        return null;
+    }
+}
 
 type AnalysisParams = {
     accountId: string;
@@ -88,7 +194,7 @@ async function buildAnalysisMessages({
     imageUrls,
     positionIndex,
 }: AnalysisParams) {
-    const [plantSorts, operations, operationsData] = await Promise.all([
+    const [plantSorts, operations, operationsData, weather] = await Promise.all([
         getEntitiesFormatted<{
             id: string;
             information?: { name?: string };
@@ -98,6 +204,7 @@ async function buildAnalysisMessages({
             id: string;
             information?: { label?: string; name?: string };
         }>('operation'),
+        buildWeatherContext(),
     ]);
 
     const plantSortNameById = new Map(
@@ -120,23 +227,32 @@ async function buildAnalysisMessages({
 
     const plantedFields = raisedBed.fields
         .filter((field) => field.active && field.plantSortId)
-        .map((field) => ({
-            positionIndex: field.positionIndex,
-            plantSortId: field.plantSortId,
-            plantName:
-                plantSortNameById.get(Number(field.plantSortId)) ??
-                String(field.plantSortId),
-            plantStatus: field.plantStatus,
-            daysFromSowing: daysSince(field.plantSowDate),
-            daysFromGrowth: daysSince(field.plantGrowthDate),
-            daysFromReady: daysSince(field.plantReadyDate),
-            daysFromHarvest: daysSince(field.plantHarvestedDate),
-            daysFromDead: daysSince(field.plantDeadDate),
-            needsRemoval: Boolean(field.toBeRemoved),
-            isAnalyzedField:
-                typeof positionIndex === 'number' &&
-                field.positionIndex === positionIndex,
-        }));
+        .map((field) => {
+            const isGreenhouseSeedling = isCurrentlyGreenhouseSeedling(field);
+            return {
+                positionIndex: field.positionIndex,
+                positionLabel: toPositionLabel(field.positionIndex),
+                plantSortId: field.plantSortId,
+                plantName:
+                    plantSortNameById.get(Number(field.plantSortId)) ??
+                    String(field.plantSortId),
+                plantStatus: field.plantStatus,
+                sowingLocation: field.sowingLocation ?? 'direct',
+                currentLocation: isGreenhouseSeedling
+                    ? ('greenhouse' as const)
+                    : ('raisedBed' as const),
+                isGreenhouseSeedling,
+                daysFromSowing: daysSince(field.plantSowDate),
+                daysFromGrowth: daysSince(field.plantGrowthDate),
+                daysFromReady: daysSince(field.plantReadyDate),
+                daysFromHarvest: daysSince(field.plantHarvestedDate),
+                daysFromDead: daysSince(field.plantDeadDate),
+                needsRemoval: Boolean(field.toBeRemoved),
+                isAnalyzedField:
+                    typeof positionIndex === 'number' &&
+                    field.positionIndex === positionIndex,
+            };
+        });
 
     const executedOperations = operations.map((op) => ({
         id: op.id,
@@ -149,11 +265,30 @@ async function buildAnalysisMessages({
         fieldId: op.raisedBedFieldId,
     }));
 
+    const totalFields = raisedBed.fields.length || RAISED_BED_FIELDS_PER_BLOCK * 2;
+    const rows = Math.max(1, Math.ceil(totalFields / RAISED_BED_COLUMNS));
+    const orientation = raisedBed.orientation ?? 'vertical';
+    const nowIso = new Date().toISOString();
+    const analyzedPositionLabel =
+        typeof positionIndex === 'number'
+            ? toPositionLabel(positionIndex)
+            : null;
+
     return [
         {
             role: 'system' as const,
-            content:
+            content: [
                 'Ti si stručni agronom za urbane vrtove. Piši ISKLJUČIVO na hrvatskom jeziku i vrati odgovor kao uredno formatiran markdown. Korisnik nema fizički pristup gredici; kada preporuka traži rad na gredici, predloži naručivanje najbliže odgovarajuće operacije iz dostupnog popisa umjesto da korisniku kažeš da to sam ručno napravi.',
+                '',
+                'Raspored polja u gredici:',
+                `- Standardna gredica ima ${RAISED_BED_COLUMNS} stupca i do ${rows} redova (ukupno do ${totalFields} polja).`,
+                '- Polja su numerirana od 1 nadalje, počevši od donjeg desnog kuta slike i čitajući zdesna nalijevo, red po red prema gore.',
+                '- Donji red: 1 (donje desno) → 2 (donje sredina) → 3 (donje lijevo).',
+                '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
+                '- U JSON kontekstu vrijednost `positionLabel` koristi ovo brojanje (1-bazirano), dok `positionIndex` ostaje 0-bazirana interna oznaka (`positionLabel = positionIndex + 1`).',
+                '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
+                '- Koristi `weather` kontekst (trenutno stanje i prognozu) i `currentDate` pri preporukama za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
+            ].join('\n'),
         },
         {
             role: 'user' as const,
@@ -162,7 +297,7 @@ async function buildAnalysisMessages({
                     type: 'text' as const,
                     text: [
                         typeof positionIndex === 'number'
-                            ? 'Analiziraj sve fotografije vrta i kontekst te napiši objedinjene praktične preporuke za označeno polje i ostatak gredice.'
+                            ? `Analiziraj sve fotografije vrta i kontekst te napiši objedinjene praktične preporuke za označeno polje (positionLabel ${analyzedPositionLabel}) i ostatak gredice.`
                             : 'Analiziraj sve fotografije gredice i kontekst te napiši objedinjene praktične preporuke za cijelu gredicu.',
                         'Fotografije su različiti pogledi istog dnevničkog unosa; nemoj ih tretirati kao zasebne zahtjeve.',
                         'Odgovor MORA imati ove markdown sekcije:',
@@ -174,9 +309,21 @@ async function buildAnalysisMessages({
                         'Kontekst (JSON):',
                         JSON.stringify(
                             {
+                                currentDate: nowIso,
+                                weather,
+                                raisedBed: {
+                                    orientation,
+                                    columns: RAISED_BED_COLUMNS,
+                                    rows,
+                                    totalFields,
+                                },
                                 analyzedField:
                                     typeof positionIndex === 'number'
-                                        ? positionIndex
+                                        ? {
+                                              positionIndex,
+                                              positionLabel:
+                                                  analyzedPositionLabel,
+                                          }
                                         : null,
                                 imageCount: imageUrls.length,
                                 plantedFields,

--- a/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
@@ -1,5 +1,6 @@
 import { client } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys as raisedBedAiHistoryQueryKeys } from './useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
 
 const mutationKey = ['gardens', 'current', 'raisedBedAiAnalysis'];
@@ -59,9 +60,18 @@ export function useRaisedBedAiAnalysis() {
             return { markdown };
         },
         onSuccess: async (_data, variables) => {
-            await queryClient.invalidateQueries({
-                queryKey: raisedBedDiaryQueryKeys.byId(variables.raisedBedId),
-            });
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: raisedBedDiaryQueryKeys.byId(
+                        variables.raisedBedId,
+                    ),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: raisedBedAiHistoryQueryKeys.byId(
+                        variables.raisedBedId,
+                    ),
+                }),
+            ]);
         },
     });
 }

--- a/packages/game/src/hooks/useRaisedBedAiHistory.ts
+++ b/packages/game/src/hooks/useRaisedBedAiHistory.ts
@@ -1,0 +1,49 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+
+export const queryKeys = {
+    byId: (raisedBedId: number) => ['raisedBeds', raisedBedId, 'ai-history'],
+};
+
+export function useRaisedBedAiHistory(
+    gardenId: number,
+    raisedBedId: number,
+    options: { enabled?: boolean } = {},
+) {
+    return useQuery({
+        queryKey: queryKeys.byId(raisedBedId),
+        queryFn: async () => {
+            const entries = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ]['raised-beds'][':raisedBedId']['ai-history'].$get({
+                param: {
+                    gardenId: gardenId.toString(),
+                    raisedBedId: raisedBedId.toString(),
+                },
+            });
+            if (entries.status === 400) {
+                console.error(
+                    'Failed to fetch AI history entries - bad request',
+                    entries,
+                );
+                return [];
+            }
+            if (entries.status === 404) {
+                console.error(
+                    'Raised bed not found or no AI history available',
+                    entries,
+                );
+                return [];
+            }
+            return (await entries.json()).map((entry) => ({
+                ...entry,
+                timestamp: new Date(entry.timestamp),
+            }));
+        },
+        staleTime: 5 * 60 * 1000,
+        enabled:
+            (options.enabled ?? true) &&
+            Boolean(gardenId) &&
+            Boolean(raisedBedId),
+    });
+}

--- a/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
@@ -1,5 +1,6 @@
 import { client } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys as raisedBedAiHistoryQueryKeys } from './useRaisedBedAiHistory';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
 
 const mutationKey = ['gardens', 'current', 'raisedBedFieldAiAnalysis'];
@@ -62,12 +63,19 @@ export function useRaisedBedFieldAiAnalysis() {
             return { markdown };
         },
         onSuccess: async (_data, variables) => {
-            await queryClient.invalidateQueries({
-                queryKey: raisedBedFieldDiaryQueryKeys.byId(
-                    variables.raisedBedId,
-                    variables.positionIndex,
-                ),
-            });
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: raisedBedFieldDiaryQueryKeys.byId(
+                        variables.raisedBedId,
+                        variables.positionIndex,
+                    ),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: raisedBedAiHistoryQueryKeys.byId(
+                        variables.raisedBedId,
+                    ),
+                }),
+            ]);
         },
     });
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -3,7 +3,6 @@ import { Button } from '@gredice/ui/Button';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
-import { useQueries } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
@@ -14,11 +13,7 @@ import {
 import { useLiveTime } from '../../hooks/useLiveTime';
 import { useOperations } from '../../hooks/useOperations';
 import { useSorts } from '../../hooks/usePlantSorts';
-import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
-import {
-    raisedBedFieldDiaryEntriesQueryOptions,
-    useRaisedBedFieldDiaryEntries,
-} from '../../hooks/useRaisedBedFieldDiaryEntries';
+import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import {
     buildSowingOperationItems,
     cartPlantSortEntityType,
@@ -118,19 +113,6 @@ function getAiHistoryForOperation({
         : undefined;
 }
 
-function getRaisedBedFieldPositionIndexes(
-    garden: ReturnType<typeof useCurrentGarden>['data'],
-    raisedBedId: number | undefined,
-) {
-    const raisedBed = garden?.raisedBeds.find(
-        (candidate) => candidate.id === raisedBedId,
-    );
-
-    return Array.from(
-        new Set(raisedBed?.fields.map((field) => field.positionIndex) ?? []),
-    );
-}
-
 export function RaisedBedOperationHistoryList({
     raisedBedId,
     positionIndex,
@@ -149,43 +131,11 @@ export function RaisedBedOperationHistoryList({
     const shouldLoadAiHistory = Boolean(
         flags.raisedBedImageAI && currentGarden?.id && raisedBedId,
     );
-    const { data: raisedBedDiaryEntries } = useRaisedBedDiaryEntries(
+    const { data: aiHistoryEntries } = useRaisedBedAiHistory(
         currentGarden?.id ?? 0,
         raisedBedId ?? 0,
-        { enabled: shouldLoadAiHistory && positionIndex === undefined },
+        { enabled: shouldLoadAiHistory },
     );
-    const { data: raisedBedFieldDiaryEntries } = useRaisedBedFieldDiaryEntries(
-        currentGarden?.id ?? 0,
-        raisedBedId ?? 0,
-        positionIndex ?? 0,
-        {
-            enabled: shouldLoadAiHistory && typeof positionIndex === 'number',
-        },
-    );
-    const raisedBedFieldPositionIndexes = useMemo(
-        () => getRaisedBedFieldPositionIndexes(currentGarden, raisedBedId),
-        [currentGarden, raisedBedId],
-    );
-    const raisedBedFieldDiaryQueries = useQueries({
-        queries: raisedBedFieldPositionIndexes.map((fieldPositionIndex) =>
-            raisedBedFieldDiaryEntriesQueryOptions(
-                currentGarden?.id ?? 0,
-                raisedBedId ?? 0,
-                fieldPositionIndex,
-                {
-                    enabled: shouldLoadAiHistory && positionIndex === undefined,
-                },
-            ),
-        ),
-    });
-    const raisedBedWideAiHistoryEntries = [
-        ...(raisedBedDiaryEntries ?? []),
-        ...raisedBedFieldDiaryQueries.flatMap((query) => query.data ?? []),
-    ];
-    const aiHistoryEntries =
-        typeof positionIndex === 'number'
-            ? raisedBedFieldDiaryEntries
-            : raisedBedWideAiHistoryEntries;
     const fieldPositionById = useMemo(
         () => buildFieldPositionById(currentGarden),
         [currentGarden],

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -2334,6 +2334,57 @@ export async function getRaisedBedFieldDiaryEntries(
     );
 }
 
+export async function getRaisedBedAiHistoryEntries(raisedBedId: number) {
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (!raisedBed) {
+        return [];
+    }
+
+    const fieldPositionIndexes = Array.from(
+        new Set(raisedBed.fields.map((field) => field.positionIndex)),
+    );
+    const aggregateIds = [
+        raisedBedId.toString(),
+        ...fieldPositionIndexes.map(
+            (positionIndex) =>
+                `${raisedBedId.toString()}|${positionIndex.toString()}`,
+        ),
+    ];
+
+    const events = await getEvents(
+        [
+            knownEventTypes.raisedBeds.aiAnalysis,
+            knownEventTypes.raisedBedFields.aiAnalysis,
+        ],
+        aggregateIds,
+        0,
+        10000,
+    );
+
+    return events
+        .map((event) => {
+            const data = event.data as Record<string, unknown> | undefined;
+            const imageUrls = Array.isArray(data?.imageUrls)
+                ? data.imageUrls.filter(
+                      (url: unknown): url is string => typeof url === 'string',
+                  )
+                : typeof data?.imageUrl === 'string'
+                  ? [data.imageUrl]
+                  : undefined;
+            return {
+                id: event.id,
+                description:
+                    typeof data?.markdown === 'string'
+                        ? data.markdown
+                        : undefined,
+                timestamp: event.createdAt,
+                imageUrls,
+                isMarkdown: true,
+            };
+        })
+        .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+}
+
 function operationStatusToLabel(status: string) {
     switch (status) {
         case 'new':


### PR DESCRIPTION
## Summary

Two related changes to the raised-bed AI analysis feature:

- **Richer prompt context.** [`raisedBedAiAnalysisService`](apps/api/lib/garden/raisedBedAiAnalysisService.ts) now hands the model:
  - `currentDate` (ISO) and a `weather` object — current conditions plus a 5-day Bjelovar forecast pulled from the same cached source as `/weather/now`. Falls back to `null` if the forecast fetch fails so analysis is never blocked.
  - Per-field `sowingLocation`, `currentLocation` (`greenhouse` vs `raisedBed`), and `isGreenhouseSeedling` flags so the model knows which plants are still in the greenhouse waiting to be transplanted.
  - A 1-based `positionLabel` per field plus a Croatian system-prompt explainer of the 3-column × up-to-6-row layout (1 = bottom-right, 18 = top-left), so recommendations referencing specific positions match what the user sees in the UI.

- **Batched bed-wide AI history fetch.** Opening a whole-bed operation history view previously fired one bed-diary request *plus one field-diary request per field position* through `useQueries` — N+1 fan-out on every open. Replaced with a single new endpoint `GET /:gardenId/raised-beds/:raisedBedId/ai-history` backed by `getRaisedBedAiHistoryEntries`, which loads only AI-analysis events for the bed aggregate + all field aggregates in one `getEvents` call. The new `useRaisedBedAiHistory` hook is invalidated by both `useRaisedBedAiAnalysis` and `useRaisedBedFieldAiAnalysis` on success, so freshly produced analyses still surface immediately.

Existing per-field/per-bed diary hooks remain (still used by the full diary timeline); only the AI-history matching path in `RaisedBedOperationHistoryList` was rewired.

## Test plan

- [ ] Open a raised bed's whole-bed history view and confirm only one `/ai-history` request fires (no per-field fan-out in the network panel).
- [ ] Open a single-field history view and confirm the same — one `/ai-history` request, no per-field diary call from this component.
- [ ] Run an AI analysis on an operation with images; verify the action button switches to "Pregledaj savjete suncokreta" without a manual refresh (cache invalidation works).
- [ ] Trigger a raised-bed AI analysis and inspect the request payload / model output to confirm `weather`, `currentDate`, `sowingLocation`, `currentLocation`, and `positionLabel` are present in the JSON context.
- [ ] Verify the recommendation text references field positions using the 1-based labels (e.g. "polje 1") rather than 0-based indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)