### PR TITLE
Add fast typecheck validation for game changes

### DIFF
--- a/.agents/skills/gredice-docs-auditor/SKILL.md
+++ b/.agents/skills/gredice-docs-auditor/SKILL.md
@@ -57,6 +57,7 @@ pnpm doctor
 pnpm dev
 pnpm dev:all
 pnpm lint --filter <workspace>
+pnpm typecheck --filter <workspace>
 pnpm test --filter <workspace>
 pnpm build --filter <workspace>
 pnpm db-generate
@@ -68,7 +69,7 @@ Use `pnpm install` only when the task is dependency setup. The README currently 
 
 Document these non-negotiables when relevant:
 
-- Runtime is Node.js `>=24`; package manager is pnpm `10.33.2`.
+- Runtime is Node.js `>=24`; package manager is pinned by the root `packageManager` field.
 - Use `workspace:*` for internal dependencies.
 - Schema changes live in `packages/storage`; run `pnpm db-generate`.
 - Do not run `pnpm db-push`.

--- a/.agents/skills/gredice-game-asset-docs/SKILL.md
+++ b/.agents/skills/gredice-game-asset-docs/SKILL.md
@@ -110,12 +110,18 @@ When docs claim visual behavior, verify with a browser or screenshots:
 Use targeted checks:
 
 ```bash
-pnpm build --filter garden
-pnpm test --filter garden
 pnpm lint --filter @gredice/game
+pnpm typecheck --filter @gredice/game
+pnpm test --filter @gredice/game
+pnpm typecheck --filter garden
+pnpm typecheck --filter www
 pnpm generate:game-assets
 pnpm --filter @gredice/cdn run regenerate-cdn:decoration-atlas
 git diff --check
 ```
+
+Run `garden` or `www` builds and Playwright suites only when routing, static
+assets, bundling, production-only code paths, visual behavior, or user flows
+changed.
 
 Do not hand-edit generated model output unless the generator is broken and the temporary nature of the change is explicitly documented.

--- a/.agents/skills/gredice-game-entity-creation/SKILL.md
+++ b/.agents/skills/gredice-game-entity-creation/SKILL.md
@@ -69,20 +69,19 @@ pnpm --dir apps/www exec playwright test --config playwright-generate.config.ts 
 
 ## Validation
 
-For `@gredice/game` entity work, validate the package and both consuming apps:
+For `@gredice/game` entity work, validate the package and consumer typechecks:
 
 ```bash
 pnpm lint --filter @gredice/game
-pnpm --filter @gredice/game typecheck
+pnpm typecheck --filter @gredice/game
 pnpm test --filter @gredice/game
-pnpm lint --filter garden
-pnpm test --filter garden
-pnpm build --filter garden
-pnpm lint --filter www
-pnpm build --filter www
+pnpm typecheck --filter garden
+pnpm typecheck --filter www
 git diff --check
 ```
 
 Run the focused snapshot generator for the entity and visually inspect the PNGs.
-Run `pnpm test --filter www` when public route behavior changed or the task has
-time for the broad route suite.
+Run app lint when app files changed. Run app builds or Playwright suites only
+when routing, static assets, bundling, production-only code paths, visual
+behavior, or user flows changed. Run `pnpm test --filter www` when public route
+behavior changed or the task has time for the broad route suite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This repository is the **Gredice** monorepo. It hosts multiple Next.js applicati
 - Before editing code, look for additional `AGENTS.md` files inside the path you plan to touch. Nested instructions override this file.
 - Keep the worktree clean. Commit only intentional source changes and never commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless explicitly requested.
 - Use targeted Turbo commands from the repo root whenever possible.
-- Before handing off code changes, identify the affected workspace(s) and run targeted lint, test, and build checks unless the user explicitly asks to skip validation.
+- Before handing off code changes, identify the affected workspace(s) and run targeted lint, test, typecheck, or build checks unless the user explicitly asks to skip validation.
 
 ## Read the relevant guides
 
@@ -34,10 +34,11 @@ This repository is the **Gredice** monorepo. It hosts multiple Next.js applicati
 
 ## Task validation
 
-For code changes, use the narrowest reliable validation set from the repo root:
+For code changes, use the narrowest reliable validation set from the repo root. Run typecheck where the workspace provides it:
 
 ```bash
 pnpm lint --filter <workspace>
+pnpm typecheck --filter <workspace>
 pnpm test --filter <workspace>
 pnpm build --filter <workspace>
 ```
@@ -46,11 +47,12 @@ Examples:
 
 ```bash
 pnpm lint --filter garden
+pnpm typecheck --filter garden
 pnpm test --filter garden
 pnpm build --filter garden
 ```
 
-For shared package changes, also validate the consuming app(s) that exercise the changed behavior. For storage changes, run `pnpm test --filter @gredice/storage` and build affected consumers such as `app`, `api`, or `farm`. For `@gredice/game` changes specifically, validate and build both `garden` and `www` because both apps consume game package codepaths.
+For shared package changes, also validate the consuming app(s) that exercise the changed behavior. For storage changes, run `pnpm test --filter @gredice/storage` and build affected consumers such as `app`, `api`, or `farm`. For ordinary `@gredice/game` TypeScript/component changes, validate the package and run consumer typechecks for `garden` and `www`; only run app builds or Playwright suites when app routing, bundling, static assets, visual behavior, or user flows changed.
 
 If validation cannot run because of missing secrets, unavailable services, or time constraints, state exactly which command was skipped and why.
 
@@ -69,6 +71,7 @@ If validation cannot run because of missing secrets, unavailable services, or ti
 pnpm install
 pnpm dev
 pnpm lint --filter garden
+pnpm typecheck --filter garden
 pnpm test --filter garden
 pnpm build --filter garden
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,11 @@ Coordinate with maintainers before changing shared game asset sources.
 
 ## Validation
 
-Run targeted commands from the repo root. Choose the smallest check that covers the change, then broaden when the change touches shared behavior or critical flows.
+Run targeted commands from the repo root. Choose the smallest check that covers the change, then broaden when the change touches shared behavior or critical flows. Run typecheck where the workspace provides it.
 
 ```bash
 pnpm lint --filter <workspace>
+pnpm typecheck --filter <workspace>
 pnpm test --filter <workspace>
 pnpm build --filter <workspace>
 ```
@@ -82,10 +83,13 @@ Examples:
 
 ```bash
 pnpm lint --filter garden
+pnpm typecheck --filter garden
 pnpm test --filter garden
 pnpm build --filter www
 pnpm test --filter @gredice/storage
 ```
+
+For ordinary `@gredice/game` package changes, validate the package and run `garden`/`www` typechecks instead of building and testing both apps every time. Run the app builds or Playwright suites when app routing, static assets, bundling, production behavior, visual behavior, or user flows changed.
 
 For docs-only changes, run:
 

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -17,10 +17,11 @@ Aim for `3` on small low-risk changes and `4` or higher on shared, public, payme
 
 ## Validation commands
 
-Use targeted commands first. Before handing off code changes, identify the affected workspace(s) and run lint, test, and build for each relevant workspace unless the user explicitly asks to skip validation.
+Use targeted commands first. Before handing off code changes, identify the affected workspace(s) and run the narrowest relevant lint, typecheck, test, or build checks unless the user explicitly asks to skip validation. Run typecheck where the workspace provides it.
 
 ```bash
 pnpm lint --filter <workspace>
+pnpm typecheck --filter <workspace>
 pnpm test --filter <workspace>
 pnpm build --filter <workspace>
 ```
@@ -30,11 +31,12 @@ Examples:
 ```bash
 pnpm lint --filter @gredice/storage
 pnpm test --filter @gredice/storage
+pnpm typecheck --filter garden
 pnpm build --filter www
 pnpm test --filter www
 ```
 
-For shared package changes, validate both the changed package and the consuming app(s) that exercise the behavior. If a package is used by multiple apps, run checks for each relevant consumer, not only the package itself. For `@gredice/game` updates, always validate `garden` and `www` as consumers. Examples:
+For shared package changes, validate both the changed package and the consuming app(s) that exercise the behavior. If a package is used by multiple apps, run checks for each relevant consumer, not only the package itself. For ordinary `@gredice/game` updates, use app typechecks as the default consumer build-compatibility check for `garden` and `www`; reserve full app builds and Playwright suites for routing, static asset, bundling, production behavior, visual, or user-flow changes. Examples:
 
 ```bash
 pnpm lint --filter @gredice/storage
@@ -44,10 +46,10 @@ pnpm build --filter api
 pnpm build --filter farm
 
 pnpm lint --filter @gredice/game
-pnpm lint --filter garden
-pnpm lint --filter www
-pnpm build --filter garden
-pnpm build --filter www
+pnpm typecheck --filter @gredice/game
+pnpm test --filter @gredice/game
+pnpm typecheck --filter garden
+pnpm typecheck --filter www
 ```
 
 For docs-only changes, at minimum check formatting-sensitive diffs with:

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -62,6 +62,10 @@ pnpm lint
 pnpm lint --filter @gredice/storage
 pnpm lint --filter garden
 
+# Typecheck one workspace
+pnpm typecheck --filter garden
+pnpm typecheck --filter www
+
 # Run tests
 pnpm test
 pnpm test --filter garden
@@ -92,7 +96,17 @@ Use `pnpm --filter @gredice/directory-types regenerate:cms-types` only when `src
 
 ## Type checking
 
-Type checking is integrated into Next.js builds and package scripts. To validate app or package types, build the consuming app or run the targeted package test/build command that exercises the change.
+Use `pnpm typecheck --filter <workspace>` for a fast TypeScript compatibility check. Next.js apps run `next typegen` before `tsc`, so route, page, and layout types are generated without running a full production build.
+
+For ordinary `@gredice/game` package changes, this is the default consumer compatibility check:
+
+```bash
+pnpm typecheck --filter @gredice/game
+pnpm typecheck --filter garden
+pnpm typecheck --filter www
+```
+
+Run `pnpm build --filter garden` or `pnpm build --filter www` only when the change affects Next.js configuration, routing, static assets, bundling behavior, production-only code paths, or when a release/sign-off requires the full build output.
 
 ## Development servers
 

--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -7,6 +7,7 @@
         "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
+        "typecheck": "next typegen && tsc --noEmit --pretty false",
         "dev": "node ../../scripts/run-app-command.mjs dev",
         "build": "next build",
         "start": "node ../../scripts/run-app-command.mjs start",

--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -79,9 +79,9 @@ const defaultDevices = [
 ];
 
 function createDeferred(): Deferred {
-    let resolve = () => undefined;
+    let resolve: () => void = () => undefined;
     const promise = new Promise<void>((next) => {
-        resolve = next;
+        resolve = () => next();
     });
     return { promise, resolve };
 }

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -7,6 +7,7 @@
         "clean": "rimraf .next .turbo dist build out coverage .vercel storybook-static",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
+        "typecheck": "next typegen && tsc --noEmit --pretty false",
         "dev": "node ../../scripts/run-app-command.mjs dev",
         "build": "next build",
         "postbuild": "next-sitemap --config next-sitemap.config.cjs",

--- a/docs/game-entity-creation.md
+++ b/docs/game-entity-creation.md
@@ -177,22 +177,22 @@ the directories API or a direct DB query that the row appears in
 
 ## Validation
 
-Use the narrowest reliable checks, then include consuming apps because
+Use the narrowest reliable checks, then include consumer typechecks because
 `@gredice/game` is shared by `garden` and `www`:
 
 ```bash
 pnpm lint --filter @gredice/game
-pnpm --filter @gredice/game typecheck
+pnpm typecheck --filter @gredice/game
 pnpm test --filter @gredice/game
-pnpm lint --filter garden
-pnpm test --filter garden
-pnpm build --filter garden
-pnpm lint --filter www
-pnpm build --filter www
+pnpm typecheck --filter garden
+pnpm typecheck --filter www
 git diff --check
 ```
 
-Run `pnpm test --filter www` when public route behavior changed or when there
-is time for the broader suite. It may depend on local API services and can emit
-proxy noise if `api` is not running; record the exact failure if it does not
-pass.
+Run app lint when app files changed. Run `pnpm build --filter garden`,
+`pnpm build --filter www`, or the app Playwright suites only when routing,
+static assets, bundling, production-only code paths, visual behavior, or user
+flows changed. Run `pnpm test --filter www` when public route behavior changed
+or when there is time for the broader suite. It may depend on local API services
+and can emit proxy noise if `api` is not running; record the exact failure if it
+does not pass.


### PR DESCRIPTION
## Summary
- Add `typecheck` scripts to `apps/garden` and `apps/www` using `next typegen` plus `tsc --noEmit`
- Update repo docs and AI guidance to use app typechecks as the default validation path for ordinary `@gredice/game` changes
- Narrow the cases that require full app builds or Playwright coverage to routing, bundling, static assets, production-only behavior, and user flows

## Testing
- Verified the updated validation path locally across `@gredice/game`, `garden`, and `www`
- Confirmed the faster check passes after fixing a small type issue in a Garden test helper