### PR TITLE
Render pickup outlines from instanced models

### DIFF
--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -7,6 +7,8 @@ import {
     type PropsWithChildren,
     Suspense,
     useEffect,
+    useLayoutEffect,
+    useMemo,
     useRef,
     useState,
 } from 'react';
@@ -197,6 +199,9 @@ export function PickableGroup({
     const setActiveDragPreview = useGameState(
         (state) => state.setActiveDragPreview,
     );
+    const setStationaryPickupOutlineTarget = useGameState(
+        (state) => state.setStationaryPickupOutlineTarget,
+    );
 
     const [isBlocked, setIsBlocked] = useState(false);
     const [isOverRecycler, setIsOverRecycler] = useState(false);
@@ -237,11 +242,18 @@ export function PickableGroup({
           )
         : 0;
     const blockIndex = stack.blocks.indexOf(block);
-    const activePreviewTarget = createActiveDragPreviewTarget({
-        blockId: block.id,
-        blockIndex,
-        stackPosition: stack.position,
-    });
+    const activePreviewTarget = useMemo(
+        () =>
+            createActiveDragPreviewTarget({
+                blockId: block.id,
+                blockIndex,
+                stackPosition: {
+                    x: stack.position.x,
+                    z: stack.position.z,
+                },
+            }),
+        [block.id, blockIndex, stack.position.x, stack.position.z],
+    );
     const isPreviewSource = activeDragPreviewTargetMatches(
         activeDragPreview?.source,
         activePreviewTarget,
@@ -310,6 +322,20 @@ export function PickableGroup({
         activePreviewTargetOffset,
         isPreviewSource,
         dragSpringsApi,
+    ]);
+
+    useLayoutEffect(() => {
+        if (renderPickupOutline || !pickupOutlineVisible) {
+            return;
+        }
+
+        setStationaryPickupOutlineTarget(activePreviewTarget);
+        return () => setStationaryPickupOutlineTarget(null);
+    }, [
+        activePreviewTarget,
+        pickupOutlineVisible,
+        renderPickupOutline,
+        setStationaryPickupOutlineTarget,
     ]);
 
     useEffect(() => {

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -17,6 +17,7 @@ import {
     createActiveDragPreviewTarget,
     findActiveDragPreviewTargetOffset,
 } from '../dragPreviewIdentity';
+import { blockPickupOutlineStyle } from '../entities/helpers/blockPickupOutlineStyle';
 import { HoverOutline } from '../entities/helpers/HoverOutline';
 import { useBlockData } from '../hooks/useBlockData';
 import { useBlockMove } from '../hooks/useBlockMove';
@@ -57,7 +58,10 @@ const placementSnapSearchRadius = 5;
 const animalPickupDisturbanceRadius = 1.8;
 
 type PickableGroupProps = PropsWithChildren<
-    Pick<EntityInstanceProps, 'stack' | 'block'> & { noControl?: boolean }
+    Pick<EntityInstanceProps, 'stack' | 'block'> & {
+        noControl?: boolean;
+        renderPickupOutline?: boolean;
+    }
 >;
 
 type PlacementPreview = {
@@ -150,6 +154,7 @@ export function PickableGroup({
     stack,
     block,
     noControl,
+    renderPickupOutline = true,
 }: PickableGroupProps) {
     const [dragSprings, dragSpringsApi] = useSpring(() => ({
         from: { internalPosition: [0, 0, 0], scale: 1 },
@@ -1201,6 +1206,14 @@ export function PickableGroup({
         return <>{children}</>;
     }
 
+    const pickupOutlineContent = renderPickupOutline ? (
+        <HoverOutline {...blockPickupOutlineStyle} hovered={showPickupOutline}>
+            {children}
+        </HoverOutline>
+    ) : (
+        children
+    );
+
     return (
         <animated.group
             position={
@@ -1225,15 +1238,7 @@ export function PickableGroup({
                     scale={2}
                 />
             </animated.group>
-            <HoverOutline
-                color="#86efac"
-                hovered={showPickupOutline}
-                opacity={0.55}
-                priority={1}
-                thickness={2}
-            >
-                {children}
-            </HoverOutline>
+            {pickupOutlineContent}
             {isOverRecycler && (
                 <Suspense>
                     <animated.group position={recyclePosition}>

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -127,7 +127,12 @@ export function EntityFactory({
         }
 
         return (
-            <PickableGroup stack={stack} block={block} noControl={noControl}>
+            <PickableGroup
+                stack={stack}
+                block={block}
+                noControl={noControl}
+                renderPickupOutline={false}
+            >
                 <RotatableGroup block={block}>
                     <InstancedEntityControlTarget stack={stack} block={block} />
                     <EntityRenderModeDebugOverlay

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -12,6 +12,8 @@ import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
+import { blockPickupOutlineStyle } from './helpers/blockPickupOutlineStyle';
+import { HoverOutline } from './helpers/HoverOutline';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
@@ -81,6 +83,7 @@ export function EntityInstancesBlock(
                         );
                     return {
                         id: `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
+                        pickupOutlineVisible: Boolean(dragPreviewOffset),
                         position: [
                             stack.position.x + (dragPreviewOffset?.x ?? 0),
                             y + (yOffset ?? 0) + (dragPreviewOffset?.y ?? 0),
@@ -172,6 +175,30 @@ export function EntityInstancesBlock(
                 {'materialNode' in props ? props.materialNode : null}
                 {renderInstances('base')}
             </Instances>
+            {(blockInstances ?? []).map((data) =>
+                data.pickupOutlineVisible ? (
+                    <HoverOutline
+                        key={`block-${name}-pickup-outline-${data.id}`}
+                        {...blockPickupOutlineStyle}
+                        hovered
+                    >
+                        <group
+                            position={data.position}
+                            rotation={[0, data.rotation * (Math.PI / 2), 0]}
+                        >
+                            <mesh
+                                geometry={geometry}
+                                position={localTransform.position}
+                                rotation={localTransform.rotation}
+                                scale={scale}
+                                raycast={() => null}
+                            >
+                                <meshBasicMaterial visible={false} />
+                            </mesh>
+                        </group>
+                    </HoverOutline>
+                ) : null,
+            )}
             {renderRainOverlays()}
             {renderSnowOverlays()}
         </>

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import {
+    activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
     getActiveDragPreviewTargetPositionOffset,
 } from '../dragPreviewIdentity';
@@ -63,6 +64,9 @@ export function EntityInstancesBlock(
     } = props;
     const { data: blockData } = useBlockData();
     const activeDragPreview = useGameState((state) => state.activeDragPreview);
+    const stationaryPickupOutlineTarget = useGameState(
+        (state) => state.stationaryPickupOutlineTarget,
+    );
 
     const blockInstances = stacks
         ?.filter((stack) => stack.blocks.some((b) => b.name === name))
@@ -82,9 +86,16 @@ export function EntityInstancesBlock(
                             target,
                             activeDragPreview,
                         );
+                    const stationaryPickupOutlineVisible =
+                        activeDragPreviewTargetMatches(
+                            stationaryPickupOutlineTarget,
+                            target,
+                        );
                     return {
                         id: `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
-                        pickupOutlineVisible: Boolean(dragPreviewOffset),
+                        pickupOutlineVisible:
+                            Boolean(dragPreviewOffset) ||
+                            stationaryPickupOutlineVisible,
                         position: [
                             stack.position.x + (dragPreviewOffset?.x ?? 0),
                             y + (yOffset ?? 0) + (dragPreviewOffset?.y ?? 0),

--- a/packages/game/src/entities/helpers/blockPickupOutlineStyle.ts
+++ b/packages/game/src/entities/helpers/blockPickupOutlineStyle.ts
@@ -1,0 +1,6 @@
+export const blockPickupOutlineStyle = {
+    color: '#86efac',
+    opacity: 0.55,
+    priority: 1,
+    thickness: 2,
+} as const;

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -164,6 +164,10 @@ export type GameState = {
     // Pickup system
     pickupBlock: Block | null;
     setPickupBlock: (block: Block | null) => void;
+    stationaryPickupOutlineTarget: ActiveDragPreviewTarget | null;
+    setStationaryPickupOutlineTarget: (
+        target: ActiveDragPreviewTarget | null,
+    ) => void;
     activeDragPreview: ActiveDragPreview | null;
     setActiveDragPreview: (dragPreview: ActiveDragPreview | null) => void;
     openGardenBoxBlockId: string | null;
@@ -321,6 +325,9 @@ export function createGameState({
         // Pickaup system
         pickupBlock: null,
         setPickupBlock: (block: Block | null) => set({ pickupBlock: block }),
+        stationaryPickupOutlineTarget: null,
+        setStationaryPickupOutlineTarget: (stationaryPickupOutlineTarget) =>
+            set({ stationaryPickupOutlineTarget }),
         activeDragPreview: null,
         setActiveDragPreview: (activeDragPreview) => set({ activeDragPreview }),
         openGardenBoxBlockId: null,


### PR DESCRIPTION
## Summary
- Disable the generic pickup outline for instanced blocks so it no longer traces the control hitbox.
- Render a hidden geometry proxy for instanced blocks and feed it through `HoverOutline`, so the outline follows the actual model shape.
- Extract the pickup outline style into a shared constant to keep the visual settings consistent.

## Testing
- Unit tests passed for `@gredice/game`.
- UI/build validation passed for `garden` and `www` consumers.