### PR TITLE
[codex] Render farm manual markdown

### DIFF
--- a/apps/farm/app/operations/OperationDetails.spec.tsx
+++ b/apps/farm/app/operations/OperationDetails.spec.tsx
@@ -1,0 +1,34 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OperationDetails } from './OperationDetails';
+
+const markdownOperation = {
+    id: 1,
+    information: {
+        name: 'Čišćenje gredice',
+        description: 'Uklanjaju se:\n* korovi\n* stare biljke',
+        instructions:
+            '1. Pregledava se cijela gredica.\n2. Ručno se čupaju korovi.',
+    },
+} satisfies EntityStandardized;
+
+test('operation details render manual markdown fields', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OperationDetails operation={markdownOperation} />);
+
+    await expect(page.getByText('Uklanjaju se:')).toBeVisible();
+    await expect(
+        page.getByRole('listitem').filter({ hasText: /^korovi$/ }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'stare biljke' }),
+    ).toBeVisible();
+    await expect(
+        page
+            .getByRole('listitem')
+            .filter({ hasText: 'Pregledava se cijela gredica.' }),
+    ).toBeVisible();
+    await expect(page.getByText('* korovi')).toHaveCount(0);
+});

--- a/apps/farm/app/operations/OperationDetails.tsx
+++ b/apps/farm/app/operations/OperationDetails.tsx
@@ -1,5 +1,6 @@
 import type { EntityStandardized } from '@gredice/storage';
 import { Card, CardContent } from '@gredice/ui/Card';
+import { Markdown } from '@gredice/ui/Markdown';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import {
@@ -48,21 +49,18 @@ export function OperationDetails({ operation }: OperationDetailsProps) {
                         </Typography>
                     )}
                     {operation.information?.description && (
-                        <Typography level="body2">
+                        <Markdown className="text-sm prose-p:first:mt-0 prose-p:last:mb-0">
                             {operation.information.description}
-                        </Typography>
+                        </Markdown>
                     )}
                     {operation.information?.instructions && (
-                        <div className="rounded-md border bg-muted/40 p-3">
+                        <div className="rounded-md border bg-muted/40 p-3 space-y-1">
                             <Typography level="body2" semiBold>
                                 Upute
                             </Typography>
-                            <Typography
-                                level="body2"
-                                className="whitespace-pre-wrap"
-                            >
+                            <Markdown className="text-sm prose-p:first:mt-0 prose-p:last:mb-0">
                                 {operation.information.instructions}
-                            </Typography>
+                            </Markdown>
                         </div>
                     )}
                     <div className="grid gap-2 text-sm sm:grid-cols-2">

--- a/apps/farm/app/plants/PlantsHandbook.spec.tsx
+++ b/apps/farm/app/plants/PlantsHandbook.spec.tsx
@@ -33,6 +33,14 @@ const basilSort = {
     },
 } satisfies EntityStandardized;
 
+const pepperSort = {
+    id: 103,
+    information: {
+        name: 'Paprika',
+        description: 'Njega uključuje:\n- zalijevanje\n- berbu',
+    },
+} satisfies EntityStandardized;
+
 test('plant handbook search includes parent plant alternative names', async ({
     mount,
     page,
@@ -51,4 +59,22 @@ test('plant handbook search includes parent plant alternative names', async ({
     await expect(
         page.getByRole('button', { name: /Genovese bosiljak/ }),
     ).toHaveCount(0);
+});
+
+test('plant handbook renders selected plant description markdown', async ({
+    mount,
+    page,
+}) => {
+    await mount(<PlantsHandbook plantSortsData={[pepperSort]} />);
+
+    await page.getByRole('button', { name: /Paprika/ }).click();
+
+    await expect(page.getByText('Njega uključuje:')).toBeVisible();
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'zalijevanje' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('listitem').filter({ hasText: 'berbu' }),
+    ).toBeVisible();
+    await expect(page.getByText('- zalijevanje')).toHaveCount(0);
 });

--- a/apps/farm/app/plants/PlantsHandbook.tsx
+++ b/apps/farm/app/plants/PlantsHandbook.tsx
@@ -3,6 +3,7 @@
 import type { EntityStandardized } from '@gredice/storage';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
 import { Search, Sprout } from '@gredice/ui/icons';
+import { Markdown } from '@gredice/ui/Markdown';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -281,9 +282,9 @@ export function PlantsHandbook({ plantSortsData }: PlantsHandbookProps) {
                                 </Typography>
                             )}
                             {selectedPlantSort.information?.description && (
-                                <Typography level="body2">
+                                <Markdown className="text-sm prose-p:first:mt-0 prose-p:last:mb-0">
                                     {selectedPlantSort.information.description}
-                                </Typography>
+                                </Markdown>
                             )}
                             {(() => {
                                 const plantValue: unknown =


### PR DESCRIPTION
## Summary
- Render farm operation manual descriptions and instructions through the shared Markdown component.
- Render selected plant handbook descriptions as Markdown in Farm.
- Add component tests for operation and plant handbook markdown list rendering.

## Root cause
Farm manual pages were rendering markdown-authored text as plain Typography text, so list markers and ordered instructions appeared literally instead of as structured content.

## Validation
- `pnpm --filter farm exec biome check --write app/operations/OperationDetails.tsx app/operations/OperationDetails.spec.tsx app/plants/PlantsHandbook.tsx app/plants/PlantsHandbook.spec.tsx`
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true GREDICE_FARM_BASE_URL=http://127.0.0.1:4842 pnpm --filter farm exec playwright test app/operations/OperationDetails.spec.tsx app/plants/PlantsHandbook.spec.tsx`
- `pnpm lint --filter farm` (passed with existing Biome schema info and unused `Row` warning in `apps/farm/app/payouts/page.tsx`)
- `pnpm build --filter farm`
- `git diff --check`