### PR TITLE
fix: correct ScheduleDateNavigation import in farm Storybook story

### DIFF
--- a/apps/storybook/stories/apps/farm/ScheduleShell.stories.tsx
+++ b/apps/storybook/stories/apps/farm/ScheduleShell.stories.tsx
@@ -1,7 +1,7 @@
 import { FarmScheduleSectionSkeleton } from '@apps/farm/app/schedule/FarmScheduleSectionSkeleton';
-import { ScheduleDateNavigation } from '@apps/farm/app/schedule/ScheduleDateNavigation';
 import { HomeButton } from '@apps/farm/components/HomeButton';
 import { Row } from '@gredice/ui/Row';
+import { ScheduleDateNavigation } from '@gredice/ui/ScheduleDateNavigation';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
@@ -12,6 +12,7 @@ const meta = {
     tags: ['autodocs'],
     args: {
         date: new Date('2026-05-21T00:00:00'),
+        basePath: '/schedule',
     },
     parameters: {
         docs: {
@@ -33,6 +34,7 @@ const meta = {
                     </Row>
                     <ScheduleDateNavigation
                         date={new Date('2026-05-21T00:00:00')}
+                        basePath="/schedule"
                     />
                 </Row>
                 <FarmScheduleSectionSkeleton />


### PR DESCRIPTION
## What

Fix the `apps/storybook/stories/apps/farm/ScheduleShell.stories.tsx` story, which imported `ScheduleDateNavigation` from the old farm path `@apps/farm/app/schedule/ScheduleDateNavigation`. That module no longer exists — the component now lives in the shared UI package — so typecheck and the Storybook build failed with:

```
TS2307: Cannot find module '@apps/farm/app/schedule/ScheduleDateNavigation' or its corresponding type declarations.
```

## Changes

- Import `ScheduleDateNavigation` from `@gredice/ui/ScheduleDateNavigation` (matching `apps/farm/app/schedule/page.tsx` and the existing UI story).
- Supply the now-required `basePath` prop in both the story `args` and the rendered component.

## Why

Keeps the story in sync with the relocated component and unblocks `pnpm run typecheck` / `storybook build`.

## Notes for reviewer

`pnpm run typecheck` passes for all packages, including `storybook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)