### PR TITLE
fix: keep plant lifecycle ring center circle aligned

### DIFF
--- a/packages/ui/src/SegmentedCircularProgress/SegmentedCircularProgress.tsx
+++ b/packages/ui/src/SegmentedCircularProgress/SegmentedCircularProgress.tsx
@@ -28,7 +28,7 @@ export const SegmentedCircularProgress: React.FC<
     let offset = 0;
     return (
         <div
-            className="relative -rotate-[80deg]"
+            className="relative shrink-0 -rotate-[80deg]"
             style={{ width: size, height: size }}
         >
             {segments.map((segment, i) => {


### PR DESCRIPTION
## What changed

Added `shrink-0` to the root container of `SegmentedCircularProgress`.

## Why

The center circle of the plant lifecycle ring (the white disk with the status icon + label) drifted off-center on some cards but not others.

The ring container declares a fixed `width`/`height` (e.g. 140px), but its visual contents — the `<svg>` rings and the centered children overlay — are all absolutely positioned. That gives the container a `min-content` width of effectively `0`. As a flex item inside `Row` (`flex-shrink: 1` by default), it got squeezed narrower than its declared size whenever the neighboring stage text/chips were wide.

When that happened:
- The `<svg>` rings kept their explicit `width` (didn't shrink visually).
- The centered `absolute inset-0 flex items-center justify-center` overlay shrank with the container, so the center circle got centered inside a narrower box — pushing it left of the ring's true center.

This is exactly why only the cards with longer labels (`firstFlowers`, `firstFruitSet`, `ready`, `harvested`, `removed`) appeared misaligned.

## Notes for reviewers

- One-line fix; applies everywhere `SegmentedCircularProgress` is used (also `GreenhouseSeedlingProgress`), not just the field lifecycle view.
- No API or behavior change beyond preventing the container from shrinking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)