### PR TITLE
[codex] Fix tablet controls HUD overlap

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -6,6 +6,7 @@ import {
     gameHudBottomBarClassName,
     gameHudBottomControlsClassName,
 } from '../../../packages/game/src/GameHud';
+import { ControlsTooltipHud } from '../../../packages/game/src/hud/ControlsTooltipHud';
 import { ItemsHud } from '../../../packages/game/src/hud/ItemsHud';
 import {
     createGameState,
@@ -160,6 +161,28 @@ export function ItemsHudAlignmentStory() {
                         className={gameHudBottomControlsClassName}
                     >
                         <div className="h-10 w-40 rounded-lg border bg-muted" />
+                    </div>
+                    <ItemsHud />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function ItemsHudControlsTooltipStory() {
+    return (
+        <ItemsHudTestProviders>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <div
+                        data-testid="bottom-controls"
+                        className={gameHudBottomControlsClassName}
+                    >
+                        <div className="h-10 w-40 rounded-lg border bg-muted" />
+                        <ControlsTooltipHud />
                     </div>
                     <ItemsHud />
                 </div>

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { ItemsHudAlignmentStory } from './ItemsHudStory';
+import {
+    ItemsHudAlignmentStory,
+    ItemsHudControlsTooltipStory,
+} from './ItemsHudStory';
 
 const TABLET_VIEWPORT = { width: 820, height: 1180 };
 const SHORT_MOBILE_VIEWPORT = { width: 414, height: 420 };
@@ -46,6 +49,29 @@ test('item picker stays centered on tablet layouts', async ({
     ).toBeLessThanOrEqual(1);
     expect((pickerBox?.x ?? 0) + (pickerBox?.width ?? 0)).toBeLessThanOrEqual(
         TABLET_VIEWPORT.width,
+    );
+});
+
+test('controls instructions clear the item picker on tablet layouts', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudControlsTooltipStory />);
+
+    const picker = page.locator('[data-items-hud]');
+    const guide = page.locator('[data-controls-tooltip-hud="open"]');
+    await expect(picker).toBeVisible();
+    await expect(guide).toBeVisible();
+    await expect(page.getByText('Pokupi / spusti')).toBeVisible();
+
+    const pickerBox = await picker.boundingBox();
+    const guideBox = await guide.boundingBox();
+    expect(pickerBox).not.toBeNull();
+    expect(guideBox).not.toBeNull();
+
+    expect((guideBox?.y ?? 0) + (guideBox?.height ?? 0)).toBeLessThanOrEqual(
+        (pickerBox?.y ?? 0) - 8,
     );
 });
 

--- a/packages/game/src/hud/ControlsTooltipHud.tsx
+++ b/packages/game/src/hud/ControlsTooltipHud.tsx
@@ -109,7 +109,10 @@ export function ControlsTooltipHud() {
     }
 
     return (
-        <div className="pointer-events-auto relative p-2 sm:p-3">
+        <div
+            data-controls-tooltip-hud="open"
+            className="pointer-events-auto relative p-2 sm:p-3 md:mb-24"
+        >
             <ControlsVisualization deviceType={deviceType} phase={phase} />
             <ButtonGreen
                 title="Zatvori"


### PR DESCRIPTION
## Summary
- Move the open controls guide above the item picker on tablet and desktop HUD layouts.
- Add a tablet regression story and Playwright assertion for controls guide clearance.

## Validation
- git diff --check
- pnpm lint --filter @gredice/game
- pnpm lint --filter garden
- pnpm typecheck --filter @gredice/game
- pnpm test --filter @gredice/game
- pnpm --filter garden exec playwright test tests/items-hud.spec.tsx --project=chromium --reporter=line
- pnpm build --filter garden
- pnpm build --filter www

## Notes
- Lint still reports existing Biome schema-version info and optional-chain warnings in packages/game/src/utils/raisedBedBlocks.ts; no fixes were applied.