### PR TITLE
Limit Garden Box capacity and update its description

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -16,6 +16,7 @@ import {
     createGardenBlock,
     createGardenStack,
     deleteGardenStack,
+    GardenBoxInventoryLimitError,
     getAccount,
     getAccountGardens,
     getEvents,
@@ -1434,7 +1435,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const gardenBox = gardenBlocks.find(
                 (candidate) => candidate.id === gardenBoxBlockId,
             );
-            if (!gardenBox || gardenBox.name !== 'GardenBox') {
+            if (gardenBox?.name !== 'GardenBox') {
                 return context.json({ error: 'Garden box not found' }, 404);
             }
 
@@ -1473,53 +1474,68 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
             }
             const inventoryEntityId = inventoryBlock.id.toString();
-            const result = await storage().transaction(async (tx) => {
-                const currentSourceStack = await getGardenStackForUpdate(
-                    gardenIdNumber,
-                    {
-                        x: sourcePosition.x,
-                        y: sourcePosition.z,
-                    },
-                    tx,
-                );
-                if (
-                    !currentSourceStack ||
-                    currentSourceStack.blocks[blockIndex] !== blockId
-                ) {
-                    return {
-                        ok: false,
-                        error: 'Source block no longer matches the garden',
-                        status: 409,
-                    } as const;
+            let result:
+                | { ok: true }
+                | { ok: false; error: string; status: ContentfulStatusCode };
+            try {
+                result = await storage().transaction(async (tx) => {
+                    const currentSourceStack = await getGardenStackForUpdate(
+                        gardenIdNumber,
+                        {
+                            x: sourcePosition.x,
+                            y: sourcePosition.z,
+                        },
+                        tx,
+                    );
+                    if (
+                        !currentSourceStack ||
+                        currentSourceStack.blocks[blockIndex] !== blockId
+                    ) {
+                        return {
+                            ok: false,
+                            error: 'Source block no longer matches the garden',
+                            status: 409,
+                        } as const;
+                    }
+
+                    const nextSourceBlocks = currentSourceStack.blocks.filter(
+                        (_sourceBlockId, index) => index !== blockIndex,
+                    );
+                    await updateGardenStack(
+                        gardenIdNumber,
+                        {
+                            x: sourcePosition.x,
+                            y: sourcePosition.z,
+                            blocks: nextSourceBlocks,
+                        },
+                        tx,
+                    );
+                    await storageDeleteGardenBlock(
+                        gardenIdNumber,
+                        block.id,
+                        tx,
+                    );
+                    await addGardenBoxInventoryItem(
+                        accountId,
+                        gardenIdNumber,
+                        gardenBoxBlockId,
+                        {
+                            entityTypeName: 'block',
+                            entityId: inventoryEntityId,
+                            amount: 1,
+                            source: 'gardenBox:drop',
+                        },
+                        tx,
+                    );
+                    return { ok: true } as const;
+                });
+            } catch (error) {
+                if (error instanceof GardenBoxInventoryLimitError) {
+                    return context.json({ error: error.message }, 400);
                 }
 
-                const nextSourceBlocks = currentSourceStack.blocks.filter(
-                    (_sourceBlockId, index) => index !== blockIndex,
-                );
-                await updateGardenStack(
-                    gardenIdNumber,
-                    {
-                        x: sourcePosition.x,
-                        y: sourcePosition.z,
-                        blocks: nextSourceBlocks,
-                    },
-                    tx,
-                );
-                await storageDeleteGardenBlock(gardenIdNumber, block.id, tx);
-                await addGardenBoxInventoryItem(
-                    accountId,
-                    gardenIdNumber,
-                    gardenBoxBlockId,
-                    {
-                        entityTypeName: 'block',
-                        entityId: inventoryEntityId,
-                        amount: 1,
-                        source: 'gardenBox:drop',
-                    },
-                    tx,
-                );
-                return { ok: true } as const;
-            });
+                throw error;
+            }
             if (!result.ok) {
                 return context.json({ error: result.error }, result.status);
             }

--- a/apps/api/app/api/[...route]/inventoryRoutes.ts
+++ b/apps/api/app/api/[...route]/inventoryRoutes.ts
@@ -3,6 +3,7 @@ import {
     createGardenBlock,
     createGardenStack,
     type EntityStandardized,
+    GardenBoxInventoryLimitError,
     getEntitiesFormatted,
     getGarden,
     getGardenBlock,
@@ -213,12 +214,21 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Garden box not found' }, 404);
             }
 
-            const inventory = await setGardenBoxInventory(
-                accountId,
-                gardenId,
-                blockId,
-                items satisfies InventoryItemInput[],
-            );
+            let inventory: InventoryItem[];
+            try {
+                inventory = await setGardenBoxInventory(
+                    accountId,
+                    gardenId,
+                    blockId,
+                    items satisfies InventoryItemInput[],
+                );
+            } catch (error) {
+                if (error instanceof GardenBoxInventoryLimitError) {
+                    return context.json({ error: error.message }, 400);
+                }
+
+                throw error;
+            }
             const [enrichedItems] = await enrichInventoryItems([inventory]);
 
             return context.json({

--- a/packages/game/src/gardenBoxInventoryLimits.ts
+++ b/packages/game/src/gardenBoxInventoryLimits.ts
@@ -1,0 +1,61 @@
+export const GARDEN_BOX_BLOCK_STACK_LIMIT = 6;
+export const GARDEN_BOX_BLOCK_STACK_SIZE = 10;
+
+type GardenBoxInventoryItem = {
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+};
+
+export function getGardenBoxInventoryCapacity(items: GardenBoxInventoryItem[]) {
+    const blockTotals = new Map<string, number>();
+
+    for (const item of items) {
+        if (item.entityTypeName !== 'block' || item.amount <= 0) {
+            continue;
+        }
+
+        blockTotals.set(
+            item.entityId,
+            (blockTotals.get(item.entityId) ?? 0) + item.amount,
+        );
+    }
+
+    const stackCount = blockTotals.size;
+    const blockCount = Array.from(blockTotals.values()).reduce(
+        (total, amount) => total + amount,
+        0,
+    );
+
+    return {
+        stackCount,
+        maxStacks: GARDEN_BOX_BLOCK_STACK_LIMIT,
+        blockCount,
+        maxBlocks: GARDEN_BOX_BLOCK_STACK_LIMIT * GARDEN_BOX_BLOCK_STACK_SIZE,
+    };
+}
+
+export function canAddBlockToGardenBox(
+    items: GardenBoxInventoryItem[],
+    entityId: string,
+) {
+    const blockTotals = new Map<string, number>();
+
+    for (const item of items) {
+        if (item.entityTypeName !== 'block' || item.amount <= 0) {
+            continue;
+        }
+
+        blockTotals.set(
+            item.entityId,
+            (blockTotals.get(item.entityId) ?? 0) + item.amount,
+        );
+    }
+
+    const currentAmount = blockTotals.get(entityId) ?? 0;
+    if (currentAmount > 0) {
+        return currentAmount < GARDEN_BOX_BLOCK_STACK_SIZE;
+    }
+
+    return blockTotals.size < GARDEN_BOX_BLOCK_STACK_LIMIT;
+}

--- a/packages/game/src/hooks/useGardenBoxStoreBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxStoreBlock.ts
@@ -1,5 +1,6 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { canAddBlockToGardenBox } from '../gardenBoxInventoryLimits';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
@@ -41,6 +42,10 @@ function incrementInventoryItem(
     args: StoreBlockArgs,
 ) {
     const entityId = args.blockEntityId ?? args.blockName;
+    if (!canAddBlockToGardenBox(items, entityId)) {
+        return items;
+    }
+
     const existingItemIndex = items.findIndex(
         (item) => item.entityTypeName === 'block' && item.entityId === entityId,
     );

--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -14,6 +14,10 @@ import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import {
+    GARDEN_BOX_BLOCK_STACK_LIMIT,
+    getGardenBoxInventoryCapacity,
+} from '../gardenBoxInventoryLimits';
 import { useBlockData } from '../hooks/useBlockData';
 import { useGardenBoxPlaceBlock } from '../hooks/useGardenBoxPlaceBlock';
 import { useInventory } from '../hooks/useInventory';
@@ -27,7 +31,7 @@ import {
 } from '../useUrlState';
 import { HudCard } from './components/HudCard';
 
-const GRID_SIZE = 24; // 3x4 grid
+const BACKPACK_GRID_SIZE = 24;
 
 type InventoryItemData = {
     entityTypeName: string;
@@ -111,7 +115,7 @@ function inventoryItemDisplayName({
 }
 
 function resolveBlockImageName(item?: InventoryItemData) {
-    if (!item || item.entityTypeName !== 'block') {
+    if (item?.entityTypeName !== 'block') {
         return null;
     }
 
@@ -205,6 +209,7 @@ function InventoryItemCell({
 function InventoryItemsGrid({
     items,
     keyPrefix,
+    minSlots = BACKPACK_GRID_SIZE,
     operationLookup,
     sortData,
     blockData,
@@ -212,6 +217,7 @@ function InventoryItemsGrid({
 }: {
     items: InventoryItemData[];
     keyPrefix: string;
+    minSlots?: number;
     operationLookup: Map<string, OperationData>;
     sortData?: PlantSortData[];
     blockData?: BlockData[] | null;
@@ -219,11 +225,11 @@ function InventoryItemsGrid({
 }) {
     const gridItems = useMemo(() => {
         const result: (InventoryItemData | null)[] = [...items];
-        while (result.length < GRID_SIZE) {
+        while (result.length < minSlots) {
             result.push(null);
         }
         return result;
-    }, [items]);
+    }, [items, minSlots]);
 
     return (
         <div className="grid grid-cols-6 gap-1">
@@ -450,7 +456,7 @@ function GardenBoxInventoryGroup({
     blockData?: BlockData[] | null;
     onItemClick: (item: InventoryItemData) => void;
 }) {
-    const itemTotal = inventoryItemTotal(gardenBox.items);
+    const capacity = getGardenBoxInventoryCapacity(gardenBox.items);
 
     return (
         <Stack spacing={3} className="rounded-lg border bg-card/50 p-3">
@@ -467,7 +473,11 @@ function GardenBoxInventoryGroup({
                         Vrtna kutija {index + 1}
                     </Typography>
                     <Typography level="body3" secondary>
-                        {[gardenBox.gardenName, `${itemTotal} predmeta`]
+                        {[
+                            gardenBox.gardenName,
+                            `${capacity.stackCount.toString()}/${capacity.maxStacks.toString()} vrsta`,
+                            `${capacity.blockCount.toString()}/${capacity.maxBlocks.toString()} blokova`,
+                        ]
                             .filter(Boolean)
                             .join(' · ')}
                     </Typography>
@@ -476,6 +486,7 @@ function GardenBoxInventoryGroup({
             <InventoryItemsGrid
                 items={gardenBox.items}
                 keyPrefix={`garden-box-${gardenBox.gardenId}-${gardenBox.blockId}`}
+                minSlots={GARDEN_BOX_BLOCK_STACK_LIMIT}
                 operationLookup={operationLookup}
                 sortData={sortData}
                 blockData={blockData}

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -9,12 +9,27 @@ type TransactionClient = Parameters<
 >[0];
 type DatabaseClient = TransactionClient | StorageClient;
 
+export const GARDEN_BOX_BLOCK_STACK_LIMIT = 6;
+export const GARDEN_BOX_BLOCK_STACK_SIZE = 10;
+
 type InventoryItemEventPayload = {
     entityTypeName: string;
     entityId: string;
     amount: number;
     source?: string | null;
 };
+
+type InventoryItemFields = Pick<
+    InventoryItemEventPayload,
+    'entityTypeName' | 'entityId' | 'amount'
+>;
+
+export class GardenBoxInventoryLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'GardenBoxInventoryLimitError';
+    }
+}
 
 const INVENTORY_PREFIX = 'inventory:';
 
@@ -61,6 +76,59 @@ function inventoryItemKey(
     item: Pick<InventoryItem, 'entityTypeName' | 'entityId'>,
 ) {
     return `${item.entityTypeName}-${item.entityId}`;
+}
+
+function normalizeGardenBoxInventoryItems(items: InventoryItemFields[]) {
+    const totals = new Map<string, InventoryItemFields>();
+
+    for (const item of items) {
+        if (item.amount <= 0) {
+            continue;
+        }
+
+        const key = inventoryItemKey(item);
+        const existing = totals.get(key);
+        totals.set(key, {
+            entityTypeName: item.entityTypeName,
+            entityId: item.entityId,
+            amount: (existing?.amount ?? 0) + item.amount,
+        });
+    }
+
+    return Array.from(totals.values());
+}
+
+function validateGardenBoxInventoryItems(items: InventoryItemFields[]) {
+    const normalizedItems = normalizeGardenBoxInventoryItems(items);
+    const nonBlockItem = normalizedItems.find(
+        (item) => item.entityTypeName !== 'block',
+    );
+    if (nonBlockItem) {
+        throw new GardenBoxInventoryLimitError(
+            'Vrtna kutija može sadržavati samo blokove.',
+        );
+    }
+
+    if (normalizedItems.length > GARDEN_BOX_BLOCK_STACK_LIMIT) {
+        throw new GardenBoxInventoryLimitError(
+            `Vrtna kutija može sadržavati najviše ${GARDEN_BOX_BLOCK_STACK_LIMIT.toString()} različitih blokova.`,
+        );
+    }
+
+    const overfilledItem = normalizedItems.find(
+        (item) => item.amount > GARDEN_BOX_BLOCK_STACK_SIZE,
+    );
+    if (overfilledItem) {
+        throw new GardenBoxInventoryLimitError(
+            `U vrtnoj kutiji može biti najviše ${GARDEN_BOX_BLOCK_STACK_SIZE.toString()} blokova iste vrste.`,
+        );
+    }
+}
+
+async function lockInventoryAggregate(aggregateId: string, db: DatabaseClient) {
+    await db.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${aggregateId}));`,
+    );
 }
 
 async function getInventoryForAggregateIds(
@@ -156,15 +224,34 @@ export async function addGardenBoxInventoryItem(
     gardenId: number,
     blockId: string,
     payload: InventoryItemEventPayload,
-    db: DatabaseClient = storage(),
+    db?: DatabaseClient,
 ) {
-    await createEvent(
-        knownEvents.inventory.addedV1(
-            getGardenBoxInventoryAggregateId({ accountId, gardenId, blockId }),
-            payload,
-        ),
+    if (!db) {
+        await storage().transaction((tx) =>
+            addGardenBoxInventoryItem(
+                accountId,
+                gardenId,
+                blockId,
+                payload,
+                tx,
+            ),
+        );
+        return;
+    }
+
+    const aggregateId = getGardenBoxInventoryAggregateId({
+        accountId,
+        gardenId,
+        blockId,
+    });
+    await lockInventoryAggregate(aggregateId, db);
+    const currentInventory = await getInventoryForAggregateIds(
+        [aggregateId],
         db,
     );
+    validateGardenBoxInventoryItems([...currentInventory, payload]);
+
+    await createEvent(knownEvents.inventory.addedV1(aggregateId, payload), db);
 }
 
 export async function consumeGardenBoxInventoryItem(
@@ -225,10 +312,10 @@ export async function setGardenBoxInventory(
         });
     }
 
+    validateGardenBoxInventoryItems(Array.from(requestedTotals.values()));
+
     await storage().transaction(async (tx) => {
-        await tx.execute(
-            sql`select pg_advisory_xact_lock(hashtext(${aggregateId}));`,
-        );
+        await lockInventoryAggregate(aggregateId, tx);
 
         const currentInventory = await getInventoryForAggregateIds(
             [aggregateId],

--- a/packages/storage/tests/inventoryRepo.node.spec.ts
+++ b/packages/storage/tests/inventoryRepo.node.spec.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    addGardenBoxInventoryItem,
     addInventoryItem,
     createAccount,
     createGardenBlock,
+    GARDEN_BOX_BLOCK_STACK_LIMIT,
+    GARDEN_BOX_BLOCK_STACK_SIZE,
     getGardenBoxBlocksForAccount,
     getGardenBoxInventory,
     getInventory,
@@ -47,11 +50,11 @@ test('garden box inventory is scoped per box and separate from account inventory
         amount: 5,
     });
     await setGardenBoxInventory(accountId, gardenId, firstBoxId, [
-        { entityTypeName: 'plantSort', entityId: '101', amount: 2 },
-        { entityTypeName: 'operation', entityId: '7', amount: 1 },
+        { entityTypeName: 'block', entityId: '101', amount: 2 },
+        { entityTypeName: 'block', entityId: '7', amount: 1 },
     ]);
     await setGardenBoxInventory(accountId, gardenId, secondBoxId, [
-        { entityTypeName: 'plantSort', entityId: '101', amount: 4 },
+        { entityTypeName: 'block', entityId: '101', amount: 4 },
     ]);
 
     assert.deepEqual(itemSummary(await getInventory(accountId)), [
@@ -62,15 +65,15 @@ test('garden box inventory is scoped per box and separate from account inventory
             await getGardenBoxInventory(accountId, gardenId, firstBoxId),
         ),
         [
-            { entityTypeName: 'operation', entityId: '7', amount: 1 },
-            { entityTypeName: 'plantSort', entityId: '101', amount: 2 },
+            { entityTypeName: 'block', entityId: '101', amount: 2 },
+            { entityTypeName: 'block', entityId: '7', amount: 1 },
         ],
     );
     assert.deepEqual(
         itemSummary(
             await getGardenBoxInventory(accountId, gardenId, secondBoxId),
         ),
-        [{ entityTypeName: 'plantSort', entityId: '101', amount: 4 }],
+        [{ entityTypeName: 'block', entityId: '101', amount: 4 }],
     );
 });
 
@@ -83,18 +86,108 @@ test('setGardenBoxInventory replaces contents and collapses duplicate items', as
     const boxId = await createGardenBlock(gardenId, 'GardenBox');
 
     await setGardenBoxInventory(accountId, gardenId, boxId, [
-        { entityTypeName: 'plantSort', entityId: '101', amount: 5 },
-        { entityTypeName: 'operation', entityId: '7', amount: 2 },
+        { entityTypeName: 'block', entityId: '101', amount: 5 },
+        { entityTypeName: 'block', entityId: '7', amount: 2 },
     ]);
     await setGardenBoxInventory(accountId, gardenId, boxId, [
-        { entityTypeName: 'plantSort', entityId: '101', amount: 1 },
-        { entityTypeName: 'plantSort', entityId: '101', amount: 2 },
-        { entityTypeName: 'operation', entityId: '7', amount: 0 },
+        { entityTypeName: 'block', entityId: '101', amount: 1 },
+        { entityTypeName: 'block', entityId: '101', amount: 2 },
+        { entityTypeName: 'block', entityId: '7', amount: 0 },
     ]);
 
     assert.deepEqual(
         itemSummary(await getGardenBoxInventory(accountId, gardenId, boxId)),
-        [{ entityTypeName: 'plantSort', entityId: '101', amount: 3 }],
+        [{ entityTypeName: 'block', entityId: '101', amount: 3 }],
+    );
+});
+
+test('setGardenBoxInventory enforces garden box block stack limits', async () => {
+    createTestDb();
+
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const boxId = await createGardenBlock(gardenId, 'GardenBox');
+
+    await setGardenBoxInventory(
+        accountId,
+        gardenId,
+        boxId,
+        Array.from({ length: GARDEN_BOX_BLOCK_STACK_LIMIT }, (_, index) => ({
+            entityTypeName: 'block',
+            entityId: `block-${index.toString()}`,
+            amount: GARDEN_BOX_BLOCK_STACK_SIZE,
+        })),
+    );
+
+    await assert.rejects(
+        setGardenBoxInventory(accountId, gardenId, boxId, [
+            ...Array.from(
+                { length: GARDEN_BOX_BLOCK_STACK_LIMIT + 1 },
+                (_, index) => ({
+                    entityTypeName: 'block',
+                    entityId: `block-${index.toString()}`,
+                    amount: 1,
+                }),
+            ),
+        ]),
+        /najviše 6 različitih blokova/u,
+    );
+
+    await assert.rejects(
+        setGardenBoxInventory(accountId, gardenId, boxId, [
+            {
+                entityTypeName: 'block',
+                entityId: 'block-1',
+                amount: GARDEN_BOX_BLOCK_STACK_SIZE + 1,
+            },
+        ]),
+        /najviše 10 blokova iste vrste/u,
+    );
+
+    await assert.rejects(
+        setGardenBoxInventory(accountId, gardenId, boxId, [
+            { entityTypeName: 'plantSort', entityId: '101', amount: 1 },
+        ]),
+        /samo blokove/u,
+    );
+});
+
+test('addGardenBoxInventoryItem rejects a seventh stack or an eleventh block in one stack', async () => {
+    createTestDb();
+
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const boxId = await createGardenBlock(gardenId, 'GardenBox');
+
+    await setGardenBoxInventory(
+        accountId,
+        gardenId,
+        boxId,
+        Array.from({ length: GARDEN_BOX_BLOCK_STACK_LIMIT }, (_, index) => ({
+            entityTypeName: 'block',
+            entityId: `block-${index.toString()}`,
+            amount: index === 0 ? GARDEN_BOX_BLOCK_STACK_SIZE : 1,
+        })),
+    );
+
+    await assert.rejects(
+        addGardenBoxInventoryItem(accountId, gardenId, boxId, {
+            entityTypeName: 'block',
+            entityId: 'new-block',
+            amount: 1,
+        }),
+        /najviše 6 različitih blokova/u,
+    );
+
+    await assert.rejects(
+        addGardenBoxInventoryItem(accountId, gardenId, boxId, {
+            entityTypeName: 'block',
+            entityId: 'block-0',
+            amount: 1,
+        }),
+        /najviše 10 blokova iste vrste/u,
     );
 });
 


### PR DESCRIPTION
## Summary
- Enforce Garden Box inventory limits at the storage, API, and game UI layers
- Update optimistic inventory handling and HUD capacity copy to reflect 6 stacks of 10 blocks each
- Refresh the live Garden Box block description with clearer usage and limit details

## Testing
- Unit tests added/updated for Garden Box inventory limits and block-only validation
- Local UI and API validation already passed in the workspace for the affected areas