### PR TITLE
Prioritize non-water placement positions

### DIFF
--- a/apps/api/lib/garden/blockPlacementService.node.spec.ts
+++ b/apps/api/lib/garden/blockPlacementService.node.spec.ts
@@ -4,9 +4,46 @@ import { resolveGardenBlockPlacement } from './blockPlacementService';
 
 const blockDataByName = new Map([
     ['Block_Grass', { attributes: { stackable: true, height: 1 } }],
+    ['Block_Water', { attributes: { stackable: true, height: 1 } }],
     ['Raised_Bed', { attributes: { stackable: true, height: 1 } }],
     ['Shade', { attributes: { stackable: false, height: 1 } }],
 ]);
+
+const maxSpiralSteps = 1000;
+
+function spiral(step: number) {
+    const r = Math.floor((Math.sqrt(step + 1) - 1) / 2) + 1;
+    const p = (8 * r * (r - 1)) / 2;
+    const en = r * 2;
+    const a = (1 + step - p) % (r * 8);
+
+    switch (Math.floor(a / (r * 2))) {
+        case 0:
+            return { x: a - r, y: -r };
+        case 1:
+            return { x: r, y: (a % en) - r };
+        case 2:
+            return { x: r - (a % en), y: r };
+        case 3:
+            return { x: -r, y: r - (a % en) };
+        default:
+            return { x: 0, y: 0 };
+    }
+}
+
+function createWaterOnlyPlacementSearch() {
+    const blockNameById = new Map([['water-origin', 'Block_Water']]);
+    const stacks = [{ positionX: 0, positionY: 0, blocks: ['water-origin'] }];
+
+    for (let step = 0; step < maxSpiralSteps; step++) {
+        const { x, y } = spiral(step);
+        const blockId = `water-${step}`;
+        blockNameById.set(blockId, 'Block_Water');
+        stacks.push({ positionX: x, positionY: y, blocks: [blockId] });
+    }
+
+    return { blockNameById, stacks };
+}
 
 describe('resolveGardenBlockPlacement', () => {
     it('skips invalid raised-bed positions near origin and finds the first valid slot', () => {
@@ -71,6 +108,51 @@ describe('resolveGardenBlockPlacement', () => {
         assert.deepStrictEqual(placement, {
             valid: false,
             error: 'Invalid block placement: ground blocks can only be placed on empty stacks',
+        });
+    });
+
+    it('prefers a valid non-water stack over a valid water stack', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Shade',
+            stacks: [
+                { positionX: 0, positionY: 0, blocks: ['water-a'] },
+                { positionX: 0, positionY: -1, blocks: ['grass-a'] },
+            ],
+            blockNameById: new Map([
+                ['water-a', 'Block_Water'],
+                ['grass-a', 'Block_Grass'],
+            ]),
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: true,
+            placement: {
+                x: 0,
+                y: -1,
+                index: 1,
+                existingBlocks: ['grass-a'],
+            },
+        });
+    });
+
+    it('uses a water stack when no non-water placement is available', () => {
+        const { blockNameById, stacks } = createWaterOnlyPlacementSearch();
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Shade',
+            stacks,
+            blockNameById,
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: true,
+            placement: {
+                x: 0,
+                y: 0,
+                index: 1,
+                existingBlocks: ['water-origin'],
+            },
         });
     });
 });

--- a/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
@@ -14,6 +14,10 @@ const blockData: PlacementBlockData[] = [
         attributes: { stackable: true, height: 1 },
     },
     {
+        information: { name: 'Block_Water' },
+        attributes: { stackable: true, height: 1 },
+    },
+    {
         information: { name: 'Raised_Bed' },
         attributes: { stackable: true, height: 1 },
     },
@@ -73,6 +77,41 @@ describe('createOptimisticBlockPlacement', () => {
                 {
                     id: 'optimistic-bed',
                     name: 'Raised_Bed',
+                    rotation: 0,
+                },
+            ],
+        });
+    });
+
+    it('avoids water stacks when automatically placing new blocks', () => {
+        const placement = createOptimisticBlockPlacement(
+            {
+                stacks: [
+                    {
+                        position: new Vector3(0, 0, 0),
+                        blocks: [
+                            {
+                                id: 'water-a',
+                                name: 'Block_Water',
+                                rotation: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+            blockData,
+            'Shade',
+            'optimistic-shade',
+        );
+
+        assert.ok(placement);
+        assert.deepStrictEqual(placement.position, new Vector3(0, 0, -1));
+        assert.deepStrictEqual(placement.stacks.at(-1), {
+            position: new Vector3(0, 0, -1),
+            blocks: [
+                {
+                    id: 'optimistic-shade',
+                    name: 'Shade',
                     rotation: 0,
                 },
             ],

--- a/packages/js/src/gardenBlocks/index.ts
+++ b/packages/js/src/gardenBlocks/index.ts
@@ -40,6 +40,7 @@ export type GardenBlockPlacementResult =
 
 const CANDIDATE_BLOCK_ID = '__candidate_block__';
 const MAX_SPIRAL_STEPS = 1000;
+const WATER_BLOCK_NAME = 'Block_Water';
 
 function spiral(step: number): Position {
     const r = Math.floor((Math.sqrt(step + 1) - 1) / 2) + 1;
@@ -70,6 +71,15 @@ function findStackAtPosition(stacks: GardenBlockStack[], position: Position) {
 
 function isGroundBlock(blockName: string) {
     return blockName.startsWith('Block');
+}
+
+function isWaterPlacement(
+    placement: Placement,
+    blockNameById: Map<string, string>,
+) {
+    return placement.existingBlocks.some(
+        (blockId) => blockNameById.get(blockId) === WATER_BLOCK_NAME,
+    );
 }
 
 export function validateStackPlacement(params: {
@@ -284,6 +294,8 @@ export function resolveGardenBlockPlacement(params: {
         });
     }
 
+    let waterPlacementFallback: GardenBlockPlacementResult | null = null;
+
     const originPlacement = validatePlacementAtPosition({
         blockName,
         position: { x: 0, y: 0 },
@@ -292,7 +304,11 @@ export function resolveGardenBlockPlacement(params: {
         blockDataByName,
     });
     if (originPlacement.valid) {
-        return originPlacement;
+        if (isWaterPlacement(originPlacement.placement, blockNameById)) {
+            waterPlacementFallback = originPlacement;
+        } else {
+            return originPlacement;
+        }
     }
 
     for (let step = 0; step < MAX_SPIRAL_STEPS; step++) {
@@ -304,9 +320,20 @@ export function resolveGardenBlockPlacement(params: {
             blockNameById,
             blockDataByName,
         });
-        if (placement.valid) {
-            return placement;
+        if (!placement.valid) {
+            continue;
         }
+
+        if (isWaterPlacement(placement.placement, blockNameById)) {
+            waterPlacementFallback ??= placement;
+            continue;
+        }
+
+        return placement;
+    }
+
+    if (waterPlacementFallback) {
+        return waterPlacementFallback;
     }
 
     return {


### PR DESCRIPTION
## Summary
- Prefer automatic block placement on non-water stacks first.
- Keep water stacks as the lowest-priority fallback when no other valid placement exists.
- Add unit coverage for both the backend resolver and the garden optimistic placement path.

## Testing
- Unit tests passed for the shared garden placement resolver and the game optimistic placement hook.
- App typechecks passed for `garden` and `www`.