### PR TITLE
[codex] Optimize dense game scenes

### DIFF
--- a/docs/game-scene-performance.md
+++ b/docs/game-scene-performance.md
@@ -52,13 +52,20 @@ not accidentally based on `next dev`.
   garden boxes, pots, cactus variants, dead trees, buckets, watering cans, water
   wells, composters, cat pillows, fences, stools, bird houses, gift boxes, and
   remaining ground block variants.
-- Snow and rain overlays are intentionally still a follow-up optimization. Many
-  newly instanced base meshes still mount per-block `SnowOverlay` or
+- The 2026-06-01 dense-scene pass replaced Drei per-instance children with
+  chunked raw `InstancedMesh` updates, batched ground decoration sprites by
+  atlas sprite/material, retained decoration wind motion through a batched
+  shader path, and rendered repeated rain/snow overlays with shared instanced
+  overlay meshes. Instanced block control wrappers are skipped for no-control
+  profile scenes and for covered instanced blocks, so stacked scenes no longer
+  mount buried grass controls under every top block.
+- Snow and rain overlays are optimized for repeated instanced blocks, but many
+  non-instanced entities can still mount per-block `SnowOverlay` or
   `RainWetOverlay` meshes when weather makes them visible, so snow/rain profiles
-  can remain overlay-bound even after base draw calls improve.
-- The remaining expensive areas are continuous `useFrame` systems, snow overlays,
-  CPU weather loops, animated sprite billboard callbacks, plant/detail LOD, and
-  profiling noise from app-level providers.
+  can remain overlay-bound outside the repeated instanced block path.
+- The remaining expensive areas are continuous `useFrame` systems, snow overlays
+  outside the repeated instanced block path, CPU weather loops, plant/detail LOD,
+  and profiling noise from app-level providers.
 
 ## Current static snapshot
 
@@ -224,6 +231,26 @@ detail counts, and repeated longer samples for optimization deltas. The useful
 confirmation is that low mobile now eliminates optional ground decorations, and
 clear scenes no longer mount snow overlays.
 
+### 2026-06-01 dense 25x25 production smoke
+
+Measured with a production `apps/garden` build started on `http://localhost:3205`
+and a synthetic `/debug/sandbox` garden injected through local storage. Each
+sample used a 3 second warmup and 3 second collection window in headless
+Playwright. Treat absolute FPS/p95 as noisy; use heap and render-work deltas for
+direction.
+
+| Scenario | Blocks | Quality | Details | Draw/frame | Heap | Notes |
+| --- | ---: | --- | ---: | ---: | ---: | --- |
+| `25x25-ground-desktop-medium` | 625 | medium | 1,370 decor | 426 | 132.6 MB | before pass: about 830 draw/frame and 179 MB |
+| `25x25-raised-desktop-medium` | 1,250 | medium | 1,352 decor | 453 | 149.7 MB | before pass: about 1,186 draw/frame and 347 MB |
+| `25x25-ground-mobile-low` | 625 | low | 0 decor | 133 | 132.6 MB | before pass: about 120 draw/frame and 179 MB |
+| `25x25-raised-mobile-low` | 1,250 | low | 0 decor | 140 | 202.2 MB | before pass: about 227 draw/frame and 391 MB |
+
+The main improvement is memory and submitted draw work for dense scenes without
+forcing a low-quality fallback. Desktop medium still creates many shadow and
+decoration draw calls, but the repeated block geometry, decoration billboards,
+and weather overlays no longer mount one React/fiber child per instance.
+
 ### Steady browser sample
 
 The VS Code browser sample stayed at DPR 2 even when different profiles were
@@ -381,14 +408,14 @@ for static sprites to reset rotation. The plant debug route also submitted far
 more draw calls and triangles than the home scene.
 
 Current status: sprite billboards now split static and animated mesh components,
-so calm/static sprites do not register a per-frame callback. Ground decorations
-are also quality-gated: low disables them, medium renders reduced density, high
-keeps full density, and far zoom skips them.
+so calm/static sprites do not register a per-frame callback. Dense ground
+decorations are batched into atlas/material instanced planes with shader-driven
+wind motion. They remain quality-gated: low disables them, medium renders
+reduced density, high keeps full density, and far zoom skips them.
 
 Recommended work:
 
-- Batch ground decoration sprites by atlas page using instanced planes and
-  per-instance UV rectangles.
+- Add distance/viewport culling for decoration batches in larger gardens.
 - Keep hiding small decoration sprites by quality tier, distance, and zoom.
 - Use plant billboards for normal/far garden views and detailed generated plants
   only for close-up or high-quality mode.

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -121,6 +121,28 @@ function useAutoQualityProfileMetrics(enabled: boolean) {
     return metrics;
 }
 
+function shouldRenderEntityFactoryForBlock({
+    blockName,
+    blockIndex,
+    noControls,
+    stackLength,
+}: {
+    blockName: string;
+    blockIndex: number;
+    noControls: boolean | undefined;
+    stackLength: number;
+}) {
+    if (!instancedBlockNames.includes(blockName)) {
+        return true;
+    }
+
+    if (noControls) {
+        return false;
+    }
+
+    return blockIndex === stackLength - 1;
+}
+
 export function GameScene({
     cameraPosition = defaultGameCameraPosition,
     zoom = 'normal',
@@ -213,12 +235,19 @@ export function GameScene({
                         />
                         <group>
                             {garden?.stacks.map((stack) =>
-                                stack.blocks?.map((block, i) => (
-                                    <Suspense
-                                        // biome-ignore lint/suspicious/noArrayIndexKey: Using array index as key is acceptable here because block IDs are unique within a stack, and the order of blocks within a stack is unlikely to change. Using block.id alone is not sufficient as it may not be unique across different stacks.
-                                        key={`${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.id}-${block.name}-${i}`}
-                                        fallback={null}
-                                    >
+                                stack.blocks?.map((block, i) => {
+                                    if (
+                                        !shouldRenderEntityFactoryForBlock({
+                                            blockName: block.name,
+                                            blockIndex: i,
+                                            noControls,
+                                            stackLength: stack.blocks.length,
+                                        })
+                                    ) {
+                                        return null;
+                                    }
+
+                                    const entityFactory = (
                                         <EntityFactory
                                             name={block.name}
                                             stack={stack}
@@ -229,8 +258,25 @@ export function GameScene({
                                             noRenderInView={instancedBlockNames}
                                             noControl={noControls}
                                         />
-                                    </Suspense>
-                                )),
+                                    );
+                                    const key = `${stack.position.x}|${stack.position.y}|${stack.position.z}|${block.id}-${block.name}-${i}`;
+
+                                    if (
+                                        instancedBlockNames.includes(block.name)
+                                    ) {
+                                        return (
+                                            <group key={key}>
+                                                {entityFactory}
+                                            </group>
+                                        );
+                                    }
+
+                                    return (
+                                        <Suspense key={key} fallback={null}>
+                                            {entityFactory}
+                                        </Suspense>
+                                    );
+                                }),
                             )}
                             {!isLocalSandbox &&
                                 renderDetails &&

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -1,6 +1,19 @@
-import { Instance, Instances } from '@react-three/drei';
-import { type ReactNode, useMemo } from 'react';
-import type { Material } from 'three';
+import {
+    cloneElement,
+    isValidElement,
+    type ReactNode,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+} from 'react';
+import {
+    Euler,
+    type InstancedMesh,
+    type Material,
+    Matrix4,
+    Quaternion,
+    Vector3,
+} from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import {
     type ActiveDragPreviewTarget,
@@ -9,19 +22,29 @@ import {
     getActiveDragPreviewTargetPositionOffset,
 } from '../dragPreviewIdentity';
 import { useBlockData } from '../hooks/useBlockData';
-import { RainWetOverlay } from '../rain/RainWetOverlay';
-import { type SnowMaterialOptions, SnowOverlay } from '../snow/SnowOverlay';
+import {
+    RainWetOverlay,
+    useRainWetOverlayMaterial,
+    useRainWetOverlayVisible,
+} from '../rain/RainWetOverlay';
+import { createSnowOverlayGeometry } from '../snow/createSnowOverlayGeometry';
+import {
+    type SnowMaterialOptions,
+    SnowOverlay,
+    useSnowMaterial,
+    useSnowOverlayVisible,
+} from '../snow/SnowOverlay';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import { type ActiveDragPreview, useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
-import { resolveBlockInstanceCapacity } from './blockInstanceCapacity';
 import { blockPickupOutlineStyle } from './helpers/blockPickupOutlineStyle';
 import { HoverOutline } from './helpers/HoverOutline';
 import { PlacementDropAnimation } from './helpers/PlacementDropAnimation';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
+const instanceChunkSize = 8;
 
 export type EntityInstancesBlockBaseProps = {
     stacks: Stack[] | undefined;
@@ -61,6 +84,81 @@ export type EntityBlockInstance = {
     stack: Stack;
     stackHeight: number;
 };
+
+type InstanceChunk = {
+    key: string;
+    instances: EntityBlockInstance[];
+};
+
+function chunkInstanceKey(position: [number, number, number]) {
+    return `${Math.floor(position[0] / instanceChunkSize)}:${Math.floor(
+        position[2] / instanceChunkSize,
+    )}`;
+}
+
+function chunkInstances(instances: EntityBlockInstance[]) {
+    const chunkByKey = new Map<string, EntityBlockInstance[]>();
+
+    for (const instance of instances) {
+        const key = chunkInstanceKey(instance.position);
+        const chunk = chunkByKey.get(key);
+        if (chunk) {
+            chunk.push(instance);
+            continue;
+        }
+        chunkByKey.set(key, [instance]);
+    }
+
+    return [...chunkByKey.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(
+            ([key, chunk]): InstanceChunk => ({
+                key,
+                instances: chunk,
+            }),
+        );
+}
+
+function createInstanceMatrix(
+    instance: EntityBlockInstance,
+    localTransform: {
+        position: [number, number, number];
+        rotation: [number, number, number];
+    },
+    scale: EntityInstancesBlockBaseProps['scale'],
+) {
+    const rootPosition = new Vector3(...instance.position);
+    const rootQuaternion = new Quaternion().setFromAxisAngle(
+        new Vector3(0, 1, 0),
+        instance.rotation * (Math.PI / 2),
+    );
+    const rootScale = new Vector3(1, 1, 1);
+    const rootMatrix = new Matrix4().compose(
+        rootPosition,
+        rootQuaternion,
+        rootScale,
+    );
+    const localPosition = new Vector3(...localTransform.position);
+    const localQuaternion = new Quaternion().setFromEuler(
+        new Euler(...localTransform.rotation),
+    );
+    const localScale = Array.isArray(scale)
+        ? new Vector3(scale[0], scale[1], scale[2])
+        : new Vector3(scale ?? 1, scale ?? 1, scale ?? 1);
+    const localMatrix = new Matrix4().compose(
+        localPosition,
+        localQuaternion,
+        localScale,
+    );
+
+    return rootMatrix.multiply(localMatrix);
+}
+
+function cloneMaterialNode(materialNode: ReactNode) {
+    return isValidElement(materialNode)
+        ? cloneElement(materialNode)
+        : materialNode;
+}
 
 function blockNameMatches(
     blockName: string,
@@ -309,15 +407,24 @@ export function EntityInstancesGeometry(
         return null;
     }
 
-    const instanceCapacity = resolveBlockInstanceCapacity(instances.length);
-
     const localTransform = {
         position: localPosition ?? defaultLocalPosition,
         rotation: localRotation ?? defaultLocalRotation,
     };
+    const animatedBlockIds = new Set(Object.keys(placementDropAnimations));
+    const stableInstances = instances.filter(
+        (data) => !animatedBlockIds.has(data.block.id),
+    );
+    const animatedInstances = instances.filter((data) =>
+        animatedBlockIds.has(data.block.id),
+    );
+    const stableChunks = chunkInstances(stableInstances);
 
-    const renderInstances = (suffix: string) =>
-        (instances ?? []).map((data) => (
+    const material = 'material' in props ? props.material : undefined;
+    const materialNode = 'materialNode' in props ? props.materialNode : null;
+
+    const renderAnimatedInstances = (suffix: string) =>
+        animatedInstances.map((data) => (
             <PlacementDropAnimation
                 key={`block-${instanceKey}-${suffix}-${data.id}`}
                 animation={placementDropAnimations[data.block.id]}
@@ -330,19 +437,26 @@ export function EntityInstancesGeometry(
                 position={data.position}
             >
                 <group rotation={[0, data.rotation * (Math.PI / 2), 0]}>
-                    <Instance
+                    <mesh
+                        geometry={geometry}
+                        material={material}
                         position={localTransform.position}
                         rotation={localTransform.rotation}
                         scale={scale}
-                    />
+                        receiveShadow={receiveShadow}
+                        castShadow={castShadow}
+                        renderOrder={renderOrder}
+                    >
+                        {cloneMaterialNode(materialNode)}
+                    </mesh>
                 </group>
             </PlacementDropAnimation>
         ));
 
-    const renderSnowOverlays = () =>
+    const renderAnimatedSnowOverlays = () =>
         !snow || !renderSnow
             ? null
-            : (instances ?? []).map((data) => (
+            : animatedInstances.map((data) => (
                   <PlacementDropAnimation
                       key={`block-${instanceKey}-snow-${data.id}`}
                       animation={placementDropAnimations[data.block.id]}
@@ -374,10 +488,10 @@ export function EntityInstancesGeometry(
                   </PlacementDropAnimation>
               ));
 
-    const renderRainOverlays = () =>
+    const renderAnimatedRainOverlays = () =>
         !renderRainWetOverlay
             ? null
-            : (instances ?? []).map((data) => (
+            : animatedInstances.map((data) => (
                   <PlacementDropAnimation
                       key={`block-${instanceKey}-rain-${data.id}`}
                       animation={placementDropAnimations[data.block.id]}
@@ -403,20 +517,21 @@ export function EntityInstancesGeometry(
 
     return (
         <>
-            <Instances
-                key={`${instanceKey}-${instanceCapacity}`}
-                limit={instanceCapacity}
-                range={instances.length}
-                geometry={geometry}
-                frustumCulled={false}
-                receiveShadow={receiveShadow}
-                castShadow={castShadow}
-                renderOrder={renderOrder}
-                material={'material' in props ? props.material : undefined}
-            >
-                {'materialNode' in props ? props.materialNode : null}
-                {renderInstances('base')}
-            </Instances>
+            {stableChunks.map((chunk) => (
+                <ChunkedInstancedMesh
+                    key={`${instanceKey}:${chunk.key}`}
+                    castShadow={castShadow}
+                    chunk={chunk}
+                    geometry={geometry}
+                    localTransform={localTransform}
+                    material={material}
+                    materialNode={materialNode}
+                    receiveShadow={receiveShadow}
+                    renderOrder={renderOrder}
+                    scale={scale}
+                />
+            ))}
+            {renderAnimatedInstances('base')}
             {(instances ?? []).map((data) =>
                 data.pickupOutlineVisible ? (
                     <HoverOutline
@@ -441,8 +556,197 @@ export function EntityInstancesGeometry(
                     </HoverOutline>
                 ) : null,
             )}
-            {renderRainOverlays()}
-            {renderSnowOverlays()}
+            {renderRainWetOverlay && (
+                <InstancedRainWetOverlays
+                    chunks={stableChunks}
+                    geometry={geometry}
+                    localTransform={localTransform}
+                    scale={scale}
+                />
+            )}
+            {snow && renderSnow && (
+                <InstancedSnowOverlays
+                    chunks={stableChunks}
+                    geometry={geometry}
+                    localTransform={localTransform}
+                    scale={scale}
+                    snow={snow}
+                    snowLift={snowLift}
+                    snowOverlayMinCoverage={snowOverlayMinCoverage}
+                />
+            )}
+            {renderAnimatedRainOverlays()}
+            {renderAnimatedSnowOverlays()}
         </>
     );
+}
+
+function ChunkedInstancedMesh({
+    castShadow,
+    chunk,
+    geometry,
+    localTransform,
+    material,
+    materialNode,
+    receiveShadow,
+    renderOrder,
+    scale,
+}: {
+    castShadow: boolean;
+    chunk: InstanceChunk;
+    geometry: BufferGeometry;
+    localTransform: {
+        position: [number, number, number];
+        rotation: [number, number, number];
+    };
+    material: Material | Material[] | undefined;
+    materialNode: ReactNode;
+    receiveShadow: boolean;
+    renderOrder?: number;
+    scale: EntityInstancesBlockBaseProps['scale'];
+}) {
+    const meshRef = useRef<InstancedMesh | null>(null);
+
+    useLayoutEffect(() => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        chunk.instances.forEach((instance, index) => {
+            mesh.setMatrixAt(
+                index,
+                createInstanceMatrix(instance, localTransform, scale),
+            );
+        });
+        mesh.count = chunk.instances.length;
+        mesh.instanceMatrix.needsUpdate = true;
+        mesh.computeBoundingBox();
+        mesh.computeBoundingSphere();
+    }, [chunk.instances, localTransform, scale]);
+
+    return (
+        <instancedMesh
+            ref={meshRef}
+            args={[geometry, material, chunk.instances.length]}
+            castShadow={castShadow}
+            receiveShadow={receiveShadow}
+            renderOrder={renderOrder}
+        >
+            {cloneMaterialNode(materialNode)}
+        </instancedMesh>
+    );
+}
+
+function InstancedSnowOverlays({
+    chunks,
+    geometry,
+    localTransform,
+    scale,
+    snow,
+    snowLift,
+    snowOverlayMinCoverage,
+}: {
+    chunks: InstanceChunk[];
+    geometry: BufferGeometry;
+    localTransform: {
+        position: [number, number, number];
+        rotation: [number, number, number];
+    };
+    scale: EntityInstancesBlockBaseProps['scale'];
+    snow: SnowMaterialOptions;
+    snowLift: number;
+    snowOverlayMinCoverage?: number;
+}) {
+    const visible = useSnowOverlayVisible({
+        coverageMultiplier: snow.coverageMultiplier,
+        minCoverage: snowOverlayMinCoverage,
+        overrideSnow: snow.overrideSnow,
+    });
+    const overlayGeometry = useMemo(
+        () => createSnowOverlayGeometry(geometry),
+        [geometry],
+    );
+    const bounds = useMemo(() => {
+        if (!overlayGeometry.boundingBox) {
+            overlayGeometry.computeBoundingBox();
+        }
+        const box = overlayGeometry.boundingBox;
+        if (!box) {
+            return snow.bounds;
+        }
+        return {
+            min: [box.min.x, box.min.y, box.min.z] as [number, number, number],
+            max: [box.max.x, box.max.y, box.max.z] as [number, number, number],
+        };
+    }, [overlayGeometry, snow.bounds]);
+    const material = useSnowMaterial({
+        ...snow,
+        bounds: snow.bounds ?? bounds,
+    });
+    const liftedTransform = useMemo(
+        () => ({
+            ...localTransform,
+            position: [
+                localTransform.position[0],
+                localTransform.position[1] + (snowLift || 0.003),
+                localTransform.position[2],
+            ] as [number, number, number],
+        }),
+        [localTransform, snowLift],
+    );
+
+    if (!visible) {
+        return null;
+    }
+
+    return chunks.map((chunk) => (
+        <ChunkedInstancedMesh
+            key={`snow:${chunk.key}`}
+            castShadow={false}
+            chunk={chunk}
+            geometry={overlayGeometry}
+            localTransform={liftedTransform}
+            material={material}
+            materialNode={null}
+            receiveShadow={false}
+            scale={scale}
+        />
+    ));
+}
+
+function InstancedRainWetOverlays({
+    chunks,
+    geometry,
+    localTransform,
+    scale,
+}: {
+    chunks: InstanceChunk[];
+    geometry: BufferGeometry;
+    localTransform: {
+        position: [number, number, number];
+        rotation: [number, number, number];
+    };
+    scale: EntityInstancesBlockBaseProps['scale'];
+}) {
+    const visible = useRainWetOverlayVisible();
+    const material = useRainWetOverlayMaterial({ geometry });
+
+    if (!visible) {
+        return null;
+    }
+
+    return chunks.map((chunk) => (
+        <ChunkedInstancedMesh
+            key={`rain:${chunk.key}`}
+            castShadow={false}
+            chunk={chunk}
+            geometry={geometry}
+            localTransform={localTransform}
+            material={material}
+            materialNode={null}
+            receiveShadow={false}
+            scale={scale}
+        />
+    ));
 }

--- a/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
     type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
@@ -8,27 +8,18 @@ import {
 } from '../../dragPreviewIdentity';
 import { useBlockData } from '../../hooks/useBlockData';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
-import { useWeatherNow } from '../../hooks/useWeatherNow';
 import { updateGameProfileMetadata } from '../../scene/gameProfileMetadata';
 import type { Stack } from '../../types/Stack';
 import { useGameState } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
-import { BlockSurfaceDecorationSprites } from './BlockSurfaceDecorationSprites';
+import {
+    type GroundDecorationInstance,
+    GroundDecorationInstances,
+} from './GroundDecorationInstances';
 import { getBlockSurfaceDecorations } from './getBlockSurfaceDecorations';
 import { resolveGroundDecorationSurface } from './groundDecorationConfig';
 
 const blockSurfaceYOffset = 0.2;
-const compassToDirection: Record<string, number> = {
-    E: 90,
-    N: 0,
-    NE: 45,
-    NW: 315,
-    S: 180,
-    SE: 135,
-    SW: 225,
-    W: 270,
-};
-
 type GroundBlockDecorationsProps = {
     density: number;
     stacks: Stack[] | undefined;
@@ -44,18 +35,6 @@ export function GroundBlockDecorations({
 }: GroundBlockDecorationsProps) {
     const { data: blockData } = useBlockData();
     const { data: garden } = useCurrentGarden();
-    const gameWeather = useGameState((state) => state.weather);
-    const { data: weatherNow } = useWeatherNow();
-    const windSpeed =
-        typeof gameWeather?.windSpeed === 'number'
-            ? gameWeather.windSpeed
-            : (weatherNow?.windSpeed ?? 0);
-    const windDirection =
-        typeof gameWeather?.windDirection === 'number'
-            ? gameWeather.windDirection
-            : typeof weatherNow?.windDirection === 'string'
-              ? (compassToDirection[weatherNow.windDirection] ?? 0)
-              : 0;
     const decorationBlocks = useMemo(() => {
         if (!stacks || density <= 0) {
             return [];
@@ -128,6 +107,61 @@ export function GroundBlockDecorations({
         (sum, block) => sum + block.placements.length,
         0,
     );
+    const decorationInstances = useMemo(() => {
+        const instances: GroundDecorationInstance[] = [];
+
+        for (const {
+            block,
+            blockIndex,
+            placements,
+            stack,
+        } of decorationBlocks) {
+            const dragPreviewOffset = getActiveDragPreviewTargetPositionOffset(
+                createActiveDragPreviewTarget({
+                    blockId: block.id,
+                    blockIndex,
+                    stackPosition: stack.position,
+                }),
+                activeDragPreview,
+            );
+            const blockRotation = block.rotation * (Math.PI / 2);
+            const cos = Math.cos(blockRotation);
+            const sin = Math.sin(blockRotation);
+            const baseHeight =
+                getStackHeight(blockData, stack, block) + blockSurfaceYOffset;
+            const offsetX = dragPreviewOffset?.x ?? 0;
+            const offsetY = dragPreviewOffset?.y ?? 0;
+            const offsetZ = dragPreviewOffset?.z ?? 0;
+
+            for (const placement of placements) {
+                const [localX, localY, localZ] = placement.position;
+                const rotatedX = localX * cos + localZ * sin;
+                const rotatedZ = -localX * sin + localZ * cos;
+
+                instances.push({
+                    alphaTest: placement.kind === 'flower' ? 0.05 : 0.06,
+                    height:
+                        placement.kind === 'flower'
+                            ? placement.scale
+                            : placement.height,
+                    opacity:
+                        placement.kind === 'flower'
+                            ? 0.95
+                            : Math.round(placement.opacity * 20) / 20,
+                    position: [
+                        stack.position.x + rotatedX + offsetX,
+                        baseHeight + localY + offsetY,
+                        stack.position.z + rotatedZ + offsetZ,
+                    ],
+                    rotationZ:
+                        placement.kind === 'flower' ? placement.rotation : 0,
+                    spriteName: placement.spriteName,
+                });
+            }
+        }
+
+        return instances;
+    }, [activeDragPreview, blockData, decorationBlocks]);
 
     useEffect(() => {
         updateGameProfileMetadata({
@@ -140,59 +174,5 @@ export function GroundBlockDecorations({
         return null;
     }
 
-    return (
-        <>
-            {stacks.map((stack) => (
-                <Fragment
-                    key={`ground-decorations:${stack.position.x}:${stack.position.z}`}
-                >
-                    {decorationBlocks
-                        .filter((block) => block.stack === stack)
-                        .map(({ block, blockIndex, placements, surface }) => {
-                            const dragPreviewOffset =
-                                getActiveDragPreviewTargetPositionOffset(
-                                    createActiveDragPreviewTarget({
-                                        blockId: block.id,
-                                        blockIndex,
-                                        stackPosition: stack.position,
-                                    }),
-                                    activeDragPreview,
-                                );
-
-                            return (
-                                <group
-                                    key={`ground-decoration:${block.id}`}
-                                    position={[
-                                        stack.position.x +
-                                            (dragPreviewOffset?.x ?? 0),
-                                        getStackHeight(
-                                            blockData,
-                                            stack,
-                                            block,
-                                        ) +
-                                            blockSurfaceYOffset +
-                                            (dragPreviewOffset?.y ?? 0),
-                                        stack.position.z +
-                                            (dragPreviewOffset?.z ?? 0),
-                                    ]}
-                                    rotation={[
-                                        0,
-                                        block.rotation * (Math.PI / 2),
-                                        0,
-                                    ]}
-                                >
-                                    <BlockSurfaceDecorationSprites
-                                        blockId={block.id}
-                                        placements={placements}
-                                        surface={surface}
-                                        windDirection={windDirection}
-                                        windSpeed={windSpeed}
-                                    />
-                                </group>
-                            );
-                        })}
-                </Fragment>
-            ))}
-        </>
-    );
+    return <GroundDecorationInstances instances={decorationInstances} />;
 }

--- a/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import { useFrame } from '@react-three/fiber';
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import {
+    Euler,
+    InstancedBufferAttribute,
+    type InstancedMesh,
+    Matrix4,
+    MeshLambertMaterial,
+    PlaneGeometry,
+    Quaternion,
+    Vector3,
+} from 'three';
+import { SeededRNG } from '../../generators/plant/lib/rng';
+import { useWeatherNow } from '../../hooks/useWeatherNow';
+import { resolveSpriteAtlasAssetPaths } from '../../sprites/resolveSpriteAtlasAssetPaths';
+import { getSpriteBrightness } from '../../sprites/spriteLighting';
+import type { SpriteAtlasPage, SpriteAtlasSprite } from '../../sprites/types';
+import { useSpriteAtlasManifest } from '../../sprites/useSpriteAtlasManifest';
+import { useSpriteAtlasTexture } from '../../sprites/useSpriteAtlasTexture';
+import { useGameState } from '../../useGameState';
+import { groundDecorationAtlasBasePath } from './groundDecorationConfig';
+
+export type GroundDecorationInstance = {
+    alphaTest: number;
+    height: number;
+    opacity: number;
+    position: [number, number, number];
+    rotationZ: number;
+    spriteName: string;
+};
+
+type GroundDecorationBatch = {
+    alphaTest: number;
+    instances: GroundDecorationInstance[];
+    opacity: number;
+    sprite: SpriteAtlasSprite;
+    spriteName: string;
+};
+
+type GroundDecorationShaderUniforms = Record<string, { value: unknown }> & {
+    uTime?: { value: number };
+    uWindDirection?: { value: Vector3 };
+    uWindStrength?: { value: number };
+};
+
+const compassToDirection: Record<string, number> = {
+    E: 90,
+    N: 0,
+    NE: 45,
+    NW: 315,
+    S: 180,
+    SE: 135,
+    SW: 225,
+    W: 270,
+};
+
+function resolvePageBasePath(atlasBasePath: string, pageIndex: number) {
+    return pageIndex === 0 ? atlasBasePath : `${atlasBasePath}.${pageIndex}`;
+}
+
+function resolveAtlasPage(
+    pages: SpriteAtlasPage[] | undefined,
+    pageIndex: number,
+    atlas: SpriteAtlasPage['atlas'] | undefined,
+) {
+    if (pages && pages.length > 0) {
+        return (
+            pages.find((page) => page.index === pageIndex) ??
+            pages[pageIndex] ??
+            null
+        );
+    }
+
+    return atlas
+        ? ({
+              atlas,
+              index: 0,
+              spriteCount: 0,
+          } satisfies SpriteAtlasPage)
+        : null;
+}
+
+function createSpriteGeometry(
+    sprite: SpriteAtlasSprite,
+    page: SpriteAtlasPage,
+) {
+    const geometry = new PlaneGeometry(1, 1);
+    geometry.translate(0, 0.5, 0);
+    const atlas = page.atlas;
+    const u0 = sprite.frame.x / atlas.width;
+    const u1 = (sprite.frame.x + sprite.frame.width) / atlas.width;
+    const v0 = 1 - (sprite.frame.y + sprite.frame.height) / atlas.height;
+    const v1 = 1 - sprite.frame.y / atlas.height;
+    const uv = geometry.getAttribute('uv');
+
+    uv.setXY(0, u0, v1);
+    uv.setXY(1, u1, v1);
+    uv.setXY(2, u0, v0);
+    uv.setXY(3, u1, v0);
+    uv.needsUpdate = true;
+
+    return geometry;
+}
+
+function addWobbleAttributes(
+    geometry: PlaneGeometry,
+    atlasPage: SpriteAtlasPage,
+    batch: GroundDecorationBatch,
+) {
+    const wobbleAttributes = new Float32Array(batch.instances.length * 4);
+
+    batch.instances.forEach((instance, index) => {
+        const positionKey = instance.position
+            .map((value) => value.toFixed(3))
+            .join(':');
+        const rng = new SeededRNG(
+            `${groundDecorationAtlasBasePath}:${atlasPage.index}:${batch.spriteName}:${positionKey}`,
+        );
+        const windProfileOffset = index * 4;
+
+        wobbleAttributes[windProfileOffset] = rng.nextRange(1.15, 1.75);
+        wobbleAttributes[windProfileOffset + 1] = rng.nextRange(0.7, 1.25);
+        wobbleAttributes[windProfileOffset + 2] = rng.nextRange(0, Math.PI * 2);
+        wobbleAttributes[windProfileOffset + 3] = rng.nextRange(0.9, 1.35);
+    });
+
+    geometry.setAttribute(
+        'instanceWobble',
+        new InstancedBufferAttribute(wobbleAttributes, 4),
+    );
+}
+
+function applyGroundDecorationWobbleShader(material: MeshLambertMaterial) {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = { value: 0 };
+        shader.uniforms.uWindDirection = { value: new Vector3(0, 0, -1) };
+        shader.uniforms.uWindStrength = { value: 0 };
+        shader.vertexShader = shader.vertexShader.replace(
+            '#include <common>',
+            `
+#include <common>
+attribute vec4 instanceWobble;
+uniform float uTime;
+uniform vec3 uWindDirection;
+uniform float uWindStrength;
+`,
+        );
+        shader.vertexShader = shader.vertexShader.replace(
+            '#include <begin_vertex>',
+            `
+#include <begin_vertex>
+float windInfluence = clamp(position.y, 0.0, 1.0) * uWindStrength;
+float directionalWave =
+    sin(uTime * (1.35 + uWindStrength * 1.45) * instanceWobble.w + instanceWobble.z) * 0.9 +
+    cos(uTime * (1.0 + uWindStrength * 0.9) * (2.0 - instanceWobble.w) + instanceWobble.z * 1.7) * 0.35 +
+    sin(uTime * (0.6 + uWindStrength * 0.8) + instanceWobble.z * 0.5) * instanceWobble.y * uWindStrength * 0.7;
+float crossWave =
+    sin(uTime * (1.1 + uWindStrength * 0.6) + instanceWobble.z * 0.7) * 0.75 +
+    cos(uTime * (0.58 + uWindStrength * 0.4) + instanceWobble.z) * 0.3;
+float wobbleAmplitude = (0.035 + uWindStrength * 0.2) * instanceWobble.x;
+vec2 crossDirection = vec2(-uWindDirection.z, uWindDirection.x);
+transformed.xz += (
+    uWindDirection.xz * directionalWave +
+    crossDirection * crossWave * 0.55
+) * wobbleAmplitude * windInfluence;
+`,
+        );
+        material.userData.groundDecorationShader = shader;
+    };
+    material.customProgramCacheKey = () => 'ground-decoration-wobble-v1';
+}
+
+function buildBatchKey(instance: GroundDecorationInstance) {
+    return `${instance.spriteName}:${instance.alphaTest}:${instance.opacity.toFixed(2)}`;
+}
+
+export function GroundDecorationInstances({
+    instances,
+}: {
+    instances: GroundDecorationInstance[];
+}) {
+    const assetPaths = useMemo(
+        () => resolveSpriteAtlasAssetPaths(groundDecorationAtlasBasePath),
+        [],
+    );
+    const { error: manifestError, manifest } = useSpriteAtlasManifest(
+        assetPaths.manifestUrl,
+    );
+
+    const instancesByPage = useMemo(() => {
+        const byPage = new Map<number, GroundDecorationInstance[]>();
+        if (!manifest) {
+            return byPage;
+        }
+
+        for (const instance of instances) {
+            const sprite = manifest.sprites[instance.spriteName];
+            if (!sprite) {
+                continue;
+            }
+            const pageIndex = sprite.page ?? 0;
+            const pageInstances = byPage.get(pageIndex);
+            if (pageInstances) {
+                pageInstances.push(instance);
+                continue;
+            }
+            byPage.set(pageIndex, [instance]);
+        }
+
+        return byPage;
+    }, [instances, manifest]);
+
+    if (manifestError) {
+        console.error(
+            `Failed to load sprite atlas manifest "${groundDecorationAtlasBasePath}":`,
+            manifestError,
+        );
+        return null;
+    }
+
+    if (!manifest || instances.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {[...instancesByPage.entries()].map(
+                ([pageIndex, pageInstances]) => {
+                    const page = resolveAtlasPage(
+                        manifest.pages,
+                        pageIndex,
+                        manifest.atlas,
+                    );
+
+                    if (!page) {
+                        return null;
+                    }
+
+                    return (
+                        <GroundDecorationPageInstances
+                            key={pageIndex}
+                            atlasPage={page}
+                            instances={pageInstances}
+                            manifestSprites={manifest.sprites}
+                        />
+                    );
+                },
+            )}
+        </>
+    );
+}
+
+function GroundDecorationPageInstances({
+    atlasPage,
+    instances,
+    manifestSprites,
+}: {
+    atlasPage: SpriteAtlasPage;
+    instances: GroundDecorationInstance[];
+    manifestSprites: Record<string, SpriteAtlasSprite>;
+}) {
+    const pageAssetPaths = useMemo(
+        () =>
+            resolveSpriteAtlasAssetPaths(
+                resolvePageBasePath(
+                    groundDecorationAtlasBasePath,
+                    atlasPage.index,
+                ),
+            ),
+        [atlasPage.index],
+    );
+    const { error: textureError, texture } =
+        useSpriteAtlasTexture(pageAssetPaths);
+    const batches = useMemo(() => {
+        const batchByKey = new Map<string, GroundDecorationBatch>();
+
+        for (const instance of instances) {
+            const sprite = manifestSprites[instance.spriteName];
+            if (!sprite) {
+                continue;
+            }
+
+            const key = buildBatchKey(instance);
+            const batch = batchByKey.get(key);
+            if (batch) {
+                batch.instances.push(instance);
+                continue;
+            }
+
+            batchByKey.set(key, {
+                alphaTest: instance.alphaTest,
+                instances: [instance],
+                opacity: instance.opacity,
+                sprite,
+                spriteName: instance.spriteName,
+            });
+        }
+
+        return [...batchByKey.values()];
+    }, [instances, manifestSprites]);
+
+    if (textureError) {
+        console.error(
+            `Failed to load sprite atlas texture "${groundDecorationAtlasBasePath}":`,
+            textureError,
+        );
+        return null;
+    }
+
+    if (!texture) {
+        return null;
+    }
+
+    return (
+        <>
+            {batches.map((batch) => (
+                <GroundDecorationInstancedBatch
+                    key={`${batch.spriteName}:${batch.alphaTest}:${batch.opacity}`}
+                    atlasPage={atlasPage}
+                    batch={batch}
+                    texture={texture}
+                />
+            ))}
+        </>
+    );
+}
+
+function GroundDecorationInstancedBatch({
+    atlasPage,
+    batch,
+    texture,
+}: {
+    atlasPage: SpriteAtlasPage;
+    batch: GroundDecorationBatch;
+    texture: NonNullable<ReturnType<typeof useSpriteAtlasTexture>['texture']>;
+}) {
+    const meshRef = useRef<InstancedMesh | null>(null);
+    const previousCameraQuaternion = useRef(new Quaternion(0, 0, 0, 0));
+    const matrix = useMemo(() => new Matrix4(), []);
+    const position = useMemo(() => new Vector3(), []);
+    const quaternion = useMemo(() => new Quaternion(), []);
+    const rotationZ = useMemo(() => new Quaternion(), []);
+    const scale = useMemo(() => new Vector3(), []);
+    const geometry = useMemo(() => {
+        const spriteGeometry = createSpriteGeometry(batch.sprite, atlasPage);
+        addWobbleAttributes(spriteGeometry, atlasPage, batch);
+        return spriteGeometry;
+    }, [atlasPage, batch]);
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const weather = useGameState((state) => state.weather);
+    const { data: weatherNow } = useWeatherNow();
+    const windSpeed =
+        typeof weather?.windSpeed === 'number'
+            ? weather.windSpeed
+            : (weatherNow?.windSpeed ?? 0);
+    const windDirectionDegrees =
+        typeof weather?.windDirection === 'number'
+            ? weather.windDirection
+            : typeof weatherNow?.windDirection === 'string'
+              ? (compassToDirection[weatherNow.windDirection] ?? 0)
+              : 0;
+    const windDirectionX = Math.sin((windDirectionDegrees * Math.PI) / 180);
+    const windDirectionZ = -Math.cos((windDirectionDegrees * Math.PI) / 180);
+    const windStrength = Math.max(0, Math.min(1, windSpeed / 16));
+    const brightness = getSpriteBrightness(timeOfDay, weather);
+    const material = useMemo(() => {
+        const batchMaterial = new MeshLambertMaterial({
+            alphaTest: batch.alphaTest,
+            color: 'white',
+            depthWrite: false,
+            map: texture,
+            opacity: batch.opacity,
+            transparent: true,
+        });
+        applyGroundDecorationWobbleShader(batchMaterial);
+        return batchMaterial;
+    }, [batch.alphaTest, batch.opacity, texture]);
+
+    useLayoutEffect(() => {
+        material.color.setScalar(brightness);
+    }, [brightness, material]);
+
+    useLayoutEffect(() => {
+        const uniforms = material.userData.groundDecorationShader?.uniforms as
+            | GroundDecorationShaderUniforms
+            | undefined;
+
+        uniforms?.uWindDirection?.value.set(windDirectionX, 0, windDirectionZ);
+        if (uniforms?.uWindStrength) {
+            uniforms.uWindStrength.value = windStrength;
+        }
+    }, [material, windDirectionX, windDirectionZ, windStrength]);
+
+    useLayoutEffect(() => () => geometry.dispose(), [geometry]);
+    useLayoutEffect(() => () => material.dispose(), [material]);
+
+    const updateMatrices = (cameraQuaternion: Quaternion) => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        batch.instances.forEach((instance, index) => {
+            position.set(...instance.position);
+            rotationZ.setFromEuler(new Euler(0, 0, instance.rotationZ));
+            quaternion.copy(cameraQuaternion).multiply(rotationZ);
+            scale.set(
+                instance.height * batch.sprite.aspect,
+                instance.height,
+                1,
+            );
+            matrix.compose(position, quaternion, scale);
+            mesh.setMatrixAt(index, matrix);
+        });
+
+        mesh.count = batch.instances.length;
+        mesh.instanceMatrix.needsUpdate = true;
+        mesh.computeBoundingBox();
+        mesh.computeBoundingSphere();
+    };
+
+    useLayoutEffect(() => {
+        previousCameraQuaternion.current.set(0, 0, 0, 0);
+    });
+
+    useFrame(({ camera, clock }) => {
+        const uniforms = material.userData.groundDecorationShader?.uniforms as
+            | GroundDecorationShaderUniforms
+            | undefined;
+
+        if (uniforms?.uTime) {
+            uniforms.uTime.value = clock.getElapsedTime();
+        }
+        uniforms?.uWindDirection?.value.set(windDirectionX, 0, windDirectionZ);
+        if (uniforms?.uWindStrength) {
+            uniforms.uWindStrength.value = windStrength;
+        }
+
+        if (previousCameraQuaternion.current.equals(camera.quaternion)) {
+            return;
+        }
+
+        updateMatrices(camera.quaternion);
+        previousCameraQuaternion.current.copy(camera.quaternion);
+    });
+
+    return (
+        <instancedMesh
+            ref={meshRef}
+            args={[geometry, material, batch.instances.length]}
+            receiveShadow
+            renderOrder={20}
+        />
+    );
+}

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -92,9 +92,21 @@ export function RainWetOverlay(props: RainWetOverlayProps) {
     return <RainWetOverlayEffect {...props} />;
 }
 
-function RainWetOverlayEffect({
-    geometry,
+export function useRainWetOverlayVisible({
+    intensityMultiplier = 1,
     minRain = 0.08,
+}: Pick<RainWetOverlayProps, 'intensityMultiplier' | 'minRain'> = {}) {
+    const flags = useGameFlags();
+    const rainAmount = useGameState((state) => state.weather?.rainy ?? 0);
+
+    return (
+        flags.enableRainWetOverlayFlag &&
+        rainAmount * intensityMultiplier >= minRain
+    );
+}
+
+export function useRainWetOverlayMaterial({
+    geometry,
     intensityMultiplier = 1,
     drySpeed = 1.8,
     wetSpeed = 5,
@@ -102,10 +114,18 @@ function RainWetOverlayEffect({
     darkness = 1,
     glossiness = 0.7,
     bounds,
-}: RainWetOverlayProps) {
+}: Pick<
+    RainWetOverlayProps,
+    | 'bounds'
+    | 'darkness'
+    | 'drySpeed'
+    | 'geometry'
+    | 'glossiness'
+    | 'intensityMultiplier'
+    | 'topSurfaceBias'
+    | 'wetSpeed'
+>) {
     const rainAmount = useGameState((state) => state.weather?.rainy ?? 0);
-    const shouldRender = rainAmount * intensityMultiplier >= minRain;
-
     const resolvedBounds = useMemo(() => {
         if (bounds) return bounds;
         if (!geometry.boundingBox) {
@@ -181,6 +201,35 @@ function RainWetOverlayEffect({
             speed,
             delta,
         );
+    });
+
+    return material;
+}
+
+function RainWetOverlayEffect({
+    geometry,
+    minRain = 0.08,
+    intensityMultiplier = 1,
+    drySpeed = 1.8,
+    wetSpeed = 5,
+    topSurfaceBias = 1.8,
+    darkness = 1,
+    glossiness = 0.7,
+    bounds,
+}: RainWetOverlayProps) {
+    const shouldRender = useRainWetOverlayVisible({
+        intensityMultiplier,
+        minRain,
+    });
+    const material = useRainWetOverlayMaterial({
+        bounds,
+        darkness,
+        drySpeed,
+        geometry,
+        glossiness,
+        intensityMultiplier,
+        topSurfaceBias,
+        wetSpeed,
     });
 
     if (!shouldRender && material.uniforms.uWetness.value < 0.01) {

--- a/packages/game/src/snow/SnowOverlay.tsx
+++ b/packages/game/src/snow/SnowOverlay.tsx
@@ -56,6 +56,25 @@ function resolveSnowOverlayActive(options: {
     );
 }
 
+export function useSnowOverlayVisible({
+    coverageMultiplier,
+    minCoverage = 0.02,
+    overrideSnow,
+}: {
+    coverageMultiplier?: number;
+    minCoverage?: number;
+    overrideSnow?: number;
+}) {
+    const gameSnowCoverage = useGameState((state) => state.snowCoverage);
+
+    return resolveSnowOverlayActive({
+        coverageMultiplier,
+        gameSnowCoverage,
+        minCoverage,
+        overrideSnow,
+    });
+}
+
 function resolveColorKey(
     color: SnowMaterialOptions['color'],
 ): ColorRepresentation {
@@ -166,10 +185,8 @@ export function SnowOverlay({
     overrideSnow,
     ...options
 }: SnowOverlayProps) {
-    const gameSnowCoverage = useGameState((state) => state.snowCoverage);
-    const isActive = resolveSnowOverlayActive({
+    const isActive = useSnowOverlayVisible({
         coverageMultiplier: options.coverageMultiplier,
-        gameSnowCoverage,
         minCoverage,
         overrideSnow,
     });


### PR DESCRIPTION
## Summary

- Replace per-child Drei instance rendering for repeated game blocks with chunked raw `InstancedMesh` updates.
- Batch dense ground decorations by atlas/material with instanced planes and shader-driven wind motion.
- Share instanced rain/snow overlay rendering for repeated block paths and reduce instanced control-wrapper work in no-control and covered-block scenes.
- Document the 25x25 dense-scene production smoke results.

## Impact

This reduces React/fiber object count, heap pressure, and submitted render work for large garden scenes without falling back to low quality first.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint` (passes with existing Biome schema info and existing optional-chain warnings in `raisedBedBlocks.ts`)
- `pnpm --filter @gredice/game test`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden build`
- `git diff --check`
- Production browser smoke on `/debug/profile/game?mode=details&controls=0&quality=medium`; canvas rendered and no page/shader errors