### PR TITLE
Add a local sandbox garden debug route

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -18,6 +18,7 @@ import {
     createGardenStack,
     createSandboxGarden,
     deleteGardenStack,
+    deleteSandboxGardenCompletely,
     GardenBoxInventoryLimitError,
     getAccount,
     getAccountGardens,
@@ -34,6 +35,7 @@ import {
     getRaisedBedFieldDiaryEntries,
     getRaisedBedIdsByAccount,
     getRaisedBedSensors,
+    getSandboxGardenDeletionCandidate,
     knownEvents,
     knownEventTypes,
     sowSandboxField,
@@ -814,6 +816,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         '/:gardenId',
         describeRoute({
             description: 'Update garden information',
+            security: authSecurity,
         }),
         zValidator(
             'param',
@@ -853,6 +856,55 @@ const app = new Hono<{ Variables: AuthVariables }>()
             await updateGarden(updateData);
 
             return context.json({ success: true });
+        },
+    )
+    .delete(
+        '/:gardenId',
+        describeRoute({
+            description:
+                'Delete a sandbox garden accessible to the current user, including related blocks, raised beds, notifications, operations, cart rows, transactions, and events. Real gardens cannot be deleted from this endpoint. Large deletions may return 202 and should be retried until complete.',
+            security: authSecurity,
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId } = context.req.valid('param');
+            const gardenIdNumber = parseInt(gardenId, 10);
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+
+            const { user } = context.get('authContext');
+            const garden =
+                await getSandboxGardenDeletionCandidate(gardenIdNumber);
+            if (!garden) {
+                return context.json(
+                    { success: true, complete: true, deletedRows: 0 },
+                    200,
+                );
+            }
+            if (!user.accountIds.includes(garden.accountId)) {
+                return context.json({ error: 'Garden not found' }, 404);
+            }
+
+            if (!garden.isSandbox) {
+                return context.json(
+                    { error: 'Only sandbox gardens can be deleted' },
+                    400,
+                );
+            }
+
+            const result = await deleteSandboxGardenCompletely(gardenIdNumber);
+
+            return context.json(
+                { success: true, ...result },
+                result.complete ? 200 : 202,
+            );
         },
     )
     // See: https://datatracker.ietf.org/doc/html/rfc6902
@@ -1831,7 +1883,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
         describeRoute({
             description: 'Delete a block in a garden.',
             summary:
-                'Recycles the block by default and refunds the sunflowers.',
+                'Recycles the block by default and refunds the sunflowers outside sandbox gardens.',
+            security: authSecurity,
+            tags: ['Gardens'],
         }),
         zValidator(
             'param',

--- a/apps/api/lib/garden/gardenBlocksService.ts
+++ b/apps/api/lib/garden/gardenBlocksService.ts
@@ -139,7 +139,8 @@ export async function deleteGardenBlock(
     // Retrieve block price
     const price = blockData.prices?.sunflowers ?? 0;
     const refundAmount = price > 0 ? price : DEFAULT_RECYCLE_REFUND;
-    if (price <= 0) {
+    const shouldRefund = !garden.isSandbox;
+    if (shouldRefund && price <= 0) {
         console.info('Block has no sunflower price. Using recycle refund.', {
             blockId,
             refundAmount,
@@ -159,11 +160,13 @@ export async function deleteGardenBlock(
         : Promise.resolve();
 
     // Prepare block refund operation
-    const refundBlockPromise = earnSunflowers(
-        garden.accountId,
-        refundAmount,
-        `recycle:${block.name}`,
-    );
+    const refundBlockPromise = shouldRefund
+        ? earnSunflowers(
+              garden.accountId,
+              refundAmount,
+              `recycle:${block.name}`,
+          )
+        : Promise.resolve();
 
     await Promise.all([
         storageDeleteGardenBlock(gardenId, blockId),

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -56,6 +56,12 @@ const debugGroups = [
                 title: 'Autumn',
                 description: 'Mock garden scene with autumn time and wind.',
             },
+            {
+                href: '/debug/sandbox',
+                title: 'Local sandbox',
+                description:
+                    'Playable sandbox scene backed by browser local storage.',
+            },
         ],
     },
     {

--- a/apps/garden/app/debug/sandbox/SandboxDebugActions.tsx
+++ b/apps/garden/app/debug/sandbox/SandboxDebugActions.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Reset } from '@gredice/ui/icons';
+
+export function SandboxDebugActions({ storageKey }: { storageKey: string }) {
+    const handleReset = () => {
+        window.localStorage.removeItem(storageKey);
+        window.location.reload();
+    };
+
+    return (
+        <div className="pointer-events-none absolute left-2 top-2 z-10">
+            <Button
+                className="pointer-events-auto rounded-full shadow-lg"
+                color="neutral"
+                onClick={handleReset}
+                size="sm"
+                startDecorator={<Reset className="size-4" />}
+                variant="soft"
+            >
+                Reset
+            </Button>
+        </div>
+    );
+}

--- a/apps/garden/app/debug/sandbox/page.tsx
+++ b/apps/garden/app/debug/sandbox/page.tsx
@@ -1,0 +1,23 @@
+import { defaultLocalSandboxStorageKey, GameScene } from '@gredice/game';
+import type { ComponentProps } from 'react';
+import { SandboxDebugActions } from './SandboxDebugActions';
+
+const debugSandboxFlags = {
+    enableRainWetOverlayFlag: true,
+} satisfies NonNullable<ComponentProps<typeof GameScene>['flags']>;
+
+export default function DebugSandboxPage() {
+    return (
+        <main className="relative h-screen w-screen overflow-hidden bg-[#e7e2cc]">
+            <GameScene
+                className="h-full w-full"
+                dayNightCycleDisabled={false}
+                deferDetails={false}
+                flags={debugSandboxFlags}
+                localSandboxStorageKey={defaultLocalSandboxStorageKey}
+                noSound
+            />
+            <SandboxDebugActions storageKey={defaultLocalSandboxStorageKey} />
+        </main>
+    );
+}

--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../packages/game/src/GameHud';
 import { ControlsTooltipHud } from '../../../packages/game/src/hud/ControlsTooltipHud';
 import { ItemsHud } from '../../../packages/game/src/hud/ItemsHud';
+import { SandboxBlockTrashDropTarget } from '../../../packages/game/src/hud/SandboxBlockTrashDropTarget';
 import {
     createGameState,
     GameStateContext,
@@ -104,7 +105,15 @@ const blockNames = [
     'Block_Snow_Reverse_Corner',
 ];
 
-function createItemsHudQueryClient() {
+type ItemsHudStoryOptions = {
+    isSandbox?: boolean;
+    pickupBlock?: boolean;
+    trashTargetActive?: boolean;
+};
+
+function createItemsHudQueryClient({
+    isSandbox = false,
+}: ItemsHudStoryOptions) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
@@ -113,10 +122,11 @@ function createItemsHudQueryClient() {
 
     queryClient.setQueryData(['blocks'], blockNames.map(createBlockData));
     queryClient.setQueryData(['currentUser'], { id: 'test-user' });
-    queryClient.setQueryData(['gardens'], [{ id: 1 }]);
+    queryClient.setQueryData(['gardens'], [{ id: 1, isSandbox }]);
     queryClient.setQueryData(['gardens', 'current', 'summer', 1], {
         id: 1,
         name: 'Test garden',
+        isSandbox,
         stacks: [],
         location: { lat: 45.739, lon: 16.572 },
         raisedBeds: [],
@@ -125,8 +135,16 @@ function createItemsHudQueryClient() {
     return queryClient;
 }
 
-function ItemsHudTestProviders({ children }: PropsWithChildren) {
-    const queryClient = useMemo(() => createItemsHudQueryClient(), []);
+function ItemsHudTestProviders({
+    children,
+    isSandbox = false,
+    pickupBlock = false,
+    trashTargetActive = false,
+}: PropsWithChildren<ItemsHudStoryOptions>) {
+    const queryClient = useMemo(
+        () => createItemsHudQueryClient({ isSandbox }),
+        [isSandbox],
+    );
     const gameStore = useMemo(() => {
         const store = createGameState({
             appBaseUrl: 'http://localhost',
@@ -134,8 +152,18 @@ function ItemsHudTestProviders({ children }: PropsWithChildren) {
             isMock: false,
             winterMode: 'summer',
         });
+        if (pickupBlock) {
+            store.setState({
+                pickupBlock: {
+                    id: 'pickup-block-1',
+                    name: 'Block_Grass',
+                    rotation: 0,
+                },
+                sandboxBlockTrashDropTargetActive: trashTargetActive,
+            });
+        }
         return store;
-    }, []);
+    }, [pickupBlock, trashTargetActive]);
 
     return (
         <NuqsTestingAdapter>
@@ -184,6 +212,28 @@ export function ItemsHudControlsTooltipStory() {
                         <div className="h-10 w-40 rounded-lg border bg-muted" />
                         <ControlsTooltipHud />
                     </div>
+                    <ItemsHud />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function SandboxBlockTrashDropTargetStory() {
+    return (
+        <ItemsHudTestProviders isSandbox pickupBlock trashTargetActive>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <div
+                        data-testid="bottom-controls"
+                        className={gameHudBottomControlsClassName}
+                    >
+                        <div className="h-10 w-40 rounded-lg border bg-muted" />
+                    </div>
+                    <SandboxBlockTrashDropTarget />
                     <ItemsHud />
                 </div>
             </div>

--- a/apps/garden/tests/SandboxEnvironmentHudStory.tsx
+++ b/apps/garden/tests/SandboxEnvironmentHudStory.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { SandboxEnvironmentHud } from '../../../packages/game/src/hud/SandboxEnvironmentHud';
+import {
+    createGameState,
+    GameStateContext,
+    useGameState,
+} from '../../../packages/game/src/useGameState';
+
+function formatLocalDate(date: Date | null | undefined) {
+    if (!date) {
+        return '';
+    }
+
+    const year = date.getFullYear().toString().padStart(4, '0');
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function formatLocalTime(date: Date | null | undefined) {
+    if (!date) {
+        return '';
+    }
+
+    return date.toLocaleTimeString('hr-HR', {
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+function SandboxEnvironmentHudStatus() {
+    const freezeTime = useGameState((state) => state.freezeTime);
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const weather = useGameState((state) => state.weather);
+
+    return (
+        <div className="absolute bottom-4 left-4 grid gap-1 rounded-md border bg-background p-3 text-xs">
+            <output data-testid="sandbox-date-value">
+                {formatLocalDate(freezeTime)}
+            </output>
+            <output data-testid="sandbox-time-value">
+                {formatLocalTime(freezeTime)}
+            </output>
+            <output data-testid="sandbox-timeofday-value">
+                {timeOfDay.toFixed(3)}
+            </output>
+            <output data-testid="sandbox-weather-value">
+                {JSON.stringify(weather ?? null)}
+            </output>
+        </div>
+    );
+}
+
+export function SandboxEnvironmentHudStory() {
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date(2026, 5, 21, 12, 0, 0),
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
+
+    return (
+        <GameStateContext.Provider value={gameStore}>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div className="absolute right-2 top-2">
+                    <SandboxEnvironmentHud />
+                </div>
+                <SandboxEnvironmentHudStatus />
+            </div>
+        </GameStateContext.Provider>
+    );
+}

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import {
     ItemsHudAlignmentStory,
     ItemsHudControlsTooltipStory,
+    SandboxBlockTrashDropTargetStory,
 } from './ItemsHudStory';
 
 const TABLET_VIEWPORT = { width: 820, height: 1180 };
@@ -73,6 +74,35 @@ test('controls instructions clear the item picker on tablet layouts', async ({
     expect((guideBox?.y ?? 0) + (guideBox?.height ?? 0)).toBeLessThanOrEqual(
         (pickerBox?.y ?? 0) - 8,
     );
+});
+
+test('sandbox trash target appears centered above item picker while dragging', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<SandboxBlockTrashDropTargetStory />);
+
+    const picker = page.locator('[data-items-hud]');
+    const trashTarget = page.locator(
+        '[data-sandbox-block-trash-drop-target="true"]',
+    );
+    await expect(picker).toBeVisible();
+    await expect(trashTarget).toBeVisible();
+
+    const pickerBox = await picker.boundingBox();
+    const trashBox = await trashTarget.boundingBox();
+    expect(pickerBox).not.toBeNull();
+    expect(trashBox).not.toBeNull();
+
+    const trashCenter = (trashBox?.x ?? 0) + (trashBox?.width ?? 0) / 2;
+    expect(
+        Math.abs(trashCenter - TABLET_VIEWPORT.width / 2),
+    ).toBeLessThanOrEqual(1);
+    expect((trashBox?.y ?? 0) + (trashBox?.height ?? 0)).toBeLessThanOrEqual(
+        (pickerBox?.y ?? 0) - 8,
+    );
+    await expect(trashTarget).toHaveClass(/bg-red-600/u);
 });
 
 test('pots are listed under the decoration picker', async ({ mount, page }) => {

--- a/apps/garden/tests/sandbox-environment-hud.spec.tsx
+++ b/apps/garden/tests/sandbox-environment-hud.spec.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { SandboxEnvironmentHudStory } from './SandboxEnvironmentHudStory';
+
+test('sandbox environment HUD applies weather presets', async ({
+    mount,
+    page,
+}) => {
+    await mount(<SandboxEnvironmentHudStory />);
+
+    await page.getByTitle('Uvjeti u vrtu').click();
+    await page.getByRole('button', { name: 'Snijeg' }).click();
+
+    await expect(page.getByTestId('sandbox-weather-value')).toContainText(
+        '"snowy":1',
+    );
+    await expect(page.getByTestId('sandbox-weather-value')).toContainText(
+        '"snowAccumulation":30',
+    );
+});
+
+test('sandbox environment HUD can scrub time and change date', async ({
+    mount,
+    page,
+}) => {
+    await mount(<SandboxEnvironmentHudStory />);
+
+    const initialTimeOfDay = await page
+        .getByTestId('sandbox-timeofday-value')
+        .textContent();
+
+    await page.getByTitle('Doba dana').click();
+
+    const visualization = page.locator('[data-sandbox-time-visualization]');
+    await expect(visualization).toBeVisible();
+
+    const box = await visualization.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) {
+        return;
+    }
+
+    await page.mouse.move(box.x + box.width * 0.84, box.y + box.height * 0.5);
+    await page.mouse.down();
+    await page.mouse.up();
+
+    await expect
+        .poll(() => page.getByTestId('sandbox-timeofday-value').textContent())
+        .not.toBe(initialTimeOfDay);
+
+    await page.getByLabel('Datum').fill('2026-12-21');
+    await expect(page.getByTestId('sandbox-date-value')).toHaveText(
+        '2026-12-21',
+    );
+});

--- a/apps/garden/tests/sandbox-environment-hud.spec.tsx
+++ b/apps/garden/tests/sandbox-environment-hud.spec.tsx
@@ -8,6 +8,7 @@ test('sandbox environment HUD applies weather presets', async ({
     await mount(<SandboxEnvironmentHudStory />);
 
     await page.getByTitle('Uvjeti u vrtu').click();
+    await expect(page.getByRole('slider', { name: 'Kiša' })).toHaveCount(0);
     await page.getByRole('button', { name: 'Snijeg' }).click();
 
     await expect(page.getByTestId('sandbox-weather-value')).toContainText(
@@ -16,6 +17,10 @@ test('sandbox environment HUD applies weather presets', async ({
     await expect(page.getByTestId('sandbox-weather-value')).toContainText(
         '"snowAccumulation":30',
     );
+
+    await expect(page.getByRole('slider', { name: 'Kiša' })).toHaveCount(0);
+    await page.getByRole('button', { name: 'Prilagođeno' }).click();
+    await expect(page.getByRole('slider', { name: 'Kiša' })).toBeVisible();
 });
 
 test('sandbox environment HUD can scrub time and change date', async ({
@@ -47,7 +52,8 @@ test('sandbox environment HUD can scrub time and change date', async ({
         .poll(() => page.getByTestId('sandbox-timeofday-value').textContent())
         .not.toBe(initialTimeOfDay);
 
-    await page.getByLabel('Datum').fill('2026-12-21');
+    await page.getByTitle('Promijeni datum').click();
+    await page.getByRole('textbox', { name: 'Datum' }).fill('2026-12-21');
     await expect(page.getByTestId('sandbox-date-value')).toHaveText(
         '2026-12-21',
     );

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -13,6 +13,8 @@ import { InventoryHud } from './hud/InventoryHud';
 import { ItemsHud } from './hud/ItemsHud';
 import { PaymentSuccessfulMessage } from './hud/PaymentSuccessfulMessage';
 import { RaisedBedFieldHud } from './hud/RaisedBedFieldHud';
+import { SandboxBlockTrashDropTarget } from './hud/SandboxBlockTrashDropTarget';
+import { SandboxEnvironmentHud } from './hud/SandboxEnvironmentHud';
 import { ShoppingCartHud } from './hud/ShoppingCartHud';
 import { SunflowersHud } from './hud/SunflowersHud';
 import { WeatherHud } from './hud/WeatherHud';
@@ -36,9 +38,11 @@ export function GameHud({
     noWeather?: boolean;
 }) {
     const isCloseup = useGameState((state) => state.view) === 'closeup';
-    // Sandbox ("play") gardens are decoration only: no economy, inventory or
-    // weather HUD.
+    // Sandbox ("play") gardens are decoration only: no economy or inventory.
     const isSandbox = useIsSandboxGarden();
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
     const closeupHiddenHudClassName = cx(
         'empty:hidden',
         isCloseup && 'hidden md:block',
@@ -47,7 +51,7 @@ export function GameHud({
     return (
         <>
             <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
-                <AccountHud />
+                {!isLocalSandbox && <AccountHud />}
                 {!isSandbox && <ShoppingCartHud />}
                 {!isSandbox && (
                     <div className={closeupHiddenHudClassName}>
@@ -62,7 +66,11 @@ export function GameHud({
             </div>
             <div className="absolute top-2 right-2 flex items-end flex-col-reverse md:flex-row gap-1 md:gap-2">
                 <div className={closeupHiddenHudClassName}>
-                    <WeatherHud noWeather={noWeather || isSandbox} />
+                    {isSandbox ? (
+                        <SandboxEnvironmentHud />
+                    ) : (
+                        <WeatherHud noWeather={noWeather} />
+                    )}
                 </div>
                 {!isSandbox && <SunflowersHud />}
             </div>
@@ -72,14 +80,15 @@ export function GameHud({
                     <AudioHud />
                     <ControlsTooltipHud />
                 </div>
+                <SandboxBlockTrashDropTarget />
                 <ItemsHud />
             </div>
-            <RaisedBedFieldHud flags={flags} />
-            <OverviewModal />
-            <AdventModal />
-            <GiftBoxModal />
-            <WelcomeMessage />
-            <PaymentSuccessfulMessage />
+            {!isLocalSandbox && <RaisedBedFieldHud flags={flags} />}
+            {!isLocalSandbox && <OverviewModal />}
+            {!isLocalSandbox && <AdventModal />}
+            {!isLocalSandbox && <GiftBoxModal />}
+            {!isLocalSandbox && <WelcomeMessage />}
+            {!isLocalSandbox && <PaymentSuccessfulMessage />}
             {Boolean(flags?.enableDebugHudFlag) && <DebugHud />}
         </>
     );

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -62,6 +62,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     noWeather?: boolean;
     noSound?: boolean;
     mockGarden?: boolean;
+    localSandboxStorageKey?: string;
     winterMode?: WinterMode;
     weather?: Partial<GameState['weather']>;
     deferDetails?: boolean;
@@ -141,6 +142,9 @@ export function GameScene({
     const weatherVisualizationDisabled = useGameState(
         (state) => state.weatherVisualizationDisabled,
     );
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
     const gameQualitySetting = useGameState(
         (state) => state.gameQualitySetting,
     );
@@ -168,7 +172,7 @@ export function GameScene({
     // Start non-critical metadata early, but don't block the first scene frame.
     useBlockData();
     const { data: garden, isLoading: gardenLoading } = useCurrentGarden();
-    useWeatherNow(!weatherDisabled && !weather);
+    useWeatherNow(!isLocalSandbox && !weatherDisabled && !weather);
     const isLoading = gardenLoading;
 
     const loadingContext = useGameLoading();
@@ -229,13 +233,15 @@ export function GameScene({
                                     </Suspense>
                                 )),
                             )}
-                            {renderDetails && zoom !== 'far' && (
-                                <Suspense fallback={null}>
-                                    <RaisedBedMulchOverlays
-                                        quality={qualityProfile}
-                                    />
-                                </Suspense>
-                            )}
+                            {!isLocalSandbox &&
+                                renderDetails &&
+                                zoom !== 'far' && (
+                                    <Suspense fallback={null}>
+                                        <RaisedBedMulchOverlays
+                                            quality={qualityProfile}
+                                        />
+                                    </Suspense>
+                                )}
                             <EntityInstances
                                 quality={qualityProfile}
                                 renderGroundDecorations={

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -19,6 +19,7 @@ export function GameSceneWrapper({
     freezeTime,
     dayNightCycleDisabled,
     mockGarden,
+    localSandboxStorageKey,
     winterMode,
     ...rest
 }: GameSceneProps) {
@@ -30,6 +31,7 @@ export function GameSceneWrapper({
             dayNightCycleDisabled,
             freezeTime: freezeTime || null,
             isMock: mockGarden || false,
+            localSandboxStorageKey,
             winterMode: winterMode ?? 'summer',
         });
     }

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -648,6 +648,7 @@ export function PickableGroup({
             )?.blockUnderId ?? null;
         const canStoreInGardenBox =
             !localSandboxStorageKey &&
+            !garden.isSandbox &&
             hoveredGardenBoxBlockId !== null &&
             sourcePreview.segment.blocks.length === 1 &&
             sourcePreview.segment.blocks[0]?.name !== 'GardenBox' &&

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -22,6 +22,7 @@ import {
 import { blockPickupOutlineStyle } from '../entities/helpers/blockPickupOutlineStyle';
 import { HoverOutline } from '../entities/helpers/HoverOutline';
 import { useBlockData } from '../hooks/useBlockData';
+import { useBlockDelete } from '../hooks/useBlockDelete';
 import { useBlockMove } from '../hooks/useBlockMove';
 import { useBlockRecycle } from '../hooks/useBlockRecycle';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
@@ -30,6 +31,7 @@ import {
     resolveBlockParticleType,
     useParticles,
 } from '../particles/ParticleSystem';
+import { isPointOverSandboxBlockTrashDropTarget } from '../sandboxBlockTrashDropTarget';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
@@ -202,10 +204,17 @@ export function PickableGroup({
     const setStationaryPickupOutlineTarget = useGameState(
         (state) => state.setStationaryPickupOutlineTarget,
     );
+    const setSandboxBlockTrashDropTargetActive = useGameState(
+        (state) => state.setSandboxBlockTrashDropTargetActive,
+    );
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
 
     const [isBlocked, setIsBlocked] = useState(false);
     const [isOverRecycler, setIsOverRecycler] = useState(false);
     const [pickupOutlineVisible, setPickupOutlineVisible] = useState(false);
+    const deleteBlocks = useBlockDelete();
     const moveBlock = useBlockMove();
     const recycleBlock = useBlockRecycle();
     const storeBlockInGardenBox = useGardenBoxStoreBlock();
@@ -466,6 +475,7 @@ export function PickableGroup({
                     : null;
                 const isRecycler =
                     segment.canRecycle &&
+                    blockUnder?.name !== 'Composter' &&
                     (blockUnderData?.functions?.recycler ?? false);
                 const isStackable =
                     blockUnderData?.attributes?.stackable ?? true;
@@ -621,6 +631,7 @@ export function PickableGroup({
                 (preview) => preview.blockUnderName === 'GardenBox',
             )?.blockUnderId ?? null;
         const canStoreInGardenBox =
+            !localSandboxStorageKey &&
             hoveredGardenBoxBlockId !== null &&
             sourcePreview.segment.blocks.length === 1 &&
             sourcePreview.segment.blocks[0]?.name !== 'GardenBox' &&
@@ -815,6 +826,14 @@ export function PickableGroup({
         setIsOverRecycler(false);
         setPickupOutlineVisible(false);
         setPickupBlock(null);
+        setSandboxBlockTrashDropTargetActive(false);
+    }
+
+    function isPointerOverSandboxTrash(clientX: number, clientY: number) {
+        return (
+            Boolean(garden?.isSandbox) &&
+            isPointOverSandboxBlockTrashDropTarget(clientX, clientY)
+        );
     }
 
     function cancelPointerSession(resetSpring: boolean) {
@@ -828,6 +847,7 @@ export function PickableGroup({
         pointerSession.current = null;
         cleanupPointerSessionListeners();
         setPickupOutlineVisible(false);
+        setSandboxBlockTrashDropTargetActive(false);
         if (resetSpring) {
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
         }
@@ -906,8 +926,50 @@ export function PickableGroup({
         applyActivePreview(preview);
     }
 
-    async function finishPickup(preview: ResolvedPlacementPreview | null) {
+    async function finishPickup(
+        preview: ResolvedPlacementPreview | null,
+        deleteRequested: boolean,
+    ) {
+        const blockIdsToDelete = deleteRequested
+            ? getMovingSegments().flatMap((segment) =>
+                  segment.blocks.map((segmentBlock) => segmentBlock.id),
+              )
+            : [];
         resetPickupVisualState();
+
+        if (deleteRequested) {
+            if (blockIdsToDelete.length === 0) {
+                dragSpringsApi.start({
+                    internalPosition: [0, 0, 0],
+                    scale: 1,
+                });
+                return;
+            }
+
+            dragSpringsApi.start({
+                internalPosition: preview
+                    ? [
+                          preview.relative.x,
+                          preview.previewHoverHeight + 0.2,
+                          preview.relative.z,
+                      ]
+                    : [0, pickupLift, 0],
+                scale: 0.1,
+            });
+            dropSound.play();
+            triggerPlaceHaptic();
+            try {
+                await deleteBlocks.mutateAsync({
+                    blockIds: blockIdsToDelete,
+                });
+            } finally {
+                dragSpringsApi.start({
+                    internalPosition: [0, 0, 0],
+                    scale: 1,
+                });
+            }
+            return;
+        }
 
         if (!preview || preview.nextIsBlocked) {
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
@@ -1065,6 +1127,10 @@ export function PickableGroup({
             session.hasDraggedAfterPickup = true;
         }
 
+        setSandboxBlockTrashDropTargetActive(
+            isPointerOverSandboxTrash(event.clientX, event.clientY),
+        );
+
         const preview = resolvePlacementPreview(
             event.clientX,
             event.clientY,
@@ -1108,7 +1174,10 @@ export function PickableGroup({
                 session.lastClientY,
                 session.pickupAnchorOffset,
             );
-        void finishPickup(preview);
+        void finishPickup(
+            preview,
+            isPointerOverSandboxTrash(session.lastClientX, session.lastClientY),
+        );
     }
 
     function handleWindowPointerCancel(event: PointerEvent) {

--- a/packages/game/src/controls/SelectableGroup.tsx
+++ b/packages/game/src/controls/SelectableGroup.tsx
@@ -2,7 +2,6 @@ import type { PropsWithChildren } from 'react';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import type { Block } from '../types/Block';
 import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
-import { GardenBoxSelectableGroup } from './GardenBoxSelectableGroup';
 import { GiftBoxSelectableGroup } from './GiftBoxSelectableGroup';
 import { RaisedBedSelectableGroup } from './RaisedBedSelectableGroup';
 
@@ -17,14 +16,6 @@ export function SelectableGroup({
             <GiftBoxSelectableGroup block={block}>
                 {children}
             </GiftBoxSelectableGroup>
-        );
-    }
-
-    if (block.name === 'GardenBox') {
-        return (
-            <GardenBoxSelectableGroup block={block}>
-                {children}
-            </GardenBoxSelectableGroup>
         );
     }
 

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -5,6 +5,7 @@ import { RotatableGroup } from '../controls/RotatableGroup';
 import { SelectableGroup } from '../controls/SelectableGroup';
 import { useDeferredSingleClick } from '../controls/useDeferredSingleClick';
 import { useBlockData } from '../hooks/useBlockData';
+import { useIsSandboxGarden } from '../hooks/useCurrentGarden';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useGameState } from '../useGameState';
 import { getBlockHitboxSize } from '../utils/blockHitbox';
@@ -82,11 +83,12 @@ function InstancedEntityControlTarget({
     const hasActiveDragPreview = useGameState((state) =>
         Boolean(state.activeDragPreview),
     );
+    const isSandbox = useIsSandboxGarden();
     const setOpenGardenBoxBlockId = useGameState(
         (state) => state.setOpenGardenBoxBlockId,
     );
     const handleGardenBoxClick = useDeferredSingleClick(() => {
-        if (block.name !== 'GardenBox' || hasActiveDragPreview) {
+        if (block.name !== 'GardenBox' || isSandbox || hasActiveDragPreview) {
             return;
         }
 

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -1,52 +1,105 @@
-import { animated } from '@react-spring/three';
+import { animated, useSpring } from '@react-spring/three';
+import { useDeferredSingleClick } from '../../controls/useDeferredSingleClick';
+import { useHoveredBlockStore } from '../../controls/useHoveredBlockStore';
 import { RainWetOverlay } from '../../rain/RainWetOverlay';
 import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
+import { useGameState } from '../../useGameState';
 import { useStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { HoverOutline } from './HoverOutline';
 import { useAnimatedEntityRotation } from './useAnimatedEntityRotation';
 
 const lidClosedRotation = 0;
+const lidOpenRotation = -Math.PI / 2;
 
 export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
     const { nodes, materials } = useGameGLTF('GardenBox');
     const [animatedRotation] = useAnimatedEntityRotation(rotation + 2);
     const currentStackHeight = useStackHeight(stack, block);
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+    const hovered =
+        useHoveredBlockStore((state) => state.hoveredBlock) === block;
+    const hoveredGardenBoxBlockId = useGameState(
+        (state) => state.activeDragPreview?.hoveredGardenBoxBlockId ?? null,
+    );
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
+    const openGardenBoxBlockId = useGameState(
+        (state) => state.openGardenBoxBlockId,
+    );
+    const setOpenGardenBoxBlockId = useGameState(
+        (state) => state.setOpenGardenBoxBlockId,
+    );
+    const isLidOpen =
+        !isLocalSandbox &&
+        (hoveredGardenBoxBlockId === block.id ||
+            openGardenBoxBlockId === block.id);
+    const { rotation: lidRotation } = useSpring({
+        config: {
+            mass: 0.18,
+            tension: 260,
+            friction: 18,
+        },
+        rotation: [isLidOpen ? lidOpenRotation : lidClosedRotation, 0, 0],
+    });
+
+    const handleClick = useDeferredSingleClick(() => {
+        if (isLocalSandbox || hasActiveDragPreview) return;
+
+        setOpenGardenBoxBlockId(block.id);
+    });
 
     return (
-        <animated.group
-            position={stack.position.clone().setY(currentStackHeight)}
-            rotation={animatedRotation as unknown as [number, number, number]}
+        <HoverOutline
+            hovered={!isLocalSandbox && (hovered || isLidOpen)}
+            thickness={7}
+            color="#f8fafc"
         >
-            <mesh
-                castShadow
-                receiveShadow
-                geometry={nodes.GardenBox_Body_Planks.geometry}
-                material={materials['Material.Planks']}
-            />
-            <SnowOverlay
-                geometry={nodes.GardenBox_Body_Planks.geometry}
-                {...snowPresets.giftBox}
-            />
-            <RainWetOverlay geometry={nodes.GardenBox_Body_Planks.geometry} />
-            <group
-                position={[0, 0.6, -0.38]}
-                rotation={[lidClosedRotation, 0, 0]}
+            <animated.group
+                onClick={handleClick}
+                position={stack.position.clone().setY(currentStackHeight)}
+                rotation={
+                    animatedRotation as unknown as [number, number, number]
+                }
             >
                 <mesh
+                    castShadow
                     receiveShadow
-                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    geometry={nodes.GardenBox_Body_Planks.geometry}
                     material={materials['Material.Planks']}
                 />
                 <SnowOverlay
-                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    geometry={nodes.GardenBox_Body_Planks.geometry}
                     {...snowPresets.giftBox}
                 />
                 <RainWetOverlay
-                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    geometry={nodes.GardenBox_Body_Planks.geometry}
                 />
-            </group>
-        </animated.group>
+                <animated.group
+                    position={[0, 0.6, -0.38]}
+                    rotation={
+                        lidRotation as unknown as [number, number, number]
+                    }
+                >
+                    <mesh
+                        receiveShadow
+                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                        material={materials['Material.Planks']}
+                    />
+                    <SnowOverlay
+                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                        {...snowPresets.giftBox}
+                    />
+                    <RainWetOverlay
+                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
+                    />
+                </animated.group>
+            </animated.group>
+        </HoverOutline>
     );
 }

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -1,96 +1,52 @@
-import { animated, useSpring } from '@react-spring/three';
-import { useDeferredSingleClick } from '../../controls/useDeferredSingleClick';
-import { useHoveredBlockStore } from '../../controls/useHoveredBlockStore';
+import { animated } from '@react-spring/three';
 import { RainWetOverlay } from '../../rain/RainWetOverlay';
 import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
-import { useGameState } from '../../useGameState';
 import { useStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
-import { HoverOutline } from './HoverOutline';
 import { useAnimatedEntityRotation } from './useAnimatedEntityRotation';
 
 const lidClosedRotation = 0;
-const lidOpenRotation = -Math.PI / 2;
 
 export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
     const { nodes, materials } = useGameGLTF('GardenBox');
     const [animatedRotation] = useAnimatedEntityRotation(rotation + 2);
     const currentStackHeight = useStackHeight(stack, block);
-    const hovered =
-        useHoveredBlockStore((state) => state.hoveredBlock) === block;
-    const activeDragPreview = useGameState((state) => state.activeDragPreview);
-    const openGardenBoxBlockId = useGameState(
-        (state) => state.openGardenBoxBlockId,
-    );
-    const setOpenGardenBoxBlockId = useGameState(
-        (state) => state.setOpenGardenBoxBlockId,
-    );
-    const isLidOpen =
-        activeDragPreview?.hoveredGardenBoxBlockId === block.id ||
-        openGardenBoxBlockId === block.id;
-    const { rotation: lidRotation } = useSpring({
-        config: {
-            mass: 0.18,
-            tension: 260,
-            friction: 18,
-        },
-        rotation: [isLidOpen ? lidOpenRotation : lidClosedRotation, 0, 0],
-    });
-
-    const handleClick = useDeferredSingleClick(() => {
-        if (activeDragPreview) return;
-
-        setOpenGardenBoxBlockId(block.id);
-    });
 
     return (
-        <HoverOutline
-            hovered={hovered || isLidOpen}
-            thickness={7}
-            color="#f8fafc"
+        <animated.group
+            position={stack.position.clone().setY(currentStackHeight)}
+            rotation={animatedRotation as unknown as [number, number, number]}
         >
-            <animated.group
-                onClick={handleClick}
-                position={stack.position.clone().setY(currentStackHeight)}
-                rotation={
-                    animatedRotation as unknown as [number, number, number]
-                }
+            <mesh
+                castShadow
+                receiveShadow
+                geometry={nodes.GardenBox_Body_Planks.geometry}
+                material={materials['Material.Planks']}
+            />
+            <SnowOverlay
+                geometry={nodes.GardenBox_Body_Planks.geometry}
+                {...snowPresets.giftBox}
+            />
+            <RainWetOverlay geometry={nodes.GardenBox_Body_Planks.geometry} />
+            <group
+                position={[0, 0.6, -0.38]}
+                rotation={[lidClosedRotation, 0, 0]}
             >
                 <mesh
-                    castShadow
                     receiveShadow
-                    geometry={nodes.GardenBox_Body_Planks.geometry}
+                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                     material={materials['Material.Planks']}
                 />
                 <SnowOverlay
-                    geometry={nodes.GardenBox_Body_Planks.geometry}
+                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                     {...snowPresets.giftBox}
                 />
                 <RainWetOverlay
-                    geometry={nodes.GardenBox_Body_Planks.geometry}
+                    geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
                 />
-                <animated.group
-                    position={[0, 0.6, -0.38]}
-                    rotation={
-                        lidRotation as unknown as [number, number, number]
-                    }
-                >
-                    <mesh
-                        receiveShadow
-                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
-                        material={materials['Material.Planks']}
-                    />
-                    <SnowOverlay
-                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
-                        {...snowPresets.giftBox}
-                    />
-                    <RainWetOverlay
-                        geometry={nodes.GardenBox_Lid_HingeOrigin.geometry}
-                    />
-                </animated.group>
-            </animated.group>
-        </HoverOutline>
+            </group>
+        </animated.group>
     );
 }

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -1,6 +1,7 @@
 import { useGameSceneDetails } from '../../GameSceneDetailContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
+import { useGameState } from '../../useGameState';
 import {
     findRaisedBedByBlockId,
     getRaisedBedBlockIds,
@@ -11,7 +12,10 @@ import { RaisedBedPlantField } from './RaisedBedPlantField';
 export function RaisedBedFields({ blockId }: { blockId: string }) {
     const { renderDetails } = useGameSceneDetails();
     const { data: currentGarden } = useCurrentGarden();
-    const { data: cart } = useShoppingCart(renderDetails);
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+    const { data: cart } = useShoppingCart(renderDetails && !isLocalSandbox);
     const raisedBed = findRaisedBedByBlockId(currentGarden, blockId);
     const orientation = raisedBed?.orientation ?? 'vertical';
 

--- a/packages/game/src/hooks/useBlockData.ts
+++ b/packages/game/src/hooks/useBlockData.ts
@@ -1,10 +1,21 @@
 import { directoriesClient } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
+import { getLocalSandboxBlockData } from '../localSandboxBlockData';
+import { useGameState } from '../useGameState';
 
 export function useBlockData() {
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+    const isLocalSandbox = localSandboxStorageKey !== null;
+
     return useQuery({
-        queryKey: ['blocks'],
+        queryKey: isLocalSandbox ? ['blocks', 'local-sandbox'] : ['blocks'],
         queryFn: async () => {
+            if (isLocalSandbox) {
+                return getLocalSandboxBlockData();
+            }
+
             return (
                 (await directoriesClient().GET('/entities/block')).data ?? null
             );

--- a/packages/game/src/hooks/useBlockDelete.ts
+++ b/packages/game/src/hooks/useBlockDelete.ts
@@ -1,0 +1,118 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { handleOptimisticUpdate } from '../helpers/queryHelpers';
+import { persistLocalSandboxGarden } from '../localSandboxGarden';
+import { useGameState } from '../useGameState';
+import { currentAccountKeys } from './useCurrentAccount';
+import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
+
+const mutationKey = ['gardens', 'current', 'blockDelete'];
+
+type DeleteBlocksArgs = {
+    blockIds: string[];
+};
+
+async function getBlockDeleteError(response: Response) {
+    const responseText = await response.text();
+    if (!responseText) {
+        return 'Failed to delete block';
+    }
+
+    try {
+        const parsedResponse = JSON.parse(responseText) as {
+            error?: string;
+        };
+        return parsedResponse.error ?? responseText;
+    } catch {
+        return responseText;
+    }
+}
+
+export function useBlockDelete() {
+    const queryClient = useQueryClient();
+    const { data: garden } = useCurrentGarden();
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+    const winterMode = useGameState((state) => state.winterMode);
+    const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
+
+    return useMutation({
+        mutationKey,
+        mutationFn: async ({ blockIds }: DeleteBlocksArgs) => {
+            if (!garden) {
+                throw new Error('No garden selected');
+            }
+
+            if (localSandboxStorageKey) {
+                return;
+            }
+
+            for (const blockId of [...new Set(blockIds)]) {
+                const response = await clientAuthenticated().api.gardens[
+                    ':gardenId'
+                ].blocks[':blockId'].$delete({
+                    param: {
+                        gardenId: garden.id.toString(),
+                        blockId,
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new Error(await getBlockDeleteError(response));
+                }
+            }
+        },
+        onMutate: async ({ blockIds }) => {
+            if (!garden) {
+                return;
+            }
+
+            const blockIdSet = new Set(blockIds);
+            const updatedStacks = garden.stacks.map((stack) => ({
+                ...stack,
+                blocks: stack.blocks.filter(
+                    (block) => !blockIdSet.has(block.id),
+                ),
+            }));
+
+            const previousItem = await handleOptimisticUpdate(
+                queryClient,
+                gardenQueryKey,
+                {
+                    stacks: updatedStacks,
+                },
+            );
+            if (localSandboxStorageKey) {
+                persistLocalSandboxGarden(localSandboxStorageKey, {
+                    ...garden,
+                    stacks: updatedStacks,
+                });
+            }
+
+            return {
+                previousItem,
+            };
+        },
+        onError: (error, _variables, context) => {
+            console.error('Error deleting block', error);
+            if (context?.previousItem) {
+                queryClient.setQueryData(gardenQueryKey, context.previousItem);
+            }
+        },
+        onSettled: async () => {
+            if (localSandboxStorageKey) {
+                return;
+            }
+
+            if (queryClient.isMutating({ mutationKey }) === 1) {
+                await queryClient.invalidateQueries({
+                    queryKey: gardenQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: currentAccountKeys,
+                });
+            }
+        },
+    });
+}

--- a/packages/game/src/hooks/useBlockMove.ts
+++ b/packages/game/src/hooks/useBlockMove.ts
@@ -2,6 +2,7 @@ import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Vector3 } from 'three';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
+import { persistLocalSandboxGarden } from '../localSandboxGarden';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
@@ -122,6 +123,9 @@ function moveBlockOptimistically(
 export function useBlockMove() {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
     const winterMode = useGameState((state) => state.winterMode);
     const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
 
@@ -130,6 +134,9 @@ export function useBlockMove() {
         mutationFn: async (args: MoveArgs) => {
             if (!garden) {
                 throw new Error('No garden selected');
+            }
+            if (localSandboxStorageKey) {
+                return;
             }
             const gardenId = garden.id;
             const operations: MovePatchOperation[] = getMoveBlocks(args).map(
@@ -177,6 +184,12 @@ export function useBlockMove() {
                     stacks: [...updatedStacks],
                 },
             );
+            if (localSandboxStorageKey) {
+                persistLocalSandboxGarden(localSandboxStorageKey, {
+                    ...garden,
+                    stacks: updatedStacks,
+                });
+            }
 
             return {
                 previousItem,
@@ -189,6 +202,10 @@ export function useBlockMove() {
             }
         },
         onSettled: async () => {
+            if (localSandboxStorageKey) {
+                return;
+            }
+
             if (queryClient.isMutating({ mutationKey }) === 1) {
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -1,5 +1,9 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    createLocalSandboxBlockId,
+    persistLocalSandboxGarden,
+} from '../localSandboxGarden';
 import { useGameState } from '../useGameState';
 import {
     createOptimisticBlockPlacement,
@@ -20,6 +24,7 @@ type CurrentGardenData = NonNullable<
 type BlockPlaceVariables = {
     blockName: string;
     expectedExistingBlocks?: string[];
+    localBlockId?: string;
     position?: BlockPlacePosition;
 };
 
@@ -77,6 +82,9 @@ export function useBlockPlace() {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
     const { data: blockData } = useBlockData();
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
     const winterMode = useGameState((state) => state.winterMode);
     const queuePlacedBlockEffect = useGameState(
         (state) => state.queuePlacedBlockEffect,
@@ -85,14 +93,19 @@ export function useBlockPlace() {
 
     return useMutation({
         mutationKey,
-        mutationFn: async ({
-            blockName,
-            expectedExistingBlocks,
-            position,
-        }: BlockPlaceVariables) => {
+        mutationFn: async (variables: BlockPlaceVariables) => {
             if (!garden) {
                 throw new Error('No garden selected');
             }
+
+            if (localSandboxStorageKey) {
+                return {
+                    id:
+                        variables.localBlockId ??
+                        createLocalSandboxBlockId(variables.blockName),
+                };
+            }
+
             const response = await clientAuthenticated().api.gardens[
                 ':gardenId'
             ].blocks.$post({
@@ -100,11 +113,16 @@ export function useBlockPlace() {
                     gardenId: garden.id.toString(),
                 },
                 json: {
-                    blockName,
-                    ...(expectedExistingBlocks
-                        ? { expectedExistingBlocks }
+                    blockName: variables.blockName,
+                    ...(variables.expectedExistingBlocks
+                        ? {
+                              expectedExistingBlocks:
+                                  variables.expectedExistingBlocks,
+                          }
                         : {}),
-                    ...(position ? { position } : {}),
+                    ...(variables.position
+                        ? { position: variables.position }
+                        : {}),
                 },
             });
             if (!response.ok) {
@@ -128,9 +146,12 @@ export function useBlockPlace() {
                         queryClient.getQueryData<CurrentGardenData>(
                             gardenQueryKey,
                         ) ?? garden;
-                    const optimisticBlockId = createOptimisticBlockId(
-                        variables.blockName,
-                    );
+                    const optimisticBlockId = localSandboxStorageKey
+                        ? createLocalSandboxBlockId(variables.blockName)
+                        : createOptimisticBlockId(variables.blockName);
+                    variables.localBlockId = localSandboxStorageKey
+                        ? optimisticBlockId
+                        : undefined;
                     const optimisticPlacement = createOptimisticBlockPlacement(
                         currentGarden,
                         blockData,
@@ -147,13 +168,20 @@ export function useBlockPlace() {
                     };
                     variables.expectedExistingBlocks =
                         optimisticPlacement.existingBlocks;
+                    const nextGarden = {
+                        ...currentGarden,
+                        stacks: optimisticPlacement.stacks,
+                    };
                     queryClient.setQueryData<CurrentGardenData>(
                         gardenQueryKey,
-                        {
-                            ...currentGarden,
-                            stacks: optimisticPlacement.stacks,
-                        },
+                        nextGarden,
                     );
+                    if (localSandboxStorageKey) {
+                        persistLocalSandboxGarden(
+                            localSandboxStorageKey,
+                            nextGarden,
+                        );
+                    }
 
                     const placedBlockData = blockData?.find(
                         (block) =>
@@ -209,6 +237,10 @@ export function useBlockPlace() {
             }
         },
         onSettled: async () => {
+            if (localSandboxStorageKey) {
+                return;
+            }
+
             await queryClient.invalidateQueries({
                 queryKey: currentAccountKeys,
             });

--- a/packages/game/src/hooks/useBlockRecycle.ts
+++ b/packages/game/src/hooks/useBlockRecycle.ts
@@ -1,6 +1,7 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
+import { persistLocalSandboxGarden } from '../localSandboxGarden';
 import { useGameState } from '../useGameState';
 import { currentAccountKeys } from './useCurrentAccount';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
@@ -38,7 +39,10 @@ async function removeShoppingCartItems(
 export function useBlockRecycle() {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
-    const { data: shoppingCart } = useShoppingCart();
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+    const { data: shoppingCart } = useShoppingCart(!localSandboxStorageKey);
     const winterMode = useGameState((state) => state.winterMode);
     const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
 
@@ -61,6 +65,9 @@ export function useBlockRecycle() {
             console.debug('Recycling block', position, blockIndex);
             if (!garden) {
                 throw new Error('No garden selected');
+            }
+            if (localSandboxStorageKey) {
+                return;
             }
             const gardenId = garden.id;
             await clientAuthenticated().api.gardens[':gardenId'].stacks.$patch({
@@ -130,6 +137,12 @@ export function useBlockRecycle() {
                     stacks: [...updatedStacks],
                 },
             );
+            if (localSandboxStorageKey) {
+                persistLocalSandboxGarden(localSandboxStorageKey, {
+                    ...garden,
+                    stacks: updatedStacks,
+                });
+            }
 
             // Optimistically remove from shopping cart if raisedBedId is provided
             let previousShoppingCart: ShoppingCartData | undefined;
@@ -166,6 +179,10 @@ export function useBlockRecycle() {
             }
         },
         onSettled: async (_data, _error, variables) => {
+            if (localSandboxStorageKey) {
+                return;
+            }
+
             // Invalidate queries only on last mutation
             if (queryClient.isMutating({ mutationKey }) === 1) {
                 await queryClient.invalidateQueries({

--- a/packages/game/src/hooks/useBlockRotate.ts
+++ b/packages/game/src/hooks/useBlockRotate.ts
@@ -1,6 +1,7 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
+import { persistLocalSandboxGarden } from '../localSandboxGarden';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
@@ -9,6 +10,9 @@ const mutationKey = ['gardens', 'current', 'blockRotate'];
 export function useBlockRotate() {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
     const winterMode = useGameState((state) => state.winterMode);
     const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
 
@@ -24,6 +28,9 @@ export function useBlockRotate() {
         }) => {
             if (!garden) {
                 throw new Error('No garden selected');
+            }
+            if (localSandboxStorageKey) {
+                return;
             }
             const gardenId = garden.id;
             const targetBlockIds = Array.from(
@@ -78,6 +85,12 @@ export function useBlockRotate() {
                     stacks: [...updatedStacks],
                 },
             );
+            if (localSandboxStorageKey) {
+                persistLocalSandboxGarden(localSandboxStorageKey, {
+                    ...currentGarden,
+                    stacks: updatedStacks,
+                });
+            }
 
             return {
                 previousItem,
@@ -90,6 +103,10 @@ export function useBlockRotate() {
             }
         },
         onSettled: async () => {
+            if (localSandboxStorageKey) {
+                return;
+            }
+
             if (queryClient.isMutating({ mutationKey }) === 1) {
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -1,6 +1,10 @@
 import { clientAuthenticated, type GardenResponse } from '@gredice/client';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import { Vector3 } from 'three';
+import {
+    loadLocalSandboxGarden,
+    localSandboxGardenId,
+} from '../localSandboxGarden';
 import type { Stack } from '../types/Stack';
 import { useGameState, type WinterMode } from '../useGameState';
 import { useCurrentGardenIdParam } from '../useUrlState';
@@ -534,18 +538,26 @@ function mockGarden(winterMode: WinterMode): useCurrentGardenResponse {
 
 export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | null> {
     const isMock = useGameState((state) => state.isMock);
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
     const winterMode = useGameState((state) => state.winterMode);
-    const { data: gardens } = useGardens(isMock);
+    const isLocalSandbox = localSandboxStorageKey !== null;
+    const { data: gardens } = useGardens(isMock || isLocalSandbox);
     const [selectedGardenId] = useCurrentGardenIdParam();
 
     // Use the selected garden ID from URL, or default to the first garden
     const currentGardenId =
-        selectedGardenId ??
+        (isLocalSandbox ? localSandboxGardenId : selectedGardenId) ??
         (gardens && gardens.length > 0 ? gardens[0].id : null);
 
     return useQuery({
         queryKey: currentGardenKeys(winterMode, currentGardenId),
         queryFn: async () => {
+            if (localSandboxStorageKey) {
+                return loadLocalSandboxGarden(localSandboxStorageKey);
+            }
+
             if (isMock) {
                 console.debug('Using mock garden data');
                 return mockGarden(winterMode);
@@ -627,15 +639,15 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
         },
         retry: false,
         staleTime: 1000 * 60, // 1m
-        enabled: isMock || Boolean(gardens),
+        enabled: isLocalSandbox || isMock || Boolean(gardens),
     });
 }
 
 /**
  * Whether the currently selected garden is a sandbox ("play") garden.
  *
- * Sandbox gardens are decoration only: free building, no inventory/economy,
- * no plant-status lifecycle and no weather.
+ * Sandbox gardens are decoration only: free building, no inventory/economy and
+ * no plant-status lifecycle.
  */
 export function useIsSandboxGarden(): boolean {
     const { data: currentGarden } = useCurrentGarden();

--- a/packages/game/src/hooks/useCurrentUser.ts
+++ b/packages/game/src/hooks/useCurrentUser.ts
@@ -37,10 +37,11 @@ async function getCurrentUser() {
     };
 }
 
-export function useCurrentUser() {
+export function useCurrentUser(enabled = true) {
     return useQuery({
         queryKey: queryKey.currentUser,
         queryFn: getCurrentUser,
+        enabled,
         retry: false,
         staleTime: 1000 * 60 * 60, // 1 hour
     });

--- a/packages/game/src/hooks/useDeleteSandboxGarden.ts
+++ b/packages/game/src/hooks/useDeleteSandboxGarden.ts
@@ -1,0 +1,91 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGameState } from '../useGameState';
+import { currentGardenKeys } from './useCurrentGarden';
+import { useGardensKeys } from './useGardens';
+
+type DeleteSandboxGardenVariables = {
+    gardenId: number;
+};
+
+type DeleteSandboxGardenResponse = {
+    success: boolean;
+    complete?: boolean;
+};
+
+const mutationKey = ['gardens', 'sandboxDelete'];
+const retryableTimeoutStatuses = new Set([408, 425, 429, 502, 503, 504]);
+const maxDeleteAttempts = 1_000;
+
+function waitForRetry() {
+    return new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+export function useDeleteSandboxGarden() {
+    const queryClient = useQueryClient();
+    const winterMode = useGameState((state) => state.winterMode);
+    const gardenQueryKey = currentGardenKeys(winterMode);
+
+    return useMutation({
+        mutationKey,
+        mutationFn: async ({ gardenId }: DeleteSandboxGardenVariables) => {
+            let lastError: unknown;
+
+            for (let attempt = 0; attempt < maxDeleteAttempts; attempt += 1) {
+                let response: Awaited<
+                    ReturnType<
+                        ReturnType<
+                            typeof clientAuthenticated
+                        >['api']['gardens'][':gardenId']['$delete']
+                    >
+                >;
+
+                try {
+                    response = await clientAuthenticated().api.gardens[
+                        ':gardenId'
+                    ].$delete({
+                        param: {
+                            gardenId: gardenId.toString(),
+                        },
+                    });
+                } catch (error) {
+                    lastError = error;
+                    await waitForRetry();
+                    continue;
+                }
+
+                if (!response.ok) {
+                    if (retryableTimeoutStatuses.has(response.status)) {
+                        await waitForRetry();
+                        continue;
+                    }
+
+                    throw new Error(
+                        `Failed to delete sandbox garden: ${response.status} ${response.statusText}`,
+                    );
+                }
+
+                const result: DeleteSandboxGardenResponse =
+                    await response.json();
+                if (result.complete !== false) {
+                    return result;
+                }
+
+                await waitForRetry();
+            }
+
+            if (lastError instanceof Error) {
+                throw lastError;
+            }
+
+            throw new Error('Sandbox garden deletion did not complete in time');
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: useGardensKeys });
+            await queryClient.invalidateQueries({ queryKey: gardenQueryKey });
+        },
+        onError: (error) => {
+            console.error('Failed to delete sandbox garden:', error);
+        },
+    });
+}

--- a/packages/game/src/hooks/useShoppingCart.ts
+++ b/packages/game/src/hooks/useShoppingCart.ts
@@ -5,7 +5,7 @@ import { useCurrentUser } from './useCurrentUser';
 export const useShoppingCartQueryKey = ['shopping-cart'];
 
 export function useShoppingCart(enabled = true) {
-    const { data: currentUser } = useCurrentUser();
+    const { data: currentUser } = useCurrentUser(enabled);
     return useQuery({
         queryKey: useShoppingCartQueryKey,
         queryFn: async () => {

--- a/packages/game/src/hooks/useWeatherNow.ts
+++ b/packages/game/src/hooks/useWeatherNow.ts
@@ -1,7 +1,12 @@
 import { clientPublic } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
+import { useGameState } from '../useGameState';
 
 export function useWeatherNow(enabled = true) {
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+
     return useQuery({
         queryKey: ['weather', 'now'],
         queryFn: async () => {
@@ -15,6 +20,6 @@ export function useWeatherNow(enabled = true) {
             return await response.json();
         },
         staleTime: 5 * 60 * 1000, // 5 minutes
-        enabled,
+        enabled: enabled && !isLocalSandbox,
     });
 }

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -1,16 +1,22 @@
-import { Add, Check, MapPinHouse } from '@gredice/ui/icons';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Add, Check, Delete, Joystick, MapPinHouse } from '@gredice/ui/icons';
 import {
     DropdownMenuItem,
     DropdownMenuLabel,
     DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
 } from '@gredice/ui/Menu';
+import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCreateGarden } from '../hooks/useCreateGarden';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useDeleteSandboxGarden } from '../hooks/useDeleteSandboxGarden';
 import { useGardenAccountGroups } from '../hooks/useGardenAccountGroups';
 import { useGardens } from '../hooks/useGardens';
 import { useSwitchGardenAccount } from '../hooks/useSwitchGardenAccount';
@@ -20,11 +26,20 @@ type GardenAccountMenuItemsProps = {
     onGardenOverviewOpen?: () => void;
 };
 
+type SandboxGardenToDelete = {
+    id: number;
+    name: string;
+    accountId: string;
+    isCurrentAccount: boolean;
+};
+
 export function GardenAccountMenuItems({
     onGardenOverviewOpen,
 }: GardenAccountMenuItemsProps) {
     const queryClient = useQueryClient();
-    const [, setSelectedGardenId] = useCurrentGardenIdParam();
+    const [sandboxGardenToDelete, setSandboxGardenToDelete] =
+        useState<SandboxGardenToDelete | null>(null);
+    const [selectedGardenId, setSelectedGardenId] = useCurrentGardenIdParam();
     const { track } = useGameAnalytics();
     const { data: currentGarden } = useCurrentGarden();
     const { data: currentAccountGardens, isLoading: currentGardensLoading } =
@@ -33,6 +48,7 @@ export function GardenAccountMenuItems({
         useGardenAccountGroups();
     const switchGardenAccount = useSwitchGardenAccount();
     const createGarden = useCreateGarden();
+    const deleteSandboxGarden = useDeleteSandboxGarden();
     const fallbackGroups =
         currentAccountGardens && currentAccountGardens.length > 0
             ? [
@@ -48,17 +64,36 @@ export function GardenAccountMenuItems({
         accountGroups && accountGroups.length > 0
             ? accountGroups
             : fallbackGroups;
-    const visibleGroups = gardenGroups.filter(
-        (group) => group.gardens.length > 0,
+    const normalGardenGroups = gardenGroups
+        .map((group) => ({
+            ...group,
+            gardens: group.gardens.filter((garden) => !garden.isSandbox),
+        }))
+        .filter((group) => group.gardens.length > 0);
+    const sandboxGardenGroups = gardenGroups
+        .map((group) => ({
+            ...group,
+            gardens: group.gardens.filter((garden) => garden.isSandbox),
+        }))
+        .filter((group) => group.gardens.length > 0);
+    const canCreateSandboxGarden = gardenGroups.some(
+        (accountGroup) => accountGroup.isCurrent,
     );
+    const showSandboxMenu =
+        sandboxGardenGroups.length > 0 || canCreateSandboxGarden;
+    const hasVisibleGardens =
+        normalGardenGroups.length > 0 || sandboxGardenGroups.length > 0;
     const showAccountLabels =
-        visibleGroups.length > 1 ||
-        visibleGroups.some((accountGroup) => !accountGroup.isCurrent);
+        normalGardenGroups.length > 1 ||
+        normalGardenGroups.some((accountGroup) => !accountGroup.isCurrent);
+    const showSandboxAccountLabels =
+        sandboxGardenGroups.length > 1 ||
+        sandboxGardenGroups.some((accountGroup) => !accountGroup.isCurrent);
     const isLoading = currentGardensLoading || accountGroupsLoading;
 
     async function handleGardenSelect(
-        accountGroup: (typeof visibleGroups)[number],
-        garden: (typeof visibleGroups)[number]['gardens'][number],
+        accountGroup: (typeof gardenGroups)[number],
+        garden: (typeof gardenGroups)[number]['gardens'][number],
     ) {
         if (switchGardenAccount.isPending) {
             return;
@@ -118,6 +153,35 @@ export function GardenAccountMenuItems({
         }
     }
 
+    async function handleDeleteSandboxGarden(target: SandboxGardenToDelete) {
+        if (deleteSandboxGarden.isPending) {
+            return;
+        }
+
+        track('game_garden_delete_submitted', {
+            garden_id: target.id,
+            garden_name: target.name,
+            account_id: target.accountId,
+            is_sandbox: true,
+            is_current_account: target.isCurrentAccount,
+            source: 'garden_switcher',
+        });
+
+        try {
+            await deleteSandboxGarden.mutateAsync({
+                gardenId: target.id,
+            });
+            if (
+                currentGarden?.id === target.id ||
+                selectedGardenId === target.id
+            ) {
+                await setSelectedGardenId(null);
+            }
+        } catch (error) {
+            console.error('Failed to delete sandbox garden:', error);
+        }
+    }
+
     if (isLoading) {
         return (
             <DropdownMenuLabel className="text-muted-foreground">
@@ -126,7 +190,7 @@ export function GardenAccountMenuItems({
         );
     }
 
-    if (visibleGroups.length <= 0) {
+    if (!hasVisibleGardens) {
         return (
             <>
                 <DropdownMenuLabel className="text-muted-foreground text-center">
@@ -147,7 +211,7 @@ export function GardenAccountMenuItems({
 
     return (
         <>
-            {visibleGroups.map((accountGroup, groupIndex) => (
+            {normalGardenGroups.map((accountGroup, groupIndex) => (
                 <Fragment key={accountGroup.accountId}>
                     {groupIndex > 0 && (
                         <DropdownMenuSeparator className="my-2" />
@@ -157,89 +221,152 @@ export function GardenAccountMenuItems({
                             <Typography noWrap>{accountGroup.name}</Typography>
                         </DropdownMenuLabel>
                     )}
-                    {accountGroup.gardens
-                        .filter((garden) => !garden.isSandbox)
-                        .map((garden) => (
-                            <DropdownMenuItem
-                                key={`${accountGroup.accountId}:${garden.id}`}
-                                className="gap-3"
-                                onClick={() =>
-                                    handleGardenSelect(accountGroup, garden)
-                                }
-                            >
-                                <Check
-                                    aria-hidden={
-                                        garden.id !== currentGarden?.id
-                                    }
-                                    className={cx(
-                                        'size-4 shrink-0 opacity-0',
-                                        garden.id === currentGarden?.id &&
-                                            'opacity-100',
-                                    )}
-                                />
-                                <Typography noWrap>{garden.name}</Typography>
-                            </DropdownMenuItem>
-                        ))}
-                    {(() => {
-                        const sandboxGardens = accountGroup.gardens.filter(
-                            (garden) => garden.isSandbox,
-                        );
-                        if (
-                            sandboxGardens.length <= 0 &&
-                            !accountGroup.isCurrent
-                        ) {
-                            return null;
-                        }
-                        return (
-                            <>
-                                <DropdownMenuLabel className="text-muted-foreground text-xs px-2 py-1">
-                                    Vrtovi za igru
-                                </DropdownMenuLabel>
-                                {sandboxGardens.map((garden) => (
-                                    <DropdownMenuItem
-                                        key={`${accountGroup.accountId}:${garden.id}`}
-                                        className="gap-3"
-                                        onClick={() =>
-                                            handleGardenSelect(
-                                                accountGroup,
-                                                garden,
-                                            )
-                                        }
-                                    >
-                                        <Check
-                                            aria-hidden={
-                                                garden.id !== currentGarden?.id
-                                            }
-                                            className={cx(
-                                                'size-4 shrink-0 opacity-0',
-                                                garden.id ===
-                                                    currentGarden?.id &&
-                                                    'opacity-100',
-                                            )}
-                                        />
-                                        <Typography noWrap>
-                                            {garden.name}
-                                        </Typography>
-                                    </DropdownMenuItem>
-                                ))}
-                                {accountGroup.isCurrent && (
-                                    <DropdownMenuItem
-                                        className="gap-3"
-                                        disabled={createGarden.isPending}
-                                        onSelect={(event) => {
-                                            event.preventDefault();
-                                            void handleCreateSandboxGarden();
-                                        }}
-                                    >
-                                        <Add className="size-4" />
-                                        <span>Kreiraj vrt za igru</span>
-                                    </DropdownMenuItem>
+                    {accountGroup.gardens.map((garden) => (
+                        <DropdownMenuItem
+                            key={`${accountGroup.accountId}:${garden.id}`}
+                            className="gap-3"
+                            onClick={() =>
+                                handleGardenSelect(accountGroup, garden)
+                            }
+                        >
+                            <Check
+                                aria-hidden={garden.id !== currentGarden?.id}
+                                className={cx(
+                                    'size-4 shrink-0 opacity-0',
+                                    garden.id === currentGarden?.id &&
+                                        'opacity-100',
                                 )}
-                            </>
-                        );
-                    })()}
+                            />
+                            <Typography noWrap>{garden.name}</Typography>
+                        </DropdownMenuItem>
+                    ))}
                 </Fragment>
             ))}
+            {normalGardenGroups.length > 0 && showSandboxMenu && (
+                <DropdownMenuSeparator className="my-2" />
+            )}
+            {showSandboxMenu && (
+                <DropdownMenuSub>
+                    <DropdownMenuSubTrigger className="gap-3">
+                        <Joystick className="size-4 shrink-0" />
+                        <span>Vrtovi za igru</span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="w-80 p-2">
+                        {sandboxGardenGroups.map((accountGroup, groupIndex) => (
+                            <Fragment key={accountGroup.accountId}>
+                                {groupIndex > 0 && (
+                                    <DropdownMenuSeparator className="my-2" />
+                                )}
+                                {showSandboxAccountLabels && (
+                                    <DropdownMenuLabel className="text-muted-foreground text-xs px-2 py-1">
+                                        <Typography noWrap>
+                                            {accountGroup.name}
+                                        </Typography>
+                                    </DropdownMenuLabel>
+                                )}
+                                {accountGroup.gardens.map((garden) => (
+                                    <div
+                                        className="flex items-center gap-1"
+                                        key={`${accountGroup.accountId}:${garden.id}`}
+                                    >
+                                        <DropdownMenuItem
+                                            className="min-w-0 flex-1 gap-3"
+                                            onClick={() =>
+                                                handleGardenSelect(
+                                                    accountGroup,
+                                                    garden,
+                                                )
+                                            }
+                                        >
+                                            <Check
+                                                aria-hidden={
+                                                    garden.id !==
+                                                    currentGarden?.id
+                                                }
+                                                className={cx(
+                                                    'size-4 shrink-0 opacity-0',
+                                                    garden.id ===
+                                                        currentGarden?.id &&
+                                                        'opacity-100',
+                                                )}
+                                            />
+                                            <Typography noWrap>
+                                                {garden.name}
+                                            </Typography>
+                                        </DropdownMenuItem>
+                                        <IconButton
+                                            title={`Obriši ${garden.name}`}
+                                            type="button"
+                                            variant="plain"
+                                            size="sm"
+                                            disabled={
+                                                deleteSandboxGarden.isPending
+                                            }
+                                            className="size-7 shrink-0 rounded-full p-0 text-red-600 hover:bg-red-50 hover:text-red-700 focus-visible:ring-red-600"
+                                            onClick={(event) => {
+                                                event.preventDefault();
+                                                event.stopPropagation();
+                                                setSandboxGardenToDelete({
+                                                    id: garden.id,
+                                                    name: garden.name,
+                                                    accountId:
+                                                        accountGroup.accountId,
+                                                    isCurrentAccount:
+                                                        accountGroup.isCurrent,
+                                                });
+                                            }}
+                                            onPointerDown={(event) => {
+                                                event.stopPropagation();
+                                            }}
+                                        >
+                                            <Delete className="size-4" />
+                                        </IconButton>
+                                    </div>
+                                ))}
+                            </Fragment>
+                        ))}
+                        {sandboxGardenGroups.length > 0 &&
+                            canCreateSandboxGarden && (
+                                <DropdownMenuSeparator className="my-2" />
+                            )}
+                        {canCreateSandboxGarden && (
+                            <DropdownMenuItem
+                                className="gap-3"
+                                disabled={createGarden.isPending}
+                                onSelect={(event) => {
+                                    event.preventDefault();
+                                    void handleCreateSandboxGarden();
+                                }}
+                            >
+                                <Add className="size-4" />
+                                <span>Kreiraj vrt za igru</span>
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuSubContent>
+                </DropdownMenuSub>
+            )}
+            <ModalConfirm
+                open={sandboxGardenToDelete !== null}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setSandboxGardenToDelete(null);
+                    }
+                }}
+                title="Potvrdi brisanje vrta za igru"
+                header="Brisanje vrta za igru"
+                confirmLabel="Obriši"
+                onConfirm={() => {
+                    if (sandboxGardenToDelete) {
+                        void handleDeleteSandboxGarden(sandboxGardenToDelete);
+                    }
+                }}
+            >
+                <Typography>
+                    Jeste li sigurni da želite obrisati vrt za igru{' '}
+                    <strong>{sandboxGardenToDelete?.name}</strong>? Ova akcija
+                    se ne može poništiti.
+                </Typography>
+            </ModalConfirm>
         </>
     );
 }

--- a/packages/game/src/hud/SandboxBlockTrashDropTarget.tsx
+++ b/packages/game/src/hud/SandboxBlockTrashDropTarget.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Delete } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
+import { useIsSandboxGarden } from '../hooks/useCurrentGarden';
+import { sandboxBlockTrashDropTargetAttribute } from '../sandboxBlockTrashDropTarget';
+import { useGameState } from '../useGameState';
+
+export function SandboxBlockTrashDropTarget() {
+    const isSandbox = useIsSandboxGarden();
+    const pickupBlock = useGameState((state) => state.pickupBlock);
+    const active = useGameState(
+        (state) => state.sandboxBlockTrashDropTargetActive,
+    );
+
+    if (!isSandbox || !pickupBlock) {
+        return null;
+    }
+
+    return (
+        <div
+            aria-hidden="true"
+            {...{ [sandboxBlockTrashDropTargetAttribute]: 'true' }}
+            className={cx(
+                'pointer-events-none mx-auto mb-4 grid size-16 place-items-center rounded-full border-2 shadow-xl backdrop-blur-md transition duration-150 ease-out md:size-[4.5rem]',
+                active
+                    ? 'scale-110 border-red-200 bg-red-600 text-white shadow-red-950/25'
+                    : 'scale-100 border-red-200 bg-white/95 text-red-600 shadow-black/20',
+            )}
+        >
+            <Delete className="size-7 md:size-8" strokeWidth={2.4} />
+        </div>
+    );
+}

--- a/packages/game/src/hud/SandboxEnvironmentHud.tsx
+++ b/packages/game/src/hud/SandboxEnvironmentHud.tsx
@@ -6,6 +6,7 @@ import { Input } from '@gredice/ui/Input';
 import {
     Calendar,
     Cloud,
+    Custom,
     Droplets,
     Lightning,
     Moon,
@@ -13,6 +14,7 @@ import {
     Snowflake,
     Sun,
     SunMoon,
+    Wind,
 } from '@gredice/ui/icons';
 import { Popper } from '@gredice/ui/Popper';
 import { Row } from '@gredice/ui/Row';
@@ -25,6 +27,7 @@ import {
     type PointerEvent as ReactPointerEvent,
     useCallback,
     useEffect,
+    useState,
 } from 'react';
 import { useLiveTime } from '../hooks/useLiveTime';
 import { type GameState, useGameState } from '../useGameState';
@@ -115,6 +118,14 @@ function formatPercent(value: number) {
     return `${Math.round(clampTimeOfDay(value) * 100)}%`;
 }
 
+function formatWholeNumber(value: number) {
+    return Math.round(value).toString();
+}
+
+function formatCentimeters(value: number) {
+    return `${Math.round(value)} cm`;
+}
+
 function formatDateInputValue(date: Date) {
     const year = date.getFullYear().toString().padStart(4, '0');
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
@@ -170,6 +181,23 @@ function formatTimeOfDayLabel(timeOfDay: number) {
     return `${hours.toString().padStart(2, '0')}:${minutes
         .toString()
         .padStart(2, '0')}`;
+}
+
+type TimeTickLabelPosition = {
+    textAnchor: 'end' | 'middle' | 'start';
+    x: number;
+};
+
+function getTimeTickLabelPosition(tick: number): TimeTickLabelPosition {
+    if (tick <= 0) {
+        return { textAnchor: 'start', x: 1 };
+    }
+
+    if (tick >= 1) {
+        return { textAnchor: 'end', x: 99 };
+    }
+
+    return { textAnchor: 'middle', x: tick * 100 };
 }
 
 function getDayPoint(timeOfDay: number) {
@@ -335,26 +363,30 @@ function SandboxTimeVisualization({
                     strokeLinecap="round"
                     strokeWidth="1.4"
                 />
-                {[0, 0.25, 0.5, 0.75, 1].map((tick) => (
-                    <g key={tick} opacity="0.55">
-                        <line
-                            x1={tick * 100}
-                            x2={tick * 100}
-                            y1="25"
-                            y2="27"
-                            stroke="currentColor"
-                            strokeWidth="0.4"
-                        />
-                        <text
-                            x={tick * 100}
-                            y="31"
-                            textAnchor="middle"
-                            className="fill-current text-[3px]"
-                        >
-                            {formatTimeOfDayLabel(tick)}
-                        </text>
-                    </g>
-                ))}
+                {[0, 0.25, 0.5, 0.75, 1].map((tick) => {
+                    const labelPosition = getTimeTickLabelPosition(tick);
+
+                    return (
+                        <g key={tick} opacity="0.55">
+                            <line
+                                x1={tick * 100}
+                                x2={tick * 100}
+                                y1="25"
+                                y2="27"
+                                stroke="currentColor"
+                                strokeWidth="0.4"
+                            />
+                            <text
+                                x={labelPosition.x}
+                                y="30.5"
+                                textAnchor={labelPosition.textAnchor}
+                                className="fill-current text-[3px]"
+                            >
+                                {formatTimeOfDayLabel(tick)}
+                            </text>
+                        </g>
+                    );
+                })}
                 <line
                     x1="0"
                     x2="100"
@@ -455,8 +487,32 @@ function weatherIcon(weather: SandboxWeather) {
     return Sun;
 }
 
+function WeatherSliderLabel({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: typeof Cloud;
+    label: string;
+    value: string;
+}) {
+    return (
+        <span className="flex w-full items-center justify-between gap-3">
+            <span className="inline-flex min-w-0 items-center gap-2">
+                <Icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">{label}</span>
+            </span>
+            <span className="shrink-0 text-right tabular-nums text-muted-foreground">
+                {value}
+            </span>
+        </span>
+    );
+}
+
 export function SandboxEnvironmentHud() {
     const currentTime = useLiveTime();
+    const [customWeatherControlsOpen, setCustomWeatherControlsOpen] =
+        useState(false);
     const weatherOverride = useGameState((state) => state.weather);
     const setWeather = useGameState((state) => state.setWeather);
     const setWeatherVisualizationDisabled = useGameState(
@@ -473,6 +529,11 @@ export function SandboxEnvironmentHud() {
         ...(weatherOverride ?? {}),
     };
     const WeatherIcon = weatherIcon(weather);
+    const activeWeatherPreset = weatherPresets.find((preset) =>
+        isPresetActive(weather, preset.weather),
+    );
+    const customWeatherSelected =
+        customWeatherControlsOpen || !activeWeatherPreset;
 
     useEffect(() => {
         if (weatherOverride) {
@@ -559,10 +620,10 @@ export function SandboxEnvironmentHud() {
                             <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                                 {weatherPresets.map((preset) => {
                                     const PresetIcon = preset.icon;
-                                    const active = isPresetActive(
-                                        weather,
-                                        preset.weather,
-                                    );
+                                    const active =
+                                        !customWeatherSelected &&
+                                        activeWeatherPreset?.label ===
+                                            preset.label;
                                     return (
                                         <Button
                                             key={preset.label}
@@ -578,137 +639,217 @@ export function SandboxEnvironmentHud() {
                                             startDecorator={
                                                 <PresetIcon className="size-4" />
                                             }
-                                            onClick={() =>
-                                                updateWeather(preset.weather)
-                                            }
+                                            onClick={() => {
+                                                setCustomWeatherControlsOpen(
+                                                    false,
+                                                );
+                                                updateWeather(preset.weather);
+                                            }}
                                         >
                                             {preset.label}
                                         </Button>
                                     );
                                 })}
+                                <Button
+                                    size="sm"
+                                    variant={
+                                        customWeatherSelected
+                                            ? 'solid'
+                                            : 'outlined'
+                                    }
+                                    startDecorator={
+                                        <Custom className="size-4" />
+                                    }
+                                    onClick={() =>
+                                        setCustomWeatherControlsOpen(true)
+                                    }
+                                >
+                                    Prilagođeno
+                                </Button>
                             </div>
-                            <Stack spacing={3}>
-                                <Slider
-                                    aria-label="Oblaci"
-                                    label={`Oblaci ${formatPercent(weather.cloudy)}`}
-                                    min={0}
-                                    max={1}
-                                    step={0.01}
-                                    value={[weather.cloudy]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                cloudy: clampTimeOfDay(
-                                                    nextValue,
-                                                ),
-                                            });
+                            {customWeatherSelected ? (
+                                <Stack spacing={3}>
+                                    <Slider
+                                        aria-label="Oblaci"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Cloud}
+                                                label="Oblaci"
+                                                value={formatPercent(
+                                                    weather.cloudy,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                                <Slider
-                                    aria-label="Kiša"
-                                    label={`Kiša ${formatPercent(weather.rainy)}`}
-                                    min={0}
-                                    max={1}
-                                    step={0.01}
-                                    value={[weather.rainy]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                rainy: clampTimeOfDay(
-                                                    nextValue,
-                                                ),
-                                            });
+                                        min={0}
+                                        max={1}
+                                        step={0.01}
+                                        value={[weather.cloudy]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    cloudy: clampTimeOfDay(
+                                                        nextValue,
+                                                    ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Slider
+                                        aria-label="Kiša"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Droplets}
+                                                label="Kiša"
+                                                value={formatPercent(
+                                                    weather.rainy,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                                <Slider
-                                    aria-label="Snijeg"
-                                    label={`Snijeg ${formatPercent(weather.snowy)}`}
-                                    min={0}
-                                    max={1}
-                                    step={0.01}
-                                    value={[weather.snowy]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                snowy: clampTimeOfDay(
-                                                    nextValue,
-                                                ),
-                                            });
+                                        min={0}
+                                        max={1}
+                                        step={0.01}
+                                        value={[weather.rainy]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    rainy: clampTimeOfDay(
+                                                        nextValue,
+                                                    ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Slider
+                                        aria-label="Snijeg"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Snowflake}
+                                                label="Snijeg"
+                                                value={formatPercent(
+                                                    weather.snowy,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                                <Slider
-                                    aria-label="Magla"
-                                    label={`Magla ${formatPercent(weather.foggy)}`}
-                                    min={0}
-                                    max={1}
-                                    step={0.01}
-                                    value={[weather.foggy]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                foggy: clampTimeOfDay(
-                                                    nextValue,
-                                                ),
-                                            });
+                                        min={0}
+                                        max={1}
+                                        step={0.01}
+                                        value={[weather.snowy]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    snowy: clampTimeOfDay(
+                                                        nextValue,
+                                                    ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Slider
+                                        aria-label="Magla"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Cloud}
+                                                label="Magla"
+                                                value={formatPercent(
+                                                    weather.foggy,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                                <Slider
-                                    aria-label="Oluja"
-                                    label={`Oluja ${formatPercent(weather.thundery ?? 0)}`}
-                                    min={0}
-                                    max={1}
-                                    step={0.01}
-                                    value={[weather.thundery ?? 0]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                thundery:
-                                                    clampTimeOfDay(nextValue),
-                                            });
+                                        min={0}
+                                        max={1}
+                                        step={0.01}
+                                        value={[weather.foggy]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    foggy: clampTimeOfDay(
+                                                        nextValue,
+                                                    ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Slider
+                                        aria-label="Oluja"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Lightning}
+                                                label="Oluja"
+                                                value={formatPercent(
+                                                    weather.thundery ?? 0,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                                <Slider
-                                    aria-label="Vjetar"
-                                    label={`Vjetar ${Math.round(weather.windSpeed ?? 0)}`}
-                                    min={0}
-                                    max={3}
-                                    step={1}
-                                    value={[weather.windSpeed ?? 0]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                windSpeed: Math.min(
-                                                    3,
-                                                    Math.max(0, nextValue),
-                                                ),
-                                            });
+                                        min={0}
+                                        max={1}
+                                        step={0.01}
+                                        value={[weather.thundery ?? 0]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    thundery:
+                                                        clampTimeOfDay(
+                                                            nextValue,
+                                                        ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Slider
+                                        aria-label="Vjetar"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Wind}
+                                                label="Vjetar"
+                                                value={formatWholeNumber(
+                                                    weather.windSpeed ?? 0,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                                <Slider
-                                    aria-label="Snježni pokrov"
-                                    label={`Snježni pokrov ${Math.round(weather.snowAccumulation ?? 0)} cm`}
-                                    min={0}
-                                    max={50}
-                                    step={1}
-                                    value={[weather.snowAccumulation ?? 0]}
-                                    onValueChange={([nextValue]) => {
-                                        if (typeof nextValue === 'number') {
-                                            updateWeather({
-                                                snowAccumulation: Math.min(
-                                                    50,
-                                                    Math.max(0, nextValue),
-                                                ),
-                                            });
+                                        min={0}
+                                        max={3}
+                                        step={1}
+                                        value={[weather.windSpeed ?? 0]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    windSpeed: Math.min(
+                                                        3,
+                                                        Math.max(0, nextValue),
+                                                    ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <Slider
+                                        aria-label="Snježni pokrov"
+                                        label={
+                                            <WeatherSliderLabel
+                                                icon={Snowflake}
+                                                label="Snježni pokrov"
+                                                value={formatCentimeters(
+                                                    weather.snowAccumulation ??
+                                                        0,
+                                                )}
+                                            />
                                         }
-                                    }}
-                                />
-                            </Stack>
+                                        min={0}
+                                        max={50}
+                                        step={1}
+                                        value={[weather.snowAccumulation ?? 0]}
+                                        onValueChange={([nextValue]) => {
+                                            if (typeof nextValue === 'number') {
+                                                updateWeather({
+                                                    snowAccumulation: Math.min(
+                                                        50,
+                                                        Math.max(0, nextValue),
+                                                    ),
+                                                });
+                                            }
+                                        }}
+                                    />
+                                </Stack>
+                            ) : null}
                         </Stack>
                     </Stack>
                 </Popper>
@@ -771,23 +912,41 @@ export function SandboxEnvironmentHud() {
                                     )}
                                     {formatTime(currentTime)}
                                 </Typography>
-                                <Typography
-                                    level="body2"
-                                    className="inline-flex items-center gap-1 text-muted-foreground"
+                                <Popper
+                                    align="end"
+                                    className="w-56 p-3"
+                                    side="bottom"
+                                    sideOffset={8}
+                                    trigger={
+                                        <Button
+                                            aria-label={`Promijeni datum ${formatShortDate(currentTime)}`}
+                                            className="-mr-2 px-2 text-muted-foreground hover:text-foreground"
+                                            color="neutral"
+                                            size="sm"
+                                            title="Promijeni datum"
+                                            type="button"
+                                            variant="plain"
+                                        >
+                                            <Calendar className="size-4" />
+                                            {formatShortDate(currentTime)}
+                                        </Button>
+                                    }
                                 >
-                                    <Calendar className="size-4" />
-                                    {formatShortDate(currentTime)}
-                                </Typography>
+                                    <Input
+                                        fullWidth
+                                        label="Datum"
+                                        type="date"
+                                        value={formatDateInputValue(
+                                            currentTime,
+                                        )}
+                                        onChange={(event) =>
+                                            updateDate(
+                                                event.currentTarget.value,
+                                            )
+                                        }
+                                    />
+                                </Popper>
                             </Row>
-                            <Input
-                                fullWidth
-                                label="Datum"
-                                type="date"
-                                value={formatDateInputValue(currentTime)}
-                                onChange={(event) =>
-                                    updateDate(event.currentTarget.value)
-                                }
-                            />
                         </Stack>
                     </Stack>
                 </Popper>

--- a/packages/game/src/hud/SandboxEnvironmentHud.tsx
+++ b/packages/game/src/hud/SandboxEnvironmentHud.tsx
@@ -1,0 +1,797 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Divider } from '@gredice/ui/Divider';
+import { Input } from '@gredice/ui/Input';
+import {
+    Calendar,
+    Cloud,
+    Droplets,
+    Lightning,
+    Moon,
+    Reset,
+    Snowflake,
+    Sun,
+    SunMoon,
+} from '@gredice/ui/icons';
+import { Popper } from '@gredice/ui/Popper';
+import { Row } from '@gredice/ui/Row';
+import { Slider } from '@gredice/ui/Slider';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import {
+    type KeyboardEvent,
+    type PointerEvent as ReactPointerEvent,
+    useCallback,
+    useEffect,
+} from 'react';
+import { useLiveTime } from '../hooks/useLiveTime';
+import { type GameState, useGameState } from '../useGameState';
+import { clampTimeOfDay, createDateForGameTimeOfDay } from '../utils/timeOfDay';
+import { HudCard } from './components/HudCard';
+
+type SandboxWeather = NonNullable<GameState['weather']>;
+
+const sandboxWeatherDefaults = {
+    cloudy: 0,
+    rainy: 0,
+    snowy: 0,
+    foggy: 0,
+    thundery: 0,
+    windSpeed: 0,
+    windDirection: 0,
+    snowAccumulation: 0,
+} satisfies SandboxWeather;
+
+const weatherPresets = [
+    {
+        label: 'Vedro',
+        icon: Sun,
+        weather: sandboxWeatherDefaults,
+    },
+    {
+        label: 'Kiša',
+        icon: Droplets,
+        weather: {
+            cloudy: 0.75,
+            rainy: 0.8,
+            snowy: 0,
+            foggy: 0.12,
+            thundery: 0,
+            windSpeed: 1,
+            windDirection: 0,
+            snowAccumulation: 0,
+        },
+    },
+    {
+        label: 'Snijeg',
+        icon: Snowflake,
+        weather: {
+            cloudy: 0.8,
+            rainy: 0,
+            snowy: 1,
+            foggy: 0.1,
+            thundery: 0,
+            windSpeed: 1,
+            windDirection: 0,
+            snowAccumulation: 30,
+        },
+    },
+    {
+        label: 'Magla',
+        icon: Cloud,
+        weather: {
+            cloudy: 0.5,
+            rainy: 0,
+            snowy: 0,
+            foggy: 0.85,
+            thundery: 0,
+            windSpeed: 0,
+            windDirection: 0,
+            snowAccumulation: 0,
+        },
+    },
+    {
+        label: 'Oluja',
+        icon: Lightning,
+        weather: {
+            cloudy: 1,
+            rainy: 1,
+            snowy: 0,
+            foggy: 0.25,
+            thundery: 1,
+            windSpeed: 3,
+            windDirection: 0,
+            snowAccumulation: 0,
+        },
+    },
+] as const;
+
+const popperClassName =
+    'w-[22rem] max-w-[calc(100vw-1rem)] overflow-hidden border-tertiary border-b-4';
+
+function formatPercent(value: number) {
+    return `${Math.round(clampTimeOfDay(value) * 100)}%`;
+}
+
+function formatDateInputValue(date: Date) {
+    const year = date.getFullYear().toString().padStart(4, '0');
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function parseDateInputValue(value: string, referenceDate: Date) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(value);
+    if (!match) {
+        return null;
+    }
+
+    const [, yearValue, monthValue, dayValue] = match;
+    const year = Number(yearValue);
+    const month = Number(monthValue);
+    const day = Number(dayValue);
+    if (
+        !Number.isFinite(year) ||
+        !Number.isFinite(month) ||
+        !Number.isFinite(day)
+    ) {
+        return null;
+    }
+
+    const nextDate = new Date(referenceDate);
+    nextDate.setFullYear(year, month - 1, day);
+    return nextDate;
+}
+
+function formatTime(date: Date) {
+    return date.toLocaleTimeString('hr-HR', {
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+function formatShortDate(date: Date) {
+    return date.toLocaleDateString('hr-HR', {
+        day: '2-digit',
+        month: '2-digit',
+    });
+}
+
+function formatTimeOfDayLabel(timeOfDay: number) {
+    const totalMinutes = Math.round(clampTimeOfDay(timeOfDay) * 24 * 60);
+    if (totalMinutes >= 24 * 60) {
+        return '24:00';
+    }
+
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes
+        .toString()
+        .padStart(2, '0')}`;
+}
+
+function getDayPoint(timeOfDay: number) {
+    const clamped = clampTimeOfDay(timeOfDay);
+    const x = clamped * 100;
+
+    if (clamped >= 0.2 && clamped <= 0.8) {
+        const t = (clamped - 0.2) / 0.6;
+        const y = (1 - t) * (1 - t) * 24 + 2 * (1 - t) * t * 5 + t * t * 24;
+        return { x, y };
+    }
+
+    if (clamped > 0.8) {
+        const t = (clamped - 0.8) / 0.2;
+        return { x, y: 24 - Math.sin(t * Math.PI * 0.5) * 8 };
+    }
+
+    const t = clamped / 0.2;
+    return { x, y: 16 + Math.sin(t * Math.PI * 0.5) * 8 };
+}
+
+function SandboxTimeVisualization({
+    onChange,
+    timeOfDay,
+}: {
+    onChange: (timeOfDay: number) => void;
+    timeOfDay: number;
+}) {
+    const point = getDayPoint(timeOfDay);
+    const isDaytime = timeOfDay >= 0.2 && timeOfDay <= 0.8;
+
+    const updateFromPointer = useCallback(
+        (event: ReactPointerEvent<HTMLDivElement>) => {
+            const rect = event.currentTarget.getBoundingClientRect();
+            const nextTimeOfDay = clampTimeOfDay(
+                (event.clientX - rect.left) / rect.width,
+            );
+            onChange(nextTimeOfDay);
+        },
+        [onChange],
+    );
+
+    const handlePointerDown = useCallback(
+        (event: ReactPointerEvent<HTMLDivElement>) => {
+            event.preventDefault();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            updateFromPointer(event);
+        },
+        [updateFromPointer],
+    );
+
+    const handlePointerMove = useCallback(
+        (event: ReactPointerEvent<HTMLDivElement>) => {
+            if (event.buttons !== 1) {
+                return;
+            }
+            updateFromPointer(event);
+        },
+        [updateFromPointer],
+    );
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        const step = event.shiftKey ? 1 / 24 : 1 / 96;
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+            event.preventDefault();
+            onChange(clampTimeOfDay(timeOfDay - step));
+        } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            onChange(clampTimeOfDay(timeOfDay + step));
+        } else if (event.key === 'Home') {
+            event.preventDefault();
+            onChange(0);
+        } else if (event.key === 'End') {
+            event.preventDefault();
+            onChange(1);
+        }
+    };
+
+    return (
+        <div
+            aria-label="Doba dana"
+            aria-valuemax={24}
+            aria-valuemin={0}
+            aria-valuenow={Math.round(timeOfDay * 24 * 100) / 100}
+            aria-valuetext={formatTimeOfDayLabel(timeOfDay)}
+            className="h-28 w-full touch-none select-none overflow-visible rounded-md bg-gradient-to-b from-sky-100 via-sky-50 to-slate-200 outline-hidden ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:from-slate-800 dark:via-slate-900 dark:to-slate-950"
+            data-sandbox-time-visualization="true"
+            onKeyDown={handleKeyDown}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            role="slider"
+            tabIndex={0}
+        >
+            <svg
+                aria-hidden="true"
+                className="h-full w-full overflow-visible"
+                viewBox="0 0 100 32"
+            >
+                <defs>
+                    <linearGradient id="sandboxDayArc" x1="20%" x2="80%">
+                        <stop
+                            offset="0%"
+                            stopColor="#f59e0b"
+                            stopOpacity="0.2"
+                        />
+                        <stop
+                            offset="50%"
+                            stopColor="#facc15"
+                            stopOpacity="1"
+                        />
+                        <stop
+                            offset="100%"
+                            stopColor="#f59e0b"
+                            stopOpacity="0.2"
+                        />
+                    </linearGradient>
+                    <linearGradient id="sandboxNightArc" x1="0%" x2="100%">
+                        <stop
+                            offset="0%"
+                            stopColor="#bfdbfe"
+                            stopOpacity="0.65"
+                        />
+                        <stop
+                            offset="50%"
+                            stopColor="#93c5fd"
+                            stopOpacity="0.25"
+                        />
+                        <stop
+                            offset="100%"
+                            stopColor="#bfdbfe"
+                            stopOpacity="0.65"
+                        />
+                    </linearGradient>
+                    <filter
+                        id="sandboxSunGlow"
+                        x="-300%"
+                        y="-300%"
+                        width="700%"
+                        height="700%"
+                    >
+                        <feGaussianBlur
+                            stdDeviation="1.6"
+                            result="coloredBlur"
+                        />
+                        <feComposite
+                            in="SourceGraphic"
+                            in2="coloredBlur"
+                            operator="over"
+                        />
+                    </filter>
+                </defs>
+                <path
+                    d="M20 24 Q50 5 80 24"
+                    fill="none"
+                    stroke="url(#sandboxDayArc)"
+                    strokeLinecap="round"
+                    strokeWidth="1.8"
+                />
+                <path
+                    d="M80 24 Q90 16 100 16 M0 16 Q10 16 20 24"
+                    fill="none"
+                    stroke="url(#sandboxNightArc)"
+                    strokeLinecap="round"
+                    strokeWidth="1.4"
+                />
+                {[0, 0.25, 0.5, 0.75, 1].map((tick) => (
+                    <g key={tick} opacity="0.55">
+                        <line
+                            x1={tick * 100}
+                            x2={tick * 100}
+                            y1="25"
+                            y2="27"
+                            stroke="currentColor"
+                            strokeWidth="0.4"
+                        />
+                        <text
+                            x={tick * 100}
+                            y="31"
+                            textAnchor="middle"
+                            className="fill-current text-[3px]"
+                        >
+                            {formatTimeOfDayLabel(tick)}
+                        </text>
+                    </g>
+                ))}
+                <line
+                    x1="0"
+                    x2="100"
+                    y1="24"
+                    y2="24"
+                    stroke="currentColor"
+                    strokeDasharray="1 2"
+                    strokeOpacity="0.3"
+                    strokeWidth="0.35"
+                />
+                <g
+                    className="transition-transform duration-100 ease-out"
+                    transform={`translate(${point.x}, ${point.y})`}
+                >
+                    {isDaytime ? (
+                        <>
+                            <circle
+                                fill="#f59e0b"
+                                filter="url(#sandboxSunGlow)"
+                                r="3.8"
+                            />
+                            <circle fill="#fde68a" r="2.2" />
+                        </>
+                    ) : (
+                        <>
+                            <circle fill="#dbeafe" r="3.6" />
+                            <circle
+                                cx="1.2"
+                                cy="-0.7"
+                                fill="currentColor"
+                                opacity="0.22"
+                                r="3.2"
+                            />
+                        </>
+                    )}
+                </g>
+            </svg>
+        </div>
+    );
+}
+
+function isPresetActive(
+    weather: SandboxWeather,
+    presetWeather: SandboxWeather,
+) {
+    return (
+        weather.cloudy === presetWeather.cloudy &&
+        weather.rainy === presetWeather.rainy &&
+        weather.snowy === presetWeather.snowy &&
+        weather.foggy === presetWeather.foggy &&
+        weather.thundery === presetWeather.thundery &&
+        weather.windSpeed === presetWeather.windSpeed &&
+        weather.snowAccumulation === presetWeather.snowAccumulation
+    );
+}
+
+function weatherLabel(weather: SandboxWeather) {
+    if ((weather.thundery ?? 0) > 0.05) {
+        return 'Oluja';
+    }
+
+    if (weather.snowy > 0.05) {
+        return 'Snijeg';
+    }
+
+    if (weather.rainy > 0.05) {
+        return 'Kiša';
+    }
+
+    if (weather.foggy > 0.05) {
+        return 'Magla';
+    }
+
+    if (weather.cloudy > 0.2) {
+        return 'Oblačno';
+    }
+
+    return 'Vedro';
+}
+
+function weatherIcon(weather: SandboxWeather) {
+    if ((weather.thundery ?? 0) > 0.05) {
+        return Lightning;
+    }
+
+    if (weather.snowy > 0.05 || (weather.snowAccumulation ?? 0) > 0) {
+        return Snowflake;
+    }
+
+    if (weather.rainy > 0.05) {
+        return Droplets;
+    }
+
+    if (weather.cloudy > 0.2 || weather.foggy > 0.05) {
+        return Cloud;
+    }
+
+    return Sun;
+}
+
+export function SandboxEnvironmentHud() {
+    const currentTime = useLiveTime();
+    const weatherOverride = useGameState((state) => state.weather);
+    const setWeather = useGameState((state) => state.setWeather);
+    const setWeatherVisualizationDisabled = useGameState(
+        (state) => state.setWeatherVisualizationDisabled,
+    );
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const setFreezeTime = useGameState((state) => state.setFreezeTime);
+    const setDayNightCycleDisabled = useGameState(
+        (state) => state.setDayNightCycleDisabled,
+    );
+
+    const weather = {
+        ...sandboxWeatherDefaults,
+        ...(weatherOverride ?? {}),
+    };
+    const WeatherIcon = weatherIcon(weather);
+
+    useEffect(() => {
+        if (weatherOverride) {
+            return;
+        }
+
+        setWeatherVisualizationDisabled(false);
+        setWeather(sandboxWeatherDefaults);
+    }, [setWeather, setWeatherVisualizationDisabled, weatherOverride]);
+
+    const updateWeather = (nextWeather: Partial<SandboxWeather>) => {
+        setWeatherVisualizationDisabled(false);
+        setWeather({
+            ...sandboxWeatherDefaults,
+            ...weather,
+            ...nextWeather,
+        });
+    };
+
+    const updateTimeOfDay = useCallback(
+        (nextTimeOfDay: number) => {
+            setDayNightCycleDisabled(false);
+            setFreezeTime(
+                createDateForGameTimeOfDay(currentTime, nextTimeOfDay),
+            );
+        },
+        [currentTime, setDayNightCycleDisabled, setFreezeTime],
+    );
+
+    const updateDate = (dateValue: string) => {
+        const nextDate = parseDateInputValue(dateValue, currentTime);
+        if (!nextDate) {
+            return;
+        }
+
+        setDayNightCycleDisabled(false);
+        setFreezeTime(createDateForGameTimeOfDay(nextDate, timeOfDay));
+    };
+
+    const resetTime = () => {
+        setDayNightCycleDisabled(false);
+        setFreezeTime(null);
+    };
+
+    return (
+        <HudCard
+            data-sandbox-environment-hud="true"
+            open
+            position="floating"
+            className="static md:px-1"
+        >
+            <Row>
+                <Popper
+                    side="bottom"
+                    sideOffset={12}
+                    className={popperClassName}
+                    trigger={
+                        <Button
+                            title="Uvjeti u vrtu"
+                            variant="plain"
+                            className="rounded-full px-2 md:pr-2 pr-3"
+                        >
+                            <WeatherIcon className="size-5" />
+                            <Typography
+                                level="body2"
+                                className="hidden text-base md:inline"
+                            >
+                                {weatherLabel(weather)}
+                            </Typography>
+                        </Button>
+                    }
+                >
+                    <Stack>
+                        <Row
+                            className="bg-background px-4 py-2"
+                            justifyContent="space-between"
+                        >
+                            <Typography level="body2" bold>
+                                Uvjeti
+                            </Typography>
+                        </Row>
+                        <Divider />
+                        <Stack spacing={4} className="px-4 py-3">
+                            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                                {weatherPresets.map((preset) => {
+                                    const PresetIcon = preset.icon;
+                                    const active = isPresetActive(
+                                        weather,
+                                        preset.weather,
+                                    );
+                                    return (
+                                        <Button
+                                            key={preset.label}
+                                            size="sm"
+                                            variant={
+                                                active ? 'solid' : 'outlined'
+                                            }
+                                            color={
+                                                preset.label === 'Oluja'
+                                                    ? 'warning'
+                                                    : 'primary'
+                                            }
+                                            startDecorator={
+                                                <PresetIcon className="size-4" />
+                                            }
+                                            onClick={() =>
+                                                updateWeather(preset.weather)
+                                            }
+                                        >
+                                            {preset.label}
+                                        </Button>
+                                    );
+                                })}
+                            </div>
+                            <Stack spacing={3}>
+                                <Slider
+                                    aria-label="Oblaci"
+                                    label={`Oblaci ${formatPercent(weather.cloudy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[weather.cloudy]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                cloudy: clampTimeOfDay(
+                                                    nextValue,
+                                                ),
+                                            });
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Kiša"
+                                    label={`Kiša ${formatPercent(weather.rainy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[weather.rainy]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                rainy: clampTimeOfDay(
+                                                    nextValue,
+                                                ),
+                                            });
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Snijeg"
+                                    label={`Snijeg ${formatPercent(weather.snowy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[weather.snowy]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                snowy: clampTimeOfDay(
+                                                    nextValue,
+                                                ),
+                                            });
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Magla"
+                                    label={`Magla ${formatPercent(weather.foggy)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[weather.foggy]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                foggy: clampTimeOfDay(
+                                                    nextValue,
+                                                ),
+                                            });
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Oluja"
+                                    label={`Oluja ${formatPercent(weather.thundery ?? 0)}`}
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[weather.thundery ?? 0]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                thundery:
+                                                    clampTimeOfDay(nextValue),
+                                            });
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Vjetar"
+                                    label={`Vjetar ${Math.round(weather.windSpeed ?? 0)}`}
+                                    min={0}
+                                    max={3}
+                                    step={1}
+                                    value={[weather.windSpeed ?? 0]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                windSpeed: Math.min(
+                                                    3,
+                                                    Math.max(0, nextValue),
+                                                ),
+                                            });
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Snježni pokrov"
+                                    label={`Snježni pokrov ${Math.round(weather.snowAccumulation ?? 0)} cm`}
+                                    min={0}
+                                    max={50}
+                                    step={1}
+                                    value={[weather.snowAccumulation ?? 0]}
+                                    onValueChange={([nextValue]) => {
+                                        if (typeof nextValue === 'number') {
+                                            updateWeather({
+                                                snowAccumulation: Math.min(
+                                                    50,
+                                                    Math.max(0, nextValue),
+                                                ),
+                                            });
+                                        }
+                                    }}
+                                />
+                            </Stack>
+                        </Stack>
+                    </Stack>
+                </Popper>
+                <div className="h-4 w-px border-r" />
+                <Popper
+                    side="bottom"
+                    sideOffset={12}
+                    className={popperClassName}
+                    trigger={
+                        <Button
+                            title="Doba dana"
+                            variant="plain"
+                            className="rounded-full px-2 md:pr-2 pr-3"
+                        >
+                            <SunMoon className="size-5" />
+                            <Typography level="body2" className="text-base">
+                                {formatTime(currentTime)}
+                            </Typography>
+                        </Button>
+                    }
+                >
+                    <Stack>
+                        <Row
+                            className="bg-background px-4 py-2"
+                            justifyContent="space-between"
+                        >
+                            <Typography level="body2" bold>
+                                Vrijeme
+                            </Typography>
+                            <Button
+                                aria-label="Vrati na sada"
+                                size="xs"
+                                variant="plain"
+                                color="neutral"
+                                onClick={resetTime}
+                            >
+                                <Reset className="size-4" />
+                            </Button>
+                        </Row>
+                        <Divider />
+                        <Stack spacing={4} className="px-4 py-3">
+                            <SandboxTimeVisualization
+                                timeOfDay={timeOfDay}
+                                onChange={updateTimeOfDay}
+                            />
+                            <Row justifyContent="space-between">
+                                <Typography
+                                    level="body2"
+                                    className={cx(
+                                        'inline-flex items-center gap-1',
+                                        timeOfDay >= 0.2 && timeOfDay <= 0.8
+                                            ? 'text-amber-700 dark:text-amber-300'
+                                            : 'text-blue-700 dark:text-blue-300',
+                                    )}
+                                >
+                                    {timeOfDay >= 0.2 && timeOfDay <= 0.8 ? (
+                                        <Sun className="size-4" />
+                                    ) : (
+                                        <Moon className="size-4" />
+                                    )}
+                                    {formatTime(currentTime)}
+                                </Typography>
+                                <Typography
+                                    level="body2"
+                                    className="inline-flex items-center gap-1 text-muted-foreground"
+                                >
+                                    <Calendar className="size-4" />
+                                    {formatShortDate(currentTime)}
+                                </Typography>
+                            </Row>
+                            <Input
+                                fullWidth
+                                label="Datum"
+                                type="date"
+                                value={formatDateInputValue(currentTime)}
+                                onChange={(event) =>
+                                    updateDate(event.currentTarget.value)
+                                }
+                            />
+                        </Stack>
+                    </Stack>
+                </Popper>
+            </Row>
+        </HudCard>
+    );
+}

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -11,6 +11,7 @@ export {
     PLANT_STAGE_LABELS,
     PLANT_STAGES,
 } from './hud/raisedBed/featuredOperations';
+export { defaultLocalSandboxStorageKey } from './localSandboxGarden';
 export type { GameQualityTier } from './scene/gameQuality';
 export { resolveSpriteAtlasAssetPaths } from './sprites/resolveSpriteAtlasAssetPaths';
 export { SpriteAtlasBillboard } from './sprites/SpriteAtlasBillboard';

--- a/packages/game/src/localSandboxBlockData.ts
+++ b/packages/game/src/localSandboxBlockData.ts
@@ -1,0 +1,107 @@
+import type { BlockData } from '@gredice/client';
+
+const localSandboxBlockNames = [
+    'Raised_Bed',
+    'Bucket',
+    'WateringCan',
+    'Composter',
+    'GardenBox',
+    'ShovelSmall',
+    'PotLowBowl',
+    'PotRoundedBowl',
+    'PotBulbousNeck',
+    'PotTallTapered',
+    'PotHourglass',
+    'PotStraightShortTub',
+    'PotNarrowFootBowl',
+    'PotSquatRidged',
+    'PotTallSlenderCone',
+    'PotWideLippedCup',
+    'StoneSmall',
+    'StoneMedium',
+    'StoneLarge',
+    'DesertStoneSmall',
+    'DesertStoneMedium',
+    'DesertStoneLarge',
+    'BaleHey',
+    'MulchHey',
+    'MulchCoconut',
+    'MulchWood',
+    'Shade',
+    'Stool',
+    'Fence',
+    'WaterWell',
+    'BirdHouse',
+    'FireflyJar',
+    'CatPillow',
+    'Bush',
+    'Tree',
+    'Pine',
+    'DeadTreeTall',
+    'DeadTreeStump',
+    'Tulip',
+    'CactusBarrel',
+    'CactusColumnCluster',
+    'CactusPricklyPear',
+    'Block_Grass',
+    'Block_Ground',
+    'Block_Sand',
+    'Block_Snow',
+    'Block_Water',
+    'Block_Grass_Angle',
+    'Block_Ground_Angle',
+    'Block_Sand_Angle',
+    'Block_Snow_Angle',
+    'Block_Grass_Corner',
+    'Block_Ground_Corner',
+    'Block_Sand_Corner',
+    'Block_Snow_Corner',
+    'Block_Grass_Reverse_Corner',
+    'Block_Ground_Reverse_Corner',
+    'Block_Sand_Reverse_Corner',
+    'Block_Snow_Reverse_Corner',
+] as const;
+
+const createdAt = new Date(0).toISOString();
+
+function createLocalSandboxBlockData(
+    name: (typeof localSandboxBlockNames)[number],
+    index: number,
+): BlockData {
+    const isGroundBlock = name.startsWith('Block_');
+    const isRaisedBed = name === 'Raised_Bed';
+    return {
+        id: index + 1,
+        entityType: {
+            id: 8,
+            name: 'block',
+            label: 'Blok',
+        },
+        slug: name.toLowerCase().replaceAll('_', '-'),
+        information: {
+            name,
+            label: name.replaceAll('_', ' '),
+            shortDescription: '',
+            fullDescription: '',
+        },
+        attributes: {
+            height: isGroundBlock ? 1 : 0.8,
+            stackable: isGroundBlock,
+            type: isRaisedBed ? 'raisedBed' : 'decoration',
+            nightOnlyPurchase: false,
+        },
+        prices: {
+            sunflowers: 0,
+        },
+        functions: {
+            recycler: false,
+            raisedBed: isRaisedBed,
+        },
+        createdAt,
+        updatedAt: createdAt,
+    };
+}
+
+export function getLocalSandboxBlockData(): BlockData[] {
+    return localSandboxBlockNames.map(createLocalSandboxBlockData);
+}

--- a/packages/game/src/localSandboxBlockData.ts
+++ b/packages/game/src/localSandboxBlockData.ts
@@ -62,10 +62,38 @@ const localSandboxBlockNames = [
     'Block_Snow_Reverse_Corner',
 ] as const;
 
+type LocalSandboxBlockName = (typeof localSandboxBlockNames)[number];
+
 const createdAt = new Date(0).toISOString();
 
+const localSandboxStackHeights: Partial<Record<LocalSandboxBlockName, number>> =
+    {
+        Block_Grass: 0.4,
+        Block_Ground: 0.4,
+        Block_Sand: 0.4,
+        Block_Snow: 0.4,
+        Block_Water: 0.4,
+        Block_Grass_Angle: 0.25,
+        Block_Ground_Angle: 0.25,
+        Block_Sand_Angle: 0.25,
+        Block_Snow_Angle: 0.4,
+        Block_Grass_Corner: 0.25,
+        Block_Ground_Corner: 0.25,
+        Block_Sand_Corner: 0.25,
+        Block_Snow_Corner: 0.4,
+        Block_Grass_Reverse_Corner: 0.25,
+        Block_Ground_Reverse_Corner: 0.25,
+        Block_Sand_Reverse_Corner: 0.25,
+        Block_Snow_Reverse_Corner: 0.4,
+        Raised_Bed: 0.35,
+    };
+
+function getLocalSandboxStackHeight(name: LocalSandboxBlockName) {
+    return localSandboxStackHeights[name] ?? 0.8;
+}
+
 function createLocalSandboxBlockData(
-    name: (typeof localSandboxBlockNames)[number],
+    name: LocalSandboxBlockName,
     index: number,
 ): BlockData {
     const isGroundBlock = name.startsWith('Block_');
@@ -85,7 +113,7 @@ function createLocalSandboxBlockData(
             fullDescription: '',
         },
         attributes: {
-            height: isGroundBlock ? 1 : 0.8,
+            height: getLocalSandboxStackHeight(name),
             stackable: isGroundBlock,
             type: isRaisedBed ? 'raisedBed' : 'decoration',
             nightOnlyPurchase: false,

--- a/packages/game/src/localSandboxBlockData.unit.ts
+++ b/packages/game/src/localSandboxBlockData.unit.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getLocalSandboxBlockData } from './localSandboxBlockData';
+
+test('local sandbox grass block data uses the rendered surface height', () => {
+    const blockData = getLocalSandboxBlockData();
+    const grass = blockData.find(
+        (block) => block.information.name === 'Block_Grass',
+    );
+
+    assert.equal(grass?.attributes.height, 0.4);
+    assert.equal(grass?.attributes.stackable, true);
+});

--- a/packages/game/src/localSandboxGarden.ts
+++ b/packages/game/src/localSandboxGarden.ts
@@ -1,0 +1,194 @@
+import { Vector3 } from 'three';
+import type { Block } from './types/Block';
+import type { Stack } from './types/Stack';
+
+export const localSandboxGardenId = 0;
+export const defaultLocalSandboxStorageKey = 'gredice.debug.sandbox.garden.v1';
+
+export type LocalSandboxGarden = {
+    id: number;
+    name: string;
+    isSandbox: true;
+    stacks: Stack[];
+    location: {
+        lat: number;
+        lon: number;
+    };
+    raisedBeds: [];
+};
+
+type StoredLocalSandboxGarden = {
+    stacks?: Array<{
+        position?: {
+            x?: unknown;
+            z?: unknown;
+        };
+        blocks?: unknown;
+    }>;
+};
+
+function createDefaultLocalSandboxStacks(): Stack[] {
+    const stacks: Stack[] = [];
+
+    for (let x = -2; x <= 2; x += 1) {
+        for (let z = -2; z <= 2; z += 1) {
+            stacks.push({
+                position: new Vector3(x, 0, z),
+                blocks: [
+                    {
+                        id: `local-ground:${x}:${z}`,
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                ],
+            });
+        }
+    }
+
+    return stacks;
+}
+
+export function createDefaultLocalSandboxGarden(): LocalSandboxGarden {
+    return {
+        id: localSandboxGardenId,
+        name: 'Debug sandbox',
+        isSandbox: true,
+        stacks: createDefaultLocalSandboxStacks(),
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [],
+    };
+}
+
+function isStoredBlock(value: unknown): value is Partial<Block> {
+    return typeof value === 'object' && value !== null;
+}
+
+function normalizeStoredBlocks(blocks: unknown): Block[] {
+    if (!Array.isArray(blocks)) {
+        return [];
+    }
+
+    return blocks.flatMap((candidate) => {
+        if (!isStoredBlock(candidate)) {
+            return [];
+        }
+
+        if (
+            typeof candidate.id !== 'string' ||
+            typeof candidate.name !== 'string'
+        ) {
+            return [];
+        }
+
+        return [
+            {
+                id: candidate.id,
+                name: candidate.name,
+                rotation:
+                    typeof candidate.rotation === 'number'
+                        ? candidate.rotation
+                        : 0,
+                variant:
+                    typeof candidate.variant === 'number' ||
+                    candidate.variant === null
+                        ? candidate.variant
+                        : undefined,
+            },
+        ];
+    });
+}
+
+function normalizeStoredGarden(
+    storedGarden: StoredLocalSandboxGarden,
+): LocalSandboxGarden {
+    const stacks =
+        storedGarden.stacks?.flatMap((stack) => {
+            const x = stack.position?.x;
+            const z = stack.position?.z;
+            if (typeof x !== 'number' || typeof z !== 'number') {
+                return [];
+            }
+
+            return [
+                {
+                    position: new Vector3(x, 0, z),
+                    blocks: normalizeStoredBlocks(stack.blocks),
+                },
+            ];
+        }) ?? [];
+
+    return {
+        ...createDefaultLocalSandboxGarden(),
+        stacks: stacks.length > 0 ? stacks : createDefaultLocalSandboxStacks(),
+    };
+}
+
+export function loadLocalSandboxGarden(storageKey: string): LocalSandboxGarden {
+    if (typeof window === 'undefined') {
+        return createDefaultLocalSandboxGarden();
+    }
+
+    try {
+        const storedValue = window.localStorage.getItem(storageKey);
+        if (!storedValue) {
+            return createDefaultLocalSandboxGarden();
+        }
+
+        return normalizeStoredGarden(
+            JSON.parse(storedValue) as StoredLocalSandboxGarden,
+        );
+    } catch (error) {
+        console.warn('Failed to load local sandbox garden', error);
+        return createDefaultLocalSandboxGarden();
+    }
+}
+
+export function persistLocalSandboxGarden(
+    storageKey: string,
+    garden: Pick<LocalSandboxGarden, 'stacks'>,
+) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    const storedGarden: StoredLocalSandboxGarden = {
+        stacks: garden.stacks.map((stack) => ({
+            position: {
+                x: stack.position.x,
+                z: stack.position.z,
+            },
+            blocks: stack.blocks.map((block) => ({
+                id: block.id,
+                name: block.name,
+                rotation: block.rotation,
+                variant: block.variant,
+            })),
+        })),
+    };
+
+    try {
+        window.localStorage.setItem(storageKey, JSON.stringify(storedGarden));
+    } catch (error) {
+        console.warn('Failed to persist local sandbox garden', error);
+    }
+}
+
+export function resetLocalSandboxGarden(storageKey: string) {
+    if (typeof window === 'undefined') {
+        return createDefaultLocalSandboxGarden();
+    }
+
+    try {
+        window.localStorage.removeItem(storageKey);
+    } catch (error) {
+        console.warn('Failed to reset local sandbox garden', error);
+    }
+
+    return createDefaultLocalSandboxGarden();
+}
+
+export function createLocalSandboxBlockId(blockName: string) {
+    const timestamp = Date.now().toString(36);
+    const randomSuffix = Math.random().toString(36).slice(2);
+    return `local-block:${blockName}:${timestamp}:${randomSuffix}`;
+}

--- a/packages/game/src/localSandboxGarden.unit.ts
+++ b/packages/game/src/localSandboxGarden.unit.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Vector3 } from 'three';
+import {
+    createDefaultLocalSandboxGarden,
+    createLocalSandboxBlockId,
+    loadLocalSandboxGarden,
+    persistLocalSandboxGarden,
+} from './localSandboxGarden';
+
+function withLocalStorage(testFn: () => void) {
+    const storage = new Map<string, string>();
+    const originalWindow = Object.getOwnPropertyDescriptor(
+        globalThis,
+        'window',
+    );
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            localStorage: {
+                getItem: (key: string) => storage.get(key) ?? null,
+                removeItem: (key: string) => storage.delete(key),
+                setItem: (key: string, value: string) => {
+                    storage.set(key, value);
+                },
+            },
+        },
+    });
+
+    try {
+        testFn();
+    } finally {
+        if (originalWindow) {
+            Object.defineProperty(globalThis, 'window', originalWindow);
+        } else {
+            Reflect.deleteProperty(globalThis, 'window');
+        }
+    }
+}
+
+test('persists local sandbox stacks in local storage', () => {
+    withLocalStorage(() => {
+        const garden = createDefaultLocalSandboxGarden();
+        const nextGarden = {
+            ...garden,
+            stacks: [
+                {
+                    position: new Vector3(3, 0, -1),
+                    blocks: [
+                        {
+                            id: createLocalSandboxBlockId('Tree'),
+                            name: 'Tree',
+                            rotation: 2,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        persistLocalSandboxGarden('test-local-sandbox', nextGarden);
+        const loadedGarden = loadLocalSandboxGarden('test-local-sandbox');
+
+        assert.equal(loadedGarden.isSandbox, true);
+        assert.equal(loadedGarden.stacks.length, 1);
+        assert.equal(loadedGarden.stacks[0]?.position.x, 3);
+        assert.equal(loadedGarden.stacks[0]?.position.z, -1);
+        assert.equal(loadedGarden.stacks[0]?.blocks[0]?.name, 'Tree');
+        assert.equal(loadedGarden.stacks[0]?.blocks[0]?.rotation, 2);
+    });
+});
+
+test('falls back to a playable default local sandbox', () => {
+    const garden = createDefaultLocalSandboxGarden();
+
+    assert.equal(garden.isSandbox, true);
+    assert.equal(garden.raisedBeds.length, 0);
+    assert.ok(garden.stacks.length >= 9);
+    assert.ok(
+        garden.stacks.some((stack) =>
+            stack.blocks.some((block) => block.name === 'Block_Grass'),
+        ),
+    );
+});

--- a/packages/game/src/sandboxBlockTrashDropTarget.ts
+++ b/packages/game/src/sandboxBlockTrashDropTarget.ts
@@ -1,0 +1,24 @@
+export const sandboxBlockTrashDropTargetAttribute =
+    'data-sandbox-block-trash-drop-target';
+
+export const sandboxBlockTrashDropTargetSelector = `[${sandboxBlockTrashDropTargetAttribute}="true"]`;
+
+export function isPointOverSandboxBlockTrashDropTarget(
+    clientX: number,
+    clientY: number,
+) {
+    const target = document.querySelector<HTMLElement>(
+        sandboxBlockTrashDropTargetSelector,
+    );
+    if (!target) {
+        return false;
+    }
+
+    const rect = target.getBoundingClientRect();
+    return (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom
+    );
+}

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -530,7 +530,7 @@ export function Environment({
     }, [garden]);
 
     const gameWeather = useGameState((state) => state.weather);
-    const hasWeatherOverride = Boolean(weather);
+    const hasWeatherOverride = Boolean(weather ?? gameWeather);
     const { data: weatherNow } = useWeatherNow(
         !weatherDisabled && !hasWeatherOverride,
     );
@@ -542,42 +542,32 @@ export function Environment({
             return undefined;
         }
 
-        if (weather) {
-            return {
-                ...fallbackWeather,
-                ...weather,
-                windDirection: resolveWindDirection(
-                    weather.windDirection,
-                    fallbackWeather.windDirection,
-                ),
-            };
-        }
-
-        if (!weatherNow) {
-            return undefined;
-        }
-
         if (!overrideWeather) {
+            if (!weatherNow) {
+                return undefined;
+            }
             return weatherNow;
         }
 
-        console.debug('Overriding weather', overrideWeather);
+        const baseWeather = weatherNow ?? fallbackWeather;
 
         return {
-            ...weatherNow,
-            rainy: overrideWeather.rainy ?? weatherNow.rainy,
-            foggy: overrideWeather.foggy ?? weatherNow.foggy,
-            cloudy: overrideWeather.cloudy ?? weatherNow.cloudy,
-            snowy: overrideWeather.snowy ?? weatherNow.snowy,
-            windSpeed: overrideWeather.windSpeed ?? weatherNow.windSpeed,
+            ...baseWeather,
+            rainy: overrideWeather.rainy ?? baseWeather.rainy,
+            foggy: overrideWeather.foggy ?? baseWeather.foggy,
+            cloudy: overrideWeather.cloudy ?? baseWeather.cloudy,
+            snowy: overrideWeather.snowy ?? baseWeather.snowy,
+            thundery: overrideWeather.thundery ?? baseWeather.thundery,
+            windSpeed: overrideWeather.windSpeed ?? baseWeather.windSpeed,
             windDirection: resolveWindDirection(
                 overrideWeather.windDirection,
-                weatherNow.windDirection,
+                baseWeather.windDirection,
             ),
             snowAccumulation:
-                overrideWeather.snowAccumulation ?? weatherNow.snowAccumulation,
+                overrideWeather.snowAccumulation ??
+                baseWeather.snowAccumulation,
         };
-    }, [overrideWeather, weather, weatherDisabled, weatherNow]);
+    }, [overrideWeather, weatherDisabled, weatherNow]);
 
     // Sound management
     const morningAmbient = ambientAudioMixer.useMusic(

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -1,5 +1,4 @@
 import { createContext, useContext, useEffect } from 'react';
-import { getTimes } from 'suncalc';
 import type { OrbitControls } from 'three-stdlib';
 import { createStore, useStore } from 'zustand';
 import { createGameAudio, type GameAudio } from './audio/audioMixer';
@@ -19,77 +18,19 @@ import { defaultWaterColors, type WaterColors } from './scene/waterColors';
 import type { Block } from './types/Block';
 import { getAudioConfig } from './utils/audioConfig';
 import {
-    ALWAYS_DAY_TIME,
     isDayNightCycleDisabled,
     setDayNightCycleDisabled as persistDayNightCycleDisabled,
 } from './utils/dayNightCycle';
 import { triggerSelectionHaptic } from './utils/haptics';
 import {
+    defaultGameLocation,
+    getGameSunriseSunset,
+    resolveGameTimeOfDay,
+} from './utils/timeOfDay';
+import {
     isWeatherVisualizationDisabled,
     setWeatherVisualizationDisabled as persistWeatherVisualizationDisabled,
 } from './utils/weather';
-
-const sunriseValue = 0.2;
-const sunsetValue = 0.8;
-function getSunriseSunset(
-    { lat, lon }: { lat: number; lon: number },
-    currentTime: Date,
-) {
-    const { sunrise: sunriseStart, sunset: sunsetStart } = getTimes(
-        currentTime,
-        lat,
-        lon,
-    );
-    return { sunrise: sunriseStart, sunset: sunsetStart };
-}
-
-/**
- * Get the current time of day based on the current date and location
- *
- * Uses suncalc to get `sunrise` and sunset times and map them to 0-1 range
- *
- * 0.2 - 0.8 is daytime (sunrise start to sunset start)
- *
- * @returns A number between 0 and 1 representing the current time of day
- */
-function getTimeOfDay(
-    { lat, lon }: { lat: number; lon: number },
-    currentTime: Date,
-) {
-    const { sunrise: sunriseStart, sunset: sunsetStart } = getSunriseSunset(
-        { lat, lon },
-        currentTime,
-    );
-
-    const sunrise = sunriseStart.getHours() * 60 + sunriseStart.getMinutes();
-    const sunset = sunsetStart.getHours() * 60 + sunsetStart.getMinutes();
-
-    // 00 - 0
-    // example: 7:00 - 0.2 (sunriseValue)
-    // example: 19:00 - 0.8 (sunsetValue)
-    // 23:59 - 1
-    const time = currentTime.getHours() * 60 + currentTime.getMinutes();
-    if (time < sunrise) {
-        return (time / sunrise) * sunriseValue;
-    } else if (time < sunset) {
-        return (
-            sunriseValue +
-            ((time - sunrise) / (sunset - sunrise)) *
-                (sunsetValue - sunriseValue)
-        );
-    } else {
-        return (
-            sunsetValue +
-            ((time - sunset) / (24 * 60 - sunset)) * (1 - sunsetValue)
-        );
-    }
-}
-
-function resolveTimeOfDay(currentTime: Date, dayNightCycleDisabled: boolean) {
-    return dayNightCycleDisabled
-        ? ALWAYS_DAY_TIME
-        : getTimeOfDay(defaultLocation, currentTime);
-}
 
 export type WinterMode = 'summer' | 'winter' | 'holiday';
 
@@ -147,6 +88,7 @@ export type GameState = {
     appBaseUrl: string;
     spriteBaseUrl: string;
     audio: GameAudio;
+    localSandboxStorageKey: string | null;
     freezeTime?: Date | null;
     setFreezeTime: (freezeTime: Date | null) => void;
     dayNightCycleDisabled: boolean;
@@ -168,6 +110,8 @@ export type GameState = {
     setStationaryPickupOutlineTarget: (
         target: ActiveDragPreviewTarget | null,
     ) => void;
+    sandboxBlockTrashDropTargetActive: boolean;
+    setSandboxBlockTrashDropTargetActive: (active: boolean) => void;
     activeDragPreview: ActiveDragPreview | null;
     setActiveDragPreview: (dragPreview: ActiveDragPreview | null) => void;
     openGardenBoxBlockId: string | null;
@@ -237,14 +181,13 @@ export type GameState = {
     setIsDragging: (isDragging: boolean) => void;
 };
 
-const defaultLocation = { lat: 45.739, lon: 16.572 };
-
 export function createGameState({
     appBaseUrl,
     spriteBaseUrl,
     dayNightCycleDisabled: initialDayNightCycleDisabled,
     freezeTime,
     isMock,
+    localSandboxStorageKey,
     winterMode,
 }: {
     appBaseUrl: string;
@@ -252,6 +195,7 @@ export function createGameState({
     dayNightCycleDisabled?: boolean;
     freezeTime: Date | null;
     isMock: boolean;
+    localSandboxStorageKey?: string;
     winterMode?: WinterMode;
 }) {
     const dayNightCycleDisabled =
@@ -260,8 +204,8 @@ export function createGameState({
     const gameQualitySetting = getGameQualitySetting();
     const weatherVisualizationDisabled = isWeatherVisualizationDisabled();
     const now = freezeTime ?? new Date();
-    const timeOfDay = resolveTimeOfDay(now, dayNightCycleDisabled);
-    const { sunrise, sunset } = getSunriseSunset(defaultLocation, now);
+    const timeOfDay = resolveGameTimeOfDay(now, dayNightCycleDisabled);
+    const { sunrise, sunset } = getGameSunriseSunset(defaultGameLocation, now);
     return createStore<GameState>((set, get) => ({
         isMock: isMock,
         winterMode: winterMode ?? 'summer',
@@ -269,16 +213,17 @@ export function createGameState({
         appBaseUrl: appBaseUrl,
         spriteBaseUrl: spriteBaseUrl ?? appBaseUrl,
         audio: createGameAudio(getAudioConfig()),
+        localSandboxStorageKey: localSandboxStorageKey ?? null,
         freezeTime,
         setFreezeTime: (freezeTime) => {
             const referenceTime = freezeTime ?? new Date();
-            const { sunrise, sunset } = getSunriseSunset(
-                defaultLocation,
+            const { sunrise, sunset } = getGameSunriseSunset(
+                defaultGameLocation,
                 referenceTime,
             );
             set({
                 freezeTime,
-                timeOfDay: resolveTimeOfDay(
+                timeOfDay: resolveGameTimeOfDay(
                     referenceTime,
                     get().dayNightCycleDisabled,
                 ),
@@ -291,7 +236,7 @@ export function createGameState({
             persistDayNightCycleDisabled(disabled);
             set({
                 dayNightCycleDisabled: disabled,
-                timeOfDay: resolveTimeOfDay(
+                timeOfDay: resolveGameTimeOfDay(
                     get().freezeTime ?? new Date(),
                     disabled,
                 ),
@@ -328,6 +273,10 @@ export function createGameState({
         stationaryPickupOutlineTarget: null,
         setStationaryPickupOutlineTarget: (stationaryPickupOutlineTarget) =>
             set({ stationaryPickupOutlineTarget }),
+        sandboxBlockTrashDropTargetActive: false,
+        setSandboxBlockTrashDropTargetActive: (
+            sandboxBlockTrashDropTargetActive,
+        ) => set({ sandboxBlockTrashDropTargetActive }),
         activeDragPreview: null,
         setActiveDragPreview: (activeDragPreview) => set({ activeDragPreview }),
         openGardenBoxBlockId: null,

--- a/packages/game/src/utils/timeOfDay.ts
+++ b/packages/game/src/utils/timeOfDay.ts
@@ -1,0 +1,114 @@
+import { getTimes } from 'suncalc';
+import { ALWAYS_DAY_TIME } from './dayNightCycle';
+
+const sunriseValue = 0.2;
+const sunsetValue = 0.8;
+const minutesPerDay = 24 * 60;
+
+export const defaultGameLocation = { lat: 45.739, lon: 16.572 };
+
+export type GameLocation = {
+    lat: number;
+    lon: number;
+};
+
+export function clampTimeOfDay(timeOfDay: number) {
+    return Math.min(1, Math.max(0, timeOfDay));
+}
+
+function dateToMinutes(date: Date) {
+    return date.getHours() * 60 + date.getMinutes();
+}
+
+export function getGameSunriseSunset(
+    { lat, lon }: GameLocation,
+    currentTime: Date,
+) {
+    const { sunrise, sunset } = getTimes(currentTime, lat, lon);
+    return { sunrise, sunset };
+}
+
+/**
+ * Get the current time of day based on the current date and location.
+ *
+ * Uses suncalc sunrise/sunset times and maps them to the stylized 0-1 game
+ * range where 0.2 is sunrise and 0.8 is sunset.
+ */
+export function getGameTimeOfDay(location: GameLocation, currentTime: Date) {
+    const { sunrise: sunriseStart, sunset: sunsetStart } = getGameSunriseSunset(
+        location,
+        currentTime,
+    );
+
+    const sunrise = dateToMinutes(sunriseStart);
+    const sunset = dateToMinutes(sunsetStart);
+    const time = dateToMinutes(currentTime);
+
+    if (time < sunrise) {
+        return sunrise > 0 ? (time / sunrise) * sunriseValue : 0;
+    }
+
+    if (time < sunset) {
+        return (
+            sunriseValue +
+            ((time - sunrise) / (sunset - sunrise)) *
+                (sunsetValue - sunriseValue)
+        );
+    }
+
+    return (
+        sunsetValue +
+        ((time - sunset) / (minutesPerDay - sunset)) * (1 - sunsetValue)
+    );
+}
+
+export function resolveGameTimeOfDay(
+    currentTime: Date,
+    dayNightCycleDisabled: boolean,
+) {
+    return dayNightCycleDisabled
+        ? ALWAYS_DAY_TIME
+        : getGameTimeOfDay(defaultGameLocation, currentTime);
+}
+
+export function createDateForGameTimeOfDay(
+    currentDate: Date,
+    timeOfDay: number,
+    location: GameLocation = defaultGameLocation,
+) {
+    const clampedTimeOfDay = clampTimeOfDay(timeOfDay);
+    const nextDate = new Date(currentDate);
+    const { sunrise, sunset } = getGameSunriseSunset(location, nextDate);
+    const sunriseMinutes = dateToMinutes(sunrise);
+    const sunsetMinutes = dateToMinutes(sunset);
+
+    let minutes: number;
+    if (clampedTimeOfDay < sunriseValue) {
+        minutes =
+            sunriseMinutes > 0
+                ? (clampedTimeOfDay / sunriseValue) * sunriseMinutes
+                : 0;
+    } else if (clampedTimeOfDay < sunsetValue) {
+        minutes =
+            sunriseMinutes +
+            ((clampedTimeOfDay - sunriseValue) / (sunsetValue - sunriseValue)) *
+                (sunsetMinutes - sunriseMinutes);
+    } else {
+        minutes =
+            sunsetMinutes +
+            ((clampedTimeOfDay - sunsetValue) / (1 - sunsetValue)) *
+                (minutesPerDay - sunsetMinutes);
+    }
+
+    const clampedMinutes = Math.min(
+        minutesPerDay - 1,
+        Math.max(0, Math.round(minutes)),
+    );
+    nextDate.setHours(
+        Math.floor(clampedMinutes / 60),
+        clampedMinutes % 60,
+        0,
+        0,
+    );
+    return nextDate;
+}

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -1,6 +1,16 @@
 import 'server-only';
 import { plantFieldStatusLabel } from '@gredice/js/plants';
-import { and, asc, count, desc, eq, inArray, isNull, or } from 'drizzle-orm';
+import {
+    and,
+    asc,
+    count,
+    desc,
+    eq,
+    inArray,
+    isNull,
+    like,
+    or,
+} from 'drizzle-orm';
 import { v4 as uuidV4 } from 'uuid';
 import { getEntitiesFormatted, getOperations, storage } from '..';
 import type { EntityStandardized } from '../@types/EntityStandardized';
@@ -24,6 +34,7 @@ import {
     type RaisedBedOrientation,
     raisedBeds,
     shoppingCartItems,
+    transactions,
     type UpdateGarden,
     type UpdateGardenBlock,
     type UpdateGardenStack,
@@ -56,6 +67,17 @@ const PLANT_CYCLE_EVENT_TYPES = [
     knownEventTypes.raisedBedFields.plantUpdate,
     knownEventTypes.raisedBedFields.plantReplaceSort,
 ] as const;
+const GARDEN_EVENT_TYPES = Object.values(knownEventTypes.gardens);
+const RAISED_BED_EVENT_TYPES = Object.values(knownEventTypes.raisedBeds);
+const SANDBOX_RAISED_BED_FIELD_EVENT_TYPES = Object.values(
+    knownEventTypes.raisedBedFields,
+);
+const OPERATION_EVENT_TYPES = Object.values(knownEventTypes.operations);
+const INVENTORY_EVENT_TYPES = Object.values(knownEventTypes.inventory);
+const DEFAULT_SANDBOX_GARDEN_DELETE_BATCH_SIZE = 500;
+const DEFAULT_SANDBOX_GARDEN_DELETE_MAX_BATCHES = 40;
+const DEFAULT_SANDBOX_GARDEN_DELETE_MAX_DURATION_MS = 8_000;
+const INVENTORY_PREFIX = 'inventory:';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -110,6 +132,18 @@ export type RaisedBedFieldAssignableFarmUser = AssignableFarmUser;
 export type GardenAssignableFarmUser = AssignableFarmUser;
 
 export type UniqueGardenAssignableFarmUser = Omit<AssignableFarmUser, 'farmId'>;
+
+export type DeleteSandboxGardenCompletelyOptions = {
+    batchSize?: number;
+    maxBatches?: number;
+    maxDurationMs?: number;
+};
+
+export type DeleteSandboxGardenCompletelyResult = {
+    complete: boolean;
+    batches: number;
+    deletedRows: number;
+};
 
 type FarmAssignableUserRow = {
     farmId: number;
@@ -1123,6 +1157,674 @@ export async function clearSandboxField(
     await deleteRaisedBedField(raisedBedId, positionIndex);
     await deleteRaisedBedFieldEvents(`${raisedBedId}|${positionIndex}`);
     await bustScheduleCache();
+}
+
+function normalizeSandboxGardenDeleteBatchSize(batchSize?: number) {
+    return Math.max(
+        1,
+        Math.floor(batchSize ?? DEFAULT_SANDBOX_GARDEN_DELETE_BATCH_SIZE),
+    );
+}
+
+async function getSandboxRaisedBedIds(gardenId: number, batchSize: number) {
+    const rows = await storage()
+        .select({ id: raisedBeds.id })
+        .from(raisedBeds)
+        .where(eq(raisedBeds.gardenId, gardenId))
+        .limit(batchSize);
+    return rows.map((row) => row.id);
+}
+
+async function getSandboxRaisedBedFieldIds(
+    raisedBedIds: number[],
+    batchSize: number,
+) {
+    if (raisedBedIds.length === 0) {
+        return [];
+    }
+
+    const rows = await storage()
+        .select({ id: raisedBedFields.id })
+        .from(raisedBedFields)
+        .where(inArray(raisedBedFields.raisedBedId, raisedBedIds))
+        .limit(batchSize);
+    return rows.map((row) => row.id);
+}
+
+async function getSandboxGardenBlockIds(gardenId: number, batchSize: number) {
+    const rows = await storage()
+        .select({ id: gardenBlocks.id })
+        .from(gardenBlocks)
+        .where(eq(gardenBlocks.gardenId, gardenId))
+        .limit(batchSize);
+    return rows.map((row) => row.id);
+}
+
+async function deleteSandboxNotificationBatch({
+    batchSize,
+    blockIds,
+    gardenId,
+    raisedBedIds,
+}: {
+    batchSize: number;
+    blockIds: string[];
+    gardenId: number;
+    raisedBedIds: number[];
+}) {
+    const byGarden = await storage()
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(eq(notifications.gardenId, gardenId))
+        .limit(batchSize);
+    if (byGarden.length > 0) {
+        await storage()
+            .delete(notifications)
+            .where(
+                inArray(
+                    notifications.id,
+                    byGarden.map((row) => row.id),
+                ),
+            );
+        return byGarden.length;
+    }
+
+    if (raisedBedIds.length > 0) {
+        const byRaisedBed = await storage()
+            .select({ id: notifications.id })
+            .from(notifications)
+            .where(inArray(notifications.raisedBedId, raisedBedIds))
+            .limit(batchSize);
+        if (byRaisedBed.length > 0) {
+            await storage()
+                .delete(notifications)
+                .where(
+                    inArray(
+                        notifications.id,
+                        byRaisedBed.map((row) => row.id),
+                    ),
+                );
+            return byRaisedBed.length;
+        }
+    }
+
+    if (blockIds.length > 0) {
+        const byBlock = await storage()
+            .select({ id: notifications.id })
+            .from(notifications)
+            .where(inArray(notifications.blockId, blockIds))
+            .limit(batchSize);
+        if (byBlock.length > 0) {
+            await storage()
+                .delete(notifications)
+                .where(
+                    inArray(
+                        notifications.id,
+                        byBlock.map((row) => row.id),
+                    ),
+                );
+            return byBlock.length;
+        }
+    }
+
+    return 0;
+}
+
+async function deleteSandboxShoppingCartItemBatch({
+    batchSize,
+    gardenId,
+    raisedBedIds,
+}: {
+    batchSize: number;
+    gardenId: number;
+    raisedBedIds: number[];
+}) {
+    const byGarden = await storage()
+        .select({ id: shoppingCartItems.id })
+        .from(shoppingCartItems)
+        .where(eq(shoppingCartItems.gardenId, gardenId))
+        .limit(batchSize);
+    if (byGarden.length > 0) {
+        await storage()
+            .delete(shoppingCartItems)
+            .where(
+                inArray(
+                    shoppingCartItems.id,
+                    byGarden.map((row) => row.id),
+                ),
+            );
+        return byGarden.length;
+    }
+
+    if (raisedBedIds.length === 0) {
+        return 0;
+    }
+
+    const byRaisedBed = await storage()
+        .select({ id: shoppingCartItems.id })
+        .from(shoppingCartItems)
+        .where(inArray(shoppingCartItems.raisedBedId, raisedBedIds))
+        .limit(batchSize);
+    if (byRaisedBed.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(shoppingCartItems)
+        .where(
+            inArray(
+                shoppingCartItems.id,
+                byRaisedBed.map((row) => row.id),
+            ),
+        );
+    return byRaisedBed.length;
+}
+
+async function deleteSandboxTransactionBatch(
+    gardenId: number,
+    batchSize: number,
+) {
+    const rows = await storage()
+        .select({ id: transactions.id })
+        .from(transactions)
+        .where(eq(transactions.gardenId, gardenId))
+        .limit(batchSize);
+    if (rows.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(transactions)
+        .where(
+            inArray(
+                transactions.id,
+                rows.map((row) => row.id),
+            ),
+        );
+    return rows.length;
+}
+
+async function deleteEventRowsByIds(eventIds: number[]) {
+    if (eventIds.length === 0) {
+        return 0;
+    }
+
+    await storage().delete(events).where(inArray(events.id, eventIds));
+    return eventIds.length;
+}
+
+async function deleteSandboxOperationBatch({
+    batchSize,
+    fieldIds,
+    gardenId,
+    raisedBedIds,
+}: {
+    batchSize: number;
+    fieldIds: number[];
+    gardenId: number;
+    raisedBedIds: number[];
+}) {
+    const operationRows =
+        raisedBedIds.length > 0 && fieldIds.length > 0
+            ? await storage()
+                  .select({ id: operations.id })
+                  .from(operations)
+                  .where(
+                      or(
+                          eq(operations.gardenId, gardenId),
+                          inArray(operations.raisedBedId, raisedBedIds),
+                          inArray(operations.raisedBedFieldId, fieldIds),
+                      ),
+                  )
+                  .limit(batchSize)
+            : raisedBedIds.length > 0
+              ? await storage()
+                    .select({ id: operations.id })
+                    .from(operations)
+                    .where(
+                        or(
+                            eq(operations.gardenId, gardenId),
+                            inArray(operations.raisedBedId, raisedBedIds),
+                        ),
+                    )
+                    .limit(batchSize)
+              : await storage()
+                    .select({ id: operations.id })
+                    .from(operations)
+                    .where(eq(operations.gardenId, gardenId))
+                    .limit(batchSize);
+
+    if (operationRows.length <= 0) {
+        return 0;
+    }
+
+    const operationAggregateIds = operationRows.map((row) => row.id.toString());
+    const operationEventRows = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            and(
+                inArray(events.type, OPERATION_EVENT_TYPES),
+                inArray(events.aggregateId, operationAggregateIds),
+            ),
+        )
+        .limit(batchSize);
+    if (operationEventRows.length > 0) {
+        return deleteEventRowsByIds(operationEventRows.map((row) => row.id));
+    }
+
+    await storage()
+        .delete(operations)
+        .where(
+            inArray(
+                operations.id,
+                operationRows.map((row) => row.id),
+            ),
+        );
+    return operationRows.length;
+}
+
+async function deleteSandboxInventoryEventBatch({
+    accountId,
+    batchSize,
+    gardenId,
+}: {
+    accountId: string;
+    batchSize: number;
+    gardenId: number;
+}) {
+    const rows = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            and(
+                inArray(events.type, INVENTORY_EVENT_TYPES),
+                like(
+                    events.aggregateId,
+                    `${INVENTORY_PREFIX}${accountId}:gardenBox:${gardenId.toString()}:%`,
+                ),
+            ),
+        )
+        .limit(batchSize);
+    return deleteEventRowsByIds(rows.map((row) => row.id));
+}
+
+async function deleteSandboxRaisedBedFieldEventBatch(
+    raisedBedIds: number[],
+    batchSize: number,
+) {
+    if (raisedBedIds.length === 0) {
+        return 0;
+    }
+
+    const raisedBedFieldEventRows = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            and(
+                inArray(events.type, SANDBOX_RAISED_BED_FIELD_EVENT_TYPES),
+                or(
+                    ...raisedBedIds.map((raisedBedId) =>
+                        like(events.aggregateId, `${raisedBedId.toString()}|%`),
+                    ),
+                ),
+            ),
+        )
+        .limit(batchSize);
+    return deleteEventRowsByIds(raisedBedFieldEventRows.map((row) => row.id));
+}
+
+async function deleteSandboxRaisedBedEventBatch(
+    raisedBedIds: number[],
+    batchSize: number,
+) {
+    if (raisedBedIds.length === 0) {
+        return 0;
+    }
+
+    const rows = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            and(
+                inArray(events.type, RAISED_BED_EVENT_TYPES),
+                inArray(
+                    events.aggregateId,
+                    raisedBedIds.map((raisedBedId) => raisedBedId.toString()),
+                ),
+            ),
+        )
+        .limit(batchSize);
+    return deleteEventRowsByIds(rows.map((row) => row.id));
+}
+
+async function deleteSandboxGardenEventBatch(
+    gardenId: number,
+    batchSize: number,
+) {
+    const rows = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            and(
+                inArray(events.type, GARDEN_EVENT_TYPES),
+                eq(events.aggregateId, gardenId.toString()),
+            ),
+        )
+        .limit(batchSize);
+    return deleteEventRowsByIds(rows.map((row) => row.id));
+}
+
+async function deleteSandboxRaisedBedSensorBatch(
+    raisedBedIds: number[],
+    batchSize: number,
+) {
+    if (raisedBedIds.length === 0) {
+        return 0;
+    }
+
+    const rows = await storage()
+        .select({ id: raisedBedSensors.id })
+        .from(raisedBedSensors)
+        .where(inArray(raisedBedSensors.raisedBedId, raisedBedIds))
+        .limit(batchSize);
+    if (rows.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(raisedBedSensors)
+        .where(
+            inArray(
+                raisedBedSensors.id,
+                rows.map((row) => row.id),
+            ),
+        );
+    return rows.length;
+}
+
+async function deleteSandboxRaisedBedFieldBatch(
+    raisedBedIds: number[],
+    batchSize: number,
+) {
+    if (raisedBedIds.length === 0) {
+        return 0;
+    }
+
+    const rows = await storage()
+        .select({ id: raisedBedFields.id })
+        .from(raisedBedFields)
+        .where(inArray(raisedBedFields.raisedBedId, raisedBedIds))
+        .limit(batchSize);
+    if (rows.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(raisedBedFields)
+        .where(
+            inArray(
+                raisedBedFields.id,
+                rows.map((row) => row.id),
+            ),
+        );
+    return rows.length;
+}
+
+async function deleteSandboxRaisedBedBatch(
+    gardenId: number,
+    batchSize: number,
+) {
+    const rows = await storage()
+        .select({ id: raisedBeds.id })
+        .from(raisedBeds)
+        .where(eq(raisedBeds.gardenId, gardenId))
+        .limit(batchSize);
+    if (rows.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(raisedBeds)
+        .where(
+            inArray(
+                raisedBeds.id,
+                rows.map((row) => row.id),
+            ),
+        );
+    return rows.length;
+}
+
+async function deleteSandboxGardenStackBatch(
+    gardenId: number,
+    batchSize: number,
+) {
+    const rows = await storage()
+        .select({ id: gardenStacks.id })
+        .from(gardenStacks)
+        .where(eq(gardenStacks.gardenId, gardenId))
+        .limit(batchSize);
+    if (rows.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(gardenStacks)
+        .where(
+            inArray(
+                gardenStacks.id,
+                rows.map((row) => row.id),
+            ),
+        );
+    return rows.length;
+}
+
+async function deleteSandboxGardenBlockBatch(
+    gardenId: number,
+    batchSize: number,
+) {
+    const rows = await storage()
+        .select({ id: gardenBlocks.id })
+        .from(gardenBlocks)
+        .where(eq(gardenBlocks.gardenId, gardenId))
+        .limit(batchSize);
+    if (rows.length <= 0) {
+        return 0;
+    }
+
+    await storage()
+        .delete(gardenBlocks)
+        .where(
+            inArray(
+                gardenBlocks.id,
+                rows.map((row) => row.id),
+            ),
+        );
+    return rows.length;
+}
+
+async function deleteNextSandboxGardenDependencyBatch(
+    garden: typeof gardens.$inferSelect,
+    batchSize: number,
+) {
+    const [raisedBedIds, blockIds] = await Promise.all([
+        getSandboxRaisedBedIds(garden.id, batchSize),
+        getSandboxGardenBlockIds(garden.id, batchSize),
+    ]);
+    const fieldIds = await getSandboxRaisedBedFieldIds(raisedBedIds, batchSize);
+
+    const notificationRows = await deleteSandboxNotificationBatch({
+        batchSize,
+        blockIds,
+        gardenId: garden.id,
+        raisedBedIds,
+    });
+    if (notificationRows > 0) {
+        return notificationRows;
+    }
+
+    const cartItemRows = await deleteSandboxShoppingCartItemBatch({
+        batchSize,
+        gardenId: garden.id,
+        raisedBedIds,
+    });
+    if (cartItemRows > 0) {
+        return cartItemRows;
+    }
+
+    const transactionRows = await deleteSandboxTransactionBatch(
+        garden.id,
+        batchSize,
+    );
+    if (transactionRows > 0) {
+        return transactionRows;
+    }
+
+    const operationRows = await deleteSandboxOperationBatch({
+        batchSize,
+        fieldIds,
+        gardenId: garden.id,
+        raisedBedIds,
+    });
+    if (operationRows > 0) {
+        return operationRows;
+    }
+
+    const inventoryEventRows = await deleteSandboxInventoryEventBatch({
+        accountId: garden.accountId,
+        batchSize,
+        gardenId: garden.id,
+    });
+    if (inventoryEventRows > 0) {
+        return inventoryEventRows;
+    }
+
+    const fieldEventRows = await deleteSandboxRaisedBedFieldEventBatch(
+        raisedBedIds,
+        batchSize,
+    );
+    if (fieldEventRows > 0) {
+        return fieldEventRows;
+    }
+
+    const raisedBedEventRows = await deleteSandboxRaisedBedEventBatch(
+        raisedBedIds,
+        batchSize,
+    );
+    if (raisedBedEventRows > 0) {
+        return raisedBedEventRows;
+    }
+
+    const gardenEventRows = await deleteSandboxGardenEventBatch(
+        garden.id,
+        batchSize,
+    );
+    if (gardenEventRows > 0) {
+        return gardenEventRows;
+    }
+
+    const sensorRows = await deleteSandboxRaisedBedSensorBatch(
+        raisedBedIds,
+        batchSize,
+    );
+    if (sensorRows > 0) {
+        return sensorRows;
+    }
+
+    const fieldRows = await deleteSandboxRaisedBedFieldBatch(
+        raisedBedIds,
+        batchSize,
+    );
+    if (fieldRows > 0) {
+        return fieldRows;
+    }
+
+    const raisedBedRows = await deleteSandboxRaisedBedBatch(
+        garden.id,
+        batchSize,
+    );
+    if (raisedBedRows > 0) {
+        return raisedBedRows;
+    }
+
+    const stackRows = await deleteSandboxGardenStackBatch(garden.id, batchSize);
+    if (stackRows > 0) {
+        return stackRows;
+    }
+
+    return deleteSandboxGardenBlockBatch(garden.id, batchSize);
+}
+
+export function getSandboxGardenDeletionCandidate(gardenId: number) {
+    return storage().query.gardens.findFirst({
+        where: eq(gardens.id, gardenId),
+    });
+}
+
+export async function deleteSandboxGardenCompletely(
+    gardenId: number,
+    options: DeleteSandboxGardenCompletelyOptions = {},
+): Promise<DeleteSandboxGardenCompletelyResult> {
+    const garden = await getSandboxGardenDeletionCandidate(gardenId);
+    if (!garden) {
+        return { batches: 0, complete: true, deletedRows: 0 };
+    }
+    if (!garden.isSandbox) {
+        throw new Error('Only sandbox gardens can be deleted completely');
+    }
+
+    const batchSize = normalizeSandboxGardenDeleteBatchSize(options.batchSize);
+    const maxBatches = Math.max(
+        1,
+        Math.floor(
+            options.maxBatches ?? DEFAULT_SANDBOX_GARDEN_DELETE_MAX_BATCHES,
+        ),
+    );
+    const maxDurationMs = Math.max(
+        1,
+        Math.floor(
+            options.maxDurationMs ??
+                DEFAULT_SANDBOX_GARDEN_DELETE_MAX_DURATION_MS,
+        ),
+    );
+    const startedAt = Date.now();
+    let batches = 0;
+    let deletedRows = 0;
+
+    if (!garden.isDeleted) {
+        await storage()
+            .update(gardens)
+            .set({ isDeleted: true })
+            .where(eq(gardens.id, garden.id));
+    }
+
+    while (batches < maxBatches && Date.now() - startedAt < maxDurationMs) {
+        const deletedBatchRows = await deleteNextSandboxGardenDependencyBatch(
+            garden,
+            batchSize,
+        );
+        if (deletedBatchRows === 0) {
+            await storage().delete(gardens).where(eq(gardens.id, garden.id));
+            await bustScheduleCache();
+            return {
+                batches,
+                complete: true,
+                deletedRows,
+            };
+        }
+
+        batches += 1;
+        deletedRows += deletedBatchRows;
+    }
+
+    if (deletedRows > 0) {
+        await bustScheduleCache();
+    }
+
+    return {
+        batches,
+        complete: false,
+        deletedRows,
+    };
 }
 
 export async function getGardens() {

--- a/packages/storage/tests/gardensRepo.sandbox.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.sandbox.node.spec.ts
@@ -3,11 +3,35 @@ import test from 'node:test';
 import {
     clearSandboxField,
     createAccount,
+    createEvent,
+    createGardenStack,
+    createNotification,
+    createOperation,
     createSandboxGarden,
+    deleteSandboxGardenCompletely,
     getGarden,
     getRaisedBedFieldsWithEvents,
+    getSandboxGardenDeletionCandidate,
+    knownEvents,
     sowSandboxField,
+    storage,
+    updateGardenStack,
 } from '@gredice/storage';
+import { and, eq, inArray, like, or } from 'drizzle-orm';
+import {
+    events,
+    gardenBlocks,
+    gardenStacks,
+    gardens,
+    notifications,
+    operations,
+    raisedBedFields,
+    raisedBedSensors,
+    raisedBeds,
+    shoppingCartItems,
+    shoppingCarts,
+    transactions,
+} from '../src/schema';
 import {
     createTestBlock,
     createTestRaisedBed,
@@ -42,6 +66,186 @@ test('createSandboxGarden falls back to a default name', async () => {
     const gardenId = await createSandboxGarden({ accountId });
     const garden = await getGarden(gardenId);
     assert.equal(garden?.name, 'Vrt za igru');
+});
+
+test('deleteSandboxGardenCompletely removes sandbox garden dependencies across retries', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const accountId = await createAccount();
+    const gardenId = await createSandboxGarden({ accountId });
+    const blockId = await createTestBlock(gardenId, 'sandbox-delete-block');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await createGardenStack(gardenId, { x: 0, y: 0 });
+    await updateGardenStack(gardenId, { x: 0, y: 0, blocks: [blockId] });
+    await sowSandboxField({
+        raisedBedId,
+        positionIndex: 4,
+        plantSortId: 337,
+        sowDate: daysAgo(30),
+        status: 'sprouted',
+    });
+    await createEvent(
+        knownEvents.raisedBeds.createdV1(raisedBedId.toString(), {
+            blockId,
+            gardenId,
+        }),
+    );
+    await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+        timestamp: new Date(),
+    });
+    await createNotification(
+        {
+            accountId,
+            blockId,
+            content: 'Sandbox cleanup test',
+            gardenId,
+            header: 'Sandbox cleanup test',
+            raisedBedId,
+            timestamp: new Date(),
+        },
+        { routeDelivery: false },
+    );
+    await storage().insert(raisedBedSensors).values({
+        raisedBedId,
+        sensorSignalcoId: 'sandbox-cleanup-sensor',
+    });
+    const cart = (
+        await storage()
+            .insert(shoppingCarts)
+            .values({ accountId })
+            .returning({ id: shoppingCarts.id })
+    )[0];
+    assert.ok(cart);
+    await storage().insert(shoppingCartItems).values({
+        amount: 1,
+        cartId: cart.id,
+        entityId: '337',
+        entityTypeName: 'plantSort',
+        gardenId,
+        raisedBedId,
+    });
+    await storage().insert(transactions).values({
+        accountId,
+        amount: 1,
+        currency: 'eur',
+        gardenId,
+        status: 'test',
+        stripePaymentId: 'sandbox-cleanup-payment',
+    });
+
+    let complete = false;
+    let attempts = 0;
+    while (!complete) {
+        const result = await deleteSandboxGardenCompletely(gardenId, {
+            batchSize: 1,
+            maxBatches: 1,
+        });
+        complete = result.complete;
+        attempts += 1;
+        assert.ok(attempts < 100, 'cleanup should finish after retries');
+    }
+
+    assert.ok(attempts > 1, 'test should exercise retry continuation');
+    assert.equal(await getGarden(gardenId), null);
+    assert.equal(await getSandboxGardenDeletionCandidate(gardenId), undefined);
+
+    const gardenRows = await storage()
+        .select({ id: gardens.id })
+        .from(gardens)
+        .where(eq(gardens.id, gardenId));
+    assert.equal(gardenRows.length, 0);
+
+    const gardenBlockRows = await storage()
+        .select({ id: gardenBlocks.id })
+        .from(gardenBlocks)
+        .where(eq(gardenBlocks.gardenId, gardenId));
+    assert.equal(gardenBlockRows.length, 0);
+
+    const gardenStackRows = await storage()
+        .select({ id: gardenStacks.id })
+        .from(gardenStacks)
+        .where(eq(gardenStacks.gardenId, gardenId));
+    assert.equal(gardenStackRows.length, 0);
+
+    const raisedBedRows = await storage()
+        .select({ id: raisedBeds.id })
+        .from(raisedBeds)
+        .where(eq(raisedBeds.gardenId, gardenId));
+    assert.equal(raisedBedRows.length, 0);
+
+    const fieldRows = await storage()
+        .select({ id: raisedBedFields.id })
+        .from(raisedBedFields)
+        .where(eq(raisedBedFields.raisedBedId, raisedBedId));
+    assert.equal(fieldRows.length, 0);
+
+    const sensorRows = await storage()
+        .select({ id: raisedBedSensors.id })
+        .from(raisedBedSensors)
+        .where(eq(raisedBedSensors.raisedBedId, raisedBedId));
+    assert.equal(sensorRows.length, 0);
+
+    const cartItemRows = await storage()
+        .select({ id: shoppingCartItems.id })
+        .from(shoppingCartItems)
+        .where(eq(shoppingCartItems.gardenId, gardenId));
+    assert.equal(cartItemRows.length, 0);
+
+    const transactionRows = await storage()
+        .select({ id: transactions.id })
+        .from(transactions)
+        .where(eq(transactions.gardenId, gardenId));
+    assert.equal(transactionRows.length, 0);
+
+    const notificationRows = await storage()
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(
+            or(
+                eq(notifications.gardenId, gardenId),
+                eq(notifications.raisedBedId, raisedBedId),
+                eq(notifications.blockId, blockId),
+            ),
+        );
+    assert.equal(notificationRows.length, 0);
+
+    const operationRows = await storage()
+        .select({ id: operations.id })
+        .from(operations)
+        .where(
+            or(
+                eq(operations.gardenId, gardenId),
+                eq(operations.raisedBedId, raisedBedId),
+            ),
+        );
+    assert.equal(operationRows.length, 0);
+
+    const eventRows = await storage()
+        .select({ id: events.id })
+        .from(events)
+        .where(
+            or(
+                and(
+                    inArray(events.type, [
+                        'garden.create',
+                        'garden.blockPlace',
+                    ]),
+                    eq(events.aggregateId, gardenId.toString()),
+                ),
+                and(
+                    eq(events.type, 'raisedBed.create'),
+                    eq(events.aggregateId, raisedBedId.toString()),
+                ),
+                like(events.aggregateId, `${raisedBedId.toString()}|%`),
+            ),
+        );
+    assert.equal(eventRows.length, 0);
 });
 
 test('sowSandboxField backdates the plant so it renders already grown', async () => {

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -67,6 +67,7 @@ export {
     Hourglass,
     Inbox,
     Info,
+    Joystick,
     KeyRound as Password,
     Landmark as Bank,
     Laptop,


### PR DESCRIPTION
## Summary
- Add `/debug/sandbox` for playing with a garden backed by browser `localStorage` instead of the database.
- Keep sandbox block placement, movement, rotation, and deletion local while preserving the existing HUD and environment controls.
- Update shared game hooks and HUD logic so the local sandbox path avoids live account, weather, and inventory side effects.

## Testing
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test`
- `pnpm lint --filter @gredice/game --filter garden --filter www`
- `pnpm build --filter garden --filter www --force`
- Verified `/debug/sandbox` in the local browser and confirmed the page renders without API proxy errors.