### PR TITLE
Stabilize scrollbar-edge measurements in HUD tests

### DIFF
--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -142,17 +142,20 @@ test.describe('Garden operations HUD', () => {
         await expect(topFade).toHaveAttribute('data-visible', 'false');
         await expect(bottomFade).toHaveAttribute('data-visible', 'true');
 
-        const dialogBox = await dialog.boundingBox();
-        const viewportBox = await viewport.boundingBox();
-        expect(dialogBox).not.toBeNull();
-        expect(viewportBox).not.toBeNull();
-        expect(
-            Math.abs(
-                (viewportBox?.x ?? 0) +
-                    (viewportBox?.width ?? 0) -
-                    ((dialogBox?.x ?? 0) + (dialogBox?.width ?? 0)),
-            ),
-        ).toBeLessThanOrEqual(2);
+        await expect
+            .poll(async () => {
+                const dialogBox = await dialog.boundingBox();
+                const viewportBox = await viewport.boundingBox();
+                if (!dialogBox || !viewportBox) {
+                    return Number.POSITIVE_INFINITY;
+                }
+                return Math.abs(
+                    viewportBox.x +
+                        viewportBox.width -
+                        (dialogBox.x + dialogBox.width),
+                );
+            })
+            .toBeLessThanOrEqual(2);
 
         const cards = dialog.locator('[data-garden-operation-card]');
         await expect(cards.nth(10)).toBeVisible();

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -858,17 +858,20 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(topFade).toHaveAttribute('data-visible', 'false');
         await expect(bottomFade).toHaveAttribute('data-visible', 'true');
 
-        const dialogBox = await dialog.boundingBox();
-        const viewportBox = await viewport.boundingBox();
-        expect(dialogBox).not.toBeNull();
-        expect(viewportBox).not.toBeNull();
-        expect(
-            Math.abs(
-                (viewportBox?.x ?? 0) +
-                    (viewportBox?.width ?? 0) -
-                    ((dialogBox?.x ?? 0) + (dialogBox?.width ?? 0)),
-            ),
-        ).toBeLessThanOrEqual(2);
+        await expect
+            .poll(async () => {
+                const dialogBox = await dialog.boundingBox();
+                const viewportBox = await viewport.boundingBox();
+                if (!dialogBox || !viewportBox) {
+                    return Number.POSITIVE_INFINITY;
+                }
+                return Math.abs(
+                    viewportBox.x +
+                        viewportBox.width -
+                        (dialogBox.x + dialogBox.width),
+                );
+            })
+            .toBeLessThanOrEqual(2);
 
         await viewport.evaluate((element) => {
             element.scrollTop = 120;


### PR DESCRIPTION
## Summary

Two Playwright tests added in commit 9e6aabba were flaky in CI (also reproduces locally — 5/10 failures):

- [`raised-bed-field-hud.spec.tsx:840`](apps/garden/tests/raised-bed-field-hud.spec.tsx) — "raised bed diary scroll view uses modal edge scrollbar and overflow fades"
- [`garden-operations-hud.spec.tsx:125`](apps/garden/tests/garden-operations-hud.spec.tsx) — "keeps history operation cards full height in scrollable modal"

Both tests captured `dialog.boundingBox()` and `viewport.boundingBox()` right after the dialog became visible, then asserted the gap between right edges was ≤2px. But the Radix `DialogPrimitive.Content` runs a 200ms open animation (`zoom-in-95`, `slide-in-from-…`, `fade-in-0`), so the one-shot snapshot landed on whatever frame happened to be current. CI saw gaps of 7px / 10px / 29px / 43px on different attempts.

Fix: replace the one-shot measurement with `expect.poll(...)` so Playwright retries the bounding-box computation until the animation settles within tolerance.

## Test plan

- [x] `playwright test … raised-bed-field-hud … "raised bed diary scroll view…"` — 10/10 passes locally (was 5/10 before)
- [x] `playwright test … garden-operations-hud … "keeps history operation cards…"` — 10/10 passes locally
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)