### PR TITLE
Add mid-air wander hops to bee flight behavior

### DIFF
--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -30,9 +30,12 @@ import { useGameGLTF } from '../../utils/useGameGLTF';
 import { tulipBouquetStems } from '../tulipBouquet';
 import {
     type BeeWeather,
+    createBeeWanderOffset,
     getBeeDwellSeconds,
     getBeeHabitatGroups,
+    getBeeWanderHoverSeconds,
     isBeeActive,
+    shouldBeeWanderNext,
 } from './beeBehavior';
 
 type BeeRaisedBedField = {
@@ -57,13 +60,14 @@ type BeeGarden = {
 
 type BeeTarget = {
     id: string;
-    kind: 'flower' | 'raised-bed-flower';
+    kind: 'flower' | 'raised-bed-flower' | 'wander';
     position: Vector3;
 };
 
 type BeeHabitat = {
     id: string;
     seed: number;
+    center: Vector3;
     startTarget: BeeTarget;
     targets: BeeTarget[];
 };
@@ -305,6 +309,18 @@ function createFlowerTargets(
     ];
 }
 
+function computeHabitatCenter(targets: BeeTarget[]) {
+    if (targets.length <= 0) {
+        return new Vector3();
+    }
+
+    const sum = new Vector3();
+    for (const target of targets) {
+        sum.add(target.position);
+    }
+    return sum.divideScalar(targets.length);
+}
+
 function createBeeHabitats(
     garden: BeeGarden | null | undefined,
     blockData: BlockData[] | null | undefined,
@@ -334,6 +350,7 @@ function createBeeHabitats(
             {
                 id: `bee-${index + 1}`,
                 seed,
+                center: computeHabitatCenter(targets),
                 startTarget:
                     targets[Math.floor(random() * targets.length)] ??
                     firstTarget,
@@ -502,27 +519,58 @@ function facePosition(
     faceYaw(group, Math.atan2(directionX, directionZ), delta, turnDamping);
 }
 
+function createWanderTarget(
+    habitatCenter: Vector3,
+    random: () => number,
+): BeeTarget {
+    const offset = createBeeWanderOffset(random);
+    const sequenceId = Math.floor(random() * 0xffffffff)
+        .toString(16)
+        .padStart(8, '0');
+    return {
+        id: `wander-${sequenceId}`,
+        kind: 'wander',
+        position: new Vector3(
+            habitatCenter.x + offset.dx,
+            habitatCenter.y + offset.dy,
+            habitatCenter.z + offset.dz,
+        ),
+    };
+}
+
 function chooseNextTarget({
     currentTarget,
+    habitatCenter,
     random,
     targets,
 }: {
     currentTarget: BeeTarget;
+    habitatCenter: Vector3;
     random: () => number;
     targets: BeeTarget[];
 }) {
-    const nearbyTargets = targets.filter(
-        (target) =>
-            target.id !== currentTarget.id &&
-            horizontalDistance(target.position, currentTarget.position) <= 6,
-    );
-    const fallbackTargets = targets.filter(
+    const otherTargets = targets.filter(
         (target) => target.id !== currentTarget.id,
+    );
+
+    if (
+        shouldBeeWanderNext({
+            otherFlowerCount: otherTargets.length,
+            currentlyWandering: currentTarget.kind === 'wander',
+            random,
+        })
+    ) {
+        return createWanderTarget(habitatCenter, random);
+    }
+
+    const nearbyTargets = otherTargets.filter(
+        (target) =>
+            horizontalDistance(target.position, currentTarget.position) <= 6,
     );
 
     return (
         pickCandidate(
-            nearbyTargets.length > 0 ? nearbyTargets : fallbackTargets,
+            nearbyTargets.length > 0 ? nearbyTargets : otherTargets,
             random,
         ) ?? currentTarget
     );
@@ -566,6 +614,10 @@ function yawTowardPosition(from: Vector3, to: Vector3) {
 }
 
 function createBeeLandingPosition(target: BeeTarget, random: () => number) {
+    if (target.kind === 'wander') {
+        return target.position.clone();
+    }
+
     const targetJitterRadius =
         target.kind === 'raised-bed-flower'
             ? 0.012 + random() * 0.018
@@ -583,11 +635,13 @@ function createBeeLandingPosition(target: BeeTarget, random: () => number) {
 }
 
 function makeForagingState({
+    flightYaw,
     landingPosition,
     now,
     random,
     target,
 }: {
+    flightYaw?: number;
     landingPosition?: Vector3;
     now: number;
     random: () => number;
@@ -595,11 +649,18 @@ function makeForagingState({
 }) {
     const position =
         landingPosition ?? createBeeLandingPosition(target, random);
+    const isWander = target.kind === 'wander';
     return {
         phase: 'foraging',
-        dwellUntil: now + getBeeDwellSeconds(random),
+        dwellUntil:
+            now +
+            (isWander
+                ? getBeeWanderHoverSeconds(random)
+                : getBeeDwellSeconds(random)),
         landingPosition: position,
-        landingYaw: yawTowardPosition(position, target.position),
+        landingYaw: isWander
+            ? (flightYaw ?? 0)
+            : yawTowardPosition(position, target.position),
         startedAt: now,
         target,
     } satisfies ForagingBeeState;
@@ -672,7 +733,9 @@ function updateBeeRig({
     runtime: BeeRuntimeState | null;
     seed: number;
 }) {
-    const flying = runtime?.phase === 'moving';
+    const flying =
+        runtime?.phase === 'moving' ||
+        (runtime?.phase === 'foraging' && runtime.target.kind === 'wander');
 
     if (!flying) {
         if (rig.wingLeft.object) {
@@ -740,6 +803,10 @@ function roundBeeDebugCoordinate(value: number) {
 function getBeeDebugActivity(runtime: BeeRuntimeState) {
     if (runtime.phase === 'moving') {
         return `flying to ${runtime.target.kind}`;
+    }
+
+    if (runtime.target.kind === 'wander') {
+        return 'hovering mid-air';
     }
 
     return 'visiting flower';
@@ -872,6 +939,7 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
 
             if (progress >= 1) {
                 runtimeRef.current = makeForagingState({
+                    flightYaw: yawTowardPosition(runtime.from, runtime.to),
                     landingPosition: runtime.to.clone(),
                     now,
                     random,
@@ -879,15 +947,33 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
                 });
             }
         } else {
-            const nextPosition = foragePositionAt(runtime);
-            group.position.copy(nextPosition);
-            group.rotation.x = -0.04;
-            group.rotation.y = runtime.landingYaw;
-            group.rotation.z = 0;
+            const isWander = runtime.target.kind === 'wander';
+            if (isWander) {
+                const seed = habitat.seed;
+                group.position.set(
+                    runtime.landingPosition.x +
+                        Math.cos(now * 1.7 + seed) * 0.05,
+                    runtime.landingPosition.y +
+                        Math.sin(now * 3 + seed) * 0.06,
+                    runtime.landingPosition.z +
+                        Math.sin(now * 2.1 + seed) * 0.05,
+                );
+                group.rotation.x =
+                    -0.05 + Math.sin(now * 6 + seed) * 0.04;
+                group.rotation.y =
+                    runtime.landingYaw + Math.sin(now * 1.3 + seed) * 0.2;
+                group.rotation.z = Math.sin(now * 4.2 + seed) * 0.08;
+            } else {
+                group.position.copy(foragePositionAt(runtime));
+                group.rotation.x = -0.04;
+                group.rotation.y = runtime.landingYaw;
+                group.rotation.z = 0;
+            }
 
             if (now >= runtime.dwellUntil) {
                 const target = chooseNextTarget({
                     currentTarget: runtime.target,
+                    habitatCenter: habitat.center,
                     random,
                     targets: habitat.targets,
                 });

--- a/packages/game/src/entities/bees/beeBehavior.ts
+++ b/packages/game/src/entities/bees/beeBehavior.ts
@@ -51,6 +51,39 @@ export function getBeeDwellSeconds(random: () => number) {
     return 2.4 + random() * 3.6;
 }
 
+export function getBeeWanderHoverSeconds(random: () => number) {
+    return 0.2 + random() * 0.4;
+}
+
+export function shouldBeeWanderNext({
+    otherFlowerCount,
+    currentlyWandering,
+    random,
+}: {
+    otherFlowerCount: number;
+    currentlyWandering: boolean;
+    random: () => number;
+}) {
+    if (otherFlowerCount <= 0) {
+        return true;
+    }
+    if (currentlyWandering) {
+        return random() < 0.35;
+    }
+    return random() < 0.4;
+}
+
+export function createBeeWanderOffset(random: () => number) {
+    const angle = random() * Math.PI * 2;
+    const radius = 1.6 + random() * 3.8;
+    const lift = 0.5 + random() * 0.9;
+    return {
+        dx: Math.cos(angle) * radius,
+        dy: lift,
+        dz: Math.sin(angle) * radius,
+    };
+}
+
 function isWithinBeeHabitatRadius(
     left: BeeTargetPosition,
     right: BeeTargetPosition,

--- a/packages/game/src/entities/bees/beeBehavior.unit.ts
+++ b/packages/game/src/entities/bees/beeBehavior.unit.ts
@@ -1,12 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    createBeeWanderOffset,
     getBeeCount,
     getBeeDwellSeconds,
     getBeeHabitatGroups,
+    getBeeWanderHoverSeconds,
     isBeeActive,
     isBeeDaytime,
     isBeeWeatherSuitable,
+    shouldBeeWanderNext,
 } from './beeBehavior';
 
 const clearWeather = {
@@ -88,4 +91,70 @@ test('uses short flower dwell windows', () => {
         getBeeDwellSeconds(() => 1),
         6,
     );
+});
+
+test('always wanders next when habitat has no other flowers', () => {
+    assert.equal(
+        shouldBeeWanderNext({
+            otherFlowerCount: 0,
+            currentlyWandering: false,
+            random: () => 0.99,
+        }),
+        true,
+    );
+});
+
+test('inserts wander between flower visits sometimes', () => {
+    assert.equal(
+        shouldBeeWanderNext({
+            otherFlowerCount: 3,
+            currentlyWandering: false,
+            random: () => 0.1,
+        }),
+        true,
+    );
+    assert.equal(
+        shouldBeeWanderNext({
+            otherFlowerCount: 3,
+            currentlyWandering: false,
+            random: () => 0.9,
+        }),
+        false,
+    );
+});
+
+test('chains wander hops less often than starting them', () => {
+    assert.equal(
+        shouldBeeWanderNext({
+            otherFlowerCount: 2,
+            currentlyWandering: true,
+            random: () => 0.34,
+        }),
+        true,
+    );
+    assert.equal(
+        shouldBeeWanderNext({
+            otherFlowerCount: 2,
+            currentlyWandering: true,
+            random: () => 0.36,
+        }),
+        false,
+    );
+});
+
+test('uses brief mid-air hover windows for wandering', () => {
+    const minHover = getBeeWanderHoverSeconds(() => 0);
+    const maxHover = getBeeWanderHoverSeconds(() => 1);
+    assert.ok(minHover >= 0.19 && minHover <= 0.21);
+    assert.ok(maxHover >= 0.59 && maxHover <= 0.61);
+    assert.ok(minHover < maxHover);
+});
+
+test('wander offsets stay within a small habitat radius', () => {
+    const minOffset = createBeeWanderOffset(() => 0);
+    const maxOffset = createBeeWanderOffset(() => 0.999);
+    assert.ok(Math.hypot(minOffset.dx, minOffset.dz) <= 1.61);
+    assert.ok(Math.hypot(maxOffset.dx, maxOffset.dz) <= 5.41);
+    assert.ok(minOffset.dy >= 0.5 && minOffset.dy <= 1.4);
+    assert.ok(maxOffset.dy >= 0.5 && maxOffset.dy <= 1.4);
 });


### PR DESCRIPTION
## Summary
- Solo-flower bee habitats now break the visit→sit cycle by zooming around the habitat between visits — bees with a single flower never stayed in motion before.
- Multi-flower habitats randomly insert a wander hop between flower-to-flower trips (~40% to start, ~35% to chain) for livelier flight paths.
- Added `shouldBeeWanderNext`, `getBeeWanderHoverSeconds`, and `createBeeWanderOffset` helpers in `beeBehavior.ts` so the decision logic is unit-testable, kept rendering in `Bees.tsx`.

## Implementation notes
- New `'wander'` kind on `BeeTarget`. Wander targets are synthetic air points generated relative to a precomputed habitat center.
- `chooseNextTarget` consults `shouldBeeWanderNext` and may return a fresh wander target instead of a flower.
- The existing `foraging` phase doubles as mid-air hover when the target is a wander point — short dwell (~0.2–0.6s), bobble + yaw drift, wings keep flapping (`updateBeeRig` treats it as flying). Flower landings are unchanged.
- Flight yaw at arrival is passed into the foraging state so the bee continues facing its travel direction when hovering at a wander point.
- Debug HUD reports `hovering mid-air` for wander hovers.

## Test plan
- [x] `pnpm test` in `packages/game` (45/45 pass, including 5 new tests covering the new helpers)
- [x] `pnpm typecheck` in `packages/game`
- [ ] Visual check in-game: solo flower → bee zooms around then returns; multi-flower → occasional air detour between flowers; bad weather / night still grounds bees

🤖 Generated with [Claude Code](https://claude.com/claude-code)