### PR TITLE
Fix missing weather and farmer payout tables

### DIFF
--- a/apps/app/app/admin/farmers/payoutSchemaStatus.ts
+++ b/apps/app/app/admin/farmers/payoutSchemaStatus.ts
@@ -1,0 +1,22 @@
+const missingPayoutSchemaCodes = new Set(['42P01', '42703']);
+
+function getErrorCode(error: unknown): string | null {
+    if (typeof error !== 'object' || error === null) {
+        return null;
+    }
+
+    if ('code' in error && typeof error.code === 'string') {
+        return error.code;
+    }
+
+    if ('cause' in error) {
+        return getErrorCode(error.cause);
+    }
+
+    return null;
+}
+
+export function isMissingPayoutSchemaError(error: unknown) {
+    const code = getErrorCode(error);
+    return code !== null && missingPayoutSchemaCodes.has(code);
+}

--- a/apps/app/app/admin/farmers/payouts/ApprovePayoutForm.tsx
+++ b/apps/app/app/admin/farmers/payouts/ApprovePayoutForm.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { useState, useTransition } from 'react';
 import {

--- a/apps/app/app/admin/farmers/payouts/PayoutStatusChip.tsx
+++ b/apps/app/app/admin/farmers/payouts/PayoutStatusChip.tsx
@@ -1,9 +1,12 @@
-import { Chip } from '@gredice/ui/Chip';
 import type { PayoutStatus } from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
 
 const config: Record<
     PayoutStatus,
-    { label: string; color: 'neutral' | 'info' | 'success' | 'error' | 'warning' }
+    {
+        label: string;
+        color: 'neutral' | 'info' | 'success' | 'error' | 'warning';
+    }
 > = {
     pending: { label: 'Na čekanju', color: 'warning' },
     approved: { label: 'Odobreno', color: 'info' },
@@ -12,7 +15,10 @@ const config: Record<
 };
 
 export function PayoutStatusChip({ status }: { status: string }) {
-    const cfg = config[status as PayoutStatus] ?? { label: status, color: 'neutral' as const };
+    const cfg = config[status as PayoutStatus] ?? {
+        label: status,
+        color: 'neutral' as const,
+    };
     return (
         <Chip color={cfg.color} size="sm" variant="soft">
             {cfg.label}

--- a/apps/app/app/admin/farmers/payouts/page.tsx
+++ b/apps/app/app/admin/farmers/payouts/page.tsx
@@ -1,5 +1,5 @@
-import { getAllPayoutRequests } from '@gredice/storage';
 import { formatPrice } from '@gredice/js/currency';
+import { getAllPayoutRequests } from '@gredice/storage';
 import {
     Card,
     CardContent,
@@ -8,20 +8,43 @@ import {
     CardTitle,
 } from '@gredice/ui/Card';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../lib/auth/auth';
+import { isMissingPayoutSchemaError } from '../payoutSchemaStatus';
 import { ApprovePayoutForm, RejectPayoutForm } from './ApprovePayoutForm';
 import { MarkAsPaidForm } from './MarkAsPaidForm';
 import { PayoutStatusChip } from './PayoutStatusChip';
 
 export const dynamic = 'force-dynamic';
 
+async function getPayoutsForPage() {
+    try {
+        return {
+            payouts: await getAllPayoutRequests(),
+            schemaAvailable: true,
+        };
+    } catch (error) {
+        if (!isMissingPayoutSchemaError(error)) {
+            throw error;
+        }
+
+        console.warn(
+            'Farmer payout tables are not available in this database.',
+        );
+        return {
+            payouts: [],
+            schemaAvailable: false,
+        };
+    }
+}
+
 export default async function AdminFarmerPayoutsPage() {
     await auth(['admin']);
-    const payouts = await getAllPayoutRequests();
+    const { payouts, schemaAvailable } = await getPayoutsForPage();
 
     const pending = payouts.filter((p) => p.status === 'pending');
     const approved = payouts.filter((p) => p.status === 'approved');
@@ -41,90 +64,112 @@ export default async function AdminFarmerPayoutsPage() {
                 </Typography>
             </Stack>
 
-            {/* Pending */}
-            <Card>
-                <CardHeader>
-                    <Row justifyContent="space-between" spacing={2}>
-                        <CardTitle>Na čekanju ({pending.length})</CardTitle>
-                    </Row>
-                </CardHeader>
-                {pending.length === 0 ? (
+            {!schemaAvailable && (
+                <Card>
                     <CardContent>
-                        <NoDataPlaceholder>
-                            Nema zahtjeva na čekanju.
-                        </NoDataPlaceholder>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Tablice za isplate nisu dostupne u ovoj bazi. Nakon
+                            migracije podaci će se prikazati ovdje.
+                        </Typography>
                     </CardContent>
-                ) : (
-                    <CardOverflow>
-                        <div className="overflow-auto">
-                            <Table>
-                                <Table.Header>
-                                    <Table.Row>
-                                        <Table.Head>Farmer</Table.Head>
-                                        <Table.Head>Farma</Table.Head>
-                                        <Table.Head>Iznos</Table.Head>
-                                        <Table.Head>Napomena farmera</Table.Head>
-                                        <Table.Head>Zatraženo</Table.Head>
-                                        <Table.Head>Odobri</Table.Head>
-                                        <Table.Head>Odbij</Table.Head>
-                                    </Table.Row>
-                                </Table.Header>
-                                <Table.Body>
-                                    {pending.map((payout) => (
-                                        <Table.Row key={payout.id}>
-                                            <Table.Cell>
-                                                <Typography level="body2" semiBold>
-                                                    {payout.displayName ??
-                                                        payout.userName}
-                                                </Typography>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                {payout.farmName}
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <Typography
-                                                    level="body2"
-                                                    semiBold
-                                                    className="tabular-nums"
-                                                >
-                                                    {formatPrice(
-                                                        parseFloat(
-                                                            payout.requestedAmount,
-                                                        ),
-                                                    )}
-                                                </Typography>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-muted-foreground"
-                                                >
-                                                    {payout.farmerNote ?? '—'}
-                                                </Typography>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <LocalDateTime>
-                                                    {payout.createdAt}
-                                                </LocalDateTime>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <ApprovePayoutForm
-                                                    id={payout.id}
-                                                />
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <RejectPayoutForm
-                                                    id={payout.id}
-                                                />
-                                            </Table.Cell>
+                </Card>
+            )}
+
+            {/* Pending */}
+            {schemaAvailable && (
+                <Card>
+                    <CardHeader>
+                        <Row justifyContent="space-between" spacing={2}>
+                            <CardTitle>Na čekanju ({pending.length})</CardTitle>
+                        </Row>
+                    </CardHeader>
+                    {pending.length === 0 ? (
+                        <CardContent>
+                            <NoDataPlaceholder>
+                                Nema zahtjeva na čekanju.
+                            </NoDataPlaceholder>
+                        </CardContent>
+                    ) : (
+                        <CardOverflow>
+                            <div className="overflow-auto">
+                                <Table>
+                                    <Table.Header>
+                                        <Table.Row>
+                                            <Table.Head>Farmer</Table.Head>
+                                            <Table.Head>Farma</Table.Head>
+                                            <Table.Head>Iznos</Table.Head>
+                                            <Table.Head>
+                                                Napomena farmera
+                                            </Table.Head>
+                                            <Table.Head>Zatraženo</Table.Head>
+                                            <Table.Head>Odobri</Table.Head>
+                                            <Table.Head>Odbij</Table.Head>
                                         </Table.Row>
-                                    ))}
-                                </Table.Body>
-                            </Table>
-                        </div>
-                    </CardOverflow>
-                )}
-            </Card>
+                                    </Table.Header>
+                                    <Table.Body>
+                                        {pending.map((payout) => (
+                                            <Table.Row key={payout.id}>
+                                                <Table.Cell>
+                                                    <Typography
+                                                        level="body2"
+                                                        semiBold
+                                                    >
+                                                        {payout.displayName ??
+                                                            payout.userName}
+                                                    </Typography>
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    {payout.farmName}
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <Typography
+                                                        level="body2"
+                                                        semiBold
+                                                        className="tabular-nums"
+                                                    >
+                                                        {formatPrice(
+                                                            parseFloat(
+                                                                payout.requestedAmount,
+                                                            ),
+                                                        )}
+                                                    </Typography>
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <Typography
+                                                        level="body3"
+                                                        className="text-muted-foreground"
+                                                    >
+                                                        {payout.farmerNote ??
+                                                            '—'}
+                                                    </Typography>
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <LocalDateTime>
+                                                        {payout.createdAt}
+                                                    </LocalDateTime>
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <ApprovePayoutForm
+                                                        id={payout.id}
+                                                    />
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <RejectPayoutForm
+                                                        id={payout.id}
+                                                    />
+                                                </Table.Cell>
+                                            </Table.Row>
+                                        ))}
+                                    </Table.Body>
+                                </Table>
+                            </div>
+                        </CardOverflow>
+                    )}
+                </Card>
+            )}
 
             {/* Approved — ready for bank transfer */}
             {approved.length > 0 && (
@@ -145,7 +190,9 @@ export default async function AdminFarmerPayoutsPage() {
                                         <Table.Head>Iznos</Table.Head>
                                         <Table.Head>Bilješka admina</Table.Head>
                                         <Table.Head>Odobreno</Table.Head>
-                                        <Table.Head>Označi kao plaćeno</Table.Head>
+                                        <Table.Head>
+                                            Označi kao plaćeno
+                                        </Table.Head>
                                     </Table.Row>
                                 </Table.Header>
                                 <Table.Body>
@@ -208,79 +255,83 @@ export default async function AdminFarmerPayoutsPage() {
             )}
 
             {/* History */}
-            <Card>
-                <CardHeader>
-                    <CardTitle>Povijest isplata</CardTitle>
-                </CardHeader>
-                {history.length === 0 ? (
-                    <CardContent>
-                        <NoDataPlaceholder>
-                            Nema završenih zahtjeva.
-                        </NoDataPlaceholder>
-                    </CardContent>
-                ) : (
-                    <CardOverflow>
-                        <div className="overflow-auto">
-                            <Table>
-                                <Table.Header>
-                                    <Table.Row>
-                                        <Table.Head>Farmer</Table.Head>
-                                        <Table.Head>Farma</Table.Head>
-                                        <Table.Head>Iznos</Table.Head>
-                                        <Table.Head>Status</Table.Head>
-                                        <Table.Head>Referenca / razlog</Table.Head>
-                                        <Table.Head>Datum</Table.Head>
-                                    </Table.Row>
-                                </Table.Header>
-                                <Table.Body>
-                                    {history.map((payout) => (
-                                        <Table.Row key={payout.id}>
-                                            <Table.Cell>
-                                                {payout.displayName ??
-                                                    payout.userName}
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                {payout.farmName}
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <span className="tabular-nums">
-                                                    {formatPrice(
-                                                        parseFloat(
-                                                            payout.requestedAmount,
-                                                        ),
-                                                    )}
-                                                </span>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <PayoutStatusChip
-                                                    status={payout.status}
-                                                />
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-muted-foreground font-mono"
-                                                >
-                                                    {payout.bankReference ??
-                                                        payout.rejectionReason ??
-                                                        '—'}
-                                                </Typography>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <LocalDateTime>
-                                                    {payout.paidAt ??
-                                                        payout.rejectedAt ??
-                                                        payout.createdAt}
-                                                </LocalDateTime>
-                                            </Table.Cell>
+            {schemaAvailable && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Povijest isplata</CardTitle>
+                    </CardHeader>
+                    {history.length === 0 ? (
+                        <CardContent>
+                            <NoDataPlaceholder>
+                                Nema završenih zahtjeva.
+                            </NoDataPlaceholder>
+                        </CardContent>
+                    ) : (
+                        <CardOverflow>
+                            <div className="overflow-auto">
+                                <Table>
+                                    <Table.Header>
+                                        <Table.Row>
+                                            <Table.Head>Farmer</Table.Head>
+                                            <Table.Head>Farma</Table.Head>
+                                            <Table.Head>Iznos</Table.Head>
+                                            <Table.Head>Status</Table.Head>
+                                            <Table.Head>
+                                                Referenca / razlog
+                                            </Table.Head>
+                                            <Table.Head>Datum</Table.Head>
                                         </Table.Row>
-                                    ))}
-                                </Table.Body>
-                            </Table>
-                        </div>
-                    </CardOverflow>
-                )}
-            </Card>
+                                    </Table.Header>
+                                    <Table.Body>
+                                        {history.map((payout) => (
+                                            <Table.Row key={payout.id}>
+                                                <Table.Cell>
+                                                    {payout.displayName ??
+                                                        payout.userName}
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    {payout.farmName}
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <span className="tabular-nums">
+                                                        {formatPrice(
+                                                            parseFloat(
+                                                                payout.requestedAmount,
+                                                            ),
+                                                        )}
+                                                    </span>
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <PayoutStatusChip
+                                                        status={payout.status}
+                                                    />
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <Typography
+                                                        level="body3"
+                                                        className="text-muted-foreground font-mono"
+                                                    >
+                                                        {payout.bankReference ??
+                                                            payout.rejectionReason ??
+                                                            '—'}
+                                                    </Typography>
+                                                </Table.Cell>
+                                                <Table.Cell>
+                                                    <LocalDateTime>
+                                                        {payout.paidAt ??
+                                                            payout.rejectedAt ??
+                                                            payout.createdAt}
+                                                    </LocalDateTime>
+                                                </Table.Cell>
+                                            </Table.Row>
+                                        ))}
+                                    </Table.Body>
+                                </Table>
+                            </div>
+                        </CardOverflow>
+                    )}
+                </Card>
+            )}
         </Stack>
     );
 }

--- a/apps/app/app/admin/farmers/prices/PriceForm.tsx
+++ b/apps/app/app/admin/farmers/prices/PriceForm.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { SelectFarm } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
 import { Row } from '@gredice/ui/Row';
@@ -11,21 +10,21 @@ import {
     setOperationPriceAction,
 } from '../../../(actions)/payoutAdminActions';
 
-type CurrentPrice = {
+export type CurrentPrice = {
     id: number;
     pricePerUnit: string;
     currency: string;
 };
 
 export function PriceRow({
-    farm,
+    farmId,
     entityTypeName,
     entityId,
     label,
     sublabel,
     currentPrice,
 }: {
-    farm: SelectFarm;
+    farmId: number;
     entityTypeName: string;
     entityId?: number | null;
     label: string;
@@ -40,7 +39,7 @@ export function PriceRow({
         if (!trimmed) return;
         startTransition(async () => {
             await setOperationPriceAction(
-                farm.id,
+                farmId,
                 entityTypeName,
                 trimmed,
                 entityId ?? null,
@@ -63,7 +62,10 @@ export function PriceRow({
                     {label}
                 </Typography>
                 {sublabel && (
-                    <Typography level="body3" className="text-muted-foreground font-mono">
+                    <Typography
+                        level="body3"
+                        className="text-muted-foreground font-mono"
+                    >
                         {sublabel}
                     </Typography>
                 )}

--- a/apps/app/app/admin/farmers/prices/page.tsx
+++ b/apps/app/app/admin/farmers/prices/page.tsx
@@ -1,16 +1,15 @@
-import { getAllOperationPrices, getFarms } from '@gredice/storage';
-import { getEntitiesFormatted } from '@gredice/storage';
 import type { OperationData } from '@gredice/directory-types';
 import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from '@gredice/ui/Card';
+    getAllOperationPrices,
+    getEntitiesFormatted,
+    getFarms,
+} from '@gredice/storage';
+import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { auth } from '../../../../lib/auth/auth';
-import { PriceRow } from './PriceForm';
+import { isMissingPayoutSchemaError } from '../payoutSchemaStatus';
+import { type CurrentPrice, PriceRow } from './PriceForm';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,14 +29,51 @@ const SOWING_ROWS = [
     },
 ];
 
+function toCurrentPrice(
+    price:
+        | Awaited<ReturnType<typeof getAllOperationPrices>>[number]
+        | undefined,
+): CurrentPrice | undefined {
+    if (!price) return undefined;
+    return {
+        id: price.id,
+        pricePerUnit: price.pricePerUnit,
+        currency: price.currency,
+    };
+}
+
+async function getOperationPricesForPage() {
+    try {
+        return {
+            prices: await getAllOperationPrices(),
+            schemaAvailable: true,
+        };
+    } catch (error) {
+        if (!isMissingPayoutSchemaError(error)) {
+            throw error;
+        }
+
+        console.warn(
+            'Operation price tables are not available in this database.',
+        );
+        return {
+            prices: [],
+            schemaAvailable: false,
+        };
+    }
+}
+
 export default async function AdminFarmerPricesPage() {
     await auth(['admin']);
 
-    const [farms, operations, allPrices] = await Promise.all([
+    const [farms, operations, pricesResult] = await Promise.all([
         getFarms(),
-        getEntitiesFormatted<OperationData>('operation').catch(() => [] as OperationData[]),
-        getAllOperationPrices(),
+        getEntitiesFormatted<OperationData>('operation').catch(
+            () => [] as OperationData[],
+        ),
+        getOperationPricesForPage(),
     ]);
+    const allPrices = pricesResult.prices;
 
     // Key: `${farmId}:${entityTypeName}:${entityId ?? 'null'}`
     const priceMap = new Map(
@@ -59,65 +95,87 @@ export default async function AdminFarmerPricesPage() {
                 </Typography>
             </Stack>
 
+            {!pricesResult.schemaAvailable && (
+                <Card>
+                    <CardContent>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Tablice za cijene radnji nisu dostupne u ovoj bazi.
+                            Nakon migracije cijene će se moći uređivati ovdje.
+                        </Typography>
+                    </CardContent>
+                </Card>
+            )}
+
             {farms.length === 0 && (
                 <Card>
                     <CardContent>
-                        <Typography level="body2" className="text-muted-foreground">
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
                             Nema farmâ u sustavu.
                         </Typography>
                     </CardContent>
                 </Card>
             )}
 
-            {farms.map((farm) => (
-                <Card key={farm.id}>
-                    <CardHeader>
-                        <CardTitle>{farm.name}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <Stack spacing={0}>
-                            {/* Sowing flat prices */}
-                            {SOWING_ROWS.map((row) => (
-                                <PriceRow
-                                    key={row.entityTypeName}
-                                    farm={farm}
-                                    entityTypeName={row.entityTypeName}
-                                    entityId={row.entityId}
-                                    label={row.label}
-                                    sublabel={row.sublabel}
-                                    currentPrice={priceMap.get(
-                                        `${farm.id}:${row.entityTypeName}:null`,
-                                    )}
-                                />
-                            ))}
-
-                            {/* Per-operation prices */}
-                            {operations.length === 0 ? (
-                                <Typography
-                                    level="body3"
-                                    className="text-muted-foreground py-2"
-                                >
-                                    Nema definiranih vrsta radnji u CMS-u.
-                                </Typography>
-                            ) : (
-                                operations.map((op) => (
+            {pricesResult.schemaAvailable &&
+                farms.map((farm) => (
+                    <Card key={farm.id}>
+                        <CardHeader>
+                            <CardTitle>{farm.name}</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Stack spacing={0}>
+                                {/* Sowing flat prices */}
+                                {SOWING_ROWS.map((row) => (
                                     <PriceRow
-                                        key={op.id}
-                                        farm={farm}
-                                        entityTypeName="operation"
-                                        entityId={op.id}
-                                        label={op.information.label}
-                                        sublabel={op.information.name}
-                                        currentPrice={priceMap.get(
-                                            `${farm.id}:operation:${op.id}`,
+                                        key={row.entityTypeName}
+                                        farmId={farm.id}
+                                        entityTypeName={row.entityTypeName}
+                                        entityId={row.entityId}
+                                        label={row.label}
+                                        sublabel={row.sublabel}
+                                        currentPrice={toCurrentPrice(
+                                            priceMap.get(
+                                                `${farm.id}:${row.entityTypeName}:null`,
+                                            ),
                                         )}
                                     />
-                                ))
-                            )}
-                        </Stack>
-                    </CardContent>
-                </Card>
-            ))}
+                                ))}
+
+                                {/* Per-operation prices */}
+                                {operations.length === 0 ? (
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground py-2"
+                                    >
+                                        Nema definiranih vrsta radnji u CMS-u.
+                                    </Typography>
+                                ) : (
+                                    operations.map((op) => (
+                                        <PriceRow
+                                            key={op.id}
+                                            farmId={farm.id}
+                                            entityTypeName="operation"
+                                            entityId={op.id}
+                                            label={op.information.label}
+                                            sublabel={op.information.name}
+                                            currentPrice={toCurrentPrice(
+                                                priceMap.get(
+                                                    `${farm.id}:operation:${op.id}`,
+                                                ),
+                                            )}
+                                        />
+                                    ))
+                                )}
+                            </Stack>
+                        </CardContent>
+                    </Card>
+                ))}
         </Stack>
     );
 }

--- a/apps/app/app/admin/weather/page.tsx
+++ b/apps/app/app/admin/weather/page.tsx
@@ -7,6 +7,26 @@ import { auth } from '../../../lib/auth/auth';
 
 export const dynamic = 'force-dynamic';
 
+async function getForecast() {
+    try {
+        const response = await clientPublic().api.data.weather.$get();
+        return response.ok ? await response.json() : [];
+    } catch (error) {
+        console.error('Failed to load weather forecast for admin page:', error);
+        return [];
+    }
+}
+
+async function getCurrentWeather() {
+    try {
+        const response = await clientPublic().api.data.weather.now.$get();
+        return response.ok ? await response.json() : null;
+    } catch (error) {
+        console.error('Failed to load current weather for admin page:', error);
+        return null;
+    }
+}
+
 export default async function WeatherPage({
     searchParams,
 }: {
@@ -21,16 +41,12 @@ export default async function WeatherPage({
     const safeFrom = Number.isNaN(from.getTime()) ? defaults.from : from;
     const safeTo = Number.isNaN(to.getTime()) ? defaults.to : to;
 
-    const [historyRows, bounds, forecastResponse, currentResponse] =
-        await Promise.all([
-            getWeatherHistory(safeFrom, safeTo),
-            getWeatherHistoryBounds(),
-            clientPublic().api.data.weather.$get(),
-            clientPublic().api.data.weather.now.$get(),
-        ]);
-
-    const forecast = forecastResponse.ok ? await forecastResponse.json() : [];
-    const current = currentResponse.ok ? await currentResponse.json() : null;
+    const [historyRows, bounds, forecast, current] = await Promise.all([
+        getWeatherHistory(safeFrom, safeTo),
+        getWeatherHistoryBounds(),
+        getForecast(),
+        getCurrentWeather(),
+    ]);
 
     const history = historyRows.map((row) => ({
         ...row,

--- a/apps/app/components/admin/weather/WeatherAdminClient.tsx
+++ b/apps/app/components/admin/weather/WeatherAdminClient.tsx
@@ -7,16 +7,31 @@ import {
     windDirectionToDegrees,
 } from '@gredice/js/weather';
 import { Card, CardOverflow } from '@gredice/ui/Card';
+import { ArrowUp } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import {
-    WeatherCharts,
-    type WeatherChartsRange,
-} from '@gredice/ui/WeatherCharts';
-import { ArrowUp } from '@gredice/ui/icons';
+import type { WeatherChartsRange } from '@gredice/ui/WeatherCharts';
+import dynamic from 'next/dynamic';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
+
+const WeatherCharts = dynamic(
+    () =>
+        import('@gredice/ui/WeatherCharts').then(
+            (module) => module.WeatherCharts,
+        ),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="flex h-80 w-full items-center justify-center">
+                <Typography level="body2" tertiary>
+                    Učitavanje podataka…
+                </Typography>
+            </div>
+        ),
+    },
+);
 
 interface CurrentWeather {
     symbol?: number | null;
@@ -58,7 +73,11 @@ function StatCard({
                         <Typography level="h4" semiBold>
                             {value}
                             {unit ? (
-                                <Typography level="body2" component="span" tertiary>
+                                <Typography
+                                    level="body2"
+                                    component="span"
+                                    tertiary
+                                >
                                     {` ${unit}`}
                                 </Typography>
                             ) : null}
@@ -109,12 +128,18 @@ export function WeatherAdminClient({
                 <div className="flex flex-col gap-3 md:flex-row">
                     <StatCard
                         label="Temperatura"
-                        value={temperature != null ? temperature.toFixed(1) : '—'}
+                        value={
+                            temperature != null ? temperature.toFixed(1) : '—'
+                        }
                         unit="°C"
                     />
                     <StatCard
                         label="Padaline"
-                        value={current?.rain != null ? current.rain.toFixed(1) : '—'}
+                        value={
+                            current?.rain != null
+                                ? current.rain.toFixed(1)
+                                : '—'
+                        }
                         unit="mm"
                     />
                     <StatCard

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -46,6 +46,7 @@
         "@biomejs/biome": "2.4.16",
         "@gredice/auth": "workspace:*",
         "@gredice/client": "workspace:*",
+        "@gredice/directory-types": "workspace:*",
         "@gredice/email": "workspace:*",
         "@gredice/fiscalization": "workspace:*",
         "@gredice/js": "workspace:*",

--- a/packages/storage/src/migrations/0039_repair_weather_payout_prices.sql
+++ b/packages/storage/src/migrations/0039_repair_weather_payout_prices.sql
@@ -1,0 +1,150 @@
+CREATE TABLE IF NOT EXISTS "operation_prices" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"farm_id" integer NOT NULL,
+	"entity_type_name" text NOT NULL,
+	"entity_id" integer,
+	"price_per_unit" numeric(10,2) NOT NULL,
+	"currency" text DEFAULT 'eur' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "operation_prices" ADD COLUMN IF NOT EXISTS "entity_id" integer;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "farmer_payout_requests" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"farm_id" integer NOT NULL,
+	"user_id" text NOT NULL,
+	"requested_amount" numeric(10,2) NOT NULL,
+	"currency" text DEFAULT 'eur' NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"farmer_note" text,
+	"admin_note" text,
+	"bank_reference" text,
+	"receipt_id" integer,
+	"approved_by_user_id" text,
+	"approved_at" timestamp,
+	"paid_at" timestamp,
+	"rejected_at" timestamp,
+	"rejection_reason" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "weather_history" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"recorded_at" timestamp DEFAULT now() NOT NULL,
+	"symbol" integer,
+	"temperature" real,
+	"rain" real DEFAULT 0 NOT NULL,
+	"wind_direction" text,
+	"wind_speed" real DEFAULT 0 NOT NULL,
+	"rainy" real DEFAULT 0 NOT NULL,
+	"snowy" real DEFAULT 0 NOT NULL,
+	"cloudy" real DEFAULT 0 NOT NULL,
+	"foggy" real DEFAULT 0 NOT NULL,
+	"thundery" real DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "receipts" ALTER COLUMN "invoice_id" DROP NOT NULL;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint
+		WHERE conname = 'operation_prices_farm_id_farms_id_fk'
+			AND conrelid = 'public.operation_prices'::regclass
+	) THEN
+		ALTER TABLE "operation_prices"
+			ADD CONSTRAINT "operation_prices_farm_id_farms_id_fk"
+			FOREIGN KEY ("farm_id")
+			REFERENCES "public"."farms"("id")
+			ON DELETE no action
+			ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint
+		WHERE conname = 'farmer_payout_requests_farm_id_farms_id_fk'
+			AND conrelid = 'public.farmer_payout_requests'::regclass
+	) THEN
+		ALTER TABLE "farmer_payout_requests"
+			ADD CONSTRAINT "farmer_payout_requests_farm_id_farms_id_fk"
+			FOREIGN KEY ("farm_id")
+			REFERENCES "public"."farms"("id")
+			ON DELETE no action
+			ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint
+		WHERE conname = 'farmer_payout_requests_user_id_users_id_fk'
+			AND conrelid = 'public.farmer_payout_requests'::regclass
+	) THEN
+		ALTER TABLE "farmer_payout_requests"
+			ADD CONSTRAINT "farmer_payout_requests_user_id_users_id_fk"
+			FOREIGN KEY ("user_id")
+			REFERENCES "public"."users"("id")
+			ON DELETE no action
+			ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint
+		WHERE conname = 'farmer_payout_requests_approved_by_user_id_users_id_fk'
+			AND conrelid = 'public.farmer_payout_requests'::regclass
+	) THEN
+		ALTER TABLE "farmer_payout_requests"
+			ADD CONSTRAINT "farmer_payout_requests_approved_by_user_id_users_id_fk"
+			FOREIGN KEY ("approved_by_user_id")
+			REFERENCES "public"."users"("id")
+			ON DELETE no action
+			ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint
+		WHERE conname = 'farmer_payout_requests_receipt_id_receipts_id_fk'
+			AND conrelid = 'public.farmer_payout_requests'::regclass
+	) THEN
+		ALTER TABLE "farmer_payout_requests"
+			ADD CONSTRAINT "farmer_payout_requests_receipt_id_receipts_id_fk"
+			FOREIGN KEY ("receipt_id")
+			REFERENCES "public"."receipts"("id")
+			ON DELETE no action
+			ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "operation_prices_farm_entity_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "operation_prices_farm_type_null_unique" ON "operation_prices" USING btree ("farm_id","entity_type_name") WHERE "entity_id" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "operation_prices_farm_type_entity_unique" ON "operation_prices" USING btree ("farm_id","entity_type_name","entity_id") WHERE "entity_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "operation_prices_farm_id_idx" ON "operation_prices" USING btree ("farm_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "farmer_payout_requests_farm_id_idx" ON "farmer_payout_requests" USING btree ("farm_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "farmer_payout_requests_user_id_idx" ON "farmer_payout_requests" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "farmer_payout_requests_status_idx" ON "farmer_payout_requests" USING btree ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "weather_history_recorded_at_idx" ON "weather_history" USING btree ("recorded_at");

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1780071062280,
       "tag": "0038_weather_history",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1780142354177,
+      "tag": "0039_repair_weather_payout_prices",
+      "breakpoints": true
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       '@gredice/client':
         specifier: workspace:*
         version: link:../../packages/client
+      '@gredice/directory-types':
+        specifier: workspace:*
+        version: link:../../packages/directory-types
       '@gredice/email':
         specifier: workspace:*
         version: link:../../packages/email


### PR DESCRIPTION
## Summary
- Add a forward repair migration that creates/repairs `operation_prices`, `farmer_payout_requests`, and `weather_history` along with the required indexes and foreign keys.
- Apply the migration to the live database so the admin weather, payouts, and prices pages can load against the real schema.
- Keep the admin pages resilient when an environment is still missing the payout schema.

## Testing
- `pnpm test --filter @gredice/storage` passed.
- `pnpm lint --filter app` passed with existing repo warnings.
- `pnpm test --filter app` passed.
- `pnpm build --filter app` passed.
- `pnpm build --filter api` passed.
- Browser smoke verified `/admin/weather`, `/admin/farmers/payouts`, and `/admin/farmers/prices` all return `200` without runtime errors.