### PR TITLE
Fix storage test race conditions

### DIFF
--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -91,7 +91,7 @@ const VERIFIED_SOWING_STATUSES = new Set([
 const SOWING_DURATION_MINUTES = 5;
 
 function getOperationDurationMinutes(operationData: OperationData | undefined) {
-    const durationValue = operationData?.attributes.duration;
+    const durationValue = operationData?.attributes?.duration;
 
     if (typeof durationValue === 'number' && Number.isFinite(durationValue)) {
         return Math.max(durationValue, 0);
@@ -279,7 +279,7 @@ export async function getFarmerBalance(
     const operationLabelById = new Map(
         operationsData.map((operation) => [
             operation.id,
-            operation.information.label || operation.information.name,
+            operation.information?.label || operation.information?.name,
         ]),
     );
     const operationDurationById = new Map(

--- a/packages/storage/tests/runNodeTests.sh
+++ b/packages/storage/tests/runNodeTests.sh
@@ -20,11 +20,9 @@ trap 'exit 143' TERM
 bash ./tests/startTestDb.sh
 bash ./tests/migrateTestDb.sh
 
-DB_PROVIDER="$(awk -F= '$1 == "GREDICE_TEST_DB_PROVIDER" { value = substr($0, index($0, "=") + 1) } END { print value }' .env.test)"
-NODE_TEST_ARGS=(--import tsx --import ./tests/testSetup.ts --test --env-file=.env.test --conditions=react-server)
-if [[ "$DB_PROVIDER" == "pglite" ]]; then
-    NODE_TEST_ARGS+=(--test-concurrency=1)
-fi
+# Storage specs share one disposable database, so run files serially to keep
+# cross-spec fixtures from racing through global farm and event state.
+NODE_TEST_ARGS=(--import tsx --import ./tests/testSetup.ts --test --test-concurrency=1 --env-file=.env.test --conditions=react-server)
 
 TEST_FILES=("$@")
 if [[ ${#TEST_FILES[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Harden payout aggregation against incomplete operation fixtures by safely reading operation metadata.
- Force storage node specs to run serially so shared test-database state does not race across files.

## Testing
- `@gredice/storage` node test suite passed locally.
- Targeted Biome check passed for the touched repository file.