### PR TITLE
Refine raised bed field details actions and dates

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
@@ -10,6 +10,7 @@ type RaisedBedFieldPlantSortSelectorProps = {
     status: string | null;
     plantSortId?: number | null;
     plantSorts: PlantSortData[];
+    variant?: 'outlined' | 'plain';
 };
 
 export function RaisedBedFieldPlantSortSelector({
@@ -18,6 +19,7 @@ export function RaisedBedFieldPlantSortSelector({
     status,
     plantSortId,
     plantSorts,
+    variant = 'outlined',
 }: RaisedBedFieldPlantSortSelectorProps) {
     const items = plantSorts
         .map((sort) => ({
@@ -64,6 +66,7 @@ export function RaisedBedFieldPlantSortSelector({
             onValueChange={handleChange}
             items={items}
             disabled={items.length === 0}
+            variant={variant}
         />
     );
 }

--- a/apps/app/components/raised-beds/MoveRaisedBedFieldPlantModal.tsx
+++ b/apps/app/components/raised-beds/MoveRaisedBedFieldPlantModal.tsx
@@ -22,7 +22,7 @@ type MoveRaisedBedFieldPlantModalProps = {
     sourcePlantPlaceEventId: number;
     sourcePlantLabel: string;
     targetOptions: MoveRaisedBedFieldPlantOption[];
-    triggerVariant?: 'button' | 'icon';
+    triggerVariant?: 'button' | 'icon' | 'fieldIndex';
 };
 
 export function MoveRaisedBedFieldPlantModal({
@@ -74,7 +74,17 @@ export function MoveRaisedBedFieldPlantModal({
         <Modal
             title={`Premjesti biljku: ${sourcePlantLabel}`}
             trigger={
-                triggerVariant === 'icon' ? (
+                triggerVariant === 'fieldIndex' ? (
+                    <button
+                        type="button"
+                        title="Premjesti biljku"
+                        disabled={targetOptions.length === 0}
+                        className="inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full bg-background/90 px-2 py-1 text-xs font-semibold text-foreground shadow transition-opacity hover:opacity-80 disabled:pointer-events-none disabled:opacity-50"
+                    >
+                        <Replace aria-hidden className="size-3.5 shrink-0" />#
+                        {sourcePositionIndex + 1}
+                    </button>
+                ) : triggerVariant === 'icon' ? (
                     <IconButton
                         variant="outlined"
                         size="sm"

--- a/apps/app/components/raised-beds/RaisedBedFieldDatesPopover.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldDatesPopover.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Calendar } from '@gredice/ui/icons';
+import { Popper } from '@gredice/ui/Popper';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useState } from 'react';
+
+export type RaisedBedFieldDateItem = {
+    key: string;
+    label: string;
+    value: string | null;
+    current?: boolean;
+};
+
+type RaisedBedFieldDatesPopoverProps = {
+    items: RaisedBedFieldDateItem[];
+};
+
+function parseDate(value: string | null) {
+    if (!value) {
+        return null;
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date;
+}
+
+function formatShortDate(value: string | null) {
+    const date = parseDate(value);
+    if (!date) {
+        return '-';
+    }
+
+    const currentYear = new Date().getFullYear();
+    const format: Intl.DateTimeFormatOptions =
+        date.getFullYear() === currentYear
+            ? { day: '2-digit', month: '2-digit' }
+            : { day: '2-digit', month: '2-digit', year: 'numeric' };
+
+    return new Intl.DateTimeFormat('hr-HR', format).format(date);
+}
+
+export function RaisedBedFieldDatesPopover({
+    items,
+}: RaisedBedFieldDatesPopoverProps) {
+    const [mounted, setMounted] = useState(false);
+    const currentItem = items.find((item) => item.current);
+    const triggerValue = currentItem?.value ?? null;
+    const triggerLabel = triggerValue
+        ? mounted
+            ? formatShortDate(triggerValue)
+            : '...'
+        : 'Datumi';
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    return (
+        <Popper
+            align="end"
+            className="w-64 p-3"
+            side="bottom"
+            trigger={
+                <Button
+                    color="neutral"
+                    size="sm"
+                    startDecorator={<Calendar className="size-3.5" />}
+                    title="Prikaži datume biljke"
+                    variant="plain"
+                    className="h-10 shrink-0 px-2 text-muted-foreground hover:text-foreground"
+                >
+                    {triggerLabel}
+                </Button>
+            }
+        >
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-2">
+                {items.map((item) => (
+                    <div className="contents" key={`${item.key}-${item.label}`}>
+                        <Typography
+                            level="body3"
+                            className={
+                                item.current
+                                    ? 'font-medium text-foreground'
+                                    : 'text-muted-foreground'
+                            }
+                        >
+                            {item.label}
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className={
+                                item.current
+                                    ? 'font-medium text-foreground'
+                                    : item.value
+                                      ? 'text-foreground'
+                                      : 'text-muted-foreground'
+                            }
+                            title={item.value ?? undefined}
+                        >
+                            {item.value
+                                ? mounted
+                                    ? formatShortDate(item.value)
+                                    : '...'
+                                : '-'}
+                        </Typography>
+                    </div>
+                ))}
+            </div>
+        </Popper>
+    );
+}

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -4,9 +4,7 @@ import {
     getRaisedBed,
     getRaisedBedFieldPlantCycles,
 } from '@gredice/storage';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { PlantOrSortImage } from '@gredice/ui/plants';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { RaisedBedFieldLocationSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector';
@@ -14,6 +12,10 @@ import { RaisedBedFieldPlantSortSelector } from '../../app/admin/raised-beds/[ra
 import { RaisedBedFieldPlantStatusSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
 import { MoveRaisedBedFieldPlantModal } from './MoveRaisedBedFieldPlantModal';
+import {
+    type RaisedBedFieldDateItem,
+    RaisedBedFieldDatesPopover,
+} from './RaisedBedFieldDatesPopover';
 import {
     RaisedBedRemovedFieldsModal,
     type RemovedFieldDetails,
@@ -87,6 +89,33 @@ function getSortLabel(sort?: PlantSortData, plantSortId?: number | null) {
         sort?.information?.name ||
         (plantSortId ? `Sorta biljke ${plantSortId}` : 'Nepoznata biljka')
     );
+}
+
+function getCurrentDateKey(status?: string | null) {
+    switch (status) {
+        case 'planned':
+            return 'plantScheduledDate';
+        case 'pendingVerification':
+        case 'sowed':
+            return 'plantSowDate';
+        case 'sprouted':
+        case 'firstFlowers':
+        case 'firstFruitSet':
+            return 'plantGrowthDate';
+        case 'ready':
+            return 'plantReadyDate';
+        case 'harvested':
+            return 'plantHarvestedDate';
+        case 'notSprouted':
+        case 'died':
+            return 'plantDeadDate';
+        case 'removed':
+            return 'plantRemovedDate';
+        case 'new':
+            return 'createdAt';
+        default:
+            return null;
+    }
 }
 
 function normalizeDate(value?: Date | string | null) {
@@ -298,18 +327,56 @@ function RaisedBedFieldTile({
     const plantLabel = field
         ? getSortLabel(sort, field.plantSortId)
         : 'Prazno polje';
-    const dateItems: {
-        label: string;
-        value: Date | string | null | undefined;
-    }[] = [
-        { label: 'Stvoreno', value: field?.createdAt },
-        { label: 'Planirano', value: field?.plantScheduledDate },
-        { label: 'Sijano', value: field?.plantSowDate },
-        { label: 'Proklijalo', value: field?.plantGrowthDate },
-        { label: 'Spremno', value: field?.plantReadyDate },
-        { label: 'Ubrano', value: field?.plantHarvestedDate },
-        { label: 'Uginulo', value: field?.plantDeadDate },
-        { label: 'Uklonjeno', value: field?.plantRemovedDate },
+    const currentDateKey = getCurrentDateKey(field?.plantStatus);
+    const dateItems: RaisedBedFieldDateItem[] = [
+        {
+            key: 'createdAt',
+            label: 'Stvoreno',
+            value: normalizeDate(field?.createdAt),
+            current: currentDateKey === 'createdAt',
+        },
+        {
+            key: 'plantScheduledDate',
+            label: 'Planirano',
+            value: normalizeDate(field?.plantScheduledDate),
+            current: currentDateKey === 'plantScheduledDate',
+        },
+        {
+            key: 'plantSowDate',
+            label: 'Sijano',
+            value: normalizeDate(field?.plantSowDate),
+            current: currentDateKey === 'plantSowDate',
+        },
+        {
+            key: 'plantGrowthDate',
+            label: 'Proklijalo',
+            value: normalizeDate(field?.plantGrowthDate),
+            current: currentDateKey === 'plantGrowthDate',
+        },
+        {
+            key: 'plantReadyDate',
+            label: 'Spremno',
+            value: normalizeDate(field?.plantReadyDate),
+            current: currentDateKey === 'plantReadyDate',
+        },
+        {
+            key: 'plantHarvestedDate',
+            label: 'Ubrano',
+            value: normalizeDate(field?.plantHarvestedDate),
+            current: currentDateKey === 'plantHarvestedDate',
+        },
+        {
+            key: 'plantDeadDate',
+            label: 'Uginulo',
+            value: normalizeDate(field?.plantDeadDate),
+            current: currentDateKey === 'plantDeadDate',
+        },
+        {
+            key: 'plantRemovedDate',
+            label: 'Uklonjeno',
+            value: normalizeDate(field?.plantRemovedDate),
+            current: currentDateKey === 'plantRemovedDate',
+        },
     ];
 
     return (
@@ -350,17 +417,33 @@ function RaisedBedFieldTile({
                         />
                     </div>
                 )}
-                <div className="absolute bottom-2 right-2 rounded-full bg-background/90 px-2 py-1 text-xs font-semibold shadow">
-                    #{positionIndex + 1}
+                <div className="absolute bottom-2 right-2">
+                    {field?.active && activePlantCycle ? (
+                        <MoveRaisedBedFieldPlantModal
+                            raisedBedId={raisedBedId}
+                            sourcePositionIndex={positionIndex}
+                            sourcePlantPlaceEventId={
+                                activePlantCycle.plantPlaceEventId
+                            }
+                            sourcePlantLabel={plantLabel}
+                            targetOptions={moveTargetOptions}
+                            triggerVariant="fieldIndex"
+                        />
+                    ) : (
+                        <div className="rounded-full bg-background/90 px-2 py-1 text-xs font-semibold shadow">
+                            #{positionIndex + 1}
+                        </div>
+                    )}
                 </div>
             </div>
-            <div className="flex flex-col gap-2 p-2">
+            <div className="flex flex-col gap-2 px-2 pb-2 pt-0">
                 <RaisedBedFieldPlantSortSelector
                     raisedBedId={raisedBedId}
                     positionIndex={positionIndex}
                     status={field?.plantStatus ?? null}
                     plantSortId={field?.plantSortId}
                     plantSorts={plantSorts}
+                    variant="plain"
                 />
                 {field?.active && (
                     <Stack spacing={2}>
@@ -373,62 +456,14 @@ function RaisedBedFieldTile({
                                         status={field.plantStatus}
                                     />
                                 </div>
-                                {activePlantCycle && (
-                                    <MoveRaisedBedFieldPlantModal
-                                        raisedBedId={raisedBedId}
-                                        sourcePositionIndex={positionIndex}
-                                        sourcePlantPlaceEventId={
-                                            activePlantCycle.plantPlaceEventId
-                                        }
-                                        sourcePlantLabel={plantLabel}
-                                        targetOptions={moveTargetOptions}
-                                        triggerVariant="icon"
-                                    />
-                                )}
+                                <RaisedBedFieldDatesPopover items={dateItems} />
                             </div>
                         )}
-                        {activePlantCycle && !field.plantStatus && (
-                            <MoveRaisedBedFieldPlantModal
-                                raisedBedId={raisedBedId}
-                                sourcePositionIndex={positionIndex}
-                                sourcePlantPlaceEventId={
-                                    activePlantCycle.plantPlaceEventId
-                                }
-                                sourcePlantLabel={plantLabel}
-                                targetOptions={moveTargetOptions}
-                                triggerVariant="icon"
-                            />
+                        {!field.plantStatus && (
+                            <div className="flex justify-end">
+                                <RaisedBedFieldDatesPopover items={dateItems} />
+                            </div>
                         )}
-                        <Stack>
-                            {dateItems.map(({ label, value }) => (
-                                <Row
-                                    key={label}
-                                    spacing={2}
-                                    alignItems="center"
-                                >
-                                    <Typography
-                                        level="body3"
-                                        className="w-20 text-muted-foreground"
-                                    >
-                                        {label}
-                                    </Typography>
-                                    {value ? (
-                                        <Typography level="body3" noWrap>
-                                            <LocalDateTime time={false}>
-                                                {value}
-                                            </LocalDateTime>
-                                        </Typography>
-                                    ) : (
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            -
-                                        </Typography>
-                                    )}
-                                </Row>
-                            ))}
-                        </Stack>
                     </Stack>
                 )}
             </div>


### PR DESCRIPTION
## Summary
- Move the plant transfer action onto the field index chip.
- Show the active date next to plant status and reveal the full date list in a popover.
- Add short date formatting that omits the year when it matches the current year.
- Remove extra spacing under the image by using the plain plant sort selector variant.

## Testing
- `pnpm lint --filter app`
- `pnpm test --filter app`
- `pnpm build --filter app`