### PR TITLE
[codex] Use instanced rendering in edit mode

### DIFF
--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -13,6 +13,10 @@ import {
     useState,
 } from 'react';
 import { Plane, Raycaster, Vector2, Vector3 } from 'three';
+import {
+    activeDragPreviewTargetMatches,
+    createActiveDragPreviewTarget,
+} from '../dragPreviewIdentity';
 import { useBlockData } from '../hooks/useBlockData';
 import { useBlockMove } from '../hooks/useBlockMove';
 import { useBlockRecycle } from '../hooks/useBlockRecycle';
@@ -152,9 +156,28 @@ export function PickableGroup({
               attachedPlacement.candidateBlock,
           )
         : 0;
+    const blockIndex = stack.blocks.indexOf(block);
+    const activePreviewTarget = createActiveDragPreviewTarget({
+        blockId: block.id,
+        blockIndex,
+        stackPosition: stack.position,
+    });
+    const attachedPreviewTarget = attachedPlacement
+        ? createActiveDragPreviewTarget({
+              blockId: attachedPlacement.candidateBlock.id,
+              blockIndex: attachedPlacement.candidateBlockIndex,
+              stackPosition: attachedPlacement.candidateStack.position,
+          })
+        : null;
 
-    const isPreviewSource = activeDragPreview?.sourceBlockId === block.id;
-    const isPreviewAttached = activeDragPreview?.attachedBlockId === block.id;
+    const isPreviewSource = activeDragPreviewTargetMatches(
+        activeDragPreview?.source,
+        activePreviewTarget,
+    );
+    const isPreviewAttached = activeDragPreviewTargetMatches(
+        activeDragPreview?.attached,
+        activePreviewTarget,
+    );
     const wasPreviewAttached = useRef(false);
     const shouldResetAttachedOnPreviewEnd = useRef(false);
     const previousStackPosition = useRef({
@@ -543,7 +566,7 @@ export function PickableGroup({
                         x: stack.position.x,
                         z: stack.position.z,
                     },
-                    blockIndex: stack.blocks.indexOf(block),
+                    blockIndex,
                     sourceBlockId: block.id,
                     blockName: block.name,
                     blockEntityId: blockDataForInventory?.id.toString(),
@@ -559,7 +582,7 @@ export function PickableGroup({
                 triggerPlaceHaptic();
                 await recycleBlock.mutateAsync({
                     position: stack.position,
-                    blockIndex: stack.blocks.indexOf(block),
+                    blockIndex,
                     raisedBedId: raisedBed?.id,
                     attached: attachedPlacement
                         ? {
@@ -603,7 +626,7 @@ export function PickableGroup({
                 await moveBlock.mutateAsync({
                     sourcePosition,
                     destinationPosition,
-                    blockIndex: stack.blocks.indexOf(block),
+                    blockIndex,
                     sourceBlockId: block.id,
                     attached: attachedPlacement
                         ? {
@@ -648,8 +671,8 @@ export function PickableGroup({
             setPickupBlock(block);
             didDrag.current = true;
             setActiveDragPreview({
-                sourceBlockId: block.id,
-                attachedBlockId: attachedPlacement?.candidateBlock.id ?? null,
+                source: activePreviewTarget,
+                attached: attachedPreviewTarget,
                 hoveredGardenBoxBlockId,
                 relative: {
                     x: relative.x,

--- a/packages/game/src/dragPreviewIdentity.ts
+++ b/packages/game/src/dragPreviewIdentity.ts
@@ -1,0 +1,45 @@
+export type ActiveDragPreviewStackPosition = {
+    x: number;
+    z: number;
+};
+
+export type ActiveDragPreviewTarget = {
+    blockId: string;
+    blockIndex: number;
+    stackPosition: ActiveDragPreviewStackPosition;
+};
+
+export function createActiveDragPreviewTarget({
+    blockId,
+    blockIndex,
+    stackPosition,
+}: {
+    blockId: string;
+    blockIndex: number;
+    stackPosition: ActiveDragPreviewStackPosition;
+}): ActiveDragPreviewTarget {
+    return {
+        blockId,
+        blockIndex,
+        stackPosition: {
+            x: stackPosition.x,
+            z: stackPosition.z,
+        },
+    };
+}
+
+export function activeDragPreviewTargetMatches(
+    target: ActiveDragPreviewTarget | null | undefined,
+    candidate: ActiveDragPreviewTarget,
+) {
+    if (!target) {
+        return false;
+    }
+
+    return (
+        target.blockId === candidate.blockId &&
+        target.blockIndex === candidate.blockIndex &&
+        target.stackPosition.x === candidate.stackPosition.x &&
+        target.stackPosition.z === candidate.stackPosition.z
+    );
+}

--- a/packages/game/src/dragPreviewIdentity.unit.ts
+++ b/packages/game/src/dragPreviewIdentity.unit.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    activeDragPreviewTargetMatches,
+    createActiveDragPreviewTarget,
+} from './dragPreviewIdentity';
+
+describe('activeDragPreviewTargetMatches', () => {
+    it('matches the same block in the same stack slot', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'duplicate-block',
+            blockIndex: 1,
+            stackPosition: { x: 2, z: 3 },
+        });
+
+        assert.equal(activeDragPreviewTargetMatches(target, target), true);
+    });
+
+    it('does not match the same block id in another stack', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'duplicate-block',
+            blockIndex: 0,
+            stackPosition: { x: 2, z: 3 },
+        });
+        const sameIdElsewhere = createActiveDragPreviewTarget({
+            blockId: 'duplicate-block',
+            blockIndex: 0,
+            stackPosition: { x: 4, z: 3 },
+        });
+
+        assert.equal(
+            activeDragPreviewTargetMatches(target, sameIdElsewhere),
+            false,
+        );
+    });
+
+    it('does not match another block at the same stack position', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'block-a',
+            blockIndex: 0,
+            stackPosition: { x: 2, z: 3 },
+        });
+        const samePositionOtherBlock = createActiveDragPreviewTarget({
+            blockId: 'block-b',
+            blockIndex: 0,
+            stackPosition: { x: 2, z: 3 },
+        });
+
+        assert.equal(
+            activeDragPreviewTargetMatches(target, samePositionOtherBlock),
+            false,
+        );
+    });
+
+    it('does not match the same block id at another stack index', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'duplicate-block',
+            blockIndex: 0,
+            stackPosition: { x: 2, z: 3 },
+        });
+        const samePositionOtherIndex = createActiveDragPreviewTarget({
+            blockId: 'duplicate-block',
+            blockIndex: 1,
+            stackPosition: { x: 2, z: 3 },
+        });
+
+        assert.equal(
+            activeDragPreviewTargetMatches(target, samePositionOtherIndex),
+            false,
+        );
+    });
+});

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -16,6 +16,54 @@ export type EntityFactoryProps = {
     noRenderInView?: string[];
 };
 
+const instancedRenderModeDebugColor = '#22c55e';
+const componentRenderModeDebugColor = '#f59e0b';
+
+function EntityRenderModeDebugOverlay({
+    stack,
+    block,
+    instanced,
+}: Pick<EntityInstanceProps, 'stack' | 'block'> & { instanced: boolean }) {
+    const { data: blockData } = useBlockData();
+    const currentStackHeight = useStackHeight(stack, block);
+    const visible = useGameState((state) => state.entityRenderModeDebugVisible);
+
+    if (!visible) {
+        return null;
+    }
+
+    const blockHeight =
+        blockData?.find((entity) => entity.information.name === block.name)
+            ?.attributes.height ?? 1;
+    const overlayHeight = Math.max(blockHeight, 0.35);
+    const overlayScale = 1.05;
+
+    return (
+        <mesh
+            position={[
+                stack.position.x,
+                currentStackHeight + overlayHeight / 2,
+                stack.position.z,
+            ]}
+            scale={[overlayScale, 1.02, overlayScale]}
+            renderOrder={10_001}
+            raycast={() => null}
+        >
+            <boxGeometry args={[1, overlayHeight, 1]} />
+            <meshBasicMaterial visible={false} />
+            <Edges
+                color={
+                    instanced
+                        ? instancedRenderModeDebugColor
+                        : componentRenderModeDebugColor
+                }
+                renderOrder={10_001}
+                threshold={1}
+            />
+        </mesh>
+    );
+}
+
 function InstancedEntityControlTarget({
     stack,
     block,
@@ -70,11 +118,24 @@ export function EntityFactory({
 
     if (isInstancedInView) {
         if (!isEditMode) {
-            return null;
+            return (
+                <EntityRenderModeDebugOverlay
+                    stack={stack}
+                    block={block}
+                    instanced
+                />
+            );
         }
 
         const controlTarget = (
-            <InstancedEntityControlTarget stack={stack} block={block} />
+            <>
+                <InstancedEntityControlTarget stack={stack} block={block} />
+                <EntityRenderModeDebugOverlay
+                    stack={stack}
+                    block={block}
+                    instanced
+                />
+            </>
         );
         const isTopBlock =
             stack.blocks.indexOf(block) === stack.blocks.length - 1;
@@ -94,7 +155,16 @@ export function EntityFactory({
 
     if (!isEditMode) {
         if (noControl) {
-            return <EntityComponent stack={stack} block={block} {...rest} />;
+            return (
+                <>
+                    <EntityRenderModeDebugOverlay
+                        stack={stack}
+                        block={block}
+                        instanced={false}
+                    />
+                    <EntityComponent stack={stack} block={block} {...rest} />
+                </>
+            );
         }
 
         const SelectableGroupWrapper =
@@ -104,6 +174,11 @@ export function EntityFactory({
 
         return (
             <SelectableGroupWrapper block={block}>
+                <EntityRenderModeDebugOverlay
+                    stack={stack}
+                    block={block}
+                    instanced={false}
+                />
                 <EntityComponent stack={stack} block={block} {...rest} />
             </SelectableGroupWrapper>
         );
@@ -114,6 +189,11 @@ export function EntityFactory({
     if (!isTopBlock) {
         return (
             <RotatableGroup block={block}>
+                <EntityRenderModeDebugOverlay
+                    stack={stack}
+                    block={block}
+                    instanced={false}
+                />
                 <EntityComponent stack={stack} block={block} {...rest} />
             </RotatableGroup>
         );
@@ -122,6 +202,11 @@ export function EntityFactory({
     return (
         <PickableGroup stack={stack} block={block} noControl={noControl}>
             <RotatableGroup block={block}>
+                <EntityRenderModeDebugOverlay
+                    stack={stack}
+                    block={block}
+                    instanced={false}
+                />
                 <EntityComponent stack={stack} block={block} {...rest} />
             </RotatableGroup>
         </PickableGroup>

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -2,9 +2,11 @@ import type { PropsWithChildren } from 'react';
 import { PickableGroup } from '../controls/PickableGroup';
 import { RotatableGroup } from '../controls/RotatableGroup';
 import { SelectableGroup } from '../controls/SelectableGroup';
+import { useBlockData } from '../hooks/useBlockData';
 import { useIsEditMode } from '../hooks/useIsEditMode';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useGameState } from '../useGameState';
+import { useStackHeight } from '../utils/getStackHeight';
 import { entityNameMap } from './entityNameMap';
 
 export type EntityFactoryProps = {
@@ -12,6 +14,36 @@ export type EntityFactoryProps = {
     noControl?: boolean;
     noRenderInView?: string[];
 };
+
+function InstancedEntityControlTarget({
+    stack,
+    block,
+}: Pick<EntityInstanceProps, 'stack' | 'block'>) {
+    const { data: blockData } = useBlockData();
+    const currentStackHeight = useStackHeight(stack, block);
+    const blockHeight =
+        blockData?.find((entity) => entity.information.name === block.name)
+            ?.attributes.height ?? 1;
+    const hitboxHeight = Math.max(blockHeight, 0.35);
+
+    return (
+        <mesh
+            position={[
+                stack.position.x,
+                currentStackHeight + hitboxHeight / 2,
+                stack.position.z,
+            ]}
+        >
+            <boxGeometry args={[1, hitboxHeight, 1]} />
+            <meshBasicMaterial
+                colorWrite={false}
+                depthWrite={false}
+                opacity={0}
+                transparent
+            />
+        </mesh>
+    );
+}
 
 export function EntityFactory({
     name,
@@ -24,6 +56,7 @@ export function EntityFactory({
     const isEditMode = useIsEditMode();
     const EntityComponent = entityNameMap[name];
     const view = useGameState((state) => state.view);
+    const isInstancedInView = noRenderInView?.includes(name) ?? false;
 
     if (!EntityComponent) {
         console.error(
@@ -33,11 +66,31 @@ export function EntityFactory({
         return null;
     }
 
-    if (!isEditMode) {
-        if (noRenderInView?.includes(name)) {
+    if (isInstancedInView) {
+        if (!isEditMode) {
             return null;
         }
 
+        const controlTarget = (
+            <InstancedEntityControlTarget stack={stack} block={block} />
+        );
+        const isTopBlock =
+            stack.blocks.indexOf(block) === stack.blocks.length - 1;
+
+        if (!isTopBlock) {
+            return (
+                <RotatableGroup block={block}>{controlTarget}</RotatableGroup>
+            );
+        }
+
+        return (
+            <PickableGroup stack={stack} block={block} noControl={noControl}>
+                <RotatableGroup block={block}>{controlTarget}</RotatableGroup>
+            </PickableGroup>
+        );
+    }
+
+    if (!isEditMode) {
         if (noControl) {
             return <EntityComponent stack={stack} block={block} {...rest} />;
         }

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -1,3 +1,4 @@
+import { Edges } from '@react-three/drei';
 import type { PropsWithChildren } from 'react';
 import { PickableGroup } from '../controls/PickableGroup';
 import { RotatableGroup } from '../controls/RotatableGroup';
@@ -21,6 +22,9 @@ function InstancedEntityControlTarget({
 }: Pick<EntityInstanceProps, 'stack' | 'block'>) {
     const { data: blockData } = useBlockData();
     const currentStackHeight = useStackHeight(stack, block);
+    const editHitboxDebugVisible = useGameState(
+        (state) => state.editHitboxDebugVisible,
+    );
     const blockHeight =
         blockData?.find((entity) => entity.information.name === block.name)
             ?.attributes.height ?? 1;
@@ -35,12 +39,10 @@ function InstancedEntityControlTarget({
             ]}
         >
             <boxGeometry args={[1, hitboxHeight, 1]} />
-            <meshBasicMaterial
-                colorWrite={false}
-                depthWrite={false}
-                opacity={0}
-                transparent
-            />
+            <meshBasicMaterial visible={false} />
+            {editHitboxDebugVisible && (
+                <Edges color="#22d3ee" renderOrder={10_000} threshold={1} />
+            )}
         </mesh>
     );
 }

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -114,18 +114,14 @@ type EntityInstancesAssetBlockProps = Omit<
 
 function hasRenderableBlockInstance({
     name,
-    pickupBlock,
     stacks,
 }: {
     name: string;
-    pickupBlock: Stack['blocks'][number] | null | undefined;
     stacks: Stack[] | undefined;
 }) {
     return (
-        stacks?.some(
-            (stack) =>
-                (!pickupBlock || !stack.blocks.includes(pickupBlock)) &&
-                stack.blocks.some((block) => block.name === name),
+        stacks?.some((stack) =>
+            stack.blocks.some((block) => block.name === name),
         ) ?? false
     );
 }
@@ -148,10 +144,8 @@ function LoadedEntityInstancesAssetBlock({
 }
 
 function EntityInstancesAssetBlock(props: EntityInstancesAssetBlockProps) {
-    const pickupBlock = useGameState((state) => state.pickupBlock);
     const hasInstances = hasRenderableBlockInstance({
         name: props.name,
-        pickupBlock,
         stacks: props.stacks,
     });
 
@@ -178,7 +172,6 @@ export function EntityInstances({
     renderDetails?: boolean;
 }) {
     const qualityProfile = quality ?? resolveGameQualityProfile();
-    const isEditMode = useGameState((state) => state.mode) === 'edit';
     const snowCoverage = useGameState((state) => state.snowCoverage);
     const snowOverlaysVisible =
         snowCoverage >= qualityProfile.snowOverlayMinCoverage;
@@ -240,11 +233,6 @@ export function EntityInstances({
         renderSnow: snowOverlaysVisible,
         snowOverlayMinCoverage: qualityProfile.snowOverlayMinCoverage,
     };
-
-    // In edit mode, blocks are rendered by EntityFactory with proper controls
-    if (isEditMode) {
-        return null;
-    }
 
     return (
         <>

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -6,7 +6,7 @@ import { useBlockData } from '../hooks/useBlockData';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
 import type { Stack } from '../types/Stack';
-import { useGameState } from '../useGameState';
+import { type ActiveDragPreview, useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
@@ -37,6 +37,28 @@ export type EntityInstancesBlockMaterialProps =
           materialNode: ReactNode;
       };
 
+function getDragPreviewOffset(
+    blockId: string,
+    activeDragPreview: ActiveDragPreview | null,
+) {
+    if (!activeDragPreview) {
+        return null;
+    }
+
+    if (
+        activeDragPreview.sourceBlockId !== blockId &&
+        activeDragPreview.attachedBlockId !== blockId
+    ) {
+        return null;
+    }
+
+    return {
+        x: activeDragPreview.relative.x,
+        y: activeDragPreview.attachedHoverHeight + 0.1,
+        z: activeDragPreview.relative.z,
+    };
+}
+
 export function EntityInstancesBlock(
     props: EntityInstancesBlockBaseProps & EntityInstancesBlockMaterialProps,
 ) {
@@ -55,25 +77,25 @@ export function EntityInstancesBlock(
         renderRainWetOverlay = false,
     } = props;
     const { data: blockData } = useBlockData();
-    const pickupBlock = useGameState((state) => state.pickupBlock);
+    const activeDragPreview = useGameState((state) => state.activeDragPreview);
 
     const blockInstances = stacks
-        ?.filter(
-            (stack) =>
-                (!pickupBlock || !stack.blocks.includes(pickupBlock)) &&
-                stack.blocks.some((b) => b.name === name),
-        )
+        ?.filter((stack) => stack.blocks.some((b) => b.name === name))
         .flatMap((stack) =>
             stack.blocks
                 ?.filter((block) => block.name === name)
                 .map((block) => {
                     const y = getStackHeight(blockData, stack, block);
+                    const dragPreviewOffset = getDragPreviewOffset(
+                        block.id,
+                        activeDragPreview,
+                    );
                     return {
                         id: block.id,
                         position: [
-                            stack.position.x,
-                            y + (yOffset ?? 0),
-                            stack.position.z,
+                            stack.position.x + (dragPreviewOffset?.x ?? 0),
+                            y + (yOffset ?? 0) + (dragPreviewOffset?.y ?? 0),
+                            stack.position.z + (dragPreviewOffset?.z ?? 0),
                         ] as const,
                         rotation: block.rotation || 0,
                     };

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -2,6 +2,11 @@ import { Instance, Instances } from '@react-three/drei';
 import type { ReactNode } from 'react';
 import type { Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
+import {
+    type ActiveDragPreviewTarget,
+    activeDragPreviewTargetMatches,
+    createActiveDragPreviewTarget,
+} from '../dragPreviewIdentity';
 import { useBlockData } from '../hooks/useBlockData';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
@@ -38,7 +43,7 @@ export type EntityInstancesBlockMaterialProps =
       };
 
 function getDragPreviewOffset(
-    blockId: string,
+    target: ActiveDragPreviewTarget,
     activeDragPreview: ActiveDragPreview | null,
 ) {
     if (!activeDragPreview) {
@@ -46,8 +51,8 @@ function getDragPreviewOffset(
     }
 
     if (
-        activeDragPreview.sourceBlockId !== blockId &&
-        activeDragPreview.attachedBlockId !== blockId
+        !activeDragPreviewTargetMatches(activeDragPreview.source, target) &&
+        !activeDragPreviewTargetMatches(activeDragPreview.attached, target)
     ) {
         return null;
     }
@@ -83,15 +88,21 @@ export function EntityInstancesBlock(
         ?.filter((stack) => stack.blocks.some((b) => b.name === name))
         .flatMap((stack) =>
             stack.blocks
-                ?.filter((block) => block.name === name)
-                .map((block) => {
+                ?.map((block, blockIndex) => ({ block, blockIndex }))
+                .filter(({ block }) => block.name === name)
+                .map(({ block, blockIndex }) => {
                     const y = getStackHeight(blockData, stack, block);
+                    const target = createActiveDragPreviewTarget({
+                        blockId: block.id,
+                        blockIndex,
+                        stackPosition: stack.position,
+                    });
                     const dragPreviewOffset = getDragPreviewOffset(
-                        block.id,
+                        target,
                         activeDragPreview,
                     );
                     return {
-                        id: block.id,
+                        id: `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
                         position: [
                             stack.position.x + (dragPreviewOffset?.x ?? 0),
                             y + (yOffset ?? 0) + (dragPreviewOffset?.y ?? 0),

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -11,7 +11,6 @@ import {
 } from 'three';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useBlockData } from '../../hooks/useBlockData';
-import { useIsEditMode } from '../../hooks/useIsEditMode';
 import { useWeatherNow } from '../../hooks/useWeatherNow';
 import type { Stack } from '../../types/Stack';
 import {
@@ -933,7 +932,6 @@ export function Bees({
     weatherDisabled?: boolean;
 }) {
     const { data: blockData } = useBlockData();
-    const isEditMode = useIsEditMode();
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const gameWeather = useGameState((state) => state.weather);
     const { data: weatherNow } = useWeatherNow(!weatherDisabled && !weather);
@@ -948,11 +946,7 @@ export function Bees({
         [blockData, garden],
     );
 
-    if (
-        isEditMode ||
-        habitats.length <= 0 ||
-        !isBeeActive(timeOfDay, beeWeather)
-    ) {
+    if (habitats.length <= 0 || !isBeeActive(timeOfDay, beeWeather)) {
         return null;
     }
 

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -6,7 +6,6 @@ import type { Group, Material, Object3D } from 'three';
 import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useBlockData } from '../../hooks/useBlockData';
-import { useIsEditMode } from '../../hooks/useIsEditMode';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
 import { type AnimalDebugEntry, useGameState } from '../../useGameState';
@@ -1637,13 +1636,12 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
 
 export function Birds({ stacks }: { stacks: Stack[] | undefined }) {
     const { data: blockData } = useBlockData();
-    const isEditMode = useIsEditMode();
     const habitats = useMemo(
         () => createBirdHabitats(stacks, blockData),
         [blockData, stacks],
     );
 
-    if (isEditMode || habitats.length <= 0) {
+    if (habitats.length <= 0) {
         return null;
     }
 

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -188,6 +188,12 @@ export function DebugHud() {
     const setEditHitboxDebugVisible = useGameState(
         (s) => s.setEditHitboxDebugVisible,
     );
+    const entityRenderModeDebugVisible = useGameState(
+        (s) => s.entityRenderModeDebugVisible,
+    );
+    const setEntityRenderModeDebugVisible = useGameState(
+        (s) => s.setEntityRenderModeDebugVisible,
+    );
     const frameStats = useFrameStats();
     const profileSnapshot = useProfileHudSnapshot();
 
@@ -565,6 +571,11 @@ export function DebugHud() {
     ) => {
         setEditHitboxDebugVisible(checked === true);
     };
+    const handleEntityRenderModeDebugChange = (
+        checked: boolean | 'indeterminate',
+    ) => {
+        setEntityRenderModeDebugVisible(checked === true);
+    };
 
     const weatherControlsDisabled = !overrideWeather;
 
@@ -686,11 +697,32 @@ export function DebugHud() {
                             </Stack>
                         </DebugPanelSection>
                         <DebugPanelSection title="Scene">
-                            <Checkbox
-                                label="Show edit hitboxes"
-                                checked={editHitboxDebugVisible}
-                                onCheckedChange={handleEditHitboxDebugChange}
-                            />
+                            <Stack spacing={2} className="text-xs">
+                                <Checkbox
+                                    label="Show edit hitboxes"
+                                    checked={editHitboxDebugVisible}
+                                    onCheckedChange={
+                                        handleEditHitboxDebugChange
+                                    }
+                                />
+                                <Checkbox
+                                    label="Show render modes"
+                                    checked={entityRenderModeDebugVisible}
+                                    onCheckedChange={
+                                        handleEntityRenderModeDebugChange
+                                    }
+                                />
+                                {entityRenderModeDebugVisible && (
+                                    <div className="grid gap-1 font-mono leading-5">
+                                        <span className="text-emerald-400">
+                                            Green instanced
+                                        </span>
+                                        <span className="text-amber-400">
+                                            Amber component
+                                        </span>
+                                    </div>
+                                )}
+                            </Stack>
                         </DebugPanelSection>
                         <DebugPanelSection title="Time">
                             <Slider

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -182,6 +182,12 @@ export function DebugHud() {
     const currentTime = useLiveTime();
     const setFreezeTime = useGameState((s) => s.setFreezeTime);
     const animalDebugEntries = useGameState((s) => s.animalDebugEntries);
+    const editHitboxDebugVisible = useGameState(
+        (s) => s.editHitboxDebugVisible,
+    );
+    const setEditHitboxDebugVisible = useGameState(
+        (s) => s.setEditHitboxDebugVisible,
+    );
     const frameStats = useFrameStats();
     const profileSnapshot = useProfileHudSnapshot();
 
@@ -554,6 +560,11 @@ export function DebugHud() {
     const handleOverrideChange = (checked: boolean | 'indeterminate') => {
         setOverrideWeather(checked === true);
     };
+    const handleEditHitboxDebugChange = (
+        checked: boolean | 'indeterminate',
+    ) => {
+        setEditHitboxDebugVisible(checked === true);
+    };
 
     const weatherControlsDisabled = !overrideWeather;
 
@@ -673,6 +684,13 @@ export function DebugHud() {
                                     ))
                                 )}
                             </Stack>
+                        </DebugPanelSection>
+                        <DebugPanelSection title="Scene">
+                            <Checkbox
+                                label="Show edit hitboxes"
+                                checked={editHitboxDebugVisible}
+                                onCheckedChange={handleEditHitboxDebugChange}
+                            />
                         </DebugPanelSection>
                         <DebugPanelSection title="Time">
                             <Slider

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -178,6 +178,8 @@ export type GameState = {
     ) => void;
 
     // Debug (overrides)
+    editHitboxDebugVisible: boolean;
+    setEditHitboxDebugVisible: (visible: boolean) => void;
     weather?: {
         cloudy: number;
         rainy: number;
@@ -397,6 +399,9 @@ export function createGameState({
             })),
         setWorldRotation: (worldRotation) => set({ worldRotation }),
         setIsDragging: (isDragging) => set({ isDragging }),
+        editHitboxDebugVisible: false,
+        setEditHitboxDebugVisible: (editHitboxDebugVisible) =>
+            set({ editHitboxDebugVisible }),
         setWeather: (weather) => set({ weather }),
         snowCoverage: 0,
         setSnowCoverage: (snowCoverage) => set({ snowCoverage }),

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -3,6 +3,7 @@ import { getTimes } from 'suncalc';
 import type { OrbitControls } from 'three-stdlib';
 import { createStore, useStore } from 'zustand';
 import { createGameAudio, type GameAudio } from './audio/audioMixer';
+import type { ActiveDragPreviewTarget } from './dragPreviewIdentity';
 import {
     type GameQualityCustomProfile,
     type GameQualitySetting,
@@ -91,8 +92,8 @@ type GameMode = 'normal' | 'edit';
 export type WinterMode = 'summer' | 'winter' | 'holiday';
 
 export type ActiveDragPreview = {
-    sourceBlockId: string;
-    attachedBlockId: string | null;
+    source: ActiveDragPreviewTarget;
+    attached: ActiveDragPreviewTarget | null;
     hoveredGardenBoxBlockId: string | null;
     relative: {
         x: number;

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -180,6 +180,8 @@ export type GameState = {
     // Debug (overrides)
     editHitboxDebugVisible: boolean;
     setEditHitboxDebugVisible: (visible: boolean) => void;
+    entityRenderModeDebugVisible: boolean;
+    setEntityRenderModeDebugVisible: (visible: boolean) => void;
     weather?: {
         cloudy: number;
         rainy: number;
@@ -402,6 +404,9 @@ export function createGameState({
         editHitboxDebugVisible: false,
         setEditHitboxDebugVisible: (editHitboxDebugVisible) =>
             set({ editHitboxDebugVisible }),
+        entityRenderModeDebugVisible: false,
+        setEntityRenderModeDebugVisible: (entityRenderModeDebugVisible) =>
+            set({ entityRenderModeDebugVisible }),
         setWeather: (weather) => set({ weather }),
         snowCoverage: 0,
         setSnowCoverage: (snowCoverage) => set({ snowCoverage }),


### PR DESCRIPTION
## Summary

- Keep the optimized instanced entity renderer active in edit mode instead of falling back to per-entity legacy rendering.
- Replace legacy edit-mode rendering for instanced blocks with invisible interaction hitboxes wired through the existing drag and rotate controls.
- Make the hitbox meshes raycast-only by using a non-rendering material, so they no longer submit hidden draw calls every frame.
- Add a Debug HUD scene toggle to draw cyan edge lines around the edit hitboxes when needed.
- Add a Debug HUD render-mode overlay: green boxes mark blocks rendered through the instanced path, amber boxes mark blocks still rendered by component entities.
- Move active drag-preview transforms into the instanced mesh path so dragged instanced blocks still visually follow the pointer.
- Use a per-instance drag-preview identity with block id, stack position, and stack index so duplicate block ids do not share the active preview offset.
- Keep ambient animals visible and active in edit mode; birds and bees now continue rendering instead of being hidden by edit-mode gates.

## Impact

This removes the old two-path rendering behavior for the instanced block set while preserving edit-mode interactions. The scene now uses the same optimized rendering path in normal and edit modes, with only lightweight control proxies added for editing. Edit mode should behave as an overlay on the scene instead of mutating ambient scene content. The hitbox overlay is off by default and only renders extra edge lines when explicitly enabled in the Debug HUD.

The render-mode overlay is also off by default. It is intended as a migration aid: turn it on in the Debug HUD to see which placed blocks have already moved to instancing and which blocks still need conversion.

## Framerate notes

The hidden hitboxes were still renderable meshes before this update, which meant edit mode paid extra WebGL draw calls even though the material wrote no color. Switching the material to `visible={false}` keeps raycasting intact while removing those hidden GPU draws.

A local production debug-scene sample after the change measured:

- Normal: `456.0` draw calls/frame, `14.6` instanced draw calls/frame
- Edit, hitboxes off: `241.5` draw calls/frame, `14.6` instanced draw calls/frame
- Edit, hitboxes on: `255.2` draw calls/frame, `28.1` instanced draw calls/frame

So if edit mode still feels slower after this, the remaining cost is likely not the instanced block renderer itself. The next suspects are edit-mode UI/control overhead: the item picker is open, each top block has gesture/raycast controls, and pointer movement raycasts against the edit hitboxes.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test`
- `pnpm build --filter garden`
- `pnpm build --filter www`
- `pnpm lint --filter garden`
- `pnpm lint --filter www`
- `git diff --check`
- Playwright canvas checks on the local production garden debug scene for normal, edit hitboxes off, and edit hitboxes on; all rendered nonblank canvases, and the hitbox-on scenario detected cyan debug edges.
- Local browser smoke on the garden debug profile with `uredivanje=true` confirmed animal debug entries for both birds and bees while edit mode is active.
- Local browser smoke with the render-mode overlay enabled confirmed green instanced boxes and amber component boxes render in the debug profile scene.
