### PR TITLE
[codex] Preserve cat white fur spots

### DIFF
--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -101,10 +101,8 @@ const catWalkTurnDamping = 7.5;
 const catIdleTurnDamping = 8.5;
 const catWalkLookAheadProgress = 0.05;
 const fullTurn = Math.PI * 2;
-const catBlackFurColor = '#07080a';
-const catSoftBlackFurColor = '#101214';
-const catDarkPatchColor = '#17191b';
-const catDarkPatchShadowColor = '#090a0b';
+const catDarkFurColor = '#2f3437';
+const catSoftDarkFurColor = '#3b4144';
 
 const catPillowBlockNames = new Set(['CatPillow', 'Cat_Pillow']);
 const groundBlockNames = new Set([
@@ -923,19 +921,11 @@ function createCatDebugEntry({
 
 function getCatMaterialTint(materialName: string) {
     if (materialName.includes('Material.Cat.BlackFurSoft')) {
-        return catSoftBlackFurColor;
+        return catSoftDarkFurColor;
     }
 
     if (materialName.includes('Material.Cat.BlackFur')) {
-        return catBlackFurColor;
-    }
-
-    if (materialName.includes('Material.Cat.WhiteFurShadow')) {
-        return catDarkPatchShadowColor;
-    }
-
-    if (materialName.includes('Material.Cat.WhiteFur')) {
-        return catDarkPatchColor;
+        return catDarkFurColor;
     }
 
     return null;


### PR DESCRIPTION
## Summary
- Keep the cat's white fur and white shadow materials untinted so white spots/parts remain visible.
- Tint only the gray/dark fur materials to roof-like charcoal tones matching the birdhouse roof direction.

## Validation
- pnpm --filter @gredice/game typecheck
- pnpm lint --filter @gredice/game
- pnpm test --filter @gredice/game
- pnpm lint --filter garden
- pnpm lint --filter www
- pnpm build --filter garden --force
- pnpm build --filter www --force
- pnpm test --filter garden --force (1 unrelated mobile HUD assertion failed once; targeted rerun passed)
- pnpm exec playwright test tests/raised-bed-field-hud.spec.tsx -g "raised bed more action sits in the header above the tabs" --project=chromium
- Browser smoke: http://127.0.0.1:3211/debug/profile/game?quality=low&controls=0 loaded canvas without console errors