### PR TITLE
[codex] Scope farm payouts and show duration stats

### DIFF
--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -69,9 +69,34 @@ function getEarningKey(earning: FarmerEarning) {
         earning.entityTypeName,
         earning.entityId ?? 'none',
         earning.entityLabel ?? '',
+        earning.durationMinutes,
         earning.pricePerUnit,
         earning.currency,
     ].join(':');
+}
+
+function formatDuration(minutes: number) {
+    const roundedMinutes = Math.ceil(Math.max(0, minutes));
+    const hours = Math.floor(roundedMinutes / 60);
+    const remainingMinutes = roundedMinutes % 60;
+
+    if (hours > 0 && remainingMinutes > 0) {
+        return `${hours} h ${remainingMinutes} min`;
+    }
+
+    if (hours > 0) {
+        return `${hours} h`;
+    }
+
+    return `${remainingMinutes} min`;
+}
+
+function formatWage(amount: number | null, unit: string) {
+    if (amount === null) {
+        return '—';
+    }
+
+    return `${formatPrice(amount)} / ${unit}`;
 }
 
 function mergeEarnings(earnings: FarmerEarning[]) {
@@ -82,6 +107,7 @@ function mergeEarnings(earnings: FarmerEarning[]) {
         const existing = merged.get(key);
         if (existing) {
             existing.operationCount += earning.operationCount;
+            existing.totalDurationMinutes += earning.totalDurationMinutes;
             existing.totalEarned += earning.totalEarned;
             continue;
         }
@@ -132,6 +158,17 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
     const currency = balance.currency;
 
     const earningsByType = mergeEarnings(balance.earningsByType);
+    const totalOperationCount = earningsByType.reduce(
+        (total, earning) => total + earning.operationCount,
+        0,
+    );
+    const totalDurationMinutes = earningsByType.reduce(
+        (total, earning) => total + earning.totalDurationMinutes,
+        0,
+    );
+    const minuteWage =
+        totalDurationMinutes > 0 ? totalEarned / totalDurationMinutes : null;
+    const hourlyWage = minuteWage === null ? null : minuteWage * 60;
 
     const farmWithBalance = selectedFarm;
 
@@ -152,7 +189,7 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
             )}
 
             {/* Balance Summary */}
-            <div className="grid gap-4 sm:grid-cols-3">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 <Card>
                     <CardContent noHeader>
                         <Stack spacing={1}>
@@ -210,6 +247,63 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
                         </Stack>
                     </CardContent>
                 </Card>
+                <Card>
+                    <CardContent noHeader>
+                        <Stack spacing={1}>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Ukupno vrijeme
+                            </Typography>
+                            <Typography
+                                level="h4"
+                                semiBold
+                                className="tabular-nums"
+                            >
+                                {formatDuration(totalDurationMinutes)}
+                            </Typography>
+                        </Stack>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent noHeader>
+                        <Stack spacing={1}>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Zarada / minuta
+                            </Typography>
+                            <Typography
+                                level="h4"
+                                semiBold
+                                className="tabular-nums"
+                            >
+                                {formatWage(minuteWage, 'min')}
+                            </Typography>
+                        </Stack>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent noHeader>
+                        <Stack spacing={1}>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Zarada / sat
+                            </Typography>
+                            <Typography
+                                level="h4"
+                                semiBold
+                                className="tabular-nums"
+                            >
+                                {formatWage(hourlyWage, 'h')}
+                            </Typography>
+                        </Stack>
+                    </CardContent>
+                </Card>
             </div>
 
             {/* Earnings breakdown */}
@@ -225,6 +319,9 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
                                     <Table.Head>Vrsta radnje</Table.Head>
                                     <Table.Head className="text-right">
                                         Broj radnji
+                                    </Table.Head>
+                                    <Table.Head className="text-right">
+                                        Vrijeme
                                     </Table.Head>
                                     <Table.Head className="text-right">
                                         Cijena / radnja
@@ -244,6 +341,11 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
                                             {e.operationCount}
                                         </Table.Cell>
                                         <Table.Cell className="text-right tabular-nums">
+                                            {formatDuration(
+                                                e.totalDurationMinutes,
+                                            )}
+                                        </Table.Cell>
+                                        <Table.Cell className="text-right tabular-nums">
                                             {formatPrice(e.pricePerUnit)}
                                         </Table.Cell>
                                         <Table.Cell className="text-right tabular-nums font-medium">
@@ -251,6 +353,21 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
                                         </Table.Cell>
                                     </Table.Row>
                                 ))}
+                                <Table.Row className="bg-muted/40 font-medium hover:bg-muted/40">
+                                    <Table.Cell>Ukupno</Table.Cell>
+                                    <Table.Cell className="text-right tabular-nums">
+                                        {totalOperationCount}
+                                    </Table.Cell>
+                                    <Table.Cell className="text-right tabular-nums">
+                                        {formatDuration(totalDurationMinutes)}
+                                    </Table.Cell>
+                                    <Table.Cell className="text-right">
+                                        —
+                                    </Table.Cell>
+                                    <Table.Cell className="text-right tabular-nums font-semibold">
+                                        {formatPrice(totalEarned)}
+                                    </Table.Cell>
+                                </Table.Row>
                             </Table.Body>
                         </Table>
                     </CardOverflow>

--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -88,6 +88,25 @@ const VERIFIED_SOWING_STATUSES = new Set([
     'removed',
 ]);
 
+const SOWING_DURATION_MINUTES = 5;
+
+function getOperationDurationMinutes(operationData: OperationData | undefined) {
+    const durationValue = operationData?.attributes.duration;
+
+    if (typeof durationValue === 'number' && Number.isFinite(durationValue)) {
+        return Math.max(durationValue, 0);
+    }
+
+    if (typeof durationValue === 'string') {
+        const parsed = Number.parseFloat(durationValue);
+        if (Number.isFinite(parsed)) {
+            return Math.max(parsed, 0);
+        }
+    }
+
+    return 0;
+}
+
 // Returns one entry per verified sowing cycle for a farm.
 async function getVerifiedSowingsForFarm(
     farmId: number,
@@ -204,6 +223,8 @@ export type FarmerEarning = {
     entityId: number | null;
     entityLabel?: string;
     operationCount: number;
+    durationMinutes: number;
+    totalDurationMinutes: number;
     pricePerUnit: number;
     totalEarned: number;
     currency: string;
@@ -214,6 +235,7 @@ export type FarmerBalance = {
     totalPaid: number;
     totalPending: number;
     availableBalance: number;
+    totalDurationMinutes: number;
     currency: string;
     earningsByType: FarmerEarning[];
 };
@@ -260,6 +282,12 @@ export async function getFarmerBalance(
             operation.information.label || operation.information.name,
         ]),
     );
+    const operationDurationById = new Map(
+        operationsData.map((operation) => [
+            operation.id,
+            getOperationDurationMinutes(operation),
+        ]),
+    );
 
     const earningsByKey = new Map<string, FarmerEarning>();
     let currency = 'eur';
@@ -277,11 +305,13 @@ export async function getFarmerBalance(
 
         currency = price.currency;
         const priceValue = parseFloat(price.pricePerUnit);
+        const durationMinutes = operationDurationById.get(op.entityId) ?? 0;
         const key = `operation:${op.entityId}`;
         const existing = earningsByKey.get(key);
 
         if (existing) {
             existing.operationCount += 1;
+            existing.totalDurationMinutes += durationMinutes;
             existing.totalEarned += priceValue;
         } else {
             earningsByKey.set(key, {
@@ -289,6 +319,8 @@ export async function getFarmerBalance(
                 entityId: op.entityId,
                 entityLabel: operationLabelById.get(op.entityId),
                 operationCount: 1,
+                durationMinutes,
+                totalDurationMinutes: durationMinutes,
                 pricePerUnit: priceValue,
                 totalEarned: priceValue,
                 currency: price.currency,
@@ -313,12 +345,15 @@ export async function getFarmerBalance(
 
         if (existing) {
             existing.operationCount += 1;
+            existing.totalDurationMinutes += SOWING_DURATION_MINUTES;
             existing.totalEarned += priceValue;
         } else {
             earningsByKey.set(typeName, {
                 entityTypeName: typeName,
                 entityId: null,
                 operationCount: 1,
+                durationMinutes: SOWING_DURATION_MINUTES,
+                totalDurationMinutes: SOWING_DURATION_MINUTES,
                 pricePerUnit: priceValue,
                 totalEarned: priceValue,
                 currency: price.currency,
@@ -328,6 +363,10 @@ export async function getFarmerBalance(
 
     const totalEarned = Array.from(earningsByKey.values()).reduce(
         (acc, e) => acc + e.totalEarned,
+        0,
+    );
+    const totalDurationMinutes = Array.from(earningsByKey.values()).reduce(
+        (acc, e) => acc + e.totalDurationMinutes,
         0,
     );
 
@@ -346,6 +385,7 @@ export async function getFarmerBalance(
         totalPaid,
         totalPending,
         availableBalance,
+        totalDurationMinutes,
         currency,
         earningsByType: Array.from(earningsByKey.values()),
     };

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -28,7 +28,10 @@ import {
 } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
-async function createPublishedOperationEntity(label: string) {
+async function createPublishedOperationEntity(
+    label: string,
+    durationMinutes = 0,
+) {
     await upsertEntityType({ name: 'operation', label: 'Radnje' });
 
     const suffix = randomUUID();
@@ -46,6 +49,13 @@ async function createPublishedOperationEntity(label: string) {
         entityTypeName: 'operation',
         dataType: 'text',
     });
+    const durationDefinitionId = await createAttributeDefinition({
+        category: 'attributes',
+        name: 'duration',
+        label: 'Duration',
+        entityTypeName: 'operation',
+        dataType: 'number',
+    });
 
     const entityId = await createEntity('operation');
     await upsertAttributeValue({
@@ -59,6 +69,12 @@ async function createPublishedOperationEntity(label: string) {
         entityTypeName: 'operation',
         entityId,
         value: label,
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: durationDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: durationMinutes.toString(),
     });
     await updateEntity({ id: entityId, state: 'published' });
 
@@ -169,9 +185,14 @@ test('getFarmerBalance groups completed operations by CMS operation name', async
     });
     await assignUserToFarm(farmId, userId);
 
-    const wateringEntityId =
-        await createPublishedOperationEntity('Zalijevanje');
-    const hoeingEntityId = await createPublishedOperationEntity('Okopavanje');
+    const wateringEntityId = await createPublishedOperationEntity(
+        'Zalijevanje',
+        10,
+    );
+    const hoeingEntityId = await createPublishedOperationEntity(
+        'Okopavanje',
+        20,
+    );
 
     await upsertOperationPrice({
         farmId,
@@ -214,11 +235,16 @@ test('getFarmerBalance groups completed operations by CMS operation name', async
 
     assert.equal(watering?.entityLabel, 'Zalijevanje');
     assert.equal(watering?.operationCount, 2);
+    assert.equal(watering?.durationMinutes, 10);
+    assert.equal(watering?.totalDurationMinutes, 20);
     assert.equal(watering?.pricePerUnit, 0.5);
     assert.equal(watering?.totalEarned, 1);
     assert.equal(hoeing?.entityLabel, 'Okopavanje');
     assert.equal(hoeing?.operationCount, 1);
+    assert.equal(hoeing?.durationMinutes, 20);
+    assert.equal(hoeing?.totalDurationMinutes, 20);
     assert.equal(balance.totalEarned, 1.75);
+    assert.equal(balance.totalDurationMinutes, 40);
 });
 
 test('getFarmerBalance includes farm raised-bed operations by effective farm', async () => {
@@ -271,8 +297,10 @@ test('getFarmerBalance includes farm raised-bed operations by effective farm', a
     });
     assert.ok(field);
 
-    const operationEntityId =
-        await createPublishedOperationEntity('Zalijevanje');
+    const operationEntityId = await createPublishedOperationEntity(
+        'Zalijevanje',
+        12,
+    );
     await upsertOperationPrice({
         farmId,
         entityTypeName: 'operation',
@@ -297,8 +325,10 @@ test('getFarmerBalance includes farm raised-bed operations by effective farm', a
         (earning) => earning.entityId === operationEntityId,
     );
     assert.equal(watering?.operationCount, 1);
+    assert.equal(watering?.totalDurationMinutes, 12);
     assert.equal(watering?.totalEarned, 0.5);
     assert.equal(otherBalance.totalEarned, 0.5);
+    assert.equal(otherBalance.totalDurationMinutes, 12);
 });
 
 test('getFarmerBalance includes farm sowing cycles regardless assignment', async () => {
@@ -361,8 +391,11 @@ test('getFarmerBalance includes farm sowing cycles regardless assignment', async
     );
 
     assert.equal(sowing?.operationCount, 1);
+    assert.equal(sowing?.durationMinutes, 5);
+    assert.equal(sowing?.totalDurationMinutes, 5);
     assert.equal(sowing?.totalEarned, 1);
     assert.equal(balance.totalEarned, 1);
+    assert.equal(balance.totalDurationMinutes, 5);
 });
 
 test('getFarmerBalance counts payable work after the last paid farm payout', async () => {
@@ -401,8 +434,10 @@ test('getFarmerBalance counts payable work after the last paid farm payout', asy
         assignUserToFarm(farmId, payoutRequesterId),
     ]);
 
-    const wateringEntityId =
-        await createPublishedOperationEntity('Zalijevanje');
+    const wateringEntityId = await createPublishedOperationEntity(
+        'Zalijevanje',
+        15,
+    );
     await upsertOperationPrice({
         farmId,
         entityTypeName: 'operation',
@@ -458,8 +493,10 @@ test('getFarmerBalance counts payable work after the last paid farm payout', asy
     );
 
     assert.equal(watering?.operationCount, 1);
+    assert.equal(watering?.totalDurationMinutes, 15);
     assert.equal(watering?.totalEarned, 0.5);
     assert.equal(balance.totalEarned, 0.5);
+    assert.equal(balance.totalDurationMinutes, 15);
     assert.equal(balance.totalPaid, 0.5);
     assert.equal(balance.totalPending, 0.2);
     assert.equal(balance.availableBalance, 0.3);


### PR DESCRIPTION
## Summary
- scope farm payout balances, payout history, and payout windows by farm instead of the signed-in user
- include farm-level accepted operations and verified sowing cycles since the last paid farm payout
- show payout operation names, total time per row, table totals, and per-minute/per-hour earning statistics

## Validation
- pnpm --dir packages/storage run test:node payoutsRepo.node.spec.ts
- pnpm --filter @gredice/storage exec biome check src/repositories/payoutsRepo.ts tests/payoutsRepo.node.spec.ts
- pnpm --filter farm exec biome check app/payouts/page.tsx app/payouts/FarmPayoutFarmSelect.tsx
- pnpm lint --filter @gredice/storage
- pnpm lint --filter farm
- pnpm test --filter @gredice/storage
- pnpm test --filter farm
- pnpm build --filter farm
- curl -I http://localhost:3092/payouts