### PR TITLE
[codex] Scope farm payouts to last paid request

### DIFF
--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -95,9 +95,9 @@ async function PayoutsContent() {
     const totalEarned = balanceResults.reduce((s, b) => s + b.totalEarned, 0);
     const totalPaid = balanceResults.reduce((s, b) => s + b.totalPaid, 0);
     const totalPending = balanceResults.reduce((s, b) => s + b.totalPending, 0);
-    const availableBalance = Math.max(
+    const availableBalance = balanceResults.reduce(
+        (s, b) => s + b.availableBalance,
         0,
-        totalEarned - totalPaid - totalPending,
     );
     const currency = balanceResults.find((b) => b.currency)?.currency ?? 'eur';
 
@@ -119,7 +119,7 @@ async function PayoutsContent() {
                                 level="body3"
                                 className="text-muted-foreground"
                             >
-                                Ukupno zarađeno
+                                Zarađeno za isplatu
                             </Typography>
                             <Typography
                                 level="h4"
@@ -175,7 +175,7 @@ async function PayoutsContent() {
             {earningsByType.length > 0 && (
                 <Card>
                     <CardHeader>
-                        <CardTitle>Zarađeno po vrsti radnje</CardTitle>
+                        <CardTitle>Radnje za isplatu</CardTitle>
                     </CardHeader>
                     <CardOverflow>
                         <Table>

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -146,19 +146,28 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
     }
 
     const aggregateIds = operations.map((op) => op.id.toString());
-    const aggregatesEvents = await getEvents(
-        [
-            knownEventTypes.operations.assign,
-            knownEventTypes.operations.schedule,
-            knownEventTypes.operations.complete,
-            knownEventTypes.operations.verify,
-            knownEventTypes.operations.fail,
-            knownEventTypes.operations.cancel,
-        ],
-        aggregateIds,
-        0,
-        10000,
-    );
+    const aggregateEventTypes = [
+        knownEventTypes.operations.assign,
+        knownEventTypes.operations.schedule,
+        knownEventTypes.operations.complete,
+        knownEventTypes.operations.verify,
+        knownEventTypes.operations.fail,
+        knownEventTypes.operations.cancel,
+    ];
+    const aggregatesEvents: Awaited<ReturnType<typeof getEvents>> = [];
+    const eventPageSize = 10000;
+    for (let offset = 0; ; offset += eventPageSize) {
+        const eventPage = await getEvents(
+            aggregateEventTypes,
+            aggregateIds,
+            offset,
+            eventPageSize,
+        );
+        aggregatesEvents.push(...eventPage);
+        if (eventPage.length < eventPageSize) {
+            break;
+        }
+    }
 
     const eventsByAggregateId = new Map<string, typeof aggregatesEvents>();
     for (const event of aggregatesEvents) {

--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -91,6 +91,7 @@ const VERIFIED_SOWING_STATUSES = new Set([
 // Returns one entry per verified sowing cycle, with the farmId it belongs to
 async function getVerifiedSowingsForFarmer(
     userId: string,
+    verifiedFrom?: Date,
 ): Promise<{ farmId: number; sowingLocation: string }[]> {
     const raisedBedRows = await storage()
         .select({
@@ -117,6 +118,14 @@ async function getVerifiedSowingsForFarmer(
                 farmId: row.farmId,
                 sowingLocation: cycle.sowingLocation,
                 plantStatus: cycle.plantStatus,
+                verifiedAt:
+                    cycle.plantSowDate ??
+                    cycle.plantGrowthDate ??
+                    cycle.plantDeadDate ??
+                    cycle.plantReadyDate ??
+                    cycle.plantHarvestedDate ??
+                    cycle.plantRemovedDate ??
+                    cycle.endedAt,
                 assignedUserIds: cycle.assignedUserIds ?? [],
             }));
         }),
@@ -128,6 +137,7 @@ async function getVerifiedSowingsForFarmer(
             (c) =>
                 c.plantStatus !== undefined &&
                 VERIFIED_SOWING_STATUSES.has(c.plantStatus) &&
+                (!verifiedFrom || c.verifiedAt > verifiedFrom) &&
                 c.assignedUserIds.includes(userId),
         );
 }
@@ -165,6 +175,22 @@ async function getOperationEffectiveFarmIds(operationIds: number[]) {
     );
 }
 
+function getLastPaidPayoutAt(payouts: SelectFarmerPayoutRequest[]) {
+    return payouts
+        .filter((payout) => payout.status === 'paid')
+        .map((payout) => payout.paidAt ?? payout.updatedAt ?? payout.createdAt)
+        .filter((paidAt): paidAt is Date => paidAt instanceof Date)
+        .sort((left, right) => right.getTime() - left.getTime())[0];
+}
+
+function getOperationPayoutEligibleAt(operation: {
+    verifiedAt?: Date;
+    completedAt?: Date;
+    timestamp: Date;
+}) {
+    return operation.verifiedAt ?? operation.completedAt ?? operation.timestamp;
+}
+
 // ── Farmer Balance ────────────────────────────────────────────────────────────
 
 export type FarmerEarning = {
@@ -190,21 +216,25 @@ export async function getFarmerBalance(
     userId: string,
     farmId: number,
 ): Promise<FarmerBalance> {
-    const [
-        prices,
-        completedOperations,
-        payouts,
-        verifiedSowings,
-        operationsData,
-    ] = await Promise.all([
+    const [prices, payouts, operationsData] = await Promise.all([
         getOperationPrices(farmId),
-        getFarmUserAcceptedOperations(userId, { status: 'completed' }),
         getFarmerPayoutRequests(userId, farmId),
-        getVerifiedSowingsForFarmer(userId),
         getEntitiesFormatted<OperationData>('operation'),
     ]);
+    const lastPaidPayoutAt = getLastPaidPayoutAt(payouts);
+    const [completedOperations, verifiedSowings] = await Promise.all([
+        getFarmUserAcceptedOperations(userId, { status: 'completed' }),
+        getVerifiedSowingsForFarmer(userId, lastPaidPayoutAt),
+    ]);
+    const payableOperations = completedOperations.filter((operation) => {
+        if (!lastPaidPayoutAt) {
+            return true;
+        }
+
+        return getOperationPayoutEligibleAt(operation) > lastPaidPayoutAt;
+    });
     const completedOperationFarmIds = await getOperationEffectiveFarmIds(
-        completedOperations.map((operation) => operation.id),
+        payableOperations.map((operation) => operation.id),
     );
 
     // Two maps: entityId-keyed (for specific operations) and typeName-keyed (for sowing)
@@ -229,7 +259,7 @@ export async function getFarmerBalance(
     let currency = 'eur';
 
     // Operations
-    for (const op of completedOperations) {
+    for (const op of payableOperations) {
         if (!(op.assignedUserIds ?? []).includes(userId)) {
             continue;
         }
@@ -307,10 +337,7 @@ export async function getFarmerBalance(
         .filter((p) => p.status === 'pending' || p.status === 'approved')
         .reduce((acc, p) => acc + parseFloat(p.requestedAmount), 0);
 
-    const availableBalance = Math.max(
-        0,
-        totalEarned - totalPaid - totalPending,
-    );
+    const availableBalance = Math.max(0, totalEarned - totalPending);
 
     return {
         totalEarned,

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -10,6 +10,7 @@ import {
     createEvent,
     createFarm,
     createOperation,
+    farmerPayoutRequests,
     getFarmerBalance,
     knownEvents,
     storage,
@@ -72,6 +73,8 @@ async function createVerifiedAcceptedOperation(input: {
     entityId: number;
     completedBy: string;
     assignedUserId?: string;
+    completedAt?: Date;
+    verifiedAt?: Date;
 }) {
     const operationId = await createOperation({
         entityId: input.entityId,
@@ -88,16 +91,20 @@ async function createVerifiedAcceptedOperation(input: {
             assignedBy: input.assignedUserId ?? input.completedBy,
         }),
     );
-    await createEvent(
-        knownEvents.operations.completedV1(operationId.toString(), {
+    await createEvent({
+        ...knownEvents.operations.completedV1(operationId.toString(), {
             completedBy: input.completedBy,
         }),
-    );
-    await createEvent(
-        knownEvents.operations.verifiedV1(operationId.toString(), {
+        ...(input.completedAt ? { createdAt: input.completedAt } : {}),
+    });
+    await createEvent({
+        ...knownEvents.operations.verifiedV1(operationId.toString(), {
             verifiedBy: randomUUID(),
         }),
-    );
+        ...(input.verifiedAt || input.completedAt
+            ? { createdAt: input.verifiedAt ?? input.completedAt }
+            : {}),
+    });
 
     return operationId;
 }
@@ -254,4 +261,90 @@ test('getFarmerBalance includes assigned raised-bed operations by effective farm
     assert.equal(watering?.operationCount, 1);
     assert.equal(watering?.totalEarned, 0.5);
     assert.equal(otherBalance.totalEarned, 0);
+});
+
+test('getFarmerBalance counts payable work after the last paid payout', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `payout-window-${userId}@example.com`,
+            displayName: 'Payout Window Farmer',
+            role: 'farmer',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+    const farmId = await createFarm({
+        name: `Payout Window Farm ${randomUUID()}`,
+        longitude: 0,
+        latitude: 0,
+    });
+    await assignUserToFarm(farmId, userId);
+
+    const wateringEntityId =
+        await createPublishedOperationEntity('Zalijevanje');
+    await upsertOperationPrice({
+        farmId,
+        entityTypeName: 'operation',
+        entityId: wateringEntityId,
+        pricePerUnit: '0.50',
+        currency: 'eur',
+    });
+
+    await createVerifiedAcceptedOperation({
+        farmId,
+        entityId: wateringEntityId,
+        completedBy: userId,
+        completedAt: new Date('2026-01-01T10:00:00.000Z'),
+        verifiedAt: new Date('2026-01-01T10:05:00.000Z'),
+    });
+
+    await storage()
+        .insert(farmerPayoutRequests)
+        .values({
+            farmId,
+            userId,
+            requestedAmount: '0.50',
+            currency: 'eur',
+            status: 'paid',
+            paidAt: new Date('2026-01-02T10:00:00.000Z'),
+            createdAt: new Date('2026-01-02T09:00:00.000Z'),
+            updatedAt: new Date('2026-01-02T10:00:00.000Z'),
+        });
+
+    await createVerifiedAcceptedOperation({
+        farmId,
+        entityId: wateringEntityId,
+        completedBy: userId,
+        completedAt: new Date('2026-01-03T10:00:00.000Z'),
+        verifiedAt: new Date('2026-01-03T10:05:00.000Z'),
+    });
+
+    await storage()
+        .insert(farmerPayoutRequests)
+        .values({
+            farmId,
+            userId,
+            requestedAmount: '0.20',
+            currency: 'eur',
+            status: 'pending',
+            createdAt: new Date('2026-01-03T11:00:00.000Z'),
+            updatedAt: new Date('2026-01-03T11:00:00.000Z'),
+        });
+
+    const balance = await getFarmerBalance(userId, farmId);
+    const watering = balance.earningsByType.find(
+        (earning) => earning.entityId === wateringEntityId,
+    );
+
+    assert.equal(watering?.operationCount, 1);
+    assert.equal(watering?.totalEarned, 0.5);
+    assert.equal(balance.totalEarned, 0.5);
+    assert.equal(balance.totalPaid, 0.5);
+    assert.equal(balance.totalPending, 0.2);
+    assert.equal(balance.availableBalance, 0.3);
 });


### PR DESCRIPTION
## Summary
- scope payout earnings rows to work verified after the latest paid payout, or all history when there is no paid payout
- keep available balance based on the current payout window while still showing paid/pending payout totals
- page operation aggregate events past the previous 10k cap so forever really includes all relevant events
- clarify the farm payout labels so the table/card describe work currently eligible for payout

## Validation
- `pnpm --dir packages/storage run test:node payoutsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage`
- `pnpm --filter farm exec biome check app/payouts/page.tsx`
- `pnpm build --filter farm`
- `pnpm test --filter farm`