### PR TITLE
Fix items-hud tests for nested decoration sub-pickers

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import { ItemsHudAlignmentStory } from './ItemsHudStory';
 
 const TABLET_VIEWPORT = { width: 820, height: 1180 };
-const SHORT_MOBILE_VIEWPORT = { width: 414, height: 600 };
+const SHORT_MOBILE_VIEWPORT = { width: 414, height: 420 };
 
 test('edit mode item picker stays centered on tablet layouts', async ({
     mount,
@@ -30,9 +30,10 @@ test('pots are listed under the decoration picker', async ({ mount, page }) => {
     await page.setViewportSize(TABLET_VIEWPORT);
     await mount(<ItemsHudAlignmentStory />);
 
-    await expect(page.getByRole('button', { name: 'Tegle' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Posude' })).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Posude' }).click();
 
     await expect(
         page.getByRole('button', { name: 'PotLowBowl' }),
@@ -84,8 +85,8 @@ test('decoration picker scrolls when the viewport is too short for all items', a
 
     await page.getByRole('button', { name: 'Dekoracija' }).click();
 
-    const firstItem = page.getByRole('button', { name: 'PotLowBowl' });
-    const lastItem = page.getByRole('button', { name: 'MulchWood' });
+    const firstItem = page.getByRole('button', { name: 'Posude' });
+    const lastItem = page.getByRole('button', { name: 'CactusPricklyPear' });
 
     await expect(firstItem).toBeVisible();
 


### PR DESCRIPTION
## Summary
PR [#3029](https://github.com/gredice/gredice/pull/3029) grouped pots, rocks, and mulch into nested sub-pickers inside the **Dekoracija** picker, but the matching playwright specs still expected those entities to be direct children of the picker. Two tests in [items-hud.spec.tsx](apps/garden/tests/items-hud.spec.tsx) now fail against `main`. This PR updates them.

## Changes
- **"pots are listed under the decoration picker"** — now drills `Dekoracija → Posude` before asserting `PotLowBowl`/`PotWideLippedCup`. The negative pre-check switched from the obsolete `Tegle` label to the real sub-picker label `Posude`, so it actually catches a regression if pots ever surface at the top level.
- **"decoration picker scrolls when the viewport is too short for all items"** — root grid shrank from ~30 to ~18 items, so `414×600` no longer overflows. Tightened `SHORT_MOBILE_VIEWPORT` to `414×420` and pointed first/last locators at `Posude` / `CactusPricklyPear`, both of which live in the current root grid.

## Verification
```
cd apps/garden && npx playwright test items-hud.spec.tsx --repeat-each=3
# 15/15 passed
```
Full garden suite shows two unrelated parallel-load flakes (`inventory-hud` and `raised-bed-field-hud`) that both pass in isolation — pre-existing, not addressed here.

## Test plan
- [ ] CI: `playwright test` passes on this branch.
- [ ] Manually open the items HUD in edit mode, click `Dekoracija`, click `Posude`, confirm pots render and clicking back returns to the root decoration grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)