### PR TITLE
Reuse soft-deleted stacks when creating at the same position

### DIFF
--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1235,7 +1235,7 @@ export async function createGardenStack(
     { x, y }: { x: number; y: number },
     db: DatabaseClient = storage(),
 ) {
-    // Check if stack at location already exists
+    // Check if an active (non-deleted) stack already exists at this location.
     const [{ count: existingStacksCount }] = await db
         .select({ count: count() })
         .from(gardenStacks)
@@ -1249,6 +1249,26 @@ export async function createGardenStack(
         );
     if (existingStacksCount > 0) {
         return false;
+    }
+
+    // If a soft-deleted stack exists at this position, reuse it instead of
+    // inserting a new row. This keeps a single canonical row per (gardenId, x, y)
+    // and prevents soft-deleted duplicates from accumulating over time.
+    const reusableStack = await db.query.gardenStacks.findFirst({
+        where: and(
+            eq(gardenStacks.gardenId, gardenId),
+            eq(gardenStacks.positionX, x),
+            eq(gardenStacks.positionY, y),
+            eq(gardenStacks.isDeleted, true),
+        ),
+        orderBy: desc(gardenStacks.id),
+    });
+    if (reusableStack) {
+        await db
+            .update(gardenStacks)
+            .set({ isDeleted: false, blocks: [] })
+            .where(eq(gardenStacks.id, reusableStack.id));
+        return true;
     }
 
     await db

--- a/packages/storage/tests/gardensRepo.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.node.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { and, eq } from 'drizzle-orm';
 import {
     createAccount,
     createDefaultGardenForAccount,
@@ -22,6 +23,7 @@ import {
     updateGardenStack,
     updateRaisedBed,
 } from '@gredice/storage';
+import { gardenStacks } from '../src/schema';
 import {
     createTestBlock,
     createTestGarden,
@@ -189,6 +191,44 @@ test('createGardenStack returns false if stack exists', async () => {
     await createGardenStack(gardenId, { x: 0, y: 0 });
     const result = await createGardenStack(gardenId, { x: 0, y: 0 });
     assert.strictEqual(result, false);
+});
+
+test('createGardenStack reuses a soft-deleted stack at the same position', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+
+    await createGardenStack(gardenId, { x: 7, y: 7 });
+    await updateGardenStack(gardenId, {
+        x: 7,
+        y: 7,
+        blocks: ['block-a', 'block-b'],
+    });
+    await deleteGardenStack(gardenId, { x: 7, y: 7 });
+
+    const result = await createGardenStack(gardenId, { x: 7, y: 7 });
+    assert.strictEqual(result, true);
+
+    const stack = await getGardenStack(gardenId, { x: 7, y: 7 });
+    assert.ok(stack);
+    assert.deepStrictEqual(stack.blocks, []);
+
+    // Only one row should exist at (7, 7) — the reused one — instead of
+    // accumulating a fresh insert alongside the soft-deleted original.
+    const db = createTestDb();
+    const allStacksAtPosition = await db
+        .select()
+        .from(gardenStacks)
+        .where(
+            and(
+                eq(gardenStacks.gardenId, gardenId),
+                eq(gardenStacks.positionX, 7),
+                eq(gardenStacks.positionY, 7),
+            ),
+        );
+    assert.strictEqual(allStacksAtPosition.length, 1);
+    assert.strictEqual(allStacksAtPosition[0].isDeleted, false);
 });
 
 test('updateGardenStack updates stack blocks', async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #3012. `createGardenStack` previously inserted a new row whenever no *active* stack existed at `(gardenId, x, y)`, even when one or more soft-deleted rows already sat at that position. Combined with `deleteGardenStack` (which marks every row at the position deleted without filtering), this accumulated dead rows over time.
- This change makes `createGardenStack` reuse the most recent soft-deleted row at the position — clearing `isDeleted` and resetting `blocks` — and only falls back to `INSERT` when no row exists at all. The result is a single canonical row per `(gardenId, x, y)`.
- Safe against legacy data: existing duplicates are tolerated (we pick one by `id desc`); no migration required.

## Test plan
- [x] Added `createGardenStack reuses a soft-deleted stack at the same position` — verifies a fresh insert is NOT created when a deleted row already exists, and that the reused row is reset to empty blocks.
- [x] `pnpm --filter @gredice/storage test:node gardensRepo.node.spec.ts` — all 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)