### PR TITLE
Send web push when an operation is assigned to a user

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -15,6 +15,9 @@ GREDICE_WWW_REVALIDATE_SECRET=
 SOCIAL_PUBLISHING_QUEUE_SECRET=
 CRON_SECRET=
 
+# Web push notifications (VAPID public key shared with @gredice/api)
+NEXT_PUBLIC_GREDICE_WEB_PUSH_VAPID_PUBLIC_KEY=
+
 # Social publishing provider config (server-only; do not use NEXT_PUBLIC_ for secrets)
 SOCIAL_PROVIDER_REDDIT_ENABLED=false
 SOCIAL_PROVIDER_REDDIT_ACCESS_TOKEN=

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -6,7 +6,10 @@ import {
     RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE,
 } from '@gredice/js/raisedBeds';
 import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
-import { notifyOperationUpdate } from '@gredice/notifications';
+import {
+    notifyOperationAssignedUsers,
+    notifyOperationUpdate,
+} from '@gredice/notifications';
 import {
     acceptOperation,
     createEvent,
@@ -274,6 +277,9 @@ export async function singleCreateOperationAction(
                     assignedBy: userId,
                 }),
             );
+            await notifyOperationAssignedUsers(operationId, [
+                selectedAssignedUserId,
+            ]);
         }
 
         revalidatePath(KnownPages.Schedule);
@@ -405,6 +411,9 @@ export async function bulkCreateOperationsAction(
                         assignedBy: userId,
                     }),
                 );
+                await notifyOperationAssignedUsers(operationId, [
+                    selectedAssignedUserId,
+                ]);
             }
             createdCount += 1;
         }
@@ -551,6 +560,13 @@ export async function assignOperationUserAction(
             assignedBy: userId,
         }),
     );
+
+    const newlyAssignedUserIds = normalizedAssignedUserIds.filter(
+        (assignedUserId) => !operationAssignedUserIds.includes(assignedUserId),
+    );
+    if (newlyAssignedUserIds.length > 0) {
+        await notifyOperationAssignedUsers(operationId, newlyAssignedUserIds);
+    }
 
     revalidatePath(KnownPages.Schedule);
     if (operation.accountId)

--- a/apps/app/app/admin/settings/_components/UserNotificationSettings.tsx
+++ b/apps/app/app/admin/settings/_components/UserNotificationSettings.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { clientAuthenticated } from '@gredice/client';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Close, Megaphone } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePushSubscription } from './usePushSubscription';
+
+const notificationDevicesKey = ['notifications', 'devices'];
+const notificationPushStatusKey = ['notifications', 'push-status'];
+
+function permissionStatusLabel(status: string) {
+    switch (status) {
+        case 'granted':
+            return 'dopušteno';
+        case 'denied':
+            return 'odbijeno';
+        case 'unsupported':
+            return 'nije podržano';
+        case 'unconfigured':
+            return 'nije konfigurirano';
+        case 'prompt-dismissed':
+            return 'odgođeno';
+        case 'subscribed':
+            return 'uključeno';
+        default:
+            return 'nije odlučeno';
+    }
+}
+
+function pushStatusLabel(status: string | undefined) {
+    switch (status) {
+        case 'subscribed':
+            return 'uključeno';
+        case 'unsubscribed':
+            return 'nije uključeno';
+        case 'denied':
+            return 'blokirano';
+        case 'disabled':
+            return 'isključeno';
+        case undefined:
+            return 'učitavanje';
+        default:
+            return status;
+    }
+}
+
+export function UserNotificationSettings() {
+    const pushOnboarding = usePushSubscription();
+    const queryClient = useQueryClient();
+
+    const devicesQuery = useQuery({
+        queryKey: notificationDevicesKey,
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications.devices.$get();
+            if (!response.ok)
+                throw new Error('Uređaji za obavijesti nisu učitani');
+            return (await response.json()).devices;
+        },
+    });
+
+    const pushStatusQuery = useQuery({
+        queryKey: notificationPushStatusKey,
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications[
+                    'push-status'
+                ].$get();
+            if (!response.ok) throw new Error('Status obavijesti nije učitan');
+            return response.json();
+        },
+    });
+
+    const updateDeviceMutation = useMutation({
+        mutationFn: async ({
+            id,
+            enabled,
+        }: {
+            id: string;
+            enabled: boolean;
+        }) => {
+            const response =
+                await clientAuthenticated().api.notifications.devices[
+                    ':id'
+                ].$patch({
+                    param: { id },
+                    json: { enabled },
+                });
+            if (!response.ok) throw new Error('Uređaj nije ažuriran');
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
+            queryClient.invalidateQueries({
+                queryKey: notificationPushStatusKey,
+            });
+        },
+    });
+
+    const revokeDeviceMutation = useMutation({
+        mutationFn: async (id: string) => {
+            const response =
+                await clientAuthenticated().api.notifications.devices[
+                    ':id'
+                ].$delete({
+                    param: { id },
+                });
+            if (!response.ok) throw new Error('Uređaj nije uklonjen');
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
+            queryClient.invalidateQueries({
+                queryKey: notificationPushStatusKey,
+            });
+        },
+    });
+
+    const sendTestMutation = useMutation({
+        mutationFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications.test.$post();
+            if (!response.ok) throw new Error('Probna obavijest nije poslana');
+            return response.json();
+        },
+    });
+
+    const handleEnablePush = async () => {
+        const result = await pushOnboarding.requestPermission();
+        if (result === 'subscribed') {
+            queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
+            queryClient.invalidateQueries({
+                queryKey: notificationPushStatusKey,
+            });
+        }
+    };
+
+    const notificationsSupported =
+        typeof window !== 'undefined' && 'Notification' in window;
+    const deviceMutationBusy =
+        updateDeviceMutation.isPending || revokeDeviceMutation.isPending;
+    const testNotificationResult = sendTestMutation.data;
+
+    return (
+        <Stack spacing={4}>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Push obavijesti na ovom uređaju</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={2}>
+                        <Typography level="body2" secondary>
+                            Primaj push obavijesti u pregledniku kad ti je
+                            dodijeljena nova radnja ili kad se dogodi važna
+                            promjena.
+                        </Typography>
+                        <Typography level="body3" secondary>
+                            Preglednik:{' '}
+                            {notificationsSupported
+                                ? 'podržava obavijesti'
+                                : 'ne podržava obavijesti'}{' '}
+                            · Dozvola:{' '}
+                            {permissionStatusLabel(pushOnboarding.status)} ·
+                            Status:{' '}
+                            {pushStatusLabel(pushStatusQuery.data?.status)}
+                        </Typography>
+                        {pushStatusQuery.isError && (
+                            <Typography level="body3" secondary>
+                                Status obavijesti nije učitan.
+                            </Typography>
+                        )}
+                        {pushOnboarding.status === 'denied' && (
+                            <Typography level="body3" secondary>
+                                Obavijesti su blokirane u pregledniku. Otvori
+                                postavke preglednika i omogući obavijesti za ovu
+                                stranicu.
+                            </Typography>
+                        )}
+                        {pushOnboarding.status === 'unconfigured' && (
+                            <Typography level="body3" secondary>
+                                Web push obavijesti nisu konfigurirane na ovom
+                                okruženju.
+                            </Typography>
+                        )}
+                        {pushOnboarding.canPrompt &&
+                            pushStatusQuery.data?.status !== 'subscribed' && (
+                                <Row justifyContent="end">
+                                    <Button
+                                        size="sm"
+                                        onClick={handleEnablePush}
+                                        startDecorator={
+                                            <Megaphone className="size-4" />
+                                        }
+                                    >
+                                        Uključi obavijesti
+                                    </Button>
+                                </Row>
+                            )}
+                    </Stack>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <Row
+                        justifyContent="space-between"
+                        alignItems="center"
+                        spacing={2}
+                        className="flex-wrap"
+                    >
+                        <CardTitle>Uređaji za obavijesti</CardTitle>
+                        <Button
+                            size="sm"
+                            disabled={sendTestMutation.isPending}
+                            onClick={() => sendTestMutation.mutate()}
+                            startDecorator={<Megaphone className="size-4" />}
+                        >
+                            Pošalji probnu obavijest
+                        </Button>
+                    </Row>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={2}>
+                        {sendTestMutation.isError && (
+                            <Typography level="body3" secondary>
+                                Probna obavijest nije poslana.
+                            </Typography>
+                        )}
+                        {sendTestMutation.isSuccess && (
+                            <Typography level="body3" secondary>
+                                Probna obavijest je poslana. Ciljano:{' '}
+                                {testNotificationResult?.targeted ?? 0} ·
+                                Prihvaćeno:{' '}
+                                {testNotificationResult?.accepted ?? 0} ·
+                                Neuspjelo: {testNotificationResult?.failed ?? 0}
+                            </Typography>
+                        )}
+                        {devicesQuery.isPending ? (
+                            <Typography level="body2" secondary>
+                                Uređaji se učitavaju.
+                            </Typography>
+                        ) : devicesQuery.isError ? (
+                            <Typography level="body2" secondary>
+                                Uređaji za obavijesti nisu učitani.
+                            </Typography>
+                        ) : devicesQuery.data?.length ? (
+                            devicesQuery.data.map((device) => (
+                                <Card key={device.id} className="bg-muted/30">
+                                    <CardContent>
+                                        <Stack spacing={1}>
+                                            <Typography semiBold>
+                                                {device.deviceLabel ||
+                                                    'Nepoznati uređaj'}
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                {device.userAgent ||
+                                                    'Nepoznat preglednik'}
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                Status:{' '}
+                                                {device.enabled
+                                                    ? 'aktivan'
+                                                    : 'isključen'}{' '}
+                                                · Zadnji put viđen:{' '}
+                                                {device.lastSeenAt
+                                                    ? new Date(
+                                                          device.lastSeenAt,
+                                                      ).toLocaleString('hr-HR')
+                                                    : 'nema podataka'}
+                                            </Typography>
+                                            <Row spacing={2}>
+                                                <Button
+                                                    size="sm"
+                                                    variant="plain"
+                                                    disabled={
+                                                        deviceMutationBusy
+                                                    }
+                                                    onClick={() =>
+                                                        updateDeviceMutation.mutate(
+                                                            {
+                                                                id: device.id,
+                                                                enabled:
+                                                                    !device.enabled,
+                                                            },
+                                                        )
+                                                    }
+                                                >
+                                                    {device.enabled
+                                                        ? 'Isključi'
+                                                        : 'Uključi'}
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="plain"
+                                                    disabled={
+                                                        deviceMutationBusy
+                                                    }
+                                                    startDecorator={
+                                                        <Close className="size-4" />
+                                                    }
+                                                    onClick={() =>
+                                                        revokeDeviceMutation.mutate(
+                                                            device.id,
+                                                        )
+                                                    }
+                                                >
+                                                    Ukloni
+                                                </Button>
+                                            </Row>
+                                        </Stack>
+                                    </CardContent>
+                                </Card>
+                            ))
+                        ) : (
+                            <Typography level="body2" secondary>
+                                Nema uređaja prijavljenih za obavijesti.
+                            </Typography>
+                        )}
+                    </Stack>
+                </CardContent>
+            </Card>
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/settings/_components/usePushSubscription.ts
+++ b/apps/app/app/admin/settings/_components/usePushSubscription.ts
@@ -1,0 +1,187 @@
+'use client';
+
+import {
+    clientAuthenticated,
+    type PushDeviceMetadata,
+    type PushDeviceRegistrationPayload,
+    subscribePushDevice,
+} from '@gredice/client';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type PushSetupStatus =
+    | 'unsupported'
+    | 'unconfigured'
+    | 'default'
+    | 'denied'
+    | 'granted'
+    | 'subscribed'
+    | 'prompt-dismissed';
+
+const pushPromptDismissedKey = 'app:push:prompt-dismissed';
+const pushDeviceIdKey = 'app:push:device-id';
+const pushServiceWorkerPath = '/push-notifications-sw.js';
+const webPushVapidPublicKey =
+    process.env.NEXT_PUBLIC_GREDICE_WEB_PUSH_VAPID_PUBLIC_KEY;
+
+function readPromptDismissed(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(pushPromptDismissedKey) === '1';
+}
+
+function readOrCreatePushDeviceId(): string | undefined {
+    if (typeof window === 'undefined') return undefined;
+    const existing = window.localStorage.getItem(pushDeviceIdKey);
+    if (existing) return existing;
+
+    const id =
+        window.crypto.randomUUID?.() ??
+        `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    window.localStorage.setItem(pushDeviceIdKey, id);
+    return id;
+}
+
+function pushDeviceMetadata(): PushDeviceMetadata {
+    if (typeof window === 'undefined') {
+        return {};
+    }
+
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const platform = navigator.platform || undefined;
+
+    return {
+        deviceId: readOrCreatePushDeviceId(),
+        deviceLabel: platform ? `Ovaj uređaj (${platform})` : 'Ovaj uređaj',
+        locale: navigator.language || undefined,
+        platform,
+        timezone,
+        userAgent: navigator.userAgent || undefined,
+    };
+}
+
+async function persistPushSubscription(payload: PushDeviceRegistrationPayload) {
+    const response =
+        await clientAuthenticated().api.notifications.devices.$post({
+            json: payload,
+        });
+    if (!response.ok) {
+        throw new Error('Push subscription was not saved.');
+    }
+}
+
+async function ensurePushServiceWorkerRegistered(): Promise<
+    ServiceWorkerRegistration | undefined
+> {
+    if (
+        typeof window === 'undefined' ||
+        !('serviceWorker' in navigator) ||
+        !('PushManager' in window) ||
+        typeof window.isSecureContext !== 'boolean' ||
+        !window.isSecureContext
+    ) {
+        return undefined;
+    }
+
+    const existing = await navigator.serviceWorker.getRegistration(
+        pushServiceWorkerPath,
+    );
+    if (existing) {
+        await existing.update();
+        return existing;
+    }
+
+    await navigator.serviceWorker.register(pushServiceWorkerPath, {
+        scope: '/',
+    });
+    return navigator.serviceWorker.ready;
+}
+
+function resolvePermissionStatus(): PushSetupStatus {
+    if (
+        typeof window === 'undefined' ||
+        !('Notification' in window) ||
+        !('serviceWorker' in navigator) ||
+        !('PushManager' in window) ||
+        typeof window.isSecureContext !== 'boolean' ||
+        !window.isSecureContext
+    ) {
+        return 'unsupported';
+    }
+
+    if (!webPushVapidPublicKey) return 'unconfigured';
+    if (window.Notification.permission === 'denied') return 'denied';
+    if (window.Notification.permission === 'granted') return 'granted';
+    return readPromptDismissed() ? 'prompt-dismissed' : 'default';
+}
+
+export function usePushSubscription() {
+    const [status, setStatus] = useState<PushSetupStatus>(() =>
+        resolvePermissionStatus(),
+    );
+
+    useEffect(() => {
+        setStatus(resolvePermissionStatus());
+    }, []);
+
+    const dismissPrompt = useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.localStorage.setItem(pushPromptDismissedKey, '1');
+        }
+        setStatus('prompt-dismissed');
+    }, []);
+
+    const requestPermission = useCallback(async () => {
+        if (
+            typeof window === 'undefined' ||
+            !('Notification' in window) ||
+            !('PushManager' in window)
+        ) {
+            setStatus('unsupported');
+            return 'unsupported' as const;
+        }
+
+        if (!webPushVapidPublicKey) {
+            setStatus('unconfigured');
+            return 'unconfigured' as const;
+        }
+
+        const permission =
+            window.Notification.permission === 'granted'
+                ? 'granted'
+                : await window.Notification.requestPermission();
+        if (permission === 'granted') {
+            const registration = await ensurePushServiceWorkerRegistered();
+            if (!registration) {
+                setStatus('unsupported');
+                return 'unsupported' as const;
+            }
+            await subscribePushDevice({
+                applicationServerKey: webPushVapidPublicKey,
+                metadata: pushDeviceMetadata(),
+                persistSubscription: persistPushSubscription,
+                pushManager: registration.pushManager,
+            });
+            setStatus('subscribed');
+            return 'subscribed' as const;
+        }
+
+        if (permission === 'denied') {
+            setStatus('denied');
+            return 'denied' as const;
+        }
+
+        setStatus('default');
+        return 'default' as const;
+    }, []);
+
+    const canPrompt = useMemo(
+        () => status === 'default' || status === 'granted',
+        [status],
+    );
+
+    return {
+        status,
+        canPrompt,
+        dismissPrompt,
+        requestPermission,
+    };
+}

--- a/apps/app/app/admin/settings/page.tsx
+++ b/apps/app/app/admin/settings/page.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
 import { SlackChannelSettingForm } from '../communication/slack/SlackChannelSettingForm';
+import { UserNotificationSettings } from './_components/UserNotificationSettings';
 import { AdminGeneralSettingForm } from './AdminGeneralSettingForm';
 import { DashboardQuickActionsSettingForm } from './DashboardQuickActionsSettingForm';
 import { GoogleCalendarSettingForm } from './GoogleCalendarSettingForm';
@@ -56,6 +57,10 @@ const SETTINGS_SECTIONS = [
     {
         id: 'notification-settings',
         title: 'Obavijesti',
+    },
+    {
+        id: 'personal-notification-settings',
+        title: 'Osobne obavijesti',
     },
 ] as const;
 
@@ -504,6 +509,30 @@ export default async function SettingsPage() {
                                     </CardContent>
                                 </Card>
                             </div>
+                        </Stack>
+                    </section>
+
+                    <section
+                        id="personal-notification-settings"
+                        className="scroll-mt-28"
+                        aria-labelledby="personal-notification-settings-heading"
+                    >
+                        <Stack spacing={6}>
+                            <Stack spacing={2}>
+                                <Typography
+                                    id="personal-notification-settings-heading"
+                                    level="h2"
+                                    semiBold
+                                >
+                                    Osobne obavijesti
+                                </Typography>
+                                <Typography level="body1">
+                                    Uključi web push obavijesti za svoj račun
+                                    kako bi te sustav obavijestio kad ti je
+                                    dodijeljena nova radnja.
+                                </Typography>
+                            </Stack>
+                            <UserNotificationSettings />
                         </Stack>
                     </section>
                 </div>

--- a/apps/app/public/push-notifications-sw.js
+++ b/apps/app/public/push-notifications-sw.js
@@ -1,0 +1,207 @@
+const DEFAULT_ICON = '/icon.svg';
+const DEFAULT_BADGE = '/badge.svg';
+const ALLOWED_PROTOCOLS = new Set(['https:', 'http:']);
+
+function isObject(value) {
+    return typeof value === 'object' && value !== null;
+}
+
+function safeString(value) {
+    return typeof value === 'string' && value.trim().length > 0
+        ? value.trim()
+        : undefined;
+}
+
+function safePositiveInteger(value) {
+    const numberValue =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'string'
+              ? Number(value)
+              : Number.NaN;
+    return Number.isSafeInteger(numberValue) && numberValue > 0
+        ? numberValue
+        : undefined;
+}
+
+function normalizeUrl(rawUrl) {
+    const safe = safeString(rawUrl);
+    if (!safe) return undefined;
+    try {
+        const url = new URL(safe, self.location.origin);
+        if (!ALLOWED_PROTOCOLS.has(url.protocol)) return undefined;
+        if (url.origin !== self.location.origin) return undefined;
+        return url.toString();
+    } catch {
+        return undefined;
+    }
+}
+
+function normalizeActions(actions) {
+    if (!Array.isArray(actions)) {
+        return { actions: undefined, actionUrls: undefined };
+    }
+    const normalized = actions
+        .filter((action) => isObject(action))
+        .map((action) => ({
+            action: safeString(action.action),
+            title: safeString(action.title),
+            icon: normalizeUrl(action.icon),
+            url: normalizeUrl(action.url),
+        }))
+        .filter((action) => action.action && action.title)
+        .slice(0, Number(self.Notification?.maxActions ?? 2));
+
+    if (normalized.length === 0) {
+        return { actions: undefined, actionUrls: undefined };
+    }
+
+    const actionUrls = normalized.reduce((urls, action) => {
+        if (action.action && action.url) {
+            urls[action.action] = action.url;
+        }
+        return urls;
+    }, {});
+
+    return {
+        actions: normalized.map((action) => ({
+            action: action.action,
+            title: action.title,
+            icon: action.icon,
+        })),
+        actionUrls: Object.keys(actionUrls).length > 0 ? actionUrls : undefined,
+    };
+}
+
+function readPushData(event) {
+    if (!event.data || typeof event.data.json !== 'function') {
+        return {};
+    }
+
+    try {
+        const raw = event.data.json();
+        return isObject(raw) ? raw : {};
+    } catch {
+        return {};
+    }
+}
+
+function createPayload(rawData) {
+    const source = isObject(rawData) ? rawData : {};
+    const data = isObject(source.data) ? source.data : {};
+
+    const title = safeString(source.title) ?? 'Gredice';
+    const body = safeString(source.body) ?? '';
+    const icon =
+        normalizeUrl(source.icon) ?? normalizeUrl(source.image) ?? DEFAULT_ICON;
+    const image = normalizeUrl(source.image);
+    const badge = normalizeUrl(source.badge) ?? DEFAULT_BADGE;
+    const url = normalizeUrl(source.url) ?? self.location.origin;
+    const tag =
+        safeString(source.tag) ??
+        safeString(source.collapseKey) ??
+        safeString(source.threadKey);
+    const actions = normalizeActions(source.actions);
+
+    return {
+        title,
+        options: {
+            body,
+            icon,
+            image,
+            badge,
+            tag,
+            renotify: Boolean(source.renotify && tag),
+            requireInteraction: Boolean(source.requireInteraction),
+            silent: Boolean(source.silent),
+            actions: actions.actions,
+            data: {
+                url,
+                actionUrls: actions.actionUrls,
+                analytics: {
+                    notificationId: safeString(source.notificationId),
+                    deliveryAttemptId: safePositiveInteger(
+                        source.deliveryAttemptId,
+                    ),
+                    campaignId: safeString(source.campaignId),
+                    category: safeString(source.category),
+                },
+                payload: data,
+            },
+        },
+    };
+}
+
+async function emitAnalytics(type, notificationData, action) {
+    const analytics = notificationData?.analytics;
+    if (!analytics?.notificationId) return;
+    const body = {
+        type,
+        action: safeString(action),
+        notificationId: analytics.notificationId,
+        deliveryAttemptId: safePositiveInteger(analytics.deliveryAttemptId),
+        campaignId: analytics.campaignId,
+        category: analytics.category,
+        at: new Date().toISOString(),
+    };
+
+    try {
+        await fetch('/api/notifications/events', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body),
+            keepalive: true,
+            credentials: 'include',
+        });
+    } catch {
+        // swallow analytics transport failures in service worker
+    }
+}
+
+self.addEventListener('push', (event) => {
+    const raw = readPushData(event);
+    const payload = createPayload(raw);
+    event.waitUntil(
+        self.registration.showNotification(payload.title, payload.options),
+    );
+});
+
+self.addEventListener('notificationclick', (event) => {
+    const data = event.notification?.data;
+    const actionCandidate = safeString(event.action);
+    const actionUrls = isObject(data?.actionUrls) ? data.actionUrls : {};
+    const actionUrl = actionCandidate
+        ? safeString(actionUrls[actionCandidate])
+        : undefined;
+    const targetUrl =
+        normalizeUrl(actionUrl) ??
+        normalizeUrl(data?.url) ??
+        self.location.origin;
+    event.notification.close();
+
+    event.waitUntil(
+        (async () => {
+            await emitAnalytics('clicked', data, actionCandidate);
+            const allClients = await clients.matchAll({
+                type: 'window',
+                includeUncontrolled: true,
+            });
+            for (const client of allClients) {
+                if (
+                    'focus' in client &&
+                    normalizeUrl(client.url) === normalizeUrl(targetUrl)
+                ) {
+                    await client.focus();
+                    return;
+                }
+            }
+            if (clients.openWindow) {
+                await clients.openWindow(targetUrl);
+            }
+        })(),
+    );
+});
+
+self.addEventListener('notificationclose', (event) => {
+    event.waitUntil(emitAnalytics('dismissed', event.notification?.data));
+});

--- a/apps/farm/.env.example
+++ b/apps/farm/.env.example
@@ -9,3 +9,6 @@ GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
 
 # Optional integration values
 COOKIE_DOMAIN=
+
+# Web push notifications (VAPID public key shared with @gredice/api)
+NEXT_PUBLIC_GREDICE_WEB_PUSH_VAPID_PUBLIC_KEY=

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -13,6 +13,7 @@ import {
     BookA,
     Calendar,
     Fence,
+    Settings,
     Shield,
     Sprout,
     User,
@@ -171,6 +172,15 @@ async function FarmerDashboard() {
                                 href="/plants"
                             >
                                 Priručnik biljaka
+                            </Button>
+                            <Button
+                                variant="soft"
+                                size="lg"
+                                className="justify-start"
+                                startDecorator={<Settings className="size-4" />}
+                                href="/settings"
+                            >
+                                Postavke
                             </Button>
                             {showDebugTools && (
                                 <Button

--- a/apps/farm/app/settings/_components/NotificationSettings.tsx
+++ b/apps/farm/app/settings/_components/NotificationSettings.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import { clientAuthenticated } from '@gredice/client';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Close, Megaphone } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePushSubscription } from './usePushSubscription';
+
+const notificationDevicesKey = ['notifications', 'devices'];
+const notificationPushStatusKey = ['notifications', 'push-status'];
+
+function permissionStatusLabel(status: string) {
+    switch (status) {
+        case 'granted':
+            return 'dopušteno';
+        case 'denied':
+            return 'odbijeno';
+        case 'unsupported':
+            return 'nije podržano';
+        case 'unconfigured':
+            return 'nije konfigurirano';
+        case 'prompt-dismissed':
+            return 'odgođeno';
+        case 'subscribed':
+            return 'uključeno';
+        default:
+            return 'nije odlučeno';
+    }
+}
+
+function pushStatusLabel(status: string | undefined) {
+    switch (status) {
+        case 'subscribed':
+            return 'uključeno';
+        case 'unsubscribed':
+            return 'nije uključeno';
+        case 'denied':
+            return 'blokirano';
+        case 'disabled':
+            return 'isključeno';
+        case undefined:
+            return 'učitavanje';
+        default:
+            return status;
+    }
+}
+
+export function NotificationSettings() {
+    const pushOnboarding = usePushSubscription();
+    const queryClient = useQueryClient();
+
+    const devicesQuery = useQuery({
+        queryKey: notificationDevicesKey,
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications.devices.$get();
+            if (!response.ok)
+                throw new Error('Uređaji za obavijesti nisu učitani');
+            return (await response.json()).devices;
+        },
+    });
+
+    const pushStatusQuery = useQuery({
+        queryKey: notificationPushStatusKey,
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications[
+                    'push-status'
+                ].$get();
+            if (!response.ok) throw new Error('Status obavijesti nije učitan');
+            return response.json();
+        },
+    });
+
+    const updateDeviceMutation = useMutation({
+        mutationFn: async ({
+            id,
+            enabled,
+        }: {
+            id: string;
+            enabled: boolean;
+        }) => {
+            const response =
+                await clientAuthenticated().api.notifications.devices[
+                    ':id'
+                ].$patch({
+                    param: { id },
+                    json: { enabled },
+                });
+            if (!response.ok) throw new Error('Uređaj nije ažuriran');
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
+            queryClient.invalidateQueries({
+                queryKey: notificationPushStatusKey,
+            });
+        },
+    });
+
+    const revokeDeviceMutation = useMutation({
+        mutationFn: async (id: string) => {
+            const response =
+                await clientAuthenticated().api.notifications.devices[
+                    ':id'
+                ].$delete({
+                    param: { id },
+                });
+            if (!response.ok) throw new Error('Uređaj nije uklonjen');
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
+            queryClient.invalidateQueries({
+                queryKey: notificationPushStatusKey,
+            });
+        },
+    });
+
+    const sendTestMutation = useMutation({
+        mutationFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications.test.$post();
+            if (!response.ok) throw new Error('Probna obavijest nije poslana');
+            return response.json();
+        },
+    });
+
+    const handleEnablePush = async () => {
+        const result = await pushOnboarding.requestPermission();
+        if (result === 'subscribed') {
+            queryClient.invalidateQueries({ queryKey: notificationDevicesKey });
+            queryClient.invalidateQueries({
+                queryKey: notificationPushStatusKey,
+            });
+        }
+    };
+
+    const notificationsSupported =
+        typeof window !== 'undefined' && 'Notification' in window;
+    const deviceMutationBusy =
+        updateDeviceMutation.isPending || revokeDeviceMutation.isPending;
+    const testNotificationResult = sendTestMutation.data;
+
+    return (
+        <Stack spacing={4}>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Obavijesti na ovom uređaju</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={2}>
+                        <Typography level="body2" secondary>
+                            Preglednik:{' '}
+                            {notificationsSupported
+                                ? 'podržava obavijesti'
+                                : 'ne podržava obavijesti'}{' '}
+                            · Dozvola:{' '}
+                            {permissionStatusLabel(pushOnboarding.status)} ·
+                            Status:{' '}
+                            {pushStatusLabel(pushStatusQuery.data?.status)}
+                        </Typography>
+                        {pushStatusQuery.isError && (
+                            <Typography level="body3" secondary>
+                                Status obavijesti nije učitan.
+                            </Typography>
+                        )}
+                        {pushOnboarding.status === 'denied' && (
+                            <Typography level="body3" secondary>
+                                Obavijesti su blokirane u pregledniku. Otvori
+                                postavke preglednika i omogući obavijesti za ovu
+                                stranicu.
+                            </Typography>
+                        )}
+                        {pushOnboarding.status === 'unconfigured' && (
+                            <Typography level="body3" secondary>
+                                Web push obavijesti nisu konfigurirane na ovom
+                                okruženju.
+                            </Typography>
+                        )}
+                        {pushOnboarding.canPrompt &&
+                            pushStatusQuery.data?.status !== 'subscribed' && (
+                                <Row justifyContent="end">
+                                    <Button
+                                        size="sm"
+                                        onClick={handleEnablePush}
+                                        startDecorator={
+                                            <Megaphone className="size-4" />
+                                        }
+                                    >
+                                        Uključi obavijesti
+                                    </Button>
+                                </Row>
+                            )}
+                    </Stack>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <Row
+                        justifyContent="space-between"
+                        alignItems="center"
+                        spacing={2}
+                        className="flex-wrap"
+                    >
+                        <CardTitle>Uređaji za obavijesti</CardTitle>
+                        <Button
+                            size="sm"
+                            disabled={sendTestMutation.isPending}
+                            onClick={() => sendTestMutation.mutate()}
+                            startDecorator={<Megaphone className="size-4" />}
+                        >
+                            Pošalji probnu obavijest
+                        </Button>
+                    </Row>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={2}>
+                        {sendTestMutation.isError && (
+                            <Typography level="body3" secondary>
+                                Probna obavijest nije poslana.
+                            </Typography>
+                        )}
+                        {sendTestMutation.isSuccess && (
+                            <Typography level="body3" secondary>
+                                Probna obavijest je poslana. Ciljano:{' '}
+                                {testNotificationResult?.targeted ?? 0} ·
+                                Prihvaćeno:{' '}
+                                {testNotificationResult?.accepted ?? 0} ·
+                                Neuspjelo: {testNotificationResult?.failed ?? 0}
+                            </Typography>
+                        )}
+                        {devicesQuery.isPending ? (
+                            <Typography level="body2" secondary>
+                                Uređaji se učitavaju.
+                            </Typography>
+                        ) : devicesQuery.isError ? (
+                            <Typography level="body2" secondary>
+                                Uređaji za obavijesti nisu učitani.
+                            </Typography>
+                        ) : devicesQuery.data?.length ? (
+                            devicesQuery.data.map((device) => (
+                                <Card key={device.id} className="bg-muted/30">
+                                    <CardContent>
+                                        <Stack spacing={1}>
+                                            <Typography semiBold>
+                                                {device.deviceLabel ||
+                                                    'Nepoznati uređaj'}
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                {device.userAgent ||
+                                                    'Nepoznat preglednik'}
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                Status:{' '}
+                                                {device.enabled
+                                                    ? 'aktivan'
+                                                    : 'isključen'}{' '}
+                                                · Zadnji put viđen:{' '}
+                                                {device.lastSeenAt
+                                                    ? new Date(
+                                                          device.lastSeenAt,
+                                                      ).toLocaleString('hr-HR')
+                                                    : 'nema podataka'}
+                                            </Typography>
+                                            <Row spacing={2}>
+                                                <Button
+                                                    size="sm"
+                                                    variant="plain"
+                                                    disabled={
+                                                        deviceMutationBusy
+                                                    }
+                                                    onClick={() =>
+                                                        updateDeviceMutation.mutate(
+                                                            {
+                                                                id: device.id,
+                                                                enabled:
+                                                                    !device.enabled,
+                                                            },
+                                                        )
+                                                    }
+                                                >
+                                                    {device.enabled
+                                                        ? 'Isključi'
+                                                        : 'Uključi'}
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="plain"
+                                                    disabled={
+                                                        deviceMutationBusy
+                                                    }
+                                                    startDecorator={
+                                                        <Close className="size-4" />
+                                                    }
+                                                    onClick={() =>
+                                                        revokeDeviceMutation.mutate(
+                                                            device.id,
+                                                        )
+                                                    }
+                                                >
+                                                    Ukloni
+                                                </Button>
+                                            </Row>
+                                        </Stack>
+                                    </CardContent>
+                                </Card>
+                            ))
+                        ) : (
+                            <Typography level="body2" secondary>
+                                Nema uređaja prijavljenih za obavijesti.
+                            </Typography>
+                        )}
+                    </Stack>
+                </CardContent>
+            </Card>
+        </Stack>
+    );
+}

--- a/apps/farm/app/settings/_components/usePushSubscription.ts
+++ b/apps/farm/app/settings/_components/usePushSubscription.ts
@@ -1,0 +1,187 @@
+'use client';
+
+import {
+    clientAuthenticated,
+    type PushDeviceMetadata,
+    type PushDeviceRegistrationPayload,
+    subscribePushDevice,
+} from '@gredice/client';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type PushSetupStatus =
+    | 'unsupported'
+    | 'unconfigured'
+    | 'default'
+    | 'denied'
+    | 'granted'
+    | 'subscribed'
+    | 'prompt-dismissed';
+
+const pushPromptDismissedKey = 'farm:push:prompt-dismissed';
+const pushDeviceIdKey = 'farm:push:device-id';
+const pushServiceWorkerPath = '/push-notifications-sw.js';
+const webPushVapidPublicKey =
+    process.env.NEXT_PUBLIC_GREDICE_WEB_PUSH_VAPID_PUBLIC_KEY;
+
+function readPromptDismissed(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(pushPromptDismissedKey) === '1';
+}
+
+function readOrCreatePushDeviceId(): string | undefined {
+    if (typeof window === 'undefined') return undefined;
+    const existing = window.localStorage.getItem(pushDeviceIdKey);
+    if (existing) return existing;
+
+    const id =
+        window.crypto.randomUUID?.() ??
+        `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    window.localStorage.setItem(pushDeviceIdKey, id);
+    return id;
+}
+
+function pushDeviceMetadata(): PushDeviceMetadata {
+    if (typeof window === 'undefined') {
+        return {};
+    }
+
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const platform = navigator.platform || undefined;
+
+    return {
+        deviceId: readOrCreatePushDeviceId(),
+        deviceLabel: platform ? `Ovaj uređaj (${platform})` : 'Ovaj uređaj',
+        locale: navigator.language || undefined,
+        platform,
+        timezone,
+        userAgent: navigator.userAgent || undefined,
+    };
+}
+
+async function persistPushSubscription(payload: PushDeviceRegistrationPayload) {
+    const response =
+        await clientAuthenticated().api.notifications.devices.$post({
+            json: payload,
+        });
+    if (!response.ok) {
+        throw new Error('Push subscription was not saved.');
+    }
+}
+
+async function ensurePushServiceWorkerRegistered(): Promise<
+    ServiceWorkerRegistration | undefined
+> {
+    if (
+        typeof window === 'undefined' ||
+        !('serviceWorker' in navigator) ||
+        !('PushManager' in window) ||
+        typeof window.isSecureContext !== 'boolean' ||
+        !window.isSecureContext
+    ) {
+        return undefined;
+    }
+
+    const existing = await navigator.serviceWorker.getRegistration(
+        pushServiceWorkerPath,
+    );
+    if (existing) {
+        await existing.update();
+        return existing;
+    }
+
+    await navigator.serviceWorker.register(pushServiceWorkerPath, {
+        scope: '/',
+    });
+    return navigator.serviceWorker.ready;
+}
+
+function resolvePermissionStatus(): PushSetupStatus {
+    if (
+        typeof window === 'undefined' ||
+        !('Notification' in window) ||
+        !('serviceWorker' in navigator) ||
+        !('PushManager' in window) ||
+        typeof window.isSecureContext !== 'boolean' ||
+        !window.isSecureContext
+    ) {
+        return 'unsupported';
+    }
+
+    if (!webPushVapidPublicKey) return 'unconfigured';
+    if (window.Notification.permission === 'denied') return 'denied';
+    if (window.Notification.permission === 'granted') return 'granted';
+    return readPromptDismissed() ? 'prompt-dismissed' : 'default';
+}
+
+export function usePushSubscription() {
+    const [status, setStatus] = useState<PushSetupStatus>(() =>
+        resolvePermissionStatus(),
+    );
+
+    useEffect(() => {
+        setStatus(resolvePermissionStatus());
+    }, []);
+
+    const dismissPrompt = useCallback(() => {
+        if (typeof window !== 'undefined') {
+            window.localStorage.setItem(pushPromptDismissedKey, '1');
+        }
+        setStatus('prompt-dismissed');
+    }, []);
+
+    const requestPermission = useCallback(async () => {
+        if (
+            typeof window === 'undefined' ||
+            !('Notification' in window) ||
+            !('PushManager' in window)
+        ) {
+            setStatus('unsupported');
+            return 'unsupported' as const;
+        }
+
+        if (!webPushVapidPublicKey) {
+            setStatus('unconfigured');
+            return 'unconfigured' as const;
+        }
+
+        const permission =
+            window.Notification.permission === 'granted'
+                ? 'granted'
+                : await window.Notification.requestPermission();
+        if (permission === 'granted') {
+            const registration = await ensurePushServiceWorkerRegistered();
+            if (!registration) {
+                setStatus('unsupported');
+                return 'unsupported' as const;
+            }
+            await subscribePushDevice({
+                applicationServerKey: webPushVapidPublicKey,
+                metadata: pushDeviceMetadata(),
+                persistSubscription: persistPushSubscription,
+                pushManager: registration.pushManager,
+            });
+            setStatus('subscribed');
+            return 'subscribed' as const;
+        }
+
+        if (permission === 'denied') {
+            setStatus('denied');
+            return 'denied' as const;
+        }
+
+        setStatus('default');
+        return 'default' as const;
+    }, []);
+
+    const canPrompt = useMemo(
+        () => status === 'default' || status === 'granted',
+        [status],
+    );
+
+    return {
+        status,
+        canPrompt,
+        dismissPrompt,
+        requestPermission,
+    };
+}

--- a/apps/farm/app/settings/page.tsx
+++ b/apps/farm/app/settings/page.tsx
@@ -1,0 +1,49 @@
+import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import LoginDialog from '../../components/auth/LoginDialog';
+import { HomeButton } from '../../components/HomeButton';
+import { auth } from '../../lib/auth/auth';
+import { NotificationSettings } from './_components/NotificationSettings';
+
+export const dynamic = 'force-dynamic';
+
+function FarmSettingsContent() {
+    return (
+        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+            <div className="flex min-w-0 items-center gap-2">
+                <HomeButton />
+                <Typography level="h4" component="h1">
+                    Postavke
+                </Typography>
+            </div>
+            <Stack spacing={6}>
+                <Stack spacing={2}>
+                    <Typography level="h5" semiBold>
+                        Obavijesti
+                    </Typography>
+                    <Typography level="body2" secondary>
+                        Uključi web push obavijesti kako bi te sustav
+                        obavijestio kada ti je dodijeljena nova radnja na farmi.
+                    </Typography>
+                </Stack>
+                <NotificationSettings />
+            </Stack>
+        </div>
+    );
+}
+
+export default function FarmSettingsPage() {
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-muted">
+            <AuthProtectedSection auth={authFarmer}>
+                <FarmSettingsContent />
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/public/push-notifications-sw.js
+++ b/apps/farm/public/push-notifications-sw.js
@@ -1,0 +1,207 @@
+const DEFAULT_ICON = '/icon.svg';
+const DEFAULT_BADGE = '/badge.svg';
+const ALLOWED_PROTOCOLS = new Set(['https:', 'http:']);
+
+function isObject(value) {
+    return typeof value === 'object' && value !== null;
+}
+
+function safeString(value) {
+    return typeof value === 'string' && value.trim().length > 0
+        ? value.trim()
+        : undefined;
+}
+
+function safePositiveInteger(value) {
+    const numberValue =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'string'
+              ? Number(value)
+              : Number.NaN;
+    return Number.isSafeInteger(numberValue) && numberValue > 0
+        ? numberValue
+        : undefined;
+}
+
+function normalizeUrl(rawUrl) {
+    const safe = safeString(rawUrl);
+    if (!safe) return undefined;
+    try {
+        const url = new URL(safe, self.location.origin);
+        if (!ALLOWED_PROTOCOLS.has(url.protocol)) return undefined;
+        if (url.origin !== self.location.origin) return undefined;
+        return url.toString();
+    } catch {
+        return undefined;
+    }
+}
+
+function normalizeActions(actions) {
+    if (!Array.isArray(actions)) {
+        return { actions: undefined, actionUrls: undefined };
+    }
+    const normalized = actions
+        .filter((action) => isObject(action))
+        .map((action) => ({
+            action: safeString(action.action),
+            title: safeString(action.title),
+            icon: normalizeUrl(action.icon),
+            url: normalizeUrl(action.url),
+        }))
+        .filter((action) => action.action && action.title)
+        .slice(0, Number(self.Notification?.maxActions ?? 2));
+
+    if (normalized.length === 0) {
+        return { actions: undefined, actionUrls: undefined };
+    }
+
+    const actionUrls = normalized.reduce((urls, action) => {
+        if (action.action && action.url) {
+            urls[action.action] = action.url;
+        }
+        return urls;
+    }, {});
+
+    return {
+        actions: normalized.map((action) => ({
+            action: action.action,
+            title: action.title,
+            icon: action.icon,
+        })),
+        actionUrls: Object.keys(actionUrls).length > 0 ? actionUrls : undefined,
+    };
+}
+
+function readPushData(event) {
+    if (!event.data || typeof event.data.json !== 'function') {
+        return {};
+    }
+
+    try {
+        const raw = event.data.json();
+        return isObject(raw) ? raw : {};
+    } catch {
+        return {};
+    }
+}
+
+function createPayload(rawData) {
+    const source = isObject(rawData) ? rawData : {};
+    const data = isObject(source.data) ? source.data : {};
+
+    const title = safeString(source.title) ?? 'Gredice';
+    const body = safeString(source.body) ?? '';
+    const icon =
+        normalizeUrl(source.icon) ?? normalizeUrl(source.image) ?? DEFAULT_ICON;
+    const image = normalizeUrl(source.image);
+    const badge = normalizeUrl(source.badge) ?? DEFAULT_BADGE;
+    const url = normalizeUrl(source.url) ?? self.location.origin;
+    const tag =
+        safeString(source.tag) ??
+        safeString(source.collapseKey) ??
+        safeString(source.threadKey);
+    const actions = normalizeActions(source.actions);
+
+    return {
+        title,
+        options: {
+            body,
+            icon,
+            image,
+            badge,
+            tag,
+            renotify: Boolean(source.renotify && tag),
+            requireInteraction: Boolean(source.requireInteraction),
+            silent: Boolean(source.silent),
+            actions: actions.actions,
+            data: {
+                url,
+                actionUrls: actions.actionUrls,
+                analytics: {
+                    notificationId: safeString(source.notificationId),
+                    deliveryAttemptId: safePositiveInteger(
+                        source.deliveryAttemptId,
+                    ),
+                    campaignId: safeString(source.campaignId),
+                    category: safeString(source.category),
+                },
+                payload: data,
+            },
+        },
+    };
+}
+
+async function emitAnalytics(type, notificationData, action) {
+    const analytics = notificationData?.analytics;
+    if (!analytics?.notificationId) return;
+    const body = {
+        type,
+        action: safeString(action),
+        notificationId: analytics.notificationId,
+        deliveryAttemptId: safePositiveInteger(analytics.deliveryAttemptId),
+        campaignId: analytics.campaignId,
+        category: analytics.category,
+        at: new Date().toISOString(),
+    };
+
+    try {
+        await fetch('/api/notifications/events', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body),
+            keepalive: true,
+            credentials: 'include',
+        });
+    } catch {
+        // swallow analytics transport failures in service worker
+    }
+}
+
+self.addEventListener('push', (event) => {
+    const raw = readPushData(event);
+    const payload = createPayload(raw);
+    event.waitUntil(
+        self.registration.showNotification(payload.title, payload.options),
+    );
+});
+
+self.addEventListener('notificationclick', (event) => {
+    const data = event.notification?.data;
+    const actionCandidate = safeString(event.action);
+    const actionUrls = isObject(data?.actionUrls) ? data.actionUrls : {};
+    const actionUrl = actionCandidate
+        ? safeString(actionUrls[actionCandidate])
+        : undefined;
+    const targetUrl =
+        normalizeUrl(actionUrl) ??
+        normalizeUrl(data?.url) ??
+        self.location.origin;
+    event.notification.close();
+
+    event.waitUntil(
+        (async () => {
+            await emitAnalytics('clicked', data, actionCandidate);
+            const allClients = await clients.matchAll({
+                type: 'window',
+                includeUncontrolled: true,
+            });
+            for (const client of allClients) {
+                if (
+                    'focus' in client &&
+                    normalizeUrl(client.url) === normalizeUrl(targetUrl)
+                ) {
+                    await client.focus();
+                    return;
+                }
+            }
+            if (clients.openWindow) {
+                await clients.openWindow(targetUrl);
+            }
+        })(),
+    );
+});
+
+self.addEventListener('notificationclose', (event) => {
+    event.waitUntil(emitAnalytics('dismissed', event.notification?.data));
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,4 +5,14 @@ export {
     type GrediceAppOrigin,
     getBrowserGrediceAppOrigin,
 } from './origins';
+export {
+    type BrowserPushManager,
+    type BrowserPushSubscription,
+    type BrowserPushSubscriptionJson,
+    type PushDeviceMetadata,
+    type PushDeviceRegistrationPayload,
+    pushSubscriptionPayload,
+    subscribePushDevice,
+    urlBase64ToUint8Array,
+} from './push';
 export { getServerGrediceApiOrigin } from './shared';

--- a/packages/client/src/push.ts
+++ b/packages/client/src/push.ts
@@ -1,0 +1,116 @@
+export type PushDeviceRegistrationPayload = {
+    endpoint: string;
+    keys: {
+        p256dh: string;
+        auth: string;
+    };
+    deviceId?: string;
+    deviceLabel?: string;
+    browserName?: string;
+    browserVersion?: string;
+    platform?: string;
+    userAgent?: string;
+    locale?: string;
+    timezone?: string;
+    permissionState: 'default' | 'granted' | 'denied';
+};
+
+export type BrowserPushSubscriptionJson = {
+    endpoint?: string;
+    keys?: {
+        p256dh?: string;
+        auth?: string;
+    };
+};
+
+export type BrowserPushSubscription = {
+    endpoint: string;
+    toJSON(): BrowserPushSubscriptionJson;
+};
+
+export type BrowserPushSubscribeOptions = {
+    applicationServerKey?: ArrayBuffer | ArrayBufferView | string | null;
+    userVisibleOnly?: boolean;
+};
+
+export type BrowserPushManager = {
+    getSubscription(): Promise<BrowserPushSubscription | null>;
+    subscribe(
+        options?: BrowserPushSubscribeOptions,
+    ): Promise<BrowserPushSubscription>;
+};
+
+export type PushDeviceMetadata = Omit<
+    PushDeviceRegistrationPayload,
+    'endpoint' | 'keys' | 'permissionState'
+>;
+
+function safeString(value: string | undefined): string | undefined {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+}
+
+export function urlBase64ToUint8Array(value: string): Uint8Array<ArrayBuffer> {
+    const padding = '='.repeat((4 - (value.length % 4)) % 4);
+    const base64 = `${value}${padding}`.replace(/-/g, '+').replace(/_/g, '/');
+    const rawData = globalThis.atob(base64);
+    const output = new Uint8Array(rawData.length);
+
+    for (let index = 0; index < rawData.length; index += 1) {
+        output[index] = rawData.charCodeAt(index);
+    }
+
+    return output;
+}
+
+export function pushSubscriptionPayload(
+    subscription: BrowserPushSubscription,
+    metadata: PushDeviceMetadata,
+): PushDeviceRegistrationPayload | null {
+    const json = subscription.toJSON();
+    const endpoint =
+        safeString(json.endpoint) ?? safeString(subscription.endpoint);
+    const p256dh = safeString(json.keys?.p256dh);
+    const auth = safeString(json.keys?.auth);
+
+    if (!endpoint || !p256dh || !auth) {
+        return null;
+    }
+
+    return {
+        ...metadata,
+        endpoint,
+        keys: { p256dh, auth },
+        permissionState: 'granted',
+    };
+}
+
+export async function subscribePushDevice({
+    applicationServerKey,
+    metadata,
+    persistSubscription,
+    pushManager,
+}: {
+    applicationServerKey: string;
+    metadata: PushDeviceMetadata;
+    persistSubscription: (
+        payload: PushDeviceRegistrationPayload,
+    ) => Promise<void>;
+    pushManager: BrowserPushManager;
+}): Promise<PushDeviceRegistrationPayload> {
+    const existingSubscription = await pushManager.getSubscription();
+    const subscription =
+        existingSubscription ??
+        (await pushManager.subscribe({
+            applicationServerKey: urlBase64ToUint8Array(applicationServerKey),
+            userVisibleOnly: true,
+        }));
+    const payload = pushSubscriptionPayload(subscription, metadata);
+
+    if (!payload) {
+        throw new Error('Push subscription is missing endpoint or keys.');
+    }
+
+    await persistSubscription(payload);
+    return payload;
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,6 +1,7 @@
 import type { OperationData } from '@gredice/directory-types';
 import { postMessage } from '@gredice/slack';
 import {
+    createNotification,
     type DeliveryRequestState,
     getDeliveryRequest,
     getEntityFormatted,
@@ -396,6 +397,64 @@ export async function notifyNewUserRegistered(userId: string) {
     ];
 
     await sendSlackMessage(channel, lines.filter(Boolean).join('\n'));
+}
+
+export async function notifyOperationAssignedUsers(
+    operationId: number,
+    assignedUserIds: string[],
+) {
+    const uniqueUserIds = Array.from(
+        new Set(assignedUserIds.filter((id) => id && id.length > 0)),
+    );
+    if (uniqueUserIds.length === 0) {
+        return;
+    }
+
+    const context = await buildOperationContext(operationId);
+    const operationName = context?.operationName ?? `Radnja #${operationId}`;
+    const formattedScheduledDate = formatDateTime(context?.scheduledDate);
+
+    const header = 'Nova radnja je dodijeljena';
+    const locationLine = context?.locationDescription
+        ? ` (${context.locationDescription})`
+        : '';
+    const scheduleLine = formattedScheduledDate
+        ? ` Termin: ${formattedScheduledDate}.`
+        : '';
+    const content = `Dodijeljena ti je radnja **${operationName}**${locationLine}.${scheduleLine}`;
+
+    await Promise.all(
+        uniqueUserIds.map(async (userId) => {
+            try {
+                const user = await getUser(userId);
+                const accountId = user?.accounts?.[0]?.accountId;
+                if (!accountId) {
+                    console.warn(
+                        'Skipping operation assignment notification: no account for user',
+                        { userId, operationId },
+                    );
+                    return;
+                }
+
+                await createNotification({
+                    accountId,
+                    userId,
+                    header,
+                    content,
+                    category: 'garden',
+                    type: 'operation_assigned',
+                    primaryChannel: 'push',
+                    priority: 'normal',
+                    timestamp: new Date(),
+                });
+            } catch (error) {
+                console.error(
+                    'Failed to create operation assignment notification',
+                    { userId, operationId, error },
+                );
+            }
+        }),
+    );
 }
 
 export async function notifyPurchase(details: PurchaseNotificationDetails) {


### PR DESCRIPTION
## Summary

- Add a **Postavke** page to the farm app and an **Osobne obavijesti** section to the admin app's settings, where users can enable web push, list/disable/remove their registered devices, and send a test push.
- Trigger a per-user notification (category `garden`) on operation assignment from `singleCreateOperationAction`, `bulkCreateOperationsAction`, and `assignOperationUserAction` (only for newly added users). The existing delivery router fans this out to web push.
- Move the browser push subscription helper from `@gredice/game` into `@gredice/client` so farm and app can use it without pulling in the 3D game stack.

The web push backend (`web_push_subscriptions` table, `/api/notifications/devices`, `/push-status`, `/test`, VAPID sender) already existed; this change wires the assignment trigger and ships the client-side service worker + subscribe UI for the two apps. The Vercel env vars (`GREDICE_WEB_PUSH_VAPID_*` on api, `NEXT_PUBLIC_GREDICE_WEB_PUSH_VAPID_PUBLIC_KEY` on app/farm/garden) have been provisioned across Production, Preview, and Development.

## Test plan

- [ ] Run farm locally, open `/settings`, click *Uključi obavijesti*, accept the browser prompt, and verify the device appears in *Uređaji za obavijesti*.
- [ ] Press *Pošalji probnu obavijest* and confirm a system notification arrives.
- [ ] In the admin app, open `/admin/settings`, scroll to *Osobne obavijesti*, and repeat the same checks.
- [ ] As an admin, assign a farmer to an operation (single create, bulk create, and the assignment dropdown). Confirm the farmer receives a push and an in-app notification.
- [ ] Toggle a device off in the settings UI and confirm subsequent assignments stop pushing to that device.
- [ ] Remove a device and confirm `/api/notifications/push-status` reports it as unsubscribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)