### PR TITLE
Match watering can water color to bucket

### DIFF
--- a/packages/game/src/entities/WateringCan.tsx
+++ b/packages/game/src/entities/WateringCan.tsx
@@ -128,14 +128,14 @@ export function WateringCan({ stack, block, rotation }: EntityInstanceProps) {
             })}
             <WateringCanPart node={nodes.WateringCan_Water}>
                 <MeshDistortMaterial
-                    color="#7cc7e8"
+                    color="#3598e7"
                     depthWrite={false}
-                    distort={0.04}
-                    metalness={0}
-                    opacity={0.68}
-                    roughness={0.18}
+                    distort={0.2}
+                    metalness={0.8}
+                    opacity={0.6}
+                    roughness={0.2}
                     side={DoubleSide}
-                    speed={1.4}
+                    speed={2}
                     transparent
                 />
             </WateringCanPart>


### PR DESCRIPTION
## Summary
- The watering can's water rendered as a pale cyan (`#7cc7e8`, low metalness, higher opacity) while the bucket used a deeper, more vibrant blue from its `Material.Water` (linear `[0.036, 0.313, 0.800]`, metalness 0.8, roughness 0.2, opacity 0.6).
- Updated `MeshDistortMaterial` props in [WateringCan.tsx](packages/game/src/entities/WateringCan.tsx:129) so the water surface matches the bucket's color (`#3598e7`), opacity, metalness, roughness, and animation parameters.

## Test plan
- [ ] Open a scene with both a bucket and a watering can in view and confirm the water in both reads as the same deep blue.
- [ ] Spot-check the watering can in the inventory/HUD/storybook previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)