### PR TITLE
Condense repeated docs and AI guidance

### DIFF
--- a/.agents/skills/gredice-api-reference/SKILL.md
+++ b/.agents/skills/gredice-api-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-api-reference
-description: Maintain Gredice API documentation and contracts. Use when changing Hono route docs, describeRoute metadata, OpenAPI generation, Scalar API reference pages, API auth/security schemes, Zod validation schemas, directories API schemas, generated directory types, packages/client API helpers, or any docs under apps/api.
+description: Use for Gredice API docs/contracts: Hono routes, OpenAPI/Scalar, auth/security, validation schemas, generated directory types, and client helpers.
 ---
 
 # Gredice API Reference
@@ -76,16 +76,6 @@ Write API descriptions that help consumers call the endpoint:
 
 ## Validation
 
-Choose the smallest check that covers the change:
-
-```bash
-pnpm --filter api test:node
-pnpm test --filter api
-pnpm build --filter api
-pnpm --filter @gredice/directory-types regenerate
-pnpm lint --filter @gredice/directory-types
-```
-
-For visual API reference changes, start the API app and inspect `https://api.gredice.test/docs/{slug}` or the local test URL defined by `scripts/app-registry.ts`.
+Choose the smallest `api` test/build check that covers the route or docs change. Regenerate and lint `@gredice/directory-types` only when public directory/CMS API docs affect generated contracts. For visual API reference changes, start the API app and inspect the relevant `/docs/{slug}` page.
 
 Only query a live API or database when source code and tests cannot answer whether a documented response matches production data.

--- a/.agents/skills/gredice-cms-page-authoring/SKILL.md
+++ b/.agents/skills/gredice-cms-page-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-cms-page-authoring
-description: Author, review, or implement Gredice CMS page content and CMS page tooling. Use for SectionData JSON, supported CMS page sections, admin CMS page forms, public CMS rendering, slug validation, publish readiness, preview behavior, meta title, meta description, canonical path, noIndex, and CMS page routes in apps/app, apps/www, apps/api, or packages/storage.
+description: Use for Gredice CMS page content/tooling: section JSON, admin/public rendering, slug/publish metadata, preview, and CMS routes/schema.
 ---
 
 # Gredice CMS Page Authoring
@@ -102,19 +102,6 @@ Public metadata uses:
 
 ## Validation
 
-For repository logic changes:
-
-```bash
-pnpm test --filter @gredice/storage
-pnpm test --filter www
-pnpm build --filter www
-pnpm build --filter app
-```
-
-For CMS content JSON only, validate it parses as an array and uses supported components. If editing docs or sample JSON only, run:
-
-```bash
-git diff --check
-```
+For repository logic changes, validate the owning storage, public `www`, and admin `app` surfaces that changed. For CMS content JSON only, verify it parses as an array and uses supported components. Docs or sample JSON only: `git diff --check`.
 
 Query the database only when asked to inspect or modify existing CMS page rows. Prefer source-defined validation for authoring guidance.

--- a/.agents/skills/gredice-docs-auditor/SKILL.md
+++ b/.agents/skills/gredice-docs-auditor/SKILL.md
@@ -1,100 +1,46 @@
 ---
 name: gredice-docs-auditor
-description: Audit, create, or update Gredice repository documentation. Use for README, CONTRIBUTING, AGENTS.md, root guides, docs/*.md, setup docs, command docs, contributor guidance, app/package maps, validation instructions, generated artifact rules, and any change that may make documentation stale against package scripts, app registry, workspace layout, or source behavior.
+description: Use for Gredice repo docs: README, CONTRIBUTING, AGENTS, root guides, docs, setup/commands, app/package maps, validation, generated artifacts.
 ---
 
 # Gredice Docs Auditor
 
-## Overview
-
-Keep Gredice repository documentation accurate to the current monorepo. Prefer concrete paths, package names, commands, and ownership boundaries over generic guidance.
+Keep docs accurate to source. Use exact paths, package names, commands, and ownership boundaries.
 
 ## Source Of Truth
 
-Read the relevant current source before writing or auditing docs:
+- Root guides: `AGENTS.md`, `WORKSPACE.md`, `FRONTEND.md`, `DESIGN.md`, `PRODUCT_SENSE.md`, `QUALITY_SCORE.md`, `RELIABILITY.md`, `SECURITY.md`, `SEO.md`.
+- Repo overview and contributor flow: `README.md`, `CONTRIBUTING.md`.
+- Commands and packages: root/app/package `package.json`, `turbo.json`, `pnpm-workspace.yaml`.
+- Apps, domains, ports, Vercel project names, and default dev stack: `scripts/app-registry.ts`.
+- Focused docs: `docs/*`, package READMEs.
+- Generated asset/schema rules: `WORKSPACE.md`, `RELIABILITY.md`, and scripts under `packages/storage`, `packages/cdn`, `packages/game`, `assets`.
 
-- Root operating guides: `AGENTS.md`, `WORKSPACE.md`, `FRONTEND.md`, `DESIGN.md`, `PRODUCT_SENSE.md`, `QUALITY_SCORE.md`, `RELIABILITY.md`, `SECURITY.md`, `SEO.md`.
-- Contributor guide and repo overview: `README.md`, `CONTRIBUTING.md`.
-- Package manager and scripts: root `package.json`, app/package `package.json`, `turbo.json`, `pnpm-workspace.yaml`.
-- App names, local domains, ports, Vercel project names, and default dev stack: `scripts/app-registry.ts`.
-- Existing focused docs: `docs/notification-workflows.md`, `docs/game-scene-performance.md`, package README files.
-- Generated asset and schema rules: `WORKSPACE.md`, `RELIABILITY.md`, package scripts under `packages/storage`, `packages/cdn`, `packages/game`, and app scripts.
+Use `rg`/`rg --files` first and confirm paths exist.
 
-Use `rg` and `rg --files` first. Confirm paths exist before documenting them.
+## Workflow
 
-## Audit Workflow
+1. Identify scope: setup, app map, contributor process, API, public content, reliability, security, generated assets, or workflow behavior.
+2. Read the closest doc and owning source before editing.
+3. Check names, commands, paths, app domains, and validation instructions against source.
+4. Remove stale or repeated guidance instead of layering new text over it.
+5. Keep docs scoped and repo-specific.
 
-1. Identify the doc scope: setup, app map, contributor process, API, public content, reliability, security, generated assets, or workflow behavior.
-2. Read the closest existing docs and the owning source files. Do not update a broad guide from memory.
-3. Check whether names, commands, paths, app domains, and validation instructions still match code.
-4. Remove stale instructions when replacing behavior. Do not leave contradictory old/new guidance.
-5. Keep docs repo-specific. Prefer "run `pnpm test --filter @gredice/storage`" over "run tests".
-6. Keep docs scoped. Do not rewrite unrelated sections for tone or style while fixing one stale fact.
+## Stable Facts
 
-## Repo Map Facts
+- App/package map lives in `WORKSPACE.md`; local domains come from `scripts/app-registry.ts`.
+- Runtime is Node.js `>=24`; pnpm is pinned by `packageManager`.
+- Internal deps use `workspace:*`.
+- Schema changes live in `packages/storage`; run `pnpm db-generate`; do not run `pnpm db-push`.
+- Do not commit build output, caches, `.next`, coverage, `node_modules`, or unexpected generated files.
 
-Use the current app registry and workspace guide as the source of truth:
+## Style
 
-- `apps/www`: public marketing, commerce, CMS-rendered pages, SEO, sitemap, public tests.
-- `apps/garden`: customer garden/game experience.
-- `apps/farm`: farm back office.
-- `apps/app`: internal operations/admin.
-- `apps/storybook`: public component documentation.
-- `apps/api`: Hono API routes, Scalar API reference, API docs, Stripe cron/webhooks.
-- `apps/status`: public status page, not part of default root dev.
-- `packages/*`: shared packages such as `@gredice/ui`, `@gredice/client`, `@gredice/storage`, `@gredice/game`, `@gredice/transactional`, `@gredice/stripe`.
-- `assets`: source brand and game assets.
-
-Local domains come from `scripts/app-registry.ts`, not hand-written lists. The default stack is started by `pnpm dev`; `status` starts separately with `pnpm --filter=status dev`.
-
-## Command Accuracy
-
-Before documenting commands, check the relevant `package.json` script. Current common commands:
-
-```bash
-pnpm bootstrap
-pnpm doctor
-pnpm dev
-pnpm dev:all
-pnpm lint --filter <workspace>
-pnpm typecheck --filter <workspace>
-pnpm test --filter <workspace>
-pnpm build --filter <workspace>
-pnpm db-generate
-pnpm regenerate
-git diff --check
-```
-
-Use `pnpm install` only when the task is dependency setup. The README currently emphasizes `pnpm bootstrap`, `pnpm doctor`, and `pnpm dev` for fresh worktrees.
-
-Document these non-negotiables when relevant:
-
-- Runtime is Node.js `>=24`; package manager is pinned by the root `packageManager` field.
-- Use `workspace:*` for internal dependencies.
-- Schema changes live in `packages/storage`; run `pnpm db-generate`.
-- Do not run `pnpm db-push`.
-- Do not commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless they are established tracked outputs required by the source change.
-
-## Documentation Style
-
-Write for contributors who need to act:
-
-- Use exact app/package names and paths.
-- Use exact command names and filters.
-- Explain ownership boundaries when behavior spans apps and packages.
-- Prefer tables only when comparing multiple items.
-- Avoid future promises, vague best practices, and generic framework descriptions.
-- Preserve Croatian product terms and nearby public-copy tone when documenting user-facing content.
+- Prefer brief, actionable text over framework explanations.
+- Link to the source guide instead of repeating setup or validation blocks.
+- Preserve Croatian product terms and nearby public-copy tone.
 - Call out secrets, migrations, generated assets, deployments, or manual coordination explicitly.
 
 ## Validation
 
-For docs-only edits, run:
-
-```bash
-git diff --check
-```
-
-For docs that describe a command or generated output, run the smallest harmless check that proves the instruction is still valid. Do not run `pnpm db-push`.
-
-If live product state matters, query the API, database, Linear, or GitHub only after the static source does not answer the question.
+Docs-only: `git diff --check`. If docs describe a command or generated output, run the smallest harmless check that proves it. Query live systems only when source cannot answer the question.

--- a/.agents/skills/gredice-domain-workflow-docs/SKILL.md
+++ b/.agents/skills/gredice-domain-workflow-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-domain-workflow-docs
-description: Document Gredice business and operational workflows across apps and packages. Use for delivery, checkout, payments, Stripe, notifications, Slack, email, inventory, garden operations, farm/admin workflows, scheduled jobs, background work, state transitions, failure handling, environment configuration, and cross-app workflow docs under docs/ or package guides.
+description: Use for documenting Gredice workflows: delivery, checkout, payments, notifications, inventory, operations, crons, env, and failures across apps/packages.
 ---
 
 # Gredice Domain Workflow Docs
@@ -92,15 +92,6 @@ For Slack notification docs, use current keys and behavior from `docs/notificati
 
 ## Validation
 
-Use the smallest commands that exercise the source you documented:
-
-```bash
-pnpm test --filter @gredice/storage
-pnpm test --filter api
-pnpm build --filter app
-pnpm build --filter farm
-pnpm build --filter garden
-git diff --check
-```
+Use the smallest checks for the source you documented, usually storage/API tests plus app builds for changed admin, farm, or garden behavior. Docs-only changes need `git diff --check`.
 
 Query Linear, GitHub, the API, or the database only when documenting current operational state, open work, live configuration, or production data that cannot be inferred from source.

--- a/.agents/skills/gredice-game-asset-docs/SKILL.md
+++ b/.agents/skills/gredice-game-asset-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-game-asset-docs
-description: Document Gredice garden game, 3D scene, generated assets, model exports, sprite atlases, performance profiling, quality tiers, canvas behavior, game asset source files, and verification workflows in apps/garden, packages/game, packages/cdn, assets, or docs/game-scene-performance.md.
+description: Use for docs on Gredice garden game assets, 3D scene, model exports, sprite atlases, performance, quality tiers, and canvas behavior.
 ---
 
 # Gredice Game Asset Docs
@@ -107,21 +107,6 @@ When docs claim visual behavior, verify with a browser or screenshots:
 
 ## Validation
 
-Use targeted checks:
-
-```bash
-pnpm lint --filter @gredice/game
-pnpm typecheck --filter @gredice/game
-pnpm test --filter @gredice/game
-pnpm typecheck --filter garden
-pnpm typecheck --filter www
-pnpm generate:game-assets
-pnpm --filter @gredice/cdn run regenerate-cdn:decoration-atlas
-git diff --check
-```
-
-Run `garden` or `www` builds and Playwright suites only when routing, static
-assets, bundling, production-only code paths, visual behavior, or user flows
-changed.
+Use targeted `@gredice/game` checks and `garden`/`www` typechecks when runtime behavior changes. Run asset or atlas generators only when source assets/manifests changed. Run app builds and Playwright suites only for routing, static assets, bundling, production behavior, visual behavior, or user flows. Docs-only changes need `git diff --check`.
 
 Do not hand-edit generated model output unless the generator is broken and the temporary nature of the change is explicitly documented.

--- a/.agents/skills/gredice-game-entity-creation/SKILL.md
+++ b/.agents/skills/gredice-game-entity-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-game-entity-creation
-description: Add or update Gredice garden game entities from model assets, including Blender source cleanup, assets/game-assets.json, generated GLBs and model types, packages/game entity components, ItemsHud placement, public block PNG snapshots, and live database block/shop rows with sunflower pricing. Use when a task mentions creating a game entity, decoration, tool, placeable item, purchasable block, Linear model attachment, Blender/GLB asset, block thumbnails, or adding an item for users to buy.
+description: Use for adding/updating Gredice game entities from Blender/GLB assets through runtime registration, shop rows, snapshots, and validation.
 ---
 
 # Gredice Game Entity Creation
@@ -69,19 +69,4 @@ pnpm --dir apps/www exec playwright test --config playwright-generate.config.ts 
 
 ## Validation
 
-For `@gredice/game` entity work, validate the package and consumer typechecks:
-
-```bash
-pnpm lint --filter @gredice/game
-pnpm typecheck --filter @gredice/game
-pnpm test --filter @gredice/game
-pnpm typecheck --filter garden
-pnpm typecheck --filter www
-git diff --check
-```
-
-Run the focused snapshot generator for the entity and visually inspect the PNGs.
-Run app lint when app files changed. Run app builds or Playwright suites only
-when routing, static assets, bundling, production-only code paths, visual
-behavior, or user flows changed. Run `pnpm test --filter www` when public route
-behavior changed or the task has time for the broad route suite.
+For `@gredice/game` entity work, validate the package plus `garden` and `www` typechecks. Run the focused snapshot generator and inspect the PNGs. Add app lint/build/Playwright or `www` tests only when the changed app surface, routing, static assets, production behavior, visual behavior, or public routes require them. Docs-only changes need `git diff --check`.

--- a/.agents/skills/gredice-public-docs-seo/SKILL.md
+++ b/.agents/skills/gredice-public-docs-seo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-public-docs-seo
-description: Create, update, or review public Gredice documentation, content pages, metadata, structured data, sitemap behavior, public Croatian copy, FAQ/legal/plant/operation/block/recipe pages, CMS-rendered public routes, and SEO-sensitive work in apps/www or apps/status.
+description: Use for public Gredice content/SEO in apps/www or status: metadata, structured data, sitemap, Croatian copy, FAQ/legal/product pages, CMS routes.
 ---
 
 # Gredice Public Docs SEO
@@ -88,20 +88,4 @@ Follow `PRODUCT_SENSE.md`:
 
 ## Validation
 
-Use targeted commands:
-
-```bash
-pnpm build --filter www
-pnpm test --filter www
-pnpm lint --filter www
-```
-
-For content-only changes, `git diff --check` may be enough when metadata, routing, sitemap, and rendering behavior are untouched.
-
-For visual layout changes, start the app and inspect responsive behavior:
-
-```bash
-pnpm --filter www dev
-```
-
-Use screenshots when validating public first-view content, responsive layout, or structured visual changes.
+Use targeted `www` lint/test/build checks when metadata, routing, sitemap, rendering, or public behavior changes. Content-only docs may only need `git diff --check`. For visual layout changes, start `www`, inspect responsive behavior, and capture screenshots when first-view or structured visual content changed.

--- a/.agents/skills/gredice-storybook-component-docs/SKILL.md
+++ b/.agents/skills/gredice-storybook-component-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-storybook-component-docs
-description: Create, update, or review Gredice Storybook component documentation. Use for apps/storybook stories, MDX docs, autodocs metadata, shared UI examples, @gredice/ui components, app-adjacent reusable components, component state coverage, accessibility story setup, and docs changes required after reusable UI changes.
+description: Use for Gredice Storybook docs: stories, MDX, autodocs, @gredice/ui/shared components, states, accessibility, and reusable UI docs.
 ---
 
 # Gredice Storybook Component Docs
@@ -99,19 +99,4 @@ Follow `FRONTEND.md` and `DESIGN.md`:
 
 ## Validation
 
-Run targeted checks:
-
-```bash
-pnpm lint --filter storybook
-pnpm build --filter storybook
-```
-
-When a story documents changed source code from another workspace, also run the smallest relevant check for that workspace.
-
-For visual confidence, start Storybook with:
-
-```bash
-pnpm --filter storybook dev
-```
-
-Open `https://storybook.dev.gredice.test` and inspect the changed story. Use screenshots when layout, responsive behavior, or visual state is part of the change.
+Run targeted Storybook lint/build checks. If the story documents changed source from another workspace, also run that workspace's smallest relevant check. For visual confidence, start Storybook, inspect the changed story, and use screenshots when layout, responsive behavior, or visual state changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,79 +1,36 @@
-# Welcome, AI collaborator
+# AI collaborator notes
 
-This repository is the **Gredice** monorepo. It hosts multiple Next.js applications, shared packages, and assets for the Gredice platform.
+Gredice is a Next.js/Turborepo monorepo with apps, shared packages, docs, and assets.
 
-## First steps
+## Start here
 
-- Use Node.js `>=24` and the pnpm version pinned by the root `packageManager` field.
-- Install dependencies from the repo root with `pnpm install`.
-- Before editing code, look for additional `AGENTS.md` files inside the path you plan to touch. Nested instructions override this file.
-- Keep the worktree clean. Commit only intentional source changes and never commit `node_modules`, build output, `.next`, coverage, or generated artifacts unless explicitly requested.
-- Use targeted Turbo commands from the repo root whenever possible.
-- Before handing off code changes, identify the affected workspace(s) and run targeted lint, test, typecheck, or build checks unless the user explicitly asks to skip validation.
+- Use Node.js `>=24` and the pnpm version pinned in `packageManager`.
+- Check for nested `AGENTS.md` files before editing; nested files override this one.
+- Read only the guide that matches the change:
+  - [WORKSPACE.md](./WORKSPACE.md): layout, setup, commands, dev servers.
+  - [FRONTEND.md](./FRONTEND.md): Next.js, React, TypeScript, UI structure.
+  - [DESIGN.md](./DESIGN.md): visual standards.
+  - [PRODUCT_SENSE.md](./PRODUCT_SENSE.md): product language and roles.
+  - [QUALITY_SCORE.md](./QUALITY_SCORE.md): validation and review expectations.
+  - [RELIABILITY.md](./RELIABILITY.md): data, migrations, background work.
+  - [SECURITY.md](./SECURITY.md): auth, secrets, private data.
+  - [SEO.md](./SEO.md): public metadata, structured data, sitemap.
 
-## Read the relevant guides
+## Rules
 
-- [WORKSPACE.md](./WORKSPACE.md): repo layout, local setup, commands, package boundaries, and development servers.
-- [FRONTEND.md](./FRONTEND.md): Next.js, React, TypeScript, shared UI, Storybook, and app structure rules.
-- [DESIGN.md](./DESIGN.md): visual design standards for product, marketing, admin, farm, garden, and Storybook work.
-- [PRODUCT_SENSE.md](./PRODUCT_SENSE.md): Gredice product expectations, user roles, language, and domain behavior.
-- [QUALITY_SCORE.md](./QUALITY_SCORE.md): quality rubric, validation commands, type standards, and review expectations.
-- [RELIABILITY.md](./RELIABILITY.md): data integrity, migrations, background work, observability, and failure handling.
-- [SECURITY.md](./SECURITY.md): auth, secrets, data exposure, validation, payments, and unsafe rendering.
-- [SEO.md](./SEO.md): metadata, structured data, sitemap, canonical URL, and public page rules.
-
-## Non-negotiables
-
-- Reuse existing packages and UI before adding new utilities or components.
+- Reuse existing packages, UI, types, and patterns before adding new ones.
 - Use `workspace:*` for internal package dependencies.
-- Do not duplicate shared TypeScript types. Prefer inferred types, use `unknown` instead of `any`, and avoid `as` assertions.
-- Schema changes live in `packages/storage`; run `pnpm db-generate` after editing schema.
-- Do not run `pnpm db-push`. Database migrations are applied manually during deployment.
-- For shared PRs, leave new migration files out of version control unless explicitly requested.
-- Follow existing Biome, TypeScript, React, Next.js, Tailwind, and package conventions.
+- Prefer inferred TypeScript types; use `unknown` over `any`; avoid `as` assertions.
+- Keep schema work in `packages/storage`; run `pnpm db-generate`; never run `pnpm db-push`.
+- Do not commit `node_modules`, build output, `.next`, coverage, or generated files unless the generated artifact is expected for the source change.
+- Preserve user changes already in the worktree.
 
-## Task validation
+## Validation
 
-For code changes, use the narrowest reliable validation set from the repo root. Run typecheck where the workspace provides it:
+Run commands from the repo root. Use the narrowest relevant checks from [QUALITY_SCORE.md](./QUALITY_SCORE.md), usually filtered `lint`, `typecheck`, `test`, or `build`. For docs-only edits, `git diff --check` is enough.
 
-```bash
-pnpm lint --filter <workspace>
-pnpm typecheck --filter <workspace>
-pnpm test --filter <workspace>
-pnpm build --filter <workspace>
-```
-
-Examples:
-
-```bash
-pnpm lint --filter garden
-pnpm typecheck --filter garden
-pnpm test --filter garden
-pnpm build --filter garden
-```
-
-For shared package changes, also validate the consuming app(s) that exercise the changed behavior. For storage changes, run `pnpm test --filter @gredice/storage` and build affected consumers such as `app`, `api`, or `farm`. For ordinary `@gredice/game` TypeScript/component changes, validate the package and run consumer typechecks for `garden` and `www`; only run app builds or Playwright suites when app routing, bundling, static assets, visual behavior, or user flows changed.
-
-If validation cannot run because of missing secrets, unavailable services, or time constraints, state exactly which command was skipped and why.
+If a check cannot run, state the skipped command and reason.
 
 ## GitHub issues
 
-- Use GitHub Issue Type as the primary kind: `Feature` for larger product capabilities or umbrella work, `Task` for concrete implementation slices, and `Bug` for broken or incorrect behavior.
-- Use labels for routing and context, not as a replacement for issue type. Apply the existing area, package, feature, asset, documentation, test, enhancement, epic, and AI-origin labels that match the issue. Use multiple labels when work spans multiple apps or packages, and do not create near-duplicate labels.
-- Title issues with the existing square-bracket scope convention when a clear product, domain, or workstream exists, for example `[CMS] Pages - define Page structure` or `[Field] Ability to see diary and history if field had plants before`. Use a short imperative or outcome-focused title for devex/tooling tasks when labels already carry the scope.
-- For product and feature work, prefer issue bodies with `User story`, `Current-system notes`, `Scope`, and `Acceptance criteria` sections. For internal tooling or reliability work, use `Goal`, `Context`, `Scope`, and `Acceptance criteria`, adding `Blocked by` when sequencing matters.
-- For umbrella issues, link implementation issues with a checklist, include a suggested implementation order, and call out dependency relationships with issue references such as `#2501`. Mark these with the epic label when they group related work.
-- Milestones are not used by default in this repo; only add one when explicitly requested.
-
-## Quick commands
-
-```bash
-pnpm install
-pnpm dev
-pnpm lint --filter garden
-pnpm typecheck --filter garden
-pnpm test --filter garden
-pnpm build --filter garden
-```
-
-For full command guidance, see [WORKSPACE.md](./WORKSPACE.md).
+Use Issue Type as the primary kind: `Feature`, `Task`, or `Bug`. Use existing labels for area/package/context, keep the square-bracket scope convention when clear, and use the section templates in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,140 +1,62 @@
-# Contributing to Gredice
+# Contributing
 
-Thank you for contributing to Gredice. This repository is a Turborepo monorepo for multiple Next.js applications, shared packages, documentation, and assets. Contributions are easiest to review when they are scoped, grounded in the existing packages, and validated with targeted commands.
-
-Please also follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+Follow the [Code of Conduct](./CODE_OF_CONDUCT.md). Keep changes scoped, reuse existing packages, and validate the work that changed.
 
 ## Before you start
 
-- Read [WORKSPACE.md](./WORKSPACE.md) for repo layout, local setup, commands, package boundaries, and development servers.
-- Read the guide that matches your change: [FRONTEND.md](./FRONTEND.md), [DESIGN.md](./DESIGN.md), [PRODUCT_SENSE.md](./PRODUCT_SENSE.md), [QUALITY_SCORE.md](./QUALITY_SCORE.md), [RELIABILITY.md](./RELIABILITY.md), [SECURITY.md](./SECURITY.md), or [SEO.md](./SEO.md).
-- Search existing issues and pull requests before opening duplicate work.
-- Discuss larger product, schema, architecture, payment, inventory, delivery, or auth changes before investing heavily in implementation.
-- Keep changes focused. Separate unrelated fixes, refactors, generated output, and feature work into different pull requests.
+- Read [WORKSPACE.md](./WORKSPACE.md) for setup, commands, app map, package boundaries, and dev servers.
+- Read the guide that matches your work: [FRONTEND.md](./FRONTEND.md), [DESIGN.md](./DESIGN.md), [PRODUCT_SENSE.md](./PRODUCT_SENSE.md), [QUALITY_SCORE.md](./QUALITY_SCORE.md), [RELIABILITY.md](./RELIABILITY.md), [SECURITY.md](./SECURITY.md), or [SEO.md](./SEO.md).
+- Search existing issues and PRs.
+- Discuss larger product, schema, architecture, payment, inventory, delivery, or auth changes first.
 
 ## Local setup
 
-Use Node.js `>=24`, the pnpm version pinned by `packageManager`, Docker, and the Vercel CLI.
+Use Node.js `>=24`, pnpm from `packageManager`, Docker, and the Vercel CLI. See [WORKSPACE.md](./WORKSPACE.md) for the full setup and local domains.
+
+Common path:
 
 ```bash
 pnpm install
-vercel login
-pnpm vercel:link
-pnpm env:pull
+pnpm bootstrap
+pnpm doctor
 pnpm dev
 ```
 
-The default dev command starts the main apps through local HTTPS domains:
+## Development
 
-- `apps/www`: <https://www.gredice.test>
-- `apps/garden`: <https://vrt.gredice.test>
-- `apps/farm`: <https://farma.gredice.test>
-- `apps/app`: <https://app.gredice.test>
-- `apps/storybook`: <https://storybook.dev.gredice.test>
-- `apps/api`: <https://api.gredice.test>
-
-The `status` app is not part of the default dev stack. Start it separately when needed:
-
-```bash
-pnpm --filter=status dev
-```
-
-## Development guidelines
-
-- Reuse existing packages and UI before adding new utilities, components, dependencies, or packages.
-- Use `workspace:*` for internal package dependencies.
-- Keep app-only behavior inside the owning app. Move shared behavior into an existing package only when reuse is real.
-- Do not duplicate shared TypeScript types. Prefer inferred types, use `unknown` instead of `any`, and avoid `as` assertions.
-- Validate data at server boundaries and avoid exposing secrets or private data to the client.
-- Preserve existing auth, authorization, cache invalidation, analytics, observability, and failure-handling patterns.
-- Do not commit `node_modules`, `.next`, build output, coverage, Storybook static output, or other generated artifacts unless the generated file is an established tracked artifact required by the source change.
+- Reuse existing packages, UI, dependencies, and conventions.
+- Use `workspace:*` for internal dependencies.
+- Keep app-only behavior in the owning app; share code only when reuse is real.
+- Prefer inferred TypeScript types, `unknown` over `any`, and avoid `as` assertions.
+- Validate server-boundary data and do not expose secrets or private data.
+- Preserve auth, authorization, cache invalidation, analytics, observability, and failure handling.
+- Do not commit ignored build/cache output or generated artifacts unless they are established tracked outputs required by the change.
 
 ## Database and generated assets
 
-Database schema changes live in `packages/storage`.
-
-```bash
-pnpm db-generate
-```
-
-Run `pnpm db-generate` after editing schema. Do not run `pnpm db-push`. For shared pull requests, leave new migration files out of version control unless maintainers explicitly request them.
-
-For game assets, use the existing generation scripts instead of hand-editing generated model output:
-
-```bash
-pnpm generate:game-assets
-pnpm generate:models-types
-```
-
-Coordinate with maintainers before changing shared game asset sources.
+- Schema changes live in `packages/storage`; run `pnpm db-generate`; do not run `pnpm db-push`.
+- Leave new migration files out of shared PRs unless maintainers request them.
+- Use repo generation scripts for game assets and model types; do not hand-edit generated model output.
+- Coordinate shared asset source changes.
 
 ## Validation
 
-Run targeted commands from the repo root. Choose the smallest check that covers the change, then broaden when the change touches shared behavior or critical flows. Run typecheck where the workspace provides it.
+Use [QUALITY_SCORE.md](./QUALITY_SCORE.md): run the narrowest relevant root command, usually filtered `lint`, `typecheck`, `test`, or `build`. Broaden checks for shared packages, critical flows, routing, static assets, production behavior, or visual/user-flow changes.
 
-```bash
-pnpm lint --filter <workspace>
-pnpm typecheck --filter <workspace>
-pnpm test --filter <workspace>
-pnpm build --filter <workspace>
-```
-
-Examples:
-
-```bash
-pnpm lint --filter garden
-pnpm typecheck --filter garden
-pnpm test --filter garden
-pnpm build --filter www
-pnpm test --filter @gredice/storage
-```
-
-For ordinary `@gredice/game` package changes, validate the package and run `garden`/`www` typechecks instead of building and testing both apps every time. Run the app builds or Playwright suites when app routing, static assets, bundling, production behavior, visual behavior, or user flows changed.
-
-For docs-only changes, run:
-
-```bash
-git diff --check
-```
-
-Note that some lint scripts run `biome check --write` and may modify files. Review the diff after linting.
+For docs-only changes, run `git diff --check`. Review the diff after linting because some lint scripts write fixes.
 
 ## Issues
 
-Use GitHub Issue Type as the primary kind:
-
-- `Feature` for larger product capabilities or umbrella work.
-- `Task` for concrete implementation slices.
-- `Bug` for broken or incorrect behavior.
-
-Use labels for routing and context, including existing area, package, feature, asset, documentation, test, enhancement, epic, and AI-origin labels. Do not create near-duplicate labels.
-
-Use the existing square-bracket scope convention when a clear scope exists, such as `[CMS] Pages - define Page structure` or `[Field] Ability to see diary and history if field had plants before`.
-
-For product and feature issues, prefer these sections:
-
-- `User story`
-- `Current-system notes`
-- `Scope`
-- `Acceptance criteria`
-
-For internal tooling or reliability issues, prefer:
-
-- `Goal`
-- `Context`
-- `Scope`
-- `Acceptance criteria`
-- `Blocked by`, when sequencing matters
-
-Umbrella issues should link implementation issues with a checklist, include a suggested implementation order, call out dependencies with issue references, and use the `epic` label.
+- Use Issue Type as the primary kind: `Feature`, `Task`, or `Bug`.
+- Use existing labels for area/package/context; do not create near-duplicates.
+- Use square-bracket scopes when clear, for example `[CMS] Pages - define Page structure`.
+- Product/feature issues: `User story`, `Current-system notes`, `Scope`, `Acceptance criteria`.
+- Internal/reliability issues: `Goal`, `Context`, `Scope`, `Acceptance criteria`, and `Blocked by` when needed.
+- Umbrella issues should checklist child work, call out ordering/dependencies, and use the `epic` label.
 
 ## Pull requests
 
-Before opening a pull request:
-
-- Confirm the change is scoped to the requested behavior.
-- Include relevant tests, stories, or docs updates for user-facing and shared behavior.
-- Run the targeted validation commands and include the results in the pull request description.
-- Call out skipped checks and why they were skipped.
-- Mention schema changes, generated assets, environment requirements, migrations, or deployment coordination explicitly.
-- Keep pull request descriptions concrete enough for reviewers to understand the user impact and the technical shape of the change.
+- Keep the PR focused.
+- Include relevant tests, stories, or docs updates.
+- Include validation results and skipped checks with reasons.
+- Mention schema changes, generated assets, environment requirements, migrations, or deployment coordination.

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -1,23 +1,21 @@
-# Quality Score Guide
+# Quality Score
 
-Use this guide to decide whether a change is ready.
+Use this as the handoff bar.
 
-## Readiness score
+## Readiness
 
-Score the change from 0 to 5 before handing it off:
-
-- `0`: Does not run, has unresolved syntax/type errors, or leaves known broken behavior.
-- `1`: Runs only on the narrow happy path and has obvious missing validation or UI states.
-- `2`: Implements the request but leaves meaningful edge cases, stale data, or test gaps.
-- `3`: Solid targeted implementation with relevant lint/test/build checks passing.
+- `0`: Does not run or leaves known broken behavior.
+- `1`: Narrow happy path only.
+- `2`: Request is implemented with meaningful edge/test gaps.
+- `3`: Targeted implementation with relevant checks passing.
 - `4`: Handles edge cases, failure states, accessibility, and cross-app/package impact.
-- `5`: Production-ready for critical paths: verified behavior, migrations handled, observability considered, and no unexplained risk.
+- `5`: Production-ready for critical paths: verified behavior, migrations/observability considered, no unexplained risk.
 
-Aim for `3` on small low-risk changes and `4` or higher on shared, public, payment, inventory, delivery, auth, or database work.
+Aim for `3` on small low-risk changes and `4+` for shared, public, payment, inventory, delivery, auth, or database work.
 
-## Validation commands
+## Validation
 
-Use targeted commands first. Before handing off code changes, identify the affected workspace(s) and run the narrowest relevant lint, typecheck, test, or build checks unless the user explicitly asks to skip validation. Run typecheck where the workspace provides it.
+Run commands from the repo root. Pick the smallest reliable filtered check:
 
 ```bash
 pnpm lint --filter <workspace>
@@ -26,63 +24,30 @@ pnpm test --filter <workspace>
 pnpm build --filter <workspace>
 ```
 
-Examples:
+Shared package changes need checks for the package and relevant consumers. For ordinary `@gredice/game` updates, use package checks plus `garden` and `www` typechecks; reserve app builds and Playwright suites for routing, static assets, bundling, production behavior, visual changes, or user flows.
 
-```bash
-pnpm lint --filter @gredice/storage
-pnpm test --filter @gredice/storage
-pnpm typecheck --filter garden
-pnpm build --filter www
-pnpm test --filter www
-```
+Docs-only changes: `git diff --check`.
 
-For shared package changes, validate both the changed package and the consuming app(s) that exercise the behavior. If a package is used by multiple apps, run checks for each relevant consumer, not only the package itself. For ordinary `@gredice/game` updates, use app typechecks as the default consumer build-compatibility check for `garden` and `www`; reserve full app builds and Playwright suites for routing, static asset, bundling, production behavior, visual, or user-flow changes. Examples:
+If a required check cannot run, report the command and concrete reason.
 
-```bash
-pnpm lint --filter @gredice/storage
-pnpm test --filter @gredice/storage
-pnpm build --filter app
-pnpm build --filter api
-pnpm build --filter farm
+## Testing
 
-pnpm lint --filter @gredice/game
-pnpm typecheck --filter @gredice/game
-pnpm test --filter @gredice/game
-pnpm typecheck --filter garden
-pnpm typecheck --filter www
-```
+- Unit-test pure domain logic, parsing, validation, and repositories.
+- Use Playwright for app flows, accessibility, and visible regressions.
+- Preserve `apps/www` sitemap-driven route, accessibility, and metadata tests for public page work.
+- Storage/API changes should cover validation, auth, success, failure, and relevant repository behavior.
+- Shared UI changes need Storybook coverage and a consuming-app check when behavior changes.
 
-For docs-only changes, at minimum check formatting-sensitive diffs with:
+## Review
 
-```bash
-git diff --check
-```
-
-If a required command cannot run because of missing secrets, unavailable services, unsupported local tooling, or time constraints, note the skipped command and the concrete reason in the handoff.
-
-## Testing expectations
-
-- Unit-test pure domain logic, parsing, validation, and repository behavior.
-- Use Playwright for app flows, accessibility, and user-visible regressions.
-- For `apps/www`, preserve sitemap-driven public route, accessibility, and metadata tests when public pages change.
-- For storage changes, run the relevant storage tests. Remember that storage tests manage their own test database scripts.
-- For API route changes, test validation, auth, success, and failure responses.
-- For shared UI, add or update Storybook stories and test the consuming app when behavior changes.
-
-## Review checklist
-
-- The change is scoped to the requested behavior.
-- Existing user changes are preserved.
-- Types come from existing shared contracts where possible.
-- No avoidable `any`, non-null assertion, or `as` assertion was introduced.
-- Loading, empty, error, disabled, and success states are handled where relevant.
+- Scope matches the request and preserves existing user changes.
+- Types come from shared contracts where possible; no avoidable `any`, non-null assertion, or `as`.
+- Relevant loading, empty, error, disabled, and success states are handled.
 - Mutations invalidate or revalidate the right data.
 - Public pages preserve metadata, structured data, accessibility, and responsive layout.
-- Secrets and private data are not logged, rendered, or sent to the client.
+- Secrets/private data are not logged, rendered, or sent to the client.
 - New dependencies are justified and added to the right workspace.
 
-## Documentation expectations
+## Docs
 
-- Update docs when behavior, setup, scripts, architecture, or contributor expectations change.
-- Keep docs concrete to this repo. Prefer exact package names, app paths, and commands over generic guidance.
-- Remove stale instructions when replacing them.
+Update docs when behavior, setup, scripts, architecture, or contributor expectations change. Keep them repo-specific and remove stale guidance.

--- a/README.md
+++ b/README.md
@@ -32,50 +32,25 @@ Gredice is a Turborepo monorepo for the Gredice platform. It includes the public
 
 ## Getting Started
 
-Prerequirenments:
-
-- [nvm](https://github.com/nvm-sh/nvm)
-  - [Node.js](https://nodejs.org/) (managed through nvm)
-  - [corepack](https://github.com/nodejs/corepack) (managed through npm)
-  - [pnpm](https://pnpm.io/) (managed through corepack)
-  - [Vercel CLI](https://vercel.com/cli) (managed through pnpm)
-- [Docker](https://www.docker.com/)
+Requirements: nvm/Node.js `>=24`, Corepack-managed pnpm, Vercel CLI, and Docker.
 
 ```bash
 nvm use
-npm install corepack
 corepack enable
 pnpm i -g vercel
 pnpm install
-vercel login
 pnpm bootstrap
 pnpm doctor
 pnpm dev
 ```
 
-The default dev command starts the main apps through local HTTPS domains such as `https://www.gredice.test`, `https://vrt.gredice.test`, and `https://api.gredice.test`. Linked Git worktrees use deterministic app and proxy port offsets so they can run beside another checkout; use the port-qualified HTTPS URLs printed by `pnpm dev` in those worktrees. The `status` app is intentionally excluded so normal startup stays fast. Use `pnpm dev:all` when you need to validate every app (including `status`) can start in a fresh worktree, and use `pnpm --filter=status dev` for status-only development.
+`pnpm dev` starts the main local HTTPS apps. `status` is separate. For domains, certificates, env files, worktree port offsets, generated assets, and command details, see [WORKSPACE.md](./WORKSPACE.md).
 
-`pnpm bootstrap` prepares a fresh worktree as far as local permissions and credentials allow.
-`pnpm doctor` runs the same checks in read-only mode and exits non-zero when required dependencies are missing.
-
-For local domains, certificates, environment files, generated assets, and detailed commands, see [WORKSPACE.md](./WORKSPACE.md).
-
-For fresh worktrees, copy each app's `.env.example` into `.env` before smoke testing. Real external secrets are only needed for explicit integration flows (for example payments, analytics, and OAuth).
+Run `vercel login` if bootstrap or environment checks report missing auth.
 
 ## Documentation
 
-- [AGENTS.md](./AGENTS.md): entry point for AI collaborators.
-- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md): expectations for respectful project participation and reporting concerns.
-- [CONTRIBUTING.md](./CONTRIBUTING.md): setup, development, validation, issue, and pull request guidance.
-- [WORKSPACE.md](./WORKSPACE.md): repo layout, setup, commands, package boundaries, and local development servers.
-- [FRONTEND.md](./FRONTEND.md): Next.js, React, TypeScript, shared UI, Storybook, and app structure rules.
-- [DESIGN.md](./DESIGN.md): visual and interaction design standards.
-- [PRODUCT_SENSE.md](./PRODUCT_SENSE.md): product expectations, user roles, language, and domain behavior.
-- [QUALITY_SCORE.md](./QUALITY_SCORE.md): quality rubric, validation commands, type standards, and review expectations.
-- [RELIABILITY.md](./RELIABILITY.md): data integrity, migrations, background work, observability, and failure handling.
-- [SECURITY.md](./SECURITY.md): auth, secrets, data exposure, validation, payments, and unsafe rendering.
-- [SEO.md](./SEO.md): metadata, structured data, sitemap, canonical URL, and public page rules.
-- [docs/game-entity-creation.md](./docs/game-entity-creation.md): model-to-shop workflow for garden game entities and purchasable blocks.
+[AGENTS.md](./AGENTS.md) is the AI entry point. [CONTRIBUTING.md](./CONTRIBUTING.md) covers contributor flow. The main operating guides are [WORKSPACE.md](./WORKSPACE.md), [FRONTEND.md](./FRONTEND.md), [DESIGN.md](./DESIGN.md), [PRODUCT_SENSE.md](./PRODUCT_SENSE.md), [QUALITY_SCORE.md](./QUALITY_SCORE.md), [RELIABILITY.md](./RELIABILITY.md), [SECURITY.md](./SECURITY.md), and [SEO.md](./SEO.md). Focused docs live under [docs](./docs).
 
 ## API Reference
 
@@ -83,7 +58,7 @@ See the [API Reference](https://api.gredice.com) for the official API documentat
 
 ## Contributing
 
-We welcome community contributions. See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, development, validation, issue, and pull request guidance, and follow the [Code of Conduct](./CODE_OF_CONDUCT.md) in project spaces.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ![Alt](https://repobeats.axiom.co/api/embed/ba847f4d1fae06c8250692c08295602bca8de554.svg "Repobeats analytics image")
 


### PR DESCRIPTION
## Summary
- Shortened root docs and repo-local AI skills to remove repeated setup, validation, and command guidance.
- Kept the main rules in the central docs and replaced long command blocks with brief references.
- Reduced the token footprint of the docs surface without changing the underlying repo policies.

## Testing
- `git diff --check` passed.
- Reviewed the edited docs for consistency and link correctness.