### PR TITLE
fix: center scale-up animation for desktop modal

### DIFF
--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -118,7 +118,7 @@ function DesktopModal({
                 <DialogPrimitive.Content
                     aria-describedby={undefined}
                     className={cx(
-                        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg min-w-0 -translate-x-1/2 -translate-y-1/2 gap-4 overflow-x-auto overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 [overflow-wrap:anywhere] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] data-[state=open]:zoom-in-95 sm:rounded-lg',
+                        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg min-w-0 -translate-x-1/2 -translate-y-1/2 gap-4 overflow-x-auto overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 [overflow-wrap:anywhere] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:rounded-lg',
                         className,
                     )}
                     onEscapeKeyDown={preventDismiss}


### PR DESCRIPTION
## Summary

The desktop/tablet `Modal` animated in by sliding from the upper-left corner. This changes it to scale up from the center instead.

## Changes

- Removed the `slide-in-from-left-1/2`, `slide-in-from-top-[48%]`, `slide-out-to-left-1/2`, and `slide-out-to-top-[48%]` classes from `DialogPrimitive.Content` in `packages/ui/src/Modal/Modal.tsx`.
- The modal stays centered via the existing `-translate-x-1/2 -translate-y-1/2` and now animates with `fade` + `zoom-95`, producing a center scale-up.
- The mobile drawer (`MobileModal`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)