### PR TITLE
Add DB-backed hitbox sizing for garden blocks

### DIFF
--- a/apps/api/lib/@types/directories-api/v1.d.ts
+++ b/apps/api/lib/@types/directories-api/v1.d.ts
@@ -2026,6 +2026,12 @@ export interface components {
                 type: string;
                 /** @description Blok je moguće kupiti samo tijekom noći. */
                 nightOnlyPurchase: boolean;
+                /** @description Širina nevidljive zone za odabir i povlačenje bloka u vrtu. */
+                hitboxWidth?: number;
+                /** @description Visina nevidljive zone za odabir i povlačenje bloka u vrtu. */
+                hitboxHeight?: number;
+                /** @description Dubina nevidljive zone za odabir i povlačenje bloka u vrtu. */
+                hitboxDepth?: number;
             };
             prices: {
                 sunflowers: number;

--- a/packages/directory-types/src/v1.d.ts
+++ b/packages/directory-types/src/v1.d.ts
@@ -2026,6 +2026,12 @@ export interface components {
                 type: string;
                 /** @description Blok je moguće kupiti samo tijekom noći. */
                 nightOnlyPurchase: boolean;
+                /** @description Širina nevidljive zone za odabir i povlačenje bloka u vrtu. */
+                hitboxWidth?: number;
+                /** @description Visina nevidljive zone za odabir i povlačenje bloka u vrtu. */
+                hitboxHeight?: number;
+                /** @description Dubina nevidljive zone za odabir i povlačenje bloka u vrtu. */
+                hitboxDepth?: number;
             };
             prices: {
                 sunflowers: number;

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -5,6 +5,7 @@ import { SelectableGroup } from '../controls/SelectableGroup';
 import { useBlockData } from '../hooks/useBlockData';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useGameState } from '../useGameState';
+import { getBlockHitboxSize } from '../utils/blockHitbox';
 import { useStackHeight } from '../utils/getStackHeight';
 import { entityNameMap } from './entityNameMap';
 
@@ -71,20 +72,21 @@ function InstancedEntityControlTarget({
     const editHitboxDebugVisible = useGameState(
         (state) => state.editHitboxDebugVisible,
     );
-    const blockHeight =
-        blockData?.find((entity) => entity.information.name === block.name)
-            ?.attributes.height ?? 1;
-    const hitboxHeight = Math.max(blockHeight, 0.35);
+    const blockEntity = blockData?.find(
+        (entity) => entity.information.name === block.name,
+    );
+    const hitbox = getBlockHitboxSize(blockEntity);
 
     return (
         <mesh
             position={[
                 stack.position.x,
-                currentStackHeight + hitboxHeight / 2,
+                currentStackHeight + hitbox.height / 2,
                 stack.position.z,
             ]}
+            rotation={[0, block.rotation * (Math.PI / 2), 0]}
         >
-            <boxGeometry args={[1, hitboxHeight, 1]} />
+            <boxGeometry args={[hitbox.width, hitbox.height, hitbox.depth]} />
             <meshBasicMaterial visible={false} />
             {editHitboxDebugVisible && (
                 <Edges color="#22d3ee" renderOrder={10_000} threshold={1} />

--- a/packages/game/src/utils/blockHitbox.ts
+++ b/packages/game/src/utils/blockHitbox.ts
@@ -1,0 +1,29 @@
+import type { BlockData } from '@gredice/client';
+
+export type BlockHitboxSize = {
+    width: number;
+    height: number;
+    depth: number;
+};
+
+function positiveNumber(value: unknown, fallback: number) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? value
+        : fallback;
+}
+
+export function getBlockHitboxSize(
+    blockData: BlockData | null | undefined,
+): BlockHitboxSize {
+    const attributes = blockData?.attributes;
+    const fallbackHeight = Math.max(
+        positiveNumber(attributes?.height, 1),
+        0.35,
+    );
+
+    return {
+        width: positiveNumber(attributes?.hitboxWidth, 1),
+        height: positiveNumber(attributes?.hitboxHeight, fallbackHeight),
+        depth: positiveNumber(attributes?.hitboxDepth, 1),
+    };
+}

--- a/packages/game/src/utils/blockHitbox.unit.ts
+++ b/packages/game/src/utils/blockHitbox.unit.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { BlockData } from '@gredice/client';
+import { getBlockHitboxSize } from './blockHitbox';
+
+const now = '2026-05-30T00:00:00.000Z';
+
+function createBlockData(attributes: Partial<BlockData['attributes']> = {}) {
+    return {
+        id: 1,
+        entityType: { id: 8, name: 'block', label: 'Blok' },
+        slug: 'test-block',
+        information: {
+            name: 'TestBlock',
+            label: 'Test block',
+            shortDescription: 'Test block.',
+            fullDescription: 'Test block.',
+        },
+        attributes: {
+            height: 0.2,
+            nightOnlyPurchase: false,
+            stackable: true,
+            type: 'decoration',
+            ...attributes,
+        },
+        prices: { sunflowers: 1 },
+        functions: {
+            recycler: false,
+            raisedBed: false,
+        },
+        createdAt: now,
+        updatedAt: now,
+    } satisfies BlockData;
+}
+
+describe('getBlockHitboxSize', () => {
+    it('uses existing control target defaults when no hitbox attributes exist', () => {
+        assert.deepEqual(getBlockHitboxSize(createBlockData()), {
+            width: 1,
+            height: 0.35,
+            depth: 1,
+        });
+    });
+
+    it('uses positive hitbox attributes from block data', () => {
+        assert.deepEqual(
+            getBlockHitboxSize(
+                createBlockData({
+                    hitboxWidth: 0.28,
+                    hitboxHeight: 0.18,
+                    hitboxDepth: 0.42,
+                }),
+            ),
+            {
+                width: 0.28,
+                height: 0.18,
+                depth: 0.42,
+            },
+        );
+    });
+
+    it('ignores non-positive and non-finite hitbox attributes', () => {
+        assert.deepEqual(
+            getBlockHitboxSize(
+                createBlockData({
+                    hitboxWidth: 0,
+                    hitboxHeight: Number.NaN,
+                    hitboxDepth: Number.POSITIVE_INFINITY,
+                }),
+            ),
+            {
+                width: 1,
+                height: 0.35,
+                depth: 1,
+            },
+        );
+    });
+});

--- a/packages/storage/scripts/upsertBlockHitboxAttributes.ts
+++ b/packages/storage/scripts/upsertBlockHitboxAttributes.ts
@@ -1,0 +1,349 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+    bustCached,
+    bustCachedByPrefixes,
+    cacheKeys,
+} from '../src/cache/directoriesCached';
+import {
+    attributeDefinitions,
+    attributeValues,
+    entities,
+    entityRevisions,
+} from '../src/schema/cmsSchema';
+import { closeStorage, storage } from '../src/storage';
+
+const actor = {
+    id: 'codex',
+    name: 'Codex',
+};
+
+type HitboxSize = {
+    width: number;
+    height: number;
+    depth: number;
+};
+
+const cell = (height: number): HitboxSize => ({
+    width: 1,
+    height,
+    depth: 1,
+});
+
+const blockHitboxes = {
+    BaleHey: { width: 0.44, height: 0.36, depth: 0.82 },
+    BirdHouse: { width: 0.72, height: 1.3, depth: 0.72 },
+    Block_Grass: cell(0.4),
+    Block_Grass_Angle: cell(0.25),
+    Block_Grass_Corner: cell(0.25),
+    Block_Grass_Reverse_Corner: cell(0.25),
+    Block_Ground: cell(0.4),
+    Block_Ground_Angle: cell(0.25),
+    Block_Ground_Corner: cell(0.25),
+    Block_Ground_Reverse_Corner: cell(0.25),
+    Block_Sand: cell(0.4),
+    Block_Sand_Angle: cell(0.25),
+    Block_Sand_Corner: cell(0.25),
+    Block_Sand_Reverse_Corner: cell(0.25),
+    Block_Snow: cell(0.4),
+    Block_Snow_Angle: cell(0.4),
+    Block_Snow_Corner: cell(0.4),
+    Block_Snow_Falling: cell(0.4),
+    Block_Snow_Reverse_Corner: cell(0.4),
+    Block_Water: cell(0.4),
+    Bucket: { width: 0.45, height: 0.5, depth: 0.45 },
+    Bush: { width: 0.72, height: 0.5, depth: 0.72 },
+    CactusBarrel: { width: 0.78, height: 0.6, depth: 0.78 },
+    CactusColumnCluster: { width: 0.72, height: 1, depth: 0.62 },
+    CactusPricklyPear: { width: 0.66, height: 0.95, depth: 0.45 },
+    CatPillow: { width: 0.95, height: 0.25, depth: 0.68 },
+    Composter: { width: 0.82, height: 0.63, depth: 0.82 },
+    DeadTreeStump: { width: 0.45, height: 0.95, depth: 0.75 },
+    DeadTreeTall: { width: 0.86, height: 1.8, depth: 0.52 },
+    DesertStoneLarge: { width: 0.82, height: 0.63, depth: 0.56 },
+    DesertStoneMedium: { width: 0.66, height: 0.33, depth: 0.45 },
+    DesertStoneSmall: { width: 0.43, height: 0.2, depth: 0.31 },
+    Fence: cell(0.58),
+    FireflyJar: { width: 0.5, height: 0.65, depth: 0.5 },
+    GardenBox: { width: 0.96, height: 0.78, depth: 0.8 },
+    GiftBox_BlueWhite: { width: 0.6, height: 0.62, depth: 0.6 },
+    GiftBox_GoldRed: { width: 0.6, height: 0.62, depth: 0.6 },
+    GiftBox_GreenGold: { width: 0.6, height: 0.62, depth: 0.6 },
+    GiftBox_PurpleSilver: { width: 0.6, height: 0.62, depth: 0.6 },
+    GiftBox_RedWhite: { width: 0.6, height: 0.62, depth: 0.6 },
+    GiftBox_WhiteGreen: { width: 0.6, height: 0.62, depth: 0.6 },
+    MulchCoconut: { width: 0.96, height: 0.08, depth: 0.96 },
+    MulchHey: { width: 0.96, height: 0.08, depth: 0.96 },
+    MulchWood: { width: 0.96, height: 0.08, depth: 0.96 },
+    Pine: { width: 0.28, height: 2.4, depth: 0.28 },
+    PineAdvent: { width: 0.34, height: 2.6, depth: 0.34 },
+    PotBulbousNeck: { width: 0.56, height: 0.47, depth: 0.56 },
+    PotHourglass: { width: 0.52, height: 0.43, depth: 0.5 },
+    PotLowBowl: { width: 0.58, height: 0.22, depth: 0.58 },
+    PotNarrowFootBowl: { width: 0.6, height: 0.35, depth: 0.6 },
+    PotRoundedBowl: { width: 0.48, height: 0.39, depth: 0.48 },
+    PotSquatRidged: { width: 0.53, height: 0.38, depth: 0.53 },
+    PotStraightShortTub: { width: 0.45, height: 0.36, depth: 0.45 },
+    PotTallSlenderCone: { width: 0.47, height: 0.58, depth: 0.45 },
+    PotTallTapered: { width: 0.5, height: 0.5, depth: 0.48 },
+    PotWideLippedCup: { width: 0.66, height: 0.45, depth: 0.66 },
+    Raised_Bed: cell(0.35),
+    Shade: cell(1.05),
+    ShovelSmall: { width: 0.32, height: 1.03, depth: 0.16 },
+    Snowman: { width: 0.42, height: 0.5, depth: 0.42 },
+    StoneLarge: { width: 0.32, height: 0.28, depth: 0.35 },
+    StoneMedium: { width: 0.24, height: 0.14, depth: 0.22 },
+    StoneSmall: { width: 0.18, height: 0.08, depth: 0.18 },
+    Stool: { width: 0.82, height: 0.48, depth: 0.82 },
+    Tree: { width: 0.34, height: 1.25, depth: 0.34 },
+    Tulip: { width: 0.24, height: 0.4, depth: 0.24 },
+    WaterWell: { width: 0.98, height: 1.1, depth: 0.9 },
+    WateringCan: { width: 1, height: 0.56, depth: 0.45 },
+} satisfies Record<string, HitboxSize>;
+
+const hitboxDefinitionSpecs = [
+    {
+        name: 'hitboxWidth',
+        label: 'Širina hitboxa',
+        description:
+            'Širina nevidljive zone za odabir i povlačenje bloka u vrtu.',
+        defaultValue: '1',
+        value: (hitbox: HitboxSize) => hitbox.width,
+    },
+    {
+        name: 'hitboxHeight',
+        label: 'Visina hitboxa',
+        description:
+            'Visina nevidljive zone za odabir i povlačenje bloka u vrtu.',
+        defaultValue: null,
+        value: (hitbox: HitboxSize) => hitbox.height,
+    },
+    {
+        name: 'hitboxDepth',
+        label: 'Dubina hitboxa',
+        description:
+            'Dubina nevidljive zone za odabir i povlačenje bloka u vrtu.',
+        defaultValue: '1',
+        value: (hitbox: HitboxSize) => hitbox.depth,
+    },
+] as const;
+
+async function upsertHitboxDefinition(
+    spec: (typeof hitboxDefinitionSpecs)[number],
+) {
+    const [existingDefinition] = await storage()
+        .select()
+        .from(attributeDefinitions)
+        .where(
+            and(
+                eq(attributeDefinitions.entityTypeName, 'block'),
+                eq(attributeDefinitions.category, 'attributes'),
+                eq(attributeDefinitions.name, spec.name),
+                eq(attributeDefinitions.isDeleted, false),
+            ),
+        );
+
+    const definitionValues = {
+        category: 'attributes',
+        name: spec.name,
+        label: spec.label,
+        description: spec.description,
+        entityTypeName: 'block',
+        dataType: 'number',
+        defaultValue: spec.defaultValue,
+        required: false,
+        display: false,
+    };
+
+    if (!existingDefinition) {
+        const [created] = await storage()
+            .insert(attributeDefinitions)
+            .values(definitionValues)
+            .returning({ id: attributeDefinitions.id });
+        return created.id;
+    }
+
+    await storage()
+        .update(attributeDefinitions)
+        .set(definitionValues)
+        .where(eq(attributeDefinitions.id, existingDefinition.id));
+    return existingDefinition.id;
+}
+
+async function getPublishedBlockIdsByName() {
+    const blockNameDefinition =
+        await storage().query.attributeDefinitions.findFirst({
+            where: and(
+                eq(attributeDefinitions.entityTypeName, 'block'),
+                eq(attributeDefinitions.category, 'information'),
+                eq(attributeDefinitions.name, 'name'),
+                eq(attributeDefinitions.isDeleted, false),
+            ),
+        });
+
+    if (!blockNameDefinition) {
+        throw new Error('Missing block information.name definition.');
+    }
+
+    const blockNames = Object.keys(blockHitboxes);
+    const rows = await storage()
+        .select({
+            entityId: entities.id,
+            name: attributeValues.value,
+        })
+        .from(entities)
+        .innerJoin(attributeValues, eq(attributeValues.entityId, entities.id))
+        .where(
+            and(
+                eq(entities.entityTypeName, 'block'),
+                eq(entities.state, 'published'),
+                eq(entities.isDeleted, false),
+                eq(attributeValues.isDeleted, false),
+                eq(
+                    attributeValues.attributeDefinitionId,
+                    blockNameDefinition.id,
+                ),
+                inArray(attributeValues.value, blockNames),
+            ),
+        );
+
+    return new Map(
+        rows.map((row) => {
+            if (!row.name) {
+                throw new Error(`Block entity ${row.entityId} has no name.`);
+            }
+            return [row.name, row.entityId] as const;
+        }),
+    );
+}
+
+async function upsertHitboxValue({
+    attributeDefinitionId,
+    entityId,
+    nextValue,
+}: {
+    attributeDefinitionId: number;
+    entityId: number;
+    nextValue: string;
+}) {
+    const [existingValue] = await storage()
+        .select()
+        .from(attributeValues)
+        .where(
+            and(
+                eq(attributeValues.entityId, entityId),
+                eq(
+                    attributeValues.attributeDefinitionId,
+                    attributeDefinitionId,
+                ),
+                eq(attributeValues.isDeleted, false),
+            ),
+        );
+
+    if (existingValue?.value === nextValue) {
+        return false;
+    }
+
+    if (existingValue) {
+        await storage()
+            .update(attributeValues)
+            .set({ value: nextValue })
+            .where(eq(attributeValues.id, existingValue.id));
+        await storage().insert(entityRevisions).values({
+            entityId,
+            entityTypeName: 'block',
+            action: 'attribute.updated',
+            actorId: actor.id,
+            actorName: actor.name,
+            attributeValueId: existingValue.id,
+            attributeDefinitionId,
+            previousValue: existingValue.value,
+            nextValue,
+        });
+        return true;
+    }
+
+    const [createdValue] = await storage()
+        .insert(attributeValues)
+        .values({
+            entityId,
+            entityTypeName: 'block',
+            attributeDefinitionId,
+            value: nextValue,
+        })
+        .returning({ id: attributeValues.id });
+    await storage().insert(entityRevisions).values({
+        entityId,
+        entityTypeName: 'block',
+        action: 'attribute.created',
+        actorId: actor.id,
+        actorName: actor.name,
+        attributeValueId: createdValue.id,
+        attributeDefinitionId,
+        previousValue: null,
+        nextValue,
+    });
+    return true;
+}
+
+async function main() {
+    const definitionIds = new Map<string, number>();
+    for (const spec of hitboxDefinitionSpecs) {
+        definitionIds.set(spec.name, await upsertHitboxDefinition(spec));
+    }
+
+    const blockIdsByName = await getPublishedBlockIdsByName();
+    const missingBlockNames = Object.keys(blockHitboxes).filter(
+        (name) => !blockIdsByName.has(name),
+    );
+    if (missingBlockNames.length > 0) {
+        throw new Error(
+            `Missing published block entities: ${missingBlockNames.join(', ')}`,
+        );
+    }
+
+    const changedEntityIds = new Set<number>();
+    let changedValueCount = 0;
+    for (const [blockName, hitbox] of Object.entries(blockHitboxes)) {
+        const entityId = blockIdsByName.get(blockName);
+        if (!entityId) {
+            continue;
+        }
+
+        for (const spec of hitboxDefinitionSpecs) {
+            const attributeDefinitionId = definitionIds.get(spec.name);
+            if (!attributeDefinitionId) {
+                throw new Error(`Missing definition id for ${spec.name}.`);
+            }
+            const changed = await upsertHitboxValue({
+                attributeDefinitionId,
+                entityId,
+                nextValue: String(spec.value(hitbox)),
+            });
+            if (changed) {
+                changedEntityIds.add(entityId);
+                changedValueCount += 1;
+            }
+        }
+    }
+
+    await Promise.all([
+        bustCached(cacheKeys.entityTypeName('block')),
+        bustCachedByPrefixes(['entities:formatted:', 'dashboard:admin:']),
+        ...Array.from(changedEntityIds).map((entityId) =>
+            bustCached(cacheKeys.entity(entityId)),
+        ),
+    ]);
+
+    console.log(
+        `Upserted ${hitboxDefinitionSpecs.length} definitions and ${changedValueCount} block hitbox values across ${changedEntityIds.size} changed entities.`,
+    );
+}
+
+main()
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await closeStorage();
+    });


### PR DESCRIPTION
## Summary
- Added `hitboxWidth`, `hitboxHeight`, and `hitboxDepth` as block attributes in the directory API types.
- Updated instanced block drag targets to use the stored hitbox dimensions and block rotation.
- Added a storage maintenance script that backfills optimized hitboxes for all published block entities.
- Added unit coverage for hitbox size resolution and regenerated the directory type contracts.

## Testing
- Unit tests for hitbox size resolution passed.
- Game tests and typecheck passed.
- API directory-type tests passed.
- Garden and www builds passed.
- DB backfill script was run against the pulled storage environment and completed successfully.