### PR TITLE
Fix farm payout operation names

### DIFF
--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -1,12 +1,13 @@
 import 'server-only';
 import type { OperationData } from '@gredice/directory-types';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
     farmerPayoutRequests,
     farmUsers,
     gardens,
     type InsertOperationPrice,
     operationPrices,
+    operations,
     type PayoutStatus,
     raisedBeds,
     type SelectFarmerPayoutRequest,
@@ -116,6 +117,7 @@ async function getVerifiedSowingsForFarmer(
                 farmId: row.farmId,
                 sowingLocation: cycle.sowingLocation,
                 plantStatus: cycle.plantStatus,
+                assignedUserIds: cycle.assignedUserIds ?? [],
             }));
         }),
     );
@@ -125,8 +127,42 @@ async function getVerifiedSowingsForFarmer(
         .filter(
             (c) =>
                 c.plantStatus !== undefined &&
-                VERIFIED_SOWING_STATUSES.has(c.plantStatus),
+                VERIFIED_SOWING_STATUSES.has(c.plantStatus) &&
+                c.assignedUserIds.includes(userId),
         );
+}
+
+async function getOperationEffectiveFarmIds(operationIds: number[]) {
+    const uniqueOperationIds = Array.from(new Set(operationIds));
+    if (uniqueOperationIds.length === 0) {
+        return new Map<number, number>();
+    }
+
+    const rows = await storage()
+        .select({
+            operationId: operations.id,
+            farmId: sql<
+                number | null
+            >`coalesce(${operations.farmId}, ${gardens.farmId})`,
+        })
+        .from(operations)
+        .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .leftJoin(
+            gardens,
+            eq(
+                gardens.id,
+                sql<
+                    number | null
+                >`coalesce(${operations.gardenId}, ${raisedBeds.gardenId})`,
+            ),
+        )
+        .where(inArray(operations.id, uniqueOperationIds));
+
+    return new Map(
+        rows
+            .filter((row) => row.farmId !== null)
+            .map((row) => [row.operationId, row.farmId]),
+    );
 }
 
 // ── Farmer Balance ────────────────────────────────────────────────────────────
@@ -167,6 +203,9 @@ export async function getFarmerBalance(
         getVerifiedSowingsForFarmer(userId),
         getEntitiesFormatted<OperationData>('operation'),
     ]);
+    const completedOperationFarmIds = await getOperationEffectiveFarmIds(
+        completedOperations.map((operation) => operation.id),
+    );
 
     // Two maps: entityId-keyed (for specific operations) and typeName-keyed (for sowing)
     const priceByEntityId = new Map<number, SelectOperationPrice>(
@@ -191,9 +230,11 @@ export async function getFarmerBalance(
 
     // Operations
     for (const op of completedOperations) {
-        const opFarmId =
-            op.farmId ??
-            (op as unknown as { garden?: { farmId?: number } }).garden?.farmId;
+        if (!(op.assignedUserIds ?? []).includes(userId)) {
+            continue;
+        }
+
+        const opFarmId = completedOperationFarmIds.get(op.id);
         if (opFarmId !== farmId) continue;
 
         // Look up price by entityId first, then fall back to entityTypeName

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
     acceptOperation,
     assignUserToFarm,
+    createAccount,
     createAttributeDefinition,
     createEntity,
     createEvent,
@@ -16,8 +17,14 @@ import {
     upsertAttributeValue,
     upsertEntityType,
     upsertOperationPrice,
+    upsertRaisedBedField,
     users,
 } from '@gredice/storage';
+import {
+    createTestBlock,
+    createTestGarden,
+    createTestRaisedBed,
+} from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
 async function createPublishedOperationEntity(label: string) {
@@ -58,16 +65,29 @@ async function createPublishedOperationEntity(label: string) {
 }
 
 async function createVerifiedAcceptedOperation(input: {
-    farmId: number;
+    farmId?: number;
+    gardenId?: number;
+    raisedBedId?: number;
+    raisedBedFieldId?: number;
     entityId: number;
     completedBy: string;
+    assignedUserId?: string;
 }) {
     const operationId = await createOperation({
         entityId: input.entityId,
         entityTypeName: 'operation',
         farmId: input.farmId,
+        gardenId: input.gardenId,
+        raisedBedId: input.raisedBedId,
+        raisedBedFieldId: input.raisedBedFieldId,
     });
     await acceptOperation(operationId);
+    await createEvent(
+        knownEvents.operations.assignedV1(operationId.toString(), {
+            assignedUserId: input.assignedUserId ?? input.completedBy,
+            assignedBy: input.assignedUserId ?? input.completedBy,
+        }),
+    );
     await createEvent(
         knownEvents.operations.completedV1(operationId.toString(), {
             completedBy: input.completedBy,
@@ -154,4 +174,84 @@ test('getFarmerBalance groups completed operations by CMS operation name', async
     assert.equal(hoeing?.entityLabel, 'Okopavanje');
     assert.equal(hoeing?.operationCount, 1);
     assert.equal(balance.totalEarned, 1.75);
+});
+
+test('getFarmerBalance includes assigned raised-bed operations by effective farm', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    const otherFarmerId = randomUUID();
+    await storage()
+        .insert(users)
+        .values([
+            {
+                id: userId,
+                userName: `payout-raised-bed-${userId}@example.com`,
+                displayName: 'Payout Raised Bed Farmer',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: otherFarmerId,
+                userName: `payout-other-${otherFarmerId}@example.com`,
+                displayName: 'Other Farmer',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
+
+    const farmId = await createFarm({
+        name: `Raised Bed Payout Farm ${randomUUID()}`,
+        longitude: 0,
+        latitude: 0,
+    });
+    await Promise.all([
+        assignUserToFarm(farmId, userId),
+        assignUserToFarm(farmId, otherFarmerId),
+    ]);
+
+    const accountId = await createAccount();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'payout-raised-bed-block');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    const [field] = await storage().query.raisedBedFields.findMany({
+        where: (raisedBedFields, { and, eq }) =>
+            and(
+                eq(raisedBedFields.raisedBedId, raisedBedId),
+                eq(raisedBedFields.positionIndex, 0),
+            ),
+    });
+    assert.ok(field);
+
+    const operationEntityId =
+        await createPublishedOperationEntity('Zalijevanje');
+    await upsertOperationPrice({
+        farmId,
+        entityTypeName: 'operation',
+        entityId: operationEntityId,
+        pricePerUnit: '0.50',
+        currency: 'eur',
+    });
+
+    await createVerifiedAcceptedOperation({
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+        entityId: operationEntityId,
+        completedBy: userId,
+        assignedUserId: userId,
+    });
+
+    const balance = await getFarmerBalance(userId, farmId);
+    const otherBalance = await getFarmerBalance(otherFarmerId, farmId);
+
+    const watering = balance.earningsByType.find(
+        (earning) => earning.entityId === operationEntityId,
+    );
+    assert.equal(watering?.operationCount, 1);
+    assert.equal(watering?.totalEarned, 0.5);
+    assert.equal(otherBalance.totalEarned, 0);
 });


### PR DESCRIPTION
## Summary
- show CMS operation labels in the farm payout earnings table
- aggregate payout rows by operation identity and price
- count assigned garden/raised-bed scoped operations and assigned sowings in farmer payout totals

## Validation
- pnpm --dir packages/storage run test:node payoutsRepo.node.spec.ts
- pnpm lint --filter @gredice/storage
- pnpm test --filter @gredice/storage
- pnpm build --filter farm
- pnpm test --filter farm