### PR TITLE
Add adaptive block instance capacity

### DIFF
--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -12,6 +12,7 @@ import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
+import { resolveBlockInstanceCapacity } from './blockInstanceCapacity';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
@@ -91,7 +92,9 @@ export function EntityInstancesBlock(
                 }),
         );
 
-    const limit = Math.max((blockInstances?.length ?? 0) + 10, 100);
+    const instanceCapacity = resolveBlockInstanceCapacity(
+        blockInstances?.length ?? 0,
+    );
 
     const localTransform = {
         position: localPosition ?? defaultLocalPosition,
@@ -162,7 +165,8 @@ export function EntityInstancesBlock(
     return (
         <>
             <Instances
-                limit={limit}
+                key={`${name}-${instanceCapacity}`}
+                limit={instanceCapacity}
                 geometry={geometry}
                 frustumCulled={false}
                 receiveShadow

--- a/packages/game/src/entities/blockInstanceCapacity.ts
+++ b/packages/game/src/entities/blockInstanceCapacity.ts
@@ -1,0 +1,17 @@
+const minimumBlockInstanceCapacity = 100;
+const blockInstanceCapacityHeadroom = 10;
+
+export function resolveBlockInstanceCapacity(instanceCount: number) {
+    if (instanceCount <= minimumBlockInstanceCapacity) {
+        return minimumBlockInstanceCapacity;
+    }
+
+    const requiredCapacity = instanceCount + blockInstanceCapacityHeadroom;
+    let capacity = minimumBlockInstanceCapacity;
+
+    while (capacity < requiredCapacity) {
+        capacity *= 2;
+    }
+
+    return capacity;
+}

--- a/packages/game/src/entities/blockInstanceCapacity.unit.ts
+++ b/packages/game/src/entities/blockInstanceCapacity.unit.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveBlockInstanceCapacity } from './blockInstanceCapacity';
+
+describe('resolveBlockInstanceCapacity', () => {
+    it('keeps the default capacity for small gardens', () => {
+        assert.equal(resolveBlockInstanceCapacity(0), 100);
+        assert.equal(resolveBlockInstanceCapacity(100), 100);
+    });
+
+    it('grows capacity in buckets when a block type exceeds the current buffer', () => {
+        assert.equal(resolveBlockInstanceCapacity(101), 200);
+        assert.equal(resolveBlockInstanceCapacity(190), 200);
+        assert.equal(resolveBlockInstanceCapacity(191), 400);
+    });
+});


### PR DESCRIPTION
## Summary
- Extract block instance capacity resolution into a shared helper
- Keep the default capacity for small gardens and grow in doubling buckets with headroom
- Remount `Instances` when capacity changes so instancing stays consistent

## Testing
- Added unit coverage for capacity resolution at the default threshold and growth boundaries
- Not run (not requested)