### PR TITLE
Expand account-wide notification delivery to all account users

### DIFF
--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -49,11 +49,18 @@ type NotificationCampaignExplicitRecipient = Extract<
 export const notificationRolloutDefaultDeviceLabel = 'Web preglednik';
 
 export type NotificationDeliveryDecision = {
+    accountId: string;
     channel: DeliveryChannel;
     outcome: DeliveryOutcome;
     reason: string;
     required: boolean;
+    userId: string | null;
 };
+
+type NotificationDeliveryOutcomeDecision = Omit<
+    NotificationDeliveryDecision,
+    'accountId' | 'userId'
+>;
 
 export type NotificationCampaignAudiencePreview = {
     audienceType: NotificationCampaignAudience['type'];
@@ -122,6 +129,11 @@ type NotificationRolloutPreferenceDefault = {
     defaultEnabled: boolean;
     digestEligible: boolean;
     required: boolean;
+};
+
+type NotificationDeliveryRecipient = {
+    accountId: string;
+    userId: string | null;
 };
 
 const notificationRolloutPreferenceDefaults: NotificationRolloutPreferenceDefault[] =
@@ -915,7 +927,7 @@ function decideDeliveryOutcome({
     preference?: SelectNotificationUserChannelPreference;
     hasPushSubscription: boolean;
     now: Date;
-}): NotificationDeliveryDecision {
+}): NotificationDeliveryOutcomeDecision {
     const required = preference?.required ?? false;
     if (channel === 'push' && !hasPushSubscription) {
         return {
@@ -1159,6 +1171,22 @@ function shouldQueuePushDelivery(decisions: NotificationDeliveryDecision[]) {
     );
 }
 
+function queueablePushDeliveryUserIds(
+    decisions: NotificationDeliveryDecision[],
+) {
+    if (!shouldQueuePushDelivery(decisions)) return [];
+    return uniqueStrings(
+        decisions.flatMap((decision) =>
+            decision.channel === 'push' &&
+            decision.userId &&
+            (decision.outcome === 'immediate' ||
+                decision.outcome === 'required')
+                ? [decision.userId]
+                : [],
+        ),
+    );
+}
+
 export async function createNotification(
     notification: InsertNotification,
     options: CreateNotificationOptions = {},
@@ -1174,9 +1202,11 @@ export async function createNotification(
 
     if (options.routeDelivery !== false) {
         const decisions = await routeNotificationDelivery(notificationId);
-        if (shouldQueuePushDelivery(decisions)) {
+        const pushUserIds = queueablePushDeliveryUserIds(decisions);
+        if (pushUserIds.length > 0) {
             await enqueuePushDeliveryAttemptsForNotification({
                 notificationId,
+                userIds: pushUserIds,
             });
         }
     }
@@ -1187,18 +1217,31 @@ export async function createNotification(
 export async function enqueuePushDeliveryAttemptsForNotification({
     notificationId,
     batchSize = 100,
+    userIds,
 }: {
     notificationId: string;
     batchSize?: number;
+    userIds?: string[];
 }) {
     const notification = await getNotification(notificationId);
-    if (!notification?.userId) return { queued: 0, skipped: 0 };
+    if (!notification) return { queued: 0, skipped: 0 };
+    const targetUserIds = userIds
+        ? uniqueStrings(userIds)
+        : uniqueStrings(
+              (await getNotificationDeliveryRecipients(notification)).flatMap(
+                  (recipient) => (recipient.userId ? [recipient.userId] : []),
+              ),
+          );
+    if (targetUserIds.length === 0) return { queued: 0, skipped: 0 };
 
     const subscriptions = await storage().query.webPushSubscriptions.findMany({
-        where: deliverablePushSubscriptionWhere({
-            accountId: notification.accountId,
-            userId: notification.userId,
-        }),
+        where: and(
+            eq(webPushSubscriptions.enabled, true),
+            eq(webPushSubscriptions.permissionState, 'granted'),
+            isNull(webPushSubscriptions.revokedAt),
+            eq(webPushSubscriptions.accountId, notification.accountId),
+            inArray(webPushSubscriptions.userId, targetUserIds),
+        ),
         limit: Math.max(1, batchSize),
     });
 
@@ -1224,9 +1267,9 @@ export async function enqueuePushDeliveryAttemptsForNotification({
             .filter((id): id is string => Boolean(id)),
     );
 
-    const pending = subscriptions.filter(
-        (subscription) => !existingIds.has(subscription.id),
-    );
+    const pending = subscriptions
+        .filter((subscription) => !existingIds.has(subscription.id))
+        .filter(hasPushSubscriptionUserId);
 
     if (!pending.length) {
         return { queued: 0, skipped: subscriptions.length };
@@ -1235,7 +1278,7 @@ export async function enqueuePushDeliveryAttemptsForNotification({
     const deliveryAttempts: (typeof notificationDeliveryAttempts.$inferInsert)[] =
         pending.map((subscription) => ({
             notificationId,
-            userId: notification.userId,
+            userId: subscription.userId,
             accountId: notification.accountId,
             channel: 'push',
             status: 'queued',
@@ -1253,60 +1296,144 @@ export async function enqueuePushDeliveryAttemptsForNotification({
         skipped: subscriptions.length - pending.length,
     };
 }
+
+function hasPushSubscriptionUserId(
+    subscription: typeof webPushSubscriptions.$inferSelect,
+): subscription is typeof webPushSubscriptions.$inferSelect & {
+    userId: string;
+} {
+    return typeof subscription.userId === 'string';
+}
+
+async function getNotificationDeliveryRecipients(
+    notification: Pick<SelectNotification, 'accountId' | 'userId'>,
+): Promise<NotificationDeliveryRecipient[]> {
+    if (notification.userId) {
+        return [
+            {
+                accountId: notification.accountId,
+                userId: notification.userId,
+            },
+        ];
+    }
+
+    const rows = await storage()
+        .select({ userId: accountUsers.userId })
+        .from(accountUsers)
+        .where(eq(accountUsers.accountId, notification.accountId));
+
+    if (rows.length === 0) {
+        return [
+            {
+                accountId: notification.accountId,
+                userId: null,
+            },
+        ];
+    }
+
+    return rows.map((row) => ({
+        accountId: notification.accountId,
+        userId: row.userId,
+    }));
+}
+
+function notificationDeliveryRoutingKey(decision: {
+    channel: string;
+    userId: string | null;
+}) {
+    return `${decision.userId ?? 'account'}:${decision.channel}`;
+}
+
 export async function routeNotificationDelivery(notificationId: string) {
     const notification = await getNotification(notificationId);
     if (!notification) return [];
     const now = new Date();
     const targetChannels: DeliveryChannel[] = ['in_app', 'email', 'push'];
-    const preferences = notification.userId
-        ? await storage().query.notificationUserChannelPreferences.findMany({
-              where: eq(
-                  notificationUserChannelPreferences.userId,
-                  notification.userId,
-              ),
-          })
-        : [];
-    const pushSubscriptionCount = notification.userId
-        ? await storage()
-              .select({ id: webPushSubscriptions.id })
-              .from(webPushSubscriptions)
-              .where(
-                  deliverablePushSubscriptionWhere({
-                      accountId: notification.accountId,
-                      userId: notification.userId,
-                  }),
+    const recipients = await getNotificationDeliveryRecipients(notification);
+    const recipientUserIds = uniqueStrings(
+        recipients.flatMap((recipient) =>
+            recipient.userId ? [recipient.userId] : [],
+        ),
+    );
+    const preferences =
+        recipientUserIds.length > 0
+            ? await storage().query.notificationUserChannelPreferences.findMany(
+                  {
+                      where: inArray(
+                          notificationUserChannelPreferences.userId,
+                          recipientUserIds,
+                      ),
+                  },
               )
-              .limit(1)
-        : [];
-    const hasPushSubscription = pushSubscriptionCount.length > 0;
+            : [];
+    const pushSubscriptionRows =
+        recipientUserIds.length > 0
+            ? await storage()
+                  .select({ userId: webPushSubscriptions.userId })
+                  .from(webPushSubscriptions)
+                  .where(
+                      and(
+                          eq(webPushSubscriptions.enabled, true),
+                          eq(webPushSubscriptions.permissionState, 'granted'),
+                          isNull(webPushSubscriptions.revokedAt),
+                          eq(
+                              webPushSubscriptions.accountId,
+                              notification.accountId,
+                          ),
+                          inArray(
+                              webPushSubscriptions.userId,
+                              recipientUserIds,
+                          ),
+                      ),
+                  )
+            : [];
+    const pushSubscriptionUserIds = new Set(
+        pushSubscriptionRows.flatMap((row) => (row.userId ? [row.userId] : [])),
+    );
 
-    const decisions: NotificationDeliveryDecision[] = targetChannels.map(
-        (channel) => {
-            const accountPref = preferences.find(
-                (p) =>
-                    p.scope === 'account' &&
-                    p.accountId === notification.accountId &&
-                    p.category === notification.category &&
-                    p.channel === channel,
-            );
-            const globalPref = preferences.find(
-                (p) =>
-                    p.scope === 'global' &&
-                    p.category === notification.category &&
-                    p.channel === channel,
-            );
-            return decideDeliveryOutcome({
-                channel,
-                preference: accountPref ?? globalPref,
-                hasPushSubscription,
-                now,
-            });
-        },
+    const decisions: NotificationDeliveryDecision[] = recipients.flatMap(
+        (recipient) =>
+            targetChannels.map((channel) => {
+                const accountPref = recipient.userId
+                    ? preferences.find(
+                          (p) =>
+                              p.userId === recipient.userId &&
+                              p.scope === 'account' &&
+                              p.accountId === notification.accountId &&
+                              p.category === notification.category &&
+                              p.channel === channel,
+                      )
+                    : undefined;
+                const globalPref = recipient.userId
+                    ? preferences.find(
+                          (p) =>
+                              p.userId === recipient.userId &&
+                              p.scope === 'global' &&
+                              p.category === notification.category &&
+                              p.channel === channel,
+                      )
+                    : undefined;
+                return {
+                    ...decideDeliveryOutcome({
+                        channel,
+                        preference: accountPref ?? globalPref,
+                        hasPushSubscription:
+                            recipient.userId != null &&
+                            pushSubscriptionUserIds.has(recipient.userId),
+                        now,
+                    }),
+                    accountId: recipient.accountId,
+                    userId: recipient.userId,
+                };
+            }),
     );
 
     if (notification.userId || notification.accountId) {
         const existingRouterAttempts = await storage()
-            .select({ channel: notificationDeliveryAttempts.channel })
+            .select({
+                channel: notificationDeliveryAttempts.channel,
+                userId: notificationDeliveryAttempts.userId,
+            })
             .from(notificationDeliveryAttempts)
             .where(
                 and(
@@ -1317,11 +1444,12 @@ export async function routeNotificationDelivery(notificationId: string) {
                     eq(notificationDeliveryAttempts.provider, 'router'),
                 ),
             );
-        const routedChannels = new Set(
-            existingRouterAttempts.map((attempt) => attempt.channel),
+        const routedKeys = new Set(
+            existingRouterAttempts.map(notificationDeliveryRoutingKey),
         );
         const unroutedDecisions = decisions.filter(
-            (decision) => !routedChannels.has(decision.channel),
+            (decision) =>
+                !routedKeys.has(notificationDeliveryRoutingKey(decision)),
         );
 
         if (unroutedDecisions.length > 0) {
@@ -1330,8 +1458,8 @@ export async function routeNotificationDelivery(notificationId: string) {
                 .values(
                     unroutedDecisions.map((decision) => ({
                         notificationId,
-                        userId: notification.userId ?? null,
-                        accountId: notification.accountId,
+                        userId: decision.userId,
+                        accountId: decision.accountId,
                         channel: decision.channel,
                         status: deliveryAttemptStatusForOutcome(
                             decision.outcome,

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    accountUsers,
     backfillNotificationRolloutDefaults,
     cancelNotificationCampaign,
     cleanupNotificationRetention,
@@ -131,6 +132,214 @@ test('createNotification routes and queues deliverable push by default', async (
                 status: attempt.status,
             })),
         [{ pushSubscriptionId: subscriptionId, status: 'queued' }],
+    );
+});
+
+test('createNotification expands account-wide push to account users', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const firstUserId = await createUserWithPassword(
+        `push-account-wide-first-${randomUUID()}@example.com`,
+        'password',
+    );
+    const firstUser = await getUser(firstUserId);
+    assert.ok(firstUser);
+    const accountId = firstUser.accounts[0]?.accountId;
+    assert.ok(accountId);
+    const secondUserId = await createUserWithPassword(
+        `push-account-wide-second-${randomUUID()}@example.com`,
+        'password',
+    );
+    await storage().insert(accountUsers).values({
+        accountId,
+        userId: secondUserId,
+    });
+
+    const firstSubscriptionId = randomUUID();
+    const secondSubscriptionId = randomUUID();
+    await storage()
+        .insert(webPushSubscriptions)
+        .values([
+            {
+                id: firstSubscriptionId,
+                accountId,
+                userId: firstUserId,
+                endpoint: `https://example.com/${firstSubscriptionId}`,
+                p256dh: 'k',
+                auth: 'a',
+                enabled: true,
+                permissionState: 'granted',
+            },
+            {
+                id: secondSubscriptionId,
+                accountId,
+                userId: secondUserId,
+                endpoint: `https://example.com/${secondSubscriptionId}`,
+                p256dh: 'k',
+                auth: 'a',
+                enabled: true,
+                permissionState: 'granted',
+            },
+        ]);
+
+    const notificationId = await createNotification({
+        accountId,
+        header: 'Account-wide push',
+        content: 'Account members should receive push delivery',
+        category: 'general',
+        timestamp: new Date(),
+    });
+
+    const attempts = await storage()
+        .select({
+            channel: notificationDeliveryAttempts.channel,
+            provider: notificationDeliveryAttempts.provider,
+            providerResponseCode:
+                notificationDeliveryAttempts.providerResponseCode,
+            pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId,
+            status: notificationDeliveryAttempts.status,
+            userId: notificationDeliveryAttempts.userId,
+        })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+
+    const pushRouterAttempts = attempts
+        .filter(
+            (attempt) =>
+                attempt.provider === 'router' && attempt.channel === 'push',
+        )
+        .sort((left, right) =>
+            (left.userId ?? '').localeCompare(right.userId ?? ''),
+        );
+    assert.deepEqual(
+        pushRouterAttempts.map((attempt) => ({
+            providerResponseCode: attempt.providerResponseCode,
+            status: attempt.status,
+            userId: attempt.userId,
+        })),
+        [firstUserId, secondUserId].sort().map((userId) => ({
+            providerResponseCode: 'eligible_immediate',
+            status: 'accepted',
+            userId,
+        })),
+    );
+
+    const queuedPushAttempts = attempts
+        .filter((attempt) => attempt.provider === 'web_push_queue')
+        .sort((left, right) =>
+            (left.pushSubscriptionId ?? '').localeCompare(
+                right.pushSubscriptionId ?? '',
+            ),
+        );
+    assert.deepEqual(
+        queuedPushAttempts.map((attempt) => ({
+            pushSubscriptionId: attempt.pushSubscriptionId,
+            status: attempt.status,
+        })),
+        [firstSubscriptionId, secondSubscriptionId].sort().map((id) => ({
+            pushSubscriptionId: id,
+            status: 'queued',
+        })),
+    );
+});
+
+test('account-wide push fan-out respects each user preference', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const enabledUserId = await createUserWithPassword(
+        `push-account-pref-enabled-${randomUUID()}@example.com`,
+        'password',
+    );
+    const enabledUser = await getUser(enabledUserId);
+    assert.ok(enabledUser);
+    const accountId = enabledUser.accounts[0]?.accountId;
+    assert.ok(accountId);
+    const disabledUserId = await createUserWithPassword(
+        `push-account-pref-disabled-${randomUUID()}@example.com`,
+        'password',
+    );
+    await storage().insert(accountUsers).values({
+        accountId,
+        userId: disabledUserId,
+    });
+
+    const enabledSubscriptionId = randomUUID();
+    const disabledSubscriptionId = randomUUID();
+    await storage()
+        .insert(webPushSubscriptions)
+        .values([
+            {
+                id: enabledSubscriptionId,
+                accountId,
+                userId: enabledUserId,
+                endpoint: `https://example.com/${enabledSubscriptionId}`,
+                p256dh: 'k',
+                auth: 'a',
+                enabled: true,
+                permissionState: 'granted',
+            },
+            {
+                id: disabledSubscriptionId,
+                accountId,
+                userId: disabledUserId,
+                endpoint: `https://example.com/${disabledSubscriptionId}`,
+                p256dh: 'k',
+                auth: 'a',
+                enabled: true,
+                permissionState: 'granted',
+            },
+        ]);
+    const category = `account-wide-preference-${randomUUID()}`;
+    await storage().insert(notificationUserChannelPreferences).values({
+        userId: disabledUserId,
+        category,
+        channel: 'push',
+        enabled: false,
+    });
+
+    const notificationId = await createNotification({
+        accountId,
+        header: 'Account preference push',
+        content: 'One account member disabled push for this category',
+        category,
+        timestamp: new Date(),
+    });
+
+    const attempts = await storage()
+        .select({
+            channel: notificationDeliveryAttempts.channel,
+            provider: notificationDeliveryAttempts.provider,
+            providerResponseCode:
+                notificationDeliveryAttempts.providerResponseCode,
+            pushSubscriptionId: notificationDeliveryAttempts.pushSubscriptionId,
+            userId: notificationDeliveryAttempts.userId,
+        })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+
+    assert.ok(
+        attempts.some(
+            (attempt) =>
+                attempt.provider === 'router' &&
+                attempt.channel === 'push' &&
+                attempt.userId === enabledUserId &&
+                attempt.providerResponseCode === 'eligible_immediate',
+        ),
+    );
+    assert.ok(
+        attempts.some(
+            (attempt) =>
+                attempt.provider === 'router' &&
+                attempt.channel === 'push' &&
+                attempt.userId === disabledUserId &&
+                attempt.providerResponseCode === 'preference_disabled',
+        ),
+    );
+    assert.deepEqual(
+        attempts
+            .filter((attempt) => attempt.provider === 'web_push_queue')
+            .map((attempt) => attempt.pushSubscriptionId),
+        [enabledSubscriptionId],
     );
 });
 


### PR DESCRIPTION
## Summary
- Fan out notifications without a direct `userId` to every user on the account during delivery routing.
- Keep the notification record account-scoped for the UI while routing push attempts per recipient.
- Respect each user's notification preferences and active push subscriptions when queuing delivery.
- Add coverage for account-wide fan-out and per-user preference suppression.

## Testing
- `pnpm --filter @gredice/storage test:node notificationsRepo.node.spec.ts`
- `pnpm test --filter @gredice/storage`
- `pnpm build --filter api`