### PR TITLE
Improve AI suggestion errors and make quotas per active raised bed

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -10,6 +10,7 @@ import {
     addGardenBoxInventoryItem,
     buildRaisedBedFieldPlantUpdatePayload,
     countAiRequestEventsSince,
+    countRaisedBedsByAccount,
     createDefaultGardenForAccount,
     createEvent,
     createGardenBlock,
@@ -54,7 +55,9 @@ import { isBlockPurchaseAvailableNow } from '../../../lib/garden/nightOnlyBlockP
 import { purchaseGardenBlock } from '../../../lib/garden/purchaseGardenBlockService';
 import {
     AI_REQUEST_QUOTAS,
+    AI_REQUEST_WEEKLY_LIMIT_PER_ACTIVE_RAISED_BED,
     type AiRequestKind,
+    getRaisedBedImageAnalysisWeeklyLimit,
     RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND,
     streamRaisedBedImageAnalysis,
     validateImageUrls,
@@ -136,13 +139,53 @@ async function getAiRequestQuotaUsage(
     requestKind: AiRequestKind,
 ) {
     const quota = AI_REQUEST_QUOTAS[requestKind];
-    const used = await countRecentAiRequests(accountId, requestKind);
+    const [used, limitDetails] = await Promise.all([
+        countRecentAiRequests(accountId, requestKind),
+        getAiRequestQuotaLimit(accountId, requestKind),
+    ]);
 
     return {
         ...quota,
+        ...limitDetails,
         used,
-        remaining: Math.max(0, quota.limit - used),
+        remaining: Math.max(0, limitDetails.limit - used),
     };
+}
+
+async function getAiRequestQuotaLimit(
+    accountId: string,
+    requestKind: AiRequestKind,
+) {
+    switch (requestKind) {
+        case RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND: {
+            const activeRaisedBedCount = await countRaisedBedsByAccount(
+                accountId,
+                { status: 'active' },
+            );
+
+            return {
+                activeRaisedBedCount,
+                limit: getRaisedBedImageAnalysisWeeklyLimit(
+                    activeRaisedBedCount,
+                ),
+                limitPerActiveRaisedBed:
+                    AI_REQUEST_WEEKLY_LIMIT_PER_ACTIVE_RAISED_BED,
+            };
+        }
+    }
+
+    const unreachable: never = requestKind;
+    throw new Error(`Unsupported AI request kind: ${unreachable}`);
+}
+
+type AiRequestQuotaUsage = Awaited<ReturnType<typeof getAiRequestQuotaUsage>>;
+
+function formatAiQuotaExceededError(aiQuota: AiRequestQuotaUsage) {
+    if (aiQuota.activeRaisedBedCount === 0) {
+        return 'AI savjeti dostupni su za aktivne gredice. Aktivirajte gredicu pa pokušajte ponovno.';
+    }
+
+    return `Iskoristili ste tjedni limit AI savjeta (${aiQuota.used.toString()}/${aiQuota.limit.toString()}). Za svaku aktivnu gredicu dostupno je ${aiQuota.limitPerActiveRaisedBed.toString()} savjeta tjedno. Pokušajte ponovno kasnije.`;
 }
 
 async function countRecentRaisedBedImageAnalyses(
@@ -2120,7 +2163,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
             if (aiQuota.used >= aiQuota.limit) {
                 return context.json(
                     {
-                        error: `Dosegnut je tjedni limit AI zahtjeva (${aiQuota.limit.toString()}/tjedan). Pokušaj ponovno kasnije.`,
+                        code: 'ai_quota_exceeded',
+                        error: formatAiQuotaExceededError(aiQuota),
                     },
                     429,
                 );
@@ -2582,7 +2626,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
             if (aiQuota.used >= aiQuota.limit) {
                 return context.json(
                     {
-                        error: `Dosegnut je tjedni limit AI zahtjeva (${aiQuota.limit.toString()}/tjedan). Pokušaj ponovno kasnije.`,
+                        code: 'ai_quota_exceeded',
+                        error: formatAiQuotaExceededError(aiQuota),
                     },
                     429,
                 );

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getRaisedBedImageAnalysisWeeklyLimit } from './raisedBedAiAnalysisService';
+
+test('getRaisedBedImageAnalysisWeeklyLimit grants 5 requests per active raised bed', () => {
+    assert.strictEqual(getRaisedBedImageAnalysisWeeklyLimit(0), 0);
+    assert.strictEqual(getRaisedBedImageAnalysisWeeklyLimit(1), 5);
+    assert.strictEqual(getRaisedBedImageAnalysisWeeklyLimit(3), 15);
+});

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -1,8 +1,8 @@
 import {
     getEntitiesFormatted,
     getOperations,
-    grediceCacheKeys,
     grediceCached,
+    grediceCacheKeys,
 } from '@gredice/storage';
 import { streamText } from 'ai';
 import { validateHostedImageUrl } from '../http/safeUrls';
@@ -23,7 +23,7 @@ const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.5';
 export const AI_REQUEST_QUOTA_WINDOW_DAYS = 7;
 export const AI_REQUEST_QUOTA_WINDOW_MS =
     AI_REQUEST_QUOTA_WINDOW_DAYS * 24 * 60 * 60 * 1000;
-export const AI_REQUEST_WEEKLY_LIMIT = 5;
+export const AI_REQUEST_WEEKLY_LIMIT_PER_ACTIVE_RAISED_BED = 5;
 export const RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND =
     'raisedBedImageAnalysis' as const;
 
@@ -31,14 +31,23 @@ export type AiRequestKind = typeof RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND;
 
 export const AI_REQUEST_QUOTAS = {
     [RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND]: {
-        limit: AI_REQUEST_WEEKLY_LIMIT,
+        baseLimit: AI_REQUEST_WEEKLY_LIMIT_PER_ACTIVE_RAISED_BED,
         windowDays: AI_REQUEST_QUOTA_WINDOW_DAYS,
         windowMs: AI_REQUEST_QUOTA_WINDOW_MS,
     },
 } as const satisfies Record<
     AiRequestKind,
-    { limit: number; windowDays: number; windowMs: number }
+    { baseLimit: number; windowDays: number; windowMs: number }
 >;
+
+export function getRaisedBedImageAnalysisWeeklyLimit(
+    activeRaisedBedCount: number,
+) {
+    return (
+        Math.max(0, activeRaisedBedCount) *
+        AI_REQUEST_WEEKLY_LIMIT_PER_ACTIVE_RAISED_BED
+    );
+}
 
 export function validateImageUrl(imageUrl: string): string | null {
     return validateHostedImageUrl(imageUrl);
@@ -171,10 +180,7 @@ async function buildWeatherContext(): Promise<WeatherContext | null> {
             })),
         };
     } catch (error) {
-        console.warn(
-            'Failed to load weather context for AI analysis:',
-            error,
-        );
+        console.warn('Failed to load weather context for AI analysis:', error);
         return null;
     }
 }
@@ -194,18 +200,20 @@ async function buildAnalysisMessages({
     imageUrls,
     positionIndex,
 }: AnalysisParams) {
-    const [plantSorts, operations, operationsData, weather] = await Promise.all([
-        getEntitiesFormatted<{
-            id: string;
-            information?: { name?: string };
-        }>('plantSort'),
-        getOperations(accountId, gardenId, raisedBed.id),
-        getEntitiesFormatted<{
-            id: string;
-            information?: { label?: string; name?: string };
-        }>('operation'),
-        buildWeatherContext(),
-    ]);
+    const [plantSorts, operations, operationsData, weather] = await Promise.all(
+        [
+            getEntitiesFormatted<{
+                id: string;
+                information?: { name?: string };
+            }>('plantSort'),
+            getOperations(accountId, gardenId, raisedBed.id),
+            getEntitiesFormatted<{
+                id: string;
+                information?: { label?: string; name?: string };
+            }>('operation'),
+            buildWeatherContext(),
+        ],
+    );
 
     const plantSortNameById = new Map(
         plantSorts.map((sort) => [
@@ -265,7 +273,8 @@ async function buildAnalysisMessages({
         fieldId: op.raisedBedFieldId,
     }));
 
-    const totalFields = raisedBed.fields.length || RAISED_BED_FIELDS_PER_BLOCK * 2;
+    const totalFields =
+        raisedBed.fields.length || RAISED_BED_FIELDS_PER_BLOCK * 2;
     const rows = Math.max(1, Math.ceil(totalFields / RAISED_BED_COLUMNS));
     const orientation = raisedBed.orientation ?? 'vertical';
     const nowIso = new Date().toISOString();

--- a/packages/game/src/hooks/aiAnalysisError.ts
+++ b/packages/game/src/hooks/aiAnalysisError.ts
@@ -1,0 +1,70 @@
+const fallbackAiAnalysisErrorMessage =
+    'Suncokret trenutno ne može dovršiti analizu. Pokušaj ponovno malo kasnije.';
+const genericAiAnalysisErrorMessage =
+    'Analiza nije uspjela. Pokušaj ponovno kasnije.';
+
+export class AiAnalysisRequestError extends Error {
+    constructor(
+        message: string,
+        readonly status: number,
+    ) {
+        super(message);
+        this.name = 'AiAnalysisRequestError';
+    }
+}
+
+function getStringProperty(value: unknown, key: string) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const candidate: unknown = Reflect.get(value, key);
+
+    return typeof candidate === 'string' && candidate.trim()
+        ? candidate.trim()
+        : null;
+}
+
+function getJsonErrorMessage(text: string) {
+    try {
+        const parsed: unknown = JSON.parse(text);
+
+        if (typeof parsed === 'string' && parsed.trim()) {
+            return parsed.trim();
+        }
+
+        return (
+            getStringProperty(parsed, 'error') ??
+            getStringProperty(parsed, 'message')
+        );
+    } catch {
+        return null;
+    }
+}
+
+export async function getAiAnalysisErrorMessage(response: Response) {
+    const text = (await response.text()).trim();
+
+    if (!text) {
+        return fallbackAiAnalysisErrorMessage;
+    }
+
+    const jsonErrorMessage = getJsonErrorMessage(text);
+    if (jsonErrorMessage) {
+        return jsonErrorMessage;
+    }
+
+    if (response.status === 429) {
+        return 'Iskoristili ste tjedni limit AI savjeta. Pokušaj ponovno kasnije.';
+    }
+
+    if (response.status >= 500) {
+        return fallbackAiAnalysisErrorMessage;
+    }
+
+    if (text.startsWith('{') || text.startsWith('[')) {
+        return genericAiAnalysisErrorMessage;
+    }
+
+    return text;
+}

--- a/packages/game/src/hooks/aiAnalysisError.unit.ts
+++ b/packages/game/src/hooks/aiAnalysisError.unit.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getAiAnalysisErrorMessage } from './aiAnalysisError';
+
+test('getAiAnalysisErrorMessage reads API error JSON bodies', async () => {
+    const message = await getAiAnalysisErrorMessage(
+        new Response(
+            JSON.stringify({
+                error: 'Iskoristili ste tjedni limit AI savjeta.',
+            }),
+            { status: 429 },
+        ),
+    );
+
+    assert.strictEqual(message, 'Iskoristili ste tjedni limit AI savjeta.');
+});
+
+test('getAiAnalysisErrorMessage falls back for empty server errors', async () => {
+    const message = await getAiAnalysisErrorMessage(
+        new Response('', { status: 500 }),
+    );
+
+    assert.match(message, /Suncokret trenutno/);
+});
+
+test('getAiAnalysisErrorMessage does not show raw structured JSON', async () => {
+    const message = await getAiAnalysisErrorMessage(
+        new Response(JSON.stringify({ details: ['Invalid image URL'] }), {
+            status: 400,
+        }),
+    );
+
+    assert.strictEqual(
+        message,
+        'Analiza nije uspjela. Pokušaj ponovno kasnije.',
+    );
+});

--- a/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
@@ -1,5 +1,9 @@
 import { client } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    AiAnalysisRequestError,
+    getAiAnalysisErrorMessage,
+} from './aiAnalysisError';
 import { queryKeys as raisedBedAiHistoryQueryKeys } from './useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
 
@@ -36,9 +40,9 @@ export function useRaisedBedAiAnalysis() {
             });
 
             if (!response.ok) {
-                const message = await response.text();
-                throw new Error(
-                    message || 'Greška prilikom AI analize fotografije.',
+                throw new AiAnalysisRequestError(
+                    await getAiAnalysisErrorMessage(response),
+                    response.status,
                 );
             }
 

--- a/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
@@ -1,5 +1,9 @@
 import { client } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    AiAnalysisRequestError,
+    getAiAnalysisErrorMessage,
+} from './aiAnalysisError';
 import { queryKeys as raisedBedAiHistoryQueryKeys } from './useRaisedBedAiHistory';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
 
@@ -39,9 +43,9 @@ export function useRaisedBedFieldAiAnalysis() {
             });
 
             if (!response.ok) {
-                const message = await response.text();
-                throw new Error(
-                    message || 'Greška prilikom AI analize fotografije.',
+                throw new AiAnalysisRequestError(
+                    await getAiAnalysisErrorMessage(response),
+                    response.status,
                 );
             }
 

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
@@ -7,6 +7,7 @@ import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { AiAnalysisRequestError } from '../../hooks/aiAnalysisError';
 import { useRaisedBedAiAnalysis } from '../../hooks/useRaisedBedAiAnalysis';
 import { useRaisedBedFieldAiAnalysis } from '../../hooks/useRaisedBedFieldAiAnalysis';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
@@ -43,6 +44,7 @@ export function RaisedBedDiaryAiAction({
     const [visibleMarkdown, setVisibleMarkdown] = useState('');
     const [phase, setPhase] = useState<AnalysisPhase>('idle');
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [errorStatus, setErrorStatus] = useState<number | null>(null);
     const [selectedHistoryEntryId, setSelectedHistoryEntryId] = useState<
         number | null
     >(null);
@@ -78,6 +80,7 @@ export function RaisedBedDiaryAiAction({
         requestIdRef.current += 1;
         setVisibleMarkdown('');
         setErrorMessage(null);
+        setErrorStatus(null);
         setPhase('idle');
         setSelectedHistoryEntryId(null);
         setResultSource(null);
@@ -97,6 +100,7 @@ export function RaisedBedDiaryAiAction({
         }
         setVisibleMarkdown('');
         setErrorMessage(null);
+        setErrorStatus(null);
         setPhase('thinking');
         setSelectedHistoryEntryId(null);
         setResultSource('analysis');
@@ -118,6 +122,11 @@ export function RaisedBedDiaryAiAction({
                 if (requestIdRef.current !== requestId) return;
                 setPhase('error');
                 setErrorMessage(error.message);
+                setErrorStatus(
+                    error instanceof AiAnalysisRequestError
+                        ? error.status
+                        : null,
+                );
                 setAnalysisCompletedAt(null);
             },
         };
@@ -177,6 +186,7 @@ export function RaisedBedDiaryAiAction({
         setSelectedImageUrl(entry.imageUrls?.[0] ?? imageUrls[0] ?? '');
         setVisibleMarkdown(entry.description ?? '');
         setErrorMessage(null);
+        setErrorStatus(null);
         setPhase('done');
         setResultSource('history');
         setAnalysisCompletedAt(null);
@@ -200,7 +210,9 @@ export function RaisedBedDiaryAiAction({
                 : phase === 'done'
                   ? 'Analiza je spremna'
                   : phase === 'error'
-                    ? 'Analiza nije uspjela'
+                    ? errorStatus === 429
+                        ? 'Tjedni limit je iskorišten'
+                        : 'Analiza nije uspjela'
                     : 'Pitaj suncokret';
     const statusDescription =
         resultSource === 'history' && phase === 'done'
@@ -212,7 +224,9 @@ export function RaisedBedDiaryAiAction({
                 : phase === 'done'
                   ? 'Odgovor je spremljen i u dnevnik, a ovdje ga vidiš odmah.'
                   : phase === 'error'
-                    ? 'Pokušaj ponovno s istim fotografijama iz dnevnika.'
+                    ? errorStatus === 429
+                        ? 'Novi AI savjeti bit će dostupni nakon što dio tjednog prozora istekne.'
+                        : 'Provjeri poruku ispod i pokušaj ponovno s istim fotografijama.'
                     : 'Pokreni analizu svih fotografija iz dnevnika.';
     const selectedHistoryEntry = historyEntries?.find(
         (historyEntry) => historyEntry.id === selectedHistoryEntryId,
@@ -234,7 +248,8 @@ export function RaisedBedDiaryAiAction({
         },
     );
     const canAnalyzeEntry =
-        !latestCompleteHistoryEntry && (phase === 'idle' || phase === 'error');
+        !latestCompleteHistoryEntry &&
+        (phase === 'idle' || (phase === 'error' && errorStatus !== 429));
 
     return (
         <>
@@ -401,7 +416,11 @@ export function RaisedBedDiaryAiAction({
                             </Stack>
                         </Row>
                         {errorMessage ? (
-                            <Alert color="danger">
+                            <Alert
+                                color={
+                                    errorStatus === 429 ? 'warning' : 'danger'
+                                }
+                            >
                                 <Typography level="body2">
                                     {errorMessage}
                                 </Typography>

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1366,6 +1366,29 @@ export async function getRaisedBedIdsByAccount(accountId: string) {
     return beds.map((b) => b.id);
 }
 
+export async function countRaisedBedsByAccount(
+    accountId: string,
+    filters?: {
+        status?: string;
+    },
+) {
+    const whereConditions = [
+        eq(raisedBeds.accountId, accountId),
+        eq(raisedBeds.isDeleted, false),
+    ];
+
+    if (filters?.status) {
+        whereConditions.push(eq(raisedBeds.status, filters.status));
+    }
+
+    const result = await storage()
+        .select({ count: count() })
+        .from(raisedBeds)
+        .where(and(...whereConditions));
+
+    return result[0]?.count ?? 0;
+}
+
 /**
  * Returns lightweight raised-bed label metadata for the provided IDs.
  * Duplicate IDs are ignored, deleted raised beds are excluded, and results are ordered by ID.

--- a/packages/storage/tests/gardensRepo.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.node.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { and, eq } from 'drizzle-orm';
 import {
+    countRaisedBedsByAccount,
     createAccount,
     createDefaultGardenForAccount,
     createGardenBlock,
@@ -23,6 +23,7 @@ import {
     updateGardenStack,
     updateRaisedBed,
 } from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
 import { gardenStacks } from '../src/schema';
 import {
     createTestBlock,
@@ -83,6 +84,41 @@ test('getAccountGardens returns gardens for account', async () => {
     const gardens = await getAccountGardens(accountId);
     assert.ok(Array.isArray(gardens));
     assert.ok(gardens.some((g) => g.id === gardenId));
+});
+
+test('countRaisedBedsByAccount counts active raised beds for account quota', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const otherAccountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const otherGardenId = await createTestGarden({
+        accountId: otherAccountId,
+        farmId,
+    });
+    const firstBlockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const secondBlockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const otherBlockId = await createTestBlock(otherGardenId, 'Raised_Bed');
+    const firstRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        firstBlockId,
+    );
+    await createTestRaisedBed(gardenId, accountId, secondBlockId);
+    const otherRaisedBedId = await createTestRaisedBed(
+        otherGardenId,
+        otherAccountId,
+        otherBlockId,
+    );
+
+    await updateRaisedBed({ id: firstRaisedBedId, status: 'active' });
+    await updateRaisedBed({ id: otherRaisedBedId, status: 'active' });
+
+    assert.strictEqual(
+        await countRaisedBedsByAccount(accountId, { status: 'active' }),
+        1,
+    );
+    assert.strictEqual(await countRaisedBedsByAccount(accountId), 2);
 });
 
 test('getGarden returns correct garden', async () => {


### PR DESCRIPTION
## Summary
- Make raised-bed AI quota enforcement scale to `5` requests per active raised bed instead of a flat account-wide cap.
- Return a friendlier quota error from the API and stop surfacing raw JSON error bodies in the Garden UI.
- Add focused tests for the quota calculation and AI error parsing.

## Testing
- `pnpm test --filter @gredice/storage --filter @gredice/game`
- `pnpm --filter api test:node`
- `pnpm build --filter api`
- `pnpm build --filter garden`
- `pnpm test --filter api` reached the Playwright phase but one spec failed because `POSTGRES_URL` is not set in this local environment