### PR TITLE
Disable frustum culling for blocks and cats

### DIFF
--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -164,6 +164,7 @@ export function EntityInstancesBlock(
             <Instances
                 limit={limit}
                 geometry={geometry}
+                frustumCulled={false}
                 receiveShadow
                 castShadow
                 material={'material' in props ? props.material : undefined}

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -946,6 +946,7 @@ function cloneCatMaterial(material: Material) {
 
 function prepareCatMesh(object: Mesh) {
     object.castShadow = true;
+    object.frustumCulled = false;
     object.receiveShadow = true;
     object.material = Array.isArray(object.material)
         ? object.material.map(cloneCatMaterial)


### PR DESCRIPTION
## Summary
- Disable frustum culling on instanced block rendering so camera movement does not drop whole block groups from view.
- Disable frustum culling on cat mesh parts so walking animations keep the full model visible instead of only isolated pieces.

## Testing
- Unit and UI validation were run on the affected game and app targets earlier in the thread; no additional test commands were requested here.