### PR TITLE
Remove garden box from the sandbox picker

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -2,8 +2,8 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import {
     ItemsHudAlignmentStory,
     ItemsHudControlsTooltipStory,
-    SandboxItemsHudStory,
     SandboxBlockTrashDropTargetStory,
+    SandboxItemsHudStory,
 } from './ItemsHudStory';
 
 const TABLET_VIEWPORT = { width: 820, height: 1180 };
@@ -137,6 +137,37 @@ test('pots are listed under the decoration picker', async ({ mount, page }) => {
     ).toBeVisible();
     await expect(
         page.getByRole('button', { name: 'PotWideLippedCup' }),
+    ).toBeVisible();
+});
+
+test('tool picker lists functional garden boxes outside sandbox', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Alat' }).click();
+    await expect(page.getByRole('button', { name: 'GardenBox' })).toBeVisible();
+});
+
+test('sandbox tool picker hides nonfunctional garden boxes', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<SandboxItemsHudStory />);
+
+    await page.getByRole('button', { name: 'Alat' }).click();
+    await expect(page.getByRole('button', { name: 'GardenBox' })).toHaveCount(
+        0,
+    );
+    await expect(page.getByRole('button', { name: 'Bucket' })).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'WateringCan' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'ShovelSmall' }),
     ).toBeVisible();
 });
 

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -153,6 +153,11 @@ const items: HudItem[] = [
     },
 ];
 
+const sandboxHiddenEntityNames = new Set(['GardenBox']);
+const sandboxPickerImageSrcByLabel = new Map([
+    ['Alat', 'https://www.gredice.com/assets/blocks/WateringCan.webp'],
+]);
+
 function collectEntityNames(hudItems: HudItem[], names = new Set<string>()) {
     for (const item of hudItems) {
         if (item.type === 'entity') {
@@ -187,7 +192,11 @@ function getSandboxExtraItemsByPicker(
     for (const block of blockData) {
         const name = block.information.name;
 
-        if (defaultHudEntityNames.has(name) || names.has(name)) {
+        if (
+            defaultHudEntityNames.has(name) ||
+            names.has(name) ||
+            sandboxHiddenEntityNames.has(name)
+        ) {
             continue;
         }
 
@@ -201,6 +210,29 @@ function getSandboxExtraItemsByPicker(
     return extraItemsByPicker;
 }
 
+function getSandboxHudItems(hudItems: HudItem[]): HudItem[] {
+    return hudItems.flatMap<HudItem>((item) => {
+        if (item.type === 'entity') {
+            return sandboxHiddenEntityNames.has(item.name) ? [] : [item];
+        }
+
+        if (item.type === 'picker') {
+            const imageSrc =
+                sandboxPickerImageSrcByLabel.get(item.label) ?? item.imageSrc;
+
+            return [
+                {
+                    ...item,
+                    imageSrc,
+                    items: getSandboxHudItems(item.items),
+                },
+            ];
+        }
+
+        return [item];
+    });
+}
+
 function getHudItems({
     blockData,
     isSandbox,
@@ -212,15 +244,16 @@ function getHudItems({
         return items;
     }
 
+    const sandboxItems = getSandboxHudItems(items);
     const sandboxExtraItemsByPicker = getSandboxExtraItemsByPicker(blockData);
     if (
         sandboxExtraItemsByPicker.Blokovi.length === 0 &&
         sandboxExtraItemsByPicker.Dekoracija.length === 0
     ) {
-        return items;
+        return sandboxItems;
     }
 
-    return items.map((item) => {
+    return sandboxItems.map((item) => {
         if (
             item.type === 'picker' &&
             (item.label === 'Blokovi' || item.label === 'Dekoracija')


### PR DESCRIPTION
## Summary
- Hide `GardenBox` from sandbox item pickers because it is not functional there
- Keep garden boxes available in normal gardens
- Add Playwright CT coverage for both sandbox and non-sandbox picker behavior

## Testing
- `pnpm test --filter @gredice/game`
- `pnpm --filter garden exec playwright test tests/items-hud.spec.tsx --grep "garden boxes"`