### PR TITLE
Add multi-block pickup outlines and move lifted stacks together

### DIFF
--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -12,9 +12,12 @@ import {
 } from 'react';
 import { Plane, Raycaster, Vector2, Vector3 } from 'three';
 import {
+    type ActiveDragPreviewTargetOffset,
     activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
+    findActiveDragPreviewTargetOffset,
 } from '../dragPreviewIdentity';
+import { HoverOutline } from '../entities/helpers/HoverOutline';
 import { useBlockData } from '../hooks/useBlockData';
 import { useBlockMove } from '../hooks/useBlockMove';
 import { useBlockRecycle } from '../hooks/useBlockRecycle';
@@ -25,6 +28,7 @@ import {
     useParticles,
 } from '../particles/ParticleSystem';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import {
     getBlockDataByName,
@@ -57,28 +61,34 @@ type PickableGroupProps = PropsWithChildren<
 >;
 
 type PlacementPreview = {
-    blockId: string;
-    blockName: string;
     blockUnderId: string | null;
     blockUnderName: string | null;
     destination: {
         x: number;
         z: number;
     };
-    destinationIndex: number;
     hoverHeight: number;
     isRecycler: boolean;
     isBlocked: boolean;
+    segment: MovingSegment;
 };
 
 type ResolvedPlacementPreview = {
     relative: Vector3;
     previewHoverHeight: number;
-    sourceHoverHeight: number;
     hoveredGardenBoxBlockId: string | null;
     canStoreInGardenBox: boolean;
     nextIsOverRecycler: boolean;
     nextIsBlocked: boolean;
+    targetOffsets: ActiveDragPreviewTargetOffset[];
+};
+
+type MovingSegment = {
+    sourceStack: Stack;
+    sourceStartIndex: number;
+    blocks: Stack['blocks'];
+    baseHeight: number;
+    canRecycle: boolean;
 };
 
 type PickupAnchorOffset = {
@@ -185,6 +195,7 @@ export function PickableGroup({
 
     const [isBlocked, setIsBlocked] = useState(false);
     const [isOverRecycler, setIsOverRecycler] = useState(false);
+    const [pickupOutlineVisible, setPickupOutlineVisible] = useState(false);
     const moveBlock = useBlockMove();
     const recycleBlock = useBlockRecycle();
     const storeBlockInGardenBox = useGardenBoxStoreBlock();
@@ -226,24 +237,17 @@ export function PickableGroup({
         blockIndex,
         stackPosition: stack.position,
     });
-    const attachedPreviewTarget = attachedPlacement
-        ? createActiveDragPreviewTarget({
-              blockId: attachedPlacement.candidateBlock.id,
-              blockIndex: attachedPlacement.candidateBlockIndex,
-              stackPosition: attachedPlacement.candidateStack.position,
-          })
-        : null;
-
     const isPreviewSource = activeDragPreviewTargetMatches(
         activeDragPreview?.source,
         activePreviewTarget,
     );
-    const isPreviewAttached = activeDragPreviewTargetMatches(
-        activeDragPreview?.attached,
+    const activePreviewTargetOffset = findActiveDragPreviewTargetOffset(
+        activeDragPreview?.targets,
         activePreviewTarget,
     );
-    const wasPreviewAttached = useRef(false);
-    const shouldResetAttachedOnPreviewEnd = useRef(false);
+    const isPreviewTarget = Boolean(activePreviewTargetOffset);
+    const wasPreviewTarget = useRef(false);
+    const shouldResetTargetOnPreviewEnd = useRef(false);
     const previousStackPosition = useRef({
         x: stack.position.x,
         z: stack.position.z,
@@ -273,28 +277,35 @@ export function PickableGroup({
             return;
         }
 
-        if (isPreviewAttached && activeDragPreview) {
-            wasPreviewAttached.current = true;
-            shouldResetAttachedOnPreviewEnd.current =
-                activeDragPreview.isBlocked;
+        if (activePreviewTargetOffset && activeDragPreview) {
+            wasPreviewTarget.current = true;
+            shouldResetTargetOnPreviewEnd.current =
+                activeDragPreview.isBlocked ||
+                (Math.abs(activeDragPreview.relative.x) <= 0.0001 &&
+                    Math.abs(activeDragPreview.relative.z) <= 0.0001);
             dragSpringsApi.start({
                 internalPosition: [
                     activeDragPreview.relative.x,
-                    activeDragPreview.attachedHoverHeight + pickupLift,
+                    activePreviewTargetOffset.hoverHeight + pickupLift,
                     activeDragPreview.relative.z,
                 ],
             });
             return;
         }
 
-        if (!activeDragPreview && wasPreviewAttached.current) {
-            wasPreviewAttached.current = false;
-            if (shouldResetAttachedOnPreviewEnd.current) {
+        if (!activeDragPreview && wasPreviewTarget.current) {
+            wasPreviewTarget.current = false;
+            if (shouldResetTargetOnPreviewEnd.current) {
                 dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
             }
-            shouldResetAttachedOnPreviewEnd.current = false;
+            shouldResetTargetOnPreviewEnd.current = false;
         }
-    }, [activeDragPreview, isPreviewAttached, isPreviewSource, dragSpringsApi]);
+    }, [
+        activeDragPreview,
+        activePreviewTargetOffset,
+        isPreviewSource,
+        dragSpringsApi,
+    ]);
 
     useEffect(() => {
         return () => {
@@ -322,40 +333,90 @@ export function PickableGroup({
         );
     }
 
-    function resolvePlacementPreviewForRelative(relative: Vector3) {
-        if (!garden || !blocksData || blockIndex < 0) {
-            return null;
+    function getMovingSegments(): MovingSegment[] {
+        if (blockIndex < 0) {
+            return [];
         }
 
-        const movingPlacements = [
+        const sourceBlocks = stack.blocks.slice(blockIndex);
+        if (sourceBlocks.length === 0) {
+            return [];
+        }
+
+        const attachedBlocks = attachedPlacement
+            ? attachedPlacement.candidateStack.blocks.slice(
+                  attachedPlacement.candidateBlockIndex,
+              )
+            : [];
+        const canRecycleSelection =
+            canRecycle &&
+            sourceBlocks.length === 1 &&
+            (!attachedPlacement || attachedBlocks.length === 1);
+
+        return [
             {
-                blockId: block.id,
-                blockName: block.name,
                 sourceStack: stack,
-                currentHeight: currentStackHeight ?? 0,
-                canRecycle,
+                sourceStartIndex: blockIndex,
+                blocks: sourceBlocks,
+                baseHeight: currentStackHeight ?? 0,
+                canRecycle: canRecycleSelection,
             },
-            ...(attachedPlacement
+            ...(attachedPlacement && attachedBlocks.length > 0
                 ? [
                       {
-                          blockId: attachedPlacement.candidateBlock.id,
-                          blockName: attachedPlacement.candidateBlock.name,
                           sourceStack: attachedPlacement.candidateStack,
-                          currentHeight: attachedCurrentStackHeight,
+                          sourceStartIndex:
+                              attachedPlacement.candidateBlockIndex,
+                          blocks: attachedBlocks,
+                          baseHeight: attachedCurrentStackHeight,
                           canRecycle: false,
                       },
                   ]
                 : []),
         ];
+    }
+
+    function createTargetOffsets(
+        placementPreviews: PlacementPreview[],
+        hoverHeight: number,
+    ): ActiveDragPreviewTargetOffset[] {
+        return placementPreviews.flatMap((preview) =>
+            preview.segment.blocks.map((segmentBlock, segmentBlockOffset) => ({
+                ...createActiveDragPreviewTarget({
+                    blockId: segmentBlock.id,
+                    blockIndex:
+                        preview.segment.sourceStartIndex + segmentBlockOffset,
+                    stackPosition: preview.segment.sourceStack.position,
+                }),
+                hoverHeight,
+            })),
+        );
+    }
+
+    function resolvePlacementPreviewForRelative(relative: Vector3) {
+        if (!garden || !blocksData || blockIndex < 0) {
+            return null;
+        }
+
+        const movingSegments = getMovingSegments();
+        if (movingSegments.length === 0) {
+            return null;
+        }
         const movingBlockIds = new Set(
-            movingPlacements.map((placement) => placement.blockId),
+            movingSegments.flatMap((segment) =>
+                segment.blocks.map((segmentBlock) => segmentBlock.id),
+            ),
         );
 
-        const placementPreviews: PlacementPreview[] = movingPlacements.map(
-            (placement) => {
+        const placementPreviews: PlacementPreview[] = movingSegments.flatMap(
+            (segment) => {
+                if (!segment.blocks[0]) {
+                    return [];
+                }
+
                 const destination = {
-                    x: placement.sourceStack.position.x + relative.x,
-                    z: placement.sourceStack.position.z + relative.z,
+                    x: segment.sourceStack.position.x + relative.x,
+                    z: segment.sourceStack.position.z + relative.z,
                 };
                 const destinationStack = getStack(destination);
                 const destinationBlocks =
@@ -373,35 +434,38 @@ export function PickableGroup({
                     ? getBlockDataByName(blocksData, blockUnder.name)
                     : null;
                 const isRecycler =
-                    placement.canRecycle &&
+                    segment.canRecycle &&
                     (blockUnderData?.functions?.recycler ?? false);
                 const isStackable =
                     blockUnderData?.attributes?.stackable ?? true;
                 const hoverHeight =
                     getStackHeight(blocksData, destinationWithoutMoving) -
-                    placement.currentHeight;
+                    segment.baseHeight;
 
-                return {
-                    blockId: placement.blockId,
-                    blockName: placement.blockName,
-                    blockUnderId: blockUnder?.id ?? null,
-                    blockUnderName: blockUnder?.name ?? null,
-                    destination,
-                    destinationIndex: destinationBlocks.length,
-                    hoverHeight,
-                    isRecycler,
-                    isBlocked: !isStackable && !isRecycler,
-                };
+                return [
+                    {
+                        blockUnderId: blockUnder?.id ?? null,
+                        blockUnderName: blockUnder?.name ?? null,
+                        destination,
+                        hoverHeight,
+                        isRecycler,
+                        isBlocked: !isStackable && !isRecycler,
+                        segment,
+                    },
+                ];
             },
         );
 
+        const movedRaisedBedPreviews = placementPreviews.filter((preview) =>
+            preview.segment.blocks.some(
+                (segmentBlock) => segmentBlock.name === 'Raised_Bed',
+            ),
+        );
         const movedRaisedBedPreviewByPosition = new Map(
-            placementPreviews
-                .filter((preview) => preview.blockName === 'Raised_Bed')
-                .map((preview) => [
-                    `${preview.destination.x}|${preview.destination.z}`,
-                    preview,
-                ]),
+            movedRaisedBedPreviews.map((preview) => [
+                `${preview.destination.x}|${preview.destination.z}`,
+                preview,
+            ]),
         );
 
         function getExternalRaisedBedBlockAtPosition(x: number, z: number) {
@@ -448,9 +512,8 @@ export function PickableGroup({
             });
         }
 
-        const raisedBedPlacementBlocked = placementPreviews
-            .filter((preview) => preview.blockName === 'Raised_Bed')
-            .some((preview) => {
+        const raisedBedPlacementBlocked = movedRaisedBedPreviews.some(
+            (preview) => {
                 const neighbors = [
                     { x: preview.destination.x - 1, z: preview.destination.z },
                     { x: preview.destination.x + 1, z: preview.destination.z },
@@ -470,10 +533,7 @@ export function PickableGroup({
                     const movedNeighbor = movedRaisedBedPreviewByPosition.get(
                         `${neighbor.x}|${neighbor.z}`,
                     );
-                    if (
-                        movedNeighbor &&
-                        movedNeighbor.blockName === 'Raised_Bed'
-                    ) {
+                    if (movedNeighbor) {
                         raisedBedNeighborCount += 1;
                         continue;
                     }
@@ -502,15 +562,10 @@ export function PickableGroup({
 
                 const excludedPositions = new Set<string>([
                     `${preview.destination.x}|${preview.destination.z}`,
-                    ...placementPreviews
-                        .filter(
-                            (candidatePreview) =>
-                                candidatePreview.blockName === 'Raised_Bed',
-                        )
-                        .map(
-                            (candidatePreview) =>
-                                `${candidatePreview.destination.x}|${candidatePreview.destination.z}`,
-                        ),
+                    ...movedRaisedBedPreviews.map(
+                        (candidatePreview) =>
+                            `${candidatePreview.destination.x}|${candidatePreview.destination.z}`,
+                    ),
                 ]);
 
                 return hasExternalRaisedBedNeighbor(
@@ -518,24 +573,17 @@ export function PickableGroup({
                     externalNeighbor.z,
                     excludedPositions,
                 );
-            });
+            },
+        );
 
         const sourcePreview = placementPreviews[0];
         if (!sourcePreview) {
             return null;
         }
 
-        const attachedPreview = attachedPlacement
-            ? placementPreviews.find(
-                  (preview) =>
-                      preview.blockId === attachedPlacement.candidateBlock.id,
-              )
-            : null;
         const sourceHoverHeight = sourcePreview.hoverHeight;
-        const attachedHoverHeight = attachedPreview?.hoverHeight ?? 0;
         const previewHoverHeight = Math.max(
-            sourceHoverHeight,
-            attachedHoverHeight,
+            ...placementPreviews.map((preview) => preview.hoverHeight),
         );
         const hoveredGardenBoxBlockId =
             placementPreviews.find(
@@ -543,12 +591,14 @@ export function PickableGroup({
             )?.blockUnderId ?? null;
         const canStoreInGardenBox =
             hoveredGardenBoxBlockId !== null &&
-            block.name !== 'GardenBox' &&
-            block.name !== 'Raised_Bed' &&
-            attachedPlacement === null;
-        const heightsMismatch =
-            attachedPlacement !== null &&
-            Math.abs(sourceHoverHeight - attachedHoverHeight) > 0.0001;
+            sourcePreview.segment.blocks.length === 1 &&
+            sourcePreview.segment.blocks[0]?.name !== 'GardenBox' &&
+            sourcePreview.segment.blocks[0]?.name !== 'Raised_Bed' &&
+            placementPreviews.length === 1;
+        const heightsMismatch = placementPreviews.some(
+            (preview) =>
+                Math.abs(sourceHoverHeight - preview.hoverHeight) > 0.0001,
+        );
         const nextIsOverRecycler = sourcePreview.isRecycler;
         const nextIsBlocked = nextIsOverRecycler
             ? false
@@ -561,11 +611,14 @@ export function PickableGroup({
         return {
             relative: relative.clone(),
             previewHoverHeight,
-            sourceHoverHeight,
             hoveredGardenBoxBlockId,
             canStoreInGardenBox,
             nextIsOverRecycler,
             nextIsBlocked,
+            targetOffsets: createTargetOffsets(
+                placementPreviews,
+                previewHoverHeight,
+            ),
         };
     }
 
@@ -729,6 +782,7 @@ export function PickableGroup({
         setActiveDragPreview(null);
         setIsBlocked(false);
         setIsOverRecycler(false);
+        setPickupOutlineVisible(false);
         setPickupBlock(null);
     }
 
@@ -742,6 +796,7 @@ export function PickableGroup({
         clearSessionTimers(session);
         pointerSession.current = null;
         cleanupPointerSessionListeners();
+        setPickupOutlineVisible(false);
         if (resetSpring) {
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
         }
@@ -758,14 +813,12 @@ export function PickableGroup({
         );
         setActiveDragPreview({
             source: activePreviewTarget,
-            attached: attachedPreviewTarget,
+            targets: preview.targetOffsets,
             hoveredGardenBoxBlockId: preview.hoveredGardenBoxBlockId,
             relative: {
                 x: preview.relative.x,
                 z: preview.relative.z,
             },
-            sourceHoverHeight: preview.sourceHoverHeight,
-            attachedHoverHeight: preview.previewHoverHeight,
             isBlocked: preview.nextIsBlocked,
             isOverRecycler: preview.nextIsOverRecycler,
         });
@@ -800,6 +853,7 @@ export function PickableGroup({
         session.hasDraggedAfterPickup = false;
         session.latestPreview = preview;
         setIsDragging(false);
+        setPickupOutlineVisible(true);
         setPickupBlock(block);
         disturbAnimals({
             sourceBlockId: block.id,
@@ -918,38 +972,29 @@ export function PickableGroup({
         dropSound.play();
         triggerPlaceHaptic();
         spawn(resolveBlockParticleType(block.name), previewDropPosition, 12);
-        const sourcePosition = {
-            x: stack.position.x,
-            z: stack.position.z,
-        };
-        const destinationPosition = {
-            x: stack.position.x + relative.x,
-            z: stack.position.z + relative.z,
-        };
+        const moveRequests = getMovingSegments().flatMap((segment) =>
+            segment.blocks.map((segmentBlock) => ({
+                sourcePosition: {
+                    x: segment.sourceStack.position.x,
+                    z: segment.sourceStack.position.z,
+                },
+                destinationPosition: {
+                    x: segment.sourceStack.position.x + relative.x,
+                    z: segment.sourceStack.position.z + relative.z,
+                },
+                blockIndex: segment.sourceStartIndex,
+                sourceBlockId: segmentBlock.id,
+            })),
+        );
+        const [primaryMoveRequest, ...additionalBlockMoves] = moveRequests;
+        if (!primaryMoveRequest) {
+            dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
+            return;
+        }
 
         await moveBlock.mutateAsync({
-            sourcePosition,
-            destinationPosition,
-            blockIndex,
-            sourceBlockId: block.id,
-            attached: attachedPlacement
-                ? {
-                      sourcePosition: {
-                          x: attachedPlacement.candidateStack.position.x,
-                          z: attachedPlacement.candidateStack.position.z,
-                      },
-                      destinationPosition: {
-                          x:
-                              attachedPlacement.candidateStack.position.x +
-                              relative.x,
-                          z:
-                              attachedPlacement.candidateStack.position.z +
-                              relative.z,
-                      },
-                      blockIndex: attachedPlacement.candidateBlockIndex,
-                      sourceBlockId: attachedPlacement.candidateBlock.id,
-                  }
-                : undefined,
+            ...primaryMoveRequest,
+            additionalBlocks: additionalBlockMoves,
         });
     }
 
@@ -1019,6 +1064,7 @@ export function PickableGroup({
                     scale: 1,
                 });
             }
+            setPickupOutlineVisible(false);
             return;
         }
 
@@ -1096,6 +1142,7 @@ export function PickableGroup({
             }
 
             activeSession.hintVisible = true;
+            setPickupOutlineVisible(true);
             dragSpringsApi.start({
                 internalPosition: [0, pickupHintLift, 0],
                 scale: 1.01,
@@ -1129,13 +1176,8 @@ export function PickableGroup({
     }
 
     const isGroupedPreviewBlocked =
-        (isPreviewSource || isPreviewAttached) &&
-        (activeDragPreview?.isBlocked ?? false);
+        isPreviewTarget && (activeDragPreview?.isBlocked ?? false);
     const showBlockedIndicator = isBlocked || isGroupedPreviewBlocked;
-    const showValidIndicator =
-        (isPreviewSource || isPreviewAttached) &&
-        Boolean(activeDragPreview) &&
-        !showBlockedIndicator;
     const blockedScaleSprings = useSpring({
         scale: showBlockedIndicator ? 1 : 0,
         opacity: showBlockedIndicator ? 1 : 0,
@@ -1143,13 +1185,7 @@ export function PickableGroup({
             tension: 350,
         },
     });
-    const validScaleSprings = useSpring({
-        scale: showValidIndicator ? 1 : 0,
-        opacity: showValidIndicator ? 0.65 : 0,
-        config: {
-            tension: 350,
-        },
-    });
+    const showPickupOutline = pickupOutlineVisible || isPreviewTarget;
     const indicatorPosition: [number, number, number] = [
         stack.position.x,
         currentStackHeight,
@@ -1179,17 +1215,6 @@ export function PickableGroup({
             onClick={handleClick}
         >
             <animated.group
-                scale={validScaleSprings.scale}
-                position={indicatorPosition}
-            >
-                <Shadow
-                    color="#22c55e"
-                    opacity={0.65}
-                    colorStop={0.45}
-                    scale={1.8}
-                />
-            </animated.group>
-            <animated.group
                 scale={blockedScaleSprings.scale}
                 position={indicatorPosition}
             >
@@ -1200,7 +1225,15 @@ export function PickableGroup({
                     scale={2}
                 />
             </animated.group>
-            {children}
+            <HoverOutline
+                color="#86efac"
+                hovered={showPickupOutline}
+                opacity={0.55}
+                priority={1}
+                thickness={2}
+            >
+                {children}
+            </HoverOutline>
             {isOverRecycler && (
                 <Suspense>
                     <animated.group position={recyclePosition}>

--- a/packages/game/src/dragPreviewIdentity.ts
+++ b/packages/game/src/dragPreviewIdentity.ts
@@ -9,6 +9,10 @@ export type ActiveDragPreviewTarget = {
     stackPosition: ActiveDragPreviewStackPosition;
 };
 
+export type ActiveDragPreviewTargetOffset = ActiveDragPreviewTarget & {
+    hoverHeight: number;
+};
+
 export function createActiveDragPreviewTarget({
     blockId,
     blockIndex,
@@ -41,5 +45,14 @@ export function activeDragPreviewTargetMatches(
         target.blockIndex === candidate.blockIndex &&
         target.stackPosition.x === candidate.stackPosition.x &&
         target.stackPosition.z === candidate.stackPosition.z
+    );
+}
+
+export function findActiveDragPreviewTargetOffset(
+    targets: ActiveDragPreviewTargetOffset[] | null | undefined,
+    candidate: ActiveDragPreviewTarget,
+) {
+    return targets?.find((target) =>
+        activeDragPreviewTargetMatches(target, candidate),
     );
 }

--- a/packages/game/src/dragPreviewIdentity.unit.ts
+++ b/packages/game/src/dragPreviewIdentity.unit.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
     activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
+    findActiveDragPreviewTargetOffset,
 } from './dragPreviewIdentity';
 
 describe('activeDragPreviewTargetMatches', () => {
@@ -67,6 +68,56 @@ describe('activeDragPreviewTargetMatches', () => {
         assert.equal(
             activeDragPreviewTargetMatches(target, samePositionOtherIndex),
             false,
+        );
+    });
+});
+
+describe('findActiveDragPreviewTargetOffset', () => {
+    it('returns the matching target offset', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'block-a',
+            blockIndex: 1,
+            stackPosition: { x: 2, z: 3 },
+        });
+        const match = { ...target, hoverHeight: 1.25 };
+
+        assert.equal(
+            findActiveDragPreviewTargetOffset(
+                [
+                    {
+                        blockId: 'block-b',
+                        blockIndex: 0,
+                        stackPosition: { x: 2, z: 3 },
+                        hoverHeight: 0,
+                    },
+                    match,
+                ],
+                target,
+            ),
+            match,
+        );
+    });
+
+    it('returns undefined when no target offset matches', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'block-a',
+            blockIndex: 1,
+            stackPosition: { x: 2, z: 3 },
+        });
+
+        assert.equal(
+            findActiveDragPreviewTargetOffset(
+                [
+                    {
+                        blockId: 'block-a',
+                        blockIndex: 0,
+                        stackPosition: { x: 2, z: 3 },
+                        hoverHeight: 0,
+                    },
+                ],
+                target,
+            ),
+            undefined,
         );
     });
 });

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -113,10 +113,8 @@ export function EntityFactory({
         return null;
     }
 
-    const isTopBlock = stack.blocks.indexOf(block) === stack.blocks.length - 1;
-
     if (isInstancedInView) {
-        if (noControl || !isTopBlock || view === 'closeup') {
+        if (noControl || view === 'closeup') {
             return (
                 <EntityRenderModeDebugOverlay
                     stack={stack}
@@ -166,17 +164,9 @@ export function EntityFactory({
 
     return (
         <SelectableGroup block={block}>
-            {isTopBlock ? (
-                <PickableGroup
-                    stack={stack}
-                    block={block}
-                    noControl={noControl}
-                >
-                    {entityContent}
-                </PickableGroup>
-            ) : (
-                entityContent
-            )}
+            <PickableGroup stack={stack} block={block} noControl={noControl}>
+                {entityContent}
+            </PickableGroup>
         </SelectableGroup>
     );
 }

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -4,8 +4,8 @@ import type { Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import {
     type ActiveDragPreviewTarget,
-    activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
+    findActiveDragPreviewTargetOffset,
 } from '../dragPreviewIdentity';
 import { useBlockData } from '../hooks/useBlockData';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
@@ -50,16 +50,17 @@ function getDragPreviewOffset(
         return null;
     }
 
-    if (
-        !activeDragPreviewTargetMatches(activeDragPreview.source, target) &&
-        !activeDragPreviewTargetMatches(activeDragPreview.attached, target)
-    ) {
+    const targetOffset = findActiveDragPreviewTargetOffset(
+        activeDragPreview.targets,
+        target,
+    );
+    if (!targetOffset) {
         return null;
     }
 
     return {
         x: activeDragPreview.relative.x,
-        y: activeDragPreview.attachedHoverHeight + 0.1,
+        y: targetOffset.hoverHeight + 0.1,
         z: activeDragPreview.relative.z,
     };
 }

--- a/packages/game/src/entities/helpers/HoverOutline.tsx
+++ b/packages/game/src/entities/helpers/HoverOutline.tsx
@@ -39,6 +39,8 @@ type HoverOutlineTarget = {
     active: boolean;
     color: string;
     object: Object3D;
+    opacity: number;
+    priority: number;
     thickness: number;
 };
 
@@ -68,6 +70,7 @@ function createOutlineMaterial() {
         uniforms: {
             maskTexture: { value: null as Texture | null },
             outlineColor: { value: new Color('white') },
+            opacity: { value: 1 },
             screenMax: { value: new Vector2(1, 1) },
             screenMin: { value: new Vector2(0, 0) },
             texelSize: { value: new Vector2(1, 1) },
@@ -90,6 +93,7 @@ function createOutlineMaterial() {
         fragmentShader: `
             uniform sampler2D maskTexture;
             uniform vec3 outlineColor;
+            uniform float opacity;
             uniform vec2 texelSize;
             uniform float thickness;
 
@@ -119,7 +123,7 @@ function createOutlineMaterial() {
                     }
                 }
 
-                float alpha = expanded * (1.0 - center);
+                float alpha = expanded * (1.0 - center) * opacity;
                 if (alpha < 0.01) {
                     discard;
                 }
@@ -386,6 +390,8 @@ export function HoverOutlineProvider({ children }: PropsWithChildren) {
 type HoverOutlineProps = PropsWithChildren<{
     color?: string;
     hovered?: boolean;
+    opacity?: number;
+    priority?: number;
     thickness?: number;
 }>;
 
@@ -393,6 +399,8 @@ export function HoverOutline({
     children,
     color = 'white',
     hovered = false,
+    opacity = 1,
+    priority = 0,
     thickness = 5,
 }: HoverOutlineProps) {
     const ref = useRef<Group>(null);
@@ -412,11 +420,13 @@ export function HoverOutline({
             active: hovered,
             color,
             object: ref.current,
+            opacity,
+            priority,
             thickness: clampedThickness,
         });
 
         return () => registry.deleteTarget(id);
-    }, [clampedThickness, color, hovered, id, registry]);
+    }, [clampedThickness, color, hovered, id, opacity, priority, registry]);
 
     return <group ref={ref}>{children}</group>;
 }
@@ -442,57 +452,85 @@ export function HoverOutlineEffect() {
             return;
         }
 
-        const [firstTarget] = targets;
-        if (!firstTarget) {
-            return;
+        const targetsByStyle = new Map<string, HoverOutlineTarget[]>();
+        for (const target of targets) {
+            const key = [
+                target.priority,
+                target.color,
+                target.opacity,
+                target.thickness,
+            ].join('|');
+            targetsByStyle.set(key, [
+                ...(targetsByStyle.get(key) ?? []),
+                target,
+            ]);
         }
 
-        renderMask({
-            camera,
-            drawingBufferSize,
-            gl,
-            maskMaterial,
-            renderTarget: maskRenderTarget,
-            scene,
-            targets,
-        });
-
-        outlineOverlay.material.uniforms.maskTexture.value =
-            maskRenderTarget.texture;
-        outlineOverlay.material.uniforms.outlineColor.value.set(
-            firstTarget.color,
+        const targetGroups = Array.from(targetsByStyle.values()).sort(
+            (left, right) => {
+                const leftTarget = left[0];
+                const rightTarget = right[0];
+                return (
+                    (leftTarget?.priority ?? 0) - (rightTarget?.priority ?? 0)
+                );
+            },
         );
-        const screenBounds = getOutlineScreenBounds({
-            camera,
-            drawingBufferSize,
-            scratch: screenBoundsScratch,
-            targets,
-            thickness: firstTarget.thickness,
-        });
 
-        if (!screenBounds) {
-            return;
+        for (const targetGroup of targetGroups) {
+            const [firstTarget] = targetGroup;
+            if (!firstTarget) {
+                continue;
+            }
+
+            renderMask({
+                camera,
+                drawingBufferSize,
+                gl,
+                maskMaterial,
+                renderTarget: maskRenderTarget,
+                scene,
+                targets: targetGroup,
+            });
+
+            outlineOverlay.material.uniforms.maskTexture.value =
+                maskRenderTarget.texture;
+            outlineOverlay.material.uniforms.outlineColor.value.set(
+                firstTarget.color,
+            );
+            outlineOverlay.material.uniforms.opacity.value =
+                firstTarget.opacity;
+            const screenBounds = getOutlineScreenBounds({
+                camera,
+                drawingBufferSize,
+                scratch: screenBoundsScratch,
+                targets: targetGroup,
+                thickness: firstTarget.thickness,
+            });
+
+            if (!screenBounds) {
+                continue;
+            }
+
+            outlineOverlay.material.uniforms.screenMin.value.set(
+                screenBounds.minX,
+                screenBounds.minY,
+            );
+            outlineOverlay.material.uniforms.screenMax.value.set(
+                screenBounds.maxX,
+                screenBounds.maxY,
+            );
+            outlineOverlay.material.uniforms.texelSize.value.set(
+                1 / maskRenderTarget.width,
+                1 / maskRenderTarget.height,
+            );
+            outlineOverlay.material.uniforms.thickness.value =
+                firstTarget.thickness;
+
+            const previousAutoClear = gl.autoClear;
+            gl.autoClear = false;
+            gl.render(outlineOverlay.scene, outlineOverlay.camera);
+            gl.autoClear = previousAutoClear;
         }
-
-        outlineOverlay.material.uniforms.screenMin.value.set(
-            screenBounds.minX,
-            screenBounds.minY,
-        );
-        outlineOverlay.material.uniforms.screenMax.value.set(
-            screenBounds.maxX,
-            screenBounds.maxY,
-        );
-        outlineOverlay.material.uniforms.texelSize.value.set(
-            1 / maskRenderTarget.width,
-            1 / maskRenderTarget.height,
-        );
-        outlineOverlay.material.uniforms.thickness.value =
-            firstTarget.thickness;
-
-        const previousAutoClear = gl.autoClear;
-        gl.autoClear = false;
-        gl.render(outlineOverlay.scene, outlineOverlay.camera);
-        gl.autoClear = previousAutoClear;
     }, outlineRenderPriority);
 
     return null;

--- a/packages/game/src/hooks/useBlockMove.ts
+++ b/packages/game/src/hooks/useBlockMove.ts
@@ -2,26 +2,45 @@ import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Vector3 } from 'three';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
+import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
 const mutationKey = ['gardens', 'current', 'blockMove'];
 
-type MoveArgs = {
+type MoveBlockArgs = {
     sourcePosition: { x: number; z: number };
     destinationPosition: { x: number; z: number };
     blockIndex: number;
     sourceBlockId?: string;
-    attached?: {
-        sourcePosition: { x: number; z: number };
-        destinationPosition: { x: number; z: number };
-        blockIndex: number;
-        sourceBlockId?: string;
-    };
 };
 
+type MoveArgs = MoveBlockArgs & {
+    additionalBlocks?: MoveBlockArgs[];
+    attached?: MoveBlockArgs;
+};
+
+type MovePatchOperation = {
+    op: 'move';
+    from: string;
+    path: string;
+};
+
+function getMoveBlocks(args: MoveArgs): MoveBlockArgs[] {
+    return [
+        {
+            sourcePosition: args.sourcePosition,
+            destinationPosition: args.destinationPosition,
+            blockIndex: args.blockIndex,
+            sourceBlockId: args.sourceBlockId,
+        },
+        ...(args.additionalBlocks ?? []),
+        ...(args.attached ? [args.attached] : []),
+    ];
+}
+
 function moveBlockOptimistically(
-    stacks: { position: Vector3; blocks: { id: string }[] }[],
+    stacks: Stack[],
     sourcePosition: { x: number; z: number },
     destinationPosition: { x: number; z: number },
     blockIndex: number,
@@ -108,31 +127,18 @@ export function useBlockMove() {
 
     return useMutation({
         mutationKey,
-        mutationFn: async ({
-            sourcePosition,
-            destinationPosition,
-            blockIndex,
-            attached,
-        }: MoveArgs) => {
+        mutationFn: async (args: MoveArgs) => {
             if (!garden) {
                 throw new Error('No garden selected');
             }
             const gardenId = garden.id;
-            const operations = [
-                {
-                    op: 'move' as const,
-                    from: `/${sourcePosition.x}/${sourcePosition.z}/${blockIndex}`,
-                    path: `/${destinationPosition.x}/${destinationPosition.z}/-`,
-                },
-            ];
-
-            if (attached) {
-                operations.push({
+            const operations: MovePatchOperation[] = getMoveBlocks(args).map(
+                (moveBlock) => ({
                     op: 'move',
-                    from: `/${attached.sourcePosition.x}/${attached.sourcePosition.z}/${attached.blockIndex}`,
-                    path: `/${attached.destinationPosition.x}/${attached.destinationPosition.z}/-`,
-                });
-            }
+                    from: `/${moveBlock.sourcePosition.x}/${moveBlock.sourcePosition.z}/${moveBlock.blockIndex}`,
+                    path: `/${moveBlock.destinationPosition.x}/${moveBlock.destinationPosition.z}/-`,
+                }),
+            );
 
             await clientAuthenticated().api.gardens[':gardenId'].stacks.$patch({
                 param: {
@@ -141,39 +147,26 @@ export function useBlockMove() {
                 json: operations,
             });
         },
-        onMutate: async ({
-            sourcePosition,
-            destinationPosition,
-            blockIndex,
-            sourceBlockId,
-            attached,
-        }) => {
+        onMutate: async (args) => {
             if (!garden) {
                 return;
             }
 
             if (
-                sourcePosition.x === destinationPosition.x &&
-                sourcePosition.z === destinationPosition.z
+                args.sourcePosition.x === args.destinationPosition.x &&
+                args.sourcePosition.z === args.destinationPosition.z
             ) {
                 return;
             }
 
-            let updatedStacks = moveBlockOptimistically(
-                garden.stacks,
-                sourcePosition,
-                destinationPosition,
-                blockIndex,
-                sourceBlockId,
-            );
-
-            if (attached) {
+            let updatedStacks = garden.stacks;
+            for (const moveBlock of getMoveBlocks(args)) {
                 updatedStacks = moveBlockOptimistically(
                     updatedStacks,
-                    attached.sourcePosition,
-                    attached.destinationPosition,
-                    attached.blockIndex,
-                    attached.sourceBlockId,
+                    moveBlock.sourcePosition,
+                    moveBlock.destinationPosition,
+                    moveBlock.blockIndex,
+                    moveBlock.sourceBlockId,
                 );
             }
 

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -3,7 +3,10 @@ import { getTimes } from 'suncalc';
 import type { OrbitControls } from 'three-stdlib';
 import { createStore, useStore } from 'zustand';
 import { createGameAudio, type GameAudio } from './audio/audioMixer';
-import type { ActiveDragPreviewTarget } from './dragPreviewIdentity';
+import type {
+    ActiveDragPreviewTarget,
+    ActiveDragPreviewTargetOffset,
+} from './dragPreviewIdentity';
 import {
     type GameQualityCustomProfile,
     type GameQualitySetting,
@@ -92,14 +95,12 @@ export type WinterMode = 'summer' | 'winter' | 'holiday';
 
 export type ActiveDragPreview = {
     source: ActiveDragPreviewTarget;
-    attached: ActiveDragPreviewTarget | null;
+    targets: ActiveDragPreviewTargetOffset[];
     hoveredGardenBoxBlockId: string | null;
     relative: {
         x: number;
         z: number;
     };
-    sourceHoverHeight: number;
-    attachedHoverHeight: number;
     isBlocked: boolean;
     isOverRecycler: boolean;
 };


### PR DESCRIPTION
## Summary
- Let pickup start on any visible block in a stack and lift the full block segment above it together.
- Replace the pickup underglow with a thin faint green outline that eases in while the block is held.
- Extend drag preview and optimistic move handling so all lifted blocks move together and keep their relative offsets.

## Testing
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint` passed with existing unrelated Biome warnings in other files.
- `pnpm build --filter garden --filter www --force`
- Local Playwright smoke check on `/debug/profile/game?quality=low&hud=0` confirmed the scene rendered and the pickup outline appeared.