### PR TITLE
[codex] Fix cat roaming behavior

### DIFF
--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -709,10 +709,13 @@ function chooseManualNextTarget({
         timeOfDay,
         weather,
     });
+    const canManuallyReturnToPillow =
+        isCatNight(timeOfDay) || shouldCatSeekCover(timeOfDay, weather);
 
     if (
-        target.id !== currentTarget.id ||
-        target.behavior !== currentTarget.behavior
+        (target.id !== currentTarget.id ||
+            target.behavior !== currentTarget.behavior) &&
+        (target.behavior !== 'pillow' || canManuallyReturnToPillow)
     ) {
         return target;
     }
@@ -759,7 +762,7 @@ function chooseManualNextTarget({
         alternatives.push(...lowEntities);
     }
 
-    if (currentTarget.behavior !== 'pillow') {
+    if (currentTarget.behavior !== 'pillow' && canManuallyReturnToPillow) {
         alternatives.push(habitat.pillow);
     }
 
@@ -1062,6 +1065,8 @@ function Cat({
 
         runtimeRef.current = makeMovingState({
             from: group.position.clone(),
+            fromTarget: runtime.target,
+            groundSurfaces: habitat.groundSurfaces,
             now,
             target,
         });

--- a/packages/game/src/entities/cats/catBehavior.ts
+++ b/packages/game/src/entities/cats/catBehavior.ts
@@ -27,11 +27,11 @@ const CAT_SHELTER_RANGE_BLOCKS = 5.5;
 const catBirdStalkChance = 0.42;
 
 const behaviorWeights = [
-    { behavior: 'pillow', dayWeight: 0.27 },
-    { behavior: 'roam', dayWeight: 0.34 },
-    { behavior: 'cover', dayWeight: 0.05 },
-    { behavior: 'low-entity', dayWeight: 0.16 },
-    { behavior: 'stalk-bird', dayWeight: 0.18 },
+    { behavior: 'pillow', dayWeight: 0.08 },
+    { behavior: 'roam', dayWeight: 0.45 },
+    { behavior: 'cover', dayWeight: 0.12 },
+    { behavior: 'low-entity', dayWeight: 0.14 },
+    { behavior: 'stalk-bird', dayWeight: 0.21 },
 ] satisfies WeightedBehavior[];
 
 export function isCatNight(timeOfDay: number) {

--- a/packages/game/src/entities/cats/catBehavior.unit.ts
+++ b/packages/game/src/entities/cats/catBehavior.unit.ts
@@ -86,6 +86,31 @@ test('does not include unavailable optional behaviors', () => {
     );
 });
 
+test('keeps daytime pillow returns rare compared with active behavior', () => {
+    const weights = getCatBehaviorWeights({
+        cover: true,
+        roam: true,
+        'low-entity': true,
+        'stalk-bird': true,
+    });
+    const weightByBehavior = new Map(
+        weights.map((item) => [item.behavior, item.dayWeight]),
+    );
+
+    assert.ok(
+        (weightByBehavior.get('pillow') ?? 0) <
+            (weightByBehavior.get('roam') ?? 0),
+    );
+    assert.ok(
+        (weightByBehavior.get('pillow') ?? 0) <
+            (weightByBehavior.get('cover') ?? 0),
+    );
+    assert.ok(
+        (weightByBehavior.get('pillow') ?? 0) <
+            (weightByBehavior.get('stalk-bird') ?? 0),
+    );
+});
+
 test('keeps night pillow naps longer than daytime roam windows', () => {
     const nightPillowDwell = getCatDwellSeconds({
         behavior: 'pillow',


### PR DESCRIPTION
## Summary
- Fix click-driven cat movement so it uses the same ground-surface height sampling as autonomous walking.
- Reduce daytime pillow returns and bias the cat toward roaming, cover, and bird-stalking behavior.
- Add a unit test that keeps daytime pillow behavior below active behaviors.

## Root Cause
Manual click transitions created moving cat state without the habitat ground surfaces. That made the walking path fall back to y=0 while autonomous transitions used the correct stack-height-aware surface data.

## Validation
- pnpm --filter @gredice/game test
- pnpm --filter @gredice/game lint
- pnpm --filter @gredice/game typecheck
- pnpm build --filter garden --force
- pnpm build --filter www --force
- pnpm --filter garden exec playwright test tests/landing.spec.ts
- pnpm --filter www exec playwright test tests/landing.spec.ts
- git diff --check

Note: lint reports existing Biome schema info and unrelated optional-chain warnings outside this change.