### PR TITLE
Make live entities advance to their next behavior on click

### DIFF
--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -1,5 +1,5 @@
 import type { BlockData } from '@gredice/client';
-import { useFrame } from '@react-three/fiber';
+import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef } from 'react';
 import type { Group, Material, Object3D } from 'three';
 import {
@@ -818,6 +818,38 @@ function chooseNextTarget({
     );
 }
 
+function chooseManualNextTarget({
+    currentTarget,
+    habitatCenter,
+    random,
+    targets,
+}: {
+    currentTarget: BeeTarget;
+    habitatCenter: Vector3;
+    random: () => number;
+    targets: BeeTarget[];
+}) {
+    const target = chooseNextTarget({
+        currentTarget,
+        habitatCenter,
+        random,
+        targets,
+    });
+
+    if (target.id !== currentTarget.id || target.kind !== currentTarget.kind) {
+        return target;
+    }
+
+    const alternatives = targets.filter(
+        (candidate) => candidate.id !== currentTarget.id,
+    );
+    if (currentTarget.kind !== 'wander') {
+        alternatives.push(createWanderTarget(habitatCenter, random));
+    }
+
+    return pickCandidate(alternatives, random) ?? target;
+}
+
 function makeMovingState({
     from,
     now,
@@ -1085,6 +1117,7 @@ function createBeeDebugEntry({
 function Bee({ habitat }: { habitat: BeeHabitat }) {
     const gltf = useGameGLTF('Bee');
     const { enableDebugHudFlag = false } = useGameFlags();
+    const clock = useThree((state) => state.clock);
     const groupRef = useRef<Group>(null);
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<BeeRuntimeState | null>(null);
@@ -1131,6 +1164,36 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
 
         return () => removeAnimalDebugEntry(habitat.id);
     }, [enableDebugHudFlag, habitat.id, removeAnimalDebugEntry]);
+
+    function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+    }
+
+    function handleClick(event: ThreeEvent<MouseEvent>) {
+        event.stopPropagation();
+
+        const group = groupRef.current;
+        const runtime = runtimeRef.current;
+        if (!group || !runtime) {
+            return;
+        }
+
+        const random = randomRef.current;
+        const now = clock.getElapsedTime();
+        const target = chooseManualNextTarget({
+            currentTarget: runtime.target,
+            habitatCenter: habitat.center,
+            random,
+            targets: habitat.targets,
+        });
+
+        runtimeRef.current = makeMovingState({
+            from: group.position.clone(),
+            now,
+            random,
+            target,
+        });
+    }
 
     useFrame(({ clock }, delta) => {
         const group = groupRef.current;
@@ -1280,7 +1343,13 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     });
 
     return (
-        <group ref={groupRef} scale={beeScale}>
+        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
+        <group
+            ref={groupRef}
+            scale={beeScale}
+            onPointerDown={handlePointerDown}
+            onClick={handleClick}
+        >
             <primitive object={beeModel.scene} />
         </group>
     );

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -1,6 +1,6 @@
 import type { BlockData } from '@gredice/client';
 import { useAnimations } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
+import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Group, Material, Object3D } from 'three';
 import { MathUtils, Mesh, MeshStandardMaterial, Vector3 } from 'three';
@@ -798,6 +798,86 @@ function chooseNextTarget({
     return habitat.home;
 }
 
+function chooseManualNextTarget({
+    currentTarget,
+    habitat,
+    random,
+    timeOfDay,
+}: {
+    currentTarget: BirdTarget;
+    habitat: BirdHabitat;
+    random: () => number;
+    timeOfDay: number;
+}) {
+    const target = chooseNextTarget({
+        currentTarget,
+        habitat,
+        random,
+        timeOfDay,
+    });
+
+    if (
+        target.id !== currentTarget.id ||
+        target.behavior !== currentTarget.behavior
+    ) {
+        return target;
+    }
+
+    const range = getBirdActivityRange(timeOfDay);
+    const airAnchors = getAirAnchorsInRange(habitat, range);
+    const circleAnchors = candidatesInRange(
+        habitat.circleAnchors,
+        habitat.home,
+        range,
+    );
+    const trees = candidatesInRange(habitat.trees, habitat.home, range);
+    const entities = candidatesInRange(habitat.entities, habitat.home, range);
+    const grounds = candidatesInRange(habitat.grounds, habitat.home, range);
+    const alternatives: BirdTarget[] = [];
+
+    if (currentTarget.behavior !== 'air') {
+        alternatives.push(
+            createAirTarget({
+                anchors: airAnchors,
+                home: habitat.home,
+                index: 0,
+                random,
+            }),
+        );
+    }
+
+    if (currentTarget.behavior !== 'circle') {
+        const circleAnchor = pickCandidate(circleAnchors, random);
+        if (circleAnchor) {
+            alternatives.push(
+                createCircleTarget({
+                    anchor: circleAnchor,
+                    home: habitat.home,
+                    random,
+                }),
+            );
+        }
+    }
+
+    if (currentTarget.behavior !== 'tree') {
+        alternatives.push(...trees);
+    }
+
+    if (currentTarget.behavior !== 'entity') {
+        alternatives.push(...entities);
+    }
+
+    if (currentTarget.behavior !== 'ground') {
+        alternatives.push(...grounds);
+    }
+
+    if (currentTarget.behavior !== 'home') {
+        alternatives.push(habitat.home);
+    }
+
+    return pickCandidate(alternatives, random) ?? target;
+}
+
 function makeMovingState({
     airUntil,
     airWaypointIndex = 0,
@@ -1302,6 +1382,7 @@ function createBirdDebugEntry({
 
 function Bird({ habitat }: { habitat: BirdHabitat }) {
     const gltf = useGameGLTF('BirdSmall');
+    const clock = useThree((state) => state.clock);
     const groupRef = useRef<Group>(null);
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<BirdRuntimeState | null>(null);
@@ -1373,6 +1454,38 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     useEffect(() => {
         return () => removeAnimalDebugEntry(habitat.id);
     }, [habitat.id, removeAnimalDebugEntry]);
+
+    function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+    }
+
+    function handleClick(event: ThreeEvent<MouseEvent>) {
+        event.stopPropagation();
+
+        const group = groupRef.current;
+        const runtime = runtimeRef.current;
+        if (!group || !runtime) {
+            return;
+        }
+
+        const random = randomRef.current;
+        const now = clock.getElapsedTime();
+        const target = chooseManualNextTarget({
+            currentTarget: runtime.target,
+            habitat,
+            random,
+            timeOfDay,
+        });
+
+        runtimeRef.current = makeMovingState({
+            from: group.position.clone(),
+            now,
+            random,
+            takeoffLead: false,
+            target,
+            timeOfDay,
+        });
+    }
 
     useFrame(({ clock }, delta) => {
         const group = groupRef.current;
@@ -1710,7 +1823,13 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     });
 
     return (
-        <group ref={groupRef} scale={birdScale}>
+        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
+        <group
+            ref={groupRef}
+            scale={birdScale}
+            onPointerDown={handlePointerDown}
+            onClick={handleClick}
+        >
             <primitive object={birdModel.scene} />
         </group>
     );

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -1,6 +1,6 @@
 import type { BlockData } from '@gredice/client';
 import { useAnimations } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
+import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Group, Object3D } from 'three';
 import { MathUtils, Mesh, Vector3 } from 'three';
@@ -561,6 +561,85 @@ function chooseNextTarget({
     return habitat.pillow;
 }
 
+function chooseManualNextTarget({
+    birdGroundEntries,
+    currentTarget,
+    habitat,
+    random,
+    timeOfDay,
+    weather,
+}: {
+    birdGroundEntries: AnimalDebugEntry[];
+    currentTarget: CatTarget;
+    habitat: CatHabitat;
+    random: () => number;
+    timeOfDay: number;
+    weather: CatWeather | null | undefined;
+}) {
+    const target = chooseNextTarget({
+        birdGroundEntries,
+        habitat,
+        random,
+        timeOfDay,
+        weather,
+    });
+
+    if (
+        target.id !== currentTarget.id ||
+        target.behavior !== currentTarget.behavior
+    ) {
+        return target;
+    }
+
+    const range = getCatActivityRange(timeOfDay, weather);
+    const covers = candidatesInRange(habitat.covers, habitat.pillow, range);
+    const lowEntities = candidatesInRange(
+        habitat.lowEntities,
+        habitat.pillow,
+        range,
+    );
+    const roamAnchors = candidatesInRange(
+        habitat.roamAnchors,
+        habitat.pillow,
+        range,
+    );
+    const birdGroundTargets = getGroundBirdTargets({
+        birdGroundEntries,
+        habitat,
+        range,
+    });
+    const alternatives: CatTarget[] = [];
+
+    if (currentTarget.behavior !== 'roam' && roamAnchors.length > 0) {
+        alternatives.push(createRoamTarget({ habitat, random, range }));
+    }
+
+    if (currentTarget.behavior !== 'cover') {
+        alternatives.push(...covers);
+    }
+
+    if (currentTarget.behavior !== 'stalk-bird') {
+        const stalkTarget = createStalkBirdTarget({
+            birdGroundTargets,
+            habitat,
+            random,
+        });
+        if (stalkTarget) {
+            alternatives.push(stalkTarget);
+        }
+    }
+
+    if (currentTarget.behavior !== 'low-entity') {
+        alternatives.push(...lowEntities);
+    }
+
+    if (currentTarget.behavior !== 'pillow') {
+        alternatives.push(habitat.pillow);
+    }
+
+    return pickCandidate(alternatives, random) ?? target;
+}
+
 function makeMovingState({
     from,
     now,
@@ -719,6 +798,7 @@ function Cat({
 }) {
     const gltf = useGameGLTF('Cat');
     const { enableDebugHudFlag = false } = useGameFlags();
+    const clock = useThree((state) => state.clock);
     const groupRef = useRef<Group>(null);
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<CatRuntimeState | null>(null);
@@ -775,6 +855,48 @@ function Cat({
 
         return () => removeAnimalDebugEntry(habitat.id);
     }, [enableDebugHudFlag, habitat.id, removeAnimalDebugEntry]);
+
+    function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+    }
+
+    function handleClick(event: ThreeEvent<MouseEvent>) {
+        event.stopPropagation();
+
+        const group = groupRef.current;
+        const runtime = runtimeRef.current;
+        if (!group || !runtime) {
+            return;
+        }
+
+        const random = randomRef.current;
+        const now = clock.getElapsedTime();
+        const target = chooseManualNextTarget({
+            birdGroundEntries,
+            currentTarget: runtime.target,
+            habitat,
+            random,
+            timeOfDay,
+            weather,
+        });
+
+        if (group.position.distanceTo(target.position) < 0.08) {
+            runtimeRef.current = makeSettledState({
+                now,
+                random,
+                target,
+                timeOfDay,
+                weather,
+            });
+            return;
+        }
+
+        runtimeRef.current = makeMovingState({
+            from: group.position.clone(),
+            now,
+            target,
+        });
+    }
 
     useFrame(({ clock }, delta) => {
         const group = groupRef.current;
@@ -925,7 +1047,13 @@ function Cat({
     });
 
     return (
-        <group ref={groupRef} scale={catScale}>
+        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
+        <group
+            ref={groupRef}
+            scale={catScale}
+            onPointerDown={handlePointerDown}
+            onClick={handleClick}
+        >
             <primitive object={catModel} />
         </group>
     );


### PR DESCRIPTION
## Summary
- Added click handling for bees, birds, and cats so a tapped live entity immediately advances to a new behavior and target from its current position.
- Kept the existing autonomous behavior loops intact by reusing each species' target selection logic and adding a manual fallback when the current target would be selected again.
- Stopped pointer events from falling through to the scene underneath the animal meshes.

## Testing
- `pnpm --filter @gredice/game typecheck`
- `pnpm test --filter @gredice/game`
- `pnpm lint --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm lint --filter www`
- `pnpm build --filter garden`
- `pnpm build --filter www`
- `git diff --check`
- `pnpm test --filter garden` was run; one unrelated mobile raised-bed HUD test failed in the full suite, and the same test passed when rerun in isolation.