### PR TITLE
Adjust bee spawning and flower-foraging behavior

### DIFF
--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -30,8 +30,8 @@ import { useGameGLTF } from '../../utils/useGameGLTF';
 import { tulipBouquetStems } from '../tulipBouquet';
 import {
     type BeeWeather,
-    getBeeCount,
     getBeeDwellSeconds,
+    getBeeHabitatGroups,
     isBeeActive,
 } from './beeBehavior';
 
@@ -89,12 +89,9 @@ type MovingBeeState = {
 
 type ForagingBeeState = {
     phase: 'foraging';
-    dipPhase: number;
     dwellUntil: number;
-    orbitDirection: -1 | 1;
-    orbitPhase: number;
-    orbitRadius: number;
-    orbitSpeed: number;
+    landingPosition: Vector3;
+    landingYaw: number;
     startedAt: number;
     target: BeeTarget;
 };
@@ -125,12 +122,12 @@ const clearBeeWeather = {
     windSpeed: 0,
 } satisfies BeeWeather;
 
-const beeScale = 0.16;
+const beeScale = 0.095;
 const beeFlightSpeedBlocksPerSecond = 1.1;
 const beeFlightTurnDamping = 7.5;
 const beeFlightLookAheadProgress = 0.06;
 const beeFlightArcMaxHeight = 0.42;
-const beeForageHoverHeight = 0.08;
+const beeFlowerRestHeight = 0.025;
 const defaultTurnDamping = 9;
 const raisedBedFlowerHoverHeight = 0.42;
 const tulipFlowerHoverHeight = 0.52;
@@ -316,25 +313,33 @@ function createBeeHabitats(
         return [];
     }
 
-    const targets = createFlowerTargets(garden, blockData);
-    const beeCount = getBeeCount(targets.length);
-    const firstTarget = targets[0];
-    if (!firstTarget) {
+    const targetGroups = getBeeHabitatGroups(
+        createFlowerTargets(garden, blockData),
+    );
+    if (targetGroups.length <= 0) {
         return [];
     }
 
-    return Array.from({ length: beeCount }, (_, index) => {
+    return targetGroups.flatMap((targets, index) => {
+        const firstTarget = targets[0];
+        if (!firstTarget) {
+            return [];
+        }
+
         const seed = hashString(
-            `${garden.id ?? 'garden'}-bee-${index}-${targets.length}`,
+            `${garden.id ?? 'garden'}-bee-${index}-${firstTarget.id}-${targets.length}`,
         );
         const random = createRandom(seed);
-        return {
-            id: `bee-${index + 1}`,
-            seed,
-            startTarget:
-                targets[Math.floor(random() * targets.length)] ?? firstTarget,
-            targets,
-        } satisfies BeeHabitat;
+        return [
+            {
+                id: `bee-${index + 1}`,
+                seed,
+                startTarget:
+                    targets[Math.floor(random() * targets.length)] ??
+                    firstTarget,
+                targets,
+            } satisfies BeeHabitat,
+        ];
     });
 }
 
@@ -534,17 +539,7 @@ function makeMovingState({
     random: () => number;
     target: BeeTarget;
 }) {
-    const targetJitterRadius = 0.035 + random() * 0.04;
-    const targetJitterAngle = random() * fullTurn;
-    const to = target.position
-        .clone()
-        .add(
-            new Vector3(
-                Math.cos(targetJitterAngle) * targetJitterRadius,
-                beeForageHoverHeight + random() * 0.035,
-                Math.sin(targetJitterAngle) * targetJitterRadius,
-            ),
-        );
+    const to = createBeeLandingPosition(target, random);
     const directFlightTangent = createFlightTangent(from, to);
     return {
         phase: 'moving',
@@ -560,43 +555,58 @@ function makeMovingState({
     } satisfies MovingBeeState;
 }
 
+function yawTowardPosition(from: Vector3, to: Vector3) {
+    const directionX = to.x - from.x;
+    const directionZ = to.z - from.z;
+    if (Math.hypot(directionX, directionZ) <= 0.001) {
+        return 0;
+    }
+
+    return Math.atan2(directionX, directionZ);
+}
+
+function createBeeLandingPosition(target: BeeTarget, random: () => number) {
+    const targetJitterRadius =
+        target.kind === 'raised-bed-flower'
+            ? 0.012 + random() * 0.018
+            : 0.02 + random() * 0.028;
+    const targetJitterAngle = random() * fullTurn;
+    return target.position
+        .clone()
+        .add(
+            new Vector3(
+                Math.cos(targetJitterAngle) * targetJitterRadius,
+                beeFlowerRestHeight,
+                Math.sin(targetJitterAngle) * targetJitterRadius,
+            ),
+        );
+}
+
 function makeForagingState({
+    landingPosition,
     now,
     random,
     target,
 }: {
+    landingPosition?: Vector3;
     now: number;
     random: () => number;
     target: BeeTarget;
 }) {
+    const position =
+        landingPosition ?? createBeeLandingPosition(target, random);
     return {
         phase: 'foraging',
-        dipPhase: random() * fullTurn,
         dwellUntil: now + getBeeDwellSeconds(random),
-        orbitDirection: random() < 0.5 ? -1 : 1,
-        orbitPhase: random() * fullTurn,
-        orbitRadius: 0.045 + random() * 0.055,
-        orbitSpeed: 4.2 + random() * 2.8,
+        landingPosition: position,
+        landingYaw: yawTowardPosition(position, target.position),
         startedAt: now,
         target,
     } satisfies ForagingBeeState;
 }
 
-function foragePositionAt(runtime: ForagingBeeState, now: number) {
-    const elapsed = now - runtime.startedAt;
-    const angle =
-        runtime.orbitPhase +
-        elapsed * runtime.orbitSpeed * runtime.orbitDirection;
-    const dip = Math.max(0, Math.sin(elapsed * 5.2 + runtime.dipPhase)) * 0.035;
-    return runtime.target.position
-        .clone()
-        .add(
-            new Vector3(
-                Math.cos(angle) * runtime.orbitRadius,
-                beeForageHoverHeight + Math.sin(elapsed * 8.4) * 0.018 - dip,
-                Math.sin(angle) * runtime.orbitRadius * 0.72,
-            ),
-        );
+function foragePositionAt(runtime: ForagingBeeState) {
+    return runtime.landingPosition.clone();
 }
 
 function cloneBeeMaterial(material: Material, objectName: string) {
@@ -609,6 +619,12 @@ function cloneBeeMaterial(material: Material, objectName: string) {
             clone.roughness = 0.34;
             clone.side = DoubleSide;
             clone.transparent = true;
+        } else if (clone.name === 'Material.Bee.Yellow') {
+            clone.color.set('#f4c400');
+            clone.roughness = 0.7;
+        } else if (clone.name === 'Material.Bee.Gold') {
+            clone.color.set('#d68a00');
+            clone.roughness = 0.74;
         } else {
             clone.roughness = 0.72;
         }
@@ -657,9 +673,35 @@ function updateBeeRig({
     seed: number;
 }) {
     const flying = runtime?.phase === 'moving';
-    const wingSpeed = flying ? 72 : 54;
+
+    if (!flying) {
+        if (rig.wingLeft.object) {
+            rig.wingLeft.object.rotation.x = rig.wingLeft.baseRotationX;
+            rig.wingLeft.object.rotation.y = rig.wingLeft.baseRotationY;
+            rig.wingLeft.object.rotation.z = rig.wingLeft.baseRotationZ;
+        }
+        if (rig.wingRight.object) {
+            rig.wingRight.object.rotation.x = rig.wingRight.baseRotationX;
+            rig.wingRight.object.rotation.y = rig.wingRight.baseRotationY;
+            rig.wingRight.object.rotation.z = rig.wingRight.baseRotationZ;
+        }
+        if (rig.bodyPivot.object) {
+            rig.bodyPivot.object.position.y = rig.bodyPivot.basePositionY;
+            rig.bodyPivot.object.rotation.x = rig.bodyPivot.baseRotationX;
+            rig.bodyPivot.object.rotation.y = rig.bodyPivot.baseRotationY;
+            rig.bodyPivot.object.rotation.z = rig.bodyPivot.baseRotationZ;
+        }
+        if (rig.headPivot.object) {
+            rig.headPivot.object.rotation.x = rig.headPivot.baseRotationX;
+            rig.headPivot.object.rotation.y = rig.headPivot.baseRotationY;
+            rig.headPivot.object.rotation.z = rig.headPivot.baseRotationZ;
+        }
+        return;
+    }
+
+    const wingSpeed = 72;
     const wingPulse = Math.abs(Math.sin(now * wingSpeed + seed));
-    const wingLift = 0.24 + wingPulse * (flying ? 1.05 : 0.82);
+    const wingLift = 0.24 + wingPulse * 1.05;
 
     if (rig.wingLeft.object) {
         rig.wingLeft.object.rotation.x =
@@ -673,14 +715,6 @@ function updateBeeRig({
             rig.wingRight.baseRotationZ + wingLift;
     }
 
-    const forageAmount =
-        runtime?.phase === 'foraging'
-            ? Math.max(
-                  0,
-                  Math.sin((now - runtime.startedAt) * 5.2 + runtime.dipPhase),
-              )
-            : 0;
-
     if (rig.bodyPivot.object) {
         rig.bodyPivot.object.position.y = MathUtils.damp(
             rig.bodyPivot.object.position.y,
@@ -689,17 +723,13 @@ function updateBeeRig({
             delta,
         );
         rig.bodyPivot.object.rotation.x =
-            rig.bodyPivot.baseRotationX +
-            Math.sin(now * 7.2 + seed) * (flying ? 0.075 : 0.035) -
-            forageAmount * 0.05;
+            rig.bodyPivot.baseRotationX + Math.sin(now * 7.2 + seed) * 0.075;
         rig.bodyPivot.object.rotation.z =
-            rig.bodyPivot.baseRotationZ +
-            Math.sin(now * 5.4 + seed) * (flying ? 0.09 : 0.045);
+            rig.bodyPivot.baseRotationZ + Math.sin(now * 5.4 + seed) * 0.09;
     }
 
     if (rig.headPivot.object) {
-        rig.headPivot.object.rotation.x =
-            rig.headPivot.baseRotationX + forageAmount * 0.12;
+        rig.headPivot.object.rotation.x = rig.headPivot.baseRotationX;
     }
 }
 
@@ -808,7 +838,7 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
                 target: habitat.startTarget,
             });
             runtimeRef.current = runtime;
-            group.position.copy(foragePositionAt(runtime, now));
+            group.position.copy(foragePositionAt(runtime));
         }
 
         if (runtime.phase === 'moving') {
@@ -842,17 +872,18 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
 
             if (progress >= 1) {
                 runtimeRef.current = makeForagingState({
+                    landingPosition: runtime.to.clone(),
                     now,
                     random,
                     target: runtime.target,
                 });
             }
         } else {
-            const nextPosition = foragePositionAt(runtime, now);
+            const nextPosition = foragePositionAt(runtime);
             group.position.copy(nextPosition);
-            facePosition(group, runtime.target.position, delta);
-            group.rotation.x = -0.02 + Math.sin(now * 7 + habitat.seed) * 0.025;
-            group.rotation.z = Math.sin(now * 6 + habitat.seed) * 0.055;
+            group.rotation.x = -0.04;
+            group.rotation.y = runtime.landingYaw;
+            group.rotation.z = 0;
 
             if (now >= runtime.dwellUntil) {
                 const target = chooseNextTarget({

--- a/packages/game/src/entities/bees/beeBehavior.ts
+++ b/packages/game/src/entities/bees/beeBehavior.ts
@@ -12,6 +12,14 @@ const BEE_DAY_END = 0.74;
 const MAX_BEE_CLOUD_COVER = 0.42;
 const MAX_BEE_WIND_SPEED = 1.2;
 const MAX_BEE_BAD_WEATHER = 0.05;
+const BEE_HABITAT_RADIUS_BLOCKS = 10;
+
+export type BeeTargetPosition = {
+    position: {
+        x: number;
+        z: number;
+    };
+};
 
 export function isBeeDaytime(timeOfDay: number) {
     return timeOfDay >= BEE_DAY_START && timeOfDay <= BEE_DAY_END;
@@ -43,10 +51,41 @@ export function getBeeDwellSeconds(random: () => number) {
     return 2.4 + random() * 3.6;
 }
 
-export function getBeeCount(flowerTargetCount: number) {
-    if (flowerTargetCount <= 0) {
-        return 0;
+function isWithinBeeHabitatRadius(
+    left: BeeTargetPosition,
+    right: BeeTargetPosition,
+    radiusSquared: number,
+) {
+    const x = left.position.x - right.position.x;
+    const z = left.position.z - right.position.z;
+    return x * x + z * z <= radiusSquared;
+}
+
+export function getBeeHabitatGroups<T extends BeeTargetPosition>(
+    flowerTargets: readonly T[],
+) {
+    const groups: T[][] = [];
+    const radiusSquared = BEE_HABITAT_RADIUS_BLOCKS * BEE_HABITAT_RADIUS_BLOCKS;
+
+    for (const target of flowerTargets) {
+        const habitat = groups.find((group) => {
+            const anchor = group[0];
+            return (
+                anchor !== undefined &&
+                isWithinBeeHabitatRadius(anchor, target, radiusSquared)
+            );
+        });
+
+        if (habitat) {
+            habitat.push(target);
+        } else {
+            groups.push([target]);
+        }
     }
 
-    return Math.min(4, Math.max(1, Math.ceil(flowerTargetCount / 6)));
+    return groups;
+}
+
+export function getBeeCount(flowerTargets: readonly BeeTargetPosition[]) {
+    return getBeeHabitatGroups(flowerTargets).length;
 }

--- a/packages/game/src/entities/bees/beeBehavior.unit.ts
+++ b/packages/game/src/entities/bees/beeBehavior.unit.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
     getBeeCount,
     getBeeDwellSeconds,
+    getBeeHabitatGroups,
     isBeeActive,
     isBeeDaytime,
     isBeeWeatherSuitable,
@@ -48,12 +49,34 @@ test('keeps bees away in heavy clouds, precipitation, fog, thunder, or wind', ()
     assert.equal(isBeeActive(0.5, { ...clearWeather, windSpeed: 2 }), false);
 });
 
-test('scales bee count by available flower targets', () => {
-    assert.equal(getBeeCount(0), 0);
-    assert.equal(getBeeCount(1), 1);
-    assert.equal(getBeeCount(6), 1);
-    assert.equal(getBeeCount(7), 2);
-    assert.equal(getBeeCount(50), 4);
+test('scales bee count by ten-block flower habitats', () => {
+    const closeFlowerTargets = [
+        { id: 'a', position: { x: 0, z: 0 } },
+        { id: 'b', position: { x: 0.5, z: 0.25 } },
+        { id: 'c', position: { x: 8, z: 1 } },
+    ];
+    const distantFlowerTargets = [
+        ...closeFlowerTargets,
+        { id: 'd', position: { x: 10.1, z: 0 } },
+        { id: 'e', position: { x: 21, z: 0 } },
+    ];
+
+    assert.equal(getBeeCount([]), 0);
+    assert.equal(getBeeCount(closeFlowerTargets), 1);
+    assert.equal(getBeeCount(distantFlowerTargets), 3);
+});
+
+test('groups nearby flowers into one bee habitat', () => {
+    const groups = getBeeHabitatGroups([
+        { id: 'a', position: { x: 0, z: 0 } },
+        { id: 'b', position: { x: 9.9, z: 0 } },
+        { id: 'c', position: { x: 10.1, z: 0 } },
+    ]);
+
+    assert.deepEqual(
+        groups.map((group) => group.map((target) => target.id)),
+        [['a', 'b'], ['c']],
+    );
 });
 
 test('uses short flower dwell windows', () => {


### PR DESCRIPTION
## Summary
- Group flower targets into 10-block bee habitats so dense flower beds spawn one bee per nearby cluster instead of overpopulating the scene.
- Reduce bee scale, strengthen the yellow/gold body tones, and keep landed bees visually still with wings at rest.
- Make bees continue moving from flower to flower within their assigned habitat.
- Add unit coverage for habitat grouping and bee count behavior.

## Testing
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm lint --filter garden`
- `pnpm lint --filter www`
- `pnpm --filter garden build`
- `pnpm --filter www build`
- `pnpm test --filter garden`
- Local debug render check on the garden game scene