### PR TITLE
fix(game): shrink inventory tab list to content width and improve contrast

### DIFF
--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -664,7 +664,7 @@ export function InventoryHud() {
                         onValueChange={handleTabChange}
                         className="flex flex-col"
                     >
-                        <TabsList className="grid grid-cols-2 border">
+                        <TabsList className="self-start bg-muted-foreground/10">
                             <TabsTrigger value="backpack">
                                 <Row spacing={2} alignItems="center">
                                     <BackpackIcon className="size-4 shrink-0" />


### PR DESCRIPTION
## Summary
- The inventory backpack tab list (Ruksak / Kutije) was using `grid grid-cols-2`, which stretched it to fill the full modal width even though there are only two short triggers.
- Replaced with `self-start` on top of the Tabs default `inline-flex`, so the list now sizes to its content.
- The active tab indicator (`bg-background`, white) had very little contrast against the default `bg-muted/80` tab list. Added `bg-muted-foreground/10` on this instance to darken the tab list slightly so the active button reads more clearly.

Change is scoped to `packages/game/src/hud/InventoryHud.tsx` — global `Tabs` defaults are untouched.

## Test plan
- [ ] Open the inventory modal in the garden game; confirm the Ruksak / Kutije tab list hugs its triggers instead of stretching across the modal.
- [ ] Confirm the active tab indicator is visibly lighter than the surrounding tab list background in both light and dark themes.
- [ ] Switch between Ruksak and Kutije; ensure the indicator animates to the active tab as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)