### PR TITLE
Add state filtering to inventory detail pages

### DIFF
--- a/apps/app/app/admin/inventory/[inventoryId]/InventoryFilters.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/InventoryFilters.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Check, Error as ErrorIcon, Warning } from '@gredice/ui/icons';
+import {
+    type FilterOption,
+    TableFilter,
+} from '../../../../components/shared/filters';
+
+const INVENTORY_STATE_FILTER_OPTIONS: FilterOption = {
+    key: 'state',
+    label: 'Stanje zalihe',
+    icon: <Check className="size-4" />,
+    options: [
+        { value: '', label: 'Sve stavke' },
+        {
+            value: 'ok',
+            label: 'OK',
+            icon: <Check className="size-4 text-green-600" />,
+        },
+        {
+            value: 'warning',
+            label: 'Upozorenje',
+            icon: <Warning className="size-4 text-amber-500" />,
+        },
+        {
+            value: 'critical',
+            label: 'Kritično',
+            icon: <ErrorIcon className="size-4 text-red-500" />,
+        },
+    ],
+};
+
+export function InventoryFilters() {
+    return (
+        <TableFilter
+            filters={[INVENTORY_STATE_FILTER_OPTIONS]}
+            defaultValues={{ state: '' }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/inventory/[inventoryId]/InventoryItemsTable.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/InventoryItemsTable.tsx
@@ -10,6 +10,10 @@ import { InventoryQuantityValue } from '../../../../components/shared/inventory/
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../../src/KnownPages';
 import { DeleteInventoryItemButton } from './DeleteInventoryItemButton';
+import {
+    getInventoryItemState,
+    type InventoryStateFilter,
+} from './inventoryStatus';
 
 type InventoryItemTableRow = {
     id: number;
@@ -39,14 +43,19 @@ export function InventoryItemsTable({
     entityTypeName,
     items,
     tracksSerialNumbers,
+    stateFilter,
 }: {
     inventoryConfigId: number;
     entityTypeName: string;
     items: InventoryItemTableRow[];
     tracksSerialNumbers: boolean;
+    stateFilter?: InventoryStateFilter | '';
 }) {
     const [sort, setSort] = useState<SortState>(defaultSort);
-    const sortedItems = [...items].sort((left, right) =>
+    const filteredItems = stateFilter
+        ? items.filter((item) => getInventoryItemState(item) === stateFilter)
+        : items;
+    const sortedItems = [...filteredItems].sort((left, right) =>
         compareInventoryItems(left, right, sort),
     );
     const columnCount = tracksSerialNumbers ? 6 : 5;
@@ -116,7 +125,9 @@ export function InventoryItemsTable({
                     <Table.Row>
                         <Table.Cell colSpan={columnCount}>
                             <NoDataPlaceholder>
-                                Nema stavki u zalihi. Dodajte prvu stavku.
+                                {items.length === 0
+                                    ? 'Nema stavki u zalihi. Dodajte prvu stavku.'
+                                    : 'Nema stavki za odabrano stanje zalihe.'}
                             </NoDataPlaceholder>
                         </Table.Cell>
                     </Table.Row>

--- a/apps/app/app/admin/inventory/[inventoryId]/InventoryStatusProgress.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/InventoryStatusProgress.tsx
@@ -1,4 +1,5 @@
 import { Typography } from '@gredice/ui/Typography';
+import { getInventoryItemState } from './inventoryStatus';
 
 type InventoryStatusProgressProps = {
     items: {
@@ -19,15 +20,11 @@ function getInventoryStatusCounts({
 }: InventoryStatusProgressProps) {
     return items.reduce(
         (counts, item) => {
-            const minimumQuantity =
-                item.lowCountThreshold ?? defaultLowCountThreshold;
+            const state = getInventoryItemState(item, defaultLowCountThreshold);
 
-            if (item.quantity === 0) {
+            if (state === 'critical') {
                 counts.empty += 1;
-            } else if (
-                minimumQuantity !== null &&
-                item.quantity <= minimumQuantity
-            ) {
+            } else if (state === 'warning') {
                 counts.low += 1;
             } else {
                 counts.normal += 1;

--- a/apps/app/app/admin/inventory/[inventoryId]/inventoryStatus.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/inventoryStatus.ts
@@ -1,0 +1,37 @@
+export type InventoryStateFilter = 'ok' | 'warning' | 'critical';
+
+type InventoryStatusItem = {
+    quantity: number;
+    lowCountThreshold: number | null;
+};
+
+export function getInventoryItemState(
+    item: InventoryStatusItem,
+    defaultLowCountThreshold: number | null = null,
+): InventoryStateFilter {
+    const minimumQuantity = item.lowCountThreshold ?? defaultLowCountThreshold;
+
+    if (item.quantity === 0) {
+        return 'critical';
+    }
+
+    if (minimumQuantity !== null && item.quantity <= minimumQuantity) {
+        return 'warning';
+    }
+
+    return 'ok';
+}
+
+export function normalizeInventoryStateFilter(
+    value: string,
+): InventoryStateFilter | '' {
+    if (value === 'ok' || value === 'warning') {
+        return value;
+    }
+
+    if (value === 'critical' || value === 'error') {
+        return 'critical';
+    }
+
+    return '';
+}

--- a/apps/app/app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getInventoryItemState,
+    normalizeInventoryStateFilter,
+} from './inventoryStatus.ts';
+
+test('getInventoryItemState marks zero quantity as critical', () => {
+    assert.equal(
+        getInventoryItemState({ quantity: 0, lowCountThreshold: null }),
+        'critical',
+    );
+    assert.equal(
+        getInventoryItemState({ quantity: 0, lowCountThreshold: 3 }, null),
+        'critical',
+    );
+});
+
+test('getInventoryItemState marks low stock as warning', () => {
+    assert.equal(
+        getInventoryItemState({ quantity: 3, lowCountThreshold: 3 }),
+        'warning',
+    );
+    assert.equal(
+        getInventoryItemState({ quantity: 2, lowCountThreshold: null }, 5),
+        'warning',
+    );
+});
+
+test('getInventoryItemState marks stock above the threshold as ok', () => {
+    assert.equal(
+        getInventoryItemState({ quantity: 4, lowCountThreshold: 3 }),
+        'ok',
+    );
+    assert.equal(
+        getInventoryItemState({ quantity: 1, lowCountThreshold: null }),
+        'ok',
+    );
+});
+
+test('normalizeInventoryStateFilter accepts supported state aliases', () => {
+    assert.equal(normalizeInventoryStateFilter('ok'), 'ok');
+    assert.equal(normalizeInventoryStateFilter('warning'), 'warning');
+    assert.equal(normalizeInventoryStateFilter('critical'), 'critical');
+    assert.equal(normalizeInventoryStateFilter('error'), 'critical');
+    assert.equal(normalizeInventoryStateFilter('unknown'), '');
+});

--- a/apps/app/app/admin/inventory/[inventoryId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/page.tsx
@@ -25,20 +25,28 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
+import { InventoryFilters } from './InventoryFilters';
 import { InventoryItemsTable } from './InventoryItemsTable';
 import { InventoryStatusProgress } from './InventoryStatusProgress';
+import { normalizeInventoryStateFilter } from './inventoryStatus';
 
 export const dynamic = 'force-dynamic';
 
 export default async function InventoryConfigPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ inventoryId: string }>;
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
     await auth(['admin']);
 
     const { inventoryId } = await params;
+    const urlParams = await searchParams;
     const id = parseInt(inventoryId, 10);
+    const stateFilter = normalizeInventoryStateFilter(
+        typeof urlParams.state === 'string' ? urlParams.state : '',
+    );
 
     const config = await getInventoryConfig(id);
 
@@ -151,16 +159,20 @@ export default async function InventoryConfigPage({
                 />
 
                 <EntityDetailsPropertiesLayout properties={propertiesPanel}>
-                    <Card>
-                        <CardOverflow>
-                            <InventoryItemsTable
-                                inventoryConfigId={id}
-                                entityTypeName={config.entityTypeName}
-                                items={tableItems}
-                                tracksSerialNumbers={tracksSerialNumbers}
-                            />
-                        </CardOverflow>
-                    </Card>
+                    <Stack spacing={3}>
+                        <InventoryFilters />
+                        <Card>
+                            <CardOverflow>
+                                <InventoryItemsTable
+                                    inventoryConfigId={id}
+                                    entityTypeName={config.entityTypeName}
+                                    items={tableItems}
+                                    tracksSerialNumbers={tracksSerialNumbers}
+                                    stateFilter={stateFilter}
+                                />
+                            </CardOverflow>
+                        </Card>
+                    </Stack>
                 </EntityDetailsPropertiesLayout>
             </Stack>
         </EntityDetailsPropertiesProvider>

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,7 @@
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
         "test:prepare": "turbo build --filter=app",
-        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/ai/aiAnalyticsCost.unit.ts src/social/providers/reddit/redditAdapter.unit.ts src/social/providers/directAdapters.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts 'app/(actions)/socialPublishActions.unit.ts' 'app/(actions)/socialAccountActions.unit.ts'",
+        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/ai/aiAnalyticsCost.unit.ts src/social/providers/reddit/redditAdapter.unit.ts src/social/providers/directAdapters.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts 'app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts' 'app/(actions)/socialPublishActions.unit.ts' 'app/(actions)/socialAccountActions.unit.ts'",
         "test:run": "pnpm run test:unit && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "test:local": "pnpm run test:prepare && pnpm run test:run"


### PR DESCRIPTION
## Summary
- Add a URL-backed state filter to `/admin/inventory/[inventoryId]` for `ok`, `warning`, and `critical` items.
- Normalize `error` to the critical state and reuse the same state logic for the inventory summary and table filter.
- Add targeted unit coverage for the inventory state helper and wire it into the app test suite.

## Testing
- `pnpm --filter app test:unit` passed.
- `pnpm --filter app build` passed.
- `next typegen` passed for `apps/app`.
- `pnpm --filter app lint` passed with unrelated existing warnings elsewhere in the app.