### PR TITLE
Filter deleted stacks from getGarden response

### DIFF
--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1042,7 +1042,9 @@ export async function getGarden(gardenId: number) {
             where: and(eq(gardens.id, gardenId), eq(gardens.isDeleted, false)),
             with: {
                 farm: true,
-                stacks: true,
+                stacks: {
+                    where: eq(gardenStacks.isDeleted, false),
+                },
             },
         }),
         getRaisedBeds(gardenId),

--- a/packages/storage/tests/gardensRepo.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.node.spec.ts
@@ -229,6 +229,22 @@ test('deleteGardenStack marks stack as deleted', async () => {
     assert.strictEqual(stack, null);
 });
 
+test('getGarden excludes deleted stacks', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    await createGardenStack(gardenId, { x: 1, y: 1 });
+    await createGardenStack(gardenId, { x: 2, y: 2 });
+    await deleteGardenStack(gardenId, { x: 1, y: 1 });
+
+    const garden = await getGarden(gardenId);
+    assert.ok(garden);
+    assert.strictEqual(garden.stacks.length, 1);
+    assert.strictEqual(garden.stacks[0].positionX, 2);
+    assert.strictEqual(garden.stacks[0].positionY, 2);
+});
+
 // Edge cases
 
 test('getGarden returns null for non-existent garden', async () => {


### PR DESCRIPTION
## Summary
- `getGarden` loaded `garden.stacks` via Drizzle's `with: { stacks: true }` relation with no `isDeleted` predicate, so soft-deleted stacks leaked into every API payload that returned a garden.
- Clients then rendered those ghost positions and could issue `move` ops against them. The server's `getGardenStack` filters `isDeleted = false`, so the lookup returned null and the PATCH handler responded with `Stack /<x>/<y>/<i> not found`.
- Fixed by adding `where: eq(gardenStacks.isDeleted, false)` to the relation query so reads and writes see the same stack set.

## Test plan
- [x] `pnpm --filter @gredice/storage test:node gardensRepo.node.spec.ts` — added `getGarden excludes deleted stacks` covering soft-deleted rows; all 24 tests pass.
- [x] `pnpm --filter @gredice/storage test:node gardensRepo.raisedBedFields.node.spec.ts` passes.
- [ ] Manual: in a garden with a soft-deleted stack, moving a block no longer returns `Stack not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)