### PR TITLE
Fit image viewer and gallery to screen with accessible keyboard controls

### DIFF
--- a/apps/storybook/stories/packages/ui/ImageGallery.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ImageGallery.stories.tsx
@@ -1,6 +1,11 @@
 import { ImageGallery } from '@gredice/ui/ImageGallery';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
+const largeImageSvg = encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="3000" viewBox="0 0 4000 3000"><rect width="4000" height="3000" fill="#2f7d46"/><circle cx="2000" cy="1500" r="900" fill="#f7d04a"/><text x="2000" y="1540" text-anchor="middle" font-size="240" font-family="Arial" fill="#1f2937">4000 x 3000</text></svg>',
+);
+const largeImageSrc = `data:image/svg+xml,${largeImageSvg}`;
+
 const sampleImages = [
     {
         src: 'https://cdn.gredice.com/sunflower-sad-500x500.png',
@@ -24,7 +29,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    'ImageGallery presents one or more images with configurable preview sizing and carousel or stacked preview layouts.',
+                    'ImageGallery presents one or more images with configurable previews and a fit-to-screen expanded gallery.',
             },
         },
     },
@@ -52,6 +57,17 @@ export const Stacked: Story = {
 export const SingleImage: Story = {
     args: {
         images: [sampleImages[0]],
+    },
+};
+
+export const LargeImage: Story = {
+    args: {
+        images: [
+            {
+                src: largeImageSrc,
+                alt: 'Large garden image',
+            },
+        ],
     },
 };
 

--- a/apps/storybook/stories/packages/ui/ImageViewer.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ImageViewer.stories.tsx
@@ -1,6 +1,11 @@
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
+const largeImageSvg = encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="3000" viewBox="0 0 4000 3000"><rect width="4000" height="3000" fill="#2f7d46"/><circle cx="2000" cy="1500" r="900" fill="#f7d04a"/><text x="2000" y="1540" text-anchor="middle" font-size="240" font-family="Arial" fill="#1f2937">4000 x 3000</text></svg>',
+);
+const largeImageSrc = `data:image/svg+xml,${largeImageSvg}`;
+
 const meta = {
     title: 'packages/ui/Media/ImageViewer',
     component: ImageViewer,
@@ -9,7 +14,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    'ImageViewer renders an image preview that can open a larger viewer while preserving alt text and preview dimensions.',
+                    'ImageViewer renders an image preview that opens a fit-to-screen viewer while preserving alt text and preview dimensions.',
             },
         },
     },
@@ -32,6 +37,13 @@ export const SmallPreview: Story = {
     args: {
         previewWidth: 120,
         previewHeight: 120,
+    },
+};
+
+export const LargeImage: Story = {
+    args: {
+        src: largeImageSrc,
+        alt: 'Large garden image',
     },
 };
 

--- a/packages/ui/src/ImageGallery/ImageGallery.tsx
+++ b/packages/ui/src/ImageGallery/ImageGallery.tsx
@@ -2,8 +2,16 @@
 
 import Image from 'next/image';
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { Chip } from '../Chip';
+import { useImageFitZoom } from '../hooks/useImageFitZoom';
 import { IconButton } from '../IconButton';
 import { Add, ArrowLeft, ArrowRight, Close, Remove, Save } from '../icons';
 import { Modal } from '../Modal';
@@ -29,22 +37,34 @@ export function ImageGallery({
     previewAs = 'button',
     previewVariant = 'carousel',
 }: ImageGalleryProps) {
+    const imageInstructionsId = useId();
+    const lastFocusedElementRef = useRef<Element | null>(null);
     const [isStackHovered, setIsStackHovered] = useState(false);
     const [isExpanded, setIsExpanded] = useState(false);
     const [selectedIndex, setSelectedIndex] = useState(0);
-    const [zoomLevel, setZoomLevel] = useState(1);
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [isDragging, setIsDragging] = useState(false);
     const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
     const [lastPinchDistance, setLastPinchDistance] = useState(0);
     const [isPinching, setIsPinching] = useState(false);
-    const imageRef = useRef<HTMLDivElement>(null);
 
     const hasImages = images.length > 0;
     const safeIndex = hasImages
         ? Math.min(selectedIndex, images.length - 1)
         : 0;
     const activeImage = images[safeIndex];
+    const {
+        clampZoomLevel,
+        handleImageLoad,
+        minimumZoomLevel,
+        resetZoomLevel,
+        setZoomLevel,
+        viewerRef: imageRef,
+        zoomLevel,
+    } = useImageFitZoom<HTMLButtonElement>(isExpanded, activeImage?.src ?? '');
+    const activeImageLabel = activeImage
+        ? activeImage.alt?.trim() || `Slika ${safeIndex + 1}`
+        : 'Slika';
 
     const resolveAlt = (imageAlt: string | null | undefined, index: number) =>
         imageAlt?.trim() || `Slika ${index + 1}`;
@@ -52,11 +72,31 @@ export function ImageGallery({
     const stackedImages = useMemo(() => images.slice(0, 4), [images]);
 
     const resetTransform = useCallback(() => {
-        setZoomLevel(1);
+        resetZoomLevel();
         setPosition({ x: 0, y: 0 });
         setIsDragging(false);
         setIsPinching(false);
         setLastPinchDistance(0);
+    }, [resetZoomLevel]);
+
+    const rememberFocusedElement = (element?: Element | null) => {
+        if (element) {
+            lastFocusedElementRef.current = element;
+            return;
+        }
+
+        if (document.activeElement instanceof HTMLElement) {
+            lastFocusedElementRef.current = document.activeElement;
+        }
+    };
+
+    const restoreFocusedElement = useCallback(() => {
+        window.requestAnimationFrame(() => {
+            const element = lastFocusedElementRef.current;
+            if (element instanceof HTMLElement && element.isConnected) {
+                element.focus({ preventScroll: true });
+            }
+        });
     }, []);
 
     const getTouchDistance = (touch1: React.Touch, touch2: React.Touch) => {
@@ -67,12 +107,12 @@ export function ImageGallery({
 
     const handleZoomIn = (e?: React.MouseEvent) => {
         e?.stopPropagation();
-        setZoomLevel((prev) => Math.min(prev + 0.5, 5));
+        setZoomLevel((prev) => clampZoomLevel(prev + 0.5));
     };
 
     const handleZoomOut = (e?: React.MouseEvent) => {
         e?.stopPropagation();
-        setZoomLevel((prev) => Math.max(prev - 0.5, 0.5));
+        setZoomLevel((prev) => clampZoomLevel(prev - 0.5));
     };
 
     const handleDownload = async (e?: React.MouseEvent) => {
@@ -94,7 +134,8 @@ export function ImageGallery({
         }
     };
 
-    const openModal = (index: number) => {
+    const openModal = (index: number, trigger?: Element | null) => {
+        rememberFocusedElement(trigger);
         setSelectedIndex(index);
         setIsExpanded(true);
         resetTransform();
@@ -105,8 +146,9 @@ export function ImageGallery({
             e?.stopPropagation?.();
             setIsExpanded(false);
             resetTransform();
+            restoreFocusedElement();
         },
-        [resetTransform],
+        [resetTransform, restoreFocusedElement],
     );
 
     const selectImage = useCallback(
@@ -188,11 +230,7 @@ export function ImageGallery({
             const scale = distance / lastPinchDistance;
 
             if (scale > 0 && Number.isFinite(scale)) {
-                const newZoomLevel = Math.min(
-                    Math.max(zoomLevel * scale, 0.5),
-                    5,
-                );
-                setZoomLevel(newZoomLevel);
+                setZoomLevel(clampZoomLevel(zoomLevel * scale));
                 setLastPinchDistance(distance);
             }
         }
@@ -217,20 +255,73 @@ export function ImageGallery({
     const handleWheel = (e: React.WheelEvent) => {
         e.stopPropagation();
         const delta = e.deltaY > 0 ? -0.2 : 0.2;
-        setZoomLevel((prev) => Math.min(Math.max(prev + delta, 0.5), 5));
+        setZoomLevel((prev) => clampZoomLevel(prev + delta));
+    };
+
+    const handleImageKeyDown = (e: React.KeyboardEvent) => {
+        e.stopPropagation();
+
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closeExpanded(e);
+            return;
+        }
+
+        if (e.key === 'ArrowLeft') {
+            e.preventDefault();
+            goToPrevious(e);
+            return;
+        }
+
+        if (e.key === 'ArrowRight') {
+            e.preventDefault();
+            goToNext(e);
+            return;
+        }
+
+        if (e.key === '+' || e.key === '=') {
+            e.preventDefault();
+            setZoomLevel((prev) => clampZoomLevel(prev + 0.5));
+            return;
+        }
+
+        if (e.key === '-' || e.key === '_') {
+            e.preventDefault();
+            setZoomLevel((prev) => clampZoomLevel(prev - 0.5));
+            return;
+        }
+
+        if (e.key === '0') {
+            e.preventDefault();
+            resetTransform();
+        }
     };
 
     const handleModalOpenChange = (open: boolean) => {
         setIsExpanded(open);
         if (!open) {
             resetTransform();
+            restoreFocusedElement();
         }
     };
 
     useEffect(() => {
         if (!isExpanded) return;
 
+        const frame = window.requestAnimationFrame(() => {
+            imageRef.current?.focus({ preventScroll: true });
+        });
+
+        return () => {
+            window.cancelAnimationFrame(frame);
+        };
+    }, [imageRef, isExpanded]);
+
+    useEffect(() => {
+        if (!isExpanded) return;
+
         const onKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented) return;
             if (event.key === 'ArrowLeft') {
                 event.preventDefault();
                 goToPrevious();
@@ -243,13 +334,33 @@ export function ImageGallery({
                 event.preventDefault();
                 closeExpanded();
             }
+            if (event.key === '+' || event.key === '=') {
+                event.preventDefault();
+                setZoomLevel((prev) => clampZoomLevel(prev + 0.5));
+            }
+            if (event.key === '-' || event.key === '_') {
+                event.preventDefault();
+                setZoomLevel((prev) => clampZoomLevel(prev - 0.5));
+            }
+            if (event.key === '0') {
+                event.preventDefault();
+                resetTransform();
+            }
         };
 
         window.addEventListener('keydown', onKeyDown);
         return () => {
             window.removeEventListener('keydown', onKeyDown);
         };
-    }, [closeExpanded, goToNext, goToPrevious, isExpanded]);
+    }, [
+        clampZoomLevel,
+        closeExpanded,
+        goToNext,
+        goToPrevious,
+        isExpanded,
+        resetTransform,
+        setZoomLevel,
+    ]);
 
     const PreviewComponent = previewAs;
 
@@ -275,8 +386,8 @@ export function ImageGallery({
                                 : {
                                       role: 'button' as const,
                                       tabIndex: 0,
-                                      'aria-label': `Otvori sliku ${index + 1} u punoj veličini`,
                                   })}
+                            aria-label={`Otvori sliku ${index + 1} u punoj veličini: ${resolveAlt(image.alt, index)}`}
                             title="Otvori u punoj veličini"
                             className="group relative shrink-0 overflow-hidden rounded-lg bg-muted shadow-md transition-shadow duration-200 hover:cursor-zoom-in hover:shadow-lg"
                             style={{
@@ -285,7 +396,7 @@ export function ImageGallery({
                             }}
                             onClick={(event: React.MouseEvent) => {
                                 event.stopPropagation();
-                                openModal(index);
+                                openModal(index, event.currentTarget);
                             }}
                             onKeyDown={(event: React.KeyboardEvent) => {
                                 if (previewAs === 'button') return;
@@ -295,7 +406,7 @@ export function ImageGallery({
                                     event.key === ' '
                                 ) {
                                     event.preventDefault();
-                                    openModal(index);
+                                    openModal(index, event.currentTarget);
                                 }
                             }}
                         >
@@ -317,8 +428,8 @@ export function ImageGallery({
                         : {
                               role: 'button' as const,
                               tabIndex: 0,
-                              'aria-label': 'Otvori galeriju u punoj veličini',
                           })}
+                    aria-label={`Otvori galeriju u punoj veličini (${images.length} ${images.length === 1 ? 'slika' : 'slike'})`}
                     title="Otvori galeriju u punoj veličini"
                     className="group relative flex items-center justify-center"
                     style={{ width: previewWidth, height: previewHeight }}
@@ -328,14 +439,14 @@ export function ImageGallery({
                     onBlur={() => setIsStackHovered(false)}
                     onClick={(event: React.MouseEvent) => {
                         event.stopPropagation();
-                        openModal(0);
+                        openModal(0, event.currentTarget);
                     }}
                     onKeyDown={(event: React.KeyboardEvent) => {
                         if (previewAs === 'button') return;
                         event.stopPropagation();
                         if (event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault();
-                            openModal(0);
+                            openModal(0, event.currentTarget);
                         }
                     }}
                 >
@@ -383,6 +494,11 @@ export function ImageGallery({
                 )}
             >
                 <div className="relative flex h-full w-full overflow-clip">
+                    <p id={imageInstructionsId} className="sr-only">
+                        Pritisni Escape za zatvaranje, lijevu ili desnu strelicu
+                        za promjenu slike, plus ili minus za zumiranje i nulu za
+                        prilagodbu zaslonu.
+                    </p>
                     <div
                         className="absolute right-4 top-4 z-10 flex gap-1"
                         style={{
@@ -390,6 +506,7 @@ export function ImageGallery({
                         }}
                     >
                         <IconButton
+                            aria-label="Prethodna slika"
                             title="Prethodna"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
@@ -398,6 +515,7 @@ export function ImageGallery({
                             <ArrowLeft className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Sljedeća slika"
                             title="Sljedeća"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
@@ -406,15 +524,17 @@ export function ImageGallery({
                             <ArrowRight className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Smanji sliku"
                             title="Smanji"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
                             onClick={handleZoomOut}
-                            disabled={zoomLevel <= 0.5}
+                            disabled={zoomLevel <= minimumZoomLevel}
                         >
                             <Remove className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Uvećaj sliku"
                             title="Uvećaj"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
@@ -424,6 +544,7 @@ export function ImageGallery({
                             <Add className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Preuzmi sliku"
                             title="Preuzmi"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
@@ -432,6 +553,7 @@ export function ImageGallery({
                             <Save className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Zatvori pregled galerije"
                             title="Zatvori"
                             variant="solid"
                             className="rounded-xl"
@@ -441,23 +563,26 @@ export function ImageGallery({
                         </IconButton>
                     </div>
 
-                    <div className="flex h-full w-full items-center justify-center pb-32 sm:pb-36">
-                        <div
+                    <div className="flex h-full min-h-0 w-full min-w-0 items-center justify-center pb-32 sm:pb-36">
+                        <button
+                            type="button"
                             ref={imageRef}
-                            role="option"
-                            tabIndex={0}
-                            className="relative h-full w-full cursor-grab overflow-hidden active:cursor-grabbing touch-none"
+                            aria-describedby={imageInstructionsId}
+                            aria-keyshortcuts="Escape ArrowLeft ArrowRight + - = 0"
+                            aria-label={`Interaktivni pregled slike ${safeIndex + 1} od ${images.length}: ${activeImageLabel}`}
+                            className="relative block h-full min-h-0 w-full min-w-0 cursor-grab overflow-hidden border-0 bg-transparent p-0 text-inherit active:cursor-grabbing touch-none"
                             onMouseDown={handleMouseDown}
                             onMouseMove={handleMouseMove}
                             onMouseUp={handleMouseUp}
                             onMouseLeave={handleMouseUp}
+                            onKeyDown={handleImageKeyDown}
                             onTouchStart={handleTouchStart}
                             onTouchMove={handleTouchMove}
                             onTouchEnd={handleTouchEnd}
                             onWheel={handleWheel}
                             style={{ touchAction: 'none' }}
                         >
-                            <div
+                            <span
                                 className="relative flex h-full w-full select-none items-center justify-center transition-transform duration-200 ease-out will-change-transform"
                                 style={{
                                     transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${position.y / zoomLevel}px)`,
@@ -466,19 +591,23 @@ export function ImageGallery({
                             >
                                 {/** biome-ignore lint/performance/noImgElement: Using raw <img> intentionally for fallback display */}
                                 <img
+                                    key={`${safeIndex}-${activeImage.src}`}
                                     src={activeImage.src}
                                     alt={resolveAlt(
                                         activeImage?.alt,
                                         safeIndex,
                                     )}
-                                    className="max-h-full max-w-full select-none object-contain"
+                                    className="h-auto w-auto max-h-none max-w-none select-none object-contain"
                                     draggable={false}
+                                    onLoad={handleImageLoad}
                                 />
-                            </div>
-                        </div>
+                            </span>
+                        </button>
                     </div>
 
                     <Chip
+                        aria-label={`Slika ${safeIndex + 1} od ${images.length}, zumiranje ${Math.round(zoomLevel * 100)} posto`}
+                        aria-live="polite"
                         className="absolute left-4 [top:calc(env(safe-area-inset-top)+1rem)] z-10 select-none border-0 bg-black/60 text-white/80 backdrop-blur"
                         variant="solid"
                     >
@@ -498,6 +627,10 @@ export function ImageGallery({
                                 <button
                                     key={image.src}
                                     type="button"
+                                    aria-current={
+                                        safeIndex === index ? 'true' : undefined
+                                    }
+                                    aria-label={`Prikaži sliku ${index + 1}: ${resolveAlt(image.alt, index)}`}
                                     onClick={(event) => {
                                         event.stopPropagation();
                                         selectImage(index);

--- a/packages/ui/src/ImageViewer/ImageViewer.tsx
+++ b/packages/ui/src/ImageViewer/ImageViewer.tsx
@@ -2,8 +2,9 @@
 
 import Image from 'next/image';
 import type React from 'react';
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { Chip } from '../Chip';
+import { useImageFitZoom } from '../hooks/useImageFitZoom';
 import { IconButton } from '../IconButton';
 import { Add, Close, Remove, Save, Search } from '../icons';
 import { Modal } from '../Modal';
@@ -29,14 +30,67 @@ export function ImageViewer({
     previewAs = 'button',
 }: ImageViewerProps) {
     const resolvedAlt = alt?.trim() || 'Slika';
+    const imageInstructionsId = useId();
+    const lastFocusedElementRef = useRef<Element | null>(null);
     const [isExpanded, setIsExpanded] = useState(false);
-    const [zoomLevel, setZoomLevel] = useState(1);
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [isDragging, setIsDragging] = useState(false);
     const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
     const [lastPinchDistance, setLastPinchDistance] = useState(0);
     const [isPinching, setIsPinching] = useState(false);
-    const imageRef = useRef<HTMLDivElement>(null);
+    const {
+        clampZoomLevel,
+        handleImageLoad,
+        minimumZoomLevel,
+        resetZoomLevel,
+        setZoomLevel,
+        viewerRef: imageRef,
+        zoomLevel,
+    } = useImageFitZoom<HTMLButtonElement>(isExpanded, src);
+
+    const resetTransform = useCallback(() => {
+        resetZoomLevel();
+        setPosition({ x: 0, y: 0 });
+        setIsDragging(false);
+        setIsPinching(false);
+        setLastPinchDistance(0);
+    }, [resetZoomLevel]);
+
+    const rememberFocusedElement = (element?: Element | null) => {
+        if (element) {
+            lastFocusedElementRef.current = element;
+            return;
+        }
+
+        if (document.activeElement instanceof HTMLElement) {
+            lastFocusedElementRef.current = document.activeElement;
+        }
+    };
+
+    const restoreFocusedElement = useCallback(() => {
+        window.requestAnimationFrame(() => {
+            const element = lastFocusedElementRef.current;
+            if (element instanceof HTMLElement && element.isConnected) {
+                element.focus({ preventScroll: true });
+            }
+        });
+    }, []);
+
+    const openExpanded = (trigger?: Element | null) => {
+        rememberFocusedElement(trigger);
+        setIsExpanded(true);
+        resetTransform();
+    };
+
+    const closeExpanded = useCallback(
+        (e?: React.MouseEvent | React.KeyboardEvent) => {
+            e?.stopPropagation();
+            setIsExpanded(false);
+            resetTransform();
+            restoreFocusedElement();
+        },
+        [resetTransform, restoreFocusedElement],
+    );
 
     const getTouchDistance = (touch1: React.Touch, touch2: React.Touch) => {
         const dx = touch1.clientX - touch2.clientX;
@@ -46,12 +100,12 @@ export function ImageViewer({
 
     const handleZoomIn = (e?: React.MouseEvent) => {
         e?.stopPropagation();
-        setZoomLevel((prev) => Math.min(prev + 0.5, 5));
+        setZoomLevel((prev) => clampZoomLevel(prev + 0.5));
     };
 
     const handleZoomOut = (e?: React.MouseEvent) => {
         e?.stopPropagation();
-        setZoomLevel((prev) => Math.max(prev - 0.5, 0.5));
+        setZoomLevel((prev) => clampZoomLevel(prev - 0.5));
     };
 
     const handleDownload = async (e?: React.MouseEvent) => {
@@ -72,15 +126,47 @@ export function ImageViewer({
         }
     };
 
-    const closeExpanded = (e?: React.MouseEvent | React.KeyboardEvent) => {
-        e?.stopPropagation();
-        setIsExpanded(false);
-        // Reset zoom and position when closing
-        setZoomLevel(1);
-        setPosition({ x: 0, y: 0 });
-        setIsDragging(false);
-        setIsPinching(false);
-        setLastPinchDistance(0);
+    const handleImageKeyDown = (e: React.KeyboardEvent) => {
+        e.stopPropagation();
+
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closeExpanded(e);
+            return;
+        }
+
+        if (e.key === '+' || e.key === '=') {
+            e.preventDefault();
+            setZoomLevel((prev) => clampZoomLevel(prev + 0.5));
+            return;
+        }
+
+        if (e.key === '-' || e.key === '_') {
+            e.preventDefault();
+            setZoomLevel((prev) => clampZoomLevel(prev - 0.5));
+            return;
+        }
+
+        if (e.key === '0') {
+            e.preventDefault();
+            resetTransform();
+            return;
+        }
+
+        const panBy = 40;
+        if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setPosition((current) => ({ ...current, y: current.y + panBy }));
+        } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setPosition((current) => ({ ...current, y: current.y - panBy }));
+        } else if (e.key === 'ArrowLeft') {
+            e.preventDefault();
+            setPosition((current) => ({ ...current, x: current.x + panBy }));
+        } else if (e.key === 'ArrowRight') {
+            e.preventDefault();
+            setPosition((current) => ({ ...current, x: current.x - panBy }));
+        }
     };
 
     const handleMouseDown = (e: React.MouseEvent) => {
@@ -107,27 +193,15 @@ export function ImageViewer({
         setIsDragging(false);
     };
 
-    const handleClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        // Additional click handling if needed
-    };
-
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        e.stopPropagation();
-        // Key handling for image container
-    };
-
     const handleTouchStart = (e: React.TouchEvent) => {
         e.stopPropagation();
         if (e.touches.length === 1) {
-            // Single touch for dragging
             setIsDragging(true);
             setDragStart({
                 x: e.touches[0].clientX - position.x,
                 y: e.touches[0].clientY - position.y,
             });
         } else if (e.touches.length === 2) {
-            // Two touches for pinching
             setIsPinching(true);
             setIsDragging(false);
             const distance = getTouchDistance(e.touches[0], e.touches[1]);
@@ -137,25 +211,19 @@ export function ImageViewer({
 
     const handleTouchMove = (e: React.TouchEvent) => {
         e.stopPropagation();
-        e.preventDefault(); // Prevent default scrolling behavior
+        e.preventDefault();
 
         if (e.touches.length === 1 && isDragging && !isPinching) {
-            // Single touch dragging
             setPosition({
                 x: e.touches[0].clientX - dragStart.x,
                 y: e.touches[0].clientY - dragStart.y,
             });
         } else if (e.touches.length === 2 && isPinching) {
-            // Two touch pinching
             const distance = getTouchDistance(e.touches[0], e.touches[1]);
             const scale = distance / lastPinchDistance;
 
             if (scale > 0 && Number.isFinite(scale)) {
-                const newZoomLevel = Math.min(
-                    Math.max(zoomLevel * scale, 0.5),
-                    5,
-                );
-                setZoomLevel(newZoomLevel);
+                setZoomLevel(clampZoomLevel(zoomLevel * scale));
                 setLastPinchDistance(distance);
             }
         }
@@ -164,12 +232,10 @@ export function ImageViewer({
     const handleTouchEnd = (e: React.TouchEvent) => {
         e.stopPropagation();
         if (e.touches.length === 0) {
-            // All touches ended
             setIsDragging(false);
             setIsPinching(false);
             setLastPinchDistance(0);
         } else if (e.touches.length === 1 && isPinching) {
-            // Went from pinch to single touch
             setIsPinching(false);
             setIsDragging(true);
             setDragStart({
@@ -182,47 +248,70 @@ export function ImageViewer({
     const handleWheel = (e: React.WheelEvent) => {
         e.stopPropagation();
         const delta = e.deltaY > 0 ? -0.2 : 0.2;
-        setZoomLevel((prev) => Math.min(Math.max(prev + delta, 0.5), 5));
+        setZoomLevel((prev) => clampZoomLevel(prev + delta));
     };
 
     const handleModalOpenChange = (open: boolean) => {
         setIsExpanded(open);
         if (!open) {
-            // Reset zoom and position when closing
-            setZoomLevel(1);
-            setPosition({ x: 0, y: 0 });
-            setIsDragging(false);
-            setIsPinching(false);
-            setLastPinchDistance(0);
+            resetTransform();
+            restoreFocusedElement();
         }
     };
+
+    useEffect(() => {
+        if (!isExpanded) return;
+
+        const frame = window.requestAnimationFrame(() => {
+            imageRef.current?.focus({ preventScroll: true });
+        });
+
+        return () => {
+            window.cancelAnimationFrame(frame);
+        };
+    }, [imageRef, isExpanded]);
+
+    useEffect(() => {
+        if (!isExpanded) return;
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeExpanded();
+            }
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+        };
+    }, [closeExpanded, isExpanded]);
 
     const PreviewComponent = previewAs;
 
     return (
         <>
-            {/* Preview Image */}
             <PreviewComponent
                 {...(previewAs === 'button'
                     ? { type: 'button' as const }
                     : {
                           role: 'button' as const,
                           tabIndex: 0,
-                          'aria-label': 'Otvori u punoj veličini',
                       })}
+                aria-label={`Otvori sliku u punoj veličini: ${resolvedAlt}`}
                 title="Otvori u punoj veličini"
                 className="group relative hover:cursor-zoom-in flex items-center justify-center overflow-hidden rounded-lg shadow-md bg-muted hover:shadow-lg transition-shadow duration-200"
                 style={{ width: previewWidth, height: previewHeight }}
                 onClick={(event: React.MouseEvent) => {
                     event.stopPropagation();
-                    setIsExpanded(true);
+                    openExpanded(event.currentTarget);
                 }}
                 onKeyDown={(event: React.KeyboardEvent) => {
                     if (previewAs === 'button') return;
                     event.stopPropagation();
                     if (event.key === 'Enter' || event.key === ' ') {
                         event.preventDefault();
-                        setIsExpanded(true);
+                        openExpanded(event.currentTarget);
                     }
                 }}
             >
@@ -237,7 +326,6 @@ export function ImageViewer({
                 <Search className="stroke-white group-hover:scale-110 size-4 shrink-0 absolute bottom-1 right-1" />
             </PreviewComponent>
 
-            {/* Modal for expanded view */}
             <Modal
                 open={isExpanded}
                 onOpenChange={handleModalOpenChange}
@@ -250,7 +338,11 @@ export function ImageViewer({
                 )}
             >
                 <div className="relative flex h-full w-full overflow-clip">
-                    {/* Controls */}
+                    <p id={imageInstructionsId} className="sr-only">
+                        Pritisni Escape za zatvaranje, plus ili minus za
+                        zumiranje, nulu za prilagodbu zaslonu, a strelice za
+                        pomicanje slike.
+                    </p>
                     <div
                         className="absolute right-4 top-4 z-10 flex gap-1"
                         style={{
@@ -258,73 +350,65 @@ export function ImageViewer({
                         }}
                     >
                         <IconButton
+                            aria-label="Smanji sliku"
                             title="Smanji"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                handleZoomOut(e);
-                            }}
-                            disabled={zoomLevel <= 0.5}
+                            onClick={handleZoomOut}
+                            disabled={zoomLevel <= minimumZoomLevel}
                         >
                             <Remove className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Uvećaj sliku"
                             title="Uvećaj"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                handleZoomIn(e);
-                            }}
+                            onClick={handleZoomIn}
                             disabled={zoomLevel >= 5}
                         >
                             <Add className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Preuzmi sliku"
                             title="Preuzmi"
                             variant="outlined"
                             className="rounded-xl bg-background/80 backdrop-blur"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                handleDownload(e);
-                            }}
+                            onClick={handleDownload}
                         >
                             <Save className="size-4 shrink-0" />
                         </IconButton>
                         <IconButton
+                            aria-label="Zatvori pregled slike"
                             title="Zatvori"
                             variant="solid"
                             className="rounded-xl"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                closeExpanded(e);
-                            }}
+                            onClick={closeExpanded}
                         >
                             <Close className="size-4 shrink-0" />
                         </IconButton>
                     </div>
 
-                    {/* Image Container */}
-                    <div className="flex h-full w-full items-center justify-center">
-                        <div
+                    <div className="flex h-full min-h-0 w-full min-w-0 items-center justify-center">
+                        <button
+                            type="button"
                             ref={imageRef}
-                            role="option"
-                            tabIndex={0}
-                            className="relative h-full w-full overflow-hidden cursor-grab active:cursor-grabbing touch-none"
+                            aria-describedby={imageInstructionsId}
+                            aria-keyshortcuts="Escape + - = 0 ArrowUp ArrowDown ArrowLeft ArrowRight"
+                            aria-label={`Interaktivni pregled slike: ${resolvedAlt}`}
+                            className="relative block h-full min-h-0 w-full min-w-0 cursor-grab overflow-hidden border-0 bg-transparent p-0 text-inherit active:cursor-grabbing touch-none"
                             onMouseDown={handleMouseDown}
                             onMouseMove={handleMouseMove}
                             onMouseUp={handleMouseUp}
                             onMouseLeave={handleMouseUp}
-                            onClick={handleClick}
-                            onKeyDown={handleKeyDown}
+                            onKeyDown={handleImageKeyDown}
                             onTouchStart={handleTouchStart}
                             onTouchMove={handleTouchMove}
                             onTouchEnd={handleTouchEnd}
                             onWheel={handleWheel}
                             style={{ touchAction: 'none' }}
                         >
-                            <div
+                            <span
                                 className="relative flex h-full w-full select-none items-center justify-center transition-transform duration-200 ease-out will-change-transform"
                                 style={{
                                     transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${position.y / zoomLevel}px)`,
@@ -335,22 +419,23 @@ export function ImageViewer({
                                 <img
                                     src={src}
                                     alt={resolvedAlt}
-                                    className="max-h-full max-w-full object-contain select-none"
+                                    className="h-auto w-auto max-h-none max-w-none object-contain select-none"
                                     draggable={false}
+                                    onLoad={handleImageLoad}
                                 />
-                            </div>
-                        </div>
+                            </span>
+                        </button>
                     </div>
 
-                    {/* Zoom Level Indicator */}
                     <Chip
+                        aria-label={`Zumiranje ${Math.round(zoomLevel * 100)} posto`}
+                        aria-live="polite"
                         className="absolute left-4 [top:calc(env(safe-area-inset-top)+1rem)] z-10 select-none bg-black/60 text-white/80 backdrop-blur border-0"
                         variant="solid"
                     >
                         {Math.round(zoomLevel * 100)}%
                     </Chip>
 
-                    {/* Instructions */}
                     <div className="pointer-events-none absolute bottom-0 left-1/2 flex -translate-x-1/2 transform justify-center text-center text-xs [padding-bottom:calc(env(safe-area-inset-bottom)+1rem)]">
                         <p className="hidden rounded-full bg-black/60 px-4 py-1 text-white/80 backdrop-blur sm:block">
                             Koristi kotač za zoom • Povuci za pomicanje slike

--- a/packages/ui/src/hooks/useImageFitZoom.ts
+++ b/packages/ui/src/hooks/useImageFitZoom.ts
@@ -1,0 +1,158 @@
+import type { SyntheticEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const DEFAULT_MIN_ZOOM_LEVEL = 0.5;
+const MAX_ZOOM_LEVEL = 5;
+const FIT_PADDING = 32;
+
+interface Size {
+    width: number;
+    height: number;
+}
+
+function calculateFitZoomLevel(viewerSize: Size, imageSize: Size) {
+    const availableWidth = Math.max(viewerSize.width - FIT_PADDING, 1);
+    const availableHeight = Math.max(viewerSize.height - FIT_PADDING, 1);
+    const fitZoomLevel = Math.min(
+        availableWidth / imageSize.width,
+        availableHeight / imageSize.height,
+        1,
+    );
+
+    return Number.isFinite(fitZoomLevel) && fitZoomLevel > 0 ? fitZoomLevel : 1;
+}
+
+export function useImageFitZoom<TElement extends HTMLElement = HTMLDivElement>(
+    isExpanded: boolean,
+    imageKey: string,
+) {
+    const viewerRef = useRef<TElement>(null);
+    const fitZoomLevelRef = useRef(1);
+    const [viewerSize, setViewerSize] = useState<Size>({ width: 0, height: 0 });
+    const [imageSize, setImageSize] = useState<Size | null>(null);
+    const [zoomLevel, setZoomLevel] = useState(1);
+
+    const fitZoomLevel = useMemo(() => {
+        if (
+            !imageSize ||
+            imageSize.width <= 0 ||
+            imageSize.height <= 0 ||
+            viewerSize.width <= 0 ||
+            viewerSize.height <= 0
+        ) {
+            return 1;
+        }
+
+        return calculateFitZoomLevel(viewerSize, imageSize);
+    }, [imageSize, viewerSize]);
+
+    const minimumZoomLevel = Math.min(DEFAULT_MIN_ZOOM_LEVEL, fitZoomLevel);
+
+    const clampZoomLevel = useCallback(
+        (nextZoomLevel: number) =>
+            Math.min(Math.max(nextZoomLevel, minimumZoomLevel), MAX_ZOOM_LEVEL),
+        [minimumZoomLevel],
+    );
+
+    useEffect(() => {
+        fitZoomLevelRef.current = fitZoomLevel;
+    }, [fitZoomLevel]);
+
+    const updateViewerSize = useCallback(() => {
+        const viewer = viewerRef.current;
+        if (!viewer) return;
+
+        const nextSize = {
+            width: viewer.clientWidth,
+            height: viewer.clientHeight,
+        };
+
+        setViewerSize((currentSize) =>
+            currentSize.width === nextSize.width &&
+            currentSize.height === nextSize.height
+                ? currentSize
+                : nextSize,
+        );
+
+        return nextSize;
+    }, []);
+
+    const resetZoomLevel = useCallback(() => {
+        setZoomLevel(fitZoomLevelRef.current);
+    }, []);
+
+    const handleImageLoad = useCallback(
+        (event: SyntheticEvent<HTMLImageElement>) => {
+            const nextImageSize = {
+                width: event.currentTarget.naturalWidth,
+                height: event.currentTarget.naturalHeight,
+            };
+            const nextViewerSize = updateViewerSize() ?? viewerSize;
+
+            setImageSize(nextImageSize);
+            setZoomLevel(calculateFitZoomLevel(nextViewerSize, nextImageSize));
+        },
+        [updateViewerSize, viewerSize],
+    );
+
+    useEffect(() => {
+        if (!imageKey) {
+            setImageSize(null);
+            resetZoomLevel();
+            return;
+        }
+
+        setImageSize(null);
+        resetZoomLevel();
+    }, [imageKey, resetZoomLevel]);
+
+    useEffect(() => {
+        if (!isExpanded) return;
+
+        updateViewerSize();
+
+        const viewer = viewerRef.current;
+        if (!viewer) return;
+
+        if (typeof ResizeObserver === 'undefined') {
+            window.addEventListener('resize', updateViewerSize);
+
+            return () => {
+                window.removeEventListener('resize', updateViewerSize);
+            };
+        }
+
+        const resizeObserver = new ResizeObserver(() => {
+            updateViewerSize();
+        });
+
+        resizeObserver.observe(viewer);
+        window.addEventListener('resize', updateViewerSize);
+
+        return () => {
+            resizeObserver.disconnect();
+            window.removeEventListener('resize', updateViewerSize);
+        };
+    }, [isExpanded, updateViewerSize]);
+
+    useEffect(() => {
+        setZoomLevel((currentZoomLevel) => clampZoomLevel(currentZoomLevel));
+    }, [clampZoomLevel]);
+
+    useEffect(() => {
+        if (!isExpanded || !imageSize) return;
+
+        setZoomLevel(fitZoomLevel);
+    }, [fitZoomLevel, imageSize, isExpanded]);
+
+    return {
+        clampZoomLevel,
+        fitZoomLevel,
+        handleImageLoad,
+        minimumZoomLevel,
+        resetZoomLevel,
+        setZoomLevel,
+        viewerRef,
+        zoomLevel,
+    };
+}


### PR DESCRIPTION
## Summary
- Fit expanded image viewer and gallery images to the available viewport, including zoom levels below 50% when required.
- Add ESC dismissal, focus restoration, and keyboard shortcuts for zooming, panning, and gallery navigation.
- Improve accessibility with clearer labels, live zoom status, and updated Storybook examples for large images.

## Testing
- Lint and typecheck passed for `@gredice/ui`.
- Storybook lint and build passed.
- Verified the viewer and gallery in the browser: large images open fit-to-screen and close with `Escape`.