### PR TITLE
fix(ui): normalize outlined button border to match input border

### DIFF
--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -97,9 +97,9 @@ const buttonColorClassNames = {
         neutral: 'bg-muted text-foreground hover:bg-muted/80',
     },
     outlined: {
-        primary: 'border-primary text-primary hover:bg-primary/10',
+        primary: 'text-primary hover:bg-primary/10',
         secondary:
-            'border-secondary text-secondary-foreground hover:bg-secondary/40',
+            'text-secondary-foreground hover:bg-secondary/40',
         danger: 'border-red-300 text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950',
         error: 'border-red-300 text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950',
         warning:


### PR DESCRIPTION
## What

Remove `border-primary` and `border-secondary` overrides from the `outlined` button color variants in the `Button` component.

## Why

The base `outlined` variant class already sets `border border-input`. The `primary` and `secondary` color overrides were clobbering it with `border-primary` / `border-secondary`, making outlined buttons appear with a colored border that didn't match the neutral gray border on `Input` components. This was most visible in composite inputs like `NumberInput` where buttons sit directly adjacent to an input field.

## Changes

- **`packages/ui/src/Button/Button.tsx`** — stripped `border-primary` from `outlined.primary` and `border-secondary` from `outlined.secondary`; text color and hover background are unchanged. Semantic colors (danger, warning, info, success) keep their own border colors since those are intentional visual signals.

## Reviewer notes

- No behaviour changes — purely visual.
- Semantic color variants (danger, warning, info, success) are unaffected.
- Any callsite that deliberately wanted a primary-colored border will need to add `className="border-primary"` explicitly, but no such usage exists in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)