### PR TITLE
Show operation duration and EUR per minute on farmer prices

### DIFF
--- a/apps/app/app/admin/farmers/prices/PriceForm.tsx
+++ b/apps/app/app/admin/farmers/prices/PriceForm.tsx
@@ -41,12 +41,18 @@ function formatPriceRange(priceRange: PriceRange) {
     return `${formatPrice(priceRange.min)} - ${formatPrice(priceRange.max)}`;
 }
 
+function formatDurationMinutes(durationMinutes: number) {
+    const rounded = Math.ceil(Math.max(0, durationMinutes));
+    return `${rounded} min`;
+}
+
 export function PriceRow({
     farmId,
     entityTypeName,
     entityId,
     label,
     sublabel,
+    durationMinutes,
     userFacingPrice,
     userFacingPriceRange,
     userFacingPriceNote,
@@ -58,6 +64,7 @@ export function PriceRow({
     entityId?: number | null;
     label: string;
     sublabel?: string;
+    durationMinutes?: number;
     userFacingPrice?: number | null;
     userFacingPriceRange?: PriceRange | null;
     userFacingPriceNote?: string;
@@ -73,6 +80,13 @@ export function PriceRow({
     const comparisonUserFacingPrice = hasUserFacingPrice
         ? userFacingPrice
         : userFacingPriceRange?.min;
+    const hasDuration = typeof durationMinutes === 'number';
+    const hasBillableDuration =
+        typeof durationMinutes === 'number' && durationMinutes > 0;
+    const pricePerMinute =
+        farmerPrice !== null && hasBillableDuration
+            ? farmerPrice / durationMinutes
+            : null;
     const userFacingPriceIsMissing =
         userFacingPrice === null || userFacingPriceRange === null;
     const showFarmerPriceWarning =
@@ -176,6 +190,49 @@ export function PriceRow({
                         </Typography>
                     )}
             </div>
+            {hasDuration && (
+                <div className="min-w-32 shrink-0">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Vrijeme
+                    </Typography>
+                    {hasBillableDuration ? (
+                        <Typography
+                            level="body2"
+                            semiBold
+                            className="tabular-nums"
+                        >
+                            {formatDurationMinutes(durationMinutes)}
+                        </Typography>
+                    ) : (
+                        <Chip color="warning" size="sm" variant="soft">
+                            Nije definirano
+                        </Chip>
+                    )}
+                </div>
+            )}
+            {hasDuration && (
+                <div className="min-w-36 shrink-0">
+                    <Typography level="body3" className="text-muted-foreground">
+                        Farmer EUR/min
+                    </Typography>
+                    {pricePerMinute === null ? (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            -
+                        </Typography>
+                    ) : (
+                        <Typography
+                            level="body2"
+                            semiBold
+                            className="tabular-nums"
+                        >
+                            {formatPrice(pricePerMinute)} / min
+                        </Typography>
+                    )}
+                </div>
+            )}
             <Row
                 spacing={2}
                 className="w-full shrink-0 items-center justify-end lg:w-auto"

--- a/apps/app/app/admin/farmers/prices/page.tsx
+++ b/apps/app/app/admin/farmers/prices/page.tsx
@@ -193,6 +193,9 @@ export default async function AdminFarmerPricesPage() {
                                             entityId={op.id}
                                             label={op.information.label}
                                             sublabel={op.information.name}
+                                            durationMinutes={
+                                                op.attributes.duration
+                                            }
                                             userFacingPrice={
                                                 op.prices?.perOperation ?? null
                                             }


### PR DESCRIPTION
## Summary
- Show each operation’s CMS duration on `/admin/farmers/prices`.
- Add a derived farmer `EUR/min` value next to the existing per-operation price.
- Keep the change read-only and scoped to the farmer prices admin view.

## Testing
- Unit and UI test coverage for the `app` workspace passed.
- App build passed through the existing workspace build path.