### PR TITLE
fix(game): de-duplicate greenhouse indicator on planted plant HUD

### DIFF
--- a/packages/game/src/hud/raisedBed/GreenhouseSeedlingPlantVisual.tsx
+++ b/packages/game/src/hud/raisedBed/GreenhouseSeedlingPlantVisual.tsx
@@ -1,5 +1,4 @@
 import type { PlantSortData } from '@gredice/client';
-import { Home } from '@gredice/ui/icons';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { cx } from '@gredice/ui/utils';
 
@@ -21,7 +20,7 @@ export function GreenhouseSeedlingPlantVisual({
             data-greenhouse-seedling-visual
         >
             <span
-                className="absolute -inset-1 rounded-full border border-emerald-500/70 bg-emerald-50/70 dark:bg-emerald-950/50"
+                className="absolute inset-0 rounded-full border border-emerald-500/70 bg-emerald-50/70 dark:bg-emerald-950/50"
                 aria-hidden="true"
             />
             <PlantOrSortImage
@@ -30,13 +29,6 @@ export function GreenhouseSeedlingPlantVisual({
                 width={imageSize}
                 height={imageSize}
             />
-            <span
-                className="absolute -right-1 -top-1 z-20 inline-flex size-5 items-center justify-center rounded-full border border-white bg-emerald-600 text-white shadow-sm"
-                title="Staklenik"
-            >
-                <Home className="size-3.5" aria-hidden="true" />
-                <span className="sr-only">Staklenik</span>
-            </span>
         </span>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -212,6 +212,19 @@ export function RaisedBedFieldItemPlanted({
     const modalTitle = isGreenhouseSeedling
         ? `Sadnica u stakleniku "${plantSort.information.name}"`
         : title;
+    const openPlantDetails = () => {
+        track('game_planted_item_opened', {
+            active_tab: activeTab,
+            is_historical: isHistorical,
+            plant_sort_id: plantSort.id,
+            position_index: positionIndex,
+            raised_bed_id: raisedBedId,
+        });
+        if (!isOpenControlled) {
+            setInternalOpen(true);
+        }
+        onOpenChange?.(true);
+    };
     const fieldBadge = isHistorical
         ? {
               className: 'bg-muted',
@@ -392,11 +405,20 @@ export function RaisedBedFieldItemPlanted({
                 />
             ))}
             {fieldBadge && (
-                <span
-                    className={`inline-flex size-8 items-center justify-center p-1 ${fieldBadge.className} rounded-full border-2 border-white shadow-lg ring-1 ring-black/10`}
+                <button
+                    type="button"
+                    className={`inline-flex size-8 items-center justify-center p-1 ${fieldBadge.className} pointer-events-auto rounded-full border-2 border-white shadow-lg ring-1 ring-black/10 transition-transform hover:scale-105 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700`}
+                    title={modalTitle}
+                    aria-label={modalTitle}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onKeyDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        openPlantDetails();
+                    }}
                 >
                     {fieldBadge.icon}
-                </span>
+                </button>
             )}
         </RaisedBedFieldIconStack>
     ) : null;


### PR DESCRIPTION
The planted-plant HUD showed two greenhouse indicators: an icon/circle badge overlaid on the plant image and a button in the icon stack. Keep only the stack button and make it open the plant details modal.

Also narrow the green seedling ring from -inset-1 to inset-0 so it matches the plant-image footprint and no longer overlaps the circular progress bar.