### PR TITLE
Fix landing game scene gap at top on mobile

### DIFF
--- a/apps/www/app/LandingGameScene.tsx
+++ b/apps/www/app/LandingGameScene.tsx
@@ -204,12 +204,7 @@ export function LandingGameScene() {
                 }
                 data-testid="landing-game-scene"
             >
-                <div
-                    className={cx(
-                        'absolute inset-0',
-                        !interactiveMounted && 'top-20 -bottom-20 md:inset-0',
-                    )}
-                >
+                <div className="absolute inset-0">
                     <GameScene
                         key={isLoggedIn ? 'user-garden' : 'landing-mock'}
                         appBaseUrl="https://vrt.gredice.com"


### PR DESCRIPTION
## Summary
- Drop the mobile-only `top-20 -bottom-20` offset on the inner game container in [LandingGameScene.tsx](apps/www/app/LandingGameScene.tsx) so the scene fills the rounded frame edge-to-edge on mobile.
- Previously the scene was shifted down 80px on mobile, leaving the frame's `bg-muted` background visible above the grass.

## Test plan
- [ ] Load `/` on a mobile viewport and confirm the game scene reaches the top of the rounded frame (no muted/blank strip behind the hero card).
- [ ] Verify desktop (≥ md) layout is unchanged.
- [ ] Open and close the interactive garden expansion to confirm the transition still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)