### PR TITLE
Skip game keyboard controls when typing in inputs

### DIFF
--- a/packages/game/src/controls/Controls.tsx
+++ b/packages/game/src/controls/Controls.tsx
@@ -61,6 +61,13 @@ const panKeys: Record<string, [number, number]> = {
 
 const rotateValueByKey = (key: string) => rotateKeys[key];
 
+const isEditableTarget = (target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target.isContentEditable) return true;
+    const tag = target.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+};
+
 const useKeyboardControls = () => {
     const [panDir, setPanDir] = useState<[number, number] | null>(null);
     const worldRotate = useGameState((state) => state.worldRotate);
@@ -71,6 +78,7 @@ const useKeyboardControls = () => {
 
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.shiftKey || e.altKey || e.ctrlKey || e.metaKey) return;
+            if (isEditableTarget(e.target)) return;
 
             // Handle rotation
             const rotateValue = rotateValueByKey(e.code);


### PR DESCRIPTION
## Summary
- The game's camera pan (arrow keys) and rotation (Q/W) handlers in `packages/game/src/controls/Controls.tsx` were attached to `document` and fired regardless of which element had focus, so the scene rotated/panned while users typed in the login form, plant search modal, or any other text input.
- Added an `isEditableTarget` check that bails out of the keydown handler when the event target is an `<input>`, `<textarea>`, `<select>`, or `contenteditable` element — mirroring the existing pattern in `PlantEditor.tsx`.

## Test plan
- [ ] On the login screen, use arrow keys inside the email/password fields and confirm the background scene no longer pans.
- [ ] Open the plant search modal, type a query containing arrow keys and Q/W, and confirm the camera stays still.
- [ ] Outside any input, arrow keys still pan the camera and Q/W still rotates the world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)