### PR TITLE
fix(game): align garden box lid hover outline with body outline params

### DIFF
--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -81,7 +81,13 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                     material={materials['Material.Planks']}
                 >
-                    <HoverOutline hovered={hovered} variant="outlines" />
+                    <HoverOutline
+                        hovered={hovered || isLidOpen}
+                        variant="outlines"
+                        thickness={7}
+                        color="#f8fafc"
+                        backingColor="#0f172a"
+                    />
                 </mesh>
                 <SnowOverlay
                     geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}


### PR DESCRIPTION
## Problem

The garden box lid's `HoverOutline` was missing style props that the body uses, causing the hover effect to look broken/inconsistent:

- Body: `thickness={7}`, `color="#f8fafc"`, `backingColor="#0f172a"`
- Lid (before): only `variant="outlines"` — defaults of thickness=5, white color, no backing

This regression was introduced in fc0431ad ("Match garden box colors to raised bed wood") when the lid mesh was refactored to use a GLTF material prop instead of a `<meshStandardMaterial>` child, and the `HoverOutline` parameters were not carried over.

## Fix

- Match lid outline params to body: `thickness={7}`, `color="#f8fafc"`, `backingColor="#0f172a"`
- Also extend lid outline to trigger on `isLidOpen` (same as body) so both meshes highlight consistently during drag previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
