### PR TITLE
Fix debug panel scrolling and stabilize entity grid rendering

### DIFF
--- a/apps/garden/app/debug/entities/EntityGridViewerDynamic.tsx
+++ b/apps/garden/app/debug/entities/EntityGridViewerDynamic.tsx
@@ -32,6 +32,6 @@ export function EntityGridViewerDynamic() {
     }
 
     return (
-        <EntityGridViewer className="w-full h-full" debugHud showBackground />
+        <EntityGridViewer className="h-full w-full" debugHud showBackground />
     );
 }

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -3,8 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 
 async function getOperations() {
     const operations = await directoriesClient().GET('/entities/operation');
-    return operations.data
-        ?.filter((operation) => operation.attributes.internal !== true)
+    return (operations.data ?? [])
+        .filter((operation) => operation.attributes.internal !== true)
         .sort((a, b) => a.information.name.localeCompare(b.information.name));
 }
 

--- a/packages/game/src/hooks/useWeatherNow.ts
+++ b/packages/game/src/hooks/useWeatherNow.ts
@@ -6,8 +6,10 @@ export function useWeatherNow(enabled = true) {
         queryKey: ['weather', 'now'],
         queryFn: async () => {
             const response = await clientPublic().api.data.weather.now.$get();
-            if (response.status === 500) {
-                console.error('Failed to fetch weather data', response);
+            if (!response.ok) {
+                console.debug('Weather data unavailable', {
+                    status: response.status,
+                });
                 return null;
             }
             return await response.json();

--- a/packages/game/src/viewers/EntityGridViewer.tsx
+++ b/packages/game/src/viewers/EntityGridViewer.tsx
@@ -102,7 +102,11 @@ export function EntityGridViewer({
                         enableRainWetOverlayFlag: debugHud,
                     }}
                 >
-                    <Scene position={100} zoom={zoom} className={className}>
+                    <Scene
+                        position={[100, 100, 100]}
+                        zoom={zoom}
+                        className={className}
+                    >
                         <Environment
                             noBackground={!showBackground}
                             noSound

--- a/packages/ui/src/DebugControls/DebugPanel.tsx
+++ b/packages/ui/src/DebugControls/DebugPanel.tsx
@@ -28,13 +28,13 @@ export function DebugPanel({
     return (
         <Card
             className={cx(
-                'w-full max-w-sm border border-border/40 bg-background/95 shadow-lg backdrop-blur',
+                'flex max-h-[calc(100dvh-2rem)] w-full max-w-sm flex-col overflow-hidden border border-border/40 bg-background/95 shadow-lg backdrop-blur',
                 className,
             )}
         >
             <CardHeader
                 className={cx(
-                    'space-y-1',
+                    'shrink-0 space-y-1',
                     onDragHandlePointerDown
                         ? 'cursor-grab select-none touch-none active:cursor-grabbing'
                         : undefined,
@@ -69,7 +69,10 @@ export function DebugPanel({
                 ) : null}
             </CardHeader>
             {collapsed ? null : (
-                <CardContent noHeader className="space-y-3">
+                <CardContent
+                    noHeader
+                    className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain"
+                >
                     {children}
                 </CardContent>
             )}


### PR DESCRIPTION
## Summary
- Constrain the debug panel to the viewport and make its content area scroll when expanded
- Stabilize the entity grid camera setup so `/debug/entities` no longer collapses into a black oversized view after load
- Harden debug data hooks to tolerate missing local API responses without tripping the dev overlay

## Testing
- Lint and formatting checks passed for the affected game and UI files
- Typecheck passed for `@gredice/game`
- Unit tests passed for `@gredice/game`
- Local browser verification confirmed the debug panel scrolls and the entity grid remains visible after hydration
- Production builds passed for `garden` and `www`