### PR TITLE
Make item picker scroll on short viewports

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import { ItemsHudAlignmentStory } from './ItemsHudStory';
 
 const TABLET_VIEWPORT = { width: 820, height: 1180 };
+const SHORT_MOBILE_VIEWPORT = { width: 414, height: 600 };
 
 test('edit mode item picker stays centered on tablet layouts', async ({
     mount,
@@ -72,4 +73,36 @@ test('item details place button keeps the soft color treatment', async ({
 
     const pricePill = placeButton.locator('div').filter({ hasText: '10' });
     await expect(pricePill).toHaveClass(/bg-primary\/15/u);
+});
+
+test('decoration picker scrolls when the viewport is too short for all items', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(SHORT_MOBILE_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    const firstItem = page.getByRole('button', { name: 'PotLowBowl' });
+    const lastItem = page.getByRole('button', { name: 'MulchWood' });
+
+    await expect(firstItem).toBeVisible();
+
+    const scrollArea = page.locator('[data-items-picker-scroll]');
+    const popoverBox = await scrollArea.boundingBox();
+    expect(popoverBox).not.toBeNull();
+    expect(
+        (popoverBox?.y ?? 0) + (popoverBox?.height ?? 0),
+    ).toBeLessThanOrEqual(SHORT_MOBILE_VIEWPORT.height + 1);
+
+    const scrollState = await scrollArea.evaluate((node) => ({
+        scrollHeight: node.scrollHeight,
+        clientHeight: node.clientHeight,
+    }));
+    expect(scrollState.scrollHeight).toBeGreaterThan(scrollState.clientHeight);
+
+    await expect(lastItem).not.toBeInViewport();
+    await lastItem.scrollIntoViewIfNeeded();
+    await expect(lastItem).toBeInViewport();
 });

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -278,7 +278,7 @@ function EntityItem({ name }: HudItemEntity) {
 function PickerItem({ label, items, imageSrc }: HudItemPicker) {
     return (
         <Popper
-            className="w-fit overflow-hidden border-tertiary border-b-4"
+            className="w-fit overflow-hidden border-tertiary border-b-4 flex flex-col max-h-[var(--radix-popover-content-available-height)]"
             sideOffset={12}
             trigger={
                 <IconButton
@@ -298,23 +298,24 @@ function PickerItem({ label, items, imageSrc }: HudItemPicker) {
                 </IconButton>
             }
         >
-            <Stack spacing={2}>
-                <div className="bg-muted p-2 border-b">
-                    <Typography semiBold level="body2">
-                        {label}
-                    </Typography>
-                </div>
-                <div className="grid gap-1 p-2 pt-0 grid-cols-4 md:grid-cols-6">
-                    {items.map((item, index) => {
-                        if (item.type === 'entity') {
-                            // biome-ignore lint/suspicious/noArrayIndexKey: Allowed
-                            return <EntityItem key={index} {...item} />;
-                        } else {
-                            return null;
-                        }
-                    })}
-                </div>
-            </Stack>
+            <div className="bg-muted p-2 border-b shrink-0">
+                <Typography semiBold level="body2">
+                    {label}
+                </Typography>
+            </div>
+            <div
+                data-items-picker-scroll
+                className="grid gap-1 p-2 grid-cols-4 md:grid-cols-6 overflow-y-auto overscroll-contain"
+            >
+                {items.map((item, index) => {
+                    if (item.type === 'entity') {
+                        // biome-ignore lint/suspicious/noArrayIndexKey: Allowed
+                        return <EntityItem key={index} {...item} />;
+                    } else {
+                        return null;
+                    }
+                })}
+            </div>
         </Popper>
     );
 }


### PR DESCRIPTION
## Summary
- Cap the edit-mode item picker popover at the available viewport height (`--radix-popover-content-available-height`) so the grid is scrollable when the viewport is too short to show every item.
- Restructure `PickerItem` to a flex column with a sticky header and a scrollable, `overscroll-contain` grid body.

## Test plan
- [x] `pnpm --filter @gredice/game lint`
- [x] `pnpm --filter @gredice/game typecheck`
- [x] `pnpm --filter garden lint`
- [x] `pnpm --filter garden test:run -- items-hud.spec.tsx` (5/5 pass, including new `decoration picker scrolls when the viewport is too short for all items`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)