### PR TITLE
Allow desktop releases without Apple Developer Program credentials

### DIFF
--- a/.github/workflows/desktop-release-farm.yml
+++ b/.github/workflows/desktop-release-farm.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: "Release - Desktop (app)"
+name: "Release - Desktop (farm)"
 
 on:
   push:
     tags:
-      - "desktop-app-v*"
+      - "desktop-farm-v*"
   workflow_dispatch:
     inputs:
       version:
@@ -48,17 +48,17 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${DISPATCH_VERSION}" ]; then
             VERSION="${DISPATCH_VERSION}"
-          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
+          elif [[ "${GITHUB_REF}" == refs/tags/desktop-farm-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/desktop-farm-v}"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Single timestamp shared across all downstream jobs so the DMG
             # filenames, package version, tag, and release name agree.
             VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
           else
-            echo "::error::Unable to resolve release version. Trigger this workflow with a desktop-app-v* tag or provide a workflow_dispatch version input." >&2
+            echo "::error::Unable to resolve release version. Trigger this workflow with a desktop-farm-v* tag or provide a workflow_dispatch version input." >&2
             exit 1
           fi
-          TAG="desktop-app-v${VERSION}"
+          TAG="desktop-farm-v${VERSION}"
           echo "Resolved version: ${VERSION}"
           echo "Resolved tag: ${TAG}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -124,19 +124,19 @@ jobs:
         working-directory: apps/desktop
         run: node scripts/prepare-macos-signing-env.mjs
 
-      - name: 🛠️ Build Gredice Admin desktop DMG (arm64)
+      - name: 🛠️ Build Gredice Farm desktop DMG (arm64)
         env:
           GREDICE_DESKTOP_VERSION: ${{ needs.resolve_version.outputs.version }}
         working-directory: apps/desktop
-        run: pnpm dist:app --mac --arm64
+        run: pnpm dist:farm --mac --arm64
 
       - name: 📤 Upload DMG artifact
         uses: actions/upload-artifact@v5.0.0
         with:
-          name: gredice-admin-desktop-arm64
+          name: gredice-farm-desktop-arm64
           path: |
-            apps/desktop/dist/app/*.dmg
-            apps/desktop/dist/app/*.dmg.blockmap
+            apps/desktop/dist/farm/*.dmg
+            apps/desktop/dist/farm/*.dmg.blockmap
           if-no-files-found: error
           retention-days: 14
 
@@ -150,7 +150,7 @@ jobs:
         uses: actions/download-artifact@v6.0.0
         with:
           path: release-artifacts
-          pattern: gredice-admin-desktop-*
+          pattern: gredice-farm-desktop-*
           merge-multiple: true
 
       - name: 📜 List artifacts
@@ -160,7 +160,7 @@ jobs:
       - name: 🚀 Create or update GitHub release
         uses: softprops/action-gh-release@v2.2.2
         with:
-          name: "Gredice Admin Desktop ${{ needs.resolve_version.outputs.version }}"
+          name: "Gredice Farm Desktop ${{ needs.resolve_version.outputs.version }}"
           tag_name: ${{ needs.resolve_version.outputs.tag }}
           draft: ${{ github.event_name == 'workflow_dispatch' && inputs.draft || false }}
           prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}

--- a/.github/workflows/desktop-release-garden.yml
+++ b/.github/workflows/desktop-release-garden.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: "Release - Desktop (app)"
+name: "Release - Desktop (garden)"
 
 on:
   push:
     tags:
-      - "desktop-app-v*"
+      - "desktop-garden-v*"
   workflow_dispatch:
     inputs:
       version:
@@ -48,17 +48,17 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${DISPATCH_VERSION}" ]; then
             VERSION="${DISPATCH_VERSION}"
-          elif [[ "${GITHUB_REF}" == refs/tags/desktop-app-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/desktop-app-v}"
+          elif [[ "${GITHUB_REF}" == refs/tags/desktop-garden-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/desktop-garden-v}"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Single timestamp shared across all downstream jobs so the DMG
             # filenames, package version, tag, and release name agree.
             VERSION="0.0.0-$(date -u +%Y%m%d%H%M%S)"
           else
-            echo "::error::Unable to resolve release version. Trigger this workflow with a desktop-app-v* tag or provide a workflow_dispatch version input." >&2
+            echo "::error::Unable to resolve release version. Trigger this workflow with a desktop-garden-v* tag or provide a workflow_dispatch version input." >&2
             exit 1
           fi
-          TAG="desktop-app-v${VERSION}"
+          TAG="desktop-garden-v${VERSION}"
           echo "Resolved version: ${VERSION}"
           echo "Resolved tag: ${TAG}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -124,19 +124,19 @@ jobs:
         working-directory: apps/desktop
         run: node scripts/prepare-macos-signing-env.mjs
 
-      - name: 🛠️ Build Gredice Admin desktop DMG (arm64)
+      - name: 🛠️ Build Gredice Garden desktop DMG (arm64)
         env:
           GREDICE_DESKTOP_VERSION: ${{ needs.resolve_version.outputs.version }}
         working-directory: apps/desktop
-        run: pnpm dist:app --mac --arm64
+        run: pnpm dist:garden --mac --arm64
 
       - name: 📤 Upload DMG artifact
         uses: actions/upload-artifact@v5.0.0
         with:
-          name: gredice-admin-desktop-arm64
+          name: gredice-garden-desktop-arm64
           path: |
-            apps/desktop/dist/app/*.dmg
-            apps/desktop/dist/app/*.dmg.blockmap
+            apps/desktop/dist/garden/*.dmg
+            apps/desktop/dist/garden/*.dmg.blockmap
           if-no-files-found: error
           retention-days: 14
 
@@ -150,7 +150,7 @@ jobs:
         uses: actions/download-artifact@v6.0.0
         with:
           path: release-artifacts
-          pattern: gredice-admin-desktop-*
+          pattern: gredice-garden-desktop-*
           merge-multiple: true
 
       - name: 📜 List artifacts
@@ -160,7 +160,7 @@ jobs:
       - name: 🚀 Create or update GitHub release
         uses: softprops/action-gh-release@v2.2.2
         with:
-          name: "Gredice Admin Desktop ${{ needs.resolve_version.outputs.version }}"
+          name: "Gredice Garden Desktop ${{ needs.resolve_version.outputs.version }}"
           tag_name: ${{ needs.resolve_version.outputs.tag }}
           draft: ${{ github.event_name == 'workflow_dispatch' && inputs.draft || false }}
           prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}

--- a/apps/desktop/scripts/package-desktop-app.mjs
+++ b/apps/desktop/scripts/package-desktop-app.mjs
@@ -127,6 +127,8 @@ async function writeEntitlements(stageDir) {
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
     <key>com.apple.security.device.microphone</key>
@@ -156,6 +158,8 @@ async function writeBuilderConfig(stageDir, desktopApp, electronVersion) {
             output: outputDir,
         },
         electronVersion,
+        forceCodeSigning:
+            process.env.GREDICE_DESKTOP_REQUIRE_MAC_SIGNING === '1',
         files: [
             'desktop-app.json',
             'favicon.ico',
@@ -179,6 +183,10 @@ async function writeBuilderConfig(stageDir, desktopApp, electronVersion) {
             gatekeeperAssess: false,
             hardenedRuntime: true,
             icon: 'icon.png',
+            notarize:
+                process.env.GREDICE_DESKTOP_SKIP_MAC_NOTARIZATION === '1'
+                    ? false
+                    : undefined,
             target: ['dmg', 'zip'],
         },
         dmg: {

--- a/apps/desktop/scripts/prepare-macos-signing-env.mjs
+++ b/apps/desktop/scripts/prepare-macos-signing-env.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import { resolve } from 'node:path';
+
+function appendGithubEnv(name, value) {
+    const githubEnvPath = process.env.GITHUB_ENV;
+    if (!githubEnvPath) {
+        return;
+    }
+
+    fs.appendFileSync(githubEnvPath, `${name}=${value}\n`);
+}
+
+function hasValue(name) {
+    return (process.env[name] ?? '').trim().length > 0;
+}
+
+function requireEnv(name) {
+    if (hasValue(name)) {
+        return process.env[name].trim();
+    }
+
+    console.error(`::error::Missing required GitHub secret: ${name}`);
+    process.exitCode = 1;
+    return '';
+}
+
+function hasAny(names) {
+    return names.some((name) => hasValue(name));
+}
+
+function requireAll(names) {
+    for (const name of names) {
+        requireEnv(name);
+    }
+}
+
+function writeApiKeyFile() {
+    const apiKeyContent = requireEnv('APPLE_API_KEY_CONTENT');
+    const apiKeyId = requireEnv('APPLE_API_KEY_ID');
+
+    if (!apiKeyContent || !apiKeyId) {
+        return;
+    }
+
+    const keyPath = resolve(
+        process.env.RUNNER_TEMP ?? os.tmpdir(),
+        `AuthKey_${apiKeyId}.p8`,
+    );
+
+    fs.writeFileSync(keyPath, apiKeyContent, { mode: 0o600 });
+    appendGithubEnv('APPLE_API_KEY', keyPath);
+    console.log(`Prepared App Store Connect API key at ${keyPath}`);
+}
+
+const appleIdNames = [
+    'APPLE_ID',
+    'APPLE_APP_SPECIFIC_PASSWORD',
+    'APPLE_TEAM_ID',
+];
+const apiKeyNames = [
+    'APPLE_API_KEY_CONTENT',
+    'APPLE_API_KEY_ID',
+    'APPLE_API_ISSUER',
+];
+
+if (!hasValue('CSC_LINK')) {
+    appendGithubEnv('GREDICE_DESKTOP_SKIP_MAC_NOTARIZATION', '1');
+    console.warn(
+        '::warning::CSC_LINK is not configured. The macOS desktop artifact will use ad-hoc signing and will not be notarized.',
+    );
+    process.exit(0);
+}
+
+console.log('Using configured Developer ID certificate for macOS signing.');
+
+if (hasAny(appleIdNames)) {
+    requireAll(appleIdNames);
+    console.log('Using Apple ID credentials for macOS notarization.');
+} else if (hasAny(apiKeyNames)) {
+    requireAll(apiKeyNames);
+    writeApiKeyFile();
+    console.log('Using App Store Connect API key for macOS notarization.');
+} else if (hasAny(['APPLE_KEYCHAIN', 'APPLE_KEYCHAIN_PROFILE'])) {
+    requireEnv('APPLE_KEYCHAIN_PROFILE');
+    console.log('Using keychain profile credentials for macOS notarization.');
+} else {
+    console.warn(
+        '::warning::No macOS notarization credentials configured. The artifact will be signed when possible, but not notarized.',
+    );
+}

--- a/apps/desktop/tests/desktop-apps.test.mjs
+++ b/apps/desktop/tests/desktop-apps.test.mjs
@@ -109,10 +109,55 @@ test('desktop shell hands OAuth login to the system browser', () => {
     assert.match(mainSource, /auth-callback/);
     assert.match(packageSource, /protocols:/);
     assert.match(packageSource, /favicon\.ico/);
+    assert.match(
+        packageSource,
+        /com\.apple\.security\.cs\.disable-library-validation/,
+    );
     assert.match(packageSource, /installerIcon: 'favicon\.ico'/);
     assert.match(packageSource, /uninstallerIcon: 'favicon\.ico'/);
     assert.match(packageSource, /icon: 'favicon\.ico'/);
     assert.match(packageSource, /schemes: \[desktopApp\.protocol\]/);
+});
+
+test('desktop release workflows can sign macOS artifacts when credentials exist', () => {
+    const packageSource = fs.readFileSync(
+        resolve(repoRoot, 'apps/desktop/scripts/package-desktop-app.mjs'),
+        'utf8',
+    );
+    const prepareSigningSource = fs.readFileSync(
+        resolve(repoRoot, 'apps/desktop/scripts/prepare-macos-signing-env.mjs'),
+        'utf8',
+    );
+    const workflowSources = [
+        '.github/workflows/desktop-release-app.yml',
+        '.github/workflows/desktop-release-farm.yml',
+        '.github/workflows/desktop-release-garden.yml',
+    ].map((workflowPath) =>
+        fs.readFileSync(resolve(repoRoot, workflowPath), 'utf8'),
+    );
+
+    assert.match(packageSource, /forceCodeSigning:/);
+    assert.match(packageSource, /GREDICE_DESKTOP_REQUIRE_MAC_SIGNING/);
+    assert.match(packageSource, /GREDICE_DESKTOP_SKIP_MAC_NOTARIZATION/);
+    assert.match(prepareSigningSource, /CSC_LINK is not configured/);
+    assert.match(prepareSigningSource, /ad-hoc signing/);
+    assert.match(prepareSigningSource, /APPLE_API_KEY_CONTENT/);
+    assert.match(prepareSigningSource, /APPLE_APP_SPECIFIC_PASSWORD/);
+    assert.match(prepareSigningSource, /APPLE_KEYCHAIN_PROFILE/);
+    assert.match(prepareSigningSource, /GREDICE_DESKTOP_SKIP_MAC_NOTARIZATION/);
+
+    for (const workflowSource of workflowSources) {
+        assert.match(workflowSource, /Prepare macOS signing and notarization/);
+        assert.match(
+            workflowSource,
+            /node scripts\/prepare-macos-signing-env\.mjs/,
+        );
+        assert.doesNotMatch(
+            workflowSource,
+            /GREDICE_DESKTOP_REQUIRE_MAC_SIGNING/,
+        );
+        assert.doesNotMatch(workflowSource, /CSC_IDENTITY_AUTO_DISCOVERY/);
+    }
 });
 
 test('desktop shell sets app identity before creating the macOS menu', () => {

--- a/docs/desktop-apps.md
+++ b/docs/desktop-apps.md
@@ -65,6 +65,20 @@ pnpm --filter desktop dist:garden -- --all-platforms
 Artifacts are written to `apps/desktop/dist/<app>`. Local unpacked builds can be
 created with `pnpm --filter desktop pack:garden`, `pack:farm`, or `pack:app`.
 
+## Release Workflows
+
+GitHub release workflows publish macOS arm64 DMGs only. Push one of these tags
+to release the matching desktop app:
+
+```bash
+git tag desktop-garden-v1.2.3
+git tag desktop-farm-v1.2.3
+git tag desktop-app-v1.2.3
+```
+
+The same workflows can also be run manually with a `version` input; without one,
+they create a timestamped version.
+
 ## Local QA
 
 Launch the Electron shell and the local services it needs:
@@ -94,10 +108,30 @@ cookies automatically; HTTPS and packaged app sessions keep secure cookies.
 
 ## Signing
 
-Electron Builder reads standard signing and notarization environment variables
-from CI. Configure macOS and Windows signing secrets in the release environment;
-do not commit certificates, app-specific passwords, provisioning profiles, or
-private keys.
+GitHub release workflows can publish without Apple Developer Program
+credentials. Without a Developer ID certificate, Electron Builder falls back to
+ad-hoc macOS signing and the app is not notarized. This keeps releases possible
+for internal or manual distribution, but macOS Gatekeeper can still show
+unidentified-developer warnings for downloaded artifacts.
+
+For public releases that should open normally after download, configure these
+GitHub secrets for Developer ID signing:
+
+- `CSC_LINK`: base64-encoded `.p12` Developer ID Application certificate or a
+  secure URL supported by Electron Builder.
+- `CSC_KEY_PASSWORD`: certificate password, when the `.p12` is encrypted.
+
+For notarization, prefer App Store Connect API key secrets:
+
+- `APPLE_API_KEY`: contents of the downloaded `AuthKey_<key-id>.p8` file.
+- `APPLE_API_KEY_ID`: App Store Connect API key ID.
+- `APPLE_API_ISSUER`: App Store Connect issuer UUID.
+
+When `CSC_LINK` is configured, the workflows also support Apple ID
+notarization via `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and
+`APPLE_TEAM_ID`, or an existing notarytool keychain profile via
+`APPLE_KEYCHAIN_PROFILE` and optional `APPLE_KEYCHAIN`. Do not commit
+certificates, app-specific passwords, provisioning profiles, or private keys.
 
 Use `GREDICE_DESKTOP_VERSION=<semver>` to override the package version stamped
 into desktop artifacts. Without it, the source app package version is used.


### PR DESCRIPTION
## Summary
- Add garden and farm macOS release workflows alongside the existing admin workflow, all building arm64 DMGs only.
- Keep the Electron launch fix for macOS by enabling library-validation entitlement for the desktop shell.
- Make notarization and Developer ID signing optional so releases can still ship without Apple Developer Program enrollment, while using signing/notarization when credentials are configured.
- Document the release tags and the new signing behavior.

## Testing
- `pnpm --filter desktop test`
- `git diff --check`
- YAML workflow parsing validation passed
- `pnpm lint:ci-filters`