### PR TITLE
[codex] Scope farm payouts by farm

### DIFF
--- a/apps/farm/app/payouts/FarmPayoutFarmSelect.tsx
+++ b/apps/farm/app/payouts/FarmPayoutFarmSelect.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { SelectItems } from '@gredice/ui/SelectItems';
+import type { Route } from 'next';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+type FarmPayoutFarmSelectProps = {
+    farms: {
+        id: number;
+        name: string;
+    }[];
+    selectedFarmId: number;
+};
+
+export function FarmPayoutFarmSelect({
+    farms,
+    selectedFarmId,
+}: FarmPayoutFarmSelectProps) {
+    const pathname = usePathname();
+    const router = useRouter();
+    const searchParams = useSearchParams();
+
+    return (
+        <SelectItems
+            className="w-full sm:max-w-xs"
+            label="Farma"
+            items={farms.map((farm) => ({
+                value: farm.id.toString(),
+                label: farm.name,
+                title: farm.name,
+            }))}
+            value={selectedFarmId.toString()}
+            onValueChange={(value) => {
+                const nextParams = new URLSearchParams(searchParams.toString());
+                nextParams.set('farmId', value);
+                const nextHref =
+                    `${pathname}?${nextParams.toString()}` as Route;
+                router.replace(nextHref);
+            }}
+        />
+    );
+}

--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -2,8 +2,8 @@ import { formatPrice } from '@gredice/js/currency';
 import {
     type FarmerEarning,
     getFarmerBalance,
-    getFarmerPayoutRequests,
-    getFarms,
+    getFarmPayoutRequests,
+    getFarmsForUser,
 } from '@gredice/storage';
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
 import {
@@ -20,9 +20,23 @@ import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
+import { FarmPayoutFarmSelect } from './FarmPayoutFarmSelect';
 import { PayoutRequestForm } from './PayoutRequestForm';
 
 export const dynamic = 'force-dynamic';
+
+type PayoutsPageProps = {
+    searchParams: Promise<{ farmId?: string }>;
+};
+
+function parseFarmId(value: string | undefined) {
+    if (!value) {
+        return undefined;
+    }
+
+    const farmId = Number.parseInt(value, 10);
+    return Number.isFinite(farmId) ? farmId : undefined;
+}
 
 const payoutStatusLabel: Record<
     string,
@@ -82,34 +96,61 @@ function mergeEarnings(earnings: FarmerEarning[]) {
     );
 }
 
-async function PayoutsContent() {
+async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
     const { userId } = await auth(['farmer', 'admin']);
 
-    const farms = await getFarms();
+    const farms = await getFarmsForUser(userId);
+    const selectedFarm =
+        farms.find((farm) => farm.id === selectedFarmId) ?? farms[0];
 
-    const [balanceResults, allPayouts] = await Promise.all([
-        Promise.all(farms.map((f) => getFarmerBalance(userId, f.id))),
-        getFarmerPayoutRequests(userId),
+    if (!selectedFarm) {
+        return (
+            <div className="max-w-5xl mx-auto w-full p-4">
+                <Card>
+                    <CardContent>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Nema dodijeljenih farmi.
+                        </Typography>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    const [balance, allPayouts] = await Promise.all([
+        getFarmerBalance(userId, selectedFarm.id),
+        getFarmPayoutRequests(selectedFarm.id),
     ]);
 
-    const totalEarned = balanceResults.reduce((s, b) => s + b.totalEarned, 0);
-    const totalPaid = balanceResults.reduce((s, b) => s + b.totalPaid, 0);
-    const totalPending = balanceResults.reduce((s, b) => s + b.totalPending, 0);
-    const availableBalance = balanceResults.reduce(
-        (s, b) => s + b.availableBalance,
-        0,
-    );
-    const currency = balanceResults.find((b) => b.currency)?.currency ?? 'eur';
+    const totalEarned = balance.totalEarned;
+    const totalPaid = balance.totalPaid;
+    const totalPending = balance.totalPending;
+    const availableBalance = balance.availableBalance;
+    const currency = balance.currency;
 
-    const earningsByType = mergeEarnings(
-        balanceResults.flatMap((b) => b.earningsByType),
-    );
+    const earningsByType = mergeEarnings(balance.earningsByType);
 
-    const farmWithBalance =
-        farms.find((_, i) => balanceResults[i].totalEarned > 0) ?? farms[0];
+    const farmWithBalance = selectedFarm;
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+            {farms.length > 1 && (
+                <Card>
+                    <CardContent noHeader>
+                        <FarmPayoutFarmSelect
+                            farms={farms.map((farm) => ({
+                                id: farm.id,
+                                name: farm.name,
+                            }))}
+                            selectedFarmId={selectedFarm.id}
+                        />
+                    </CardContent>
+                </Card>
+            )}
+
             {/* Balance Summary */}
             <div className="grid gap-4 sm:grid-cols-3">
                 <Card>
@@ -254,7 +295,7 @@ async function PayoutsContent() {
                             className="text-muted-foreground"
                         >
                             {totalPending > 0
-                                ? `Imaš ${formatPrice(totalPending)} u zahtjevima na čekanju. Pričekaj da administrator obradi zahtjev.`
+                                ? `Farma ima ${formatPrice(totalPending)} u zahtjevima na čekanju. Pričekaj da administrator obradi zahtjev.`
                                 : 'Svi iznosi su isplaćeni.'}
                         </Typography>
                     </CardContent>
@@ -332,13 +373,15 @@ async function PayoutsContent() {
     );
 }
 
-export default function PayoutsPage() {
+export default async function PayoutsPage({ searchParams }: PayoutsPageProps) {
+    const { farmId } = await searchParams;
+    const selectedFarmId = parseFarmId(farmId);
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
         <div className="min-h-[100dvh] w-full bg-muted">
             <AuthProtectedSection auth={authFarmer}>
-                <PayoutsContent />
+                <PayoutsContent selectedFarmId={selectedFarmId} />
             </AuthProtectedSection>
             <SignedOut auth={authFarmer}>
                 <LoginDialog />

--- a/packages/storage/src/repositories/farmsRepo.ts
+++ b/packages/storage/src/repositories/farmsRepo.ts
@@ -29,6 +29,17 @@ export async function getFarms() {
     });
 }
 
+export async function getFarmsForUser(userId: string) {
+    const rows = await storage()
+        .select({ farm: farms })
+        .from(farmUsers)
+        .innerJoin(farms, eq(farmUsers.farmId, farms.id))
+        .where(and(eq(farmUsers.userId, userId), eq(farms.isDeleted, false)))
+        .orderBy(desc(farms.createdAt));
+
+    return rows.map((row) => row.farm);
+}
+
 export async function getFarm(farmId: number) {
     return (
         (await storage().query.farms.findFirst({

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -696,6 +696,73 @@ async function getFarmUserAcceptedOperationsUncached(
     return operationsWithAggregates;
 }
 
+export async function getFarmAcceptedOperations(
+    farmId: number,
+    filter?: OperationsFilter,
+) {
+    const rows = await storage()
+        .select({ operation: operations })
+        .from(operations)
+        .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .leftJoin(gardens, eq(gardens.id, operationGardenIdExpression()))
+        .where(
+            and(
+                eq(operationFarmIdExpression(), farmId),
+                eq(operations.isAccepted, true),
+                eq(operations.isDeleted, false),
+                operationLocationIntegrityWhere(),
+                filter?.from
+                    ? gte(operations.timestamp, filter.from)
+                    : undefined,
+                filter?.to ? lte(operations.timestamp, filter.to) : undefined,
+            ),
+        )
+        .orderBy(desc(operations.timestamp));
+
+    let operationsWithAggregates = await fillOperationAggregates(
+        rows.map((row) => row.operation),
+    );
+
+    if (filter?.completedFrom || filter?.completedTo) {
+        operationsWithAggregates = operationsWithAggregates.filter(
+            (operation) => {
+                if (!operation.completedAt) {
+                    return false;
+                }
+
+                if (
+                    filter.completedFrom &&
+                    operation.completedAt < filter.completedFrom
+                ) {
+                    return false;
+                }
+
+                if (
+                    filter.completedTo &&
+                    operation.completedAt > filter.completedTo
+                ) {
+                    return false;
+                }
+
+                return true;
+            },
+        );
+    }
+
+    if (filter?.status) {
+        const statusArray = Array.isArray(filter.status)
+            ? filter.status
+            : [filter.status];
+        operationsWithAggregates = operationsWithAggregates.filter(
+            (operation) =>
+                operation &&
+                statusArray.includes(operation.status as OperationStatus),
+        );
+    }
+
+    return operationsWithAggregates;
+}
+
 export async function getFarmUserAcceptedOperationById(
     userId: string,
     id: number,

--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -19,7 +19,7 @@ import { createEvent, knownEvents } from './eventsRepo';
 import { getRaisedBedFieldPlantCycles } from './gardensRepo';
 import { createReceipt } from './invoicesRepo';
 import { createNotification } from './notificationsRepo';
-import { getFarmUserAcceptedOperations } from './operationsRepo';
+import { getFarmAcceptedOperations } from './operationsRepo';
 import { getUser } from './usersRepo';
 
 // ── Operation Prices ─────────────────────────────────────────────────────────
@@ -88,9 +88,9 @@ const VERIFIED_SOWING_STATUSES = new Set([
     'removed',
 ]);
 
-// Returns one entry per verified sowing cycle, with the farmId it belongs to
-async function getVerifiedSowingsForFarmer(
-    userId: string,
+// Returns one entry per verified sowing cycle for a farm.
+async function getVerifiedSowingsForFarm(
+    farmId: number,
     verifiedFrom?: Date,
 ): Promise<{ farmId: number; sowingLocation: string }[]> {
     const raisedBedRows = await storage()
@@ -100,10 +100,9 @@ async function getVerifiedSowingsForFarmer(
         })
         .from(raisedBeds)
         .innerJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
-        .innerJoin(farmUsers, eq(gardens.farmId, farmUsers.farmId))
         .where(
             and(
-                eq(farmUsers.userId, userId),
+                eq(gardens.farmId, farmId),
                 eq(raisedBeds.isDeleted, false),
                 eq(gardens.isDeleted, false),
             ),
@@ -126,7 +125,6 @@ async function getVerifiedSowingsForFarmer(
                     cycle.plantHarvestedDate ??
                     cycle.plantRemovedDate ??
                     cycle.endedAt,
-                assignedUserIds: cycle.assignedUserIds ?? [],
             }));
         }),
     );
@@ -137,8 +135,8 @@ async function getVerifiedSowingsForFarmer(
             (c) =>
                 c.plantStatus !== undefined &&
                 VERIFIED_SOWING_STATUSES.has(c.plantStatus) &&
-                (!verifiedFrom || c.verifiedAt > verifiedFrom) &&
-                c.assignedUserIds.includes(userId),
+                (!verifiedFrom ||
+                    (c.verifiedAt && c.verifiedAt > verifiedFrom)),
         );
 }
 
@@ -191,6 +189,14 @@ function getOperationPayoutEligibleAt(operation: {
     return operation.verifiedAt ?? operation.completedAt ?? operation.timestamp;
 }
 
+async function isUserAssignedToFarm(userId: string, farmId: number) {
+    const farmUser = await storage().query.farmUsers.findFirst({
+        where: and(eq(farmUsers.userId, userId), eq(farmUsers.farmId, farmId)),
+    });
+
+    return Boolean(farmUser);
+}
+
 // ── Farmer Balance ────────────────────────────────────────────────────────────
 
 export type FarmerEarning = {
@@ -213,18 +219,18 @@ export type FarmerBalance = {
 };
 
 export async function getFarmerBalance(
-    userId: string,
+    _userId: string,
     farmId: number,
 ): Promise<FarmerBalance> {
     const [prices, payouts, operationsData] = await Promise.all([
         getOperationPrices(farmId),
-        getFarmerPayoutRequests(userId, farmId),
+        getFarmPayoutRequests(farmId),
         getEntitiesFormatted<OperationData>('operation'),
     ]);
     const lastPaidPayoutAt = getLastPaidPayoutAt(payouts);
     const [completedOperations, verifiedSowings] = await Promise.all([
-        getFarmUserAcceptedOperations(userId, { status: 'completed' }),
-        getVerifiedSowingsForFarmer(userId, lastPaidPayoutAt),
+        getFarmAcceptedOperations(farmId, { status: 'completed' }),
+        getVerifiedSowingsForFarm(farmId, lastPaidPayoutAt),
     ]);
     const payableOperations = completedOperations.filter((operation) => {
         if (!lastPaidPayoutAt) {
@@ -260,10 +266,6 @@ export async function getFarmerBalance(
 
     // Operations
     for (const op of payableOperations) {
-        if (!(op.assignedUserIds ?? []).includes(userId)) {
-            continue;
-        }
-
         const opFarmId = completedOperationFarmIds.get(op.id);
         if (opFarmId !== farmId) continue;
 
@@ -361,6 +363,9 @@ export async function createPayoutRequest(
     if (requestedAmount <= 0) {
         throw new Error('Iznos isplate mora biti veći od nule.');
     }
+    if (!(await isUserAssignedToFarm(userId, farmId))) {
+        throw new Error('Nemaš pristup odabranoj farmi.');
+    }
 
     return storage().transaction(async (tx) => {
         // Lock and re-verify balance inside the transaction
@@ -417,6 +422,15 @@ export async function getFarmerPayoutRequests(
                 ? eq(farmerPayoutRequests.farmId, farmId)
                 : undefined,
         ),
+        orderBy: desc(farmerPayoutRequests.createdAt),
+    });
+}
+
+export async function getFarmPayoutRequests(
+    farmId: number,
+): Promise<SelectFarmerPayoutRequest[]> {
+    return storage().query.farmerPayoutRequests.findMany({
+        where: eq(farmerPayoutRequests.farmId, farmId),
         orderBy: desc(farmerPayoutRequests.createdAt),
     });
 }

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -109,6 +109,44 @@ async function createVerifiedAcceptedOperation(input: {
     return operationId;
 }
 
+async function createSowedPlantCycle(input: {
+    raisedBedId: number;
+    positionIndex: number;
+    sowingLocation?: 'direct' | 'greenhouse';
+    assignedUserIds?: string[];
+    placedAt?: Date;
+    sowedAt?: Date;
+}) {
+    const aggregateId = `${input.raisedBedId}|${input.positionIndex}`;
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            plantSortId: '1',
+            scheduledDate: null,
+            sowingLocation: input.sowingLocation ?? 'direct',
+        }),
+        ...(input.placedAt ? { createdAt: input.placedAt } : {}),
+    });
+
+    if (input.assignedUserIds) {
+        await createEvent({
+            ...knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+                status: 'sowed',
+                assignedUserIds: input.assignedUserIds,
+                assignedBy: input.assignedUserIds[0] ?? null,
+            }),
+            ...(input.sowedAt ? { createdAt: input.sowedAt } : {}),
+        });
+        return;
+    }
+
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'sowed',
+        }),
+        ...(input.sowedAt ? { createdAt: input.sowedAt } : {}),
+    });
+}
+
 test('getFarmerBalance groups completed operations by CMS operation name', async () => {
     createTestDb();
 
@@ -183,7 +221,7 @@ test('getFarmerBalance groups completed operations by CMS operation name', async
     assert.equal(balance.totalEarned, 1.75);
 });
 
-test('getFarmerBalance includes assigned raised-bed operations by effective farm', async () => {
+test('getFarmerBalance includes farm raised-bed operations by effective farm', async () => {
     createTestDb();
 
     const userId = randomUUID();
@@ -260,30 +298,108 @@ test('getFarmerBalance includes assigned raised-bed operations by effective farm
     );
     assert.equal(watering?.operationCount, 1);
     assert.equal(watering?.totalEarned, 0.5);
-    assert.equal(otherBalance.totalEarned, 0);
+    assert.equal(otherBalance.totalEarned, 0.5);
 });
 
-test('getFarmerBalance counts payable work after the last paid payout', async () => {
+test('getFarmerBalance includes farm sowing cycles regardless assignment', async () => {
     createTestDb();
 
     const userId = randomUUID();
+    const otherFarmerId = randomUUID();
     await storage()
         .insert(users)
-        .values({
-            id: userId,
-            userName: `payout-window-${userId}@example.com`,
-            displayName: 'Payout Window Farmer',
-            role: 'farmer',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-        });
+        .values([
+            {
+                id: userId,
+                userName: `payout-sowing-${userId}@example.com`,
+                displayName: 'Payout Sowing Farmer',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: otherFarmerId,
+                userName: `payout-sowing-other-${otherFarmerId}@example.com`,
+                displayName: 'Payout Sowing Other Farmer',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
+
+    const farmId = await createFarm({
+        name: `Sowing Payout Farm ${randomUUID()}`,
+        longitude: 0,
+        latitude: 0,
+    });
+    await Promise.all([
+        assignUserToFarm(farmId, userId),
+        assignUserToFarm(farmId, otherFarmerId),
+    ]);
+
+    const accountId = await createAccount();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'payout-sowing-block');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+
+    await upsertOperationPrice({
+        farmId,
+        entityTypeName: 'sowing',
+        pricePerUnit: '1.00',
+        currency: 'eur',
+    });
+    await createSowedPlantCycle({
+        raisedBedId,
+        positionIndex: 0,
+        assignedUserIds: [otherFarmerId],
+    });
+
+    const balance = await getFarmerBalance(userId, farmId);
+    const sowing = balance.earningsByType.find(
+        (earning) => earning.entityTypeName === 'sowing',
+    );
+
+    assert.equal(sowing?.operationCount, 1);
+    assert.equal(sowing?.totalEarned, 1);
+    assert.equal(balance.totalEarned, 1);
+});
+
+test('getFarmerBalance counts payable work after the last paid farm payout', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    const payoutRequesterId = randomUUID();
+    await storage()
+        .insert(users)
+        .values([
+            {
+                id: userId,
+                userName: `payout-window-${userId}@example.com`,
+                displayName: 'Payout Window Farmer',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: payoutRequesterId,
+                userName: `payout-requester-${payoutRequesterId}@example.com`,
+                displayName: 'Payout Requester',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
 
     const farmId = await createFarm({
         name: `Payout Window Farm ${randomUUID()}`,
         longitude: 0,
         latitude: 0,
     });
-    await assignUserToFarm(farmId, userId);
+    await Promise.all([
+        assignUserToFarm(farmId, userId),
+        assignUserToFarm(farmId, payoutRequesterId),
+    ]);
 
     const wateringEntityId =
         await createPublishedOperationEntity('Zalijevanje');
@@ -307,7 +423,7 @@ test('getFarmerBalance counts payable work after the last paid payout', async ()
         .insert(farmerPayoutRequests)
         .values({
             farmId,
-            userId,
+            userId: payoutRequesterId,
             requestedAmount: '0.50',
             currency: 'eur',
             status: 'paid',
@@ -328,7 +444,7 @@ test('getFarmerBalance counts payable work after the last paid payout', async ()
         .insert(farmerPayoutRequests)
         .values({
             farmId,
-            userId,
+            userId: payoutRequesterId,
             requestedAmount: '0.20',
             currency: 'eur',
             status: 'pending',


### PR DESCRIPTION
## Summary
- change farm payout earnings to be farm-scoped instead of assigned-user-scoped
- include farm sowing cycles regardless of individual sowing assignment
- use the latest paid payout request for the farm as the payout cutoff, and subtract farm-level pending/approved payout requests
- add a farm selector on the farm payout page for users assigned to multiple farms
- list payout history for the selected farm and guard payout requests to assigned farm users

## Validation
- `pnpm --dir packages/storage run test:node payoutsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage`
- `pnpm --filter @gredice/storage exec biome check src/repositories/farmsRepo.ts src/repositories/operationsRepo.ts src/repositories/payoutsRepo.ts tests/payoutsRepo.node.spec.ts`
- `pnpm lint --filter farm`
- `pnpm --filter farm exec biome check app/payouts/page.tsx app/payouts/FarmPayoutFarmSelect.tsx`
- `pnpm build --filter farm`
- `pnpm test --filter farm`
- `curl -I http://localhost:3092/payouts`