### PR TITLE
Refine bee habitats around cactus and ground flowers

### DIFF
--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -252,6 +252,9 @@ export function GameScene({
                                 <Suspense fallback={null}>
                                     <Bees
                                         garden={garden}
+                                        groundDecorationDensity={
+                                            qualityProfile.groundDecorationDensity
+                                        }
                                         weather={weather}
                                         weatherDisabled={weatherDisabled}
                                     />

--- a/packages/game/src/entities/Cactus.tsx
+++ b/packages/game/src/entities/Cactus.tsx
@@ -9,9 +9,12 @@ import { useGameGLTF } from '../utils/useGameGLTF';
 import { GardenFlowerModel } from './helpers/GardenFlowerModel';
 import { useAnimatedEntityRotation } from './helpers/useAnimatedEntityRotation';
 
-type CactusNodeName = Extract<keyof GLTFResult['nodes'], `Cactus_${string}`>;
+export type CactusNodeName = Extract<
+    keyof GLTFResult['nodes'],
+    `Cactus_${string}`
+>;
 
-type CactusFlowerPlacement = {
+export type CactusFlowerPlacement = {
     color: string;
     id: string;
     position: [number, number, number];
@@ -19,7 +22,7 @@ type CactusFlowerPlacement = {
     scale: number;
 };
 
-type CactusVariantConfig = {
+export type CactusVariantConfig = {
     assetName: GameAssetName;
     bodyNode: CactusNodeName;
     flowers: CactusFlowerPlacement[];
@@ -97,6 +100,10 @@ const cactusVariantByName = new Map<string, CactusVariantConfig>(
     Object.entries(cactusVariants),
 );
 
+export function getCactusVariantConfig(blockName: string) {
+    return cactusVariantByName.get(blockName) ?? null;
+}
+
 const cactusBodyMaterial = {
     color: '#4a6411',
     roughness: 0.82,
@@ -163,7 +170,7 @@ function CactusEntity({
 }
 
 export function Cactus(props: EntityInstanceProps) {
-    const config = cactusVariantByName.get(props.block.name);
+    const config = getCactusVariantConfig(props.block.name);
     if (!config) {
         console.error(`Unknown cactus variant: ${props.block.name}`);
         return null;

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -26,12 +26,15 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { getCactusVariantConfig } from '../Cactus';
+import { getBlockSurfaceDecorations } from '../groundDecorations/getBlockSurfaceDecorations';
+import { resolveGroundDecorationSurface } from '../groundDecorations/groundDecorationConfig';
 import { tulipBouquetStems } from '../tulipBouquet';
 import {
     type BeeWeather,
     createBeeWanderOffset,
     getBeeDwellSeconds,
-    getBeeHabitatGroups,
+    getBeeSpawnHabitatGroups,
     getBeeWanderHoverSeconds,
     isBeeActive,
     shouldBeeWanderNext,
@@ -59,7 +62,12 @@ type BeeGarden = {
 
 type BeeTarget = {
     id: string;
-    kind: 'flower' | 'raised-bed-flower' | 'wander';
+    kind:
+        | 'flower'
+        | 'raised-bed-flower'
+        | 'cactus-flower'
+        | 'ground-flower'
+        | 'wander';
     position: Vector3;
 };
 
@@ -131,7 +139,10 @@ const beeFlightTurnDamping = 7.5;
 const beeFlightLookAheadProgress = 0.06;
 const beeFlightArcMaxHeight = 0.42;
 const beeFlowerRestHeight = 0.025;
+const cactusFlowerHoverHeight = 0.08;
 const defaultTurnDamping = 9;
+const groundDecorationBlockYOffset = 0.2;
+const groundFlowerHoverHeight = 0.08;
 const raisedBedFlowerHoverHeight = 0.42;
 const tulipFlowerHoverHeight = 0.52;
 const fullTurn = Math.PI * 2;
@@ -225,7 +236,9 @@ function createTulipTargets(
 function isBeeFloweringField(field: BeeRaisedBedField) {
     return (
         isRaisedBedFieldOccupied(field) &&
-        (field.plantStatus === 'sprouted' || field.plantStatus === 'ready')
+        (field.plantStatus === 'firstFlowers' ||
+            field.plantStatus === 'firstFruitSet' ||
+            field.plantStatus === 'ready')
     );
 }
 
@@ -298,13 +311,140 @@ function createRaisedBedTargets(
     return targets;
 }
 
-function createFlowerTargets(
+function createCactusTargets(
+    stacks: Stack[],
+    blockData: BlockData[] | null | undefined,
+) {
+    const targets: BeeTarget[] = [];
+
+    for (const stack of stacks) {
+        for (const block of stack.blocks) {
+            const config = getCactusVariantConfig(block.name);
+            if (!config) {
+                continue;
+            }
+
+            const baseHeight = getStackHeight(blockData, stack, block);
+            for (const flower of config.flowers) {
+                const offset = rotateLocalPosition(
+                    new Vector3(
+                        flower.position[0] * config.scale,
+                        0,
+                        flower.position[2] * config.scale,
+                    ),
+                    block.rotation,
+                );
+
+                targets.push({
+                    id: `cactus-${block.id}-${flower.id}`,
+                    kind: 'cactus-flower',
+                    position: new Vector3(
+                        stack.position.x + offset.x,
+                        baseHeight -
+                            config.groundSink +
+                            flower.position[1] * config.scale +
+                            cactusFlowerHoverHeight,
+                        stack.position.z + offset.z,
+                    ),
+                });
+            }
+        }
+    }
+
+    return targets;
+}
+
+function createGroundFlowerTargets({
+    blockData,
+    density,
+    garden,
+}: {
+    blockData: BlockData[] | null | undefined;
+    density: number;
+    garden: BeeGarden;
+}) {
+    if (density <= 0) {
+        return [];
+    }
+
+    const targets: BeeTarget[] = [];
+    const gardenId = garden.id ?? null;
+
+    for (const stack of garden.stacks) {
+        for (const block of stack.blocks) {
+            const surface = resolveGroundDecorationSurface(block.name);
+            if (!surface) {
+                continue;
+            }
+
+            const placements = getBlockSurfaceDecorations({
+                block,
+                density,
+                gardenId,
+                surface,
+            });
+            const blockBaseY =
+                getStackHeight(blockData, stack, block) +
+                groundDecorationBlockYOffset;
+
+            placements.forEach((placement, index) => {
+                if (placement.kind !== 'flower') {
+                    return;
+                }
+
+                const offset = rotateLocalPosition(
+                    new Vector3(
+                        placement.position[0],
+                        0,
+                        placement.position[2],
+                    ),
+                    block.rotation,
+                );
+                targets.push({
+                    id: `ground-flower-${block.id}-${index}`,
+                    kind: 'ground-flower',
+                    position: new Vector3(
+                        stack.position.x + offset.x,
+                        blockBaseY +
+                            placement.position[1] +
+                            Math.max(
+                                groundFlowerHoverHeight,
+                                placement.scale * 0.24,
+                            ),
+                        stack.position.z + offset.z,
+                    ),
+                });
+            });
+        }
+    }
+
+    return targets;
+}
+
+function createFlowerEntityTargets(
     garden: BeeGarden,
     blockData: BlockData[] | null | undefined,
 ) {
+    return createTulipTargets(garden.stacks, blockData);
+}
+
+function createFlowerInteractionTargets({
+    blockData,
+    garden,
+    groundDecorationDensity,
+}: {
+    blockData: BlockData[] | null | undefined;
+    garden: BeeGarden;
+    groundDecorationDensity: number;
+}) {
     return [
-        ...createTulipTargets(garden.stacks, blockData),
         ...createRaisedBedTargets(garden, blockData),
+        ...createCactusTargets(garden.stacks, blockData),
+        ...createGroundFlowerTargets({
+            blockData,
+            density: groundDecorationDensity,
+            garden,
+        }),
     ];
 }
 
@@ -323,14 +463,25 @@ function computeHabitatCenter(targets: BeeTarget[]) {
 function createBeeHabitats(
     garden: BeeGarden | null | undefined,
     blockData: BlockData[] | null | undefined,
+    groundDecorationDensity: number,
 ) {
     if (!garden) {
         return [];
     }
 
-    const targetGroups = getBeeHabitatGroups(
-        createFlowerTargets(garden, blockData),
-    );
+    const spawnTargets = createFlowerEntityTargets(garden, blockData);
+    if (spawnTargets.length <= 0) {
+        return [];
+    }
+
+    const targetGroups = getBeeSpawnHabitatGroups({
+        spawnTargets,
+        additionalTargets: createFlowerInteractionTargets({
+            blockData,
+            garden,
+            groundDecorationDensity,
+        }),
+    });
     if (targetGroups.length <= 0) {
         return [];
     }
@@ -952,13 +1103,11 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
                 group.position.set(
                     runtime.landingPosition.x +
                         Math.cos(now * 1.7 + seed) * 0.05,
-                    runtime.landingPosition.y +
-                        Math.sin(now * 3 + seed) * 0.06,
+                    runtime.landingPosition.y + Math.sin(now * 3 + seed) * 0.06,
                     runtime.landingPosition.z +
                         Math.sin(now * 2.1 + seed) * 0.05,
                 );
-                group.rotation.x =
-                    -0.05 + Math.sin(now * 6 + seed) * 0.04;
+                group.rotation.x = -0.05 + Math.sin(now * 6 + seed) * 0.04;
                 group.rotation.y =
                     runtime.landingYaw + Math.sin(now * 1.3 + seed) * 0.2;
                 group.rotation.z = Math.sin(now * 4.2 + seed) * 0.08;
@@ -1041,10 +1190,12 @@ function resolveBeeWeather({
 
 export function Bees({
     garden,
+    groundDecorationDensity = 1,
     weather,
     weatherDisabled = false,
 }: {
     garden: BeeGarden | null | undefined;
+    groundDecorationDensity?: number;
     weather?: BeeWeatherOverride;
     weatherDisabled?: boolean;
 }) {
@@ -1059,8 +1210,8 @@ export function Bees({
         weatherOverride: weather,
     });
     const habitats = useMemo(
-        () => createBeeHabitats(garden, blockData),
-        [blockData, garden],
+        () => createBeeHabitats(garden, blockData, groundDecorationDensity),
+        [blockData, garden, groundDecorationDensity],
     );
 
     if (habitats.length <= 0 || !isBeeActive(timeOfDay, beeWeather)) {

--- a/packages/game/src/entities/bees/beeBehavior.ts
+++ b/packages/game/src/entities/bees/beeBehavior.ts
@@ -84,11 +84,11 @@ export function createBeeWanderOffset(random: () => number) {
     };
 }
 
-function isWithinBeeHabitatRadius(
+export function isWithinBeeHabitatRadius(
     left: BeeTargetPosition,
     right: BeeTargetPosition,
-    radiusSquared: number,
 ) {
+    const radiusSquared = BEE_HABITAT_RADIUS_BLOCKS * BEE_HABITAT_RADIUS_BLOCKS;
     const x = left.position.x - right.position.x;
     const z = left.position.z - right.position.z;
     return x * x + z * z <= radiusSquared;
@@ -98,14 +98,12 @@ export function getBeeHabitatGroups<T extends BeeTargetPosition>(
     flowerTargets: readonly T[],
 ) {
     const groups: T[][] = [];
-    const radiusSquared = BEE_HABITAT_RADIUS_BLOCKS * BEE_HABITAT_RADIUS_BLOCKS;
 
     for (const target of flowerTargets) {
         const habitat = groups.find((group) => {
             const anchor = group[0];
             return (
-                anchor !== undefined &&
-                isWithinBeeHabitatRadius(anchor, target, radiusSquared)
+                anchor !== undefined && isWithinBeeHabitatRadius(anchor, target)
             );
         });
 
@@ -117,6 +115,23 @@ export function getBeeHabitatGroups<T extends BeeTargetPosition>(
     }
 
     return groups;
+}
+
+export function getBeeSpawnHabitatGroups<T extends BeeTargetPosition>({
+    additionalTargets,
+    spawnTargets,
+}: {
+    additionalTargets: readonly T[];
+    spawnTargets: readonly T[];
+}) {
+    return getBeeHabitatGroups(spawnTargets).map((spawnGroup) => [
+        ...spawnGroup,
+        ...additionalTargets.filter((target) =>
+            spawnGroup.some((spawnTarget) =>
+                isWithinBeeHabitatRadius(spawnTarget, target),
+            ),
+        ),
+    ]);
 }
 
 export function getBeeCount(flowerTargets: readonly BeeTargetPosition[]) {

--- a/packages/game/src/entities/bees/beeBehavior.unit.ts
+++ b/packages/game/src/entities/bees/beeBehavior.unit.ts
@@ -5,6 +5,7 @@ import {
     getBeeCount,
     getBeeDwellSeconds,
     getBeeHabitatGroups,
+    getBeeSpawnHabitatGroups,
     getBeeWanderHoverSeconds,
     isBeeActive,
     isBeeDaytime,
@@ -79,6 +80,37 @@ test('groups nearby flowers into one bee habitat', () => {
     assert.deepEqual(
         groups.map((group) => group.map((target) => target.id)),
         [['a', 'b'], ['c']],
+    );
+});
+
+test('requires flower entity spawn targets before creating bee habitats', () => {
+    const groups = getBeeSpawnHabitatGroups({
+        spawnTargets: [],
+        additionalTargets: [
+            { id: 'raised-bed-flower', position: { x: 0, z: 0 } },
+            { id: 'cactus-flower', position: { x: 1, z: 1 } },
+        ],
+    });
+
+    assert.equal(groups.length, 0);
+});
+
+test('adds nearby non-spawn flowers to flower entity habitats', () => {
+    const tulipTargets = [
+        { id: 'tulip-a', position: { x: 0, z: 0 } },
+        { id: 'tulip-b', position: { x: 0.3, z: 0.2 } },
+    ];
+    const groups = getBeeSpawnHabitatGroups({
+        spawnTargets: tulipTargets,
+        additionalTargets: [
+            { id: 'raised-bed-flower', position: { x: 2, z: 2 } },
+            { id: 'far-grass-flower', position: { x: 12, z: 0 } },
+        ],
+    });
+
+    assert.deepEqual(
+        groups.map((group) => group.map((target) => target.id)),
+        [['tulip-a', 'tulip-b', 'raised-bed-flower']],
     );
 });
 

--- a/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
+++ b/packages/game/src/entities/groundDecorations/getBlockSurfaceDecorations.ts
@@ -261,7 +261,7 @@ function getFlowerPlacements({
 export function getBlockSurfaceDecorations(options: {
     block: Block;
     density?: number;
-    gardenId: number | null | undefined;
+    gardenId: number | string | null | undefined;
     surface: GroundDecorationSurface;
 }) {
     const { block, density = 1, gardenId, surface } = options;


### PR DESCRIPTION
## Summary
- Require actual flower spawn targets before bees form habitats
- Add cactus and ground flower interaction targets to bee habitat grouping
- Pass ground decoration density into the game scene so bee behavior matches quality settings
- Export cactus variant helpers for reuse and cover the new grouping behavior with unit tests

## Testing
- Unit tests updated for bee habitat grouping behavior
- Not run (not requested)