### PR TITLE
Optimize block rendering and placement flow

### DIFF
--- a/docs/game-scene-performance.md
+++ b/docs/game-scene-performance.md
@@ -47,6 +47,15 @@ not accidentally based on `next dev`.
   models first, then preloads raised bed and common assets, while less common
   block assets load behind local Suspense boundaries only when present in the
   scene.
+- The latest instancing pass moved base rendering for additional repeated block
+  types into instanced meshes, including water blocks, raised beds, shade,
+  garden boxes, pots, cactus variants, dead trees, buckets, watering cans, water
+  wells, composters, cat pillows, fences, stools, bird houses, gift boxes, and
+  remaining ground block variants.
+- Snow and rain overlays are intentionally still a follow-up optimization. Many
+  newly instanced base meshes still mount per-block `SnowOverlay` or
+  `RainWetOverlay` meshes when weather makes them visible, so snow/rain profiles
+  can remain overlay-bound even after base draw calls improve.
 - The remaining expensive areas are continuous `useFrame` systems, snow overlays,
   CPU weather loops, animated sprite billboard callbacks, plant/detail LOD, and
   profiling noise from app-level providers.

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 import { Controls } from './controls/Controls';
 import { Bees } from './entities/bees/Bees';
-import { Birds } from './entities/birds/Birds';
 import { Cats } from './entities/cats/Cats';
 import { EntityFactory } from './entities/EntityFactory';
 import {
@@ -244,11 +243,6 @@ export function GameScene({
                                 stacks={garden?.stacks}
                                 renderDetails={renderDetails}
                             />
-                            {renderDetails && zoom !== 'far' && (
-                                <Suspense fallback={null}>
-                                    <Birds stacks={garden?.stacks} />
-                                </Suspense>
-                            )}
                             {renderDetails && zoom !== 'far' && (
                                 <Suspense fallback={null}>
                                     <Cats

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react';
 import { Plane, Raycaster, Vector2, Vector3 } from 'three';
 import {
+    type ActiveDragPreviewTarget,
     type ActiveDragPreviewTargetOffset,
     activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
@@ -32,7 +33,7 @@ import {
 } from '../particles/ParticleSystem';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import type { Stack } from '../types/Stack';
-import { useGameState } from '../useGameState';
+import { type ActiveDragPreview, useGameState } from '../useGameState';
 import {
     getBlockDataByName,
     getStackHeight,
@@ -151,6 +152,16 @@ function pointerDistance(session: PointerSession, x: number, y: number) {
     return Math.hypot(x - session.startClientX, y - session.startClientY);
 }
 
+function activeDragPreviewAffectsTarget(
+    preview: ActiveDragPreview | null | undefined,
+    target: ActiveDragPreviewTarget,
+) {
+    return (
+        activeDragPreviewTargetMatches(preview?.source, target) ||
+        Boolean(findActiveDragPreviewTargetOffset(preview?.targets, target))
+    );
+}
+
 export function PickableGroup({
     children,
     stack,
@@ -193,9 +204,6 @@ export function PickableGroup({
 
     const setPickupBlock = useGameState((state) => state.setPickupBlock);
     const disturbAnimals = useGameState((state) => state.disturbAnimals);
-    const activeDragPreview = useGameState(
-        (state) => state.activeDragPreview ?? null,
-    );
     const setActiveDragPreview = useGameState(
         (state) => state.setActiveDragPreview,
     );
@@ -253,6 +261,14 @@ export function PickableGroup({
                 },
             }),
         [block.id, blockIndex, stack.position.x, stack.position.z],
+    );
+    const activeDragPreview = useGameState((state) =>
+        activeDragPreviewAffectsTarget(
+            state.activeDragPreview,
+            activePreviewTarget,
+        )
+            ? state.activeDragPreview
+            : null,
     );
     const isPreviewSource = activeDragPreviewTargetMatches(
         activeDragPreview?.source,
@@ -811,10 +827,36 @@ export function PickableGroup({
 
     function resetPickupVisualState() {
         setActiveDragPreview(null);
+        clearPickupInteractionState();
+    }
+
+    function clearPickupInteractionState() {
         setIsBlocked(false);
         setIsOverRecycler(false);
         setPickupOutlineVisible(false);
         setPickupBlock(null);
+    }
+
+    function createActivePreviewResetQueue() {
+        let resetQueued = false;
+
+        return {
+            queue: () => {
+                if (resetQueued) {
+                    return;
+                }
+
+                resetQueued = true;
+                window.requestAnimationFrame(() => {
+                    setActiveDragPreview(null);
+                });
+            },
+            resetIfUnqueued: () => {
+                if (!resetQueued) {
+                    setActiveDragPreview(null);
+                }
+            },
+        };
     }
 
     function cancelPointerSession(resetSpring: boolean) {
@@ -907,9 +949,8 @@ export function PickableGroup({
     }
 
     async function finishPickup(preview: ResolvedPlacementPreview | null) {
-        resetPickupVisualState();
-
         if (!preview || preview.nextIsBlocked) {
+            resetPickupVisualState();
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
             return;
         }
@@ -923,6 +964,7 @@ export function PickableGroup({
             !preview.canStoreInGardenBox &&
             !preview.nextIsOverRecycler
         ) {
+            resetPickupVisualState();
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
             return;
         }
@@ -933,6 +975,8 @@ export function PickableGroup({
             .setY(preview.previewHoverHeight + currentStackHeight);
 
         if (preview.canStoreInGardenBox && preview.hoveredGardenBoxBlockId) {
+            clearPickupInteractionState();
+            const activePreviewReset = createActivePreviewResetQueue();
             dragSpringsApi.start({
                 internalPosition: [
                     relative.x,
@@ -953,56 +997,55 @@ export function PickableGroup({
                 block.name,
             );
 
-            await storeBlockInGardenBox.mutateAsync({
-                sourcePosition: {
-                    x: stack.position.x,
-                    z: stack.position.z,
-                },
-                blockIndex,
-                sourceBlockId: block.id,
-                blockName: block.name,
-                blockEntityId: blockDataForInventory?.id.toString(),
-                blockLabel:
-                    blockDataForInventory?.information?.label ?? block.name,
-                gardenBoxBlockId: preview.hoveredGardenBoxBlockId,
-            });
+            await storeBlockInGardenBox
+                .mutateAsync({
+                    sourcePosition: {
+                        x: stack.position.x,
+                        z: stack.position.z,
+                    },
+                    blockIndex,
+                    sourceBlockId: block.id,
+                    blockName: block.name,
+                    blockEntityId: blockDataForInventory?.id.toString(),
+                    blockLabel:
+                        blockDataForInventory?.information?.label ?? block.name,
+                    gardenBoxBlockId: preview.hoveredGardenBoxBlockId,
+                    onOptimisticUpdate: activePreviewReset.queue,
+                })
+                .finally(activePreviewReset.resetIfUnqueued);
             return;
         }
 
         if (preview.nextIsOverRecycler) {
+            clearPickupInteractionState();
+            const activePreviewReset = createActivePreviewResetQueue();
             dragSpringsApi.start({
                 internalPosition: [relative.x, -1.5, relative.z],
                 scale: 0.1,
             });
             triggerPlaceHaptic();
-            await recycleBlock.mutateAsync({
-                position: stack.position,
-                blockIndex,
-                raisedBedId: raisedBed?.id,
-                attached: attachedPlacement
-                    ? {
-                          position: {
-                              x: attachedPlacement.candidateStack.position.x,
-                              z: attachedPlacement.candidateStack.position.z,
-                          },
-                          blockIndex: attachedPlacement.candidateBlockIndex,
-                      }
-                    : undefined,
-            });
+            await recycleBlock
+                .mutateAsync({
+                    position: stack.position,
+                    blockIndex,
+                    raisedBedId: raisedBed?.id,
+                    attached: attachedPlacement
+                        ? {
+                              position: {
+                                  x: attachedPlacement.candidateStack.position
+                                      .x,
+                                  z: attachedPlacement.candidateStack.position
+                                      .z,
+                              },
+                              blockIndex: attachedPlacement.candidateBlockIndex,
+                          }
+                        : undefined,
+                    onOptimisticUpdate: activePreviewReset.queue,
+                })
+                .finally(activePreviewReset.resetIfUnqueued);
             return;
         }
 
-        dragSpringsApi.start({
-            internalPosition: [
-                relative.x,
-                preview.previewHoverHeight,
-                relative.z,
-            ],
-            scale: 1,
-        });
-        dropSound.play();
-        triggerPlaceHaptic();
-        spawn(resolveBlockParticleType(block.name), previewDropPosition, 12);
         const moveRequests = getMovingSegments().flatMap((segment) =>
             segment.blocks.map((segmentBlock) => ({
                 sourcePosition: {
@@ -1019,14 +1062,32 @@ export function PickableGroup({
         );
         const [primaryMoveRequest, ...additionalBlockMoves] = moveRequests;
         if (!primaryMoveRequest) {
+            resetPickupVisualState();
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
             return;
         }
 
-        await moveBlock.mutateAsync({
-            ...primaryMoveRequest,
-            additionalBlocks: additionalBlockMoves,
+        clearPickupInteractionState();
+        const activePreviewReset = createActivePreviewResetQueue();
+        dragSpringsApi.start({
+            internalPosition: [
+                relative.x,
+                preview.previewHoverHeight,
+                relative.z,
+            ],
+            scale: 1,
         });
+        dropSound.play();
+        triggerPlaceHaptic();
+        spawn(resolveBlockParticleType(block.name), previewDropPosition, 12);
+
+        await moveBlock
+            .mutateAsync({
+                ...primaryMoveRequest,
+                additionalBlocks: additionalBlockMoves,
+                onOptimisticUpdate: activePreviewReset.queue,
+            })
+            .finally(activePreviewReset.resetIfUnqueued);
     }
 
     function handleWindowPointerMove(event: PointerEvent) {

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -1,0 +1,1911 @@
+import { type ReactNode, Suspense, useMemo } from 'react';
+import {
+    Color,
+    DoubleSide,
+    type Material,
+    MeshStandardMaterial,
+    Vector4,
+} from 'three';
+import type { BufferGeometry } from 'three/src/Three.Core.js';
+import type { GameAssetName } from '../data/models';
+import type { GLTFResult } from '../models/GameAssets';
+import { snowPresets } from '../snow/snowPresets';
+import type { Stack } from '../types/Stack';
+import { useGameState } from '../useGameState';
+import { useGameGLTF } from '../utils/useGameGLTF';
+import { useWaterBlockMaterial } from './BlockWater';
+import { getCactusVariantConfig } from './Cactus';
+import {
+    type EntityBlockInstance,
+    EntityInstancesBlock,
+    type EntityInstancesBlockBaseProps,
+    EntityInstancesGeometry,
+    useEntityBlockInstances,
+} from './EntityInstancesBlock';
+import { GardenFlowerModel } from './helpers/GardenFlowerModel';
+import { resolveEntityNeighbors } from './helpers/useEntityNeighbors';
+import { RaisedBedFields } from './raisedBed/RaisedBedFields';
+import { resolveWaterFoamEdges } from './waterBlockFoam';
+
+type CommonWeatherProps = Pick<
+    EntityInstancesBlockBaseProps,
+    'renderSnow' | 'snowOverlayMinCoverage'
+>;
+
+type ScaleTuple = [number, number, number];
+type ScaleInput = number | ScaleTuple | { x: number; y: number; z: number };
+type RotationTuple = [number, number, number];
+type AssetBlockMaterialProps =
+    | {
+          material: (gltf: GLTFResult) => Material | Material[];
+          materialNode?: never;
+      }
+    | {
+          material?: never;
+          materialNode: ReactNode;
+      };
+type AssetBlockProps = Omit<EntityInstancesBlockBaseProps, 'geometry'> &
+    AssetBlockMaterialProps & {
+        assetName: GameAssetName;
+        geometry: (gltf: GLTFResult) => BufferGeometry;
+    };
+
+const potBlockNames = [
+    'PotLowBowl',
+    'PotRoundedBowl',
+    'PotBulbousNeck',
+    'PotTallTapered',
+    'PotHourglass',
+    'PotStraightShortTub',
+    'PotNarrowFootBowl',
+    'PotSquatRidged',
+    'PotTallSlenderCone',
+    'PotWideLippedCup',
+] as const;
+
+const cactusBlockNames = [
+    'CactusBarrel',
+    'CactusColumnCluster',
+    'CactusPricklyPear',
+] as const;
+
+const deadTreeBlockNames = ['DeadTreeTall', 'DeadTreeStump'] as const;
+
+const giftBoxConfigs = {
+    GiftBox_RedWhite: {
+        boxColor: '#ff0000',
+        ribbonColor: '#ffffff',
+        boxMetalness: 0.5,
+        boxRoughness: 1,
+    },
+    GiftBox_GreenGold: {
+        boxColor: '#228B22',
+        ribbonColor: '#FFD700',
+        boxMetalness: 0.3,
+        boxRoughness: 0.7,
+    },
+    GiftBox_BlueWhite: {
+        boxColor: '#1E90FF',
+        ribbonColor: '#FFFFFF',
+        boxMetalness: 0.3,
+        boxRoughness: 0.7,
+    },
+    GiftBox_PurpleSilver: {
+        boxColor: '#8B008B',
+        ribbonColor: '#C0C0C0',
+        boxMetalness: 0.3,
+        boxRoughness: 0.7,
+    },
+    GiftBox_GoldRed: {
+        boxColor: '#FFD700',
+        ribbonColor: '#DC143C',
+        boxMetalness: 0.7,
+        boxRoughness: 0.3,
+    },
+    GiftBox_WhiteGreen: {
+        boxColor: '#FFFFFF',
+        ribbonColor: '#006400',
+        boxMetalness: 0.3,
+        boxRoughness: 0.7,
+    },
+} satisfies Record<
+    string,
+    {
+        boxColor: string;
+        ribbonColor: string;
+        boxMetalness: number;
+        boxRoughness: number;
+    }
+>;
+
+export const additionalInstancedBlockNames = [
+    'Block_Ground',
+    'Block_Ground_Angle',
+    'Block_Ground_Corner',
+    'Block_Ground_Reverse_Corner',
+    'Block_Water',
+    'Raised_Bed',
+    'Shade',
+    'Fence',
+    'GardenBox',
+    'Stool',
+    'Bucket',
+    'WateringCan',
+    'WaterWell',
+    'BirdHouse',
+    'CatPillow',
+    'Cat_Pillow',
+    'Composter',
+    'Snowman',
+    ...potBlockNames,
+    ...cactusBlockNames,
+    ...deadTreeBlockNames,
+    ...Object.keys(giftBoxConfigs),
+];
+
+function hasRenderableBlockInstance({
+    name,
+    stacks,
+}: {
+    name: string;
+    stacks: Stack[] | undefined;
+}) {
+    return (
+        stacks?.some((stack) =>
+            stack.blocks.some((block) => block.name === name),
+        ) ?? false
+    );
+}
+
+function LoadedAssetBlock({ assetName, geometry, ...props }: AssetBlockProps) {
+    const gltf = useGameGLTF(assetName);
+    const resolvedGeometry = geometry(gltf);
+
+    if (props.material) {
+        return (
+            <EntityInstancesBlock
+                {...props}
+                geometry={resolvedGeometry}
+                material={props.material(gltf)}
+            />
+        );
+    }
+
+    return (
+        <EntityInstancesBlock
+            {...props}
+            geometry={resolvedGeometry}
+            materialNode={props.materialNode}
+        />
+    );
+}
+
+function AssetBlock(props: AssetBlockProps) {
+    const hasInstances = hasRenderableBlockInstance({
+        name: props.name,
+        stacks: props.stacks,
+    });
+
+    if (!hasInstances) {
+        return null;
+    }
+
+    return (
+        <Suspense fallback={null}>
+            <LoadedAssetBlock {...props} />
+        </Suspense>
+    );
+}
+
+function toScaleTuple(scale: ScaleInput): ScaleTuple {
+    if (typeof scale === 'number') {
+        return [scale, scale, scale];
+    }
+
+    if (Array.isArray(scale)) {
+        return scale;
+    }
+
+    return [scale.x, scale.y, scale.z];
+}
+
+function multiplyScale(left: ScaleInput, right: ScaleInput) {
+    const leftTuple = toScaleTuple(left);
+    const rightTuple = toScaleTuple(right);
+
+    return [
+        leftTuple[0] * rightTuple[0],
+        leftTuple[1] * rightTuple[1],
+        leftTuple[2] * rightTuple[2],
+    ] satisfies ScaleTuple;
+}
+
+function scaledPosition(
+    position: { x: number; y: number; z: number },
+    scale: ScaleInput,
+) {
+    const scaleTuple = toScaleTuple(scale);
+
+    return [
+        position.x * scaleTuple[0],
+        position.y * scaleTuple[1],
+        position.z * scaleTuple[2],
+    ] satisfies ScaleTuple;
+}
+
+function rotationTuple(rotation: { x: number; y: number; z: number }) {
+    return [rotation.x, rotation.y, rotation.z] satisfies RotationTuple;
+}
+
+function transformNode(
+    node: GLTFResult['nodes'][keyof GLTFResult['nodes']],
+    groupScale: ScaleInput,
+    localScale: ScaleInput = 1,
+) {
+    return {
+        localPosition: scaledPosition(node.position, groupScale),
+        localRotation: rotationTuple(node.rotation),
+        scale: multiplyScale(groupScale, multiplyScale(node.scale, localScale)),
+    };
+}
+
+function mapInstanceRotation(
+    instance: EntityBlockInstance,
+    rotation: number,
+): EntityBlockInstance {
+    return { ...instance, rotation };
+}
+
+const planksMaterialName = 'Material.Planks';
+const dirtMaterialName = 'Material.Dirt';
+const metalMaterialName = 'Material.Metal';
+
+function InstancedWaterSurfaceMaterial() {
+    const waterColor = useGameState((state) => state.waterColors.shallow);
+
+    return (
+        <meshStandardMaterial
+            color={waterColor}
+            depthWrite={false}
+            metalness={0.35}
+            opacity={0.58}
+            roughness={0.24}
+            side={DoubleSide}
+            transparent
+        />
+    );
+}
+
+function BlockGroundInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes } = useGameGLTF('BlockGround');
+    const groundInstances = useEntityBlockInstances({
+        name: 'Block_Ground',
+        stacks,
+        yOffset: 1,
+    });
+    const oddVariantInstances = groundInstances?.filter(
+        (instance) => (instance.block.variant ?? 1) % 2 !== 0,
+    );
+    const evenVariantInstances = groundInstances?.filter(
+        (instance) => (instance.block.variant ?? 1) % 2 === 0,
+    );
+
+    return (
+        <>
+            <EntityInstancesGeometry
+                instanceKey="Block_Ground_1_1"
+                instances={oddVariantInstances}
+                geometry={nodes.Block_Ground_1_1.geometry}
+                material={nodes.Block_Ground_1_1.material}
+                snow={{
+                    maxThickness: 0.22,
+                    slopeExponent: 3.2,
+                    noiseScale: 1.7,
+                }}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey="Block_Ground_1_2"
+                instances={oddVariantInstances}
+                geometry={nodes.Block_Ground_1_2.geometry}
+                material={nodes.Block_Ground_1_2.material}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey="Block_Ground_2_1"
+                instances={evenVariantInstances}
+                geometry={nodes.Block_Ground_2_1.geometry}
+                material={nodes.Block_Ground_2_1.material}
+                snow={{
+                    maxThickness: 0.22,
+                    slopeExponent: 3.2,
+                    noiseScale: 1.7,
+                }}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey="Block_Ground_2_2"
+                instances={evenVariantInstances}
+                geometry={nodes.Block_Ground_2_2.geometry}
+                material={nodes.Block_Ground_2_2.material}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
+    const { nodes } = useGameGLTF('BlockSand');
+    const waterInstances = useEntityBlockInstances({
+        name: 'Block_Water',
+        stacks,
+        yOffset: 0.14,
+    });
+
+    if (!waterInstances?.length) {
+        return null;
+    }
+
+    const groupedInstances = waterFoamEdgeMasks
+        .map((mask) => ({
+            ...mask,
+            instances: waterInstances.filter((instance) => {
+                const foamEdges = resolveWaterFoamEdges({
+                    block: instance.block,
+                    stack: instance.stack,
+                    stacks,
+                });
+                return foamEdgeKey(foamEdges) === mask.key;
+            }),
+        }))
+        .filter((mask) => mask.instances.length > 0);
+
+    return (
+        <>
+            {groupedInstances.map((mask) => (
+                <WaterBlockMaskInstances
+                    key={`Block_Water-${mask.key}`}
+                    foamEdges={mask.foamEdges}
+                    geometry={nodes.Block_Sand_1.geometry}
+                    instances={mask.instances}
+                    maskKey={mask.key}
+                />
+            ))}
+        </>
+    );
+}
+
+const waterFoamEdgeMasks = Array.from({ length: 16 }, (_, mask) => {
+    const foamEdges = new Vector4(
+        mask & 1 ? 1 : 0,
+        mask & 2 ? 1 : 0,
+        mask & 4 ? 1 : 0,
+        mask & 8 ? 1 : 0,
+    );
+
+    return {
+        key: foamEdgeKey(foamEdges),
+        foamEdges,
+    };
+});
+
+function foamEdgeKey(foamEdges: Vector4) {
+    return `${foamEdges.x}${foamEdges.y}${foamEdges.z}${foamEdges.w}`;
+}
+
+function WaterBlockMaskInstances({
+    foamEdges,
+    geometry,
+    instances,
+    maskKey,
+}: {
+    foamEdges: Vector4;
+    geometry: BufferGeometry;
+    instances: EntityBlockInstance[];
+    maskKey: string;
+}) {
+    const material = useWaterBlockMaterial(foamEdges);
+
+    if (instances.length === 0) {
+        return null;
+    }
+
+    return (
+        <EntityInstancesGeometry
+            instanceKey={`Block_Water-${maskKey}`}
+            instances={instances}
+            geometry={geometry}
+            material={material}
+            castShadow={false}
+            renderOrder={1}
+        />
+    );
+}
+
+type RaisedBedShapeKey =
+    | 'Raised_Bed_O'
+    | 'Raised_Bed_L'
+    | 'Raised_Bed_I'
+    | 'Raised_Bed_U';
+
+type RaisedBedResolvedInstance = EntityBlockInstance & {
+    shape: RaisedBedShapeKey;
+};
+
+function resolveRaisedBedInstance(
+    instance: EntityBlockInstance,
+    stacks: Stack[] | undefined,
+): RaisedBedResolvedInstance {
+    const neighbors = resolveEntityNeighbors(
+        stacks,
+        instance.stack,
+        instance.block,
+    );
+    let shape: RaisedBedShapeKey = 'Raised_Bed_O';
+    let shapeRotation = 0;
+    const overlapOffset = { x: 0, z: 0 };
+
+    if (neighbors.total === 1) {
+        shape = 'Raised_Bed_U';
+
+        if (neighbors.n) {
+            shapeRotation = 0;
+            overlapOffset.x = 0.05;
+        } else if (neighbors.e) {
+            shapeRotation = 1;
+            overlapOffset.z = -0.05;
+        } else if (neighbors.s) {
+            shapeRotation = 2;
+            overlapOffset.x = -0.05;
+        } else if (neighbors.w) {
+            shapeRotation = 3;
+            overlapOffset.z = 0.05;
+        }
+    } else if (neighbors.total === 2) {
+        if ((neighbors.n && neighbors.s) || (neighbors.e && neighbors.w)) {
+            shape = 'Raised_Bed_I';
+            shapeRotation = neighbors.n && neighbors.s ? 1 : 0;
+        } else {
+            shape = 'Raised_Bed_L';
+            if (neighbors.n && neighbors.e) {
+                shapeRotation = 0;
+            } else if (neighbors.e && neighbors.s) {
+                shapeRotation = 1;
+            } else if (neighbors.s && neighbors.w) {
+                shapeRotation = 2;
+            } else {
+                shapeRotation = 3;
+            }
+        }
+    }
+
+    return {
+        ...instance,
+        position: [
+            instance.position[0] + overlapOffset.x,
+            instance.position[1],
+            instance.position[2] + overlapOffset.z,
+        ],
+        rotation: shapeRotation,
+        shape,
+    };
+}
+
+function RaisedBedInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes, materials } = useGameGLTF('RaisedBed');
+    const instances = useEntityBlockInstances({
+        name: 'Raised_Bed',
+        stacks,
+        yOffset: 1,
+    })?.map((instance) => resolveRaisedBedInstance(instance, stacks));
+
+    if (!instances?.length) {
+        return null;
+    }
+
+    return (
+        <>
+            {raisedBedShapeKeys.map((shape) => {
+                const shapeInstances = instances.filter(
+                    (instance) => instance.shape === shape,
+                );
+                const shape1 = `${shape}_1` as keyof GLTFResult['nodes'];
+                const shape2 = `${shape}_2` as keyof GLTFResult['nodes'];
+                const shape1Material =
+                    shape1 === 'Raised_Bed_O_1'
+                        ? planksMaterialName
+                        : dirtMaterialName;
+                const shape2Material =
+                    shape2 === 'Raised_Bed_O_2'
+                        ? dirtMaterialName
+                        : planksMaterialName;
+
+                return (
+                    <Suspense key={shape} fallback={null}>
+                        <EntityInstancesGeometry
+                            instanceKey={shape1}
+                            instances={shapeInstances}
+                            geometry={nodes[shape1].geometry}
+                            material={materials[shape1Material]}
+                            renderRainWetOverlay
+                            snow={{
+                                maxThickness: 0.16,
+                                slopeExponent: 2.8,
+                                noiseScale: 3,
+                                coverageMultiplier: 0.9,
+                            }}
+                            {...commonSnowProps}
+                        />
+                        <EntityInstancesGeometry
+                            instanceKey={shape2}
+                            instances={shapeInstances}
+                            geometry={nodes[shape2].geometry}
+                            material={materials[shape2Material]}
+                            renderRainWetOverlay
+                            snow={{
+                                maxThickness: 0.16,
+                                slopeExponent: 2.8,
+                                noiseScale: 3,
+                                coverageMultiplier: 0.9,
+                            }}
+                            {...commonSnowProps}
+                        />
+                    </Suspense>
+                );
+            })}
+            {instances.map((instance) => (
+                <group
+                    key={`Raised_Bed-fields-${instance.id}`}
+                    position={instance.position}
+                >
+                    <RaisedBedFields blockId={instance.block.id} />
+                </group>
+            ))}
+        </>
+    );
+}
+
+const raisedBedShapeKeys = [
+    'Raised_Bed_O',
+    'Raised_Bed_L',
+    'Raised_Bed_I',
+    'Raised_Bed_U',
+] satisfies RaisedBedShapeKey[];
+
+type ShadeKey =
+    | 'Shade_Solo'
+    | 'Shade_Single_Left'
+    | 'Shade_Single_Right'
+    | 'Shade_N'
+    | 'Shade_E'
+    | 'Shade_W'
+    | 'Shade_S'
+    | 'Shade_Middle';
+
+function resolveShadePieces(
+    instance: EntityBlockInstance,
+    stacks: Stack[] | undefined,
+) {
+    const neighbors = resolveEntityNeighbors(
+        stacks,
+        instance.stack,
+        instance.block,
+    );
+    let realizedRotation = instance.rotation % 2;
+    const pieces = new Set<ShadeKey>();
+
+    if (neighbors.total === 1) {
+        if (neighbors.n) {
+            pieces.add('Shade_Single_Left');
+            if (realizedRotation % 2 === 0) {
+                pieces.add('Shade_S');
+            } else {
+                pieces.add('Shade_Single_Right');
+                pieces.add('Shade_W');
+                pieces.add('Shade_Middle');
+            }
+        } else if (neighbors.e) {
+            pieces.add('Shade_Single_Left');
+            if (realizedRotation % 2 === 1) {
+                pieces.add('Shade_S');
+            } else {
+                pieces.add('Shade_Single_Right');
+                pieces.add('Shade_E');
+                pieces.add('Shade_Middle');
+            }
+        } else if (neighbors.s) {
+            pieces.add('Shade_Single_Right');
+            if (realizedRotation % 2 === 0) {
+                pieces.add('Shade_N');
+            } else {
+                pieces.add('Shade_Single_Left');
+                pieces.add('Shade_E');
+                pieces.add('Shade_Middle');
+            }
+        } else if (neighbors.w) {
+            pieces.add('Shade_Single_Right');
+            if (realizedRotation % 2 === 1) {
+                pieces.add('Shade_N');
+            } else {
+                pieces.add('Shade_Single_Left');
+                pieces.add('Shade_W');
+                pieces.add('Shade_Middle');
+            }
+        }
+    } else if (neighbors.total >= 2) {
+        let sides = 0;
+
+        if (neighbors.n) {
+            pieces.add('Shade_S');
+            sides++;
+        }
+        if (neighbors.w) {
+            pieces.add('Shade_W');
+            sides++;
+        }
+        if (neighbors.e) {
+            pieces.add('Shade_E');
+            sides++;
+        }
+        if (neighbors.s) {
+            pieces.add('Shade_N');
+            sides++;
+        }
+
+        if (sides >= 3) {
+            pieces.add('Shade_Middle');
+        } else if (
+            sides === 2 &&
+            ((pieces.has('Shade_S') && pieces.has('Shade_E')) ||
+                (pieces.has('Shade_N') && pieces.has('Shade_W')) ||
+                (pieces.has('Shade_N') && pieces.has('Shade_E')) ||
+                (pieces.has('Shade_S') && pieces.has('Shade_W')))
+        ) {
+            pieces.add('Shade_Middle');
+        }
+
+        realizedRotation = 0;
+    }
+
+    if (pieces.size === 0) {
+        pieces.add('Shade_Solo');
+    }
+
+    return { pieces, rotation: realizedRotation };
+}
+
+function ShadeInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes, materials } = useGameGLTF('Shade');
+    const instances = useEntityBlockInstances({
+        name: 'Shade',
+        stacks,
+        yOffset: 1,
+    });
+    const resolved = instances?.map((instance) => ({
+        instance,
+        shade: resolveShadePieces(instance, stacks),
+    }));
+
+    if (!resolved?.length) {
+        return null;
+    }
+
+    return (
+        <>
+            {shadeKeys.map((key) => (
+                <EntityInstancesGeometry
+                    key={key}
+                    instanceKey={key}
+                    instances={resolved
+                        .filter(({ shade }) => shade.pieces.has(key))
+                        .map(({ instance, shade }) =>
+                            mapInstanceRotation(instance, shade.rotation),
+                        )}
+                    geometry={nodes[key].geometry}
+                    material={materials[planksMaterialName]}
+                    snow={{
+                        maxThickness: 0.03,
+                        slopeExponent: 2.2,
+                        noiseScale: 4,
+                        coverageMultiplier: 0.35,
+                    }}
+                    {...commonSnowProps}
+                />
+            ))}
+        </>
+    );
+}
+
+const shadeKeys = [
+    'Shade_Solo',
+    'Shade_Single_Left',
+    'Shade_Single_Right',
+    'Shade_N',
+    'Shade_E',
+    'Shade_W',
+    'Shade_S',
+    'Shade_Middle',
+] satisfies ShadeKey[];
+
+type FenceKey =
+    | 'Fence_Solo'
+    | 'Fence_Single'
+    | 'Fence_Middle'
+    | 'Fence_Corner'
+    | 'Fence_T'
+    | 'Fence_Cross';
+
+function resolveFenceVariant(
+    instance: EntityBlockInstance,
+    stacks: Stack[] | undefined,
+) {
+    const neighbors = resolveEntityNeighbors(
+        stacks,
+        instance.stack,
+        instance.block,
+    );
+    let variant: FenceKey = 'Fence_Solo';
+    let realizedRotation = instance.rotation % 4;
+
+    if (neighbors.total === 1) {
+        variant = 'Fence_Single';
+        realizedRotation = neighbors.n
+            ? 3
+            : neighbors.s
+              ? 1
+              : neighbors.e
+                ? 0
+                : 2;
+    } else if (neighbors.total === 2) {
+        if (neighbors.n && neighbors.s) {
+            variant = 'Fence_Middle';
+            realizedRotation = 1;
+        } else if (neighbors.e && neighbors.w) {
+            variant = 'Fence_Middle';
+            realizedRotation = 0;
+        } else {
+            variant = 'Fence_Corner';
+            if (neighbors.n && neighbors.e) {
+                realizedRotation = 0;
+            } else if (neighbors.e && neighbors.s) {
+                realizedRotation = 1;
+            } else if (neighbors.s && neighbors.w) {
+                realizedRotation = 2;
+            } else if (neighbors.w && neighbors.n) {
+                realizedRotation = 3;
+            }
+        }
+    } else if (neighbors.total === 3) {
+        variant = 'Fence_T';
+        if (neighbors.n && neighbors.e && neighbors.s) {
+            realizedRotation = 0;
+        } else if (neighbors.e && neighbors.s && neighbors.w) {
+            realizedRotation = 1;
+        } else if (neighbors.s && neighbors.w && neighbors.n) {
+            realizedRotation = 2;
+        } else if (neighbors.w && neighbors.n && neighbors.e) {
+            realizedRotation = 3;
+        }
+    } else if (neighbors.total === 4) {
+        variant = 'Fence_Cross';
+    }
+
+    return {
+        instance: mapInstanceRotation(instance, realizedRotation),
+        variant,
+    };
+}
+
+function FenceInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes, materials } = useGameGLTF('Fence');
+    const instances = useEntityBlockInstances({
+        name: 'Fence',
+        stacks,
+        yOffset: 1,
+    });
+    const resolved = instances?.map((instance) =>
+        resolveFenceVariant(instance, stacks),
+    );
+
+    if (!resolved?.length) {
+        return null;
+    }
+
+    return (
+        <>
+            {fenceKeys.map((key) => (
+                <EntityInstancesGeometry
+                    key={key}
+                    instanceKey={key}
+                    instances={resolved
+                        .filter(({ variant }) => variant === key)
+                        .map(({ instance }) => instance)}
+                    geometry={nodes[key].geometry}
+                    material={materials[planksMaterialName]}
+                    renderRainWetOverlay
+                    snow={{
+                        maxThickness: 0.09,
+                        slopeExponent: 2.9,
+                        noiseScale: 3.3,
+                    }}
+                    {...commonSnowProps}
+                />
+            ))}
+        </>
+    );
+}
+
+const fenceKeys = [
+    'Fence_Solo',
+    'Fence_Single',
+    'Fence_Middle',
+    'Fence_Corner',
+    'Fence_T',
+    'Fence_Cross',
+] satisfies FenceKey[];
+
+function GardenBoxInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes, materials } = useGameGLTF('GardenBox');
+    const instances = useEntityBlockInstances({
+        name: 'GardenBox',
+        stacks,
+    })?.map((instance) => mapInstanceRotation(instance, instance.rotation + 2));
+    const hoveredGardenBoxBlockId = useGameState(
+        (state) => state.activeDragPreview?.hoveredGardenBoxBlockId ?? null,
+    );
+    const openGardenBoxBlockId = useGameState(
+        (state) => state.openGardenBoxBlockId,
+    );
+    const bodyInstances = instances ?? [];
+    const openLidInstances = bodyInstances.filter(
+        (instance) =>
+            hoveredGardenBoxBlockId === instance.block.id ||
+            openGardenBoxBlockId === instance.block.id,
+    );
+    const closedLidInstances = bodyInstances.filter(
+        (instance) =>
+            hoveredGardenBoxBlockId !== instance.block.id &&
+            openGardenBoxBlockId !== instance.block.id,
+    );
+
+    if (bodyInstances.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <EntityInstancesGeometry
+                instanceKey="GardenBox_Body_Planks"
+                instances={bodyInstances}
+                geometry={nodes.GardenBox_Body_Planks.geometry}
+                material={materials[planksMaterialName]}
+                renderRainWetOverlay
+                snow={snowPresets.giftBox}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey="GardenBox_Lid_HingeOrigin-closed"
+                instances={closedLidInstances}
+                geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                material={materials[planksMaterialName]}
+                localPosition={[0, 0.6, -0.38]}
+                renderRainWetOverlay
+                snow={snowPresets.giftBox}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey="GardenBox_Lid_HingeOrigin-open"
+                instances={openLidInstances}
+                geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                material={materials[planksMaterialName]}
+                localPosition={[0, 0.6, -0.38]}
+                localRotation={[-Math.PI / 2, 0, 0]}
+                renderRainWetOverlay
+                snow={snowPresets.giftBox}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+function PotInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    return (
+        <>
+            {potConfigs.map((config) => (
+                <Suspense key={config.name} fallback={null}>
+                    <LoadedPotVariant
+                        config={config}
+                        stacks={stacks}
+                        {...commonSnowProps}
+                    />
+                </Suspense>
+            ))}
+        </>
+    );
+}
+
+const potConfigs = [
+    {
+        name: 'PotLowBowl',
+        assetName: 'PotLowBowl',
+        potNode: 'PotVariant_01_Low_Bowl',
+        soilNode: 'PotVariant_Soil_01',
+        color: '#C56C45',
+    },
+    {
+        name: 'PotRoundedBowl',
+        assetName: 'PotRoundedBowl',
+        potNode: 'PotVariant_02_Rounded_Bowl',
+        soilNode: 'PotVariant_Soil_02',
+        color: '#7D8F68',
+    },
+    {
+        name: 'PotBulbousNeck',
+        assetName: 'PotBulbousNeck',
+        potNode: 'PotVariant_03_Bulbous_Neck',
+        soilNode: 'PotVariant_Soil_03',
+        color: '#B85A3E',
+    },
+    {
+        name: 'PotTallTapered',
+        assetName: 'PotTallTapered',
+        potNode: 'PotVariant_04_Tall_Tapered',
+        soilNode: 'PotVariant_Soil_04',
+        color: '#D7A354',
+    },
+    {
+        name: 'PotHourglass',
+        assetName: 'PotHourglass',
+        potNode: 'PotVariant_05_Hourglass',
+        soilNode: 'PotVariant_Soil_05',
+        color: '#637994',
+    },
+    {
+        name: 'PotStraightShortTub',
+        assetName: 'PotStraightShortTub',
+        potNode: 'PotVariant_06_Straight_Short_Tub',
+        soilNode: 'PotVariant_Soil_06',
+        color: '#9B7656',
+    },
+    {
+        name: 'PotNarrowFootBowl',
+        assetName: 'PotNarrowFootBowl',
+        potNode: 'PotVariant_07_Narrow_Foot_Bowl',
+        soilNode: 'PotVariant_Soil_07',
+        color: '#D18A5A',
+    },
+    {
+        name: 'PotSquatRidged',
+        assetName: 'PotSquatRidged',
+        potNode: 'PotVariant_08_Squat_Ridged_Pot',
+        soilNode: 'PotVariant_Soil_08',
+        color: '#676F58',
+    },
+    {
+        name: 'PotTallSlenderCone',
+        assetName: 'PotTallSlenderCone',
+        potNode: 'PotVariant_09_Tall_Slender_Cone',
+        soilNode: 'PotVariant_Soil_09',
+        color: '#C74E3A',
+    },
+    {
+        name: 'PotWideLippedCup',
+        assetName: 'PotWideLippedCup',
+        potNode: 'PotVariant_10_Wide_Lipped_Cup',
+        soilNode: 'PotVariant_Soil_10',
+        color: '#C18B45',
+    },
+] satisfies {
+    name: (typeof potBlockNames)[number];
+    assetName: GameAssetName;
+    potNode: keyof GLTFResult['nodes'];
+    soilNode: keyof GLTFResult['nodes'];
+    color: string;
+}[];
+
+function LoadedPotVariant({
+    config,
+    stacks,
+    ...commonSnowProps
+}: {
+    config: (typeof potConfigs)[number];
+    stacks: Stack[] | undefined;
+} & CommonWeatherProps) {
+    const { nodes } = useGameGLTF(config.assetName);
+
+    return (
+        <>
+            <EntityInstancesBlock
+                stacks={stacks}
+                name={config.name}
+                geometry={nodes[config.potNode].geometry}
+                materialNode={
+                    <meshStandardMaterial
+                        color={config.color}
+                        roughness={0.78}
+                        metalness={0.02}
+                    />
+                }
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.035,
+                    slopeExponent: 3.1,
+                    noiseScale: 4,
+                    coverageMultiplier: 0.45,
+                }}
+                {...commonSnowProps}
+            />
+            <EntityInstancesBlock
+                stacks={stacks}
+                name={config.name}
+                geometry={nodes[config.soilNode].geometry}
+                materialNode={
+                    <meshStandardMaterial
+                        color="#3F2A1C"
+                        roughness={0.95}
+                        metalness={0}
+                    />
+                }
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.025,
+                    slopeExponent: 2.2,
+                    noiseScale: 3,
+                    coverageMultiplier: 0.3,
+                }}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+function CactusInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    return (
+        <>
+            {cactusBlockNames.map((name) => (
+                <CactusVariantInstances
+                    key={name}
+                    name={name}
+                    stacks={stacks}
+                    {...commonSnowProps}
+                />
+            ))}
+        </>
+    );
+}
+
+function CactusVariantInstances({
+    name,
+    stacks,
+    ...commonSnowProps
+}: {
+    name: (typeof cactusBlockNames)[number];
+    stacks: Stack[] | undefined;
+} & CommonWeatherProps) {
+    const config = getCactusVariantConfig(name);
+    const instances = useEntityBlockInstances({
+        name,
+        stacks,
+        yOffset: -(config?.groundSink ?? 0),
+    });
+
+    if (!config || !instances?.length) {
+        return null;
+    }
+
+    return (
+        <Suspense fallback={null}>
+            <LoadedCactusVariant
+                config={config}
+                instances={instances}
+                name={name}
+                {...commonSnowProps}
+            />
+        </Suspense>
+    );
+}
+
+function LoadedCactusVariant({
+    config,
+    instances,
+    name,
+    ...commonSnowProps
+}: {
+    config: NonNullable<ReturnType<typeof getCactusVariantConfig>>;
+    instances: EntityBlockInstance[];
+    name: string;
+} & CommonWeatherProps) {
+    const { nodes } = useGameGLTF(config.assetName);
+    const scaledInstances = instances.map((instance) => ({
+        ...instance,
+        position: instance.position,
+    }));
+
+    return (
+        <>
+            <EntityInstancesGeometry
+                instanceKey={`${name}-body`}
+                instances={scaledInstances}
+                geometry={nodes[config.bodyNode].geometry}
+                scale={config.scale}
+                materialNode={
+                    <meshStandardMaterial
+                        color="#4a6411"
+                        roughness={0.82}
+                        metalness={0}
+                    />
+                }
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.04,
+                    slopeExponent: 1.9,
+                    noiseScale: 4.5,
+                    coverageMultiplier: 0.55,
+                }}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey={`${name}-spines`}
+                instances={scaledInstances}
+                geometry={nodes[config.spineNode].geometry}
+                scale={config.scale}
+                materialNode={
+                    <meshStandardMaterial
+                        color="#8a5a2b"
+                        roughness={0.78}
+                        metalness={0}
+                    />
+                }
+                {...commonSnowProps}
+            />
+            {instances.map((instance) => (
+                <group
+                    key={`${name}-flowers-${instance.id}`}
+                    position={instance.position}
+                    rotation={[0, instance.rotation * (Math.PI / 2), 0]}
+                    scale={config.scale}
+                >
+                    {config.flowers.map((flower) => (
+                        <GardenFlowerModel
+                            key={`${config.assetName}-flower-${flower.id}`}
+                            bloomOnly
+                            petalColor={flower.color}
+                            position={flower.position}
+                            rotation={flower.rotation}
+                            scale={flower.scale}
+                        />
+                    ))}
+                </group>
+            ))}
+        </>
+    );
+}
+
+const deadTreeConfigs = {
+    DeadTreeTall: {
+        assetName: 'DeadTreeTall',
+        nodes: [
+            'DeadTreeTall_Trunk',
+            'DeadTreeTall_LeftBranch',
+            'DeadTreeTall_LeftSubBranch',
+            'DeadTreeTall_LeftTip',
+            'DeadTreeTall_RightBranch',
+            'DeadTreeTall_RightSubBranch',
+            'DeadTreeTall_RightTip',
+        ],
+        scale: 0.92,
+        groundSink: 0,
+    },
+    DeadTreeStump: {
+        assetName: 'DeadTreeStump',
+        nodes: [
+            'DeadTreeStump_Trunk',
+            'DeadTreeStump_BrokenTop',
+            'DeadTreeStump_BrokenTop001',
+            'DeadTreeStump_SideStub',
+        ],
+        scale: 0.95,
+        groundSink: 0,
+    },
+} satisfies Record<
+    (typeof deadTreeBlockNames)[number],
+    {
+        assetName: GameAssetName;
+        nodes: (keyof GLTFResult['nodes'])[];
+        scale: number;
+        groundSink: number;
+    }
+>;
+
+function DeadTreeInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    return (
+        <>
+            {deadTreeBlockNames.map((name) => (
+                <Suspense key={name} fallback={null}>
+                    <LoadedDeadTreeVariant
+                        name={name}
+                        stacks={stacks}
+                        {...commonSnowProps}
+                    />
+                </Suspense>
+            ))}
+        </>
+    );
+}
+
+function LoadedDeadTreeVariant({
+    name,
+    stacks,
+    ...commonSnowProps
+}: {
+    name: (typeof deadTreeBlockNames)[number];
+    stacks: Stack[] | undefined;
+} & CommonWeatherProps) {
+    const config = deadTreeConfigs[name];
+    const { nodes } = useGameGLTF(config.assetName);
+
+    return (
+        <>
+            {config.nodes.map((nodeName) => {
+                const node = nodes[nodeName];
+
+                return (
+                    <EntityInstancesBlock
+                        key={`${name}-${nodeName}`}
+                        stacks={stacks}
+                        name={name}
+                        geometry={node.geometry}
+                        materialNode={
+                            <meshStandardMaterial
+                                color="#70401f"
+                                roughness={0.86}
+                                metalness={0}
+                            />
+                        }
+                        yOffset={-config.groundSink}
+                        renderRainWetOverlay
+                        snow={{
+                            maxThickness: 0.035,
+                            slopeExponent: 1.8,
+                            noiseScale: 4.2,
+                            coverageMultiplier: 0.45,
+                        }}
+                        {...transformNode(node, config.scale)}
+                        {...commonSnowProps}
+                    />
+                );
+            })}
+        </>
+    );
+}
+
+function GiftBoxInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes } = useGameGLTF('GiftBox');
+
+    return (
+        <>
+            {Object.entries(giftBoxConfigs).map(([name, config]) => (
+                <Suspense key={name} fallback={null}>
+                    <EntityInstancesBlock
+                        stacks={stacks}
+                        name={name}
+                        geometry={nodes.GiftBox_Box.geometry}
+                        yOffset={0.25}
+                        materialNode={
+                            <meshStandardMaterial
+                                color={config.boxColor}
+                                metalness={config.boxMetalness}
+                                roughness={config.boxRoughness}
+                            />
+                        }
+                        snow={snowPresets.giftBox}
+                        {...commonSnowProps}
+                    />
+                    <EntityInstancesBlock
+                        stacks={stacks}
+                        name={name}
+                        geometry={nodes.GiftBox_Strip.geometry}
+                        yOffset={0.25}
+                        materialNode={
+                            <meshStandardMaterial
+                                color={config.ribbonColor}
+                                metalness={0.5}
+                                roughness={0.3}
+                            />
+                        }
+                        snow={snowPresets.giftBox}
+                        {...commonSnowProps}
+                    />
+                    <EntityInstancesBlock
+                        stacks={stacks}
+                        name={name}
+                        geometry={nodes.GiftBox_Bow.geometry}
+                        yOffset={0.25}
+                        localPosition={[0, 0.25, 0]}
+                        localRotation={[0, -Math.PI / 4, 0]}
+                        materialNode={
+                            <meshStandardMaterial
+                                color={config.ribbonColor}
+                                metalness={0.5}
+                                roughness={0.3}
+                            />
+                        }
+                        snow={snowPresets.giftBox}
+                        {...commonSnowProps}
+                    />
+                </Suspense>
+            ))}
+        </>
+    );
+}
+
+function CatPillowInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes } = useGameGLTF('CatPillow');
+    const cushion = transformNode(nodes.CatPillow_Cushion, 0.62);
+    const seam = transformNode(nodes.CatPillow_Seam, 0.62);
+    const names = ['CatPillow', 'Cat_Pillow'];
+    const instances = useEntityBlockInstances({ names, stacks });
+
+    return (
+        <>
+            <EntityInstancesGeometry
+                instanceKey="CatPillow_Cushion"
+                instances={instances}
+                geometry={nodes.CatPillow_Cushion.geometry}
+                materialNode={
+                    <meshStandardMaterial
+                        color="#b80718"
+                        metalness={0}
+                        roughness={0.94}
+                        side={DoubleSide}
+                    />
+                }
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.045,
+                    slopeExponent: 2.4,
+                    noiseScale: 3.2,
+                    coverageMultiplier: 0.5,
+                }}
+                {...cushion}
+                {...commonSnowProps}
+            />
+            <EntityInstancesGeometry
+                instanceKey="CatPillow_Seam"
+                instances={instances}
+                geometry={nodes.CatPillow_Seam.geometry}
+                materialNode={
+                    <meshStandardMaterial
+                        color="#6b0610"
+                        metalness={0}
+                        roughness={0.92}
+                        side={DoubleSide}
+                    />
+                }
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.025,
+                    slopeExponent: 2.4,
+                    noiseScale: 3.2,
+                    coverageMultiplier: 0.42,
+                }}
+                {...seam}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+function BucketInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    return (
+        <>
+            <AssetBlock
+                assetName="Bucket"
+                stacks={stacks}
+                name="Bucket"
+                scale={[0.3, 0.25, 0.3]}
+                geometry={(gltf) => gltf.nodes.Bucket_1.geometry}
+                materialNode={<InstancedWaterSurfaceMaterial />}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Bucket"
+                stacks={stacks}
+                name="Bucket"
+                scale={[0.3, 0.25, 0.3]}
+                geometry={(gltf) => gltf.nodes.Bucket_2.geometry}
+                material={(gltf) => gltf.materials[metalMaterialName]}
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.06,
+                    slopeExponent: 3.5,
+                    noiseScale: 3.5,
+                    coverageMultiplier: 0.5,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Bucket"
+                stacks={stacks}
+                name="Bucket"
+                scale={[0.3, 0.25, 0.3]}
+                geometry={(gltf) => gltf.nodes.Bucket_3.geometry}
+                material={(gltf) => gltf.materials[planksMaterialName]}
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.08,
+                    slopeExponent: 2.8,
+                    noiseScale: 3.2,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Bucket"
+                stacks={stacks}
+                name="Bucket"
+                scale={[1, 1, 1]}
+                geometry={(gltf) => gltf.nodes['Bucket_-_Handle'].geometry}
+                material={(gltf) => gltf.nodes['Bucket_-_Handle'].material}
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.04,
+                    slopeExponent: 4.5,
+                    noiseScale: 5,
+                    coverageMultiplier: 0.4,
+                }}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+function WateringCanInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes } = useGameGLTF('WateringCan');
+    const metalMaterial = (
+        <meshStandardMaterial
+            color="#555555"
+            metalness={0}
+            roughness={0.5}
+            side={DoubleSide}
+        />
+    );
+    const groupScale = 0.35;
+
+    return (
+        <>
+            {wateringCanBodyNodeNames.map((nodeName) => (
+                <EntityInstancesBlock
+                    key={nodeName}
+                    stacks={stacks}
+                    name="WateringCan"
+                    geometry={nodes[nodeName].geometry}
+                    materialNode={metalMaterial}
+                    renderRainWetOverlay
+                    snow={snowPresets.tool}
+                    {...transformNode(nodes[nodeName], groupScale)}
+                    {...commonSnowProps}
+                />
+            ))}
+            {wateringCanTrimNodeNames.map((nodeName) => (
+                <EntityInstancesBlock
+                    key={nodeName}
+                    stacks={stacks}
+                    name="WateringCan"
+                    geometry={nodes[nodeName].geometry}
+                    materialNode={metalMaterial}
+                    renderRainWetOverlay
+                    snow={snowPresets.tool}
+                    {...transformNode(nodes[nodeName], groupScale)}
+                    {...commonSnowProps}
+                />
+            ))}
+            {wateringCanDarkNodeNames.map((nodeName) => (
+                <EntityInstancesBlock
+                    key={nodeName}
+                    stacks={stacks}
+                    name="WateringCan"
+                    geometry={nodes[nodeName].geometry}
+                    materialNode={metalMaterial}
+                    renderRainWetOverlay
+                    snow={snowPresets.tool}
+                    {...transformNode(nodes[nodeName], groupScale)}
+                    {...commonSnowProps}
+                />
+            ))}
+            <EntityInstancesBlock
+                stacks={stacks}
+                name="WateringCan"
+                geometry={nodes.WateringCan_Water.geometry}
+                materialNode={<InstancedWaterSurfaceMaterial />}
+                {...transformNode(nodes.WateringCan_Water, groupScale)}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+const wateringCanBodyNodeNames = [
+    'WateringCan_Body',
+    'WateringCan_Spout',
+] satisfies (keyof GLTFResult['nodes'])[];
+const wateringCanTrimNodeNames = [
+    'WateringCan_Base_Ring',
+    'WateringCan_Fill_Rim',
+    'WateringCan_Handle',
+    'WateringCan_Rose_Head',
+] satisfies (keyof GLTFResult['nodes'])[];
+const wateringCanDarkNodeNames = [
+    'WateringCan_Rose_Face_Dots',
+] satisfies (keyof GLTFResult['nodes'])[];
+
+function WaterWellInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes } = useGameGLTF('WaterWell');
+    const groupScale = 0.78;
+
+    return (
+        <>
+            {waterWellStoneNodeNames.map((nodeName) => (
+                <EntityInstancesBlock
+                    key={nodeName}
+                    stacks={stacks}
+                    name="WaterWell"
+                    geometry={nodes[nodeName].geometry}
+                    material={nodes[nodeName].material}
+                    renderRainWetOverlay
+                    snow={snowPresets.stone}
+                    {...transformNode(nodes[nodeName], groupScale)}
+                    {...commonSnowProps}
+                />
+            ))}
+            {waterWellWoodNodeNames.map((nodeName) => (
+                <EntityInstancesBlock
+                    key={nodeName}
+                    stacks={stacks}
+                    name="WaterWell"
+                    geometry={nodes[nodeName].geometry}
+                    material={nodes[nodeName].material}
+                    renderRainWetOverlay
+                    snow={{
+                        maxThickness: 0.08,
+                        slopeExponent: 2.8,
+                        noiseScale: 3.2,
+                        coverageMultiplier: 0.72,
+                    }}
+                    {...transformNode(nodes[nodeName], groupScale)}
+                    {...commonSnowProps}
+                />
+            ))}
+            <EntityInstancesBlock
+                stacks={stacks}
+                name="WaterWell"
+                geometry={nodes.WaterWell_Rope.geometry}
+                material={nodes.WaterWell_Rope.material}
+                renderRainWetOverlay
+                {...transformNode(nodes.WaterWell_Rope, groupScale)}
+                {...commonSnowProps}
+            />
+            <EntityInstancesBlock
+                stacks={stacks}
+                name="WaterWell"
+                geometry={nodes.WaterWell_Water.geometry}
+                materialNode={<InstancedWaterSurfaceMaterial />}
+                castShadow={false}
+                receiveShadow={false}
+                {...transformNode(nodes.WaterWell_Water, groupScale)}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+const waterWellStoneNodeNames = [
+    'WaterWell_Stone_Mid',
+    'WaterWell_Stone_Light',
+    'WaterWell_Stone_Dark',
+] satisfies (keyof GLTFResult['nodes'])[];
+const waterWellWoodNodeNames = [
+    'WaterWell_Wood_Frame',
+] satisfies (keyof GLTFResult['nodes'])[];
+
+function BirdHouseInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const { nodes } = useGameGLTF('BirdHouse');
+    const instances = useEntityBlockInstances({
+        name: 'BirdHouse',
+        stacks,
+    })?.map((instance) => mapInstanceRotation(instance, instance.rotation + 2));
+    const woodMaterial = (
+        <meshStandardMaterial
+            color="#956247"
+            metalness={0}
+            roughness={0.9}
+            side={DoubleSide}
+        />
+    );
+    const roofMaterial = (
+        <meshStandardMaterial
+            color="#2f3437"
+            metalness={0}
+            roughness={0.62}
+            side={DoubleSide}
+        />
+    );
+
+    return (
+        <>
+            {birdHouseWoodNodes.map((nodeName) => (
+                <EntityInstancesGeometry
+                    key={nodeName}
+                    instanceKey={nodeName}
+                    instances={instances}
+                    geometry={nodes[nodeName].geometry}
+                    materialNode={woodMaterial}
+                    renderRainWetOverlay
+                    snow={{
+                        maxThickness:
+                            nodeName === 'Birdhouse_Center_Post' ? 0.04 : 0.08,
+                        slopeExponent:
+                            nodeName === 'Birdhouse_Center_Post' ||
+                            nodeName === 'Birdhouse_Perch'
+                                ? 4
+                                : 2.8,
+                        noiseScale: nodeName === 'Birdhouse_Perch' ? 4 : 3,
+                        coverageMultiplier:
+                            nodeName === 'Birdhouse_Center_Post'
+                                ? 0.35
+                                : nodeName === 'Birdhouse_Perch'
+                                  ? 0.3
+                                  : 1,
+                    }}
+                    {...commonSnowProps}
+                />
+            ))}
+            {birdHouseRoofNodes.map((nodeName) => (
+                <EntityInstancesGeometry
+                    key={nodeName}
+                    instanceKey={nodeName}
+                    instances={instances}
+                    geometry={nodes[nodeName].geometry}
+                    materialNode={roofMaterial}
+                    renderRainWetOverlay
+                    snow={{
+                        maxThickness:
+                            nodeName === 'Birdhouse_Roof_Panels' ? 0.12 : 0.08,
+                        slopeExponent:
+                            nodeName === 'Birdhouse_Roof_Panels' ? 2.4 : 2.8,
+                        noiseScale:
+                            nodeName === 'Birdhouse_Roof_Panels' ? 2.8 : 3,
+                    }}
+                    {...commonSnowProps}
+                />
+            ))}
+        </>
+    );
+}
+
+const birdHouseWoodNodes = [
+    'Birdhouse_Angled_Supports',
+    'Birdhouse_Center_Post',
+    'Birdhouse_Upper_Platform',
+    'Birdhouse_Cabin_Walls',
+    'Birdhouse_Perch',
+] satisfies (keyof GLTFResult['nodes'])[];
+const birdHouseRoofNodes = [
+    'Birdhouse_Roof_Panels',
+    'Birdhouse_Ridge_Cap',
+] satisfies (keyof GLTFResult['nodes'])[];
+
+function SimpleAdditionalInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    const snowmanMaterial = useMemo(
+        () =>
+            new MeshStandardMaterial({
+                color: new Color('#FFFFFF'),
+                roughness: 1,
+                metalness: 0,
+            }),
+        [],
+    );
+
+    return (
+        <>
+            <AssetBlock
+                assetName="BlockGroundAngle"
+                stacks={stacks}
+                name="Block_Ground_Angle"
+                yOffset={1}
+                geometry={(gltf) => gltf.nodes.Block_Ground_Angle_1_1.geometry}
+                material={(gltf) => gltf.nodes.Block_Ground_Angle_1_1.material}
+                snow={{
+                    maxThickness: 0.18,
+                    slopeExponent: 2.2,
+                    noiseScale: 1.8,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="BlockGroundAngle"
+                stacks={stacks}
+                name="Block_Ground_Angle"
+                yOffset={1}
+                geometry={(gltf) => gltf.nodes.Block_Ground_Angle_1_2.geometry}
+                material={(gltf) => gltf.nodes.Block_Ground_Angle_1_2.material}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="BlockTerrainCorner"
+                stacks={stacks}
+                name="Block_Ground_Corner"
+                yOffset={1}
+                geometry={(gltf) => gltf.nodes.Block_Ground_Corner_1_1.geometry}
+                material={(gltf) => gltf.nodes.Block_Ground_Corner_1_1.material}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="BlockTerrainCorner"
+                stacks={stacks}
+                name="Block_Ground_Corner"
+                yOffset={1}
+                geometry={(gltf) => gltf.nodes.Block_Ground_Corner_1_2.geometry}
+                material={(gltf) => gltf.nodes.Block_Ground_Corner_1_2.material}
+                snow={{
+                    maxThickness: 0.18,
+                    slopeExponent: 2.2,
+                    noiseScale: 1.8,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="BlockTerrainReverseCorner"
+                stacks={stacks}
+                name="Block_Ground_Reverse_Corner"
+                yOffset={1}
+                geometry={(gltf) =>
+                    gltf.nodes.Block_Ground_Reverse_Corner_1_1.geometry
+                }
+                material={(gltf) =>
+                    gltf.nodes.Block_Ground_Reverse_Corner_1_1.material
+                }
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="BlockTerrainReverseCorner"
+                stacks={stacks}
+                name="Block_Ground_Reverse_Corner"
+                yOffset={1}
+                geometry={(gltf) =>
+                    gltf.nodes.Block_Ground_Reverse_Corner_1_2.geometry
+                }
+                material={(gltf) =>
+                    gltf.nodes.Block_Ground_Reverse_Corner_1_2.material
+                }
+                snow={{
+                    maxThickness: 0.18,
+                    slopeExponent: 2.2,
+                    noiseScale: 1.8,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Composter"
+                stacks={stacks}
+                name="Composter"
+                geometry={(gltf) => gltf.nodes.Composter_1.geometry}
+                material={(gltf) => gltf.materials[dirtMaterialName]}
+                snow={{
+                    maxThickness: 0.18,
+                    slopeExponent: 2.6,
+                    noiseScale: 2.4,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Composter"
+                stacks={stacks}
+                name="Composter"
+                geometry={(gltf) => gltf.nodes.Composter_2.geometry}
+                material={(gltf) => gltf.materials[planksMaterialName]}
+                snow={{
+                    maxThickness: 0.12,
+                    slopeExponent: 2.8,
+                    noiseScale: 3,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Stool"
+                stacks={stacks}
+                name="Stool"
+                yOffset={1}
+                geometry={(gltf) => gltf.nodes.Stool.geometry}
+                material={(gltf) => gltf.materials[planksMaterialName]}
+                renderRainWetOverlay
+                snow={{
+                    maxThickness: 0.11,
+                    slopeExponent: 2.9,
+                    noiseScale: 3,
+                }}
+                {...commonSnowProps}
+            />
+            <AssetBlock
+                assetName="Snowman"
+                stacks={stacks}
+                name="Snowman"
+                yOffset={1.139}
+                scale={0.36}
+                geometry={(gltf) => gltf.nodes.Snowman.geometry}
+                material={() => snowmanMaterial}
+                {...commonSnowProps}
+            />
+        </>
+    );
+}
+
+export function AdditionalEntityInstances({
+    stacks,
+    ...commonSnowProps
+}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+    return (
+        <>
+            <BlockGroundInstances stacks={stacks} {...commonSnowProps} />
+            <SimpleAdditionalInstances stacks={stacks} {...commonSnowProps} />
+            <WaterBlockInstances stacks={stacks} />
+            <RaisedBedInstances stacks={stacks} {...commonSnowProps} />
+            <ShadeInstances stacks={stacks} {...commonSnowProps} />
+            <FenceInstances stacks={stacks} {...commonSnowProps} />
+            <GardenBoxInstances stacks={stacks} {...commonSnowProps} />
+            <BucketInstances stacks={stacks} {...commonSnowProps} />
+            <WateringCanInstances stacks={stacks} {...commonSnowProps} />
+            <WaterWellInstances stacks={stacks} {...commonSnowProps} />
+            <BirdHouseInstances stacks={stacks} {...commonSnowProps} />
+            <CatPillowInstances stacks={stacks} {...commonSnowProps} />
+            <PotInstances stacks={stacks} {...commonSnowProps} />
+            <CactusInstances stacks={stacks} {...commonSnowProps} />
+            <DeadTreeInstances stacks={stacks} {...commonSnowProps} />
+            <GiftBoxInstances stacks={stacks} {...commonSnowProps} />
+        </>
+    );
+}

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -929,15 +929,22 @@ function PotInstances({
 }: { stacks: Stack[] | undefined } & CommonWeatherProps) {
     return (
         <>
-            {potConfigs.map((config) => (
-                <Suspense key={config.name} fallback={null}>
-                    <LoadedPotVariant
-                        config={config}
-                        stacks={stacks}
-                        {...commonSnowProps}
-                    />
-                </Suspense>
-            ))}
+            {potConfigs
+                .filter((config) =>
+                    hasRenderableBlockInstance({
+                        name: config.name,
+                        stacks,
+                    }),
+                )
+                .map((config) => (
+                    <Suspense key={config.name} fallback={null}>
+                        <LoadedPotVariant
+                            config={config}
+                            stacks={stacks}
+                            {...commonSnowProps}
+                        />
+                    </Suspense>
+                ))}
         </>
     );
 }

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -121,7 +121,7 @@ void main() {
 }
 `;
 
-function useWaterBlockMaterial(foamEdges: Vector4) {
+export function useWaterBlockMaterial(foamEdges: Vector4) {
     const waterColors = useGameState((state) => state.waterColors);
     const material = useMemo(() => {
         const waterMaterial = new ShaderMaterial({

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -1,13 +1,16 @@
 import { Edges } from '@react-three/drei';
+import type { PropsWithChildren } from 'react';
 import { PickableGroup } from '../controls/PickableGroup';
 import { RotatableGroup } from '../controls/RotatableGroup';
 import { SelectableGroup } from '../controls/SelectableGroup';
+import { useDeferredSingleClick } from '../controls/useDeferredSingleClick';
 import { useBlockData } from '../hooks/useBlockData';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useGameState } from '../useGameState';
 import { getBlockHitboxSize } from '../utils/blockHitbox';
 import { useStackHeight } from '../utils/getStackHeight';
 import { entityNameMap } from './entityNameMap';
+import { QueuedPlacementDropAnimation } from './helpers/PlacementDropAnimation';
 
 export type EntityFactoryProps = {
     name: string;
@@ -76,9 +79,26 @@ function InstancedEntityControlTarget({
         (entity) => entity.information.name === block.name,
     );
     const hitbox = getBlockHitboxSize(blockEntity);
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
+    const setOpenGardenBoxBlockId = useGameState(
+        (state) => state.setOpenGardenBoxBlockId,
+    );
+    const handleGardenBoxClick = useDeferredSingleClick(() => {
+        if (block.name !== 'GardenBox' || hasActiveDragPreview) {
+            return;
+        }
+
+        setOpenGardenBoxBlockId(block.id);
+    });
 
     return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js mesh is an invisible block interaction target.
         <mesh
+            onClick={
+                block.name === 'GardenBox' ? handleGardenBoxClick : undefined
+            }
             position={[
                 stack.position.x,
                 currentStackHeight + hitbox.height / 2,
@@ -92,6 +112,27 @@ function InstancedEntityControlTarget({
                 <Edges color="#22d3ee" renderOrder={10_000} threshold={1} />
             )}
         </mesh>
+    );
+}
+
+function EntityPlacementDropAnimation({
+    children,
+    stack,
+    block,
+}: PropsWithChildren<Pick<EntityInstanceProps, 'stack' | 'block'>>) {
+    const currentStackHeight = useStackHeight(stack, block);
+
+    return (
+        <QueuedPlacementDropAnimation
+            block={block}
+            particlePosition={[
+                stack.position.x,
+                currentStackHeight,
+                stack.position.z,
+            ]}
+        >
+            {children}
+        </QueuedPlacementDropAnimation>
     );
 }
 
@@ -127,21 +168,26 @@ export function EntityFactory({
         }
 
         return (
-            <PickableGroup
-                stack={stack}
-                block={block}
-                noControl={noControl}
-                renderPickupOutline={false}
-            >
-                <RotatableGroup block={block}>
-                    <InstancedEntityControlTarget stack={stack} block={block} />
-                    <EntityRenderModeDebugOverlay
-                        stack={stack}
-                        block={block}
-                        instanced
-                    />
-                </RotatableGroup>
-            </PickableGroup>
+            <SelectableGroup block={block}>
+                <PickableGroup
+                    stack={stack}
+                    block={block}
+                    noControl={noControl}
+                    renderPickupOutline={false}
+                >
+                    <RotatableGroup block={block}>
+                        <InstancedEntityControlTarget
+                            stack={stack}
+                            block={block}
+                        />
+                        <EntityRenderModeDebugOverlay
+                            stack={stack}
+                            block={block}
+                            instanced
+                        />
+                    </RotatableGroup>
+                </PickableGroup>
+            </SelectableGroup>
         );
     }
 
@@ -159,14 +205,16 @@ export function EntityFactory({
     }
 
     const entityContent = (
-        <RotatableGroup block={block}>
-            <EntityRenderModeDebugOverlay
-                stack={stack}
-                block={block}
-                instanced={false}
-            />
-            <EntityComponent stack={stack} block={block} {...rest} />
-        </RotatableGroup>
+        <EntityPlacementDropAnimation stack={stack} block={block}>
+            <RotatableGroup block={block}>
+                <EntityRenderModeDebugOverlay
+                    stack={stack}
+                    block={block}
+                    instanced={false}
+                />
+                <EntityComponent stack={stack} block={block} {...rest} />
+            </RotatableGroup>
+        </EntityPlacementDropAnimation>
     );
 
     return (

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -12,6 +12,10 @@ import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { useGameGLTF } from '../utils/useGameGLTF';
 import {
+    AdditionalEntityInstances,
+    additionalInstancedBlockNames,
+} from './AdditionalEntityInstances';
+import {
     EntityInstancesBlock,
     type EntityInstancesBlockBaseProps,
 } from './EntityInstancesBlock';
@@ -48,6 +52,7 @@ export const instancedBlockNames = [
     'DesertStoneSmall',
     'DesertStoneMedium',
     'DesertStoneLarge',
+    ...additionalInstancedBlockNames,
 ];
 
 const instancedSnowOverlayCounts = {
@@ -77,6 +82,39 @@ const instancedSnowOverlayCounts = {
     DesertStoneLarge: 1,
     DesertStoneMedium: 1,
     DesertStoneSmall: 1,
+    Block_Ground: 1,
+    Block_Ground_Angle: 1,
+    Block_Ground_Corner: 1,
+    Block_Ground_Reverse_Corner: 1,
+    Bucket: 3,
+    CatPillow: 2,
+    Cat_Pillow: 2,
+    Composter: 2,
+    DeadTreeStump: 4,
+    DeadTreeTall: 7,
+    Fence: 1,
+    GardenBox: 2,
+    GiftBox_BlueWhite: 3,
+    GiftBox_GoldRed: 3,
+    GiftBox_GreenGold: 3,
+    GiftBox_PurpleSilver: 3,
+    GiftBox_RedWhite: 3,
+    GiftBox_WhiteGreen: 3,
+    PotBulbousNeck: 2,
+    PotHourglass: 2,
+    PotLowBowl: 2,
+    PotNarrowFootBowl: 2,
+    PotRoundedBowl: 2,
+    PotSquatRidged: 2,
+    PotStraightShortTub: 2,
+    PotTallSlenderCone: 2,
+    PotTallTapered: 2,
+    PotWideLippedCup: 2,
+    Raised_Bed: 2,
+    Shade: 1,
+    Stool: 1,
+    WateringCan: 7,
+    WaterWell: 4,
     Tree: 1,
     Tulip: tulipBouquetStems.length * 2,
 } satisfies Partial<Record<(typeof instancedBlockNames)[number], number>>;
@@ -685,6 +723,12 @@ export function EntityInstances({
                 geometry={(gltf) => gltf.nodes.Seed.geometry}
                 material={(gltf) => gltf.nodes.Seed.material}
             />
+            <Suspense fallback={null}>
+                <AdditionalEntityInstances
+                    stacks={stacks}
+                    {...commonSnowProps}
+                />
+            </Suspense>
         </>
     );
 }

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -1,8 +1,9 @@
 import { Instance, Instances } from '@react-three/drei';
-import type { ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import type { Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import {
+    type ActiveDragPreviewTarget,
     activeDragPreviewTargetMatches,
     createActiveDragPreviewTarget,
     getActiveDragPreviewTargetPositionOffset,
@@ -10,12 +11,14 @@ import {
 import { useBlockData } from '../hooks/useBlockData';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
+import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
-import { useGameState } from '../useGameState';
+import { type ActiveDragPreview, useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
 import { resolveBlockInstanceCapacity } from './blockInstanceCapacity';
 import { blockPickupOutlineStyle } from './helpers/blockPickupOutlineStyle';
 import { HoverOutline } from './helpers/HoverOutline';
+import { PlacementDropAnimation } from './helpers/PlacementDropAnimation';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
@@ -29,10 +32,13 @@ export type EntityInstancesBlockBaseProps = {
     yOffset?: number;
     snowLift?: number;
     snowOverlayMinCoverage?: number;
-    scale?: [number, number, number];
+    scale?: number | [number, number, number];
     geometry: BufferGeometry;
     snow?: SnowMaterialOptions;
     renderRainWetOverlay?: boolean;
+    castShadow?: boolean;
+    receiveShadow?: boolean;
+    renderOrder?: number;
 };
 
 export type EntityInstancesBlockMaterialProps =
@@ -44,6 +50,173 @@ export type EntityInstancesBlockMaterialProps =
           material?: never;
           materialNode: ReactNode;
       };
+
+export type EntityBlockInstance = {
+    block: Block;
+    blockIndex: number;
+    id: string;
+    pickupOutlineVisible: boolean;
+    position: [number, number, number];
+    rotation: number;
+    stack: Stack;
+    stackHeight: number;
+};
+
+function blockNameMatches(
+    blockName: string,
+    name: string | undefined,
+    names: readonly string[] | undefined,
+) {
+    return blockName === name || (names?.includes(blockName) ?? false);
+}
+
+function activeDragTargetKey(target: ActiveDragPreviewTarget) {
+    return `${target.stackPosition.x}|${target.stackPosition.z}|${target.blockId}|${target.blockIndex}`;
+}
+
+function activeDragTargetTouchesBlockNames(
+    target: ActiveDragPreviewTarget | null | undefined,
+    blockNameByActiveDragTargetKey: Map<string, string>,
+    name: string | undefined,
+    names: readonly string[] | undefined,
+) {
+    if (!target) {
+        return false;
+    }
+
+    const blockName = blockNameByActiveDragTargetKey.get(
+        activeDragTargetKey(target),
+    );
+
+    return blockName ? blockNameMatches(blockName, name, names) : false;
+}
+
+function activeDragPreviewTouchesBlockNames(
+    preview: ActiveDragPreview | null,
+    blockNameByActiveDragTargetKey: Map<string, string>,
+    name: string | undefined,
+    names: readonly string[] | undefined,
+) {
+    if (!preview) {
+        return false;
+    }
+
+    return (
+        activeDragTargetTouchesBlockNames(
+            preview.source,
+            blockNameByActiveDragTargetKey,
+            name,
+            names,
+        ) ||
+        preview.targets.some((target) =>
+            activeDragTargetTouchesBlockNames(
+                target,
+                blockNameByActiveDragTargetKey,
+                name,
+                names,
+            ),
+        )
+    );
+}
+
+export function useEntityBlockInstances({
+    name,
+    names,
+    stacks,
+    yOffset,
+}: {
+    name?: string;
+    names?: readonly string[];
+    stacks: Stack[] | undefined;
+    yOffset?: number;
+}) {
+    const { data: blockData } = useBlockData();
+    const blockNameByActiveDragTargetKey = useMemo(() => {
+        const lookup = new Map<string, string>();
+
+        for (const stack of stacks ?? []) {
+            stack.blocks.forEach((block, blockIndex) => {
+                lookup.set(
+                    `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
+                    block.name,
+                );
+            });
+        }
+
+        return lookup;
+    }, [stacks]);
+    const activeDragPreview = useGameState((state) =>
+        activeDragPreviewTouchesBlockNames(
+            state.activeDragPreview,
+            blockNameByActiveDragTargetKey,
+            name,
+            names,
+        )
+            ? state.activeDragPreview
+            : null,
+    );
+    const stationaryPickupOutlineTarget = useGameState((state) =>
+        activeDragTargetTouchesBlockNames(
+            state.stationaryPickupOutlineTarget,
+            blockNameByActiveDragTargetKey,
+            name,
+            names,
+        )
+            ? state.stationaryPickupOutlineTarget
+            : null,
+    );
+
+    return stacks
+        ?.filter((stack) =>
+            stack.blocks.some((block) =>
+                blockNameMatches(block.name, name, names),
+            ),
+        )
+        .flatMap((stack) =>
+            stack.blocks
+                .map((block, blockIndex) => ({ block, blockIndex }))
+                .filter(({ block }) =>
+                    blockNameMatches(block.name, name, names),
+                )
+                .map(({ block, blockIndex }): EntityBlockInstance => {
+                    const stackHeight = getStackHeight(blockData, stack, block);
+                    const target = createActiveDragPreviewTarget({
+                        blockId: block.id,
+                        blockIndex,
+                        stackPosition: stack.position,
+                    });
+                    const dragPreviewOffset =
+                        getActiveDragPreviewTargetPositionOffset(
+                            target,
+                            activeDragPreview,
+                        );
+                    const stationaryPickupOutlineVisible =
+                        activeDragPreviewTargetMatches(
+                            stationaryPickupOutlineTarget,
+                            target,
+                        );
+
+                    return {
+                        block,
+                        blockIndex,
+                        id: `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
+                        pickupOutlineVisible:
+                            Boolean(dragPreviewOffset) ||
+                            stationaryPickupOutlineVisible,
+                        position: [
+                            stack.position.x + (dragPreviewOffset?.x ?? 0),
+                            stackHeight +
+                                (yOffset ?? 0) +
+                                (dragPreviewOffset?.y ?? 0),
+                            stack.position.z + (dragPreviewOffset?.z ?? 0),
+                        ],
+                        rotation: block.rotation || 0,
+                        stack,
+                        stackHeight,
+                    };
+                }),
+        );
+}
 
 export function EntityInstancesBlock(
     props: EntityInstancesBlockBaseProps & EntityInstancesBlockMaterialProps,
@@ -61,54 +234,82 @@ export function EntityInstancesBlock(
         geometry,
         snow,
         renderRainWetOverlay = false,
+        castShadow = true,
+        receiveShadow = true,
+        renderOrder,
     } = props;
-    const { data: blockData } = useBlockData();
-    const activeDragPreview = useGameState((state) => state.activeDragPreview);
-    const stationaryPickupOutlineTarget = useGameState(
-        (state) => state.stationaryPickupOutlineTarget,
-    );
+    const blockInstances = useEntityBlockInstances({
+        name,
+        stacks,
+        yOffset,
+    });
 
-    const blockInstances = stacks
-        ?.filter((stack) => stack.blocks.some((b) => b.name === name))
-        .flatMap((stack) =>
-            stack.blocks
-                ?.map((block, blockIndex) => ({ block, blockIndex }))
-                .filter(({ block }) => block.name === name)
-                .map(({ block, blockIndex }) => {
-                    const y = getStackHeight(blockData, stack, block);
-                    const target = createActiveDragPreviewTarget({
-                        blockId: block.id,
-                        blockIndex,
-                        stackPosition: stack.position,
-                    });
-                    const dragPreviewOffset =
-                        getActiveDragPreviewTargetPositionOffset(
-                            target,
-                            activeDragPreview,
-                        );
-                    const stationaryPickupOutlineVisible =
-                        activeDragPreviewTargetMatches(
-                            stationaryPickupOutlineTarget,
-                            target,
-                        );
-                    return {
-                        id: `${stack.position.x}|${stack.position.z}|${block.id}|${blockIndex}`,
-                        pickupOutlineVisible:
-                            Boolean(dragPreviewOffset) ||
-                            stationaryPickupOutlineVisible,
-                        position: [
-                            stack.position.x + (dragPreviewOffset?.x ?? 0),
-                            y + (yOffset ?? 0) + (dragPreviewOffset?.y ?? 0),
-                            stack.position.z + (dragPreviewOffset?.z ?? 0),
-                        ] as const,
-                        rotation: block.rotation || 0,
-                    };
-                }),
+    const commonProps = {
+        castShadow,
+        geometry,
+        instanceKey: name,
+        instances: blockInstances,
+        localPosition,
+        localRotation,
+        receiveShadow,
+        renderOrder,
+        renderRainWetOverlay,
+        renderSnow,
+        scale,
+        snow,
+        snowLift,
+        snowOverlayMinCoverage,
+    };
+
+    if (props.material) {
+        return (
+            <EntityInstancesGeometry
+                {...commonProps}
+                material={props.material}
+            />
         );
+    }
 
-    const instanceCapacity = resolveBlockInstanceCapacity(
-        blockInstances?.length ?? 0,
+    return (
+        <EntityInstancesGeometry
+            {...commonProps}
+            materialNode={props.materialNode}
+        />
     );
+}
+
+export function EntityInstancesGeometry(
+    props: Omit<EntityInstancesBlockBaseProps, 'name' | 'stacks' | 'yOffset'> &
+        EntityInstancesBlockMaterialProps & {
+            instanceKey: string;
+            instances: EntityBlockInstance[] | undefined;
+        },
+) {
+    const {
+        instanceKey,
+        instances,
+        renderSnow = true,
+        localPosition,
+        localRotation,
+        scale,
+        geometry,
+        snow,
+        snowLift = 0,
+        snowOverlayMinCoverage,
+        renderRainWetOverlay = false,
+        castShadow = true,
+        receiveShadow = true,
+        renderOrder,
+    } = props;
+    const placementDropAnimations = useGameState(
+        (state) => state.blockPlacementDropAnimations,
+    );
+
+    if (!instances?.length) {
+        return null;
+    }
+
+    const instanceCapacity = resolveBlockInstanceCapacity(instances.length);
 
     const localTransform = {
         position: localPosition ?? defaultLocalPosition,
@@ -116,84 +317,110 @@ export function EntityInstancesBlock(
     };
 
     const renderInstances = (suffix: string) =>
-        (blockInstances ?? []).map((data) => (
-            <group
-                key={`block-${name}-${suffix}-${data.id}`}
+        (instances ?? []).map((data) => (
+            <PlacementDropAnimation
+                key={`block-${instanceKey}-${suffix}-${data.id}`}
+                animation={placementDropAnimations[data.block.id]}
+                block={data.block}
+                particlePosition={[
+                    data.position[0],
+                    data.stackHeight,
+                    data.position[2],
+                ]}
                 position={data.position}
-                rotation={[0, data.rotation * (Math.PI / 2), 0]}
             >
-                <Instance
-                    position={localTransform.position}
-                    rotation={localTransform.rotation}
-                    scale={scale}
-                />
-            </group>
+                <group rotation={[0, data.rotation * (Math.PI / 2), 0]}>
+                    <Instance
+                        position={localTransform.position}
+                        rotation={localTransform.rotation}
+                        scale={scale}
+                    />
+                </group>
+            </PlacementDropAnimation>
         ));
 
     const renderSnowOverlays = () =>
         !snow || !renderSnow
             ? null
-            : (blockInstances ?? []).map((data) => (
-                  <group
-                      key={`block-${name}-snow-${data.id}`}
+            : (instances ?? []).map((data) => (
+                  <PlacementDropAnimation
+                      key={`block-${instanceKey}-snow-${data.id}`}
+                      animation={placementDropAnimations[data.block.id]}
+                      block={data.block}
+                      particlePosition={[
+                          data.position[0],
+                          data.stackHeight,
+                          data.position[2],
+                      ]}
                       position={[
                           data.position[0],
                           data.position[1] + (snowLift || 0.003),
                           data.position[2],
                       ]}
-                      rotation={[0, data.rotation * (Math.PI / 2), 0]}
                   >
-                      <group
-                          position={localTransform.position}
-                          rotation={localTransform.rotation}
-                          scale={scale}
-                      >
-                          <SnowOverlay
-                              geometry={geometry}
-                              minCoverage={snowOverlayMinCoverage}
-                              {...snow}
-                          />
+                      <group rotation={[0, data.rotation * (Math.PI / 2), 0]}>
+                          <group
+                              position={localTransform.position}
+                              rotation={localTransform.rotation}
+                              scale={scale}
+                          >
+                              <SnowOverlay
+                                  geometry={geometry}
+                                  minCoverage={snowOverlayMinCoverage}
+                                  {...snow}
+                              />
+                          </group>
                       </group>
-                  </group>
+                  </PlacementDropAnimation>
               ));
 
     const renderRainOverlays = () =>
         !renderRainWetOverlay
             ? null
-            : (blockInstances ?? []).map((data) => (
-                  <group
-                      key={`block-${name}-rain-${data.id}`}
+            : (instances ?? []).map((data) => (
+                  <PlacementDropAnimation
+                      key={`block-${instanceKey}-rain-${data.id}`}
+                      animation={placementDropAnimations[data.block.id]}
+                      block={data.block}
+                      particlePosition={[
+                          data.position[0],
+                          data.stackHeight,
+                          data.position[2],
+                      ]}
                       position={data.position}
-                      rotation={[0, data.rotation * (Math.PI / 2), 0]}
                   >
-                      <group
-                          position={localTransform.position}
-                          rotation={localTransform.rotation}
-                          scale={scale}
-                      >
-                          <RainWetOverlay geometry={geometry} />
+                      <group rotation={[0, data.rotation * (Math.PI / 2), 0]}>
+                          <group
+                              position={localTransform.position}
+                              rotation={localTransform.rotation}
+                              scale={scale}
+                          >
+                              <RainWetOverlay geometry={geometry} />
+                          </group>
                       </group>
-                  </group>
+                  </PlacementDropAnimation>
               ));
 
     return (
         <>
             <Instances
-                key={`${name}-${instanceCapacity}`}
+                key={`${instanceKey}-${instanceCapacity}`}
                 limit={instanceCapacity}
+                range={instances.length}
                 geometry={geometry}
                 frustumCulled={false}
-                receiveShadow
-                castShadow
+                receiveShadow={receiveShadow}
+                castShadow={castShadow}
+                renderOrder={renderOrder}
                 material={'material' in props ? props.material : undefined}
             >
                 {'materialNode' in props ? props.materialNode : null}
                 {renderInstances('base')}
             </Instances>
-            {(blockInstances ?? []).map((data) =>
+            {(instances ?? []).map((data) =>
                 data.pickupOutlineVisible ? (
                     <HoverOutline
-                        key={`block-${name}-pickup-outline-${data.id}`}
+                        key={`block-${instanceKey}-pickup-outline-${data.id}`}
                         {...blockPickupOutlineStyle}
                         hovered
                     >

--- a/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useMemo } from 'react';
 import {
+    type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
     getActiveDragPreviewTargetPositionOffset,
 } from '../../dragPreviewIdentity';
@@ -33,13 +34,16 @@ type GroundBlockDecorationsProps = {
     stacks: Stack[] | undefined;
 };
 
+function activeDragTargetKey(target: ActiveDragPreviewTarget) {
+    return `${target.stackPosition.x}|${target.stackPosition.z}|${target.blockId}|${target.blockIndex}`;
+}
+
 export function GroundBlockDecorations({
     density,
     stacks,
 }: GroundBlockDecorationsProps) {
     const { data: blockData } = useBlockData();
     const { data: garden } = useCurrentGarden();
-    const activeDragPreview = useGameState((state) => state.activeDragPreview);
     const gameWeather = useGameState((state) => state.weather);
     const { data: weatherNow } = useWeatherNow();
     const windSpeed =
@@ -87,6 +91,39 @@ export function GroundBlockDecorations({
             }),
         );
     }, [density, garden?.id, stacks]);
+    const decoratedBlockPreviewKeys = useMemo(
+        () =>
+            new Set(
+                decorationBlocks.map(({ block, blockIndex, stack }) =>
+                    activeDragTargetKey(
+                        createActiveDragPreviewTarget({
+                            blockId: block.id,
+                            blockIndex,
+                            stackPosition: stack.position,
+                        }),
+                    ),
+                ),
+            ),
+        [decorationBlocks],
+    );
+    const activeDragPreview = useGameState((state) => {
+        const preview = state.activeDragPreview;
+        if (!preview) {
+            return null;
+        }
+
+        if (
+            decoratedBlockPreviewKeys.has(activeDragTargetKey(preview.source))
+        ) {
+            return preview;
+        }
+
+        return preview.targets.some((target) =>
+            decoratedBlockPreviewKeys.has(activeDragTargetKey(target)),
+        )
+            ? preview
+            : null;
+    });
     const decorationCount = decorationBlocks.reduce(
         (sum, block) => sum + block.placements.length,
         0,

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -20,7 +20,12 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
     const currentStackHeight = useStackHeight(stack, block);
     const hovered =
         useHoveredBlockStore((state) => state.hoveredBlock) === block;
-    const activeDragPreview = useGameState((state) => state.activeDragPreview);
+    const hoveredGardenBoxBlockId = useGameState(
+        (state) => state.activeDragPreview?.hoveredGardenBoxBlockId ?? null,
+    );
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const openGardenBoxBlockId = useGameState(
         (state) => state.openGardenBoxBlockId,
     );
@@ -28,7 +33,7 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
         (state) => state.setOpenGardenBoxBlockId,
     );
     const isLidOpen =
-        activeDragPreview?.hoveredGardenBoxBlockId === block.id ||
+        hoveredGardenBoxBlockId === block.id ||
         openGardenBoxBlockId === block.id;
     const { rotation: lidRotation } = useSpring({
         config: {
@@ -40,7 +45,7 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
     });
 
     const handleClick = useDeferredSingleClick(() => {
-        if (activeDragPreview) return;
+        if (hasActiveDragPreview) return;
 
         setOpenGardenBoxBlockId(block.id);
     });

--- a/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
+++ b/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
@@ -1,0 +1,136 @@
+import { animated, useSpring } from '@react-spring/three';
+import { type PropsWithChildren, useEffect, useRef } from 'react';
+import { Vector3 } from 'three';
+import {
+    resolveBlockParticleType,
+    useParticles,
+} from '../../particles/ParticleSystem';
+import type { Block } from '../../types/Block';
+import {
+    type BlockPlacementDropAnimation,
+    useGameState,
+} from '../../useGameState';
+
+const placementDropLift = 0.1;
+const reducedMotionQuery = '(prefers-reduced-motion: reduce)';
+
+function prefersReducedMotion() {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia(reducedMotionQuery).matches
+    );
+}
+
+function toVector3(position: Vector3 | [number, number, number]) {
+    return Array.isArray(position)
+        ? new Vector3(position[0], position[1], position[2])
+        : position.clone();
+}
+
+export function PlacementDropAnimation({
+    animation,
+    block,
+    children,
+    particlePosition,
+    position = [0, 0, 0],
+}: PropsWithChildren<{
+    animation: BlockPlacementDropAnimation | null | undefined;
+    block: Block;
+    particlePosition: Vector3 | [number, number, number];
+    position?: [number, number, number];
+}>) {
+    const { spawn } = useParticles();
+    const markParticlesSpawned = useGameState(
+        (state) => state.markBlockPlacementDropParticlesSpawned,
+    );
+    const completeAnimation = useGameState(
+        (state) => state.completeBlockPlacementDropAnimation,
+    );
+    const startedSequence = useRef<number | null>(null);
+    const [{ dropOffsetY }, api] = useSpring(() => ({
+        dropOffsetY:
+            animation && !prefersReducedMotion() ? placementDropLift : 0,
+        config: {
+            mass: 0.1,
+            tension: 200,
+            friction: 10,
+        },
+    }));
+
+    useEffect(() => {
+        if (!animation || startedSequence.current === animation.sequence) {
+            return;
+        }
+
+        startedSequence.current = animation.sequence;
+        const spawnLandingParticles = () => {
+            if (!markParticlesSpawned(block.id)) {
+                return;
+            }
+
+            spawn(
+                resolveBlockParticleType(block.name),
+                toVector3(particlePosition),
+                12,
+            );
+        };
+        const finish = () => {
+            spawnLandingParticles();
+            completeAnimation(block.id);
+        };
+
+        if (prefersReducedMotion()) {
+            api.set({ dropOffsetY: 0 });
+            finish();
+            return;
+        }
+
+        api.set({ dropOffsetY: placementDropLift });
+        void api.start({
+            dropOffsetY: 0,
+            onRest: finish,
+        });
+    }, [
+        animation,
+        api,
+        block.id,
+        block.name,
+        completeAnimation,
+        markParticlesSpawned,
+        particlePosition,
+        spawn,
+    ]);
+
+    return (
+        <group position={position}>
+            <animated.group position-y={dropOffsetY}>{children}</animated.group>
+        </group>
+    );
+}
+
+export function QueuedPlacementDropAnimation({
+    block,
+    children,
+    particlePosition,
+    position,
+}: PropsWithChildren<{
+    block: Block;
+    particlePosition: Vector3 | [number, number, number];
+    position?: [number, number, number];
+}>) {
+    const animation = useGameState(
+        (state) => state.blockPlacementDropAnimations[block.id] ?? null,
+    );
+
+    return (
+        <PlacementDropAnimation
+            animation={animation}
+            block={block}
+            particlePosition={particlePosition}
+            position={position}
+        >
+            {children}
+        </PlacementDropAnimation>
+    );
+}

--- a/packages/game/src/entities/helpers/useEntityNeighbors.ts
+++ b/packages/game/src/entities/helpers/useEntityNeighbors.ts
@@ -2,11 +2,13 @@ import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
 
-export function useEntityNeighbors(stack: Stack, block: Block) {
-    const { data: garden } = useCurrentGarden();
-
+export function resolveEntityNeighbors(
+    stacks: Stack[] | undefined,
+    stack: Stack,
+    block: Block,
+) {
     function getStack({ x, z }: { x: number; z: number }) {
-        return garden?.stacks.find(
+        return stacks?.find(
             (stack) => stack.position.x === x && stack.position.z === z,
         );
     }
@@ -62,4 +64,10 @@ export function useEntityNeighbors(stack: Stack, block: Block) {
             (neighbors.s ? 1 : 0),
         ...neighbors,
     };
+}
+
+export function useEntityNeighbors(stack: Stack, block: Block) {
+    const { data: garden } = useCurrentGarden();
+
+    return resolveEntityNeighbors(garden?.stacks, stack, block);
 }

--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { BufferGeometry, Material } from 'three';
 import {
+    type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
     getActiveDragPreviewTargetPositionOffset,
 } from '../../dragPreviewIdentity';
@@ -18,7 +19,7 @@ import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { Block } from '../../types/Block';
 import type { Stack } from '../../types/Stack';
-import { useGameState } from '../../useGameState';
+import { type ActiveDragPreview, useGameState } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
@@ -168,6 +169,36 @@ function getBlockPlacement(garden: CurrentGardenData, blockId: string) {
     }
 
     return null;
+}
+
+function activeDragTargetMatchesRaisedBedPlacement(
+    target: ActiveDragPreviewTarget,
+    garden: CurrentGardenData,
+) {
+    const placement = getBlockPlacement(garden, target.blockId);
+
+    return (
+        placement?.block.name === 'Raised_Bed' &&
+        placement.stackBlockIndex === target.blockIndex &&
+        placement.stack.position.x === target.stackPosition.x &&
+        placement.stack.position.z === target.stackPosition.z
+    );
+}
+
+function activeDragPreviewTouchesRaisedBed(
+    preview: ActiveDragPreview | null,
+    garden: CurrentGardenData | null | undefined,
+) {
+    if (!preview || !garden) {
+        return false;
+    }
+
+    return (
+        activeDragTargetMatchesRaisedBedPlacement(preview.source, garden) ||
+        preview.targets.some((target) =>
+            activeDragTargetMatchesRaisedBedPlacement(target, garden),
+        )
+    );
 }
 
 function getRaisedBedNeighbors(
@@ -594,7 +625,14 @@ export function RaisedBedMulchOverlays({
         MulchWood: useGameGLTF('MulchWood'),
     };
     const qualityProfile = quality ?? resolveGameQualityProfile();
-    const activeDragPreview = useGameState((state) => state.activeDragPreview);
+    const activeDragPreview = useGameState((state) =>
+        activeDragPreviewTouchesRaisedBed(
+            state.activeDragPreview,
+            currentGarden,
+        )
+            ? state.activeDragPreview
+            : null,
+    );
     const snowCoverage = useGameState((state) => state.snowCoverage);
     const renderSnow = snowCoverage >= qualityProfile.snowOverlayMinCoverage;
 

--- a/packages/game/src/hooks/useBlockMove.ts
+++ b/packages/game/src/hooks/useBlockMove.ts
@@ -18,6 +18,7 @@ type MoveBlockArgs = {
 type MoveArgs = MoveBlockArgs & {
     additionalBlocks?: MoveBlockArgs[];
     attached?: MoveBlockArgs;
+    onOptimisticUpdate?: () => void;
 };
 
 type MovePatchOperation = {
@@ -177,6 +178,9 @@ export function useBlockMove() {
                     stacks: [...updatedStacks],
                 },
             );
+            if (previousItem) {
+                args.onOptimisticUpdate?.();
+            }
 
             return {
                 previousItem,

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -81,6 +81,9 @@ export function useBlockPlace() {
     const queuePlacedBlockEffect = useGameState(
         (state) => state.queuePlacedBlockEffect,
     );
+    const queueBlockPlacementDropAnimation = useGameState(
+        (state) => state.queueBlockPlacementDropAnimation,
+    );
     const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
 
     return useMutation({
@@ -147,6 +150,7 @@ export function useBlockPlace() {
                     };
                     variables.expectedExistingBlocks =
                         optimisticPlacement.existingBlocks;
+                    queueBlockPlacementDropAnimation(optimisticBlockId);
                     queryClient.setQueryData<CurrentGardenData>(
                         gardenQueryKey,
                         {

--- a/packages/game/src/hooks/useBlockRecycle.ts
+++ b/packages/game/src/hooks/useBlockRecycle.ts
@@ -57,6 +57,7 @@ export function useBlockRecycle() {
                 position: { x: number; z: number };
                 blockIndex: number;
             };
+            onOptimisticUpdate?: () => void;
         }) => {
             console.debug('Recycling block', position, blockIndex);
             if (!garden) {
@@ -87,7 +88,13 @@ export function useBlockRecycle() {
                 await removeShoppingCartItems(shoppingCart, raisedBedId);
             }
         },
-        onMutate: async ({ position, blockIndex, raisedBedId, attached }) => {
+        onMutate: async ({
+            position,
+            blockIndex,
+            raisedBedId,
+            attached,
+            onOptimisticUpdate,
+        }) => {
             if (!garden) {
                 return;
             }
@@ -130,6 +137,9 @@ export function useBlockRecycle() {
                     stacks: [...updatedStacks],
                 },
             );
+            if (previousItem) {
+                onOptimisticUpdate?.();
+            }
 
             // Optimistically remove from shopping cart if raisedBedId is provided
             let previousShoppingCart: ShoppingCartData | undefined;

--- a/packages/game/src/hooks/useFocusPlacedBlock.ts
+++ b/packages/game/src/hooks/useFocusPlacedBlock.ts
@@ -6,14 +6,17 @@ import { useGameState } from '../useGameState';
 import { useCurrentGarden } from './useCurrentGarden';
 
 const focusAnimationDurationMs = 650;
+const focusFollowTimeConstantMs = focusAnimationDurationMs / 4;
 const sunflowerAnimationDelayMs = 420;
 const reducedMotionQuery = '(prefers-reduced-motion: reduce)';
+const focusStopDistance = 0.01;
 
-function easeInOutCubic(progress: number) {
-    return progress < 0.5
-        ? 4 * progress * progress * progress
-        : 1 - (-2 * progress + 2) ** 3 / 2;
-}
+type FocusAnimationState = {
+    cameraPosition: Vector3;
+    lastFrameTime: number | null;
+    orbitControls: OrbitControls;
+    targetPosition: Vector3;
+};
 
 function prefersReducedMotion() {
     return (
@@ -23,61 +26,97 @@ function prefersReducedMotion() {
     );
 }
 
+function stepFocusAnimation({
+    animationFrameRef,
+    focusAnimationRef,
+}: {
+    animationFrameRef: MutableRefObject<number | null>;
+    focusAnimationRef: MutableRefObject<FocusAnimationState | null>;
+}) {
+    const step = (currentTime: number) => {
+        const state = focusAnimationRef.current;
+        if (!state) {
+            animationFrameRef.current = null;
+            return;
+        }
+
+        const deltaMs =
+            state.lastFrameTime === null
+                ? 16.67
+                : Math.min(currentTime - state.lastFrameTime, 100);
+        state.lastFrameTime = currentTime;
+
+        const alpha = 1 - Math.exp(-deltaMs / focusFollowTimeConstantMs);
+        state.orbitControls.target.lerp(state.targetPosition, alpha);
+        state.orbitControls.object.position.lerp(state.cameraPosition, alpha);
+        state.orbitControls.update();
+
+        const targetDistance = state.orbitControls.target.distanceTo(
+            state.targetPosition,
+        );
+        const cameraDistance = state.orbitControls.object.position.distanceTo(
+            state.cameraPosition,
+        );
+
+        if (
+            targetDistance <= focusStopDistance &&
+            cameraDistance <= focusStopDistance
+        ) {
+            state.orbitControls.target.copy(state.targetPosition);
+            state.orbitControls.object.position.copy(state.cameraPosition);
+            state.orbitControls.update();
+            focusAnimationRef.current = null;
+            animationFrameRef.current = null;
+            return;
+        }
+
+        animationFrameRef.current = window.requestAnimationFrame(step);
+    };
+
+    animationFrameRef.current = window.requestAnimationFrame(step);
+}
+
 function focusOrbitControlsOnPosition({
     animationFrameRef,
+    focusAnimationRef,
     orbitControls,
     targetPosition,
 }: {
     animationFrameRef: MutableRefObject<number | null>;
+    focusAnimationRef: MutableRefObject<FocusAnimationState | null>;
     orbitControls: OrbitControls;
     targetPosition: Vector3;
 }) {
-    if (animationFrameRef.current !== null) {
-        window.cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-    }
-
-    const offset = new Vector3().subVectors(
-        targetPosition,
+    const cameraOffset = new Vector3().subVectors(
+        orbitControls.object.position,
         orbitControls.target,
     );
-    const startTarget = orbitControls.target.clone();
-    const endTarget = startTarget.clone().add(offset);
-    const startCameraPosition = orbitControls.object.position.clone();
-    const endCameraPosition = startCameraPosition.clone().add(offset);
+    const nextTargetPosition = targetPosition.clone();
+    const nextCameraPosition = targetPosition.clone().add(cameraOffset);
 
     if (prefersReducedMotion()) {
-        orbitControls.target.copy(endTarget);
-        orbitControls.object.position.copy(endCameraPosition);
+        if (animationFrameRef.current !== null) {
+            window.cancelAnimationFrame(animationFrameRef.current);
+            animationFrameRef.current = null;
+        }
+
+        focusAnimationRef.current = null;
+        orbitControls.target.copy(nextTargetPosition);
+        orbitControls.object.position.copy(nextCameraPosition);
         orbitControls.update();
         return;
     }
 
-    const startTime = performance.now();
-    const step = (currentTime: number) => {
-        const progress = Math.min(
-            (currentTime - startTime) / focusAnimationDurationMs,
-            1,
-        );
-        const easedProgress = easeInOutCubic(progress);
-
-        orbitControls.target.lerpVectors(startTarget, endTarget, easedProgress);
-        orbitControls.object.position.lerpVectors(
-            startCameraPosition,
-            endCameraPosition,
-            easedProgress,
-        );
-        orbitControls.update();
-
-        if (progress < 1) {
-            animationFrameRef.current = window.requestAnimationFrame(step);
-            return;
-        }
-
-        animationFrameRef.current = null;
+    focusAnimationRef.current = {
+        cameraPosition: nextCameraPosition,
+        lastFrameTime: focusAnimationRef.current?.lastFrameTime ?? null,
+        orbitControls,
+        targetPosition: nextTargetPosition,
     };
 
-    animationFrameRef.current = window.requestAnimationFrame(step);
+    if (animationFrameRef.current === null) {
+        stepFocusAnimation({ animationFrameRef, focusAnimationRef });
+    }
 }
 
 function getWorldScreenPoint({
@@ -108,6 +147,7 @@ export function useFocusPlacedBlock() {
     );
 
     const previousPlacements = useRef<Set<string> | null>(null);
+    const focusAnimationRef = useRef<FocusAnimationState | null>(null);
     const animationFrameRef = useRef<number | null>(null);
     const sunflowerTimeoutsRef = useRef<number[]>([]);
 
@@ -116,6 +156,7 @@ export function useFocusPlacedBlock() {
             if (animationFrameRef.current !== null) {
                 window.cancelAnimationFrame(animationFrameRef.current);
             }
+            focusAnimationRef.current = null;
             for (const timeoutId of sunflowerTimeoutsRef.current) {
                 window.clearTimeout(timeoutId);
             }
@@ -153,6 +194,7 @@ export function useFocusPlacedBlock() {
                 const targetPosition = latestPlacement.position.clone();
                 focusOrbitControlsOnPosition({
                     animationFrameRef,
+                    focusAnimationRef,
                     orbitControls,
                     targetPosition,
                 });

--- a/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
@@ -96,6 +96,9 @@ export function useGardenBoxPlaceBlock() {
     const { data: currentGarden } = useCurrentGarden();
     const { data: blockData } = useBlockData();
     const winterMode = useGameState((state) => state.winterMode);
+    const queueBlockPlacementDropAnimation = useGameState(
+        (state) => state.queueBlockPlacementDropAnimation,
+    );
 
     return useMutation({
         mutationKey,
@@ -159,7 +162,8 @@ export function useGardenBoxPlaceBlock() {
                       )
                     : null;
 
-            if (garden && optimisticPlacement) {
+            if (garden && optimisticBlockId && optimisticPlacement) {
+                queueBlockPlacementDropAnimation(optimisticBlockId);
                 queryClient.setQueryData<CurrentGardenData>(gardenQueryKey, {
                     ...garden,
                     stacks: optimisticPlacement.stacks,

--- a/packages/game/src/hooks/useGardenBoxStoreBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxStoreBlock.ts
@@ -35,6 +35,7 @@ type StoreBlockArgs = {
     blockEntityId?: string;
     blockLabel?: string;
     gardenBoxBlockId: string;
+    onOptimisticUpdate?: () => void;
 };
 
 function incrementInventoryItem(
@@ -161,6 +162,9 @@ export function useGardenBoxStoreBlock() {
                     stacks: updatedStacks,
                 },
             );
+            if (previousGarden) {
+                args.onOptimisticUpdate?.();
+            }
 
             await queryClient.cancelQueries({ queryKey: inventoryQueryKey });
             const previousInventory =

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -110,6 +110,12 @@ export type PlacedBlockEffect = {
     amount: number;
 };
 
+export type BlockPlacementDropAnimation = {
+    createdAt: number;
+    particlesSpawned: boolean;
+    sequence: number;
+};
+
 export type AnimalDebugEntry = {
     id: string;
     species: string;
@@ -178,6 +184,10 @@ export type GameState = {
         effect: PlacedBlockEffect,
     ) => void;
     consumePlacedBlockEffect: (blockId: string) => PlacedBlockEffect | null;
+    blockPlacementDropAnimations: Record<string, BlockPlacementDropAnimation>;
+    queueBlockPlacementDropAnimation: (blockId: string) => void;
+    markBlockPlacementDropParticlesSpawned: (blockId: string) => boolean;
+    completeBlockPlacementDropAnimation: (blockId: string) => void;
     animalDebugEntries: AnimalDebugEntry[];
     setAnimalDebugEntry: (entry: AnimalDebugEntry) => void;
     removeAnimalDebugEntry: (id: string) => void;
@@ -354,6 +364,57 @@ export function createGameState({
             });
             return effect;
         },
+        blockPlacementDropAnimations: {},
+        queueBlockPlacementDropAnimation: (blockId) =>
+            set((state) => ({
+                blockPlacementDropAnimations: {
+                    ...state.blockPlacementDropAnimations,
+                    [blockId]: {
+                        createdAt: Date.now(),
+                        particlesSpawned: false,
+                        sequence:
+                            (state.blockPlacementDropAnimations[blockId]
+                                ?.sequence ?? 0) + 1,
+                    },
+                },
+            })),
+        markBlockPlacementDropParticlesSpawned: (blockId) => {
+            const animation = get().blockPlacementDropAnimations[blockId];
+            if (!animation || animation.particlesSpawned) {
+                return false;
+            }
+
+            set((state) => {
+                const current = state.blockPlacementDropAnimations[blockId];
+                if (!current || current.particlesSpawned) {
+                    return state;
+                }
+
+                return {
+                    blockPlacementDropAnimations: {
+                        ...state.blockPlacementDropAnimations,
+                        [blockId]: {
+                            ...current,
+                            particlesSpawned: true,
+                        },
+                    },
+                };
+            });
+            return true;
+        },
+        completeBlockPlacementDropAnimation: (blockId) =>
+            set((state) => {
+                if (!state.blockPlacementDropAnimations[blockId]) {
+                    return state;
+                }
+
+                const blockPlacementDropAnimations = {
+                    ...state.blockPlacementDropAnimations,
+                };
+                delete blockPlacementDropAnimations[blockId];
+
+                return { blockPlacementDropAnimations };
+            }),
         animalDebugEntries: [],
         setAnimalDebugEntry: (entry) =>
             set((state) => {


### PR DESCRIPTION
## Summary
- Move shared block families to instanced rendering and narrow drag-preview subscriptions so unrelated blocks do not re-render on drag updates.
- Add placement-drop animation handling for HUD and garden-box placements so new blocks appear above the target, settle into place, and emit landing particles.
- Smooth repeated placement camera focus so rapid item placement keeps following the latest target instead of stuttering between restarts.
- Update performance docs to defer snow and rain optimization work.

## Testing
- Unit tests passed for the game package.
- Local garden and www builds completed successfully.