### PR TITLE
[codex] Make forced daytime use light theme

### DIFF
--- a/packages/game/src/hooks/dayNightTheme.ts
+++ b/packages/game/src/hooks/dayNightTheme.ts
@@ -1,0 +1,9 @@
+export function resolveDayNightTheme({
+    dayNightCycleDisabled,
+    isDaytime,
+}: {
+    dayNightCycleDisabled: boolean;
+    isDaytime: boolean;
+}) {
+    return dayNightCycleDisabled || isDaytime ? 'light' : 'dark';
+}

--- a/packages/game/src/hooks/useThemeManager.ts
+++ b/packages/game/src/hooks/useThemeManager.ts
@@ -1,6 +1,11 @@
 import { useTheme } from 'next-themes';
 import { useEffect } from 'react';
 import { getTimes } from 'suncalc';
+import {
+    DAY_NIGHT_CYCLE_DISABLED_CHANGE_EVENT,
+    isDayNightCycleDisabled,
+} from '../utils/dayNightCycle';
+import { resolveDayNightTheme } from './dayNightTheme';
 
 // Zagreb, Croatia coordinates
 const defaultLocation = { lat: 45.739, lon: 16.572 };
@@ -15,7 +20,8 @@ function isDaytime(now: Date): boolean {
 }
 
 /**
- * Syncs the next-themes theme based on actual sunrise/sunset times.
+ * Syncs the next-themes theme based on actual sunrise/sunset times and the
+ * user's forced daytime setting.
  * Should be mounted once at the app level (inside a ThemeProvider).
  */
 export function useThemeManager() {
@@ -23,16 +29,24 @@ export function useThemeManager() {
 
     useEffect(() => {
         function sync() {
-            const isDay = isDaytime(new Date());
-            if (isDay && resolvedTheme !== 'light') {
-                setTheme('light');
-            } else if (!isDay && resolvedTheme !== 'dark') {
-                setTheme('dark');
+            const nextTheme = resolveDayNightTheme({
+                dayNightCycleDisabled: isDayNightCycleDisabled(),
+                isDaytime: isDaytime(new Date()),
+            });
+            if (resolvedTheme !== nextTheme) {
+                setTheme(nextTheme);
             }
         }
 
         sync();
         const interval = setInterval(sync, 60_000);
-        return () => clearInterval(interval);
+        window.addEventListener(DAY_NIGHT_CYCLE_DISABLED_CHANGE_EVENT, sync);
+        return () => {
+            clearInterval(interval);
+            window.removeEventListener(
+                DAY_NIGHT_CYCLE_DISABLED_CHANGE_EVENT,
+                sync,
+            );
+        };
     }, [resolvedTheme, setTheme]);
 }

--- a/packages/game/src/hooks/useThemeManager.unit.ts
+++ b/packages/game/src/hooks/useThemeManager.unit.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveDayNightTheme } from './dayNightTheme';
+
+test('uses the light theme while the day-night cycle is disabled', () => {
+    assert.equal(
+        resolveDayNightTheme({
+            dayNightCycleDisabled: true,
+            isDaytime: false,
+        }),
+        'light',
+    );
+});
+
+test('uses the dark theme at night while the day-night cycle is active', () => {
+    assert.equal(
+        resolveDayNightTheme({
+            dayNightCycleDisabled: false,
+            isDaytime: false,
+        }),
+        'dark',
+    );
+});
+
+test('uses the light theme during the day while the day-night cycle is active', () => {
+    assert.equal(
+        resolveDayNightTheme({
+            dayNightCycleDisabled: false,
+            isDaytime: true,
+        }),
+        'light',
+    );
+});

--- a/packages/game/src/utils/dayNightCycle.ts
+++ b/packages/game/src/utils/dayNightCycle.ts
@@ -1,6 +1,9 @@
 const DAY_NIGHT_CYCLE_DISABLED_STORAGE_KEY = 'game-day-night-cycle-disabled';
 let cachedDayNightCycleDisabled: boolean | undefined;
 
+export const DAY_NIGHT_CYCLE_DISABLED_CHANGE_EVENT =
+    'game-day-night-cycle-disabled-change';
+
 // Normalized midpoint of the day-night cycle, equivalent to noon.
 export const ALWAYS_DAY_TIME = 0.5;
 
@@ -35,4 +38,5 @@ export function setDayNightCycleDisabled(disabled: boolean) {
     } catch {
         // Ignore storage failures and keep the in-memory state updated.
     }
+    window.dispatchEvent(new Event(DAY_NIGHT_CYCLE_DISABLED_CHANGE_EVENT));
 }


### PR DESCRIPTION
## Summary

- Make the day/night theme manager respect the `Uvijek dan` setting by resolving the UI theme to light when the day-night cycle is disabled.
- Emit a local setting-change event when the persisted day-night-cycle preference changes so the app shell updates immediately.
- Add unit coverage for the forced-daytime theme resolution.

## Why

The game scene already pins time to daytime when users enable `Uvijek dan`, but the app shell still followed real sunrise/sunset and could switch to dark mode at night. This keeps the UI consistent with the user's forced daytime preference.

## Validation

- `pnpm --filter @gredice/game exec biome check src/hooks/useThemeManager.ts src/utils/dayNightCycle.ts src/hooks/dayNightTheme.ts src/hooks/useThemeManager.unit.ts`
- `pnpm test --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm build --filter garden`
- `pnpm build --filter www`