### PR TITLE
ci(desktop): add macOS release workflow for apps/app

### DIFF
--- a/.github/workflows/desktop-release-app.yml
+++ b/.github/workflows/desktop-release-app.yml
@@ -1,0 +1,159 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: "Release - Desktop (app)"
+
+on:
+  push:
+    tags:
+      - "desktop-app-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 1.2.3). Defaults to the tag suffix when triggered by a tag."
+        required: false
+        type: string
+      prerelease:
+        description: "Mark the GitHub release as a pre-release."
+        required: false
+        type: boolean
+        default: false
+      draft:
+        description: "Create the GitHub release as a draft."
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: "Build macOS DMG"
+    runs-on: macos-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x64]
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: 🏷️ Resolve release version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
+          else
+            VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          echo "Resolved version: ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v6.0.4
+        name: ✨ Install pnpm
+
+      - name: ✨ Setup Node
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24.15.0"
+
+      - name: ✨ Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v5.0.5
+        name: ✨ Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - uses: actions/cache@v5.0.5
+        name: ✨ Setup electron-builder cache
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-${{ hashFiles('apps/desktop/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+
+      - name: 📦️ Install dependencies
+        run: pnpm install --frozen-lockfile --filter desktop... --filter .
+
+      - name: 🛠️ Build Gredice Admin desktop DMG (${{ matrix.arch }})
+        env:
+          GREDICE_DESKTOP_VERSION: ${{ steps.version.outputs.version }}
+          # electron-builder publishing is disabled in the config; the workflow
+          # uploads artifacts to the GitHub release in a later step.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        working-directory: apps/desktop
+        run: pnpm dist:app --mac --${{ matrix.arch }}
+
+      - name: 📤 Upload DMG artifact
+        uses: actions/upload-artifact@v5.0.0
+        with:
+          name: gredice-admin-desktop-${{ matrix.arch }}
+          path: |
+            apps/desktop/dist/app/*.dmg
+            apps/desktop/dist/app/*.dmg.blockmap
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    name: "Publish GitHub Release"
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 🏷️ Resolve release version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
+          else
+            VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          TAG="desktop-app-v${VERSION}"
+          echo "Resolved version: ${VERSION}"
+          echo "Resolved tag: ${TAG}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: 📥 Download DMG artifacts
+        uses: actions/download-artifact@v6.0.0
+        with:
+          path: release-artifacts
+          pattern: gredice-admin-desktop-*
+          merge-multiple: true
+
+      - name: 📜 List artifacts
+        shell: bash
+        run: ls -lR release-artifacts
+
+      - name: 🚀 Create or update GitHub release
+        uses: softprops/action-gh-release@v2.2.2
+        with:
+          name: "Gredice Admin Desktop ${{ steps.version.outputs.version }}"
+          tag_name: ${{ steps.version.outputs.tag }}
+          draft: ${{ github.event_name == 'workflow_dispatch' && inputs.draft || false }}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            release-artifacts/*.dmg
+            release-artifacts/*.dmg.blockmap

--- a/.github/workflows/desktop-release-app.yml
+++ b/.github/workflows/desktop-release-app.yml
@@ -31,8 +31,42 @@ permissions:
   contents: write
 
 jobs:
+  resolve_version:
+    name: "Resolve release version"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: 🏷️ Resolve release version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${DISPATCH_VERSION}" ]; then
+            VERSION="${DISPATCH_VERSION}"
+          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Single timestamp shared across all downstream jobs so the DMG
+            # filenames, package version, tag, and release name agree.
+            VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
+          else
+            echo "::error::Unable to resolve release version. Trigger this workflow with a desktop-app-v* tag or provide a workflow_dispatch version input." >&2
+            exit 1
+          fi
+          TAG="desktop-app-v${VERSION}"
+          echo "Resolved version: ${VERSION}"
+          echo "Resolved tag: ${TAG}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
   build:
     name: "Build macOS DMG"
+    needs: resolve_version
     runs-on: macos-latest
     timeout-minutes: 45
     strategy:
@@ -43,20 +77,6 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
-
-      - name: 🏷️ Resolve release version
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
-          else
-            VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
-          fi
-          echo "Resolved version: ${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v6.0.4
         name: ✨ Install pnpm
@@ -94,7 +114,7 @@ jobs:
 
       - name: 🛠️ Build Gredice Admin desktop DMG (${{ matrix.arch }})
         env:
-          GREDICE_DESKTOP_VERSION: ${{ steps.version.outputs.version }}
+          GREDICE_DESKTOP_VERSION: ${{ needs.resolve_version.outputs.version }}
           # electron-builder publishing is disabled in the config; the workflow
           # uploads artifacts to the GitHub release in a later step.
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
@@ -113,27 +133,10 @@ jobs:
 
   release:
     name: "Publish GitHub Release"
-    needs: build
+    needs: [resolve_version, build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: 🏷️ Resolve release version
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
-          else
-            VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
-          fi
-          TAG="desktop-app-v${VERSION}"
-          echo "Resolved version: ${VERSION}"
-          echo "Resolved tag: ${TAG}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
       - name: 📥 Download DMG artifacts
         uses: actions/download-artifact@v6.0.0
         with:
@@ -148,8 +151,8 @@ jobs:
       - name: 🚀 Create or update GitHub release
         uses: softprops/action-gh-release@v2.2.2
         with:
-          name: "Gredice Admin Desktop ${{ steps.version.outputs.version }}"
-          tag_name: ${{ steps.version.outputs.tag }}
+          name: "Gredice Admin Desktop ${{ needs.resolve_version.outputs.version }}"
+          tag_name: ${{ needs.resolve_version.outputs.tag }}
           draft: ${{ github.event_name == 'workflow_dispatch' && inputs.draft || false }}
           prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
           generate_release_notes: true

--- a/apps/desktop/scripts/package-desktop-app.mjs
+++ b/apps/desktop/scripts/package-desktop-app.mjs
@@ -181,6 +181,27 @@ async function writeBuilderConfig(stageDir, desktopApp, electronVersion) {
             icon: 'icon.png',
             target: ['dmg', 'zip'],
         },
+        dmg: {
+            icon: 'icon.png',
+            iconSize: 100,
+            window: {
+                width: 540,
+                height: 380,
+            },
+            contents: [
+                {
+                    x: 140,
+                    y: 220,
+                    type: 'file',
+                },
+                {
+                    x: 400,
+                    y: 220,
+                    type: 'link',
+                    path: '/Applications',
+                },
+            ],
+        },
         nsis: {
             allowToChangeInstallationDirectory: true,
             installerIcon: 'favicon.ico',


### PR DESCRIPTION
## Summary
- New `.github/workflows/desktop-release-app.yml` builds the `apps/app` desktop shell (Gredice Admin) on `macos-latest` for both `arm64` and `x64`, then publishes the resulting `.dmg` files to a GitHub Release.
- Made the electron-builder DMG layout explicit so the installer opens a Finder window with the app icon on the left and the `/Applications` symlink on the right — the standard drag-to-Applications experience.

## What changed
- **`.github/workflows/desktop-release-app.yml`** — release pipeline triggered by `desktop-app-v*` tag pushes or manual `workflow_dispatch` (with `version`, `prerelease`, `draft` inputs).
  - Matrix job over `[arm64, x64]` on `macos-latest`.
  - Resolves the release version from the tag suffix or the dispatch input and threads it through `GREDICE_DESKTOP_VERSION` so the existing `apps/desktop/scripts/package-desktop-app.mjs` stamps the version into the staged `package.json`.
  - Caches pnpm store and electron / electron-builder caches.
  - Runs `pnpm dist:app --mac --<arch>` and uploads `.dmg` + `.dmg.blockmap` as artifacts.
  - Follow-up `ubuntu-latest` job downloads all artifacts and creates / updates the release via `softprops/action-gh-release` with auto-generated notes.
- **`apps/desktop/scripts/package-desktop-app.mjs`** — added a `dmg` block to the generated electron-builder config (icon at 140,220, `/Applications` link at 400,220, 540×380 window). Default electron-builder DMG background includes the directional arrow between them.

## Why
There was no release path for the desktop builds yet — `apps/desktop` already wraps `apps/app` as an Electron app and had `dist:app` wired up, but nothing automated cutting a Mac DMG for it. This adds the missing workflow without changing how local builds work.

## Notes for reviewers
- **Code signing is intentionally off** (`CSC_IDENTITY_AUTO_DISCOVERY=false`). First-run users on macOS will see a Gatekeeper warning. To enable signing later, drop that env var and provision `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `CSC_LINK`, `CSC_KEY_PASSWORD` secrets.
- Versioning is tag-driven (`desktop-app-v1.2.3`) or dispatch-input-driven; the package version stays at `0.0.0` in the repo.
- Action versions match what is already used elsewhere in the repo (`actions/checkout@v6.0.2`, `actions/cache@v5.0.5`, `actions/upload-artifact@v5.0.0`, `actions/download-artifact@v6.0.0`, `actions/setup-node@v6.4.0`, `pnpm/action-setup@v6.0.4`). New addition: `softprops/action-gh-release@v2.2.2`.
- If you want a branded DMG background later, drop a ~540×380 `background.png` into `apps/desktop/electron/`, copy it alongside `icon.png` in `copyDesktopShellFiles`, and add `background: 'background.png'` to the `dmg` config.

## Test plan
- [ ] Trigger the workflow manually from the Actions tab with a test version (e.g. `0.1.0-test`) and `draft: true`.
- [ ] Verify both `arm64` and `x64` DMGs build and upload as artifacts.
- [ ] Verify the draft GitHub Release contains both `.dmg` files.
- [ ] Download a DMG on a Mac, double-click, and confirm the Finder window shows the app icon and the Applications shortcut so the user can drag to install.
- [ ] Once happy, push tag `desktop-app-v0.1.0` and confirm the published (non-draft) release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)