### PR TITLE
Enlarge ground flower decorations

### DIFF
--- a/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
+++ b/packages/game/src/entities/groundDecorations/groundDecorationConfig.ts
@@ -50,7 +50,7 @@ export const groundDecorationOptions: Record<
             ],
             maxCount: 2,
             minDistance: 0.055,
-            scaleRange: [0.11, 0.16],
+            scaleRange: [0.165, 0.4],
             spread: 0.085,
             spawnChance: 0.7,
         },


### PR DESCRIPTION
## Summary
- Bump grass-surface flower `scaleRange` from `[0.11, 0.16]` to `[0.165, 0.4]` in [groundDecorationConfig.ts](packages/game/src/entities/groundDecorations/groundDecorationConfig.ts), applying a 1.5x-2.5x multiplier over the previous values.
- Existing `rng.nextRange` call in [getBlockSurfaceDecorations.ts](packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts) already samples uniformly across the range, so each flower now also gets a wider per-instance size variation.

## Test plan
- [ ] Open the game scene with a Grass block and confirm ground flowers are noticeably larger.
- [ ] Verify variation: multiple flowers on the same/nearby tiles render at clearly different sizes.
- [ ] Run existing `getBlockSurfaceDecorations` unit tests (bounds are derived from `scaleRange`, so they should continue to pass).

Generated with [Claude Code](https://claude.com/claude-code)