### PR TITLE
[codex] Fix farm payout operation names

### DIFF
--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -1,11 +1,10 @@
+import { formatPrice } from '@gredice/js/currency';
 import {
+    type FarmerEarning,
     getFarmerBalance,
     getFarmerPayoutRequests,
     getFarms,
 } from '@gredice/storage';
-
-export const dynamic = 'force-dynamic';
-import { formatPrice } from '@gredice/js/currency';
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
 import {
     Card,
@@ -16,7 +15,6 @@ import {
 } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
@@ -24,9 +22,14 @@ import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
 import { PayoutRequestForm } from './PayoutRequestForm';
 
+export const dynamic = 'force-dynamic';
+
 const payoutStatusLabel: Record<
     string,
-    { label: string; color: 'neutral' | 'warning' | 'info' | 'success' | 'error' }
+    {
+        label: string;
+        color: 'neutral' | 'warning' | 'info' | 'success' | 'error';
+    }
 > = {
     pending: { label: 'Na čekanju', color: 'warning' },
     approved: { label: 'Odobreno', color: 'info' },
@@ -39,6 +42,46 @@ const earningTypeLabel: Record<string, string> = {
     sowingGreenhouse: 'Sijanje (staklenički rasad)',
 };
 
+function getEarningLabel(earning: FarmerEarning) {
+    return (
+        earningTypeLabel[earning.entityTypeName] ??
+        earning.entityLabel ??
+        earning.entityTypeName
+    );
+}
+
+function getEarningKey(earning: FarmerEarning) {
+    return [
+        earning.entityTypeName,
+        earning.entityId ?? 'none',
+        earning.entityLabel ?? '',
+        earning.pricePerUnit,
+        earning.currency,
+    ].join(':');
+}
+
+function mergeEarnings(earnings: FarmerEarning[]) {
+    const merged = new Map<string, FarmerEarning>();
+
+    for (const earning of earnings) {
+        const key = getEarningKey(earning);
+        const existing = merged.get(key);
+        if (existing) {
+            existing.operationCount += earning.operationCount;
+            existing.totalEarned += earning.totalEarned;
+            continue;
+        }
+
+        merged.set(key, { ...earning });
+    }
+
+    return Array.from(merged.values()).sort((left, right) =>
+        getEarningLabel(left).localeCompare(getEarningLabel(right), 'hr', {
+            numeric: true,
+        }),
+    );
+}
+
 async function PayoutsContent() {
     const { userId } = await auth(['farmer', 'admin']);
 
@@ -49,23 +92,18 @@ async function PayoutsContent() {
         getFarmerPayoutRequests(userId),
     ]);
 
-    const totalEarned = balanceResults.reduce(
-        (s, b) => s + b.totalEarned,
-        0,
-    );
+    const totalEarned = balanceResults.reduce((s, b) => s + b.totalEarned, 0);
     const totalPaid = balanceResults.reduce((s, b) => s + b.totalPaid, 0);
-    const totalPending = balanceResults.reduce(
-        (s, b) => s + b.totalPending,
-        0,
-    );
+    const totalPending = balanceResults.reduce((s, b) => s + b.totalPending, 0);
     const availableBalance = Math.max(
         0,
         totalEarned - totalPaid - totalPending,
     );
-    const currency =
-        balanceResults.find((b) => b.currency)?.currency ?? 'eur';
+    const currency = balanceResults.find((b) => b.currency)?.currency ?? 'eur';
 
-    const earningsByType = balanceResults.flatMap((b) => b.earningsByType);
+    const earningsByType = mergeEarnings(
+        balanceResults.flatMap((b) => b.earningsByType),
+    );
 
     const farmWithBalance =
         farms.find((_, i) => balanceResults[i].totalEarned > 0) ?? farms[0];
@@ -157,11 +195,9 @@ async function PayoutsContent() {
                             </Table.Header>
                             <Table.Body>
                                 {earningsByType.map((e) => (
-                                    <Table.Row key={e.entityTypeName}>
+                                    <Table.Row key={getEarningKey(e)}>
                                         <Table.Cell>
-                                            {earningTypeLabel[e.entityTypeName] ??
-                                                e.entityTypeLabel ??
-                                                e.entityTypeName}
+                                            {getEarningLabel(e)}
                                         </Table.Cell>
                                         <Table.Cell className="text-right tabular-nums">
                                             {e.operationCount}
@@ -213,7 +249,10 @@ async function PayoutsContent() {
             {availableBalance <= 0 && totalEarned > 0 && (
                 <Card>
                     <CardContent>
-                        <Typography level="body2" className="text-muted-foreground">
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
                             {totalPending > 0
                                 ? `Imaš ${formatPrice(totalPending)} u zahtjevima na čekanju. Pričekaj da administrator obradi zahtjev.`
                                 : 'Svi iznosi su isplaćeni.'}

--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -1,22 +1,25 @@
 import 'server-only';
+import type { OperationData } from '@gredice/directory-types';
 import { and, desc, eq, sql } from 'drizzle-orm';
 import {
-    type InsertFarmerPayoutRequest,
-    type InsertOperationPrice,
     farmerPayoutRequests,
-    type PayoutStatus,
+    farmUsers,
+    gardens,
+    type InsertOperationPrice,
     operationPrices,
+    type PayoutStatus,
+    raisedBeds,
     type SelectFarmerPayoutRequest,
     type SelectOperationPrice,
 } from '../schema';
 import { storage } from '../storage';
-import { createReceipt } from './invoicesRepo';
-import { getFarmUserAcceptedOperations } from './operationsRepo';
-import { getRaisedBedFieldPlantCycles } from './gardensRepo';
+import { getEntitiesFormatted } from './entitiesRepo';
 import { createEvent, knownEvents } from './eventsRepo';
+import { getRaisedBedFieldPlantCycles } from './gardensRepo';
+import { createReceipt } from './invoicesRepo';
 import { createNotification } from './notificationsRepo';
+import { getFarmUserAcceptedOperations } from './operationsRepo';
 import { getUser } from './usersRepo';
-import { farmUsers, gardens, raisedBeds } from '../schema';
 
 // ── Operation Prices ─────────────────────────────────────────────────────────
 
@@ -38,14 +41,19 @@ export async function getAllOperationPrices(): Promise<SelectOperationPrice[]> {
 export async function upsertOperationPrice(
     input: InsertOperationPrice,
 ): Promise<SelectOperationPrice> {
-    const isEntitySpecific = input.entityId !== null && input.entityId !== undefined;
+    const isEntitySpecific =
+        input.entityId !== null && input.entityId !== undefined;
 
     const [row] = await storage()
         .insert(operationPrices)
         .values(input)
         .onConflictDoUpdate({
             target: isEntitySpecific
-                ? [operationPrices.farmId, operationPrices.entityTypeName, operationPrices.entityId]
+                ? [
+                      operationPrices.farmId,
+                      operationPrices.entityTypeName,
+                      operationPrices.entityId,
+                  ]
                 : [operationPrices.farmId, operationPrices.entityTypeName],
             targetWhere: isEntitySpecific
                 ? sql`${operationPrices.entityId} IS NOT NULL`
@@ -61,9 +69,7 @@ export async function upsertOperationPrice(
 }
 
 export async function deleteOperationPrice(id: number): Promise<void> {
-    await storage()
-        .delete(operationPrices)
-        .where(eq(operationPrices.id, id));
+    await storage().delete(operationPrices).where(eq(operationPrices.id, id));
 }
 
 // ── Sowing helpers ────────────────────────────────────────────────────────────
@@ -127,7 +133,8 @@ async function getVerifiedSowingsForFarmer(
 
 export type FarmerEarning = {
     entityTypeName: string;
-    entityTypeLabel?: string;
+    entityId: number | null;
+    entityLabel?: string;
     operationCount: number;
     pricePerUnit: number;
     totalEarned: number;
@@ -147,13 +154,19 @@ export async function getFarmerBalance(
     userId: string,
     farmId: number,
 ): Promise<FarmerBalance> {
-    const [prices, completedOperations, payouts, verifiedSowings] =
-        await Promise.all([
-            getOperationPrices(farmId),
-            getFarmUserAcceptedOperations(userId, { status: 'completed' }),
-            getFarmerPayoutRequests(userId, farmId),
-            getVerifiedSowingsForFarmer(userId),
-        ]);
+    const [
+        prices,
+        completedOperations,
+        payouts,
+        verifiedSowings,
+        operationsData,
+    ] = await Promise.all([
+        getOperationPrices(farmId),
+        getFarmUserAcceptedOperations(userId, { status: 'completed' }),
+        getFarmerPayoutRequests(userId, farmId),
+        getVerifiedSowingsForFarmer(userId),
+        getEntitiesFormatted<OperationData>('operation'),
+    ]);
 
     // Two maps: entityId-keyed (for specific operations) and typeName-keyed (for sowing)
     const priceByEntityId = new Map<number, SelectOperationPrice>(
@@ -162,7 +175,15 @@ export async function getFarmerBalance(
             .map((p) => [p.entityId as number, p]),
     );
     const priceByTypeName = new Map<string, SelectOperationPrice>(
-        prices.filter((p) => p.entityId === null).map((p) => [p.entityTypeName, p]),
+        prices
+            .filter((p) => p.entityId === null)
+            .map((p) => [p.entityTypeName, p]),
+    );
+    const operationLabelById = new Map(
+        operationsData.map((operation) => [
+            operation.id,
+            operation.information.label || operation.information.name,
+        ]),
     );
 
     const earningsByKey = new Map<string, FarmerEarning>();
@@ -192,6 +213,8 @@ export async function getFarmerBalance(
         } else {
             earningsByKey.set(key, {
                 entityTypeName: op.entityTypeName,
+                entityId: op.entityId,
+                entityLabel: operationLabelById.get(op.entityId),
                 operationCount: 1,
                 pricePerUnit: priceValue,
                 totalEarned: priceValue,
@@ -221,6 +244,7 @@ export async function getFarmerBalance(
         } else {
             earningsByKey.set(typeName, {
                 entityTypeName: typeName,
+                entityId: null,
                 operationCount: 1,
                 pricePerUnit: priceValue,
                 totalEarned: priceValue,
@@ -418,7 +442,12 @@ export async function approvePayoutRequest(
     );
 
     // Notify the farmer
-    await notifyFarmerPayoutStatus(existing.userId, 'approved', parseFloat(existing.requestedAmount), existing.currency);
+    await notifyFarmerPayoutStatus(
+        existing.userId,
+        'approved',
+        parseFloat(existing.requestedAmount),
+        existing.currency,
+    );
 
     return row;
 }
@@ -451,7 +480,12 @@ export async function rejectPayoutRequest(
     );
 
     // Notify the farmer
-    await notifyFarmerPayoutStatus(existing.userId, 'rejected', parseFloat(existing.requestedAmount), existing.currency);
+    await notifyFarmerPayoutStatus(
+        existing.userId,
+        'rejected',
+        parseFloat(existing.requestedAmount),
+        existing.currency,
+    );
 
     return row;
 }
@@ -515,7 +549,12 @@ export async function markPayoutAsPaid(
     );
 
     // Notify the farmer
-    await notifyFarmerPayoutStatus(existing.userId, 'paid', parseFloat(existing.requestedAmount), existing.currency);
+    await notifyFarmerPayoutStatus(
+        existing.userId,
+        'paid',
+        parseFloat(existing.requestedAmount),
+        existing.currency,
+    );
 
     return { payoutRequest: row, receiptId };
 }
@@ -534,7 +573,10 @@ async function notifyFarmerPayoutStatus(
         const accountId = user.accounts[0].account.id;
         const amountStr = `${amount.toFixed(2)} ${currency.toUpperCase()}`;
 
-        const messages: Record<typeof status, { header: string; content: string }> = {
+        const messages: Record<
+            typeof status,
+            { header: string; content: string }
+        > = {
             approved: {
                 header: 'Zahtjev za isplatu odobren',
                 content: `Tvoj zahtjev za isplatu ${amountStr} je odobren. Uskoro će biti obrađen.`,

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    acceptOperation,
+    assignUserToFarm,
+    createAttributeDefinition,
+    createEntity,
+    createEvent,
+    createFarm,
+    createOperation,
+    getFarmerBalance,
+    knownEvents,
+    storage,
+    updateEntity,
+    upsertAttributeValue,
+    upsertEntityType,
+    upsertOperationPrice,
+    users,
+} from '@gredice/storage';
+import { createTestDb } from './testDb';
+
+async function createPublishedOperationEntity(label: string) {
+    await upsertEntityType({ name: 'operation', label: 'Radnje' });
+
+    const suffix = randomUUID();
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Name',
+        entityTypeName: 'operation',
+        dataType: 'text',
+    });
+    const labelDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'label',
+        label: 'Label',
+        entityTypeName: 'operation',
+        dataType: 'text',
+    });
+
+    const entityId = await createEntity('operation');
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: `operation-${suffix}`,
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: labelDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: label,
+    });
+    await updateEntity({ id: entityId, state: 'published' });
+
+    return entityId;
+}
+
+async function createVerifiedAcceptedOperation(input: {
+    farmId: number;
+    entityId: number;
+    completedBy: string;
+}) {
+    const operationId = await createOperation({
+        entityId: input.entityId,
+        entityTypeName: 'operation',
+        farmId: input.farmId,
+    });
+    await acceptOperation(operationId);
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: input.completedBy,
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.verifiedV1(operationId.toString(), {
+            verifiedBy: randomUUID(),
+        }),
+    );
+
+    return operationId;
+}
+
+test('getFarmerBalance groups completed operations by CMS operation name', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `payout-${userId}@example.com`,
+            displayName: 'Payout Test Farmer',
+            role: 'farmer',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+    const farmId = await createFarm({
+        name: `Payout Farm ${randomUUID()}`,
+        longitude: 0,
+        latitude: 0,
+    });
+    await assignUserToFarm(farmId, userId);
+
+    const wateringEntityId =
+        await createPublishedOperationEntity('Zalijevanje');
+    const hoeingEntityId = await createPublishedOperationEntity('Okopavanje');
+
+    await upsertOperationPrice({
+        farmId,
+        entityTypeName: 'operation',
+        entityId: wateringEntityId,
+        pricePerUnit: '0.50',
+        currency: 'eur',
+    });
+    await upsertOperationPrice({
+        farmId,
+        entityTypeName: 'operation',
+        entityId: hoeingEntityId,
+        pricePerUnit: '0.75',
+        currency: 'eur',
+    });
+
+    await createVerifiedAcceptedOperation({
+        farmId,
+        entityId: wateringEntityId,
+        completedBy: userId,
+    });
+    await createVerifiedAcceptedOperation({
+        farmId,
+        entityId: wateringEntityId,
+        completedBy: userId,
+    });
+    await createVerifiedAcceptedOperation({
+        farmId,
+        entityId: hoeingEntityId,
+        completedBy: userId,
+    });
+
+    const balance = await getFarmerBalance(userId, farmId);
+    const watering = balance.earningsByType.find(
+        (earning) => earning.entityId === wateringEntityId,
+    );
+    const hoeing = balance.earningsByType.find(
+        (earning) => earning.entityId === hoeingEntityId,
+    );
+
+    assert.equal(watering?.entityLabel, 'Zalijevanje');
+    assert.equal(watering?.operationCount, 2);
+    assert.equal(watering?.pricePerUnit, 0.5);
+    assert.equal(watering?.totalEarned, 1);
+    assert.equal(hoeing?.entityLabel, 'Okopavanje');
+    assert.equal(hoeing?.operationCount, 1);
+    assert.equal(balance.totalEarned, 1.75);
+});


### PR DESCRIPTION
## Summary

- Resolve CMS operation labels for farmer payout earnings so payout rows show names like `Zalijevanje` instead of the generic `operation` fallback.
- Carry operation `entityId`/`entityLabel` through the storage balance aggregate and merge identical payout rows in the farm payouts table.
- Add a storage regression test covering repeated completed operations grouped under the same operation label.

## Root Cause

`getFarmerBalance` grouped completed operations by operation entity id, but the returned earning rows only exposed `entityTypeName`. The farm payouts table therefore fell back to `operation`, and page-level flattening could leave identical earnings as separate one-count rows across farm balance results.

## Validation

- `pnpm --dir packages/storage exec biome check src/repositories/payoutsRepo.ts tests/payoutsRepo.node.spec.ts`
- `pnpm --dir apps/farm exec biome check app/payouts/page.tsx`
- `pnpm --dir packages/storage run test:node payoutsRepo.node.spec.ts`
- `pnpm build --filter farm`

Additional validation run before rebasing onto current `origin/main`:

- `pnpm test --filter @gredice/storage` - 217 passed
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter farm`
- `pnpm test --filter farm` - 16 passed