### PR TITLE
[codex] Add farm operation label printing

### DIFF
--- a/apps/farm/app/debug/labels/HarvestLabelDebugPage.tsx
+++ b/apps/farm/app/debug/labels/HarvestLabelDebugPage.tsx
@@ -20,6 +20,7 @@ import { DebugTextInput } from './DebugTextInput';
 const DEFAULT_LABEL_DATA: HarvestLabelData = {
     raisedBedPhysicalId: '12B',
     fieldIndex: 4,
+    operationLabel: 'Berba',
     plantSortName: 'Salata Batavia',
 };
 
@@ -36,6 +37,7 @@ const LABEL_SAMPLES: Array<{
         data: {
             raisedBedPhysicalId: '3A',
             fieldIndex: 2,
+            operationLabel: 'Berba',
             plantSortName: 'Mladi špinat',
         },
     },
@@ -44,6 +46,7 @@ const LABEL_SAMPLES: Array<{
         data: {
             raisedBedPhysicalId: '18',
             fieldIndex: 7,
+            operationLabel: 'Berba zrelih plodova',
             plantSortName: 'Cherry rajčica',
         },
     },
@@ -129,6 +132,16 @@ export function HarvestLabelDebugPage() {
                                         }
                                     />
                                 </div>
+                                <DebugTextInput
+                                    label="Naziv radnje"
+                                    value={labelData.operationLabel ?? ''}
+                                    onChange={(value) =>
+                                        setLabelData((current) => ({
+                                            ...current,
+                                            operationLabel: value,
+                                        }))
+                                    }
+                                />
                                 <DebugTextInput
                                     label="Sorta biljke"
                                     value={labelData.plantSortName}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -1,3 +1,4 @@
+import type { FieldOperationLabelData } from '@gredice/label-printer';
 import type { EntityStandardized } from '@gredice/storage';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
@@ -7,7 +8,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
 import { CompleteOperationModal } from './CompleteOperationModal';
-import { HarvestOperationPrintModal } from './HarvestOperationPrintModal';
+import { FieldOperationPrintModal } from './FieldOperationPrintModal';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
@@ -23,6 +24,7 @@ type FarmOperationCardData = FarmOperation & {
     durationMinutes: number;
     label: string;
 };
+const RAISED_BED_FIELDS_PER_BLOCK = 9;
 
 interface FarmScheduleOperationsSectionProps {
     raisedBeds: FarmScheduleDayData['raisedBeds'];
@@ -51,7 +53,7 @@ function buildOperationLabel(
         ? plantSortById.get(field.plantSortId)
         : undefined;
     const physicalPositionIndex = field
-        ? (field.positionIndex + 1).toString()
+        ? getFieldPhysicalPositionIndex(field, raisedBeds).toString()
         : '';
     const isFullRaisedBed =
         operationData?.attributes?.application === 'raisedBedFull';
@@ -59,12 +61,55 @@ function buildOperationLabel(
     return `${isFullRaisedBed || !physicalPositionIndex ? '' : `${physicalPositionIndex} - `}${operationData?.information?.label ?? operation.entityId}${sort ? `: ${sort.information?.name ?? 'Nepoznato'}` : ''}`;
 }
 
-function shouldPrintHarvestLabel(
+function isHarvestOperation(operationData: EntityStandardized | undefined) {
+    const stageName =
+        operationData?.attributes?.stage?.information?.name?.toLowerCase();
+    if (stageName === 'harvest') {
+        return true;
+    }
+
+    const operationName = operationData?.information?.name?.toLowerCase();
+    return (
+        operationName === 'harvestplant' ||
+        operationName === 'harvestall' ||
+        operationName === 'harvestmature' ||
+        operationName === 'harvest50mature' ||
+        operationName === 'harvest25mature'
+    );
+}
+
+function shouldPrintOperationLabel(
     operationData: EntityStandardized | undefined,
 ) {
     return (
-        (operationData as { attributes?: { printLabel?: unknown } } | undefined)
-            ?.attributes?.printLabel === true
+        operationData?.attributes?.printLabel === true ||
+        isHarvestOperation(operationData)
+    );
+}
+
+function getOperationDetailLabel(
+    operation: FarmOperationCardData,
+    operationData: EntityStandardized | undefined,
+) {
+    return (
+        operationData?.information?.label ??
+        operationData?.information?.name ??
+        operation.label
+    );
+}
+
+function getFieldPhysicalPositionIndex(
+    field: FarmRaisedBed['fields'][number],
+    raisedBeds: FarmRaisedBed[],
+) {
+    const raisedBedIndex = [...raisedBeds]
+        .sort((left, right) => left.id - right.id)
+        .findIndex((raisedBed) => raisedBed.id === field.raisedBedId);
+
+    return (
+        field.positionIndex +
+        1 +
+        Math.max(raisedBedIndex, 0) * RAISED_BED_FIELDS_PER_BLOCK
     );
 }
 
@@ -72,7 +117,8 @@ function buildHarvestLabelData(
     operation: FarmOperation,
     raisedBeds: FarmRaisedBed[],
     plantSortById: Map<number, EntityStandardized>,
-) {
+    detailLabel: string,
+): FieldOperationLabelData | null {
     if (!operation.raisedBedFieldId || operation.raisedBedId === null) {
         return null;
     }
@@ -97,9 +143,24 @@ function buildHarvestLabelData(
 
     return {
         raisedBedPhysicalId: raisedBed.physicalId,
-        fieldIndex: field.positionIndex + 1,
+        fieldLabel: getFieldPhysicalPositionIndex(field, raisedBeds).toString(),
+        detailLabel,
         plantSortName,
     };
+}
+
+function renderHarvestLabelDescription(
+    operationLabel: string,
+    labelData: FieldOperationLabelData,
+) {
+    return (
+        <Typography>
+            Etiketa za <strong>{operationLabel}</strong> sadržavat će gredicu{' '}
+            <strong>{labelData.raisedBedPhysicalId}</strong>, polje{' '}
+            <strong>{labelData.fieldLabel}</strong> i sortu{' '}
+            <strong>{labelData.plantSortName}</strong>.
+        </Typography>
+    );
 }
 
 export function FarmScheduleOperationsSection({
@@ -176,14 +237,14 @@ export function FarmScheduleOperationsSection({
         const canComplete =
             !completed &&
             (!operation.assignedUserId || operation.assignedUserId === userId);
-        const harvestLabelData =
-            !completed && shouldPrintHarvestLabel(operationData)
-                ? buildHarvestLabelData(
-                      operation,
-                      groupedRaisedBeds,
-                      plantSortById,
-                  )
-                : null;
+        const harvestLabelData = shouldPrintOperationLabel(operationData)
+            ? buildHarvestLabelData(
+                  operation,
+                  groupedRaisedBeds,
+                  plantSortById,
+                  getOperationDetailLabel(operation, operationData),
+              )
+            : null;
         const attachImages = Boolean(
             operationData?.conditions?.completionAttachImages ||
                 operationData?.conditions?.completionAttachImagesRequired,
@@ -295,9 +356,13 @@ export function FarmScheduleOperationsSection({
                                         </Typography>
                                     )}
                                 {harvestLabelData && (
-                                    <HarvestOperationPrintModal
-                                        operationLabel={operation.label}
+                                    <FieldOperationPrintModal
+                                        title="Ispis etikete za berbu"
                                         labelData={harvestLabelData}
+                                        description={renderHarvestLabelDescription(
+                                            operation.label,
+                                            harvestLabelData,
+                                        )}
                                     />
                                 )}
                             </Row>
@@ -438,12 +503,15 @@ export function FarmScheduleOperationsSection({
                                             operation.assignedUserId ===
                                                 userId);
                                     const harvestLabelData =
-                                        !completed &&
-                                        shouldPrintHarvestLabel(operationData)
+                                        shouldPrintOperationLabel(operationData)
                                             ? buildHarvestLabelData(
                                                   operation,
                                                   groupedRaisedBeds,
                                                   plantSortById,
+                                                  getOperationDetailLabel(
+                                                      operation,
+                                                      operationData,
+                                                  ),
                                               )
                                             : null;
                                     const attachImages = Boolean(
@@ -596,13 +664,15 @@ export function FarmScheduleOperationsSection({
                                                                     </Typography>
                                                                 )}
                                                             {harvestLabelData && (
-                                                                <HarvestOperationPrintModal
-                                                                    operationLabel={
-                                                                        operation.label
-                                                                    }
+                                                                <FieldOperationPrintModal
+                                                                    title="Ispis etikete za berbu"
                                                                     labelData={
                                                                         harvestLabelData
                                                                     }
+                                                                    description={renderHarvestLabelDescription(
+                                                                        operation.label,
+                                                                        harvestLabelData,
+                                                                    )}
                                                                 />
                                                             )}
                                                         </Row>

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -1,4 +1,5 @@
 import { calculatePlantsPerField } from '@gredice/js/plants';
+import type { FieldOperationLabelData } from '@gredice/label-printer';
 import type {
     EntityStandardized,
     RaisedBedFieldAssignableFarmUser,
@@ -12,6 +13,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
 import { CompletePlantingModal } from './CompletePlantingModal';
+import { FieldOperationPrintModal } from './FieldOperationPrintModal';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
     formatMinutes,
@@ -22,6 +24,13 @@ import {
 } from './scheduleShared';
 
 type FarmRaisedBedField = FarmScheduleDayData['scheduledFields'][number];
+type FarmRaisedBed = FarmScheduleDayData['raisedBeds'][number];
+type FarmRaisedBedFieldCardData = FarmRaisedBedField & {
+    label: string;
+    physicalPositionIndex: number;
+};
+
+const RAISED_BED_FIELDS_PER_BLOCK = 9;
 
 interface FarmSchedulePlantingsSectionProps {
     raisedBeds: FarmScheduleDayData['raisedBeds'];
@@ -34,6 +43,7 @@ interface FarmSchedulePlantingsSectionProps {
 function buildFieldLabel(
     field: FarmRaisedBedField,
     plantSortById: Map<number, EntityStandardized>,
+    physicalPositionIndex: number,
 ) {
     const taskName =
         field.sowingLocation === 'greenhouse'
@@ -43,7 +53,7 @@ function buildFieldLabel(
         ? plantSortById.get(field.plantSortId)
         : null;
     if (!field.plantSortId || !sort) {
-        return `${field.positionIndex + 1} - ${taskName}: ? Nepoznato`;
+        return `${physicalPositionIndex} - ${taskName}: ? Nepoznato`;
     }
 
     const seedingDistance =
@@ -51,7 +61,122 @@ function buildFieldLabel(
     const totalPlants = seedingDistance
         ? calculatePlantsPerField(seedingDistance).totalPlants
         : null;
-    return `${field.positionIndex + 1} - ${taskName}: ${totalPlants ?? '?'} ${sort.information?.name ?? 'Nepoznato'}`;
+    return `${physicalPositionIndex} - ${taskName}: ${totalPlants ?? '?'} ${sort.information?.name ?? 'Nepoznato'}`;
+}
+
+function getFieldPhysicalPositionIndex(
+    field: FarmRaisedBedField,
+    raisedBeds: FarmRaisedBed[],
+) {
+    const raisedBedIndex = [...raisedBeds]
+        .sort((left, right) => left.id - right.id)
+        .findIndex((raisedBed) => raisedBed.id === field.raisedBedId);
+
+    return (
+        field.positionIndex +
+        1 +
+        Math.max(raisedBedIndex, 0) * RAISED_BED_FIELDS_PER_BLOCK
+    );
+}
+
+function formatPieceCountLabel(count: number) {
+    return `${count} ${count === 1 ? 'KOMAD' : 'KOMADA'}`;
+}
+
+function formatFieldRange(fields: FarmRaisedBedFieldCardData[]) {
+    const positions = fields.map((field) => field.physicalPositionIndex);
+    const firstPosition = positions.at(0);
+    const lastPosition = positions.at(-1);
+
+    if (firstPosition === undefined || lastPosition === undefined) {
+        return '';
+    }
+
+    return firstPosition === lastPosition
+        ? firstPosition.toString()
+        : `${firstPosition}-${lastPosition}`;
+}
+
+function buildGreenhouseSowingLabelDataByFieldId(
+    fields: FarmRaisedBedFieldCardData[],
+    physicalId: string | null,
+    plantSortById: Map<number, EntityStandardized>,
+) {
+    const labelDataByFieldId = new Map<number, FieldOperationLabelData>();
+    if (!physicalId) {
+        return labelDataByFieldId;
+    }
+
+    const greenhouseFields = fields
+        .filter(
+            (field) =>
+                field.sowingLocation === 'greenhouse' &&
+                typeof field.plantSortId === 'number',
+        )
+        .sort(
+            (left, right) =>
+                left.physicalPositionIndex - right.physicalPositionIndex,
+        );
+
+    let groupStartIndex = 0;
+    while (groupStartIndex < greenhouseFields.length) {
+        const firstField = greenhouseFields[groupStartIndex];
+        if (!firstField?.plantSortId) {
+            groupStartIndex += 1;
+            continue;
+        }
+
+        const group = [firstField];
+        let nextIndex = groupStartIndex + 1;
+        while (nextIndex < greenhouseFields.length) {
+            const previousField = group[group.length - 1];
+            const nextField = greenhouseFields[nextIndex];
+            if (
+                !previousField ||
+                !nextField ||
+                nextField.plantSortId !== firstField.plantSortId ||
+                nextField.physicalPositionIndex !==
+                    previousField.physicalPositionIndex + 1
+            ) {
+                break;
+            }
+
+            group.push(nextField);
+            nextIndex += 1;
+        }
+
+        const plantSortName = plantSortById.get(firstField.plantSortId)
+            ?.information?.name;
+        if (plantSortName) {
+            const labelData = {
+                raisedBedPhysicalId: physicalId,
+                fieldLabel: formatFieldRange(group),
+                detailLabel: formatPieceCountLabel(group.length),
+                plantSortName,
+            };
+            for (const field of group) {
+                labelDataByFieldId.set(field.id, labelData);
+            }
+        }
+
+        groupStartIndex = nextIndex;
+    }
+
+    return labelDataByFieldId;
+}
+
+function renderGreenhouseSowingLabelDescription(
+    labelData: FieldOperationLabelData,
+) {
+    return (
+        <Typography>
+            Etiketa za stakleničko sijanje sadržavat će gredicu{' '}
+            <strong>{labelData.raisedBedPhysicalId}</strong>, polje{' '}
+            <strong>{labelData.fieldLabel}</strong>, količinu{' '}
+            <strong>{labelData.detailLabel}</strong> i sortu{' '}
+            <strong>{labelData.plantSortName}</strong>.
+        </Typography>
+    );
 }
 
 export function FarmSchedulePlantingsSection({
@@ -95,10 +220,29 @@ export function FarmSchedulePlantingsSection({
                             (left, right) =>
                                 left.positionIndex - right.positionIndex,
                         )
-                        .map((field) => ({
-                            ...field,
-                            label: buildFieldLabel(field, plantSortById),
-                        }));
+                        .map((field) => {
+                            const physicalPositionIndex =
+                                getFieldPhysicalPositionIndex(
+                                    field,
+                                    groupedRaisedBeds,
+                                );
+
+                            return {
+                                ...field,
+                                physicalPositionIndex,
+                                label: buildFieldLabel(
+                                    field,
+                                    plantSortById,
+                                    physicalPositionIndex,
+                                ),
+                            };
+                        });
+                    const greenhouseSowingLabelDataByFieldId =
+                        buildGreenhouseSowingLabelDataByFieldId(
+                            dayFields,
+                            physicalId,
+                            plantSortById,
+                        );
 
                     const totalDuration =
                         dayFields.length * PLANTING_TASK_DURATION_MINUTES;
@@ -149,6 +293,10 @@ export function FarmSchedulePlantingsSection({
                                         assignedUserByFieldId.get(field.id);
                                     const greenhouseSowing =
                                         field.sowingLocation === 'greenhouse';
+                                    const greenhouseSowingLabelData =
+                                        greenhouseSowingLabelDataByFieldId.get(
+                                            field.id,
+                                        );
 
                                     return (
                                         <div
@@ -235,6 +383,17 @@ export function FarmSchedulePlantingsSection({
                                                                 >
                                                                     Staklenik
                                                                 </Chip>
+                                                            )}
+                                                            {greenhouseSowingLabelData && (
+                                                                <FieldOperationPrintModal
+                                                                    title="Ispis etikete za sijanje u stakleniku"
+                                                                    labelData={
+                                                                        greenhouseSowingLabelData
+                                                                    }
+                                                                    description={renderGreenhouseSowingLabelDescription(
+                                                                        greenhouseSowingLabelData,
+                                                                    )}
+                                                                />
                                                             )}
                                                             <Typography
                                                                 level="body2"

--- a/apps/farm/app/schedule/FieldOperationPrintModal.tsx
+++ b/apps/farm/app/schedule/FieldOperationPrintModal.tsx
@@ -2,9 +2,9 @@
 
 import {
     DEFAULT_HARVEST_LABEL_PRESET,
+    type FieldOperationLabelData,
     GrediceLabelPrinter,
     getLabelPrinterAvailabilityMessage,
-    type HarvestLabelData,
     type LabelPrinterSnapshot,
 } from '@gredice/label-printer';
 import { Button } from '@gredice/ui/Button';
@@ -12,8 +12,8 @@ import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useEffect, useState } from 'react';
-import { HarvestLabelPreviewCanvas } from '../../components/labels/HarvestLabelPreviewCanvas';
+import { type ReactNode, useEffect, useState } from 'react';
+import { FieldOperationLabelPreviewCanvas } from '../../components/labels/FieldOperationLabelPreviewCanvas';
 
 const sharedLabelPrinter = new GrediceLabelPrinter();
 
@@ -44,15 +44,19 @@ function getConsumableUsageLabel(snapshot: LabelPrinterSnapshot) {
     return `${snapshot.consumableUsage.remaining}/${snapshot.consumableUsage.total} etiketa`;
 }
 
-interface HarvestOperationPrintModalProps {
-    operationLabel: string;
-    labelData: HarvestLabelData;
+interface FieldOperationPrintModalProps {
+    title: string;
+    description: ReactNode;
+    labelData: FieldOperationLabelData;
+    triggerLabel?: string;
 }
 
-export function HarvestOperationPrintModal({
-    operationLabel,
+export function FieldOperationPrintModal({
+    title,
+    description,
     labelData,
-}: HarvestOperationPrintModalProps) {
+    triggerLabel = 'Etiketa',
+}: FieldOperationPrintModalProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [snapshot, setSnapshot] = useState(() =>
         sharedLabelPrinter.getSnapshot(),
@@ -120,7 +124,7 @@ export function HarvestOperationPrintModal({
         setSuccessMessage(null);
 
         try {
-            await sharedLabelPrinter.printHarvestLabel(labelData, {
+            await sharedLabelPrinter.printFieldOperationLabel(labelData, {
                 preset: DEFAULT_HARVEST_LABEL_PRESET,
             });
             setSuccessMessage('Etiketa je poslana na pisač.');
@@ -142,7 +146,7 @@ export function HarvestOperationPrintModal({
 
     return (
         <Modal
-            title="Ispis etikete za berbu"
+            title={title}
             open={isOpen}
             onOpenChange={handleOpenChange}
             trigger={
@@ -151,20 +155,15 @@ export function HarvestOperationPrintModal({
                     type="button"
                     className="h-8 px-3 text-xs"
                 >
-                    Etiketa
+                    {triggerLabel}
                 </Button>
             }
         >
             <Stack spacing={4}>
-                <Typography>
-                    Etiketa za <strong>{operationLabel}</strong> sadržavat će
-                    gredicu <strong>{labelData.raisedBedPhysicalId}</strong>,
-                    polje <strong>{labelData.fieldIndex}</strong> i sortu{' '}
-                    <strong>{labelData.plantSortName}</strong>.
-                </Typography>
+                {description}
 
                 <div className="rounded-lg border bg-muted/20 p-3">
-                    <HarvestLabelPreviewCanvas
+                    <FieldOperationLabelPreviewCanvas
                         labelData={labelData}
                         className="mx-auto block w-full max-w-sm rounded border bg-white shadow-xs"
                     />
@@ -361,4 +360,4 @@ export function HarvestOperationPrintModal({
     );
 }
 
-export default HarvestOperationPrintModal;
+export default FieldOperationPrintModal;

--- a/apps/farm/components/labels/FieldOperationLabelPreviewCanvas.tsx
+++ b/apps/farm/components/labels/FieldOperationLabelPreviewCanvas.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {
+    DEFAULT_HARVEST_LABEL_PRESET,
+    type FieldOperationLabelData,
+    type HarvestLabelPreset,
+    renderFieldOperationLabel,
+} from '@gredice/label-printer';
+import { type ComponentPropsWithoutRef, useEffect, useRef } from 'react';
+
+interface FieldOperationLabelPreviewCanvasProps
+    extends ComponentPropsWithoutRef<'canvas'> {
+    labelData: FieldOperationLabelData;
+    preset?: HarvestLabelPreset;
+}
+
+export function FieldOperationLabelPreviewCanvas({
+    labelData,
+    preset = DEFAULT_HARVEST_LABEL_PRESET,
+    ...canvasProps
+}: FieldOperationLabelPreviewCanvasProps) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        if (!canvasRef.current) {
+            return;
+        }
+
+        renderFieldOperationLabel(canvasRef.current, labelData, preset);
+    }, [labelData, preset]);
+
+    return <canvas ref={canvasRef} {...canvasProps} />;
+}

--- a/packages/label-printer/src/grediceLabelPrinter.ts
+++ b/packages/label-printer/src/grediceLabelPrinter.ts
@@ -8,9 +8,11 @@ import {
 } from "@mmote/niimbluelib";
 import {
 	DEFAULT_HARVEST_LABEL_PRESET,
+	renderFieldOperationLabel,
 	renderHarvestLabel,
 } from "./harvestLabelCanvas";
 import type {
+	FieldOperationLabelData,
 	HarvestLabelData,
 	HarvestLabelPreset,
 	LabelConsumableUsage,
@@ -344,8 +346,11 @@ export class GrediceLabelPrinter {
 		return this.getSnapshot();
 	}
 
-	async printHarvestLabel(
-		data: HarvestLabelData,
+	private async printCanvasLabel(
+		renderLabel: (
+			canvas: HTMLCanvasElement,
+			preset: HarvestLabelPreset,
+		) => void,
 		options?: {
 			quantity?: number;
 			preset?: HarvestLabelPreset;
@@ -362,7 +367,7 @@ export class GrediceLabelPrinter {
 		const quantity = Math.max(1, Math.round(options?.quantity ?? 1));
 		const preset = options?.preset ?? DEFAULT_HARVEST_LABEL_PRESET;
 		const canvas = document.createElement("canvas");
-		renderHarvestLabel(canvas, data, preset);
+		renderLabel(canvas, preset);
 
 		const encoded = ImageEncoder.encodeCanvas(canvas, preset.printDirection);
 		const printTask = this.client.abstraction.newPrintTask(
@@ -402,5 +407,31 @@ export class GrediceLabelPrinter {
 			await printTask.printEnd().catch(() => undefined);
 			this.updateSnapshot({ isPrinting: false });
 		}
+	}
+
+	async printHarvestLabel(
+		data: HarvestLabelData,
+		options?: {
+			quantity?: number;
+			preset?: HarvestLabelPreset;
+		},
+	) {
+		await this.printCanvasLabel(
+			(canvas, preset) => renderHarvestLabel(canvas, data, preset),
+			options,
+		);
+	}
+
+	async printFieldOperationLabel(
+		data: FieldOperationLabelData,
+		options?: {
+			quantity?: number;
+			preset?: HarvestLabelPreset;
+		},
+	) {
+		await this.printCanvasLabel(
+			(canvas, preset) => renderFieldOperationLabel(canvas, data, preset),
+			options,
+		);
 	}
 }

--- a/packages/label-printer/src/harvestLabelCanvas.ts
+++ b/packages/label-printer/src/harvestLabelCanvas.ts
@@ -1,4 +1,8 @@
-import type { HarvestLabelData, HarvestLabelPreset } from "./types";
+import type {
+	FieldOperationLabelData,
+	HarvestLabelData,
+	HarvestLabelPreset,
+} from "./types";
 
 const FONT_FAMILY = '"Noto Sans", "Segoe UI", Arial, sans-serif';
 const DEFAULT_LINE_HEIGHT = 1.1;
@@ -129,9 +133,77 @@ export function getHarvestLabelCanvasSize(
 	};
 }
 
-export function renderHarvestLabel(
+function drawSowingIcon(
+	context: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+) {
+	const groundY = y + height * 0.72;
+	const stemBaseY = groundY - height * 0.04;
+	const stemTopY = y + height * 0.14;
+
+	context.save();
+	context.strokeStyle = "#000000";
+	context.fillStyle = "#000000";
+	context.lineWidth = Math.max(2, Math.round(width * 0.035));
+	context.lineCap = "round";
+	context.lineJoin = "round";
+
+	for (const offset of [0, height * 0.15, height * 0.3]) {
+		context.beginPath();
+		context.moveTo(x + width * 0.08, groundY + offset);
+		context.lineTo(x + width * 0.92, groundY + offset);
+		context.stroke();
+	}
+
+	for (const stemX of [x + width * 0.28, x + width * 0.5, x + width * 0.72]) {
+		context.beginPath();
+		context.moveTo(stemX, stemBaseY);
+		context.bezierCurveTo(
+			stemX - width * 0.08,
+			y + height * 0.48,
+			stemX + width * 0.08,
+			y + height * 0.32,
+			stemX,
+			stemTopY,
+		);
+		context.stroke();
+
+		for (const side of [-1, 1]) {
+			context.beginPath();
+			context.ellipse(
+				stemX + side * width * 0.08,
+				y + height * 0.42,
+				width * 0.08,
+				height * 0.035,
+				side * 0.9,
+				0,
+				Math.PI * 2,
+			);
+			context.stroke();
+
+			context.beginPath();
+			context.ellipse(
+				stemX + side * width * 0.06,
+				y + height * 0.24,
+				width * 0.07,
+				height * 0.03,
+				side * 0.85,
+				0,
+				Math.PI * 2,
+			);
+			context.stroke();
+		}
+	}
+
+	context.restore();
+}
+
+export function renderFieldOperationLabel(
 	canvas: HTMLCanvasElement,
-	data: HarvestLabelData,
+	data: FieldOperationLabelData,
 	preset = DEFAULT_HARVEST_LABEL_PRESET,
 ) {
 	const { width, height } = getHarvestLabelCanvasSize(preset);
@@ -143,85 +215,123 @@ export function renderHarvestLabel(
 		throw new Error("Unable to render label preview.");
 	}
 
-	const paddingX = Math.round(width * 0.07);
-	const paddingY = Math.round(height * 0.08);
-	const headerText = "BERBA";
-	const fieldText = `Polje ${data.fieldIndex}`;
-	const bedText = `Gr ${sanitizeText(data.raisedBedPhysicalId)}`;
+	const paddingX = Math.round(width * 0.06);
+	const paddingY = Math.round(height * 0.07);
+	const iconBox = {
+		x: paddingX + Math.round(width * 0.02),
+		y: paddingY + Math.round(height * 0.02),
+		width: Math.round(width * 0.22),
+		height: Math.round(height * 0.28),
+	};
+	const centerHeaderX = Math.round(width * 0.55);
+	const rightColumnX = width - paddingX - Math.round(width * 0.04);
+	const headerTop = paddingY + Math.round(height * 0.01);
+	const headerLineHeight = Math.round(height * 0.16);
+	const topBedText = sanitizeText(data.raisedBedPhysicalId);
+	const topFieldText = sanitizeText(data.fieldLabel);
+	const detailText = sanitizeText(data.detailLabel);
 	const plantSortName = sanitizeText(data.plantSortName);
-	const dividerY = Math.round(height * 0.26);
-	const bedAreaTop = dividerY + Math.round(height * 0.06);
-	const bedAreaHeight = Math.round(height * 0.32);
-	const sortAreaTop = bedAreaTop + bedAreaHeight + Math.round(height * 0.06);
-	const sortAreaHeight = height - sortAreaTop - paddingY;
+	const detailTop = Math.round(height * 0.58);
+	const plantTop = Math.round(height * 0.75);
+	const bottomMaxWidth = width - paddingX * 2;
 
 	context.clearRect(0, 0, width, height);
 	context.fillStyle = "#ffffff";
 	context.fillRect(0, 0, width, height);
-	context.strokeStyle = "#000000";
-	context.lineWidth = Math.max(2, Math.round(width * 0.008));
-	context.strokeRect(
-		context.lineWidth / 2,
-		context.lineWidth / 2,
-		width - context.lineWidth,
-		height - context.lineWidth,
-	);
+	drawSowingIcon(context, iconBox.x, iconBox.y, iconBox.width, iconBox.height);
 
-	const headerFontSize = Math.max(14, Math.round(height * 0.1));
 	context.fillStyle = "#000000";
 	context.textBaseline = "alphabetic";
 
-	context.font = `800 ${headerFontSize}px ${FONT_FAMILY}`;
-	context.textAlign = "left";
-	context.fillText(headerText, paddingX, paddingY + headerFontSize);
-
-	const fieldFontSize = fitSingleLineFont(
+	const centerFontSize = fitSingleLineFont(
 		context,
-		fieldText,
+		"Gredica",
 		width * 0.42,
-		headerFontSize,
-		Math.max(11, headerFontSize - 8),
-		700,
+		Math.round(height * 0.18),
+		Math.round(height * 0.12),
+		500,
 	);
-	context.font = `700 ${fieldFontSize}px ${FONT_FAMILY}`;
-	context.textAlign = "right";
-	context.fillText(fieldText, width - paddingX, paddingY + fieldFontSize);
-
-	context.beginPath();
-	context.moveTo(paddingX, dividerY);
-	context.lineTo(width - paddingX, dividerY);
-	context.stroke();
+	context.font = `500 ${centerFontSize}px ${FONT_FAMILY}`;
+	context.textAlign = "center";
+	context.fillText("Gredica", centerHeaderX, headerTop + centerFontSize);
+	context.fillText(
+		"Polje",
+		centerHeaderX,
+		headerTop + centerFontSize + headerLineHeight,
+	);
 
 	const bedFontSize = fitSingleLineFont(
 		context,
-		bedText,
-		width - paddingX * 2,
-		Math.round(height * 0.26),
-		Math.round(height * 0.14),
+		topBedText,
+		width * 0.2,
+		Math.round(height * 0.22),
+		Math.round(height * 0.13),
 		800,
 	);
 	context.font = `800 ${bedFontSize}px ${FONT_FAMILY}`;
-	context.textAlign = "center";
-	context.fillText(bedText, width / 2, bedAreaTop + bedAreaHeight * 0.75);
+	context.textAlign = "right";
+	context.fillText(topBedText, rightColumnX, headerTop + bedFontSize);
+
+	const fieldFontSize = fitSingleLineFont(
+		context,
+		topFieldText,
+		width * 0.24,
+		Math.round(height * 0.2),
+		Math.round(height * 0.12),
+		800,
+	);
+	context.font = `800 ${fieldFontSize}px ${FONT_FAMILY}`;
+	context.fillText(
+		topFieldText,
+		rightColumnX,
+		headerTop + bedFontSize + headerLineHeight,
+	);
+
+	const detailFontSize = fitSingleLineFont(
+		context,
+		detailText,
+		bottomMaxWidth,
+		Math.round(height * 0.18),
+		Math.round(height * 0.1),
+		500,
+	);
+	context.font = `500 ${detailFontSize}px ${FONT_FAMILY}`;
+	context.textAlign = "left";
+	context.fillText(detailText, paddingX, detailTop + detailFontSize);
 
 	const sortLayout = fitWrappedFont(
 		context,
 		plantSortName,
-		width - paddingX * 2,
-		sortAreaHeight,
+		bottomMaxWidth,
+		height - plantTop - paddingY,
 		2,
-		Math.round(height * 0.17),
-		Math.round(height * 0.1),
-		700,
+		Math.round(height * 0.18),
+		Math.round(height * 0.11),
+		500,
 	);
 	const sortLineHeight = sortLayout.fontSize * DEFAULT_LINE_HEIGHT;
-	const sortBlockHeight = sortLineHeight * sortLayout.lines.length;
-	let sortBaseline =
-		sortAreaTop + (sortAreaHeight - sortBlockHeight) / 2 + sortLayout.fontSize;
+	let sortBaseline = plantTop + sortLayout.fontSize;
 
-	context.font = `700 ${sortLayout.fontSize}px ${FONT_FAMILY}`;
+	context.font = `500 ${sortLayout.fontSize}px ${FONT_FAMILY}`;
 	for (const line of sortLayout.lines) {
-		context.fillText(line, width / 2, sortBaseline);
+		context.fillText(line, paddingX, sortBaseline);
 		sortBaseline += sortLineHeight;
 	}
+}
+
+export function renderHarvestLabel(
+	canvas: HTMLCanvasElement,
+	data: HarvestLabelData,
+	preset = DEFAULT_HARVEST_LABEL_PRESET,
+) {
+	renderFieldOperationLabel(
+		canvas,
+		{
+			raisedBedPhysicalId: data.raisedBedPhysicalId,
+			fieldLabel: data.fieldIndex.toString(),
+			detailLabel: data.operationLabel ?? "BERBA",
+			plantSortName: data.plantSortName,
+		},
+		preset,
+	);
 }

--- a/packages/label-printer/src/types.ts
+++ b/packages/label-printer/src/types.ts
@@ -1,9 +1,17 @@
 import type { PrintDirection } from "@mmote/niimbluelib";
 
+export type FieldOperationLabelData = {
+	raisedBedPhysicalId: string;
+	fieldLabel: string;
+	detailLabel: string;
+	plantSortName: string;
+};
+
 export type HarvestLabelData = {
 	raisedBedPhysicalId: string;
 	fieldIndex: number;
 	plantSortName: string;
+	operationLabel?: string;
 };
 
 export type HarvestLabelPreset = {


### PR DESCRIPTION
## Summary

Adds reusable farm field-operation label printing for greenhouse sowing and harvest workflows.

- Adds greenhouse sowing label printing from the farm schedule, including contiguous greenhouse field ranges, piece counts, raised bed identifiers, and plant sort names.
- Makes harvest label printing available for harvest operations without requiring a `printLabel` attribute.
- Updates harvest labels to print the operation label instead of a count.
- Generalizes the label-printer package with field-operation label data/rendering/printing while preserving the existing harvest print path.
- Replaces the harvest-specific farm print modal with a reusable field-operation print modal and preview canvas.

## Impact

Farm users can print greenhouse sowing labels matching the physical greenhouse label format, and harvest operation labels are available broadly from the schedule UI.

## Validation

- `pnpm lint --filter @gredice/label-printer`
- `pnpm lint --filter farm` passed with an existing unrelated warning in `apps/farm/app/payouts/page.tsx`
- `pnpm build --filter farm`
- `pnpm test --filter farm` passed: 16 tests
- `git diff --check`

No manual browser print preview was run because the farm schedule requires authenticated seeded state.