### PR TITLE
Reset sandbox weather and time when leaving sandbox gardens

### DIFF
--- a/apps/garden/tests/SandboxEnvironmentHudStory.tsx
+++ b/apps/garden/tests/SandboxEnvironmentHudStory.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useClearSandboxEnvironmentOverrides } from '../../../packages/game/src/hooks/useClearSandboxEnvironmentOverrides';
 import { SandboxEnvironmentHud } from '../../../packages/game/src/hud/SandboxEnvironmentHud';
 import {
     createGameState,
@@ -71,6 +72,70 @@ export function SandboxEnvironmentHudStory() {
                 </div>
                 <SandboxEnvironmentHudStatus />
             </div>
+        </GameStateContext.Provider>
+    );
+}
+
+function SandboxEnvironmentResetControls({
+    garden,
+    onNormalGardenSelect,
+}: {
+    garden: { id: number; isSandbox: boolean };
+    onNormalGardenSelect: () => void;
+}) {
+    const setWeather = useGameState((state) => state.setWeather);
+    useClearSandboxEnvironmentOverrides(garden);
+
+    useEffect(() => {
+        setWeather({
+            cloudy: 0.9,
+            rainy: 1,
+            snowy: 0,
+            foggy: 0.2,
+            thundery: 1,
+            windSpeed: 3,
+            snowAccumulation: 0,
+        });
+    }, [setWeather]);
+
+    return (
+        <div className="relative h-screen w-screen overflow-hidden">
+            <button
+                data-testid="select-normal-garden"
+                type="button"
+                onClick={onNormalGardenSelect}
+            >
+                Select normal garden
+            </button>
+            <output data-testid="garden-mode-value">
+                {garden.isSandbox ? 'sandbox' : 'normal'}
+            </output>
+            <SandboxEnvironmentHudStatus />
+        </div>
+    );
+}
+
+export function SandboxEnvironmentResetStory() {
+    const [garden, setGarden] = useState({ id: 1, isSandbox: true });
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date(2026, 5, 21, 22, 0, 0),
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
+
+    return (
+        <GameStateContext.Provider value={gameStore}>
+            <SandboxEnvironmentResetControls
+                garden={garden}
+                onNormalGardenSelect={() =>
+                    setGarden({ id: 2, isSandbox: false })
+                }
+            />
         </GameStateContext.Provider>
     );
 }

--- a/apps/garden/tests/SandboxEnvironmentHudStory.tsx
+++ b/apps/garden/tests/SandboxEnvironmentHudStory.tsx
@@ -80,7 +80,7 @@ function SandboxEnvironmentResetControls({
     garden,
     onNormalGardenSelect,
 }: {
-    garden: { id: number; isSandbox: boolean };
+    garden: { id: number; isSandbox: boolean } | null;
     onNormalGardenSelect: () => void;
 }) {
     const setWeather = useGameState((state) => state.setWeather);
@@ -108,7 +108,7 @@ function SandboxEnvironmentResetControls({
                 Select normal garden
             </button>
             <output data-testid="garden-mode-value">
-                {garden.isSandbox ? 'sandbox' : 'normal'}
+                {garden ? (garden.isSandbox ? 'sandbox' : 'normal') : 'loading'}
             </output>
             <SandboxEnvironmentHudStatus />
         </div>
@@ -116,7 +116,10 @@ function SandboxEnvironmentResetControls({
 }
 
 export function SandboxEnvironmentResetStory() {
-    const [garden, setGarden] = useState({ id: 1, isSandbox: true });
+    const [garden, setGarden] = useState<{
+        id: number;
+        isSandbox: boolean;
+    } | null>({ id: 1, isSandbox: true });
     const gameStore = useMemo(
         () =>
             createGameState({
@@ -132,9 +135,13 @@ export function SandboxEnvironmentResetStory() {
         <GameStateContext.Provider value={gameStore}>
             <SandboxEnvironmentResetControls
                 garden={garden}
-                onNormalGardenSelect={() =>
-                    setGarden({ id: 2, isSandbox: false })
-                }
+                onNormalGardenSelect={() => {
+                    setGarden(null);
+                    window.setTimeout(
+                        () => setGarden({ id: 2, isSandbox: false }),
+                        100,
+                    );
+                }}
             />
         </GameStateContext.Provider>
     );

--- a/apps/garden/tests/sandbox-environment-hud.spec.tsx
+++ b/apps/garden/tests/sandbox-environment-hud.spec.tsx
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { SandboxEnvironmentHudStory } from './SandboxEnvironmentHudStory';
+import {
+    SandboxEnvironmentHudStory,
+    SandboxEnvironmentResetStory,
+} from './SandboxEnvironmentHudStory';
 
 test('sandbox environment HUD applies weather presets', async ({
     mount,
@@ -57,4 +60,23 @@ test('sandbox environment HUD can scrub time and change date', async ({
     await expect(page.getByTestId('sandbox-date-value')).toHaveText(
         '2026-12-21',
     );
+});
+
+test('switching from sandbox to a normal garden clears environment overrides', async ({
+    mount,
+    page,
+}) => {
+    await mount(<SandboxEnvironmentResetStory />);
+
+    await expect(page.getByTestId('garden-mode-value')).toHaveText('sandbox');
+    await expect(page.getByTestId('sandbox-time-value')).toHaveText('22:00');
+    await expect(page.getByTestId('sandbox-weather-value')).toContainText(
+        '"rainy":1',
+    );
+
+    await page.getByTestId('select-normal-garden').click();
+
+    await expect(page.getByTestId('garden-mode-value')).toHaveText('normal');
+    await expect(page.getByTestId('sandbox-time-value')).toHaveText('');
+    await expect(page.getByTestId('sandbox-weather-value')).toHaveText('null');
 });

--- a/apps/garden/tests/sandbox-environment-hud.spec.tsx
+++ b/apps/garden/tests/sandbox-environment-hud.spec.tsx
@@ -62,7 +62,7 @@ test('sandbox environment HUD can scrub time and change date', async ({
     );
 });
 
-test('switching from sandbox to a normal garden clears environment overrides', async ({
+test('switching from sandbox to a normal garden clears environment overrides after loading', async ({
     mount,
     page,
 }) => {
@@ -75,6 +75,11 @@ test('switching from sandbox to a normal garden clears environment overrides', a
     );
 
     await page.getByTestId('select-normal-garden').click();
+
+    await expect(page.getByTestId('garden-mode-value')).toHaveText('loading');
+    await expect(page.getByTestId('sandbox-weather-value')).toContainText(
+        '"rainy":1',
+    );
 
     await expect(page.getByTestId('garden-mode-value')).toHaveText('normal');
     await expect(page.getByTestId('sandbox-time-value')).toHaveText('');

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -2,7 +2,8 @@
 
 import { cx } from '@gredice/ui/utils';
 import type { GameSceneProps } from './GameScene';
-import { useIsSandboxGarden } from './hooks/useCurrentGarden';
+import { useClearSandboxEnvironmentOverrides } from './hooks/useClearSandboxEnvironmentOverrides';
+import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { AccountHud } from './hud/AccountHud';
 import { AdventHud } from './hud/AdventHud';
 import { AudioHud } from './hud/AudioHud';
@@ -38,8 +39,10 @@ export function GameHud({
     noWeather?: boolean;
 }) {
     const isCloseup = useGameState((state) => state.view) === 'closeup';
+    const { data: currentGarden } = useCurrentGarden();
     // Sandbox ("play") gardens are decoration only: no economy or inventory.
-    const isSandbox = useIsSandboxGarden();
+    const isSandbox = Boolean(currentGarden?.isSandbox);
+    useClearSandboxEnvironmentOverrides(currentGarden);
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -2,7 +2,6 @@
 
 import { cx } from '@gredice/ui/utils';
 import type { GameSceneProps } from './GameScene';
-import { useClearSandboxEnvironmentOverrides } from './hooks/useClearSandboxEnvironmentOverrides';
 import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { AccountHud } from './hud/AccountHud';
 import { AdventHud } from './hud/AdventHud';
@@ -42,7 +41,6 @@ export function GameHud({
     const { data: currentGarden } = useCurrentGarden();
     // Sandbox ("play") gardens are decoration only: no economy or inventory.
     const isSandbox = Boolean(currentGarden?.isSandbox);
-    useClearSandboxEnvironmentOverrides(currentGarden);
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -27,6 +27,7 @@ import {
     farGameCameraZoom,
 } from './gameCamera';
 import { useBlockData } from './hooks/useBlockData';
+import { useClearSandboxEnvironmentOverrides } from './hooks/useClearSandboxEnvironmentOverrides';
 import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { useDeferredSceneDetails } from './hooks/useDeferredSceneDetails';
 import { useFocusPlacedBlock } from './hooks/useFocusPlacedBlock';
@@ -171,6 +172,7 @@ export function GameScene({
     // Start non-critical metadata early, but don't block the first scene frame.
     useBlockData();
     const { data: garden, isLoading: gardenLoading } = useCurrentGarden();
+    useClearSandboxEnvironmentOverrides(garden);
     useWeatherNow(!isLocalSandbox && !weatherDisabled && !weather);
     const isLoading = gardenLoading;
 

--- a/packages/game/src/hooks/useClearSandboxEnvironmentOverrides.ts
+++ b/packages/game/src/hooks/useClearSandboxEnvironmentOverrides.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { useGameState } from '../useGameState';
+
+type GardenEnvironmentMode = {
+    id: number;
+    isSandbox: boolean;
+};
+
+export function useClearSandboxEnvironmentOverrides(
+    garden: GardenEnvironmentMode | null | undefined,
+) {
+    const previousGardenRef = useRef<GardenEnvironmentMode | null>(null);
+    const clearEnvironmentOverrides = useGameState(
+        (state) => state.clearEnvironmentOverrides,
+    );
+    const gardenId = garden?.id;
+    const isSandbox = garden?.isSandbox;
+
+    useEffect(() => {
+        if (gardenId == null || isSandbox == null) {
+            return;
+        }
+
+        const previousGarden = previousGardenRef.current;
+        previousGardenRef.current = { id: gardenId, isSandbox };
+
+        if (previousGarden?.isSandbox && !isSandbox) {
+            clearEnvironmentOverrides();
+        }
+    }, [clearEnvironmentOverrides, gardenId, isSandbox]);
+}

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -86,6 +86,17 @@ export type AnimalDisturbance = {
     radius: number;
 };
 
+type WeatherOverride = {
+    cloudy: number;
+    rainy: number;
+    snowy: number;
+    foggy: number;
+    thundery?: number;
+    windSpeed?: number;
+    windDirection?: number;
+    snowAccumulation?: number;
+};
+
 export type GameState = {
     // General
     isMock: boolean;
@@ -154,26 +165,9 @@ export type GameState = {
     setEditHitboxDebugVisible: (visible: boolean) => void;
     entityRenderModeDebugVisible: boolean;
     setEntityRenderModeDebugVisible: (visible: boolean) => void;
-    weather?: {
-        cloudy: number;
-        rainy: number;
-        snowy: number;
-        foggy: number;
-        thundery?: number;
-        windSpeed?: number;
-        windDirection?: number;
-        snowAccumulation?: number;
-    };
-    setWeather: (weather: {
-        cloudy: number;
-        rainy: number;
-        snowy: number;
-        foggy: number;
-        thundery?: number;
-        windSpeed?: number;
-        windDirection?: number;
-        snowAccumulation?: number;
-    }) => void;
+    weather?: WeatherOverride;
+    setWeather: (weather: WeatherOverride | undefined) => void;
+    clearEnvironmentOverrides: () => void;
 
     // Environment derived state
     snowCoverage: number;
@@ -436,6 +430,23 @@ export function createGameState({
         setEntityRenderModeDebugVisible: (entityRenderModeDebugVisible) =>
             set({ entityRenderModeDebugVisible }),
         setWeather: (weather) => set({ weather }),
+        clearEnvironmentOverrides: () => {
+            const referenceTime = new Date();
+            const { sunrise, sunset } = getGameSunriseSunset(
+                defaultGameLocation,
+                referenceTime,
+            );
+            set({
+                freezeTime: null,
+                weather: undefined,
+                timeOfDay: resolveGameTimeOfDay(
+                    referenceTime,
+                    get().dayNightCycleDisabled,
+                ),
+                sunriseTime: sunrise,
+                sunsetTime: sunset,
+            });
+        },
         snowCoverage: 0,
         setSnowCoverage: (snowCoverage) => set({ snowCoverage }),
         waterColors: defaultWaterColors,


### PR DESCRIPTION
## Summary
- Clear sandbox weather and frozen time overrides when the current garden switches from sandbox to a normal garden.
- Keep the reset logic inside `@gredice/game` and reuse it from the garden HUD transition.
- Add component coverage for the sandbox-to-normal switch case.

## Testing
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/sandbox-environment-hud.spec.tsx`