### PR TITLE
Use shared side panels for admin chrome

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -8,9 +8,9 @@ import { SignedOut } from '@gredice/ui/auth';
 import { AuthProtectedSection } from '@gredice/ui/auth/server';
 import { type PropsWithChildren, Suspense } from 'react';
 import {
+    AdminDesktopFrame,
     AdminPageCardHeader,
     AdminPageHeaderProvider,
-    DesktopNav,
     DesktopNavProvider,
     LoginDialog,
 } from '../../components/admin/navigation';
@@ -91,32 +91,21 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                 <div className="grow bg-secondary/40" data-gredice-admin-shell>
                     <main className="relative h-full min-h-screen">
                         <DesktopNavProvider>
-                            <div
-                                className="flex min-h-full flex-row gap-3 md:gap-4 md:p-4"
-                                data-gredice-admin-frame
-                            >
-                                {/* Desktop Navigation */}
-                                <DesktopNav />
-                                {/* Main Content */}
+                            <AdminDesktopFrame>
                                 <div
-                                    className="min-h-full grow"
-                                    data-gredice-admin-content
+                                    className="min-h-full border bg-[var(--admin-page-content-background)] p-3 md:rounded-2xl md:p-4"
+                                    data-gredice-admin-content-panel
                                 >
-                                    <div
-                                        className="min-h-full border bg-[var(--admin-page-content-background)] p-3 md:rounded-2xl md:p-4"
-                                        data-gredice-admin-content-panel
-                                    >
-                                        <AuthProtectedSection auth={authAdmin}>
-                                            <Suspense>
-                                                <AdminPageHeaderProvider>
-                                                    <AdminPageCardHeader />
-                                                    {children}
-                                                </AdminPageHeaderProvider>
-                                            </Suspense>
-                                        </AuthProtectedSection>
-                                    </div>
+                                    <AuthProtectedSection auth={authAdmin}>
+                                        <Suspense>
+                                            <AdminPageHeaderProvider>
+                                                <AdminPageCardHeader />
+                                                {children}
+                                            </AdminPageHeaderProvider>
+                                        </Suspense>
+                                    </AuthProtectedSection>
                                 </div>
-                            </div>
+                            </AdminDesktopFrame>
                         </DesktopNavProvider>
                         <SignedOut>
                             <LoginDialog />

--- a/apps/app/components/admin/details/EntityDetailsPropertiesLayout.tsx
+++ b/apps/app/components/admin/details/EntityDetailsPropertiesLayout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { SidePanelLayout } from '@gredice/ui/SidePanelLayout';
 import { cx } from '@gredice/ui/utils';
 import type { ReactNode } from 'react';
 import { useEntityDetailsProperties } from './EntityDetailsPropertiesContext';
@@ -14,26 +15,29 @@ export function EntityDetailsPropertiesLayout({
     const { isOpen } = useEntityDetailsProperties();
 
     return (
-        <div
-            className={cx(
-                'relative grid min-w-0 gap-3',
-                isOpen && 'lg:grid-cols-[minmax(0,1fr)_20rem]',
+        <SidePanelLayout
+            className="relative min-w-0"
+            desktopBreakpoint="lg"
+            hideClosedPanelsOnStack={false}
+            rightOpen={isOpen}
+            rightPanel={
+                <section
+                    aria-label="Detalji zapisa"
+                    className="h-full"
+                    id="entity-details-properties-panel"
+                >
+                    {properties}
+                </section>
+            }
+            rightPanelClassName={cx(
+                'fixed bottom-3 right-3 top-20 z-40 w-[min(22rem,calc(100vw-1.5rem))] transition-transform duration-200 lg:bottom-auto lg:right-auto lg:z-10 lg:w-auto',
+                isOpen
+                    ? 'translate-x-0'
+                    : 'pointer-events-none translate-x-[calc(100%+1rem)] lg:translate-x-0',
             )}
+            rightWidth="20rem"
         >
-            <div className="min-w-0">{children}</div>
-            <aside
-                id="entity-details-properties-panel"
-                aria-label="Detalji zapisa"
-                aria-hidden={!isOpen}
-                className={cx(
-                    'fixed bottom-3 right-3 top-20 z-40 w-[min(22rem,calc(100vw-1.5rem))] transition-transform duration-200 lg:sticky lg:bottom-auto lg:right-auto lg:top-4 lg:z-10 lg:w-80 lg:self-start',
-                    isOpen
-                        ? 'translate-x-0'
-                        : 'pointer-events-none translate-x-[calc(100%+1rem)] lg:hidden',
-                )}
-            >
-                {isOpen ? properties : null}
-            </aside>
-        </div>
+            {children}
+        </SidePanelLayout>
     );
 }

--- a/apps/app/components/admin/navigation/AdminDesktopFrame.tsx
+++ b/apps/app/components/admin/navigation/AdminDesktopFrame.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { SidePanelLayout } from '@gredice/ui/SidePanelLayout';
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { isAdminChromeHiddenPath } from './adminChromeVisibility';
+import { DesktopNav } from './DesktopNav';
+import { useDesktopNav } from './DesktopNavProvider';
+
+export function AdminDesktopFrame({ children }: { children: ReactNode }) {
+    const pathname = usePathname();
+    const { isExpanded } = useDesktopNav();
+    const showChrome = !isAdminChromeHiddenPath(pathname);
+
+    return (
+        <SidePanelLayout
+            className="min-h-full md:p-4"
+            data-gredice-admin-frame
+            desktopBreakpoint="md"
+            leftOpen={showChrome && isExpanded}
+            leftPanel={showChrome ? <DesktopNav /> : null}
+            leftPanelClassName="hidden md:block"
+            leftWidth="18rem"
+        >
+            <div className="min-h-full" data-gredice-admin-content>
+                {children}
+            </div>
+        </SidePanelLayout>
+    );
+}

--- a/apps/app/components/admin/navigation/DesktopNav.tsx
+++ b/apps/app/components/admin/navigation/DesktopNav.tsx
@@ -1,33 +1,14 @@
-'use client';
-
-import { usePathname } from 'next/navigation';
-import { isAdminChromeHiddenPath } from './adminChromeVisibility';
-import { useDesktopNav } from './DesktopNavProvider';
 import { Nav } from './Nav';
 
 export function DesktopNav() {
-    const pathname = usePathname();
-    const { isExpanded } = useDesktopNav();
-
-    if (isAdminChromeHiddenPath(pathname)) {
-        return null;
-    }
-
-    if (!isExpanded) {
-        return null;
-    }
-
     return (
-        <aside
-            className="hidden md:block md:w-72 md:shrink-0"
-            data-gredice-admin-nav
-        >
+        <div data-gredice-admin-nav>
             <div
-                className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-3 shadow-xs"
+                className="max-h-[calc(100vh-2rem)] overflow-y-auto rounded-2xl border bg-background/95 p-3 shadow-xs"
                 data-gredice-admin-nav-panel
             >
                 <Nav idPrefix="desktop-admin-nav" />
             </div>
-        </aside>
+        </div>
     );
 }

--- a/apps/app/components/admin/navigation/DesktopNavToggle.tsx
+++ b/apps/app/components/admin/navigation/DesktopNavToggle.tsx
@@ -1,28 +1,18 @@
 'use client';
 
-import { IconButton } from '@gredice/ui/IconButton';
-import { PanelRightClose } from '@gredice/ui/icons';
+import { SidePanelToggleButton } from '@gredice/ui/SidePanelLayout';
 import { useDesktopNav } from './DesktopNavProvider';
 
 export function DesktopNavToggle() {
     const { isExpanded, toggle } = useDesktopNav();
 
     return (
-        <IconButton
-            variant="plain"
+        <SidePanelToggleButton
+            className="hidden md:inline-flex"
+            label="navigaciju"
             onClick={toggle}
-            title={
-                isExpanded
-                    ? 'Sažmi bočnu navigaciju'
-                    : 'Proširi bočnu navigaciju'
-            }
-            className="hidden rounded-md text-muted-foreground hover:text-foreground md:inline-flex"
-        >
-            <PanelRightClose
-                className={`size-4 transition-transform ${
-                    isExpanded ? 'rotate-180' : ''
-                }`}
-            />
-        </IconButton>
+            open={isExpanded}
+            side="left"
+        />
     );
 }

--- a/apps/app/components/admin/navigation/index.ts
+++ b/apps/app/components/admin/navigation/index.ts
@@ -1,3 +1,4 @@
+export { AdminDesktopFrame } from './AdminDesktopFrame';
 export { AdminDirectoryBreadcrumbs } from './AdminDirectoryBreadcrumbs';
 export { AdminPageBreadcrumbs } from './AdminPageBreadcrumbs';
 export { AdminPageCardHeader } from './AdminPageCardHeader';

--- a/apps/storybook/stories/packages/ui/primitives/SidePanelLayout.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/SidePanelLayout.stories.tsx
@@ -3,6 +3,7 @@ import { PanelSection } from '@gredice/ui/PanelSection';
 import { Row } from '@gredice/ui/Row';
 import {
     SidePanelLayout,
+    type SidePanelLayoutBreakpoint,
     SidePanelToggleButton,
 } from '@gredice/ui/SidePanelLayout';
 import { Stack } from '@gredice/ui/Stack';
@@ -32,9 +33,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 function Demo({
+    desktopBreakpoint = 'xl',
     initialLeftOpen = true,
     initialRightOpen = true,
 }: {
+    desktopBreakpoint?: SidePanelLayoutBreakpoint;
     initialLeftOpen?: boolean;
     initialRightOpen?: boolean;
 }) {
@@ -61,6 +64,7 @@ function Demo({
                 />
             </Row>
             <SidePanelLayout
+                desktopBreakpoint={desktopBreakpoint}
                 leftOpen={leftOpen}
                 leftPanel={
                     <Stack spacing={2}>
@@ -126,4 +130,8 @@ export const LeftClosed: Story = {
 
 export const BothClosed: Story = {
     render: () => <Demo initialLeftOpen={false} initialRightOpen={false} />,
+};
+
+export const MediumBreakpoint: Story = {
+    render: () => <Demo desktopBreakpoint="md" />,
 };

--- a/packages/ui/src/SidePanelLayout/SidePanelLayout.tsx
+++ b/packages/ui/src/SidePanelLayout/SidePanelLayout.tsx
@@ -17,6 +17,7 @@ import {
 import { cx } from '../utils';
 
 export type SidePanelSide = 'left' | 'right';
+export type SidePanelLayoutBreakpoint = 'md' | 'lg' | 'xl';
 
 export type SidePanelLayoutProps = Omit<
     HTMLAttributes<HTMLDivElement>,
@@ -27,6 +28,14 @@ export type SidePanelLayoutProps = Omit<
     leftOpen?: boolean;
     leftPanelClassName?: string;
     leftWidth?: string;
+    /**
+     * Breakpoint where panels become side columns instead of stacked content.
+     */
+    desktopBreakpoint?: SidePanelLayoutBreakpoint;
+    /**
+     * Keep closed stacked panels mounted when callers animate them manually.
+     */
+    hideClosedPanelsOnStack?: boolean;
     panelClassName?: string;
     /**
      * @deprecated No-op. Panels now always stay mounted so their width can
@@ -43,6 +52,39 @@ export type SidePanelLayoutProps = Omit<
 // baked into the open track width (and the panel's inner margin) so the gap can
 // collapse together with the panel during the width animation.
 const SIDE_PANEL_GAP = '1.5rem';
+
+const breakpointClasses: Record<
+    SidePanelLayoutBreakpoint,
+    {
+        closedPanel: string;
+        leftPanelInner: string;
+        layout: string;
+        panel: string;
+        rightPanelInner: string;
+    }
+> = {
+    md: {
+        closedPanel: 'hidden md:block',
+        leftPanelInner: 'md:mr-6 md:w-[var(--side-panel-left-width)]',
+        layout: 'md:gap-0 md:[grid-template-columns:var(--side-panel-layout-columns)] md:transition-[grid-template-columns] md:duration-300 md:ease-in-out motion-reduce:md:transition-none',
+        panel: 'md:sticky md:top-4 md:overflow-hidden',
+        rightPanelInner: 'md:ml-6 md:w-[var(--side-panel-right-width)]',
+    },
+    lg: {
+        closedPanel: 'hidden lg:block',
+        leftPanelInner: 'lg:mr-6 lg:w-[var(--side-panel-left-width)]',
+        layout: 'lg:gap-0 lg:[grid-template-columns:var(--side-panel-layout-columns)] lg:transition-[grid-template-columns] lg:duration-300 lg:ease-in-out motion-reduce:lg:transition-none',
+        panel: 'lg:sticky lg:top-4 lg:overflow-hidden',
+        rightPanelInner: 'lg:ml-6 lg:w-[var(--side-panel-right-width)]',
+    },
+    xl: {
+        closedPanel: 'hidden xl:block',
+        leftPanelInner: 'xl:mr-6 xl:w-[var(--side-panel-left-width)]',
+        layout: 'xl:gap-0 xl:[grid-template-columns:var(--side-panel-layout-columns)] xl:transition-[grid-template-columns] xl:duration-300 xl:ease-in-out motion-reduce:xl:transition-none',
+        panel: 'xl:sticky xl:top-4 xl:overflow-hidden',
+        rightPanelInner: 'xl:ml-6 xl:w-[var(--side-panel-right-width)]',
+    },
+};
 
 function sidePanelColumns({
     leftOpen,
@@ -75,6 +117,8 @@ function sidePanelColumns({
 export function SidePanelLayout({
     children,
     className,
+    desktopBreakpoint = 'xl',
+    hideClosedPanelsOnStack = true,
     leftPanel,
     leftOpen = true,
     leftPanelClassName,
@@ -88,6 +132,7 @@ export function SidePanelLayout({
     style,
     ...props
 }: SidePanelLayoutProps) {
+    const responsiveClasses = breakpointClasses[desktopBreakpoint];
     const columns = sidePanelColumns({
         leftOpen,
         leftPanel,
@@ -100,20 +145,20 @@ export function SidePanelLayout({
         '--side-panel-left-width': leftWidth,
         '--side-panel-right-width': rightWidth,
     } as CSSProperties;
-    // Panels stay mounted while closed so their width can animate; below the xl
-    // breakpoint (stacked layout) closed panels are hidden instead.
+    // Panels stay mounted while closed so their width can animate; below the
+    // configured breakpoint (stacked layout) closed panels are hidden by default.
     const basePanelClassName = cx(
-        'h-fit min-w-0 xl:sticky xl:top-4 xl:overflow-hidden',
+        'min-w-0 self-start',
+        responsiveClasses.panel,
         panelClassName,
     );
+    const closedPanelClassName = hideClosedPanelsOnStack
+        ? responsiveClasses.closedPanel
+        : null;
 
     return (
         <div
-            className={cx(
-                'grid gap-6 xl:gap-0 xl:[grid-template-columns:var(--side-panel-layout-columns)]',
-                'xl:transition-[grid-template-columns] xl:duration-300 xl:ease-in-out motion-reduce:xl:transition-none',
-                className,
-            )}
+            className={cx('grid gap-6', responsiveClasses.layout, className)}
             style={layoutStyle}
             {...props}
         >
@@ -122,14 +167,19 @@ export function SidePanelLayout({
                     aria-hidden={!leftOpen || undefined}
                     className={cx(
                         basePanelClassName,
-                        !leftOpen && 'hidden xl:block',
+                        !leftOpen && closedPanelClassName,
                         leftPanelClassName,
                     )}
                     data-side="left"
                     data-state={leftOpen ? 'open' : 'closed'}
                     inert={!leftOpen || undefined}
                 >
-                    <div className="xl:mr-6 xl:w-[var(--side-panel-left-width)]">
+                    <div
+                        className={cx(
+                            'h-full',
+                            responsiveClasses.leftPanelInner,
+                        )}
+                    >
                         {leftPanel}
                     </div>
                 </aside>
@@ -140,14 +190,19 @@ export function SidePanelLayout({
                     aria-hidden={!rightOpen || undefined}
                     className={cx(
                         basePanelClassName,
-                        !rightOpen && 'hidden xl:block',
+                        !rightOpen && closedPanelClassName,
                         rightPanelClassName,
                     )}
                     data-side="right"
                     data-state={rightOpen ? 'open' : 'closed'}
                     inert={!rightOpen || undefined}
                 >
-                    <div className="xl:ml-6 xl:w-[var(--side-panel-right-width)]">
+                    <div
+                        className={cx(
+                            'h-full',
+                            responsiveClasses.rightPanelInner,
+                        )}
+                    >
                         {rightPanel}
                     </div>
                 </aside>

--- a/packages/ui/src/SidePanelLayout/index.ts
+++ b/packages/ui/src/SidePanelLayout/index.ts
@@ -1,5 +1,6 @@
 export {
     SidePanelLayout,
+    type SidePanelLayoutBreakpoint,
     type SidePanelLayoutProps,
     type SidePanelSide,
     SidePanelToggleButton,


### PR DESCRIPTION
## Summary
- Switched the admin shell and entity details panel to the shared `@gredice/ui/SidePanelLayout` and `SidePanelToggleButton` primitives.
- Extended `SidePanelLayout` with configurable desktop breakpoints so the app can animate its panels at `md`/`lg` instead of only `xl`.
- Added a Storybook sample for the `md` breakpoint to reflect the new shared behavior.

## Testing
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter storybook typecheck`
- `pnpm build --filter app`
- Browser-verified the shared panel story in Storybook and confirmed left/right panel collapse updates the grid tracks as expected.