### PR TITLE
Allow editing raised bed event date from events table

### DIFF
--- a/apps/app/app/(actions)/raisedBedEventsActions.ts
+++ b/apps/app/app/(actions)/raisedBedEventsActions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { deleteEventById } from '@gredice/storage';
+import { deleteEventById, updateEventCreatedAt } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
@@ -12,6 +12,25 @@ export async function deleteRaisedBedEventAction(
     await auth(['admin']);
 
     await deleteEventById(eventId);
+
+    revalidatePath(KnownPages.RaisedBed(raisedBedId));
+
+    return { success: true } as const;
+}
+
+export async function updateRaisedBedEventDateAction(
+    eventId: number,
+    raisedBedId: number,
+    createdAt: string,
+) {
+    await auth(['admin']);
+
+    const parsed = new Date(createdAt);
+    if (Number.isNaN(parsed.getTime())) {
+        return { success: false, error: 'invalid_date' } as const;
+    }
+
+    await updateEventCreatedAt(eventId, parsed);
 
     revalidatePath(KnownPages.RaisedBed(raisedBedId));
 

--- a/apps/app/components/raised-beds/RaisedBedEventsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedEventsTable.tsx
@@ -7,6 +7,8 @@ import {
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Stack } from '@gredice/ui/Stack';
 import type { ReactNode } from 'react';
+import { updateRaisedBedEventDateAction } from '../../app/(actions)/raisedBedEventsActions';
+import { EventDateEditButton } from '../shared/events/EventDateEditButton';
 import { EventsTable } from '../shared/events/EventsTable';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
 import { RaisedBedEventDeleteButton } from './RaisedBedEventDeleteButton';
@@ -176,6 +178,16 @@ export async function RaisedBedEventsTable({
             renderLocation={(event) =>
                 getEventLocationLabel(event.aggregateId, raisedBedId)
             }
+            renderTime={(event) => (
+                <EventDateEditButton
+                    date={event.createdAt}
+                    onSave={updateRaisedBedEventDateAction.bind(
+                        null,
+                        event.id,
+                        raisedBedId,
+                    )}
+                />
+            )}
             renderActions={(event) => (
                 <RaisedBedEventDeleteButton
                     eventId={event.id}

--- a/apps/app/components/shared/events/EventDateEditButton.tsx
+++ b/apps/app/components/shared/events/EventDateEditButton.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Input } from '@gredice/ui/Input';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Popper } from '@gredice/ui/Popper';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useState, useTransition } from 'react';
+
+function toDateTimeLocalValue(date: Date): string {
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return (
+        `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+        `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+    );
+}
+
+export interface EventDateEditButtonProps {
+    date: Date;
+    onSave: (
+        isoDate: string,
+    ) => Promise<{ success: boolean; error?: string } | undefined>;
+}
+
+export function EventDateEditButton({
+    date,
+    onSave,
+}: EventDateEditButtonProps) {
+    const [open, setOpen] = useState(false);
+    const [value, setValue] = useState(() => toDateTimeLocalValue(date));
+    const [isPending, startTransition] = useTransition();
+
+    const handleOpenChange = (next: boolean) => {
+        if (next) {
+            setValue(toDateTimeLocalValue(date));
+        }
+        setOpen(next);
+    };
+
+    const handleSave = () => {
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            alert('Neispravan datum.');
+            return;
+        }
+
+        startTransition(async () => {
+            try {
+                const result = await onSave(parsed.toISOString());
+                if (result && result.success === false) {
+                    alert('Došlo je do greške pri ažuriranju datuma.');
+                    return;
+                }
+                setOpen(false);
+            } catch (error) {
+                console.error('Error updating event date:', error);
+                alert('Došlo je do greške pri ažuriranju datuma.');
+            }
+        });
+    };
+
+    return (
+        <Popper
+            open={open}
+            onOpenChange={handleOpenChange}
+            className="w-72 p-3"
+            align="start"
+            trigger={
+                <Button
+                    type="button"
+                    variant="plain"
+                    size="sm"
+                    className="px-1 -mx-1"
+                >
+                    <LocalDateTime>{date}</LocalDateTime>
+                </Button>
+            }
+        >
+            <Stack spacing={3}>
+                <Typography level="h5">Promijeni datum</Typography>
+                <Input
+                    type="datetime-local"
+                    label="Datum i vrijeme"
+                    value={value}
+                    onChange={(event) => setValue(event.target.value)}
+                    disabled={isPending}
+                    fullWidth
+                />
+                <Row spacing={2} className="justify-end">
+                    <Button
+                        type="button"
+                        variant="plain"
+                        onClick={() => setOpen(false)}
+                        disabled={isPending}
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="solid"
+                        onClick={handleSave}
+                        disabled={isPending}
+                        loading={isPending}
+                    >
+                        Spremi
+                    </Button>
+                </Row>
+            </Stack>
+        </Popper>
+    );
+}

--- a/apps/app/components/shared/events/EventsTable.tsx
+++ b/apps/app/components/shared/events/EventsTable.tsx
@@ -11,6 +11,7 @@ export interface EventsTableProps<
     renderType: (event: TEvent) => ReactNode;
     renderDetails?: (event: TEvent) => ReactNode | null;
     renderLocation?: (event: TEvent) => ReactNode;
+    renderTime?: (event: TEvent) => ReactNode;
     renderActions?: (event: TEvent) => ReactNode;
     actionsColumnClassName?: string;
     labels?: {
@@ -30,6 +31,7 @@ export function EventsTable<
     renderType,
     renderDetails,
     renderLocation,
+    renderTime,
     renderActions,
     actionsColumnClassName,
     labels = {},
@@ -96,7 +98,13 @@ export function EventsTable<
                                 )}
                             </Table.Cell>
                             <Table.Cell>
-                                <LocalDateTime>{event.createdAt}</LocalDateTime>
+                                {renderTime ? (
+                                    renderTime(event)
+                                ) : (
+                                    <LocalDateTime>
+                                        {event.createdAt}
+                                    </LocalDateTime>
+                                )}
                             </Table.Cell>
                             {hasActions && (
                                 <Table.Cell className={actionsColumnClassName}>

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -19,6 +19,7 @@ export {
     getPlantPlaceEventsCount,
     getPlantUpdateEvents,
     getSunflowersDailyTotals,
+    updateEventCreatedAt,
 } from './queries';
 export type {
     // Account

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -318,6 +318,20 @@ export async function deleteEventById(eventId: number) {
     }
 }
 
+export async function updateEventCreatedAt(eventId: number, createdAt: Date) {
+    const event = await storage().query.events.findFirst({
+        where: eq(events.id, eventId),
+    });
+    if (!event) {
+        return;
+    }
+    await storage()
+        .update(events)
+        .set({ createdAt })
+        .where(eq(events.id, eventId));
+    await bustReadModelCachesForEvent(event);
+}
+
 export async function getLastBirthdayRewardEvent(userId: string) {
     const event = await storage().query.events.findFirst({
         where: and(


### PR DESCRIPTION
## Summary

- Adds the ability to change the recorded date of a raised bed event by clicking it in the admin events table.
- The date cell is now a plain button that opens a popover with a `datetime-local` picker and Save / Cancel actions.
- Backed by a new admin-gated server action that updates `events.createdAt` via a new `updateEventCreatedAt` storage helper and revalidates the raised bed page.

## What changed

- `packages/storage/.../events/queries.ts`: new `updateEventCreatedAt(eventId, createdAt)` that updates the row and busts the same read-model caches as `deleteEventById`. Exported from the events repo index.
- `apps/app/app/(actions)/raisedBedEventsActions.ts`: new `updateRaisedBedEventDateAction(eventId, raisedBedId, createdAt)` — admin-gated, validates the date, revalidates the raised bed page.
- `apps/app/components/shared/events/EventsTable.tsx`: optional `renderTime` prop. When provided it replaces the default `LocalDateTime` cell; otherwise behavior is unchanged.
- `apps/app/components/shared/events/EventDateEditButton.tsx` (new): client component that renders a `Button` showing `LocalDateTime` and opens a `Popper` with a `datetime-local` input plus Save/Cancel. Calls the bound server action on save and closes on success.
- `apps/app/components/raised-beds/RaisedBedEventsTable.tsx`: wires `renderTime` with `updateRaisedBedEventDateAction.bind(null, event.id, raisedBedId)`.

## Notes for reviewer

- The other `EventsTable` consumer (`AccountEventsCard`) is intentionally left on the plain `LocalDateTime` fallback — those events are financial (sunflowers, referrals) and editing dates there felt out of scope. Opt-in is a one-liner if we want it later.
- Existing `'use client'` `RaisedBedEventDeleteButton` and the existing `confirm()` / `alert()` UX patterns in the table are mirrored here for consistency.

## Test plan

- [ ] Open a raised bed in admin → events table renders, date column shows clickable buttons.
- [ ] Click a date → popover opens with the current date+time prefilled.
- [ ] Change the value, click Save → row updates with the new date after revalidation.
- [ ] Click Cancel or outside the popover → no change.
- [ ] Submitting an invalid value surfaces an error rather than corrupting the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)