### PR TITLE
Fix farm mobile viewport overflow

### DIFF
--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
                 <meta name="theme-color" content="#8b5e34" />
                 <title>Gredice Farm</title>
             </Head>
-            <body className="antialiased min-h-screen flex bg-muted">
+            <body className="antialiased min-h-screen flex w-full min-w-0 overflow-x-hidden bg-muted">
                 {postHogApiKey ? (
                     <PostHogProvider
                         apiKey={postHogApiKey}

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -89,8 +89,11 @@ async function FarmerDashboard() {
             <Card>
                 <CardContent noHeader>
                     <Stack spacing={4}>
-                        <Row justifyContent="space-between">
-                            <Stack>
+                        <Row
+                            justifyContent="space-between"
+                            className="flex-wrap items-start gap-3"
+                        >
+                            <Stack className="min-w-0">
                                 <Typography level="h4" component="h1" semiBold>
                                     {`Dobrodošli, ${displayName}!`}
                                 </Typography>
@@ -105,7 +108,7 @@ async function FarmerDashboard() {
                             </Stack>
                             <LogoutButton />
                         </Row>
-                        <Row spacing={2}>
+                        <Row spacing={2} className="flex-wrap gap-y-2">
                             <Chip
                                 color={role?.color ?? 'neutral'}
                                 startDecorator={<RoleIcon className="size-4" />}

--- a/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
@@ -9,7 +9,7 @@ import { UrlAuthForward } from '../../UrlAuthForward';
 export default function FacebookCallbackPage() {
     return (
         <div className="min-h-[100dvh] flex items-center justify-center bg-muted p-4">
-            <Card className="w-[350px] p-12">
+            <Card className="w-full max-w-[350px] p-6 sm:p-12">
                 <CardHeader>
                     <svg
                         className="mx-auto size-12 text-[#1877F2] mb-4"

--- a/apps/farm/app/prijava/google-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/google-prijava/povratak/page.tsx
@@ -9,7 +9,7 @@ import { UrlAuthForward } from '../../UrlAuthForward';
 export default function GoogleCallbackPage() {
     return (
         <div className="min-h-[100dvh] flex items-center justify-center bg-muted p-4">
-            <Card className="w-[350px] p-12">
+            <Card className="w-full max-w-[350px] p-6 sm:p-12">
                 <CardHeader>
                     <svg
                         className="mx-auto size-12 mb-4"

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -486,7 +486,11 @@ export function CompleteOperationModal({
                         {errorMessage}
                     </Typography>
                 )}
-                <Row spacing={2} justifyContent="end">
+                <Row
+                    spacing={2}
+                    justifyContent="end"
+                    className="flex-wrap gap-y-2"
+                >
                     <Button
                         variant="outlined"
                         onClick={() => handleOpenChange(false)}

--- a/apps/farm/app/schedule/CompletePlantingModal.tsx
+++ b/apps/farm/app/schedule/CompletePlantingModal.tsx
@@ -53,7 +53,11 @@ export function CompletePlantingModal({
                     Jeste li sigurni da želite označiti da je posijano:{' '}
                     <strong>{label}</strong>?
                 </Typography>
-                <Row spacing={2} justifyContent="end">
+                <Row
+                    spacing={2}
+                    justifyContent="end"
+                    className="flex-wrap gap-y-2"
+                >
                     <Button
                         variant="outlined"
                         onClick={() => setOpen(false)}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -216,7 +216,10 @@ export function FarmScheduleOperationsSection({
                 key={operation.id}
                 className="rounded-lg border bg-white px-3 py-2"
             >
-                <Row spacing={2} className="items-start justify-between gap-3">
+                <Row
+                    spacing={2}
+                    className="min-w-0 items-start justify-between gap-3"
+                >
                     <Row spacing={2} className="min-w-0 grow items-start">
                         {completed ? (
                             <Checkbox className="size-5" checked disabled />
@@ -235,8 +238,8 @@ export function FarmScheduleOperationsSection({
                             <Typography
                                 className={
                                     completed
-                                        ? 'line-through text-muted-foreground'
-                                        : undefined
+                                        ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                        : '[overflow-wrap:anywhere]'
                                 }
                             >
                                 {operation.label}
@@ -485,7 +488,7 @@ export function FarmScheduleOperationsSection({
                                         >
                                             <Row
                                                 spacing={2}
-                                                className="items-start justify-between gap-3"
+                                                className="min-w-0 items-start justify-between gap-3"
                                             >
                                                 <Row
                                                     spacing={2}
@@ -526,8 +529,8 @@ export function FarmScheduleOperationsSection({
                                                         <Typography
                                                             className={
                                                                 completed
-                                                                    ? 'line-through text-muted-foreground'
-                                                                    : undefined
+                                                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                                                    : '[overflow-wrap:anywhere]'
                                                             }
                                                         >
                                                             {operation.label}

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -157,7 +157,7 @@ export function FarmSchedulePlantingsSection({
                                         >
                                             <Row
                                                 spacing={2}
-                                                className="items-start justify-between gap-3"
+                                                className="min-w-0 items-start justify-between gap-3"
                                             >
                                                 <Row
                                                     spacing={2}
@@ -194,8 +194,8 @@ export function FarmSchedulePlantingsSection({
                                                         <Typography
                                                             className={
                                                                 completed
-                                                                    ? 'line-through text-muted-foreground'
-                                                                    : undefined
+                                                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                                                    : '[overflow-wrap:anywhere]'
                                                             }
                                                         >
                                                             {field.label}

--- a/apps/farm/app/schedule/OperationCompletionAttachments.tsx
+++ b/apps/farm/app/schedule/OperationCompletionAttachments.tsx
@@ -65,7 +65,7 @@ export function OperationCompletionAttachments({
                         >
                             Radnja #{operationId}
                         </Typography>
-                        <Typography className="whitespace-pre-wrap">
+                        <Typography className="whitespace-pre-wrap [overflow-wrap:anywhere]">
                             {trimmedNotes}
                         </Typography>
                     </Stack>

--- a/apps/farm/app/schedule/ScheduleDateNavigation.tsx
+++ b/apps/farm/app/schedule/ScheduleDateNavigation.tsx
@@ -37,7 +37,7 @@ export function ScheduleDateNavigation({ date }: ScheduleDateNavigationProps) {
     const nextDateParam = formatDateParam(getOffsetDate(date, 1));
 
     return (
-        <Row spacing={2}>
+        <Row spacing={2} className="shrink-0">
             <Link
                 href={`/schedule?date=${prevDateParam}`}
                 title="Prethodni dan"

--- a/apps/farm/app/schedule/ScheduleDaySummary.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.tsx
@@ -54,7 +54,7 @@ export function ScheduleDaySummary({
         scheduledFields.length * PLANTING_TASK_DURATION_MINUTES;
 
     return (
-        <Row spacing={8}>
+        <Row spacing={8} className="flex-wrap gap-y-2">
             <SummaryItem label="Zadataka" value={taskCount} />
             <SummaryItem label="Gredica" value={raisedBedCount} />
             {totalMinutes > 0 && (

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -1,5 +1,4 @@
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
 import LoginDialog from '../../components/auth/LoginDialog';
@@ -25,21 +24,25 @@ async function FarmScheduleContent({ date }: { date: Date }) {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <Row spacing={4} justifyContent="space-between">
-                <Row spacing={2}>
-                    <HomeButton />
-                    <Typography level="h4" component="h1">
-                        Raspored
-                    </Typography>
-                </Row>
-                <ScheduleDateNavigation date={date} />
-                <Suspense fallback={<ScheduleDaySummarySkeleton />}>
-                    <ScheduleDaySummarySection
-                        dayDataPromise={dayDataPromise}
-                        operationsDataPromise={operationsDataPromise}
-                    />
-                </Suspense>
-            </Row>
+            <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                    <div className="flex min-w-0 items-center gap-2">
+                        <HomeButton />
+                        <Typography level="h4" component="h1">
+                            Raspored
+                        </Typography>
+                    </div>
+                    <ScheduleDateNavigation date={date} />
+                </div>
+                <div className="min-w-0">
+                    <Suspense fallback={<ScheduleDaySummarySkeleton />}>
+                        <ScheduleDaySummarySection
+                            dayDataPromise={dayDataPromise}
+                            operationsDataPromise={operationsDataPromise}
+                        />
+                    </Suspense>
+                </div>
+            </div>
             <FarmScheduleDay
                 dayDataPromise={dayDataPromise}
                 operationsDataPromise={operationsDataPromise}

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -118,7 +118,7 @@ function DesktopModal({
                 <DialogPrimitive.Content
                     aria-describedby={undefined}
                     className={cx(
-                        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] data-[state=open]:zoom-in-95 sm:rounded-lg',
+                        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg min-w-0 -translate-x-1/2 -translate-y-1/2 gap-4 overflow-x-auto overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 [overflow-wrap:anywhere] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] data-[state=open]:zoom-in-95 sm:rounded-lg',
                         className,
                     )}
                     onEscapeKeyDown={preventDismiss}
@@ -173,14 +173,14 @@ function MobileModal({
                 />
                 <Drawer.Content
                     className={cx(
-                        'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] flex-col rounded-t-[10px] border bg-background',
+                        'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] w-full max-w-full min-w-0 flex-col overflow-hidden rounded-t-[10px] border bg-background',
                         className,
                     )}
                     {...rest}
                 >
                     <Drawer.Title className="sr-only">{title}</Drawer.Title>
                     <Drawer.Handle className="mx-auto mt-4 h-2 w-[100px] shrink-0 rounded-full bg-muted" />
-                    <div className="min-h-0 overflow-y-auto p-4">
+                    <div className="min-h-0 min-w-0 max-w-full overflow-x-auto overflow-y-auto p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] [overflow-wrap:anywhere]">
                         {children}
                     </div>
                 </Drawer.Content>


### PR DESCRIPTION
## Summary
- keep shared modal and mobile drawer content constrained to the viewport
- make farm schedule header, summaries, task rows, action rows, and long labels wrap on narrow screens
- prevent fixed-width farm login callback cards and dashboard chips from widening mobile layout

## Validation
- pnpm lint --filter @gredice/ui --filter farm
- pnpm --filter @gredice/ui typecheck
- pnpm test --filter farm
- 360px Playwright smoke check on `/` and `/schedule`: no horizontal overflow; login dialog/drawer fits viewport

Note: farm tests pass, with existing local auth/proxy warnings from missing dev services/secrets.