### PR TITLE
fix(ui+game): Chip asChild trigger + de-dupe greenhouse HUD indicator

### DIFF
--- a/packages/ui/src/Chip/Chip.tsx
+++ b/packages/ui/src/Chip/Chip.tsx
@@ -1,9 +1,11 @@
 import NextLink from 'next/link';
-import type {
-    ComponentProps,
-    MouseEventHandler,
-    PropsWithChildren,
-    ReactNode,
+import {
+    type ComponentProps,
+    forwardRef,
+    type HTMLAttributes,
+    type MouseEventHandler,
+    type ReactNode,
+    type Ref,
 } from 'react';
 import { cx } from '../utils';
 
@@ -16,7 +18,7 @@ export type ColorPaletteProp =
     | 'success'
     | 'neutral';
 
-export type ChipProps = PropsWithChildren<{
+export type ChipProps = Omit<HTMLAttributes<HTMLElement>, 'color' | 'onClick'> & {
     disabled?: boolean;
     color?: ColorPaletteProp;
     variant?: 'plain' | 'outlined' | 'soft' | 'solid';
@@ -24,9 +26,7 @@ export type ChipProps = PropsWithChildren<{
     onClick?: MouseEventHandler<HTMLButtonElement>;
     href?: string | undefined;
     startDecorator?: ReactNode;
-    className?: string;
-    title?: string;
-}>;
+};
 
 const sizeClassNames = {
     sm: 'min-h-6 px-1.5 py-0.5 text-xs',
@@ -89,18 +89,22 @@ const variantColorClassNames = {
     },
 };
 
-export function Chip({
-    children,
-    className,
-    color = 'neutral',
-    disabled,
-    href,
-    onClick,
-    size = 'md',
-    startDecorator,
-    title,
-    variant = 'solid',
-}: ChipProps) {
+export const Chip = forwardRef<HTMLElement, ChipProps>(function Chip(
+    {
+        children,
+        className,
+        color = 'neutral',
+        disabled,
+        href,
+        onClick,
+        size = 'md',
+        startDecorator,
+        title,
+        variant = 'solid',
+        ...rest
+    },
+    ref,
+) {
     const content = (
         <>
             {startDecorator ? (
@@ -131,8 +135,10 @@ export function Chip({
                 aria-disabled={disabled}
                 className={mergedClassName}
                 href={href as ComponentProps<typeof NextLink>['href']}
+                ref={ref as Ref<HTMLAnchorElement>}
                 tabIndex={disabled ? -1 : undefined}
                 title={title}
+                {...rest}
             >
                 {content}
             </NextLink>
@@ -145,8 +151,10 @@ export function Chip({
                 className={mergedClassName}
                 disabled={disabled}
                 onClick={onClick}
+                ref={ref as Ref<HTMLButtonElement>}
                 title={title}
                 type="button"
+                {...rest}
             >
                 {content}
             </button>
@@ -154,8 +162,13 @@ export function Chip({
     }
 
     return (
-        <span className={mergedClassName} title={title}>
+        <span
+            className={mergedClassName}
+            ref={ref as Ref<HTMLSpanElement>}
+            title={title}
+            {...rest}
+        >
             {content}
         </span>
     );
-}
+});


### PR DESCRIPTION
## Summary
Two related UI fixes in the raised-bed / plant flows.

### 1. `Chip` works as a Radix `asChild` trigger (`packages/ui`)
The plant location selector badge (chip at the top-left of a plant image in the raised-bed view) did nothing when clicked — the dropdown never opened.

Root cause: `RaisedBedFieldLocationSelector` renders a `Chip` as a Radix `DropdownMenuTrigger` via `asChild`. Radix `asChild` clones the child and forwards its own `ref` plus the props that open the menu (`onPointerDown`, `onKeyDown`, `aria-haspopup`, `data-state`). The old `Chip` forwarded no ref and spread no extra props, so all of those were silently dropped and the trigger was inert.

- `packages/ui/src/Chip/Chip.tsx`: wrapped `Chip` in `forwardRef` and forward the ref to the rendered element (anchor / button / span); widened `ChipProps` to extend `HTMLAttributes<HTMLElement>` and spread leftover `...rest` onto the element. The original button-typed `onClick` signature is preserved so existing callers are unaffected.

### 2. De-duplicate greenhouse indicator on the planted-plant HUD (`packages/game`)
The planted-plant HUD showed two greenhouse indicators: an icon/circle badge overlaid on the plant image and a button in the icon stack.

- `GreenhouseSeedlingPlantVisual.tsx`: removed the overlaid emerald circle + `Home` icon badge (and its unused import). Greenhouse status is now signaled only by the stack button.
- `RaisedBedFieldItemPlanted.tsx`: converted the decorative stack badge `<span>` into a `<button>` that opens the plant details modal (reusing the existing `game_planted_item_opened` analytics event), with propagation stopped to match the sibling stack buttons.
- `GreenhouseSeedlingPlantVisual.tsx`: narrowed the green seedling ring from `-inset-1` to `inset-0` so it matches the plant-image footprint (~26px) and no longer overlaps the circular progress arc (inner edge ~27px).

## Reviewer notes
- `Chip` type changes are additive (`onClick` signature unchanged), so existing `Chip` callers should not break.
- Could not run `tsc` or click/visual-test in this environment (no `node_modules` in the worktree). Recommend a quick `pnpm typecheck` plus a manual check before merge.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Raised-bed view: click the location badge on a plant tile — dropdown opens; selecting Staklenik/Gredica switches the sowing location
- [ ] Game HUD: a greenhouse-seedling field shows only the stack button (no overlay badge); clicking the badge opens the plant details modal
- [ ] Greenhouse seedling: green ring no longer overlaps the circular progress bar
- [ ] Spot-check other `Chip` usages (filters, table chips) still render and click correctly