### PR TITLE
Fix raised bed plant location updates

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -436,23 +436,15 @@ export async function setRaisedBedFieldSowingLocationAction(
         return { success: true };
     }
 
-    const activeCycle = field.plantCycles?.find((cycle) => cycle.active);
-    const sowingMoment =
-        field.plantSowDate ??
-        activeCycle?.startedAt ??
-        field.plantScheduledDate ??
-        undefined;
-
-    await createEvent({
-        ...knownEvents.raisedBedFields.plantScheduleV1(
+    await createEvent(
+        knownEvents.raisedBedFields.plantScheduleV1(
             `${raisedBedId}|${positionIndex}`,
             {
                 scheduledDate: field.plantScheduledDate?.toISOString() ?? null,
                 sowingLocation,
             },
         ),
-        ...(sowingMoment ? { createdAt: new Date(sowingMoment) } : {}),
-    });
+    );
 
     await revalidateRaisedBedPaths(raisedBed);
 

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
@@ -2,14 +2,15 @@
 
 import type { RaisedBedFieldSowingLocation } from '@gredice/storage';
 import { Chip } from '@gredice/ui/Chip';
+import { Check } from '@gredice/ui/icons';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@gredice/ui/Menu';
-import { Check } from '@gredice/ui/icons';
-import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState, useTransition } from 'react';
 import { setRaisedBedFieldSowingLocationAction } from '../../../(actions)/raisedBedFieldsActions';
 
 type RaisedBedFieldLocationSelectorProps = {
@@ -17,6 +18,7 @@ type RaisedBedFieldLocationSelectorProps = {
     positionIndex: number;
     sowingLocation: RaisedBedFieldSowingLocation;
     currentLocation: 'greenhouse' | 'raisedBed';
+    greenhouseCurrentLocationEligible: boolean;
 };
 
 const locationLabels = {
@@ -24,25 +26,57 @@ const locationLabels = {
     raisedBed: { label: 'Gredica', icon: '🪴' },
 } as const;
 
+function getOptimisticCurrentLocation(
+    sowingLocation: RaisedBedFieldSowingLocation,
+    greenhouseCurrentLocationEligible: boolean,
+): 'greenhouse' | 'raisedBed' {
+    return sowingLocation === 'greenhouse' && greenhouseCurrentLocationEligible
+        ? 'greenhouse'
+        : 'raisedBed';
+}
+
 export function RaisedBedFieldLocationSelector({
     raisedBedId,
     positionIndex,
     sowingLocation,
     currentLocation,
+    greenhouseCurrentLocationEligible,
 }: RaisedBedFieldLocationSelectorProps) {
+    const router = useRouter();
     const [isPending, startTransition] = useTransition();
-    const current = locationLabels[currentLocation];
+    const [optimisticSowingLocation, setOptimisticSowingLocation] =
+        useState(sowingLocation);
+    const optimisticCurrentLocation =
+        optimisticSowingLocation === sowingLocation
+            ? currentLocation
+            : getOptimisticCurrentLocation(
+                  optimisticSowingLocation,
+                  greenhouseCurrentLocationEligible,
+              );
+    const current = locationLabels[optimisticCurrentLocation];
+
+    useEffect(() => {
+        setOptimisticSowingLocation(sowingLocation);
+    }, [sowingLocation]);
 
     const handleSelect = (nextLocation: RaisedBedFieldSowingLocation) => {
-        if (nextLocation === sowingLocation) {
+        if (nextLocation === optimisticSowingLocation) {
             return;
         }
+        setOptimisticSowingLocation(nextLocation);
         startTransition(async () => {
-            await setRaisedBedFieldSowingLocationAction(
-                raisedBedId,
-                positionIndex,
-                nextLocation,
-            );
+            try {
+                await setRaisedBedFieldSowingLocationAction(
+                    raisedBedId,
+                    positionIndex,
+                    nextLocation,
+                );
+                router.refresh();
+            } catch (error) {
+                console.error('Error updating sowing location:', error);
+                setOptimisticSowingLocation(sowingLocation);
+                alert('Promjena lokacije sijanja nije uspjela.');
+            }
         });
     };
 
@@ -53,7 +87,9 @@ export function RaisedBedFieldLocationSelector({
                     size="sm"
                     variant="solid"
                     color={
-                        currentLocation === 'greenhouse' ? 'success' : 'neutral'
+                        optimisticCurrentLocation === 'greenhouse'
+                            ? 'success'
+                            : 'neutral'
                     }
                     startDecorator={<span aria-hidden>{current.icon}</span>}
                     title="Promijeni trenutnu lokaciju biljke"
@@ -66,7 +102,7 @@ export function RaisedBedFieldLocationSelector({
                 <DropdownMenuItem
                     startDecorator={
                         <span aria-hidden className="w-4 text-center">
-                            {sowingLocation === 'greenhouse' ? (
+                            {optimisticSowingLocation === 'greenhouse' ? (
                                 <Check className="size-4" />
                             ) : null}
                         </span>
@@ -81,7 +117,7 @@ export function RaisedBedFieldLocationSelector({
                 <DropdownMenuItem
                     startDecorator={
                         <span aria-hidden className="w-4 text-center">
-                            {sowingLocation === 'direct' ? (
+                            {optimisticSowingLocation === 'direct' ? (
                                 <Check className="size-4" />
                             ) : null}
                         </span>

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -34,19 +34,28 @@ const STATUSES_BEFORE_TRANSPLANT = new Set([
     'sprouted',
 ]);
 
-function getCurrentLocation(
-    field: RaisedBedField,
-): 'greenhouse' | 'raisedBed' {
+function canFieldCurrentlyBeInGreenhouse(field: RaisedBedField) {
     if (
         field.active &&
-        field.sowingLocation === 'greenhouse' &&
         STATUSES_BEFORE_TRANSPLANT.has(field.plantStatus ?? '') &&
         !field.plantDeadDate &&
         !field.plantHarvestedDate &&
         !field.plantRemovedDate
     ) {
+        return true;
+    }
+
+    return false;
+}
+
+function getCurrentLocation(field: RaisedBedField): 'greenhouse' | 'raisedBed' {
+    if (
+        field.sowingLocation === 'greenhouse' &&
+        canFieldCurrentlyBeInGreenhouse(field)
+    ) {
         return 'greenhouse';
     }
+
     return 'raisedBed';
 }
 
@@ -335,6 +344,9 @@ function RaisedBedFieldTile({
                             positionIndex={positionIndex}
                             sowingLocation={field.sowingLocation}
                             currentLocation={getCurrentLocation(field)}
+                            greenhouseCurrentLocationEligible={canFieldCurrentlyBeInGreenhouse(
+                                field,
+                            )}
                         />
                     </div>
                 )}


### PR DESCRIPTION
## Summary
- stop backdating sowing-location correction events so the latest location change wins
- make the raised-bed location chip update optimistically and refresh after a successful save
- keep the current-location indicator aligned with the editable location state

## Testing
- `pnpm --filter app test:unit`
- `pnpm build --filter app`
- `pnpm test --filter app`