### PR TITLE
Fix notifications filter button in game notifications

### DIFF
--- a/apps/garden/tests/NotificationsTabStory.tsx
+++ b/apps/garden/tests/NotificationsTabStory.tsx
@@ -2,6 +2,7 @@ import * as ReactQuery from '@tanstack/react-query';
 import { type PropsWithChildren, useMemo } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import { NotificationsTab } from '../../../packages/game/src/modals/components/NotificationsTab';
+import type { NotificationsFilter } from '../../../packages/game/src/notificationFilters';
 
 const currentUser = {
     avatarUrl: null,
@@ -41,11 +42,15 @@ function Providers({ children }: PropsWithChildren) {
     );
 }
 
-export function NotificationsTabStory() {
+export function NotificationsTabStory({
+    initialFilter,
+}: {
+    initialFilter?: NotificationsFilter;
+}) {
     return (
         <Providers>
             <div className="w-[520px] p-4">
-                <NotificationsTab />
+                <NotificationsTab initialFilter={initialFilter} />
             </div>
         </Providers>
     );

--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -16,6 +16,7 @@ type MockEndpoint<T> = {
 type RecordedNotificationRequests = {
     deviceDeletes: string[];
     devicePatches: unknown[];
+    notificationReads: Array<string | null>;
     preferencesUpdates: unknown[];
     testSends: number;
 };
@@ -118,6 +119,7 @@ async function mockNotificationSettingsApi(
     const recorded: RecordedNotificationRequests = {
         deviceDeletes: [],
         devicePatches: [],
+        notificationReads: [],
         preferencesUpdates: [],
         testSends: 0,
     };
@@ -219,6 +221,9 @@ async function mockNotificationSettingsApi(
         }
 
         if (pathname.endsWith('/api/notifications') && method === 'GET') {
+            recorded.notificationReads.push(
+                new URL(request.url()).searchParams.get('read'),
+            );
             await fulfillJson(route, []);
             return;
         }
@@ -247,6 +252,17 @@ test('notification tabs size to their labels', async ({ mount, page }) => {
     });
 
     expect(widths.list).toBeLessThan(widths.parent * 0.75);
+});
+
+test('notification list starts with the requested all filter', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockNotificationSettingsApi(page);
+
+    await mount(<NotificationsTabStory initialFilter="all" />);
+
+    await expect.poll(() => recorded.notificationReads).toContain('true');
 });
 
 test('notification settings shows loading, status, and empty device states', async ({

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -25,13 +25,18 @@ import { Row } from '@gredice/ui/Row';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useMarkAllNotificationsRead } from '../hooks/useMarkAllNotificationsRead';
 import { useNotifications } from '../hooks/useNotifications';
 import { KnownPages } from '../knownPages';
+import {
+    type NotificationsFilter,
+    notificationsFilterSearchParam,
+} from '../notificationFilters';
 import { ProfileAvatar } from '../shared-ui/ProfileAvatar';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { HudCard } from './components/HudCard';
@@ -39,12 +44,38 @@ import { GardenAccountMenuItems } from './GardenAccountMenuItems';
 import { GardenOperationsHud } from './GardenOperationsHud';
 import { NotificationList } from './NotificationList';
 
+function useOpenNotificationsOverview() {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    return useCallback(
+        (filter: NotificationsFilter = 'unread') => {
+            const next = new URLSearchParams(
+                Array.from(searchParams.entries()),
+            );
+            next.set('pregled', 'obavijesti');
+
+            if (filter === 'all') {
+                next.set(notificationsFilterSearchParam, filter);
+            } else {
+                next.delete(notificationsFilterSearchParam);
+            }
+
+            const query = next.toString();
+            const nextUrl = `${pathname}${query ? `?${query}` : ''}`;
+            router.replace(nextUrl as Parameters<typeof router.replace>[0]);
+        },
+        [pathname, router, searchParams],
+    );
+}
+
 function NotificationsCard({
     onNotificationSelected,
 }: {
     onNotificationSelected: () => void;
 }) {
-    const [, setProfileModalOpen] = useSearchParam('pregled');
+    const openNotificationsOverview = useOpenNotificationsOverview();
     const markAllNotificationsRead = useMarkAllNotificationsRead();
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser();
@@ -98,7 +129,7 @@ function NotificationsCard({
                                 track('game_notifications_view_all_opened', {
                                     source: 'quick_panel_no_unread',
                                 });
-                                setProfileModalOpen('obavijesti');
+                                openNotificationsOverview('all');
                             }}
                         >
                             Prikaži sve pročitane
@@ -117,7 +148,7 @@ function NotificationsCard({
                         track('game_notifications_view_all_opened', {
                             source: 'quick_panel',
                         });
-                        setProfileModalOpen('obavijesti');
+                        openNotificationsOverview('all');
                     }}
                 >
                     Prikaži sve obavijesti
@@ -129,6 +160,7 @@ function NotificationsCard({
 
 function ProfileCard() {
     const [, setProfileModalOpen] = useSearchParam('pregled');
+    const openNotificationsOverview = useOpenNotificationsOverview();
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser();
     const { data: notifications } = useNotifications(currentUser?.id, false);
@@ -153,7 +185,7 @@ function ProfileCard() {
             </DropdownMenuItem>
             <DropdownMenuItem
                 className="gap-3"
-                onClick={() => setProfileModalOpen('obavijesti')}
+                onClick={() => openNotificationsOverview()}
                 endDecorator={
                     hasUnreadNotifications && <DotIndicator color={'success'} />
                 }

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -7,6 +7,10 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { Fragment, useEffect } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import {
+    isNotificationsFilter,
+    notificationsFilterSearchParam,
+} from '../notificationFilters';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { AccountUsersTab } from './components/AccountUsersTab';
 import { AchievementsTab } from './components/AchievementsTab';
@@ -108,7 +112,13 @@ const allNavItems = navGroups.flatMap((g) => g.items);
 
 export function OverviewModal() {
     const [settingsMode, setProfileModalOpen] = useSearchParam('pregled');
+    const [notificationsFilterParam] = useSearchParam(
+        notificationsFilterSearchParam,
+    );
     const { track } = useGameAnalytics();
+    const notificationsFilter = isNotificationsFilter(notificationsFilterParam)
+        ? notificationsFilterParam
+        : 'unread';
 
     useEffect(() => {
         if (!settingsMode) {
@@ -181,7 +191,9 @@ export function OverviewModal() {
                     {settingsMode === 'sigurnost' && <SecurityTab />}
                     {settingsMode === 'dostava' && <DeliveryTab />}
                     {settingsMode === 'zvuk' && <SoundTab />}
-                    {settingsMode === 'obavijesti' && <NotificationsTab />}
+                    {settingsMode === 'obavijesti' && (
+                        <NotificationsTab initialFilter={notificationsFilter} />
+                    )}
                     {settingsMode === 'suncokreti' && <SunflowersTab />}
                     {settingsMode === 'postignuca' && <AchievementsTab />}
                     {settingsMode === 'korisnici' && <AccountUsersTab />}

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -15,6 +15,7 @@ import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useMarkAllNotificationsRead } from '../../hooks/useMarkAllNotificationsRead';
 import { usePushPermissionOnboarding } from '../../hooks/usePushPermissionOnboarding';
 import { NotificationList } from '../../hud/NotificationList';
+import type { NotificationsFilter } from '../../notificationFilters';
 
 type ApiClient = ReturnType<typeof clientAuthenticated>;
 
@@ -32,7 +33,6 @@ type DigestFrequency = NonNullable<
 type DigestPeriod = Exclude<DigestFrequency, 'off'>;
 
 type NotificationsView = 'notifications' | 'settings';
-type NotificationsFilter = 'unread' | 'all';
 type NotificationPreferenceItem = {
     category: string;
     channel: NotificationPreferenceUpdate['channel'];
@@ -137,10 +137,6 @@ function isNotificationsView(value: string): value is NotificationsView {
     return value === 'notifications' || value === 'settings';
 }
 
-function isNotificationsFilter(value: string): value is NotificationsFilter {
-    return value === 'unread' || value === 'all';
-}
-
 function isDigestPeriod(value: string): value is DigestPeriod {
     return digestFrequencyItems.some((item) => item.value === value);
 }
@@ -207,11 +203,17 @@ function pushStatusLabel(status: string | undefined) {
     }
 }
 
-export function NotificationsTab() {
+type NotificationsTabProps = {
+    initialFilter?: NotificationsFilter;
+};
+
+export function NotificationsTab({
+    initialFilter = 'unread',
+}: NotificationsTabProps = {}) {
     const [activeView, setActiveView] =
         useState<NotificationsView>('notifications');
     const [notificationsFilter, setNotificationsFilter] =
-        useState<NotificationsFilter>('unread');
+        useState<NotificationsFilter>(initialFilter);
     const [quietHoursEnabled, setQuietHoursEnabled] = useState(false);
     const [quietHoursStartMinute, setQuietHoursStartMinute] = useState(
         defaultQuietHoursStartMinute,
@@ -226,6 +228,10 @@ export function NotificationsTab() {
     const { track } = useGameAnalytics();
     const pushOnboarding = usePushPermissionOnboarding();
     const queryClient = useQueryClient();
+
+    useEffect(() => {
+        setNotificationsFilter(initialFilter);
+    }, [initialFilter]);
 
     const preferencesQuery = useQuery({
         queryKey: notificationPreferencesKey,
@@ -497,9 +503,6 @@ export function NotificationsTab() {
                                 <SelectItems
                                     value={notificationsFilter}
                                     onValueChange={(value) => {
-                                        if (!isNotificationsFilter(value)) {
-                                            return;
-                                        }
                                         track(
                                             'game_notifications_filter_changed',
                                             {

--- a/packages/game/src/notificationFilters.ts
+++ b/packages/game/src/notificationFilters.ts
@@ -1,0 +1,9 @@
+export const notificationsFilterSearchParam = 'obavijestiFilter';
+
+export type NotificationsFilter = 'unread' | 'all';
+
+export function isNotificationsFilter(
+    value: string | null | undefined,
+): value is NotificationsFilter {
+    return value === 'unread' || value === 'all';
+}


### PR DESCRIPTION
## Summary
- Route the quick-panel and profile-menu notification actions through a shared URL update so opening notifications can also set the `all` filter.
- Let the overview modal read the notification filter from the query string and pass it into the notifications tab.
- Add a component test that verifies the notifications list starts in the `all` state when requested.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm --filter @gredice/game typecheck`
- `pnpm test --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm build --filter garden`
- `pnpm --filter garden exec playwright test tests/notifications-tab.spec.tsx`
- `pnpm build --filter www --force`