### PR TITLE
Ignore empty desktop signing secrets

### DIFF
--- a/apps/desktop/scripts/package-desktop-app.mjs
+++ b/apps/desktop/scripts/package-desktop-app.mjs
@@ -33,6 +33,13 @@ const appsToBuild =
     targetName === 'all'
         ? desktopAppNames
         : [getDesktopApp(targetName).appName];
+const signingEnvNames = [
+    'CSC_INSTALLER_KEY_PASSWORD',
+    'CSC_INSTALLER_LINK',
+    'CSC_KEY_PASSWORD',
+    'CSC_LINK',
+    'CSC_NAME',
+];
 
 function selectedPlatformArgs() {
     if (shouldBuildAllPlatforms) {
@@ -61,6 +68,18 @@ function selectedPlatformArgs() {
     }
 
     throw new Error('Specify --mac or --win when building from this platform.');
+}
+
+function withoutEmptySigningEnv(env) {
+    const nextEnv = { ...env };
+
+    for (const name of signingEnvNames) {
+        if ((nextEnv[name] ?? '').trim().length === 0) {
+            delete nextEnv[name];
+        }
+    }
+
+    return nextEnv;
 }
 
 async function readPackageJson(packagePath) {
@@ -272,6 +291,7 @@ function runElectronBuilder(stageDir, desktopApp) {
     return new Promise((resolveBuild, rejectBuild) => {
         const child = spawn(electronBuilderCommand, builderArgs, {
             cwd: repoRoot,
+            env: withoutEmptySigningEnv(process.env),
             shell: process.platform === 'win32',
             stdio: 'inherit',
         });

--- a/apps/desktop/tests/desktop-apps.test.mjs
+++ b/apps/desktop/tests/desktop-apps.test.mjs
@@ -139,6 +139,8 @@ test('desktop release workflows can sign macOS artifacts when credentials exist'
     assert.match(packageSource, /forceCodeSigning:/);
     assert.match(packageSource, /GREDICE_DESKTOP_REQUIRE_MAC_SIGNING/);
     assert.match(packageSource, /GREDICE_DESKTOP_SKIP_MAC_NOTARIZATION/);
+    assert.match(packageSource, /withoutEmptySigningEnv/);
+    assert.match(packageSource, /delete nextEnv\[name\]/);
     assert.match(prepareSigningSource, /CSC_LINK is not configured/);
     assert.match(prepareSigningSource, /ad-hoc signing/);
     assert.match(prepareSigningSource, /APPLE_API_KEY_CONTENT/);


### PR DESCRIPTION
## Summary

- remove empty Electron Builder signing environment variables before spawning `electron-builder`
- prevents empty GitHub secrets like `CSC_LINK` from being treated as an explicit certificate path
- keeps no-Apple-Developer desktop releases on the intended ad-hoc signing path

## Validation

- `pnpm --filter desktop lint`
- `pnpm --filter desktop test`
- `git diff --check`
- `ruby -e "require 'yaml'; Dir['.github/workflows/*.yml'].sort.each { |p| YAML.load_file(p); puts p }"`\n- `pnpm lint:ci-filters`