### PR TITLE
Shard www Playwright tests and stabilize landing navbar checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,8 @@ jobs:
       name: "www"
       path: "apps/www"
       vercelProjectIdSecretName: "VERCEL_PROJECT_ID_WWW"
+      testShardMatrix: '[{"index":1,"total":2},{"index":2,"total":2}]'
+      testShardPrepareScript: "test:prepare:routes"
     secrets: inherit
 
   ci_garden:

--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -17,6 +17,21 @@ on:
         required: true
         type: string
         description: "Name of the secret containing the Vercel project ID"
+      testShardMatrix:
+        required: false
+        type: string
+        description: "JSON matrix of Playwright test shards to run"
+        default: '[{"index":1,"total":1}]'
+      testShardPrepareScript:
+        required: false
+        type: string
+        description: "Package script to run after build and before sharded tests"
+        default: ""
+      testShardRunScript:
+        required: false
+        type: string
+        description: "Package script that runs Playwright tests for a shard"
+        default: "test:run"
 
 env:
   VERCEL_PROJECT_ID: ${{ secrets[format(inputs.vercelProjectIdSecretName)] }}
@@ -64,6 +79,11 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    name: "test${{ matrix.shard.total != 1 && format(' ({0}/{1})', matrix.shard.index, matrix.shard.total) || '' }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(inputs.testShardMatrix) }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -115,8 +135,11 @@ jobs:
           };
           const hasPlaywright =
             '@playwright/test' in dependencies || 'playwright' in dependencies;
+          const playwrightVersion =
+            dependencies['@playwright/test'] ?? dependencies.playwright ?? 'none';
 
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `enabled=${hasPlaywright}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${playwrightVersion}\n`);
           NODE
 
       - name: ✨ Cache Playwright browsers
@@ -125,7 +148,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
           restore-keys: |
             ${{ runner.os }}-playwright-
 
@@ -135,4 +158,13 @@ jobs:
         working-directory: ${{ inputs.path }}/
 
       - name: ⚒️ Test app
-        run: pnpm test --filter=${{ inputs.name }}
+        run: |
+          if [ "${{ matrix.shard.total }}" = "1" ]; then
+            pnpm test --filter=${{ inputs.name }}
+          else
+            pnpm build --filter=${{ inputs.name }}
+            if [ -n "${{ inputs.testShardPrepareScript }}" ]; then
+              pnpm --dir ${{ inputs.path }} run ${{ inputs.testShardPrepareScript }}
+            fi
+            pnpm --dir ${{ inputs.path }} run ${{ inputs.testShardRunScript }} --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
+          fi

--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -12,16 +12,23 @@ async function expectMobileNavActionsDoNotOverlap(page: Page) {
     await expect(cta).toBeVisible();
     await expect(menuButton).toBeVisible();
 
-    const ctaBox = await cta.boundingBox();
-    const menuButtonBox = await menuButton.boundingBox();
-    expect(ctaBox).not.toBeNull();
-    expect(menuButtonBox).not.toBeNull();
-    if (!ctaBox || !menuButtonBox) {
-        throw new Error('Expected mobile nav CTA and menu button boxes.');
-    }
+    await expect
+        .poll(async () => {
+            const ctaBox = await cta.boundingBox();
+            const menuButtonBox = await menuButton.boundingBox();
+            if (!ctaBox || !menuButtonBox) {
+                return Number.NEGATIVE_INFINITY;
+            }
 
-    expect(menuButtonBox.x).toBeGreaterThanOrEqual(ctaBox.x + ctaBox.width + 4);
-    expect(ctaBox.width).toBeLessThanOrEqual(50);
+            return menuButtonBox.x - (ctaBox.x + ctaBox.width);
+        })
+        .toBeGreaterThanOrEqual(4);
+    await expect
+        .poll(async () => {
+            const ctaBox = await cta.boundingBox();
+            return ctaBox?.width ?? Number.POSITIVE_INFINITY;
+        })
+        .toBeLessThanOrEqual(50);
 }
 
 test('has title', async ({ page }) => {
@@ -180,14 +187,18 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
     await expect(header).toHaveCSS('border-bottom-width', '1px');
     await expectMobileNavActionsDoNotOverlap(page);
 
-    const mobileHeaderBox = await header.boundingBox();
-    expect(mobileHeaderBox).not.toBeNull();
-    if (!mobileHeaderBox) {
-        throw new Error('Expected mobile navbar to have a bounding box.');
-    }
-
-    expect(mobileHeaderBox.x).toBeGreaterThanOrEqual(7);
-    expect(mobileHeaderBox.y).toBeGreaterThanOrEqual(7);
+    await expect
+        .poll(async () => {
+            const mobileHeaderBox = await header.boundingBox();
+            return mobileHeaderBox?.x ?? Number.NEGATIVE_INFINITY;
+        })
+        .toBeGreaterThanOrEqual(7);
+    await expect
+        .poll(async () => {
+            const mobileHeaderBox = await header.boundingBox();
+            return mobileHeaderBox?.y ?? Number.NEGATIVE_INFINITY;
+        })
+        .toBeGreaterThanOrEqual(7);
 });
 
 test('desktop floating navbar keeps container width', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Split `www` Playwright CI into two shards so the slowest test job finishes sooner without reducing coverage.
- Add reusable workflow inputs for sharded test matrices and per-app prepare/run scripts.
- Cache Playwright browsers by Playwright version instead of lockfile hash to avoid unnecessary browser reinstalls.
- Stabilize the landing navbar geometry assertions by polling for settled layout after scroll transitions.

## Testing
- `pnpm build --filter=www`
- `pnpm lint --filter www`
- `pnpm lint:ci-filters`
- Workflow YAML parsed successfully
- Local Playwright validation passed for both `www` shards, with 316 tests in each shard