### PR TITLE
Add plant location indicator and editor to raised bed field tiles

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -436,15 +436,23 @@ export async function setRaisedBedFieldSowingLocationAction(
         return { success: true };
     }
 
-    await createEvent(
-        knownEvents.raisedBedFields.plantScheduleV1(
+    const activeCycle = field.plantCycles?.find((cycle) => cycle.active);
+    const sowingMoment =
+        field.plantSowDate ??
+        activeCycle?.startedAt ??
+        field.plantScheduledDate ??
+        undefined;
+
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantScheduleV1(
             `${raisedBedId}|${positionIndex}`,
             {
                 scheduledDate: field.plantScheduledDate?.toISOString() ?? null,
                 sowingLocation,
             },
         ),
-    );
+        ...(sowingMoment ? { createdAt: new Date(sowingMoment) } : {}),
+    });
 
     await revalidateRaisedBedPaths(raisedBed);
 

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { RaisedBedFieldSowingLocation } from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@gredice/ui/Menu';
+import { Check } from '@gredice/ui/icons';
+import { useTransition } from 'react';
+import { setRaisedBedFieldSowingLocationAction } from '../../../(actions)/raisedBedFieldsActions';
+
+type RaisedBedFieldLocationSelectorProps = {
+    raisedBedId: number;
+    positionIndex: number;
+    sowingLocation: RaisedBedFieldSowingLocation;
+    currentLocation: 'greenhouse' | 'raisedBed';
+};
+
+const locationLabels = {
+    greenhouse: { label: 'Staklenik', icon: '🏡' },
+    raisedBed: { label: 'Gredica', icon: '🪴' },
+} as const;
+
+export function RaisedBedFieldLocationSelector({
+    raisedBedId,
+    positionIndex,
+    sowingLocation,
+    currentLocation,
+}: RaisedBedFieldLocationSelectorProps) {
+    const [isPending, startTransition] = useTransition();
+    const current = locationLabels[currentLocation];
+
+    const handleSelect = (nextLocation: RaisedBedFieldSowingLocation) => {
+        if (nextLocation === sowingLocation) {
+            return;
+        }
+        startTransition(async () => {
+            await setRaisedBedFieldSowingLocationAction(
+                raisedBedId,
+                positionIndex,
+                nextLocation,
+            );
+        });
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild disabled={isPending}>
+                <Chip
+                    size="sm"
+                    variant="solid"
+                    color={
+                        currentLocation === 'greenhouse' ? 'success' : 'neutral'
+                    }
+                    startDecorator={<span aria-hidden>{current.icon}</span>}
+                    title="Promijeni trenutnu lokaciju biljke"
+                    onClick={() => {}}
+                >
+                    {current.label}
+                </Chip>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+                <DropdownMenuItem
+                    startDecorator={
+                        <span aria-hidden className="w-4 text-center">
+                            {sowingLocation === 'greenhouse' ? (
+                                <Check className="size-4" />
+                            ) : null}
+                        </span>
+                    }
+                    onSelect={() => handleSelect('greenhouse')}
+                >
+                    <span aria-hidden className="mr-1">
+                        {locationLabels.greenhouse.icon}
+                    </span>
+                    {locationLabels.greenhouse.label}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    startDecorator={
+                        <span aria-hidden className="w-4 text-center">
+                            {sowingLocation === 'direct' ? (
+                                <Check className="size-4" />
+                            ) : null}
+                        </span>
+                    }
+                    onSelect={() => handleSelect('direct')}
+                >
+                    <span aria-hidden className="mr-1">
+                        {locationLabels.raisedBed.icon}
+                    </span>
+                    {locationLabels.raisedBed.label}
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -9,6 +9,7 @@ import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { RaisedBedFieldLocationSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector';
 import { RaisedBedFieldPlantSortSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector';
 import { RaisedBedFieldPlantStatusSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
@@ -24,6 +25,30 @@ type RaisedBedField = NonNullable<
 type RaisedBedFieldPlantCycle = Awaited<
     ReturnType<typeof getRaisedBedFieldPlantCycles>
 >[number];
+
+const STATUSES_BEFORE_TRANSPLANT = new Set([
+    'new',
+    'planned',
+    'pendingVerification',
+    'sowed',
+    'sprouted',
+]);
+
+function getCurrentLocation(
+    field: RaisedBedField,
+): 'greenhouse' | 'raisedBed' {
+    if (
+        field.active &&
+        field.sowingLocation === 'greenhouse' &&
+        STATUSES_BEFORE_TRANSPLANT.has(field.plantStatus ?? '') &&
+        !field.plantDeadDate &&
+        !field.plantHarvestedDate &&
+        !field.plantRemovedDate
+    ) {
+        return 'greenhouse';
+    }
+    return 'raisedBed';
+}
 
 const fieldStatusMetadata: Record<string, { label: string; icon: string }> = {
     new: { label: 'Novo', icon: '🆕' },
@@ -300,6 +325,16 @@ function RaisedBedFieldTile({
                             raisedBedId={raisedBedId}
                             fields={removedFields}
                             targetOptions={moveTargetOptions}
+                        />
+                    </div>
+                )}
+                {field?.active && field.plantSortId && (
+                    <div className="absolute top-2 left-2">
+                        <RaisedBedFieldLocationSelector
+                            raisedBedId={raisedBedId}
+                            positionIndex={positionIndex}
+                            sowingLocation={field.sowingLocation}
+                            currentLocation={getCurrentLocation(field)}
                         />
                     </div>
                 )}


### PR DESCRIPTION
## Summary

- Adds a chip on each active raised bed field tile (admin) showing whether the plant is currently in the **Staklenik** (greenhouse) or **Gredica** (raised bed), with a dropdown menu to correct the location if it was misrecorded at sowing.
- Backdates the `plantScheduleV1` event used to update `sowingLocation` to the sowing moment (`plantSowDate`, falling back to the active cycle start, then the scheduled date) so the correction reads as a retroactive fix rather than a present-time transfer.
- Current location is derived from `sowingLocation` + plant status: greenhouse only while the plant is in `new` / `planned` / `pendingVerification` / `sowed` / `sprouted` and not dead/harvested/removed; raised bed otherwise.

## Why

Greenhouse → raised bed is the only legitimate transition in the lifecycle. When a plant's sowing location is recorded incorrectly, admins need a way to correct it after the fact. Backdating the event keeps the event timeline coherent and avoids the appearance of a raised-bed-to-greenhouse move.

## Notes for reviewers

- New client component: `apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx`
- The action reuses the existing `setRaisedBedFieldSowingLocationAction` server action; the only behavior change is the `createdAt` on the emitted event.
- The chip overlays the top-left of the field image, mirroring the position number at top-right.

## Test plan

- [ ] Open a raised bed in the admin app, verify the location chip appears on each active field tile.
- [ ] Tile with `sowingLocation = 'greenhouse'` and status `sowed`/`sprouted` shows **Staklenik** (green).
- [ ] Tile with `sowingLocation = 'greenhouse'` but status `firstFlowers` (or later) shows **Gredica**.
- [ ] Tile with `sowingLocation = 'direct'` shows **Gredica**.
- [ ] Clicking the chip opens the dropdown; selecting the other option updates `sowingLocation`.
- [ ] After the change, the emitted `raisedBedField.plantSchedule` event's `createdAt` is at the plant's sowing date (check via the events table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)