### PR TITLE
Tint water to match sky color

### DIFF
--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -2,7 +2,9 @@ import { animated } from '@react-spring/three';
 import { useFrame } from '@react-three/fiber';
 import { useEffect, useMemo } from 'react';
 import { Color, DoubleSide, ShaderMaterial, type Vector4 } from 'three';
+import { defaultWaterColors } from '../scene/waterColors';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import { useGameState } from '../useGameState';
 import { useStackHeight } from '../utils/getStackHeight';
 import { useGameGLTF } from '../utils/useGameGLTF';
 import { resolveWaterFoamEdges } from './waterBlockFoam';
@@ -119,6 +121,7 @@ void main() {
 `;
 
 function useWaterBlockMaterial(foamEdges: Vector4) {
+    const waterColors = useGameState((state) => state.waterColors);
     const material = useMemo(() => {
         const waterMaterial = new ShaderMaterial({
             vertexShader: waterVertexShader,
@@ -129,9 +132,11 @@ function useWaterBlockMaterial(foamEdges: Vector4) {
             side: DoubleSide,
             uniforms: {
                 uTime: { value: 0 },
-                uDeepColor: { value: new Color('#8fcfc4') },
-                uShallowColor: { value: new Color('#d6eee3') },
-                uFoamColor: { value: new Color('#f8fff8') },
+                uDeepColor: { value: new Color(defaultWaterColors.deep) },
+                uShallowColor: {
+                    value: new Color(defaultWaterColors.shallow),
+                },
+                uFoamColor: { value: new Color(defaultWaterColors.foam) },
                 uFoamEdges: { value: foamEdges.clone() },
             },
         });
@@ -144,6 +149,12 @@ function useWaterBlockMaterial(foamEdges: Vector4) {
     useEffect(() => {
         material.uniforms.uFoamEdges.value.copy(foamEdges);
     }, [foamEdges, material]);
+
+    useEffect(() => {
+        material.uniforms.uDeepColor.value.set(waterColors.deep);
+        material.uniforms.uShallowColor.value.set(waterColors.shallow);
+        material.uniforms.uFoamColor.value.set(waterColors.foam);
+    }, [material, waterColors.deep, waterColors.foam, waterColors.shallow]);
 
     useEffect(() => () => material.dispose(), [material]);
 

--- a/packages/game/src/entities/WaterWell.tsx
+++ b/packages/game/src/entities/WaterWell.tsx
@@ -7,6 +7,7 @@ import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import { snowPresets } from '../snow/snowPresets';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import { useGameState } from '../useGameState';
 import { useStackHeight } from '../utils/getStackHeight';
 import { useGameGLTF } from '../utils/useGameGLTF';
 import { useAnimatedEntityRotation } from './helpers/useAnimatedEntityRotation';
@@ -53,6 +54,7 @@ export function WaterWell({ stack, block, rotation }: EntityInstanceProps) {
     const { nodes } = useGameGLTF('WaterWell');
     const [animatedRotation] = useAnimatedEntityRotation(rotation);
     const currentStackHeight = useStackHeight(stack, block);
+    const waterColor = useGameState((state) => state.waterColors.shallow);
 
     return (
         <animated.group
@@ -108,7 +110,7 @@ export function WaterWell({ stack, block, rotation }: EntityInstanceProps) {
                 scale={nodes.WaterWell_Water.scale}
             >
                 <MeshDistortMaterial
-                    color="#3598e7"
+                    color={waterColor}
                     depthWrite={false}
                     distort={0.14}
                     metalness={0.6}

--- a/packages/game/src/entities/WateringCan.tsx
+++ b/packages/game/src/entities/WateringCan.tsx
@@ -7,6 +7,7 @@ import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import { snowPresets } from '../snow/snowPresets';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import { useGameState } from '../useGameState';
 import { useStackHeight } from '../utils/getStackHeight';
 import { useGameGLTF } from '../utils/useGameGLTF';
 import { useAnimatedEntityRotation } from './helpers/useAnimatedEntityRotation';
@@ -67,6 +68,7 @@ export function WateringCan({ stack, block, rotation }: EntityInstanceProps) {
     const { nodes } = useGameGLTF('WateringCan');
     const [animatedRotation] = useAnimatedEntityRotation(rotation);
     const currentStackHeight = useStackHeight(stack, block);
+    const waterColor = useGameState((state) => state.waterColors.shallow);
 
     return (
         <animated.group
@@ -128,7 +130,7 @@ export function WateringCan({ stack, block, rotation }: EntityInstanceProps) {
             })}
             <WateringCanPart node={nodes.WateringCan_Water}>
                 <MeshDistortMaterial
-                    color="#3598e7"
+                    color={waterColor}
                     depthWrite={false}
                     distort={0.2}
                     metalness={0.8}

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -20,6 +20,7 @@ import { Drops } from './Rain/Drops';
 import Snow from './Snow/Snow';
 import { Stars } from './Stars';
 import { SunMoon } from './SunMoon';
+import { resolveWaterColors } from './waterColors';
 
 const backgroundColorScale = chroma
     .scale([
@@ -369,6 +370,12 @@ function useEnvironmentElements({
         ); // * (weather.cloudy > 0.9 ? 0.8 : (weather.cloudy > 0.4 ? 0.9 : 0.95)));
     }
 
+    const waterColors = resolveWaterColors({
+        skyColor: backgroundColor.current,
+        timeOfDay,
+        weather: weather ?? undefined,
+    });
+
     const hemisphereColor = useRef<Color>(new Color());
     hemisphereColor.current.setRGB(
         (hemisphereSkyColor[0] / 255) * -0,
@@ -402,6 +409,7 @@ function useEnvironmentElements({
             position: directionalLightPosition,
             intensity: directionalLightIntensity,
         },
+        waterColors,
     };
 }
 
@@ -415,13 +423,25 @@ export function StaticEnvironment({
     const qualityProfile = quality ?? resolveGameQualityProfile();
     const currentTime = useSnapshotTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
-    const { background, ambient, hemisphere, directionalLight } =
+    const setWaterColors = useGameState((state) => state.setWaterColors);
+    const { background, ambient, hemisphere, directionalLight, waterColors } =
         useEnvironmentElements({
             location: defaultLocation,
             currentTime,
             timeOfDay,
             weather: undefined,
         });
+    const waterDeep = waterColors.deep;
+    const waterFoam = waterColors.foam;
+    const waterShallow = waterColors.shallow;
+
+    useEffect(() => {
+        setWaterColors({
+            deep: waterDeep,
+            foam: waterFoam,
+            shallow: waterShallow,
+        });
+    }, [setWaterColors, waterDeep, waterFoam, waterShallow]);
 
     return (
         <>
@@ -477,6 +497,7 @@ export function Environment({
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const ambientAudioMixer = useGameState((state) => state.audio.ambient);
     const setSnowCoverage = useGameState((state) => state.setSnowCoverage);
+    const setWaterColors = useGameState((state) => state.setWaterColors);
     const weatherVisualizationDisabled = useGameState(
         (state) => state.weatherVisualizationDisabled,
     );
@@ -647,13 +668,24 @@ export function Environment({
         blendConfig,
     );
 
-    const { background, ambient, hemisphere, directionalLight } =
+    const { background, ambient, hemisphere, directionalLight, waterColors } =
         useEnvironmentElements({
             location,
             currentTime,
             timeOfDay,
             weather: blendedWeather,
         });
+    const waterDeep = waterColors.deep;
+    const waterFoam = waterColors.foam;
+    const waterShallow = waterColors.shallow;
+
+    useEffect(() => {
+        setWaterColors({
+            deep: waterDeep,
+            foam: waterFoam,
+            shallow: waterShallow,
+        });
+    }, [setWaterColors, waterDeep, waterFoam, waterShallow]);
 
     // Handle fog
     const fog = blendedWeather?.foggy ?? 0;

--- a/packages/game/src/scene/waterColors.ts
+++ b/packages/game/src/scene/waterColors.ts
@@ -1,0 +1,92 @@
+import { Color } from 'three';
+import { getNightAmount } from './moonlight';
+
+export type WaterEnvironmentWeather = {
+    cloudy?: number;
+    foggy?: number;
+    rainy?: number;
+    snowy?: number;
+};
+
+export type WaterColors = {
+    deep: string;
+    shallow: string;
+    foam: string;
+};
+
+export const defaultWaterColors: WaterColors = {
+    deep: '#8fcfc4',
+    shallow: '#d6eee3',
+    foam: '#f8fff8',
+};
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function smoothstep(edge0: number, edge1: number, value: number) {
+    const t = clamp01((value - edge0) / (edge1 - edge0));
+    return t * t * (3 - 2 * t);
+}
+
+function twilightAmount(timeOfDay: number) {
+    const sunrise = 1 - smoothstep(0.025, 0.07, Math.abs(timeOfDay - 0.235));
+    const sunset = 1 - smoothstep(0.015, 0.065, Math.abs(timeOfDay - 0.765));
+    return Math.max(sunrise, sunset);
+}
+
+function weatherReflectionAmount(weather: WaterEnvironmentWeather | undefined) {
+    if (!weather) {
+        return 0;
+    }
+
+    return clamp01(
+        (weather.cloudy ?? 0) * 0.75 +
+            (weather.foggy ?? 0) * 0.65 +
+            (weather.rainy ?? 0) * 0.25 +
+            (weather.snowy ?? 0) * 0.35,
+    );
+}
+
+function toHex(color: Color) {
+    return `#${color.getHexString()}`;
+}
+
+function mixColor(from: string, to: Color, amount: number) {
+    return new Color(from).lerp(to, clamp01(amount));
+}
+
+export function resolveWaterColors({
+    skyColor,
+    timeOfDay,
+    weather,
+}: {
+    skyColor: Color;
+    timeOfDay: number;
+    weather?: WaterEnvironmentWeather;
+}): WaterColors {
+    const night = getNightAmount(timeOfDay);
+    const twilight = twilightAmount(timeOfDay);
+    const weatherReflection = weatherReflectionAmount(weather);
+    const skyInfluence = clamp01(
+        0.14 + night * 0.58 + twilight * 0.24 + weatherReflection * 0.34,
+    );
+
+    return {
+        deep: toHex(mixColor(defaultWaterColors.deep, skyColor, skyInfluence)),
+        shallow: toHex(
+            mixColor(
+                defaultWaterColors.shallow,
+                skyColor,
+                skyInfluence * 0.82 + night * 0.12,
+            ),
+        ),
+        foam: toHex(
+            mixColor(
+                defaultWaterColors.foam,
+                skyColor,
+                skyInfluence * 0.72 + night * 0.1 + weatherReflection * 0.1,
+            ),
+        ),
+    };
+}

--- a/packages/game/src/scene/waterColors.unit.ts
+++ b/packages/game/src/scene/waterColors.unit.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Color } from 'three';
+import { resolveWaterColors } from './waterColors';
+
+const clearWeather = {
+    cloudy: 0,
+    foggy: 0,
+    rainy: 0,
+    snowy: 0,
+};
+
+function brightness(hex: string) {
+    const color = new Color(hex);
+    return color.r + color.g + color.b;
+}
+
+function red(hex: string) {
+    return new Color(hex).r;
+}
+
+function blue(hex: string) {
+    return new Color(hex).b;
+}
+
+function colorDistance(hex: string, target: Color) {
+    const color = new Color(hex);
+    return Math.hypot(
+        color.r - target.r,
+        color.g - target.g,
+        color.b - target.b,
+    );
+}
+
+test('darkens water with the night sky', () => {
+    const day = resolveWaterColors({
+        skyColor: new Color('#e7e2cc'),
+        timeOfDay: 0.5,
+        weather: clearWeather,
+    });
+    const night = resolveWaterColors({
+        skyColor: new Color('#2d3947'),
+        timeOfDay: 0.97,
+        weather: clearWeather,
+    });
+
+    assert.ok(brightness(night.shallow) < brightness(day.shallow) * 0.7);
+    assert.ok(brightness(night.foam) < brightness(day.foam) * 0.8);
+});
+
+test('leans water toward warm twilight sky colors', () => {
+    const day = resolveWaterColors({
+        skyColor: new Color('#e7e2cc'),
+        timeOfDay: 0.5,
+        weather: clearWeather,
+    });
+    const sunset = resolveWaterColors({
+        skyColor: new Color('#f8b195'),
+        timeOfDay: 0.765,
+        weather: clearWeather,
+    });
+
+    assert.ok(red(sunset.deep) > red(day.deep));
+    assert.ok(blue(sunset.deep) < blue(day.deep));
+});
+
+test('pulls water toward gray overcast sky colors', () => {
+    const overcastSky = new Color('#8a8f95');
+    const clear = resolveWaterColors({
+        skyColor: new Color('#e7e2cc'),
+        timeOfDay: 0.5,
+        weather: clearWeather,
+    });
+    const overcast = resolveWaterColors({
+        skyColor: overcastSky,
+        timeOfDay: 0.5,
+        weather: {
+            cloudy: 1,
+            foggy: 0.4,
+            rainy: 0,
+            snowy: 0,
+        },
+    });
+
+    assert.ok(
+        colorDistance(overcast.shallow, overcastSky) <
+            colorDistance(clear.shallow, overcastSky),
+    );
+});

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -11,6 +11,7 @@ import {
     setGameQualityCustomProfile as persistGameQualityCustomProfile,
     setGameQualitySetting as persistGameQualitySetting,
 } from './scene/gameQuality';
+import { defaultWaterColors, type WaterColors } from './scene/waterColors';
 import type { Block } from './types/Block';
 import { getAudioConfig } from './utils/audioConfig';
 import {
@@ -190,6 +191,8 @@ export type GameState = {
     // Environment derived state
     snowCoverage: number;
     setSnowCoverage: (snowCoverage: number) => void;
+    waterColors: WaterColors;
+    setWaterColors: (waterColors: WaterColors) => void;
 
     // World
     orbitControls: OrbitControls | null;
@@ -365,6 +368,15 @@ export function createGameState({
         setWeather: (weather) => set({ weather }),
         snowCoverage: 0,
         setSnowCoverage: (snowCoverage) => set({ snowCoverage }),
+        waterColors: defaultWaterColors,
+        setWaterColors: (waterColors) =>
+            set((state) =>
+                state.waterColors.deep === waterColors.deep &&
+                state.waterColors.shallow === waterColors.shallow &&
+                state.waterColors.foam === waterColors.foam
+                    ? state
+                    : { waterColors },
+            ),
     }));
 }
 


### PR DESCRIPTION
## Summary
- derive water colors from the environment sky color across day, night, twilight, and weather
- apply the shared water color state to water blocks, wells, and watering cans
- add unit coverage for night, twilight, and overcast water color behavior

## Validation
- pnpm --filter @gredice/game lint
- pnpm --filter @gredice/game test
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden lint
- pnpm --filter garden build
- pnpm --filter www lint
- pnpm --filter www build