### PR TITLE
fix: keep breadcrumbs on one line with ellipsis for long labels

### DIFF
--- a/packages/ui/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/ui/src/Breadcrumbs/Breadcrumbs.tsx
@@ -21,7 +21,7 @@ export function BreadcrumbsSeparator() {
     return (
         <Typography
             aria-hidden
-            className="text-muted-foreground/50"
+            className="shrink-0 text-muted-foreground/50"
             component="span"
         >
             /
@@ -47,7 +47,12 @@ export function BreadcrumbsItem({ href, label }: BreadcrumbItem) {
 
     if (typeof label === 'string') {
         return (
-            <Typography component="span" level="body2" noWrap>
+            <Typography
+                className="min-w-0"
+                component="span"
+                level="body2"
+                noWrap
+            >
                 {label}
             </Typography>
         );
@@ -67,7 +72,7 @@ export function Breadcrumbs({
 
     return (
         <nav aria-label="Breadcrumb" className={cx('max-w-full', className)}>
-            <ol className="flex min-w-0 flex-wrap items-center gap-1">
+            <ol className="flex min-w-0 flex-nowrap items-center gap-1">
                 {items.length > 3 ? (
                     <>
                         <li className="flex min-w-0 items-center gap-1">


### PR DESCRIPTION
## What changed

The `Breadcrumbs` component's `<ol>` used `flex-wrap`, causing long labels to break onto new lines instead of staying on a single line. This switches to `flex-nowrap` and makes items shrink/truncate gracefully:

- `flex-wrap` → `flex-nowrap` on the `<ol>` so the trail stays on one line.
- Added `shrink-0` to the `/` separators so they are never collapsed or squeezed.
- Added `min-w-0` to the plain-string (current page) item so `noWrap`'s existing ellipsis styling can actually trigger inside the flex row. Link items already had `min-w-0 truncate`.

## Why

The "Long Labels" breadcrumbs were wrapping onto multiple lines (see linked screenshot in the issue). Breadcrumbs should stay on a single line; overflow should be clipped with an ellipsis, and long trails collapse into the `…` dropdown.

## Behavior

- With everything on one line and `min-w-0` on each item, flexbox distributes shrinkage proportionally to content length — the longest item absorbs most of the truncation (ellipsis) while short items stay readable.
- The `>3 items` case still collapses the middle items into the dropdown menu as before.

## Notes for reviewers

Verify in Storybook: `Breadcrumbs` → `LongLabels` and `CollapsedMiddleItems` stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)