### PR TITLE
Optimize www Playwright CI sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,13 @@ jobs:
       name: "www"
       path: "apps/www"
       vercelProjectIdSecretName: "VERCEL_PROJECT_ID_WWW"
-      testShardMatrix: '[{"index":1,"total":2},{"index":2,"total":2}]'
+      testShardMatrix: >-
+        [
+          {"name":"a11y 1/3","index":1,"total":4,"args":"tests/a11y.spec.ts --shard=1/3"},
+          {"name":"a11y 2/3","index":2,"total":4,"args":"tests/a11y.spec.ts --shard=2/3"},
+          {"name":"a11y 3/3","index":3,"total":4,"args":"tests/a11y.spec.ts --shard=3/3"},
+          {"name":"rest","index":4,"total":4,"args":"tests/landing.spec.ts tests/search.spec.ts tests/search-interactive.spec.tsx tests/titlesPresent.spec.ts"}
+        ]
       testShardPrepareScript: "test:prepare:routes"
     secrets: inherit
 

--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -20,7 +20,7 @@ on:
       testShardMatrix:
         required: false
         type: string
-        description: "JSON matrix of Playwright test shards to run"
+        description: "JSON matrix of Playwright test shards or named args to run"
         default: '[{"index":1,"total":1}]'
       testShardPrepareScript:
         required: false
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    name: "test${{ matrix.shard.total != 1 && format(' ({0}/{1})', matrix.shard.index, matrix.shard.total) || '' }}"
+    name: "test${{ matrix.shard.name && format(' ({0})', matrix.shard.name) || (matrix.shard.total != 1 && format(' ({0}/{1})', matrix.shard.index, matrix.shard.total) || '') }}"
     strategy:
       fail-fast: false
       matrix:
@@ -158,13 +158,15 @@ jobs:
         working-directory: ${{ inputs.path }}/
 
       - name: ⚒️ Test app
+        env:
+          TEST_ARGS: ${{ matrix.shard.args || (matrix.shard.total != 1 && format('--shard={0}/{1}', matrix.shard.index, matrix.shard.total)) || '' }}
         run: |
-          if [ "${{ matrix.shard.total }}" = "1" ]; then
+          if [ -z "$TEST_ARGS" ]; then
             pnpm test --filter=${{ inputs.name }}
           else
             pnpm build --filter=${{ inputs.name }}
             if [ -n "${{ inputs.testShardPrepareScript }}" ]; then
               pnpm --dir ${{ inputs.path }} run ${{ inputs.testShardPrepareScript }}
             fi
-            pnpm --dir ${{ inputs.path }} run ${{ inputs.testShardRunScript }} --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
+            pnpm --dir ${{ inputs.path }} run ${{ inputs.testShardRunScript }} $TEST_ARGS
           fi


### PR DESCRIPTION
## Summary
- split the www Playwright job into three a11y route buckets plus one faster landing/search/title bucket
- extend the reusable Next.js CI workflow so named matrix entries can pass explicit Playwright args while default app jobs keep their existing behavior

## Validation
- pnpm build --filter=www
- pnpm --dir apps/www run test:prepare:routes
- pnpm --dir apps/www run test:run tests/a11y.spec.ts --shard=1/3
- pnpm --dir apps/www run test:run tests/a11y.spec.ts --shard=2/3
- pnpm --dir apps/www run test:run tests/a11y.spec.ts --shard=3/3
- pnpm --dir apps/www run test:run tests/landing.spec.ts tests/search.spec.ts tests/search-interactive.spec.tsx tests/titlesPresent.spec.ts
- pnpm lint:ci-filters
- workflow YAML parse
- git diff --check