### PR TITLE
Replace hover outline with screen-space outside-only pass

### DIFF
--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -1,10 +1,15 @@
 import { animated } from '@react-spring/three';
 import { Vector3 } from 'three';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
+import {
+    findRaisedBedByBlockId,
+    getRaisedBedBlockIds,
+} from '../utils/raisedBedBlocks';
 import { useGameGLTF } from '../utils/useGameGLTF';
 import { HoverOutline } from './helpers/HoverOutline';
 import { useEntityNeighbors } from './helpers/useEntityNeighbors';
@@ -16,8 +21,18 @@ const halfOverlap = combinedOverlap / 2;
 export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const { nodes, materials } = useGameGLTF('RaisedBed');
     const currentStackHeight = useStackHeight(stack, block);
-    const hovered =
-        useHoveredBlockStore((state) => state.hoveredBlock) === block;
+    const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
+    const { data: garden } = useCurrentGarden();
+    const hoveredRaisedBed = hoveredBlock
+        ? findRaisedBedByBlockId(garden, hoveredBlock.id)
+        : null;
+    const hovered = Boolean(
+        garden &&
+            hoveredRaisedBed &&
+            getRaisedBedBlockIds(garden, hoveredRaisedBed.id).includes(
+                block.id,
+            ),
+    );
 
     // Switch between shapes (O, L, I, U) based on neighbors
     let shape2:
@@ -97,55 +112,53 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
 
     return (
         <>
-            <animated.group
-                position={raisedBedPosition}
-                rotation={[0, shapeRotation * (Math.PI / 2), 0]}
-            >
-                <mesh
-                    castShadow
-                    receiveShadow
-                    geometry={nodes[shape1].geometry}
-                    material={
-                        materials[
-                            shape1 === 'Raised_Bed_O_1'
-                                ? 'Material.Planks'
-                                : 'Material.Dirt'
-                        ]
-                    }
+            <HoverOutline hovered={hovered}>
+                <animated.group
+                    position={raisedBedPosition}
+                    rotation={[0, shapeRotation * (Math.PI / 2), 0]}
                 >
-                    <HoverOutline hovered={hovered} />
-                </mesh>
-                <SnowOverlay
-                    geometry={nodes[shape1].geometry}
-                    maxThickness={0.16}
-                    slopeExponent={2.8}
-                    noiseScale={3}
-                    coverageMultiplier={0.9}
-                />
-                <RainWetOverlay geometry={nodes[shape1].geometry} />
-                <mesh
-                    castShadow
-                    receiveShadow
-                    geometry={nodes[shape2].geometry}
-                    material={
-                        materials[
-                            shape2 === 'Raised_Bed_O_2'
-                                ? 'Material.Dirt'
-                                : 'Material.Planks'
-                        ]
-                    }
-                >
-                    <HoverOutline hovered={hovered} />
-                </mesh>
-                <SnowOverlay
-                    geometry={nodes[shape2].geometry}
-                    maxThickness={0.16}
-                    slopeExponent={2.8}
-                    noiseScale={3}
-                    coverageMultiplier={0.9}
-                />
-                <RainWetOverlay geometry={nodes[shape2].geometry} />
-            </animated.group>
+                    <mesh
+                        castShadow
+                        receiveShadow
+                        geometry={nodes[shape1].geometry}
+                        material={
+                            materials[
+                                shape1 === 'Raised_Bed_O_1'
+                                    ? 'Material.Planks'
+                                    : 'Material.Dirt'
+                            ]
+                        }
+                    />
+                    <SnowOverlay
+                        geometry={nodes[shape1].geometry}
+                        maxThickness={0.16}
+                        slopeExponent={2.8}
+                        noiseScale={3}
+                        coverageMultiplier={0.9}
+                    />
+                    <RainWetOverlay geometry={nodes[shape1].geometry} />
+                    <mesh
+                        castShadow
+                        receiveShadow
+                        geometry={nodes[shape2].geometry}
+                        material={
+                            materials[
+                                shape2 === 'Raised_Bed_O_2'
+                                    ? 'Material.Dirt'
+                                    : 'Material.Planks'
+                            ]
+                        }
+                    />
+                    <SnowOverlay
+                        geometry={nodes[shape2].geometry}
+                        maxThickness={0.16}
+                        slopeExponent={2.8}
+                        noiseScale={3}
+                        coverageMultiplier={0.9}
+                    />
+                    <RainWetOverlay geometry={nodes[shape2].geometry} />
+                </animated.group>
+            </HoverOutline>
             <group position={raisedBedPosition}>
                 <RaisedBedFields blockId={block.id} />
             </group>

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -48,55 +48,51 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
     }
 
     return (
-        <animated.group
-            onClick={handleClick}
-            position={stack.position.clone().setY(currentStackHeight)}
-            rotation={animatedRotation as unknown as [number, number, number]}
+        <HoverOutline
+            hovered={hovered || isLidOpen}
+            thickness={7}
+            color="#f8fafc"
         >
-            <mesh
-                castShadow
-                receiveShadow
-                geometry={nodes.GardenBox_Body_Planks.geometry}
-                material={materials['Material.Planks']}
-            >
-                <HoverOutline
-                    hovered={hovered || isLidOpen}
-                    variant="outlines"
-                    thickness={7}
-                    color="#f8fafc"
-                    backingColor="#0f172a"
-                />
-            </mesh>
-            <SnowOverlay
-                geometry={nodes.GardenBox_Body_Planks.geometry}
-                {...snowPresets.giftBox}
-            />
-            <RainWetOverlay geometry={nodes.GardenBox_Body_Planks.geometry} />
             <animated.group
-                position={[0, 0.6, -0.38]}
-                rotation={lidRotation as unknown as [number, number, number]}
+                onClick={handleClick}
+                position={stack.position.clone().setY(currentStackHeight)}
+                rotation={
+                    animatedRotation as unknown as [number, number, number]
+                }
             >
                 <mesh
+                    castShadow
                     receiveShadow
-                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    geometry={nodes.GardenBox_Body_Planks.geometry}
                     material={materials['Material.Planks']}
-                >
-                    <HoverOutline
-                        hovered={hovered || isLidOpen}
-                        variant="outlines"
-                        thickness={7}
-                        color="#f8fafc"
-                        backingColor="#0f172a"
-                    />
-                </mesh>
+                />
                 <SnowOverlay
-                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    geometry={nodes.GardenBox_Body_Planks.geometry}
                     {...snowPresets.giftBox}
                 />
                 <RainWetOverlay
-                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    geometry={nodes.GardenBox_Body_Planks.geometry}
                 />
+                <animated.group
+                    position={[0, 0.6, -0.38]}
+                    rotation={
+                        lidRotation as unknown as [number, number, number]
+                    }
+                >
+                    <mesh
+                        receiveShadow
+                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                        material={materials['Material.Planks']}
+                    />
+                    <SnowOverlay
+                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                        {...snowPresets.giftBox}
+                    />
+                    <RainWetOverlay
+                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    />
+                </animated.group>
             </animated.group>
-        </animated.group>
+        </HoverOutline>
     );
 }

--- a/packages/game/src/entities/helpers/GiftBox.tsx
+++ b/packages/game/src/entities/helpers/GiftBox.tsx
@@ -31,58 +31,63 @@ export function GiftBox({
         useHoveredBlockStore((state) => state.hoveredBlock) === block;
 
     return (
-        <animated.group
-            position={stack.position.clone().setY(currentStackHeight + 0.25)}
-            rotation={animatedRotation as unknown as [number, number, number]}
-        >
-            <mesh
-                castShadow
-                receiveShadow
-                geometry={nodes.GiftBox_Box.geometry}
+        <HoverOutline hovered={hovered}>
+            <animated.group
+                position={stack.position
+                    .clone()
+                    .setY(currentStackHeight + 0.25)}
+                rotation={
+                    animatedRotation as unknown as [number, number, number]
+                }
             >
-                <meshStandardMaterial
-                    color={boxColor}
-                    metalness={boxMetalness}
-                    roughness={boxRoughness}
+                <mesh
+                    castShadow
+                    receiveShadow
+                    geometry={nodes.GiftBox_Box.geometry}
+                >
+                    <meshStandardMaterial
+                        color={boxColor}
+                        metalness={boxMetalness}
+                        roughness={boxRoughness}
+                    />
+                </mesh>
+                <mesh
+                    castShadow
+                    receiveShadow
+                    geometry={nodes.GiftBox_Strip.geometry}
+                >
+                    <meshStandardMaterial
+                        color={ribbonColor}
+                        metalness={0.5}
+                        roughness={0.3}
+                    />
+                </mesh>
+                <mesh
+                    castShadow
+                    receiveShadow
+                    geometry={nodes.GiftBox_Bow.geometry}
+                    position={[0, 0.25, 0]}
+                    rotation={[0, -Math.PI / 4, 0]}
+                >
+                    <meshStandardMaterial
+                        color={ribbonColor}
+                        metalness={0.5}
+                        roughness={0.3}
+                    />
+                </mesh>
+                <SnowOverlay
+                    geometry={nodes.GiftBox_Box.geometry}
+                    {...snowPresets.giftBox}
                 />
-                <HoverOutline hovered={hovered} variant="outlines" />
-            </mesh>
-            <mesh
-                castShadow
-                receiveShadow
-                geometry={nodes.GiftBox_Strip.geometry}
-            >
-                <meshStandardMaterial
-                    color={ribbonColor}
-                    metalness={0.5}
-                    roughness={0.3}
+                <SnowOverlay
+                    geometry={nodes.GiftBox_Strip.geometry}
+                    {...snowPresets.giftBox}
                 />
-            </mesh>
-            <mesh
-                castShadow
-                receiveShadow
-                geometry={nodes.GiftBox_Bow.geometry}
-                position={[0, 0.25, 0]}
-                rotation={[0, -Math.PI / 4, 0]}
-            >
-                <meshStandardMaterial
-                    color={ribbonColor}
-                    metalness={0.5}
-                    roughness={0.3}
+                <SnowOverlay
+                    geometry={nodes.GiftBox_Bow.geometry}
+                    {...snowPresets.giftBox}
                 />
-            </mesh>
-            <SnowOverlay
-                geometry={nodes.GiftBox_Box.geometry}
-                {...snowPresets.giftBox}
-            />
-            <SnowOverlay
-                geometry={nodes.GiftBox_Strip.geometry}
-                {...snowPresets.giftBox}
-            />
-            <SnowOverlay
-                geometry={nodes.GiftBox_Bow.geometry}
-                {...snowPresets.giftBox}
-            />
-        </animated.group>
+            </animated.group>
+        </HoverOutline>
     );
 }

--- a/packages/game/src/entities/helpers/HoverOutline.tsx
+++ b/packages/game/src/entities/helpers/HoverOutline.tsx
@@ -1,37 +1,499 @@
-import { Edges, Outlines } from '@react-three/drei';
+import { type RootState, useFrame } from '@react-three/fiber';
+import {
+    createContext,
+    type PropsWithChildren,
+    useContext,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+} from 'react';
+import {
+    Box3,
+    type Camera,
+    Color,
+    DoubleSide,
+    type Group,
+    LinearFilter,
+    Mesh,
+    MeshBasicMaterial,
+    NoBlending,
+    type Object3D,
+    OrthographicCamera,
+    PlaneGeometry,
+    RGBAFormat,
+    Scene,
+    ShaderMaterial,
+    type Texture,
+    UnsignedByteType,
+    Vector2,
+    Vector3,
+    WebGLRenderTarget,
+} from 'three';
 
-type HoverOutlineProps = {
-    hovered?: boolean;
-    variant?: 'edges' | 'outlines';
-    color?: string;
-    backingColor?: string;
-    thickness?: number;
+const hoverOutlineLayer = 29;
+const maxOutlineThickness = 12;
+const outlineRenderPriority = 1;
+
+type HoverOutlineTarget = {
+    active: boolean;
+    color: string;
+    object: Object3D;
+    thickness: number;
 };
 
-export function HoverOutline({
-    hovered,
-    variant,
-    color = 'white',
-    backingColor,
-    thickness = 5,
-}: HoverOutlineProps) {
-    if (!hovered) return null;
-    if (variant === 'outlines') {
-        return (
-            <>
-                {backingColor && (
-                    <Outlines thickness={thickness + 3} color={backingColor} />
-                )}
-                <Outlines thickness={thickness} color={color} />
-            </>
-        );
+type HoverOutlineRegistry = {
+    deleteTarget: (id: symbol) => void;
+    getActiveTargets: () => HoverOutlineTarget[];
+    setTarget: (id: symbol, target: HoverOutlineTarget) => void;
+};
+
+const HoverOutlineContext = createContext<HoverOutlineRegistry | null>(null);
+
+function createMaskMaterial() {
+    const material = new MeshBasicMaterial({
+        blending: NoBlending,
+        color: 'white',
+        depthTest: false,
+        depthWrite: false,
+        side: DoubleSide,
+        toneMapped: false,
+    });
+    material.fog = false;
+    return material;
+}
+
+function createOutlineMaterial() {
+    return new ShaderMaterial({
+        uniforms: {
+            maskTexture: { value: null as Texture | null },
+            outlineColor: { value: new Color('white') },
+            screenMax: { value: new Vector2(1, 1) },
+            screenMin: { value: new Vector2(0, 0) },
+            texelSize: { value: new Vector2(1, 1) },
+            thickness: { value: 5 },
+        },
+        vertexShader: `
+            uniform vec2 screenMax;
+            uniform vec2 screenMin;
+
+            varying vec2 vUv;
+
+            void main() {
+                vec2 clipMin = screenMin * 2.0 - 1.0;
+                vec2 clipMax = screenMax * 2.0 - 1.0;
+
+                vUv = mix(screenMin, screenMax, uv);
+                gl_Position = vec4(mix(clipMin, clipMax, uv), 0.0, 1.0);
+            }
+        `,
+        fragmentShader: `
+            uniform sampler2D maskTexture;
+            uniform vec3 outlineColor;
+            uniform vec2 texelSize;
+            uniform float thickness;
+
+            varying vec2 vUv;
+
+            void main() {
+                float center = texture2D(maskTexture, vUv).r;
+                float expanded = 0.0;
+
+                for (int x = -${maxOutlineThickness}; x <= ${maxOutlineThickness}; x++) {
+                    for (int y = -${maxOutlineThickness}; y <= ${maxOutlineThickness}; y++) {
+                        vec2 offset = vec2(float(x), float(y));
+                        if (dot(offset, offset) <= thickness * thickness) {
+                            vec2 sampleUv = vUv + offset * texelSize;
+                            if (
+                                sampleUv.x >= 0.0 &&
+                                sampleUv.x <= 1.0 &&
+                                sampleUv.y >= 0.0 &&
+                                sampleUv.y <= 1.0
+                            ) {
+                                expanded = max(
+                                    expanded,
+                                    texture2D(maskTexture, sampleUv).r
+                                );
+                            }
+                        }
+                    }
+                }
+
+                float alpha = expanded * (1.0 - center);
+                if (alpha < 0.01) {
+                    discard;
+                }
+
+                gl_FragColor = vec4(outlineColor, alpha);
+            }
+        `,
+        depthTest: false,
+        depthWrite: false,
+        transparent: true,
+    });
+}
+
+type ScreenBounds = {
+    maxX: number;
+    maxY: number;
+    minX: number;
+    minY: number;
+};
+
+type ScreenBoundsScratch = {
+    box: Box3;
+    point: Vector3;
+};
+
+function getOutlineScreenBounds({
+    camera,
+    drawingBufferSize,
+    scratch,
+    targets,
+    thickness,
+}: {
+    camera: Camera;
+    drawingBufferSize: Vector2;
+    scratch: ScreenBoundsScratch;
+    targets: HoverOutlineTarget[];
+    thickness: number;
+}): ScreenBounds | null {
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+
+    for (const target of targets) {
+        scratch.box.setFromObject(target.object);
+
+        if (scratch.box.isEmpty()) {
+            continue;
+        }
+
+        const { max, min } = scratch.box;
+
+        for (let xIndex = 0; xIndex < 2; xIndex++) {
+            for (let yIndex = 0; yIndex < 2; yIndex++) {
+                for (let zIndex = 0; zIndex < 2; zIndex++) {
+                    scratch.point
+                        .set(
+                            xIndex === 0 ? min.x : max.x,
+                            yIndex === 0 ? min.y : max.y,
+                            zIndex === 0 ? min.z : max.z,
+                        )
+                        .project(camera);
+
+                    if (
+                        !Number.isFinite(scratch.point.x) ||
+                        !Number.isFinite(scratch.point.y)
+                    ) {
+                        continue;
+                    }
+
+                    const x = scratch.point.x * 0.5 + 0.5;
+                    const y = scratch.point.y * 0.5 + 0.5;
+
+                    maxX = Math.max(maxX, x);
+                    maxY = Math.max(maxY, y);
+                    minX = Math.min(minX, x);
+                    minY = Math.min(minY, y);
+                }
+            }
+        }
     }
 
-    return (
-        <Edges
-            linewidth={thickness}
-            threshold={60} // Display edges only when the angle between two faces exceeds this value (default=15 degrees)
-            color={color}
-        />
+    if (!Number.isFinite(minX) || !Number.isFinite(minY)) {
+        return null;
+    }
+
+    const marginX = (thickness + 2) / drawingBufferSize.x;
+    const marginY = (thickness + 2) / drawingBufferSize.y;
+    const bounds = {
+        maxX: Math.min(1, maxX + marginX),
+        maxY: Math.min(1, maxY + marginY),
+        minX: Math.max(0, minX - marginX),
+        minY: Math.max(0, minY - marginY),
+    };
+
+    if (bounds.minX >= bounds.maxX || bounds.minY >= bounds.maxY) {
+        return null;
+    }
+
+    return bounds;
+}
+
+function useHoverOutlineRegistry() {
+    const targets = useRef(new Map<symbol, HoverOutlineTarget>());
+
+    return useMemo<HoverOutlineRegistry>(
+        () => ({
+            deleteTarget: (id) => {
+                targets.current.delete(id);
+            },
+            getActiveTargets: () =>
+                Array.from(targets.current.values()).filter(
+                    (target) => target.active && target.object.parent,
+                ),
+            setTarget: (id, target) => {
+                targets.current.set(id, target);
+            },
+        }),
+        [],
     );
+}
+
+function useTargetId() {
+    const id = useRef<symbol>(Symbol('hover-outline-target'));
+    return id.current;
+}
+
+function setLayerMask(objects: Object3D[], layer: number) {
+    const previousLayers: [object: Object3D, mask: number][] = [];
+
+    for (const object of objects) {
+        object.traverse((child) => {
+            previousLayers.push([child, child.layers.mask]);
+            child.layers.set(layer);
+        });
+    }
+
+    return () => {
+        for (const [object, mask] of previousLayers) {
+            object.layers.mask = mask;
+        }
+    };
+}
+
+function resizeRenderTargetToDrawingBuffer(
+    gl: RootState['gl'],
+    renderTarget: WebGLRenderTarget,
+    drawingBufferSize: Vector2,
+) {
+    gl.getDrawingBufferSize(drawingBufferSize);
+
+    if (
+        renderTarget.width !== drawingBufferSize.x ||
+        renderTarget.height !== drawingBufferSize.y
+    ) {
+        renderTarget.setSize(drawingBufferSize.x, drawingBufferSize.y);
+    }
+}
+
+function renderMask({
+    camera,
+    drawingBufferSize,
+    gl,
+    maskMaterial,
+    renderTarget,
+    scene,
+    targets,
+}: {
+    camera: Camera;
+    drawingBufferSize: Vector2;
+    gl: RootState['gl'];
+    maskMaterial: MeshBasicMaterial;
+    renderTarget: WebGLRenderTarget;
+    scene: Scene;
+    targets: HoverOutlineTarget[];
+}) {
+    resizeRenderTargetToDrawingBuffer(gl, renderTarget, drawingBufferSize);
+
+    const restoreLayers = setLayerMask(
+        targets.map((target) => target.object),
+        hoverOutlineLayer,
+    );
+    const previousCameraLayers = camera.layers.mask;
+    const previousOverrideMaterial = scene.overrideMaterial;
+    const previousBackground = scene.background;
+    const previousRenderTarget = gl.getRenderTarget();
+    const previousClearAlpha = gl.getClearAlpha();
+    const previousAutoClear = gl.autoClear;
+    const previousClearColor = gl.getClearColor(new Color());
+
+    try {
+        camera.layers.set(hoverOutlineLayer);
+        scene.background = null;
+        scene.overrideMaterial = maskMaterial;
+        gl.autoClear = true;
+        gl.setRenderTarget(renderTarget);
+        gl.setClearColor(0x000000, 0);
+        gl.clear(true, true, true);
+        gl.render(scene, camera);
+    } finally {
+        restoreLayers();
+        camera.layers.mask = previousCameraLayers;
+        scene.background = previousBackground;
+        scene.overrideMaterial = previousOverrideMaterial;
+        gl.setRenderTarget(previousRenderTarget);
+        gl.setClearColor(previousClearColor, previousClearAlpha);
+        gl.autoClear = previousAutoClear;
+    }
+}
+
+function useOutlineOverlay() {
+    const material = useMemo(createOutlineMaterial, []);
+
+    const overlay = useMemo(() => {
+        const scene = new Scene();
+        const camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+        const geometry = new PlaneGeometry(1, 1);
+        const mesh = new Mesh(geometry, material);
+        mesh.frustumCulled = false;
+        scene.add(mesh);
+        return { camera, geometry, scene };
+    }, [material]);
+
+    useEffect(
+        () => () => {
+            overlay.geometry.dispose();
+            material.dispose();
+        },
+        [material, overlay],
+    );
+
+    return { ...overlay, material };
+}
+
+function useMaskRenderTarget() {
+    const renderTarget = useMemo(
+        () =>
+            new WebGLRenderTarget(1, 1, {
+                depthBuffer: false,
+                format: RGBAFormat,
+                magFilter: LinearFilter,
+                minFilter: LinearFilter,
+                stencilBuffer: false,
+                type: UnsignedByteType,
+            }),
+        [],
+    );
+
+    useEffect(() => () => renderTarget.dispose(), [renderTarget]);
+
+    return renderTarget;
+}
+
+export function HoverOutlineProvider({ children }: PropsWithChildren) {
+    const registry = useHoverOutlineRegistry();
+
+    return (
+        <HoverOutlineContext.Provider value={registry}>
+            {children}
+        </HoverOutlineContext.Provider>
+    );
+}
+
+type HoverOutlineProps = PropsWithChildren<{
+    color?: string;
+    hovered?: boolean;
+    thickness?: number;
+}>;
+
+export function HoverOutline({
+    children,
+    color = 'white',
+    hovered = false,
+    thickness = 5,
+}: HoverOutlineProps) {
+    const ref = useRef<Group>(null);
+    const registry = useContext(HoverOutlineContext);
+    const id = useTargetId();
+    const clampedThickness = Math.min(
+        Math.max(thickness, 1),
+        maxOutlineThickness,
+    );
+
+    useLayoutEffect(() => {
+        if (!registry || !ref.current) {
+            return;
+        }
+
+        registry.setTarget(id, {
+            active: hovered,
+            color,
+            object: ref.current,
+            thickness: clampedThickness,
+        });
+
+        return () => registry.deleteTarget(id);
+    }, [clampedThickness, color, hovered, id, registry]);
+
+    return <group ref={ref}>{children}</group>;
+}
+
+export function HoverOutlineEffect() {
+    const registry = useContext(HoverOutlineContext);
+    const drawingBufferSize = useMemo(() => new Vector2(), []);
+    const maskMaterial = useMemo(createMaskMaterial, []);
+    const maskRenderTarget = useMaskRenderTarget();
+    const outlineOverlay = useOutlineOverlay();
+    const screenBoundsScratch = useMemo<ScreenBoundsScratch>(
+        () => ({ box: new Box3(), point: new Vector3() }),
+        [],
+    );
+
+    useEffect(() => () => maskMaterial.dispose(), [maskMaterial]);
+
+    useFrame(({ camera, gl, scene }) => {
+        gl.render(scene, camera);
+
+        const targets = registry?.getActiveTargets() ?? [];
+        if (targets.length === 0) {
+            return;
+        }
+
+        const [firstTarget] = targets;
+        if (!firstTarget) {
+            return;
+        }
+
+        renderMask({
+            camera,
+            drawingBufferSize,
+            gl,
+            maskMaterial,
+            renderTarget: maskRenderTarget,
+            scene,
+            targets,
+        });
+
+        outlineOverlay.material.uniforms.maskTexture.value =
+            maskRenderTarget.texture;
+        outlineOverlay.material.uniforms.outlineColor.value.set(
+            firstTarget.color,
+        );
+        const screenBounds = getOutlineScreenBounds({
+            camera,
+            drawingBufferSize,
+            scratch: screenBoundsScratch,
+            targets,
+            thickness: firstTarget.thickness,
+        });
+
+        if (!screenBounds) {
+            return;
+        }
+
+        outlineOverlay.material.uniforms.screenMin.value.set(
+            screenBounds.minX,
+            screenBounds.minY,
+        );
+        outlineOverlay.material.uniforms.screenMax.value.set(
+            screenBounds.maxX,
+            screenBounds.maxY,
+        );
+        outlineOverlay.material.uniforms.texelSize.value.set(
+            1 / maskRenderTarget.width,
+            1 / maskRenderTarget.height,
+        );
+        outlineOverlay.material.uniforms.thickness.value =
+            firstTarget.thickness;
+
+        const previousAutoClear = gl.autoClear;
+        gl.autoClear = false;
+        gl.render(outlineOverlay.scene, outlineOverlay.camera);
+        gl.autoClear = previousAutoClear;
+    }, outlineRenderPriority);
+
+    return null;
 }

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -3,6 +3,10 @@
 import { Canvas, type Vector3 as FiberVector3 } from '@react-three/fiber';
 import { type HTMLAttributes, type PropsWithChildren, useEffect } from 'react';
 import { PCFShadowMap } from 'three';
+import {
+    HoverOutlineEffect,
+    HoverOutlineProvider,
+} from '../entities/helpers/HoverOutline';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
 import {
     type GameQualityProfile,
@@ -56,7 +60,10 @@ export function Scene({
             }}
             {...rest}
         >
-            {children}
+            <HoverOutlineProvider>
+                {children}
+                <HoverOutlineEffect />
+            </HoverOutlineProvider>
         </Canvas>
     );
 }


### PR DESCRIPTION
## Summary
- Replaced the old mesh-edge hover outline with a custom render pass that draws a white outline only on the outside, ignores depth, and renders above the scene.
- Grouped targets are now outlined as a single entity, so adjacent raised-bed blocks no longer show an internal seam when hovered.
- Updated raised beds, garden boxes, and gift boxes to register the full grouped mesh instead of outlining individual sub-meshes.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm --filter @gredice/game typecheck`
- `pnpm test --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm lint --filter www`
- `pnpm --filter garden build`
- `pnpm --filter www build`
- Local Playwright smoke test on the garden debug profile confirmed the outline renders only around the exterior of the hovered raised-bed group.