### PR TITLE
ci: enable Turborepo remote cache via Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  TURBO_TEAM: gredice
+
 jobs:
   changes:
     name: "Detect changes"

--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -21,6 +21,8 @@ on:
 env:
   VERCEL_PROJECT_ID: ${{ secrets[format(inputs.vercelProjectIdSecretName)] }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  TURBO_TEAM: gredice
 
 jobs:
   lint:

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -160,6 +160,15 @@ pnpm env:pull
 
 `pnpm env:pull` runs `vercel env pull .env` in `apps/www`, `apps/garden`, `apps/farm`, `apps/app`, `apps/storybook`, `apps/api`, and `apps/status`.
 
+### Turborepo remote cache
+
+Turbo build/test results are cached remotely through Vercel for the `gredice` team, which speeds up cold builds locally and in CI.
+
+- Local and worktrees: `pnpm bootstrap` runs `pnpm turbo link --yes --scope=gredice`, which writes `.turbo/config.json` for the current worktree. The link relies on Vercel CLI auth, so run `vercel login` first if it has not been done on the machine. Each linked worktree gets its own `.turbo/config.json` (the `.turbo` directory is gitignored).
+- CI: the `TURBO_TOKEN` (set to `VERCEL_TOKEN`) and `TURBO_TEAM=gredice` environment variables are wired in `.github/workflows/ci.yml` and `.github/workflows/nextjs_ci_reusable.yml`. No per-repo link file is needed.
+
+`pnpm doctor` reports the link status under the optional "Turbo remote cache" check.
+
 ### Public page revalidation
 
 `apps/app` triggers public `apps/www` ISR revalidation after admin changes to directory plants, plant sorts, and operations. Configure the same `GREDICE_WWW_REVALIDATE_SECRET` in both apps. In production the admin app calls `https://www.gredice.com/api/revalidate/directories`; for preview or custom environments, set `GREDICE_WWW_REVALIDATE_URL` in `apps/app` to the target `www` deployment URL.

--- a/scripts/worktree-health.mjs
+++ b/scripts/worktree-health.mjs
@@ -140,6 +140,26 @@ function checkVercelLinks() {
   addCheck('Vercel project links', true, missing.length === 0, missing.length === 0 ? 'All apps linked.' : `Missing links: ${missing.map((m) => m.name).join(', ')}.`, 'Run `pnpm vercel:link`.');
 }
 
+function checkTurboRemoteCache() {
+  const configPath = resolve(rootDir, '.turbo', 'config.json');
+  let ok = existsSync(configPath);
+  let detail = ok ? `Turbo remote cache linked at ${configPath}.` : 'Turbo remote cache config not found.';
+  if (ok) {
+    try {
+      const config = JSON.parse(readFileSync(configPath, 'utf8'));
+      const slug = typeof config?.teamSlug === 'string' ? config.teamSlug : '';
+      if (slug && slug !== 'gredice') {
+        ok = false;
+        detail = `Turbo remote cache linked to "${slug}"; expected "gredice".`;
+      }
+    } catch (error) {
+      ok = false;
+      detail = `Could not parse ${configPath}: ${error instanceof Error ? error.message : String(error)}.`;
+    }
+  }
+  addCheck('Turbo remote cache', false, ok, detail, 'Run `pnpm bootstrap` (or `pnpm turbo link --yes --scope=gredice`) after `vercel login`.');
+}
+
 function checkEnvFiles() {
   const missing = appRegistry.filter((app) => !existsSync(resolve(rootDir, app.packagePath, '.env')));
   addCheck('App env files', true, missing.length === 0, missing.length === 0 ? 'All app .env files present.' : `Missing .env in: ${missing.map((m) => m.name).join(', ')}.`, 'Run `pnpm env:pull`.');
@@ -359,6 +379,14 @@ async function maybeRunSetupActions() {
   if (failure) {
     process.exit(failure.code || 1);
   }
+
+  const turboChain = [
+    { label: 'Linking Turbo remote cache to "gredice"', cmd: 'pnpm', args: ['turbo', 'link', '--yes', '--scope=gredice'] },
+  ];
+  const turboResult = await runChain('turbo', turboChain);
+  if (turboResult) {
+    process.exit(turboResult.code || 1);
+  }
 }
 
 function printResults() {
@@ -388,6 +416,7 @@ async function runChecks() {
   checkDocker();
   checkVercelAuth();
   checkVercelLinks();
+  checkTurboRemoteCache();
   checkEnvFiles();
   checkPlaywright();
   checkHosts();


### PR DESCRIPTION
## Summary

- Wires Turborepo's Vercel-hosted remote cache (team `gredice`) into CI workflows and the local bootstrap so build/test/lint outputs are reused across runs and developer machines.
- CI gets the cache via `TURBO_TOKEN` (reusing `VERCEL_TOKEN`) and `TURBO_TEAM=gredice` at the workflow `env:` level — applies to both `ci.yml` and the reusable `nextjs_ci_reusable.yml`.
- Local/worktree gets the cache via `pnpm bootstrap`, which now runs `pnpm turbo link --yes --scope=gredice` after the install + Vercel chains complete, producing a per-worktree `.turbo/config.json` (already gitignored).

## Why

Cold CI builds and worktree bootstraps were rebuilding everything from scratch. With the cache enabled, repeated CI runs on the same inputs and local builds across worktrees can short-circuit through Vercel's remote cache for the `gredice` team. Reference: https://vercel.com/docs/monorepos/remote-caching

## Notes for reviewers

- `pnpm turbo link` needs Vercel CLI auth (`vercel login`) — the same prerequisite as the existing `pnpm vercel:link` and `pnpm env:pull` steps. The link step runs after both parallel chains succeed, so node_modules is present and Vercel auth has been exercised before we hit it.
- Each worktree has its own `.turbo/config.json` (the `.turbo` directory is gitignored), so the link must be rerun per worktree via `pnpm bootstrap`.
- `pnpm doctor` now reports an optional "Turbo remote cache" check that flags an unlinked or wrong-team config.
- WORKSPACE.md documents both the local and CI paths.

## Test plan

- [ ] CI run on this PR shows `TURBO_TOKEN`/`TURBO_TEAM` flowing through (no auth errors in turbo invocations) and reports cache writes/hits in the turbo summary.
- [ ] `pnpm bootstrap` on a fresh worktree (with `vercel login` already done) creates `.turbo/config.json` with `teamSlug: "gredice"`.
- [ ] `pnpm doctor` shows the new "Turbo remote cache" check as ✅ after bootstrap, and ⚠️ when `.turbo/config.json` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)