### PR TITLE
Fix pickup outlines and moving decoration layers

### DIFF
--- a/packages/game/src/dragPreviewIdentity.ts
+++ b/packages/game/src/dragPreviewIdentity.ts
@@ -13,6 +13,16 @@ export type ActiveDragPreviewTargetOffset = ActiveDragPreviewTarget & {
     hoverHeight: number;
 };
 
+export type ActiveDragPreviewTransform = {
+    relative: {
+        x: number;
+        z: number;
+    };
+    targets: ActiveDragPreviewTargetOffset[] | null | undefined;
+};
+
+export const activeDragPreviewLift = 0.1;
+
 export function createActiveDragPreviewTarget({
     blockId,
     blockIndex,
@@ -55,4 +65,28 @@ export function findActiveDragPreviewTargetOffset(
     return targets?.find((target) =>
         activeDragPreviewTargetMatches(target, candidate),
     );
+}
+
+export function getActiveDragPreviewTargetPositionOffset(
+    target: ActiveDragPreviewTarget,
+    activeDragPreview: ActiveDragPreviewTransform | null | undefined,
+    lift = activeDragPreviewLift,
+) {
+    if (!activeDragPreview) {
+        return null;
+    }
+
+    const targetOffset = findActiveDragPreviewTargetOffset(
+        activeDragPreview.targets,
+        target,
+    );
+    if (!targetOffset) {
+        return null;
+    }
+
+    return {
+        x: activeDragPreview.relative.x,
+        y: targetOffset.hoverHeight + lift,
+        z: activeDragPreview.relative.z,
+    };
 }

--- a/packages/game/src/dragPreviewIdentity.unit.ts
+++ b/packages/game/src/dragPreviewIdentity.unit.ts
@@ -4,6 +4,7 @@ import {
     activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
     findActiveDragPreviewTargetOffset,
+    getActiveDragPreviewTargetPositionOffset,
 } from './dragPreviewIdentity';
 
 describe('activeDragPreviewTargetMatches', () => {
@@ -118,6 +119,40 @@ describe('findActiveDragPreviewTargetOffset', () => {
                 target,
             ),
             undefined,
+        );
+    });
+});
+
+describe('getActiveDragPreviewTargetPositionOffset', () => {
+    it('returns the active drag transform for a matching target', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'block-a',
+            blockIndex: 1,
+            stackPosition: { x: 2, z: 3 },
+        });
+
+        assert.deepEqual(
+            getActiveDragPreviewTargetPositionOffset(target, {
+                relative: { x: -2, z: 4 },
+                targets: [{ ...target, hoverHeight: 0.75 }],
+            }),
+            { x: -2, y: 0.85, z: 4 },
+        );
+    });
+
+    it('returns null when there is no active drag transform match', () => {
+        const target = createActiveDragPreviewTarget({
+            blockId: 'block-a',
+            blockIndex: 1,
+            stackPosition: { x: 2, z: 3 },
+        });
+
+        assert.equal(
+            getActiveDragPreviewTargetPositionOffset(target, {
+                relative: { x: -2, z: 4 },
+                targets: [],
+            }),
+            null,
         );
     });
 });

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -3,15 +3,14 @@ import type { ReactNode } from 'react';
 import type { Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import {
-    type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
-    findActiveDragPreviewTargetOffset,
+    getActiveDragPreviewTargetPositionOffset,
 } from '../dragPreviewIdentity';
 import { useBlockData } from '../hooks/useBlockData';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
 import type { Stack } from '../types/Stack';
-import { type ActiveDragPreview, useGameState } from '../useGameState';
+import { useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
@@ -41,29 +40,6 @@ export type EntityInstancesBlockMaterialProps =
           material?: never;
           materialNode: ReactNode;
       };
-
-function getDragPreviewOffset(
-    target: ActiveDragPreviewTarget,
-    activeDragPreview: ActiveDragPreview | null,
-) {
-    if (!activeDragPreview) {
-        return null;
-    }
-
-    const targetOffset = findActiveDragPreviewTargetOffset(
-        activeDragPreview.targets,
-        target,
-    );
-    if (!targetOffset) {
-        return null;
-    }
-
-    return {
-        x: activeDragPreview.relative.x,
-        y: targetOffset.hoverHeight + 0.1,
-        z: activeDragPreview.relative.z,
-    };
-}
 
 export function EntityInstancesBlock(
     props: EntityInstancesBlockBaseProps & EntityInstancesBlockMaterialProps,
@@ -98,10 +74,11 @@ export function EntityInstancesBlock(
                         blockIndex,
                         stackPosition: stack.position,
                     });
-                    const dragPreviewOffset = getDragPreviewOffset(
-                        target,
-                        activeDragPreview,
-                    );
+                    const dragPreviewOffset =
+                        getActiveDragPreviewTargetPositionOffset(
+                            target,
+                            activeDragPreview,
+                        );
                     return {
                         id: `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
                         position: [

--- a/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { Fragment, useEffect, useMemo } from 'react';
+import {
+    createActiveDragPreviewTarget,
+    getActiveDragPreviewTargetPositionOffset,
+} from '../../dragPreviewIdentity';
 import { useBlockData } from '../../hooks/useBlockData';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useWeatherNow } from '../../hooks/useWeatherNow';
@@ -35,6 +39,7 @@ export function GroundBlockDecorations({
 }: GroundBlockDecorationsProps) {
     const { data: blockData } = useBlockData();
     const { data: garden } = useCurrentGarden();
+    const activeDragPreview = useGameState((state) => state.activeDragPreview);
     const gameWeather = useGameState((state) => state.weather);
     const { data: weatherNow } = useWeatherNow();
     const windSpeed =
@@ -53,7 +58,7 @@ export function GroundBlockDecorations({
         }
 
         return stacks.flatMap((stack) =>
-            stack.blocks.flatMap((block) => {
+            stack.blocks.flatMap((block, blockIndex) => {
                 const surface = resolveGroundDecorationSurface(block.name);
                 if (!surface) {
                     return [];
@@ -73,6 +78,7 @@ export function GroundBlockDecorations({
                 return [
                     {
                         block,
+                        blockIndex,
                         placements,
                         stack,
                         surface,
@@ -105,18 +111,32 @@ export function GroundBlockDecorations({
                 >
                     {decorationBlocks
                         .filter((block) => block.stack === stack)
-                        .map(({ block, placements, surface }) => {
+                        .map(({ block, blockIndex, placements, surface }) => {
+                            const dragPreviewOffset =
+                                getActiveDragPreviewTargetPositionOffset(
+                                    createActiveDragPreviewTarget({
+                                        blockId: block.id,
+                                        blockIndex,
+                                        stackPosition: stack.position,
+                                    }),
+                                    activeDragPreview,
+                                );
+
                             return (
                                 <group
                                     key={`ground-decoration:${block.id}`}
                                     position={[
-                                        stack.position.x,
+                                        stack.position.x +
+                                            (dragPreviewOffset?.x ?? 0),
                                         getStackHeight(
                                             blockData,
                                             stack,
                                             block,
-                                        ) + blockSurfaceYOffset,
-                                        stack.position.z,
+                                        ) +
+                                            blockSurfaceYOffset +
+                                            (dragPreviewOffset?.y ?? 0),
+                                        stack.position.z +
+                                            (dragPreviewOffset?.z ?? 0),
                                     ]}
                                     rotation={[
                                         0,

--- a/packages/game/src/entities/helpers/HoverOutline.tsx
+++ b/packages/game/src/entities/helpers/HoverOutline.tsx
@@ -15,6 +15,7 @@ import {
     DoubleSide,
     type Group,
     LinearFilter,
+    type Material,
     Mesh,
     MeshBasicMaterial,
     NoBlending,
@@ -149,6 +150,26 @@ type ScreenBoundsScratch = {
     point: Vector3;
 };
 
+type ObjectWithMaterial = Object3D & {
+    material: Material | Material[] | null | undefined;
+};
+
+function hasMaterial(object: Object3D): object is ObjectWithMaterial {
+    return 'material' in object;
+}
+
+function getObjectMaterials(object: Object3D) {
+    if (!hasMaterial(object)) {
+        return [];
+    }
+
+    if (!object.material) {
+        return [];
+    }
+
+    return Array.isArray(object.material) ? object.material : [object.material];
+}
+
 function getOutlineScreenBounds({
     camera,
     drawingBufferSize,
@@ -253,15 +274,29 @@ function useTargetId() {
 
 function setLayerMask(objects: Object3D[], layer: number) {
     const previousLayers: [object: Object3D, mask: number][] = [];
+    const previousMaterialVisibility: [material: Material, visible: boolean][] =
+        [];
 
     for (const object of objects) {
         object.traverse((child) => {
             previousLayers.push([child, child.layers.mask]);
             child.layers.set(layer);
+            for (const material of getObjectMaterials(child)) {
+                if (!material.visible) {
+                    previousMaterialVisibility.push([
+                        material,
+                        material.visible,
+                    ]);
+                    material.visible = true;
+                }
+            }
         });
     }
 
     return () => {
+        for (const [material, visible] of previousMaterialVisibility) {
+            material.visible = visible;
+        }
         for (const [object, mask] of previousLayers) {
             object.layers.mask = mask;
         }

--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -1,5 +1,9 @@
 import { useEffect } from 'react';
 import type { BufferGeometry, Material } from 'three';
+import {
+    createActiveDragPreviewTarget,
+    getActiveDragPreviewTargetPositionOffset,
+} from '../../dragPreviewIdentity';
 import { useBlockData } from '../../hooks/useBlockData';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useOperations } from '../../hooks/useOperations';
@@ -58,6 +62,7 @@ type RaisedBedPlacement = {
     origin: [number, number, number];
     rotationQuarterTurns: number;
     stack: Stack;
+    stackBlockIndex: number;
 };
 
 type MulchVisual = {
@@ -589,6 +594,7 @@ export function RaisedBedMulchOverlays({
         MulchWood: useGameGLTF('MulchWood'),
     };
     const qualityProfile = quality ?? resolveGameQualityProfile();
+    const activeDragPreview = useGameState((state) => state.activeDragPreview);
     const snowCoverage = useGameState((state) => state.snowCoverage);
     const renderSnow = snowCoverage >= qualityProfile.snowOverlayMinCoverage;
 
@@ -622,20 +628,34 @@ export function RaisedBedMulchOverlays({
                 placement.block,
             );
             const surfaceGeometry = getRaisedBedSurfaceGeometry(neighbors);
+            const origin = getRaisedBedOrigin(
+                blockData,
+                placement.stack,
+                placement.block,
+                neighbors,
+            );
+            const dragPreviewOffset = getActiveDragPreviewTargetPositionOffset(
+                createActiveDragPreviewTarget({
+                    blockId: placement.block.id,
+                    blockIndex: placement.stackBlockIndex,
+                    stackPosition: placement.stack.position,
+                }),
+                activeDragPreview,
+            );
 
             placements.push({
                 block: placement.block,
                 blockIndex,
                 blockOffset: Math.max(blockIds.length - 1 - blockIndex, 0) * 9,
                 dirtGeometryName: surfaceGeometry.dirtGeometryName,
-                origin: getRaisedBedOrigin(
-                    blockData,
-                    placement.stack,
-                    placement.block,
-                    neighbors,
-                ),
+                origin: [
+                    origin[0] + (dragPreviewOffset?.x ?? 0),
+                    origin[1] + (dragPreviewOffset?.y ?? 0),
+                    origin[2] + (dragPreviewOffset?.z ?? 0),
+                ],
                 rotationQuarterTurns: surfaceGeometry.rotationQuarterTurns,
                 stack: placement.stack,
+                stackBlockIndex: placement.stackBlockIndex,
             });
         }
 


### PR DESCRIPTION
## Summary
- Added a shared drag-preview offset helper and reused it for instanced entities.
- Made the outline mask pass include hidden control meshes so instanced and non-instanced targets can outline correctly.
- Applied drag-preview offsets to grass/sand decorations and raised-bed mulch overlays so they move with picked blocks instead of floating in place.
- Added unit coverage for the new drag-preview helper.

## Testing
- `@gredice/game` unit tests passed.
- `@gredice/game` typecheck and lint passed.
- `garden` and `www` builds passed.
- `garden` Playwright suite was rerun; one unrelated mobile HUD assertion is flaky in the full parallel run but passes in isolation.