### PR TITLE
feat: shared schedule date navigation, see previous days in admin

### DIFF
--- a/apps/app/app/admin/schedule/page.tsx
+++ b/apps/app/app/admin/schedule/page.tsx
@@ -1,6 +1,6 @@
 import { DailySchedule } from '@gredice/ui/DailySchedule';
+import { ScheduleDateNavigation } from '@gredice/ui/ScheduleDateNavigation';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
 import { auth } from '../../../lib/auth/auth';
 import { ScheduleDay } from './ScheduleDay';
@@ -50,11 +50,15 @@ export default async function AdminSchedulePage({
     const resolvedSearchParams = await searchParams;
     const startDate = parseDateParam(resolvedSearchParams?.date);
 
+    const navigationDate = startDate ?? new Date();
+    navigationDate.setHours(0, 0, 0, 0);
+
     return (
         <Stack spacing={4}>
-            <Typography level="h4" component="h1">
-                Rasprored
-            </Typography>
+            <ScheduleDateNavigation
+                date={navigationDate}
+                basePath="/admin/schedule"
+            />
             <DailySchedule
                 startDate={startDate}
                 renderDay={({ date, isToday }) => (

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -1,11 +1,10 @@
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { Typography } from '@gredice/ui/Typography';
+import { ScheduleDateNavigation } from '@gredice/ui/ScheduleDateNavigation';
 import { Suspense } from 'react';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmScheduleDay } from './FarmScheduleDay';
-import { ScheduleDateNavigation } from './ScheduleDateNavigation';
 import { ScheduleDaySummarySection } from './ScheduleDaySummarySection';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 import {
@@ -28,11 +27,8 @@ async function FarmScheduleContent({ date }: { date: Date }) {
                 <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
                     <div className="flex min-w-0 items-center gap-2">
                         <HomeButton />
-                        <Typography level="h4" component="h1">
-                            Raspored
-                        </Typography>
                     </div>
-                    <ScheduleDateNavigation date={date} />
+                    <ScheduleDateNavigation date={date} basePath="/schedule" />
                 </div>
                 <div className="min-w-0">
                     <Suspense fallback={<ScheduleDaySummarySkeleton />}>

--- a/apps/storybook/stories/packages/ui/ScheduleDateNavigation.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ScheduleDateNavigation.stories.tsx
@@ -1,0 +1,44 @@
+import { ScheduleDateNavigation } from '@gredice/ui/ScheduleDateNavigation';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Navigation/ScheduleDateNavigation',
+    component: ScheduleDateNavigation,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'ScheduleDateNavigation renders previous/next day links around the selected date and shows the human-readable date. It is used at the top of schedule views in the admin and farm apps to navigate between days.',
+            },
+        },
+    },
+    args: {
+        date: new Date('2025-06-09'),
+        basePath: '/schedule',
+    },
+    render: (args) => (
+        <div className="flex justify-center p-4">
+            <ScheduleDateNavigation {...args} />
+        </div>
+    ),
+} satisfies Meta<typeof ScheduleDateNavigation>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Today: Story = {
+    args: {
+        date: new Date(),
+    },
+};
+
+export const CustomParam: Story = {
+    args: {
+        basePath: '/admin/schedule',
+        paramName: 'date',
+    },
+};

--- a/packages/ui/src/ScheduleDateNavigation/ScheduleDateNavigation.tsx
+++ b/packages/ui/src/ScheduleDateNavigation/ScheduleDateNavigation.tsx
@@ -1,7 +1,7 @@
-import { Left, Navigate } from '@gredice/ui/icons';
-import { Row } from '@gredice/ui/Row';
-import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
+import { Left, Navigate } from '../icons';
+import { Row } from '../Row';
+import { Typography } from '../Typography';
 
 function formatDateParam(date: Date) {
     const year = date.getFullYear();
@@ -16,11 +16,29 @@ function getOffsetDate(date: Date, offset: number) {
     return newDate;
 }
 
-interface ScheduleDateNavigationProps {
-    date: Date;
+function buildHref(basePath: string, paramName: string, date: Date) {
+    const separator = basePath.includes('?') ? '&' : '?';
+    return `${basePath}${separator}${paramName}=${formatDateParam(date)}`;
 }
 
-export function ScheduleDateNavigation({ date }: ScheduleDateNavigationProps) {
+export interface ScheduleDateNavigationProps {
+    /** The currently selected date. */
+    date: Date;
+    /** Base path the navigation links should point to (e.g. `/schedule`). */
+    basePath: string;
+    /** Name of the query parameter used to carry the selected date. */
+    paramName?: string;
+}
+
+/**
+ * Date navigation for schedule views. Renders previous/next day links around
+ * the currently selected date and shows the human-readable date.
+ */
+export function ScheduleDateNavigation({
+    date,
+    basePath,
+    paramName = 'date',
+}: ScheduleDateNavigationProps) {
     const dayOfWeek = new Intl.DateTimeFormat('hr-HR', {
         weekday: 'long',
     }).format(date);
@@ -33,13 +51,13 @@ export function ScheduleDateNavigation({ date }: ScheduleDateNavigationProps) {
 
     const isToday = new Date().toDateString() === date.toDateString();
 
-    const prevDateParam = formatDateParam(getOffsetDate(date, -1));
-    const nextDateParam = formatDateParam(getOffsetDate(date, 1));
+    const prevHref = buildHref(basePath, paramName, getOffsetDate(date, -1));
+    const nextHref = buildHref(basePath, paramName, getOffsetDate(date, 1));
 
     return (
         <Row spacing={2} className="shrink-0">
             <Link
-                href={`/schedule?date=${prevDateParam}`}
+                href={prevHref}
                 title="Prethodni dan"
                 className="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
             >
@@ -54,7 +72,7 @@ export function ScheduleDateNavigation({ date }: ScheduleDateNavigationProps) {
                 </Typography>
             </div>
             <Link
-                href={`/schedule?date=${nextDateParam}`}
+                href={nextHref}
                 title="Sljedeći dan"
                 className="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
             >

--- a/packages/ui/src/ScheduleDateNavigation/index.ts
+++ b/packages/ui/src/ScheduleDateNavigation/index.ts
@@ -1,0 +1,1 @@
+export * from './ScheduleDateNavigation';


### PR DESCRIPTION
## What

- **Extract a shared `ScheduleDateNavigation` component** to `@gredice/ui` (moved out of the farm app). It now accepts a `basePath` prop (and optional `paramName`, default `"date"`) so the prev/next-day links can target any route.
- **apps/app admin schedule** ([page.tsx](apps/app/app/admin/schedule/page.tsx)): adds the date navigation at the top (`basePath="/admin/schedule"`), driven off the existing `?date=` param, so reviewers/admins can now page backward to see previous days.
- **Farm app schedule** ([page.tsx](apps/farm/app/schedule/page.tsx)): now consumes the shared component (`basePath="/schedule"`) instead of a local copy.
- **Removed the redundant "Raspored"/"Rasprored" page headers** from both the admin and farm schedule pages — the date navigation now sits at the top of each.
- **Storybook**: new story `packages/ui/Navigation/ScheduleDateNavigation` with `Default`, `Today`, and `CustomParam` variants.

## Why

The farm schedule already had day navigation but it was hardcoded to `/schedule` and not reusable. The admin schedule had no way to browse earlier days. Sharing one component keeps both apps consistent and lets admins navigate previous days.

## Notes for reviewers

- The sidebar nav label `Schedule: { label: 'Raspored' }` in `adminPages.ts` is intentionally left untouched — that's the navigation link, not the page header.
- The worktree had no installed `node_modules`, so typecheck/lint couldn't be run locally; the component is a faithful extraction of the already-working farm code and follows the existing package import conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)