### PR TITLE
[codex] Fix weather chart click focus outline

### DIFF
--- a/packages/ui/src/WeatherCharts/WeatherCharts.tsx
+++ b/packages/ui/src/WeatherCharts/WeatherCharts.tsx
@@ -12,6 +12,7 @@ import {
 } from '@gredice/js/weather';
 import {
     type ComponentType,
+    type MouseEvent,
     useLayoutEffect,
     useMemo,
     useRef,
@@ -413,6 +414,15 @@ function getCalendarDayDiff(from: Date, to: Date): number {
     return Math.round((toDay.getTime() - fromDay.getTime()) / DAY_MS);
 }
 
+function preventRechartsPointerFocus(event: MouseEvent<HTMLDivElement>) {
+    if (
+        event.target instanceof Element &&
+        event.target.closest('.recharts-surface')
+    ) {
+        event.preventDefault();
+    }
+}
+
 function getPresetSelectableBounds(
     bounds: { min: Date; max: Date },
     now: Date,
@@ -616,7 +626,11 @@ export function WeatherCharts({
             : toEmptyMetricChartData(range);
 
         return (
-            <div style={{ height: chartHeight }} className="relative w-full">
+            <div
+                style={{ height: chartHeight }}
+                className="relative w-full"
+                onMouseDownCapture={preventRechartsPointerFocus}
+            >
                 <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart
                         data={chartData}
@@ -698,6 +712,9 @@ export function WeatherCharts({
                                 fill={color}
                                 fillOpacity={0.025}
                                 ifOverflow="visible"
+                                pointerEvents="none"
+                                focusable={false}
+                                aria-hidden="true"
                             />
                         )}
                         {nowTs >= range.from.getTime() &&


### PR DESCRIPTION
## Summary

- Prevent pointer clicks on WeatherCharts from focusing Recharts' internal SVG layers.
- Mark the forecast reference area as decorative and non-interactive while keeping chart tooltip behavior intact.
- Rebased the fix onto the latest `origin/main`, preserving the upstream responsive WeatherCharts changes.

## Validation

- `pnpm --filter @gredice/ui exec biome check src/WeatherCharts/WeatherCharts.tsx`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter storybook typecheck`
- `pnpm build --filter garden --force`
- `pnpm build --filter app --force`
- Storybook Playwright click check on `packages-ui-data-weathercharts--rain-tab`: forecast area has `pointer-events: none`, does not focus an SVG element, and tooltip remains visible.
