### PR TITLE
Improve game scene debug controls

### DIFF
--- a/.agents/skills/gredice-api-reference/SKILL.md
+++ b/.agents/skills/gredice-api-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-api-reference
-description: Use for Gredice API docs/contracts: Hono routes, OpenAPI/Scalar, auth/security, validation schemas, generated directory types, and client helpers.
+description: "Use for Gredice API docs/contracts: Hono routes, OpenAPI/Scalar, auth/security, validation schemas, generated directory types, and client helpers."
 ---
 
 # Gredice API Reference

--- a/.agents/skills/gredice-cms-page-authoring/SKILL.md
+++ b/.agents/skills/gredice-cms-page-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-cms-page-authoring
-description: Use for Gredice CMS page content/tooling: section JSON, admin/public rendering, slug/publish metadata, preview, and CMS routes/schema.
+description: "Use for Gredice CMS page content/tooling: section JSON, admin/public rendering, slug/publish metadata, preview, and CMS routes/schema."
 ---
 
 # Gredice CMS Page Authoring

--- a/.agents/skills/gredice-docs-auditor/SKILL.md
+++ b/.agents/skills/gredice-docs-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-docs-auditor
-description: Use for Gredice repo docs: README, CONTRIBUTING, AGENTS, root guides, docs, setup/commands, app/package maps, validation, generated artifacts.
+description: "Use for Gredice repo docs: README, CONTRIBUTING, AGENTS, root guides, docs, setup/commands, app/package maps, validation, generated artifacts."
 ---
 
 # Gredice Docs Auditor

--- a/.agents/skills/gredice-domain-workflow-docs/SKILL.md
+++ b/.agents/skills/gredice-domain-workflow-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-domain-workflow-docs
-description: Use for documenting Gredice workflows: delivery, checkout, payments, notifications, inventory, operations, crons, env, and failures across apps/packages.
+description: "Use for documenting Gredice workflows: delivery, checkout, payments, notifications, inventory, operations, crons, env, and failures across apps/packages."
 ---
 
 # Gredice Domain Workflow Docs

--- a/.agents/skills/gredice-public-docs-seo/SKILL.md
+++ b/.agents/skills/gredice-public-docs-seo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-public-docs-seo
-description: Use for public Gredice content/SEO in apps/www or status: metadata, structured data, sitemap, Croatian copy, FAQ/legal/product pages, CMS routes.
+description: "Use for public Gredice content/SEO in apps/www or status: metadata, structured data, sitemap, Croatian copy, FAQ/legal/product pages, CMS routes."
 ---
 
 # Gredice Public Docs SEO

--- a/.agents/skills/gredice-storybook-component-docs/SKILL.md
+++ b/.agents/skills/gredice-storybook-component-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gredice-storybook-component-docs
-description: Use for Gredice Storybook docs: stories, MDX, autodocs, @gredice/ui/shared components, states, accessibility, and reusable UI docs.
+description: "Use for Gredice Storybook docs: stories, MDX, autodocs, @gredice/ui/shared components, states, accessibility, and reusable UI docs."
 ---
 
 # Gredice Storybook Component Docs

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "garden",
+            "runtimeExecutable": "pnpm",
+            "runtimeArgs": ["--filter", "garden", "dev"],
+            "port": 4171,
+            "autoPort": false
+        }
+    ]
+}

--- a/apps/garden/app/debug/GameSceneLauncher.tsx
+++ b/apps/garden/app/debug/GameSceneLauncher.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const MODE_OPTIONS = [
+    { value: 'baseline', label: 'Baseline', description: 'Clear sky · noon' },
+    { value: 'rain', label: 'Rain', description: 'Cloudy · heavy rain' },
+    { value: 'snow', label: 'Snow', description: 'Winter · snow cover' },
+    { value: 'night', label: 'Night', description: '22:30 · clear' },
+    { value: 'storm', label: 'Storm', description: '18:30 · thunder + wind' },
+    { value: 'autumn', label: 'Autumn', description: '16:30 · breezy' },
+] as const;
+
+const QUALITY_OPTIONS = [
+    { value: 'auto', label: 'Auto', description: 'Detect from device' },
+    { value: 'low', label: 'Low', description: 'Cheapest preset' },
+    { value: 'medium', label: 'Medium', description: 'Balanced preset' },
+    { value: 'high', label: 'High', description: 'Maximum detail' },
+] as const;
+
+type Mode = (typeof MODE_OPTIONS)[number]['value'];
+type Quality = (typeof QUALITY_OPTIONS)[number]['value'];
+
+const segmentBase =
+    'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors';
+const segmentActive = 'border-white bg-white text-neutral-950';
+const segmentInactive =
+    'border-neutral-700 bg-neutral-900 text-neutral-300 hover:border-neutral-500 hover:text-white';
+
+function SegmentedControl<T extends string>({
+    label,
+    description,
+    options,
+    value,
+    onChange,
+}: {
+    label: string;
+    description: string;
+    options: ReadonlyArray<{
+        value: T;
+        label: string;
+        description?: string;
+    }>;
+    value: T;
+    onChange: (value: T) => void;
+}) {
+    const activeDescription = options.find(
+        (option) => option.value === value,
+    )?.description;
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div>
+                <span className="block text-sm font-semibold text-white">
+                    {label}
+                </span>
+                <span className="block text-xs text-neutral-400">
+                    {description}
+                </span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+                {options.map((option) => (
+                    <button
+                        type="button"
+                        key={option.value}
+                        onClick={() => onChange(option.value)}
+                        title={option.description}
+                        className={`${segmentBase} ${
+                            option.value === value
+                                ? segmentActive
+                                : segmentInactive
+                        }`}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
+            {activeDescription ? (
+                <span className="text-xs text-neutral-500">
+                    {activeDescription}
+                </span>
+            ) : null}
+        </div>
+    );
+}
+
+function ToggleButton({
+    label,
+    description,
+    enabled,
+    onToggle,
+}: {
+    label: string;
+    description: string;
+    enabled: boolean;
+    onToggle: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onToggle}
+            aria-pressed={enabled}
+            className={`flex flex-1 flex-col gap-1 rounded-md border p-3 text-left transition-colors ${
+                enabled
+                    ? 'border-white bg-white/10'
+                    : 'border-neutral-700 bg-neutral-900 hover:border-neutral-500'
+            }`}
+        >
+            <span className="flex items-center justify-between gap-2">
+                <span className="text-sm font-semibold text-white">
+                    {label}
+                </span>
+                <span
+                    className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide ${
+                        enabled
+                            ? 'bg-white text-neutral-950'
+                            : 'bg-neutral-800 text-neutral-400'
+                    }`}
+                >
+                    {enabled ? 'On' : 'Off'}
+                </span>
+            </span>
+            <span className="text-xs text-neutral-400">{description}</span>
+        </button>
+    );
+}
+
+export function GameSceneLauncher() {
+    const [mode, setMode] = useState<Mode>('baseline');
+    const [quality, setQuality] = useState<Quality>('auto');
+    const [details, setDetails] = useState(false);
+    const [hud, setHud] = useState(true);
+    const [controls, setControls] = useState(true);
+
+    const href = useMemo(() => {
+        const params = new URLSearchParams();
+        if (mode !== 'baseline') {
+            params.set('mode', mode);
+        }
+        if (quality !== 'auto') {
+            params.set('quality', quality);
+        }
+        if (details) {
+            params.set('details', '1');
+        }
+        if (hud) {
+            params.set('hud', '1');
+        }
+        if (!controls) {
+            params.set('controls', '0');
+        }
+        const queryString = params.toString();
+        return `/debug/profile/game${queryString ? `?${queryString}` : ''}`;
+    }, [mode, quality, details, hud, controls]);
+
+    return (
+        <div className="flex flex-col gap-5 rounded-lg border border-neutral-800 bg-neutral-900 p-5">
+            <div>
+                <span className="block text-base font-semibold text-white">
+                    Scene launcher
+                </span>
+                <span className="mt-1 block text-sm text-neutral-400">
+                    Configure every query parameter the game scene accepts, then
+                    open it. Replaces the fixed weather/time profiles.
+                </span>
+            </div>
+
+            <SegmentedControl
+                label="Weather & time"
+                description="Preset weather conditions and time of day (mode)."
+                options={MODE_OPTIONS}
+                value={mode}
+                onChange={setMode}
+            />
+
+            <SegmentedControl
+                label="Render quality"
+                description="Force a quality tier, or let the device decide (quality)."
+                options={QUALITY_OPTIONS}
+                value={quality}
+                onChange={setQuality}
+            />
+
+            <div className="flex flex-col gap-2">
+                <div>
+                    <span className="block text-sm font-semibold text-white">
+                        Options
+                    </span>
+                    <span className="block text-xs text-neutral-400">
+                        Independent on/off flags.
+                    </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                    <ToggleButton
+                        label="Details"
+                        description="Render deferred scene details: mulch, ground decoration (details)."
+                        enabled={details}
+                        onToggle={() => setDetails((current) => !current)}
+                    />
+                    <ToggleButton
+                        label="HUD"
+                        description="Show the in-game HUD overlay, including the debug HUD (hud)."
+                        enabled={hud}
+                        onToggle={() => setHud((current) => !current)}
+                    />
+                    <ToggleButton
+                        label="Controls"
+                        description="Allow camera pan, zoom and rotation (controls)."
+                        enabled={controls}
+                        onToggle={() => setControls((current) => !current)}
+                    />
+                </div>
+            </div>
+
+            <div className="flex flex-col gap-3 border-t border-neutral-800 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                <code className="break-all rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-400">
+                    {href}
+                </code>
+                <a
+                    href={href}
+                    className="shrink-0 rounded-md bg-white px-4 py-2 text-center text-sm font-semibold text-neutral-950 transition-colors hover:bg-neutral-200"
+                >
+                    Open scene →
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { GameSceneLauncher } from './GameSceneLauncher';
 
 const debugGroups = [
     {
@@ -18,44 +19,8 @@ const debugGroups = [
         ],
     },
     {
-        title: 'Game Scene Profiles',
+        title: 'Game Scene',
         pages: [
-            {
-                href: '/debug/profile/game',
-                title: 'Baseline',
-                description: 'Full mock garden scene for baseline rendering.',
-            },
-            {
-                href: '/debug/profile/game?mode=details',
-                title: 'Details',
-                description:
-                    'Mock garden scene with deferred detail rendering enabled.',
-            },
-            {
-                href: '/debug/profile/game?mode=rain&quality=low',
-                title: 'Rain',
-                description: 'Mock garden scene with rainy weather.',
-            },
-            {
-                href: '/debug/profile/game?mode=snow&quality=low',
-                title: 'Snow',
-                description: 'Mock garden scene with winter weather.',
-            },
-            {
-                href: '/debug/profile/game?mode=night&quality=low',
-                title: 'Night',
-                description: 'Mock garden scene at night.',
-            },
-            {
-                href: '/debug/profile/game?mode=storm&quality=low',
-                title: 'Storm',
-                description: 'Mock garden scene with heavy rain and thunder.',
-            },
-            {
-                href: '/debug/profile/game?mode=autumn&quality=low',
-                title: 'Autumn',
-                description: 'Mock garden scene with autumn time and wind.',
-            },
             {
                 href: '/debug/sandbox',
                 title: 'Local sandbox',
@@ -92,6 +57,9 @@ export default function DebugIndexPage() {
                         <h2 className="text-sm font-semibold uppercase text-neutral-500">
                             {group.title}
                         </h2>
+                        {group.title === 'Game Scene' ? (
+                            <GameSceneLauncher />
+                        ) : null}
                         <div className="grid gap-3 md:grid-cols-2">
                             {group.pages.map((page) => (
                                 <Link

--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -166,10 +166,10 @@ export default async function GameProfilePage({
                 flags={debugGameFlags}
                 freezeTime={freezeTime}
                 hideHud={!showHud}
+                initialQualitySetting={quality}
                 mockGarden
                 noControls={!enableControls}
                 noSound
-                quality={quality}
                 weather={weather}
                 winterMode={mode === 'snow' ? 'winter' : 'summer'}
             />

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -39,6 +39,7 @@ import { ParticleSystemProvider } from './particles/ParticleSystem';
 import { Environment } from './scene/Environment';
 import {
     type GameQualityAutoProfileMetrics,
+    type GameQualitySetting,
     type GameQualityTier,
     getGameQualityAutoProfileMetrics,
     resolveGameQualityProfile,
@@ -67,10 +68,13 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     weather?: Partial<GameState['weather']>;
     deferDetails?: boolean;
     quality?: GameQualityTier;
+    initialQualitySetting?: GameQualitySetting;
 
     // Development purposes
     flags?: GameFeatureFlags;
 };
+
+type GameSceneInnerProps = Omit<GameSceneProps, 'initialQualitySetting'>;
 
 function useAutoQualityProfileMetrics(enabled: boolean) {
     const [metrics, setMetrics] = useState<
@@ -158,7 +162,7 @@ export function GameScene({
     weather,
     deferDetails,
     ...rest
-}: GameSceneProps) {
+}: GameSceneInnerProps) {
     useFocusPlacedBlock();
     useRaisedBedCloseup();
     const weatherVisualizationDisabled = useGameState(

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -18,6 +18,7 @@ export function GameSceneWrapper({
     flags,
     freezeTime,
     dayNightCycleDisabled,
+    initialQualitySetting,
     mockGarden,
     localSandboxStorageKey,
     winterMode,
@@ -30,6 +31,7 @@ export function GameSceneWrapper({
             spriteBaseUrl,
             dayNightCycleDisabled,
             freezeTime: freezeTime || null,
+            initialQualitySetting,
             isMock: mockGarden || false,
             localSandboxStorageKey,
             winterMode: winterMode ?? 'summer',
@@ -50,6 +52,14 @@ export function GameSceneWrapper({
             storeRef.current.getState().setFreezeTime(freezeTime ?? null);
         }
     }, [freezeTime]);
+
+    useEffect(() => {
+        if (initialQualitySetting && storeRef.current) {
+            storeRef.current.setState({
+                gameQualitySetting: initialQualitySetting,
+            });
+        }
+    }, [initialQualitySetting]);
 
     const resolvedAppBaseUrl = appBaseUrl ?? '';
     preloadGameAssetModels(resolvedAppBaseUrl, groundGameAssetNames);

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -1,12 +1,40 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { Checkbox } from '@gredice/ui/Checkbox';
 import { DebugPanel, DebugPanelSection } from '@gredice/ui/DebugControls';
+import { IconButton } from '@gredice/ui/IconButton';
+import {
+    Cloud,
+    Custom,
+    Desktop,
+    Droplets,
+    Fence,
+    FullWidth,
+    Ghost,
+    Graph,
+    Layers,
+    Lightning,
+    MapPin,
+    Moon,
+    Reset,
+    Settings,
+    Snowflake,
+    Sun,
+    SunMoon,
+    Thermometer,
+    Wind,
+} from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Slider } from '@gredice/ui/Slider';
 import { Stack } from '@gredice/ui/Stack';
-import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type {
+    ComponentType,
+    CSSProperties,
+    ReactNode,
+    PointerEvent as ReactPointerEvent,
+} from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLiveTime } from '../hooks/useLiveTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
@@ -15,16 +43,10 @@ import {
     readGameProfileMetadata,
 } from '../scene/gameProfileMetadata';
 import { type AnimalDebugEntry, useGameState } from '../useGameState';
+import { clampTimeOfDay, createDateForGameTimeOfDay } from '../utils/timeOfDay';
+import { TimeOfDayVisualization } from './components/TimeOfDayVisualization';
 
-function getTimeOfDayFromDate(date: Date) {
-    const totalSeconds =
-        date.getHours() * 60 * 60 + date.getMinutes() * 60 + date.getSeconds();
-    return totalSeconds / (24 * 60 * 60);
-}
-
-// Avoid thrashing the time-of-day slider when the live clock only moves by a
-// handful of milliseconds between frames.
-const TIME_OF_DAY_SYNC_THRESHOLD = 0.0005;
+type IconType = ComponentType<{ className?: string }>;
 
 function clampToRange(value: number, min: number, max: number) {
     if (value < min) {
@@ -38,14 +60,22 @@ function clampToRange(value: number, min: number, max: number) {
     return value;
 }
 
-function formatTimeLabel(value: number) {
-    const clamped = clampToRange(value, 0, 1);
-    const totalSeconds = Math.round(clamped * 24 * 60 * 60);
-    const hours = Math.floor(totalSeconds / (60 * 60));
-    const minutes = Math.floor((totalSeconds % (60 * 60)) / 60);
+function formatClockLabel(timeOfDay: number) {
+    const totalMinutes = Math.round(clampTimeOfDay(timeOfDay) * 24 * 60);
+    const hours = Math.floor(totalMinutes / 60) % 24;
+    const minutes = totalMinutes % 60;
     return `${hours.toString().padStart(2, '0')}:${minutes
         .toString()
         .padStart(2, '0')}`;
+}
+
+function formatTime(date: Date | null | undefined) {
+    return (
+        date?.toLocaleTimeString('hr-HR', {
+            hour: '2-digit',
+            minute: '2-digit',
+        }) ?? 'n/a'
+    );
 }
 
 function formatPercent(value: number) {
@@ -55,7 +85,7 @@ function formatPercent(value: number) {
 function formatWindSpeed(value: number) {
     const intensity = Math.round(value);
     const labels = ['None', 'Light', 'Moderate', 'Strong'];
-    return `${intensity} - ${labels[intensity] || 'Unknown'}`;
+    return `${intensity} · ${labels[intensity] || 'Unknown'}`;
 }
 
 function formatWindDirection(value: number) {
@@ -70,8 +100,58 @@ function formatMetric(value: number | null | undefined, suffix = '') {
         : 'n/a';
 }
 
+function formatTemperature(value: number | null | undefined) {
+    return typeof value === 'number' && Number.isFinite(value)
+        ? `${Math.round(value)}°C`
+        : 'n/a';
+}
+
 function formatAnimalPosition(position: AnimalDebugEntry['position']) {
     return `${formatMetric(position.x)}, ${formatMetric(position.y)}, ${formatMetric(position.z)}`;
+}
+
+function InfoRow({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: IconType;
+    label: string;
+    value: ReactNode;
+}) {
+    return (
+        <div className="flex items-center justify-between gap-2 text-[11px] leading-tight">
+            <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+                <Icon className="size-3 shrink-0" />
+                <span className="truncate">{label}</span>
+            </span>
+            <span className="shrink-0 text-right font-mono tabular-nums">
+                {value}
+            </span>
+        </div>
+    );
+}
+
+function WeatherSliderLabel({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: IconType;
+    label: string;
+    value: string;
+}) {
+    return (
+        <span className="flex w-full items-center justify-between gap-2 text-xs">
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+                <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate">{label}</span>
+            </span>
+            <span className="shrink-0 text-right font-mono tabular-nums text-muted-foreground">
+                {value}
+            </span>
+        </span>
+    );
 }
 
 type FrameStats = {
@@ -163,11 +243,13 @@ function useProfileHudSnapshot() {
 }
 
 const SNOW_ACCUMULATION_PRESETS = [
-    { label: '0 cm', value: 0 },
-    { label: 'Light 5 cm', value: 5 },
-    { label: 'Medium 15 cm', value: 15 },
-    { label: 'Heavy 30 cm', value: 30 },
+    { label: '0', value: 0 },
+    { label: '5', value: 5 },
+    { label: '15', value: 15 },
+    { label: '30', value: 30 },
 ] as const;
+
+const QUALITY_OPTIONS = ['auto', 'low', 'medium', 'high'] as const;
 
 const PANEL_MARGIN_PX = 16;
 const PANEL_STORAGE_KEY = 'gredice.debugPanel.position';
@@ -181,6 +263,12 @@ export function DebugHud() {
     const setWeather = useGameState((s) => s.setWeather);
     const currentTime = useLiveTime();
     const setFreezeTime = useGameState((s) => s.setFreezeTime);
+    const timeOfDay = useGameState((s) => s.timeOfDay);
+    const sunriseTime = useGameState((s) => s.sunriseTime);
+    const sunsetTime = useGameState((s) => s.sunsetTime);
+    const setDayNightCycleDisabled = useGameState(
+        (s) => s.setDayNightCycleDisabled,
+    );
     const animalDebugEntries = useGameState((s) => s.animalDebugEntries);
     const editHitboxDebugVisible = useGameState(
         (s) => s.editHitboxDebugVisible,
@@ -194,6 +282,8 @@ export function DebugHud() {
     const setEntityRenderModeDebugVisible = useGameState(
         (s) => s.setEntityRenderModeDebugVisible,
     );
+    const gameQualitySetting = useGameState((s) => s.gameQualitySetting);
+    const setGameQualitySetting = useGameState((s) => s.setGameQualitySetting);
     const frameStats = useFrameStats();
     const profileSnapshot = useProfileHudSnapshot();
 
@@ -454,14 +544,12 @@ export function DebugHud() {
         };
     }, [handlePanelPointerMove, handlePanelPointerUp]);
 
-    const [timeOfDay, setTimeOfDay] = useState(() =>
-        getTimeOfDayFromDate(currentTime),
-    );
     const [overrideWeather, setOverrideWeather] = useState(false);
     const [cloudy, setCloudy] = useState(weather?.cloudy ?? 0);
     const [rainy, setRainy] = useState(weather?.rainy ?? 0);
     const [snowy, setSnowy] = useState(weather?.snowy ?? 0);
     const [foggy, setFoggy] = useState(weather?.foggy ?? 0);
+    const [thundery, setThundery] = useState(weather?.thundery ?? 0);
     const [windSpeed, setWindSpeed] = useState(
         typeof weather?.windSpeed === 'number' ? weather.windSpeed : 0,
     );
@@ -474,23 +562,20 @@ export function DebugHud() {
             : 0,
     );
 
-    useEffect(() => {
-        const nextTimeOfDay = getTimeOfDayFromDate(currentTime);
-        setTimeOfDay((previous) =>
-            Math.abs(previous - nextTimeOfDay) < TIME_OF_DAY_SYNC_THRESHOLD
-                ? previous
-                : nextTimeOfDay,
-        );
-    }, [currentTime]);
+    const updateTimeOfDay = useCallback(
+        (nextTimeOfDay: number) => {
+            setDayNightCycleDisabled(false);
+            setFreezeTime(
+                createDateForGameTimeOfDay(currentTime, nextTimeOfDay),
+            );
+        },
+        [currentTime, setDayNightCycleDisabled, setFreezeTime],
+    );
 
-    useEffect(() => {
-        const seconds = clampToRange(timeOfDay, 0, 1) * 24 * 60 * 60;
-        const date = new Date();
-        date.setHours(seconds / 60 / 60);
-        date.setMinutes((seconds / 60) % 60);
-        date.setSeconds(seconds % 60);
-        setFreezeTime(date);
-    }, [timeOfDay, setFreezeTime]);
+    const resetTime = useCallback(() => {
+        setDayNightCycleDisabled(false);
+        setFreezeTime(null);
+    }, [setDayNightCycleDisabled, setFreezeTime]);
 
     useEffect(() => {
         if (overrideWeather) {
@@ -499,6 +584,7 @@ export function DebugHud() {
                 rainy,
                 snowy,
                 foggy,
+                thundery,
                 windSpeed,
                 windDirection,
                 snowAccumulation,
@@ -512,6 +598,10 @@ export function DebugHud() {
                 rainy: weather.rainy ?? 0,
                 snowy: weather.snowy ?? 0,
                 foggy: weather.foggy ?? 0,
+                thundery:
+                    typeof weather.thundery === 'number'
+                        ? weather.thundery
+                        : undefined,
                 windSpeed:
                     typeof weather.windSpeed === 'number'
                         ? weather.windSpeed
@@ -532,6 +622,7 @@ export function DebugHud() {
         rainy,
         snowy,
         foggy,
+        thundery,
         windSpeed,
         windDirection,
         snowAccumulation,
@@ -548,6 +639,9 @@ export function DebugHud() {
         setRainy(weather.rainy ?? 0);
         setSnowy(weather.snowy ?? 0);
         setFoggy(weather.foggy ?? 0);
+        setThundery(
+            typeof weather.thundery === 'number' ? weather.thundery : 0,
+        );
         setWindSpeed(
             typeof weather.windSpeed === 'number' ? weather.windSpeed : 0,
         );
@@ -563,19 +657,10 @@ export function DebugHud() {
         );
     }, [weather, overrideWeather]);
 
-    const handleOverrideChange = (checked: boolean | 'indeterminate') => {
-        setOverrideWeather(checked === true);
-    };
-    const handleEditHitboxDebugChange = (
-        checked: boolean | 'indeterminate',
-    ) => {
-        setEditHitboxDebugVisible(checked === true);
-    };
-    const handleEntityRenderModeDebugChange = (
-        checked: boolean | 'indeterminate',
-    ) => {
-        setEntityRenderModeDebugVisible(checked === true);
-    };
+    const resetWeather = useCallback(() => {
+        // Drop the override and fall back to the live forecast.
+        setOverrideWeather(false);
+    }, []);
 
     const weatherControlsDisabled = !overrideWeather;
 
@@ -602,6 +687,13 @@ export function DebugHud() {
         ? { top: `${panelPosition.y}px`, left: `${panelPosition.x}px` }
         : { bottom: `${PANEL_MARGIN_PX}px`, right: `${PANEL_MARGIN_PX}px` };
 
+    const isDaytime = timeOfDay >= 0.2 && timeOfDay <= 0.8;
+    const qualityTier = profileSnapshot?.qualityTier ?? 'n/a';
+    const canvasSize =
+        profileSnapshot?.canvasWidth && profileSnapshot.canvasHeight
+            ? `${profileSnapshot.canvasWidth}×${profileSnapshot.canvasHeight}`
+            : 'n/a';
+
     return (
         <div
             className="pointer-events-none fixed z-50"
@@ -609,147 +701,295 @@ export function DebugHud() {
         >
             <div ref={panelWrapperRef} className="pointer-events-auto">
                 <DebugPanel
-                    title="Env"
+                    title="Debug"
                     dragging={isDraggingPanel}
+                    defaultCollapsed
+                    collapsedSummary={
+                        <span className="inline-flex items-center gap-1">
+                            <Graph className="size-3 shrink-0" />
+                            <span className="inline-block w-[5ch] text-right tabular-nums">
+                                {formatMetric(frameStats.fps)}
+                            </span>
+                            <span className="shrink-0">
+                                FPS · {qualityTier}
+                            </span>
+                        </span>
+                    }
                     onDragHandlePointerDown={handlePanelPointerDown}
                 >
-                    <Stack spacing={4}>
-                        <DebugPanelSection title="Performance">
-                            <Stack
-                                spacing={2}
-                                className="text-xs font-mono leading-5"
-                            >
-                                <div>
-                                    FPS {formatMetric(frameStats.fps)} / p95{' '}
-                                    {formatMetric(frameStats.p95FrameMs, ' ms')}
-                                </div>
-                                <div>
-                                    Tier {profileSnapshot?.qualityTier ?? 'n/a'}{' '}
-                                    / DPR{' '}
-                                    {formatMetric(profileSnapshot?.dprCap)} of{' '}
-                                    {formatMetric(profileSnapshot?.reportedDpr)}
-                                </div>
-                                <div>
-                                    Canvas{' '}
-                                    {profileSnapshot?.canvasWidth &&
-                                    profileSnapshot.canvasHeight
-                                        ? `${profileSnapshot.canvasWidth}x${profileSnapshot.canvasHeight}`
-                                        : 'n/a'}
-                                </div>
-                                <div>
-                                    Shadow{' '}
-                                    {profileSnapshot?.shadowsEnabled
-                                        ? `${profileSnapshot.shadowMapSize}px`
-                                        : 'off'}
-                                </div>
-                                <div>
-                                    Weather{' '}
-                                    {profileSnapshot?.rainParticleCount ?? 0} /{' '}
-                                    {profileSnapshot?.snowParticleCount ?? 0}
-                                </div>
-                                <div>
-                                    Details snow{' '}
-                                    {profileSnapshot?.instancedSnowOverlayCount ??
-                                        0}{' '}
-                                    / mulch{' '}
-                                    {profileSnapshot?.raisedBedMulchOverlayCount ??
-                                        0}{' '}
-                                    / decor{' '}
-                                    {profileSnapshot?.groundDecorationCount ??
-                                        0}
-                                </div>
+                    <Stack spacing={2}>
+                        <DebugPanelSection title="Performance" icon={Graph}>
+                            <Stack spacing={1}>
+                                <InfoRow
+                                    icon={Graph}
+                                    label="FPS"
+                                    value={`${formatMetric(frameStats.fps)} · p95 ${formatMetric(frameStats.p95FrameMs)} ms`}
+                                />
+                                <InfoRow
+                                    icon={Desktop}
+                                    label="Quality"
+                                    value={`${qualityTier} · DPR ${formatMetric(profileSnapshot?.dprCap)}/${formatMetric(profileSnapshot?.reportedDpr)}`}
+                                />
+                                <InfoRow
+                                    icon={FullWidth}
+                                    label="Canvas"
+                                    value={canvasSize}
+                                />
+                                <InfoRow
+                                    icon={Sun}
+                                    label="Shadows"
+                                    value={
+                                        profileSnapshot?.shadowsEnabled
+                                            ? `${profileSnapshot.shadowMapSize}px`
+                                            : 'off'
+                                    }
+                                />
+                                <InfoRow
+                                    icon={Droplets}
+                                    label="Particles"
+                                    value={`rain ${profileSnapshot?.rainParticleCount ?? 0} · snow ${profileSnapshot?.snowParticleCount ?? 0}`}
+                                />
+                                <InfoRow
+                                    icon={Layers}
+                                    label="Overlays"
+                                    value={`snow ${profileSnapshot?.instancedSnowOverlayCount ?? 0} · mulch ${profileSnapshot?.raisedBedMulchOverlayCount ?? 0} · decor ${profileSnapshot?.groundDecorationCount ?? 0}`}
+                                />
+                                <InfoRow
+                                    icon={Settings}
+                                    label="Decor density"
+                                    value={formatMetric(
+                                        profileSnapshot?.groundDecorationDensity,
+                                    )}
+                                />
                             </Stack>
+                            <Row spacing={1}>
+                                {QUALITY_OPTIONS.map((option) => (
+                                    <Button
+                                        key={option}
+                                        size="xs"
+                                        className="flex-1 px-1 capitalize"
+                                        variant={
+                                            gameQualitySetting === option
+                                                ? 'solid'
+                                                : 'outlined'
+                                        }
+                                        onClick={() =>
+                                            setGameQualitySetting(option)
+                                        }
+                                    >
+                                        {option}
+                                    </Button>
+                                ))}
+                            </Row>
                         </DebugPanelSection>
-                        <DebugPanelSection title="Animals">
-                            <Stack
-                                spacing={2}
-                                className="text-xs font-mono leading-5"
-                            >
-                                {animalDebugEntries.length === 0 ? (
-                                    <div>No active animals</div>
-                                ) : (
-                                    animalDebugEntries.map((entry) => (
+                        <DebugPanelSection title="Animals" icon={Ghost}>
+                            {animalDebugEntries.length === 0 ? (
+                                <Typography
+                                    level="body3"
+                                    secondary
+                                    className="italic"
+                                >
+                                    No active animals
+                                </Typography>
+                            ) : (
+                                <Stack spacing={1}>
+                                    {animalDebugEntries.map((entry) => (
                                         <div
                                             key={entry.id}
-                                            className="rounded-md border border-border/50 bg-card/60 p-2"
+                                            className="rounded-md border border-border/50 bg-card/60 p-1.5 text-[11px] leading-tight"
                                         >
-                                            <div className="flex justify-between gap-3">
-                                                <span>
-                                                    {entry.species}{' '}
-                                                    {entry.label}
+                                            <div className="flex items-center justify-between gap-2">
+                                                <span className="inline-flex min-w-0 items-center gap-1 font-medium">
+                                                    <Ghost className="size-3 shrink-0 text-muted-foreground" />
+                                                    <span className="truncate">
+                                                        {entry.species}{' '}
+                                                        {entry.label}
+                                                    </span>
                                                 </span>
-                                                <span>{entry.phase}</span>
+                                                <span className="shrink-0 rounded bg-muted px-1 font-mono">
+                                                    {entry.phase}
+                                                </span>
                                             </div>
-                                            <div>Playing {entry.activity}</div>
-                                            <div>
-                                                Behavior {entry.behavior} /{' '}
-                                                target {entry.targetId}
+                                            <div className="mt-0.5 text-muted-foreground">
+                                                {entry.activity} ·{' '}
+                                                {entry.behavior} →{' '}
+                                                {entry.targetId || 'none'}
                                             </div>
-                                            <div>
-                                                Pos{' '}
+                                            <div className="inline-flex items-center gap-1 font-mono text-muted-foreground">
+                                                <MapPin className="size-3 shrink-0" />
                                                 {formatAnimalPosition(
                                                     entry.position,
                                                 )}
                                             </div>
                                         </div>
-                                    ))
-                                )}
-                            </Stack>
+                                    ))}
+                                </Stack>
+                            )}
                         </DebugPanelSection>
-                        <DebugPanelSection title="Scene">
-                            <Stack spacing={2} className="text-xs">
-                                <Checkbox
-                                    label="Show edit hitboxes"
-                                    checked={editHitboxDebugVisible}
-                                    onCheckedChange={
-                                        handleEditHitboxDebugChange
+                        <DebugPanelSection title="Scene" icon={Layers}>
+                            <Row spacing={1} className="flex-wrap">
+                                <Button
+                                    size="xs"
+                                    className="flex-1"
+                                    startDecorator={
+                                        <Fence className="size-3.5" />
                                     }
-                                />
-                                <Checkbox
-                                    label="Show render modes"
-                                    checked={entityRenderModeDebugVisible}
-                                    onCheckedChange={
-                                        handleEntityRenderModeDebugChange
+                                    variant={
+                                        editHitboxDebugVisible
+                                            ? 'solid'
+                                            : 'outlined'
                                     }
-                                />
-                                {entityRenderModeDebugVisible && (
-                                    <div className="grid gap-1 font-mono leading-5">
-                                        <span className="text-emerald-400">
-                                            Green instanced
-                                        </span>
-                                        <span className="text-amber-400">
-                                            Amber component
-                                        </span>
-                                    </div>
-                                )}
-                            </Stack>
+                                    onClick={() =>
+                                        setEditHitboxDebugVisible(
+                                            !editHitboxDebugVisible,
+                                        )
+                                    }
+                                >
+                                    Edit hitboxes
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    className="flex-1"
+                                    startDecorator={
+                                        <Layers className="size-3.5" />
+                                    }
+                                    variant={
+                                        entityRenderModeDebugVisible
+                                            ? 'solid'
+                                            : 'outlined'
+                                    }
+                                    onClick={() =>
+                                        setEntityRenderModeDebugVisible(
+                                            !entityRenderModeDebugVisible,
+                                        )
+                                    }
+                                >
+                                    Render modes
+                                </Button>
+                            </Row>
+                            {entityRenderModeDebugVisible && (
+                                <div className="grid gap-0.5 font-mono text-[11px]">
+                                    <span className="text-emerald-500">
+                                        ● instanced
+                                    </span>
+                                    <span className="text-amber-500">
+                                        ● component
+                                    </span>
+                                </div>
+                            )}
                         </DebugPanelSection>
-                        <DebugPanelSection title="Time">
-                            <Slider
-                                label={formatTimeLabel(timeOfDay)}
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={[timeOfDay]}
-                                onValueChange={(value) => {
-                                    const [nextValue] = value;
-                                    if (typeof nextValue === 'number') {
-                                        setTimeOfDay(
-                                            clampToRange(nextValue, 0, 1),
-                                        );
-                                    }
-                                }}
+                        <DebugPanelSection
+                            title="Time"
+                            icon={SunMoon}
+                            action={
+                                <IconButton
+                                    type="button"
+                                    size="sm"
+                                    variant="plain"
+                                    title="Reset time"
+                                    className="size-6 rounded-full"
+                                    onClick={resetTime}
+                                >
+                                    <Reset className="size-3.5" />
+                                </IconButton>
+                            }
+                        >
+                            <TimeOfDayVisualization
+                                interactive
+                                onChange={updateTimeOfDay}
+                                timeOfDay={timeOfDay}
                             />
+                            <Row
+                                justifyContent="space-between"
+                                className="text-[11px]"
+                            >
+                                <Typography
+                                    level="body3"
+                                    className="inline-flex items-center gap-1 whitespace-nowrap"
+                                >
+                                    <Sun className="size-3 text-amber-500" />
+                                    {formatTime(sunriseTime)}
+                                </Typography>
+                                <Typography
+                                    level="body3"
+                                    className={cx(
+                                        'inline-flex items-center gap-1 whitespace-nowrap font-mono font-medium',
+                                        isDaytime
+                                            ? 'text-amber-600 dark:text-amber-300'
+                                            : 'text-blue-600 dark:text-blue-300',
+                                    )}
+                                >
+                                    {isDaytime ? (
+                                        <Sun className="size-3" />
+                                    ) : (
+                                        <Moon className="size-3" />
+                                    )}
+                                    {formatTime(currentTime)} ·{' '}
+                                    {formatClockLabel(timeOfDay)}
+                                </Typography>
+                                <Typography
+                                    level="body3"
+                                    className="inline-flex items-center gap-1 whitespace-nowrap"
+                                >
+                                    <Moon className="size-3 text-blue-500" />
+                                    {formatTime(sunsetTime)}
+                                </Typography>
+                            </Row>
                         </DebugPanelSection>
-                        <DebugPanelSection title="Weather">
-                            <Checkbox
-                                label="Override"
-                                checked={overrideWeather}
-                                onCheckedChange={handleOverrideChange}
-                            />
-                            <Stack spacing={2} className="pt-1">
+                        <DebugPanelSection
+                            title="Weather"
+                            icon={Cloud}
+                            action={
+                                <IconButton
+                                    type="button"
+                                    size="sm"
+                                    variant="plain"
+                                    title="Reset weather"
+                                    className="size-6 rounded-full"
+                                    disabled={weatherControlsDisabled}
+                                    onClick={resetWeather}
+                                >
+                                    <Reset className="size-3.5" />
+                                </IconButton>
+                            }
+                        >
+                            {weather ? (
+                                <Stack spacing={1}>
+                                    <InfoRow
+                                        icon={Thermometer}
+                                        label="Temperature"
+                                        value={formatTemperature(
+                                            weather.temperature,
+                                        )}
+                                    />
+                                    <InfoRow
+                                        icon={Cloud}
+                                        label="Source"
+                                        value={`${weather.source ?? 'n/a'}${weather.isStale ? ' (stale)' : ''}`}
+                                    />
+                                </Stack>
+                            ) : null}
+                            <Button
+                                size="xs"
+                                className="self-start"
+                                startDecorator={<Custom className="size-3.5" />}
+                                variant={overrideWeather ? 'solid' : 'outlined'}
+                                onClick={() =>
+                                    setOverrideWeather((current) => !current)
+                                }
+                            >
+                                Override forecast
+                            </Button>
+                            <Stack spacing={2}>
                                 <Slider
-                                    label={`Cloud ${formatPercent(cloudy)}`}
+                                    aria-label="Clouds"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Cloud}
+                                            label="Clouds"
+                                            value={formatPercent(cloudy)}
+                                        />
+                                    }
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -765,7 +1005,14 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Rain ${formatPercent(rainy)}`}
+                                    aria-label="Rain"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Droplets}
+                                            label="Rain"
+                                            value={formatPercent(rainy)}
+                                        />
+                                    }
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -781,7 +1028,14 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Snow ${formatPercent(snowy)}`}
+                                    aria-label="Snow"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Snowflake}
+                                            label="Snow"
+                                            value={formatPercent(snowy)}
+                                        />
+                                    }
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -797,7 +1051,14 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Fog ${formatPercent(foggy)}`}
+                                    aria-label="Fog"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Cloud}
+                                            label="Fog"
+                                            value={formatPercent(foggy)}
+                                        />
+                                    }
                                     min={0}
                                     max={1}
                                     step={0.01}
@@ -813,7 +1074,37 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Wind ${formatWindSpeed(windSpeed)}`}
+                                    aria-label="Thunder"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Lightning}
+                                            label="Thunder"
+                                            value={formatPercent(thundery)}
+                                        />
+                                    }
+                                    min={0}
+                                    max={1}
+                                    step={0.01}
+                                    value={[thundery]}
+                                    disabled={weatherControlsDisabled}
+                                    onValueChange={(value) => {
+                                        const [nextValue] = value;
+                                        if (typeof nextValue === 'number') {
+                                            setThundery(
+                                                clampToRange(nextValue, 0, 1),
+                                            );
+                                        }
+                                    }}
+                                />
+                                <Slider
+                                    aria-label="Wind"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Wind}
+                                            label="Wind"
+                                            value={formatWindSpeed(windSpeed)}
+                                        />
+                                    }
                                     min={0}
                                     max={3}
                                     step={1}
@@ -829,7 +1120,16 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Dir ${formatWindDirection(windDirection)}`}
+                                    aria-label="Wind direction"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Wind}
+                                            label="Direction"
+                                            value={formatWindDirection(
+                                                windDirection,
+                                            )}
+                                        />
+                                    }
                                     min={0}
                                     max={315}
                                     step={45}
@@ -845,7 +1145,14 @@ export function DebugHud() {
                                     }}
                                 />
                                 <Slider
-                                    label={`Accum ${snowAccumulation} cm`}
+                                    aria-label="Snow cover"
+                                    label={
+                                        <WeatherSliderLabel
+                                            icon={Snowflake}
+                                            label="Snow cover"
+                                            value={`${snowAccumulation} cm`}
+                                        />
+                                    }
                                     min={0}
                                     max={50}
                                     step={1}
@@ -860,11 +1167,16 @@ export function DebugHud() {
                                         }
                                     }}
                                 />
-                                <Row spacing={2} className="flex-wrap">
+                                <Row spacing={1} alignItems="center">
+                                    <span className="inline-flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+                                        <Snowflake className="size-3.5" />
+                                        cm
+                                    </span>
                                     {SNOW_ACCUMULATION_PRESETS.map((preset) => (
                                         <Button
                                             key={preset.label}
-                                            size="sm"
+                                            size="xs"
+                                            className="flex-1 px-1"
                                             disabled={weatherControlsDisabled}
                                             onClick={() =>
                                                 setSnowAccumulation(

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -12,7 +12,7 @@ export {
     PLANT_STAGES,
 } from './hud/raisedBed/featuredOperations';
 export { defaultLocalSandboxStorageKey } from './localSandboxGarden';
-export type { GameQualityTier } from './scene/gameQuality';
+export type { GameQualitySetting, GameQualityTier } from './scene/gameQuality';
 export { resolveSpriteAtlasAssetPaths } from './sprites/resolveSpriteAtlasAssetPaths';
 export { SpriteAtlasBillboard } from './sprites/SpriteAtlasBillboard';
 export type {

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -190,6 +190,7 @@ export function createGameState({
     spriteBaseUrl,
     dayNightCycleDisabled: initialDayNightCycleDisabled,
     freezeTime,
+    initialQualitySetting,
     isMock,
     localSandboxStorageKey,
     winterMode,
@@ -198,6 +199,7 @@ export function createGameState({
     spriteBaseUrl?: string;
     dayNightCycleDisabled?: boolean;
     freezeTime: Date | null;
+    initialQualitySetting?: GameQualitySetting;
     isMock: boolean;
     localSandboxStorageKey?: string;
     winterMode?: WinterMode;
@@ -205,7 +207,7 @@ export function createGameState({
     const dayNightCycleDisabled =
         initialDayNightCycleDisabled ?? isDayNightCycleDisabled();
     const gameQualityCustomProfile = getGameQualityCustomProfile();
-    const gameQualitySetting = getGameQualitySetting();
+    const gameQualitySetting = initialQualitySetting ?? getGameQualitySetting();
     const weatherVisualizationDisabled = isWeatherVisualizationDisabled();
     const now = freezeTime ?? new Date();
     const timeOfDay = resolveGameTimeOfDay(now, dayNightCycleDisabled);

--- a/packages/ui/src/DebugControls/DebugPanel.tsx
+++ b/packages/ui/src/DebugControls/DebugPanel.tsx
@@ -1,17 +1,29 @@
-import type { PointerEvent, PropsWithChildren } from 'react';
+import type {
+    ComponentType,
+    PointerEvent,
+    PropsWithChildren,
+    ReactNode,
+} from 'react';
 import { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../Card';
+import { Card } from '../Card';
+import { Divider } from '../Divider';
 import { IconButton } from '../IconButton';
-import { Down, Up } from '../icons';
+import { Down, Drag, Up } from '../icons';
 import { Stack } from '../Stack';
 import { Typography } from '../Typography';
 import { cx } from '../utils';
+
+type IconType = ComponentType<{ className?: string }>;
 
 interface DebugPanelProps extends PropsWithChildren {
     title: string;
     description?: string;
     className?: string;
     dragging?: boolean;
+    /** Collapse the panel on first render to keep the in-game footprint small. */
+    defaultCollapsed?: boolean;
+    /** Rendered to the right of the title while collapsed (e.g. live FPS). */
+    collapsedSummary?: ReactNode;
     onDragHandlePointerDown?: (event: PointerEvent<HTMLDivElement>) => void;
 }
 
@@ -20,61 +32,76 @@ export function DebugPanel({
     description,
     className,
     dragging = false,
+    defaultCollapsed = false,
+    collapsedSummary,
     onDragHandlePointerDown,
     children,
 }: DebugPanelProps) {
-    const [collapsed, setCollapsed] = useState(false);
+    const [collapsed, setCollapsed] = useState(defaultCollapsed);
+    const draggable = Boolean(onDragHandlePointerDown);
 
     return (
         <Card
             className={cx(
-                'flex max-h-[calc(100dvh-2rem)] w-full max-w-sm flex-col overflow-hidden border border-border/40 bg-background/95 shadow-lg backdrop-blur',
+                'flex max-h-[calc(100dvh-2rem)] w-full max-w-xs flex-col overflow-hidden border border-border/40 bg-background/95 p-0 shadow-lg backdrop-blur',
                 className,
             )}
         >
-            <CardHeader
+            <div
                 className={cx(
-                    'shrink-0 space-y-1',
-                    onDragHandlePointerDown
-                        ? 'cursor-grab select-none touch-none active:cursor-grabbing'
+                    'flex shrink-0 items-center gap-1.5 px-2 py-1',
+                    draggable
+                        ? 'cursor-grab touch-none select-none active:cursor-grabbing'
                         : undefined,
                     dragging ? 'cursor-grabbing' : undefined,
                 )}
                 onPointerDown={onDragHandlePointerDown}
             >
-                <div className="flex items-start justify-between gap-2">
-                    <CardTitle className="text-base font-semibold">
-                        {title}
-                    </CardTitle>
-                    <IconButton
-                        type="button"
-                        size="sm"
-                        variant="plain"
-                        title={collapsed ? 'Expand' : 'Collapse'}
-                        className="size-7 shrink-0 rounded-full"
-                        onClick={() => setCollapsed((current) => !current)}
-                        onPointerDown={(event) => event.stopPropagation()}
-                    >
-                        {collapsed ? (
-                            <Down className="size-4" />
-                        ) : (
-                            <Up className="size-4" />
-                        )}
-                    </IconButton>
-                </div>
-                {description ? (
-                    <Typography level="body3" secondary>
-                        {description}
-                    </Typography>
+                {draggable ? (
+                    <Drag className="size-3.5 shrink-0 text-muted-foreground" />
                 ) : null}
-            </CardHeader>
-            {collapsed ? null : (
-                <CardContent
-                    noHeader
-                    className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain"
+                <Typography
+                    level="body2"
+                    semiBold
+                    className="shrink-0 leading-none"
                 >
-                    {children}
-                </CardContent>
+                    {title}
+                </Typography>
+                {collapsed && collapsedSummary ? (
+                    <div className="ml-1 min-w-0 flex-1 truncate text-right font-mono text-[11px] leading-none text-muted-foreground">
+                        {collapsedSummary}
+                    </div>
+                ) : (
+                    <div className="flex-1" />
+                )}
+                <IconButton
+                    type="button"
+                    size="sm"
+                    variant="plain"
+                    title={collapsed ? 'Expand' : 'Collapse'}
+                    className="-my-1 size-6 shrink-0 rounded-full"
+                    onClick={() => setCollapsed((current) => !current)}
+                    onPointerDown={(event) => event.stopPropagation()}
+                >
+                    {collapsed ? (
+                        <Down className="size-3.5" />
+                    ) : (
+                        <Up className="size-3.5" />
+                    )}
+                </IconButton>
+            </div>
+            {collapsed ? null : (
+                <>
+                    <Divider />
+                    <div className="min-h-0 flex-1 space-y-2 overflow-y-auto overscroll-contain p-2">
+                        {description ? (
+                            <Typography level="body3" secondary>
+                                {description}
+                            </Typography>
+                        ) : null}
+                        {children}
+                    </div>
+                </>
             )}
         </Card>
     );
@@ -84,50 +111,66 @@ interface DebugPanelSectionProps extends PropsWithChildren {
     title: string;
     description?: string;
     className?: string;
+    icon?: IconType;
+    /** Rendered to the left of the collapse toggle (e.g. a reset action). */
+    action?: ReactNode;
 }
 
 export function DebugPanelSection({
     title,
     description,
     className,
+    icon: Icon,
+    action,
     children,
 }: DebugPanelSectionProps) {
     const [collapsed, setCollapsed] = useState(false);
 
     return (
         <Stack
-            spacing={3}
+            spacing={2}
             className={cx(
-                'rounded-lg border border-border/40 bg-background/80 p-3 shadow-xs backdrop-blur-xs',
+                'rounded-md border border-border/40 bg-background/80 p-2 shadow-xs backdrop-blur-xs',
                 className,
             )}
         >
-            <div className="flex items-start justify-between gap-2">
-                <div className="space-y-1">
-                    <Typography level="body2" semiBold>
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-1.5">
+                    {Icon ? (
+                        <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+                    ) : null}
+                    <Typography
+                        level="body3"
+                        semiBold
+                        uppercase
+                        className="truncate tracking-wide"
+                    >
                         {title}
                     </Typography>
-                    {description ? (
-                        <Typography level="body3" secondary>
-                            {description}
-                        </Typography>
-                    ) : null}
                 </div>
-                <IconButton
-                    type="button"
-                    size="sm"
-                    variant="plain"
-                    title={collapsed ? 'Expand' : 'Collapse'}
-                    className="size-7 shrink-0 rounded-full"
-                    onClick={() => setCollapsed((current) => !current)}
-                >
-                    {collapsed ? (
-                        <Down className="size-4" />
-                    ) : (
-                        <Up className="size-4" />
-                    )}
-                </IconButton>
+                <div className="-my-1 -mr-1 flex shrink-0 items-center gap-0.5">
+                    {!collapsed && action ? action : null}
+                    <IconButton
+                        type="button"
+                        size="sm"
+                        variant="plain"
+                        title={collapsed ? 'Expand' : 'Collapse'}
+                        className="size-6 shrink-0 rounded-full"
+                        onClick={() => setCollapsed((current) => !current)}
+                    >
+                        {collapsed ? (
+                            <Down className="size-3.5" />
+                        ) : (
+                            <Up className="size-3.5" />
+                        )}
+                    </IconButton>
+                </div>
             </div>
+            {!collapsed && description ? (
+                <Typography level="body3" secondary>
+                    {description}
+                </Typography>
+            ) : null}
             {collapsed ? null : children}
         </Stack>
     );


### PR DESCRIPTION
## Summary
- add an interactive game scene launcher for debug profile mode, quality, details, HUD, and controls query params
- condense and enhance the in-game debug HUD with collapsible sections, live performance summary, time controls, quality selection, and weather override controls
- extend the shared debug panel with compact headers, default collapsed state, section icons, and section actions
- include local launch config and quoted skill frontmatter descriptions from the staged worktree

## Validation
- pnpm typecheck --filter @gredice/game --filter @gredice/ui --filter garden --filter www (passed; Turbo emitted cache IO permission warnings)