### PR TITLE
test(garden): fix HUD status badge selectors (span → button)

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -553,7 +553,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const stack = page.locator('[data-field-icon-stack]');
         await expect(stack).toBeVisible();
         await expect(
-            stack.locator('span.bg-blue-600 svg.lucide-sprout'),
+            stack.locator('button.bg-blue-600 svg.lucide-sprout'),
         ).toBeVisible();
     });
 
@@ -615,7 +615,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const stack = page.locator('[data-field-icon-stack]');
         await expect(stack).toBeVisible();
         await expect(
-            stack.locator('span.bg-green-600 svg.lucide-check'),
+            stack.locator('button.bg-green-600 svg.lucide-check'),
         ).toBeVisible();
     });
 
@@ -682,7 +682,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const stack = page.locator('[data-field-icon-stack]');
         await expect(stack).toBeVisible();
         await expect(
-            stack.locator('span.bg-blue-600 svg.lucide-sprout'),
+            stack.locator('button.bg-blue-600 svg.lucide-sprout'),
         ).toBeVisible();
         await expect(
             page.getByRole('button', { name: /Povijest biljke / }),


### PR DESCRIPTION
## Problem

The `CI - garden / test` job has been failing on every PR. Three tests in `apps/garden/tests/raised-bed-field-hud.spec.tsx` time out:

- `ready-to-harvest field shows the sprout status badge` (`:542`)
- `harvested field shows check indicator` (`:607`)
- `planted field with history stacks status badge with historical avatars` (`:671`)

(These tests only run on `pull_request` events, never on push to `main`, which is why `main` CI stays green while every PR fails.)

## Root cause

Commit 13872ed4 ("fix(game): de-duplicate greenhouse indicator on planted plant HUD") changed the status badge in `RaisedBedFieldItemPlanted.tsx` from a `<span>` to a clickable `<button>` (so it opens plant details on click). The icon and CSS classes were unchanged, but the tests still queried:

```js
stack.locator('span.bg-blue-600 svg.lucide-sprout')
stack.locator('span.bg-green-600 svg.lucide-check')
```

A `span` selector no longer matches the `button` element, so the badge assertions find nothing and time out.

## Fix

Update the three selectors to target `button` instead of `span`. Test-only change — no source/behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)