### PR TITLE
Add directory-types to the app CI filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
               - apps/app/**
               - packages/auth/**
               - packages/client/**
+              - packages/directory-types/**
               - packages/email/**
               - packages/fiscalization/**
               - packages/js/**


### PR DESCRIPTION
## Summary
- Add `packages/directory-types/**` to the `app_app` paths filter in CI
- Keep the filter list aligned with `apps/app` workspace dependencies so the CI filter check passes

## Testing
- Not run (not requested)