### PR TITLE
Add scheduled automation operations support

### DIFF
--- a/apps/app/app/admin/automations/AutomationFlowEditor.tsx
+++ b/apps/app/app/admin/automations/AutomationFlowEditor.tsx
@@ -720,6 +720,16 @@ export function AutomationFlowEditor({
                                                             }}
                                                             className="min-h-28 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
                                                         />
+                                                        {field.description ? (
+                                                            <Typography
+                                                                level="body3"
+                                                                className="text-muted-foreground"
+                                                            >
+                                                                {
+                                                                    field.description
+                                                                }
+                                                            </Typography>
+                                                        ) : null}
                                                     </Stack>
                                                 );
                                             }

--- a/apps/app/app/admin/automations/AutomationFlowEditor.tsx
+++ b/apps/app/app/admin/automations/AutomationFlowEditor.tsx
@@ -2,6 +2,7 @@
 
 import '@xyflow/react/dist/style.css';
 
+import { slugify } from '@gredice/js/slug';
 import type {
     AutomationDefinitionStatus,
     AutomationGraph,
@@ -10,11 +11,18 @@ import type {
     AutomationModuleMetadata,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { Input } from '@gredice/ui/Input';
-import { Add, Delete, Save } from '@gredice/ui/icons';
+import {
+    Add,
+    Configuration,
+    Delete,
+    Layers,
+    Play,
+    Save,
+    Settings,
+} from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
@@ -33,8 +41,10 @@ import {
     useNodesState,
 } from '@xyflow/react';
 import { useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
 import { useMemo, useState, useTransition } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
+import { AutomationSlidePanel } from './AutomationSlidePanel';
 import {
     type AutomationSaveResult,
     saveAutomationDefinitionAction,
@@ -49,6 +59,7 @@ type FlowNodeData = Record<string, unknown> & {
 };
 
 type FlowNode = Node<FlowNodeData>;
+type AutomationEditorPanel = 'details' | 'modules' | 'settings' | 'testing';
 
 type AutomationFlowEditorProps = {
     automationId?: number;
@@ -58,6 +69,7 @@ type AutomationFlowEditorProps = {
     initialStatus: AutomationDefinitionStatus;
     initialGraph: AutomationGraph;
     modules: AutomationModuleMetadata[];
+    testPanel?: ReactNode;
 };
 
 const definitionStatusItems = [
@@ -190,6 +202,66 @@ function parseJsonField(value: string): unknown {
     return JSON.parse(value);
 }
 
+function panelTitle(panel: AutomationEditorPanel | null) {
+    switch (panel) {
+        case 'details':
+            return 'Detalji workflowa';
+        case 'modules':
+            return 'Moduli';
+        case 'settings':
+            return 'Postavke modula';
+        case 'testing':
+            return 'Testiranje';
+        default:
+            return '';
+    }
+}
+
+function panelDescription(panel: AutomationEditorPanel | null) {
+    switch (panel) {
+        case 'details':
+            return 'Naziv, ključ, status i opis automatizacije.';
+        case 'modules':
+            return 'Dodajte triggere, uvjete i akcije u dijagram.';
+        case 'settings':
+            return 'Konfiguracija trenutno odabranog modula.';
+        case 'testing':
+            return 'Pokrenite probno izvođenje iz sintetičkog ili postojećeg ulaza.';
+        default:
+            return undefined;
+    }
+}
+
+function SaveResultNotice({ result }: { result: AutomationSaveResult }) {
+    if (result.ok) {
+        return (
+            <div
+                role="status"
+                className="rounded-md border border-green-200 bg-green-50 p-3 text-green-800 dark:border-green-900 dark:bg-green-950 dark:text-green-200"
+            >
+                <Typography level="body2">
+                    Automatizacija je spremljena.
+                </Typography>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            role="alert"
+            className="rounded-md border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+        >
+            <Stack spacing={1}>
+                {result.errors.map((error) => (
+                    <Typography key={error} level="body2">
+                        {error}
+                    </Typography>
+                ))}
+            </Stack>
+        </div>
+    );
+}
+
 export function AutomationFlowEditor({
     automationId,
     initialDescription,
@@ -198,17 +270,19 @@ export function AutomationFlowEditor({
     initialName,
     initialStatus,
     modules,
+    testPanel,
 }: AutomationFlowEditorProps) {
     const router = useRouter();
     const modulesByKey = useMemo(
         () => new Map(modules.map((module) => [module.key, module])),
         [modules],
     );
-    const [key, setKey] = useState(initialKey);
     const [name, setName] = useState(initialName);
     const [description, setDescription] = useState(initialDescription ?? '');
     const [status, setStatus] =
         useState<AutomationDefinitionStatus>(initialStatus);
+    const [activePanel, setActivePanel] =
+        useState<AutomationEditorPanel | null>(automationId ? null : 'details');
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
         initialGraph.nodes[0]?.id ?? null,
     );
@@ -228,6 +302,10 @@ export function AutomationFlowEditor({
     const selectedModule = selectedNode
         ? modulesByKey.get(selectedNode.data.moduleKey)
         : null;
+    const generatedKey = useMemo(
+        () => slugify(name) || initialKey || 'nova-automatizacija',
+        [initialKey, name],
+    );
     const groupedModules = useMemo(
         () =>
             modules.reduce<
@@ -268,6 +346,12 @@ export function AutomationFlowEditor({
         );
     };
 
+    function openPanel(panel: AutomationEditorPanel) {
+        setActivePanel((currentPanel) =>
+            currentPanel === panel ? null : panel,
+        );
+    }
+
     function addModule(module: AutomationModuleMetadata) {
         const moduleCount = nodes.filter(
             (node) => node.data.moduleKey === module.key,
@@ -293,6 +377,7 @@ export function AutomationFlowEditor({
             updateNodeClassNames([...current, nextNode], nextNode.id),
         );
         setSelectedNodeId(nextNode.id);
+        setActivePanel('settings');
         setResult(null);
     }
 
@@ -312,6 +397,7 @@ export function AutomationFlowEditor({
             ),
         );
         setSelectedNodeId(null);
+        setResult(null);
     }
 
     function updateSelectedConfig(key: string, value: unknown) {
@@ -343,7 +429,7 @@ export function AutomationFlowEditor({
         startTransition(async () => {
             const saveResult = await saveAutomationDefinitionAction({
                 id: automationId,
-                key,
+                key: generatedKey,
                 name,
                 description,
                 status,
@@ -360,83 +446,297 @@ export function AutomationFlowEditor({
 
     const statusMeta = automationStatusMeta(status);
 
-    return (
+    const detailPanel = (
         <Stack spacing={4}>
-            <Card>
-                <CardContent className="grid gap-3 md:grid-cols-[1fr_1fr_180px_auto] md:items-end">
-                    <Input
-                        label="Naziv"
-                        value={name}
-                        onChange={(event) => setName(event.target.value)}
-                        fullWidth
-                    />
-                    <Input
-                        label="Ključ"
-                        value={key}
-                        onChange={(event) => setKey(event.target.value)}
-                        fullWidth
-                    />
-                    <SelectItems<AutomationDefinitionStatus>
-                        label="Status"
-                        value={status}
-                        items={definitionStatusItems}
-                        onValueChange={(nextStatus) => setStatus(nextStatus)}
-                    />
-                    <Button
-                        type="button"
-                        disabled={isPending}
-                        onClick={save}
-                        startDecorator={<Save className="size-4" />}
-                    >
-                        Spremi
-                    </Button>
-                    <div className="md:col-span-4">
-                        <label
-                            className="mb-1 block text-sm font-medium"
-                            htmlFor="automation-description"
+            <Input
+                label="Naziv"
+                value={name}
+                onChange={(event) => {
+                    setName(event.target.value);
+                    setResult(null);
+                }}
+                fullWidth
+            />
+            <Input
+                label="Ključ"
+                value={generatedKey}
+                readOnly
+                helperText="Automatski se generira iz naziva."
+                fullWidth
+            />
+            <SelectItems<AutomationDefinitionStatus>
+                className="w-full"
+                label="Status"
+                value={status}
+                items={definitionStatusItems}
+                onValueChange={(nextStatus) => {
+                    setStatus(nextStatus);
+                    setResult(null);
+                }}
+            />
+            <Stack spacing={1}>
+                <label
+                    className="text-sm font-medium"
+                    htmlFor="automation-description"
+                >
+                    Opis
+                </label>
+                <textarea
+                    id="automation-description"
+                    value={description}
+                    onChange={(event) => {
+                        setDescription(event.target.value);
+                        setResult(null);
+                    }}
+                    className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                />
+            </Stack>
+            <Button
+                type="button"
+                disabled={isPending}
+                loading={isPending}
+                onClick={save}
+                startDecorator={<Save className="size-4" />}
+            >
+                Spremi
+            </Button>
+        </Stack>
+    );
+
+    const modulesPanel = (
+        <Stack spacing={4}>
+            {(
+                [
+                    'trigger',
+                    'filter',
+                    'condition',
+                    'action',
+                ] satisfies AutomationModuleKind[]
+            ).map((kind) => (
+                <Stack key={kind} spacing={2}>
+                    <Typography level="body2" semiBold>
+                        {kindLabel(kind)}
+                    </Typography>
+                    {groupedModules[kind].length === 0 ? (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
                         >
-                            Opis
-                        </label>
-                        <textarea
-                            id="automation-description"
-                            value={description}
-                            onChange={(event) =>
-                                setDescription(event.target.value)
-                            }
-                            className="min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                        />
-                    </div>
-                </CardContent>
-            </Card>
-
-            {result && !result.ok ? (
-                <Card className="border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950">
-                    <CardContent>
-                        <Stack spacing={1}>
-                            {result.errors.map((error) => (
-                                <Typography key={error} level="body2">
-                                    {error}
-                                </Typography>
-                            ))}
-                        </Stack>
-                    </CardContent>
-                </Card>
-            ) : null}
-
-            {result?.ok ? (
-                <Card className="border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950">
-                    <CardContent>
-                        <Typography level="body2">
-                            Automatizacija je spremljena.
+                            Nema dostupnih modula.
                         </Typography>
-                    </CardContent>
-                </Card>
-            ) : null}
+                    ) : (
+                        groupedModules[kind].map((module) => (
+                            <button
+                                key={module.key}
+                                type="button"
+                                onClick={() => addModule(module)}
+                                className="w-full rounded-md border bg-background p-3 text-left transition-colors hover:border-primary/60 hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                            >
+                                <Row spacing={2} className="items-start">
+                                    <Add className="mt-0.5 size-4 shrink-0" />
+                                    <Stack spacing={1}>
+                                        <Typography level="body2" semiBold>
+                                            {module.title}
+                                        </Typography>
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            {module.description}
+                                        </Typography>
+                                        <Typography
+                                            level="body3"
+                                            className="break-all text-muted-foreground"
+                                        >
+                                            {module.key}
+                                        </Typography>
+                                    </Stack>
+                                </Row>
+                            </button>
+                        ))
+                    )}
+                </Stack>
+            ))}
+        </Stack>
+    );
 
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
-                <Card className="min-w-0 overflow-hidden p-0">
-                    <div className="flex items-center justify-between border-b px-4 py-3">
-                        <Row spacing={2}>
+    const settingsPanel =
+        !selectedNode || !selectedModule ? (
+            <Typography level="body2" className="text-muted-foreground">
+                Odaberite modul u grafu.
+            </Typography>
+        ) : (
+            <Stack spacing={3}>
+                <Stack spacing={1}>
+                    <Typography level="body2" semiBold>
+                        {selectedModule.title}
+                    </Typography>
+                    <Typography level="body3" className="text-muted-foreground">
+                        {selectedModule.description}
+                    </Typography>
+                    <Row spacing={1} className="flex-wrap">
+                        <Chip size="sm" variant="soft">
+                            {kindLabel(selectedModule.kind)}
+                        </Chip>
+                        {selectedModule.mutatesData ? (
+                            <Chip size="sm" color="warning" variant="soft">
+                                Mijenja podatke
+                            </Chip>
+                        ) : null}
+                        {selectedModule.dryRunSupported ? (
+                            <Chip size="sm" color="info" variant="soft">
+                                Dry-run
+                            </Chip>
+                        ) : null}
+                    </Row>
+                </Stack>
+
+                {selectedModule.configFields.length === 0 ? (
+                    <Typography level="body3" className="text-muted-foreground">
+                        Modul nema konfiguracijskih polja.
+                    </Typography>
+                ) : null}
+
+                {selectedModule.configFields.map((field) => {
+                    const value = selectedNode.data.config[field.key];
+
+                    if (field.type === 'select') {
+                        return (
+                            <SelectItems
+                                key={field.key}
+                                className="w-full"
+                                label={field.label}
+                                value={typeof value === 'string' ? value : ''}
+                                items={
+                                    field.options?.map((option) => ({
+                                        value: option.value,
+                                        label: option.label,
+                                    })) ?? []
+                                }
+                                helperText={field.description}
+                                onValueChange={(nextValue) =>
+                                    updateSelectedConfig(field.key, nextValue)
+                                }
+                            />
+                        );
+                    }
+
+                    if (field.type === 'boolean') {
+                        return (
+                            <Checkbox
+                                key={field.key}
+                                label={field.label}
+                                checked={value === true}
+                                onCheckedChange={(checked) =>
+                                    updateSelectedConfig(
+                                        field.key,
+                                        checked === true,
+                                    )
+                                }
+                            />
+                        );
+                    }
+
+                    if (field.type === 'json') {
+                        return (
+                            <Stack key={field.key} spacing={1}>
+                                <label
+                                    className="text-sm font-medium"
+                                    htmlFor={`automation-config-${field.key}`}
+                                >
+                                    {field.label}
+                                </label>
+                                <textarea
+                                    id={`automation-config-${field.key}`}
+                                    value={jsonFieldValue(value)}
+                                    onChange={(event) => {
+                                        try {
+                                            updateSelectedConfig(
+                                                field.key,
+                                                parseJsonField(
+                                                    event.target.value,
+                                                ),
+                                            );
+                                            setJsonError(null);
+                                        } catch (error) {
+                                            setJsonError(
+                                                error instanceof Error
+                                                    ? error.message
+                                                    : 'Invalid JSON.',
+                                            );
+                                        }
+                                    }}
+                                    className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                />
+                                {field.description ? (
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        {field.description}
+                                    </Typography>
+                                ) : null}
+                            </Stack>
+                        );
+                    }
+
+                    return (
+                        <Input
+                            key={field.key}
+                            label={field.label}
+                            helperText={field.description}
+                            placeholder={field.placeholder}
+                            type={field.type === 'number' ? 'number' : 'text'}
+                            value={
+                                typeof value === 'string' ||
+                                typeof value === 'number'
+                                    ? value
+                                    : ''
+                            }
+                            onChange={(event) =>
+                                updateSelectedConfig(
+                                    field.key,
+                                    field.type === 'number'
+                                        ? event.target.value.trim()
+                                            ? Number(event.target.value)
+                                            : undefined
+                                        : event.target.value,
+                                )
+                            }
+                            fullWidth
+                        />
+                    );
+                })}
+
+                {selectedModule.inputDescription ? (
+                    <Typography level="body3" className="text-muted-foreground">
+                        Ulaz: {selectedModule.inputDescription}
+                    </Typography>
+                ) : null}
+                {selectedModule.outputDescription ? (
+                    <Typography level="body3" className="text-muted-foreground">
+                        Izlaz: {selectedModule.outputDescription}
+                    </Typography>
+                ) : null}
+                {jsonError ? (
+                    <Typography
+                        level="body3"
+                        className="text-red-700 dark:text-red-300"
+                    >
+                        {jsonError}
+                    </Typography>
+                ) : null}
+            </Stack>
+        );
+
+    return (
+        <>
+            <Stack spacing={3}>
+                {result ? <SaveResultNotice result={result} /> : null}
+
+                <div className="min-w-0 overflow-hidden rounded-md border bg-background">
+                    <div className="flex flex-col gap-3 border-b px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+                        <Row spacing={2} className="min-w-0 flex-wrap">
                             <Chip
                                 color={statusMeta.color}
                                 size="sm"
@@ -448,19 +748,91 @@ export function AutomationFlowEditor({
                                 {nodes.length} modula, {edges.length} veza
                             </Typography>
                         </Row>
-                        <Button
-                            type="button"
-                            size="sm"
-                            variant="outlined"
-                            color="danger"
-                            disabled={!selectedNodeId}
-                            onClick={removeSelectedNode}
-                            startDecorator={<Delete className="size-4" />}
-                        >
-                            Ukloni
-                        </Button>
+                        <Row spacing={2} className="flex-wrap">
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant={
+                                    activePanel === 'details'
+                                        ? 'soft'
+                                        : 'outlined'
+                                }
+                                aria-pressed={activePanel === 'details'}
+                                onClick={() => openPanel('details')}
+                                startDecorator={<Settings className="size-4" />}
+                            >
+                                Detalji
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant={
+                                    activePanel === 'modules'
+                                        ? 'soft'
+                                        : 'outlined'
+                                }
+                                aria-pressed={activePanel === 'modules'}
+                                onClick={() => openPanel('modules')}
+                                startDecorator={<Layers className="size-4" />}
+                            >
+                                Moduli
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant={
+                                    activePanel === 'settings'
+                                        ? 'soft'
+                                        : 'outlined'
+                                }
+                                aria-pressed={activePanel === 'settings'}
+                                onClick={() => openPanel('settings')}
+                                startDecorator={
+                                    <Configuration className="size-4" />
+                                }
+                            >
+                                Postavke
+                            </Button>
+                            {testPanel ? (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant={
+                                        activePanel === 'testing'
+                                            ? 'soft'
+                                            : 'outlined'
+                                    }
+                                    aria-pressed={activePanel === 'testing'}
+                                    onClick={() => openPanel('testing')}
+                                    startDecorator={<Play className="size-4" />}
+                                >
+                                    Testiranje
+                                </Button>
+                            ) : null}
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outlined"
+                                color="danger"
+                                disabled={!selectedNodeId}
+                                onClick={removeSelectedNode}
+                                startDecorator={<Delete className="size-4" />}
+                            >
+                                Ukloni
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                disabled={isPending}
+                                loading={isPending}
+                                onClick={save}
+                                startDecorator={<Save className="size-4" />}
+                            >
+                                Spremi
+                            </Button>
+                        </Row>
                     </div>
-                    <div className="h-[640px] min-h-[420px]">
+                    <div className="h-[calc(100vh-260px)] min-h-[560px]">
                         <ReactFlowProvider>
                             <ReactFlow
                                 nodes={nodes}
@@ -468,9 +840,10 @@ export function AutomationFlowEditor({
                                 onNodesChange={onNodesChange}
                                 onEdgesChange={onEdgesChange}
                                 onConnect={onConnect}
-                                onNodeClick={(_event, node) =>
-                                    selectNode(node.id)
-                                }
+                                onNodeClick={(_event, node) => {
+                                    selectNode(node.id);
+                                    setActivePanel('settings');
+                                }}
                                 onPaneClick={() => selectNode(null)}
                                 fitView
                             >
@@ -479,338 +852,24 @@ export function AutomationFlowEditor({
                             </ReactFlow>
                         </ReactFlowProvider>
                     </div>
-                </Card>
+                </div>
+            </Stack>
 
-                <Stack spacing={4}>
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>Moduli</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <Stack spacing={4}>
-                                {(
-                                    [
-                                        'trigger',
-                                        'filter',
-                                        'condition',
-                                        'action',
-                                    ] satisfies AutomationModuleKind[]
-                                ).map((kind) => (
-                                    <Stack key={kind} spacing={2}>
-                                        <Typography level="body2" semiBold>
-                                            {kindLabel(kind)}
-                                        </Typography>
-                                        {groupedModules[kind].length === 0 ? (
-                                            <Typography
-                                                level="body3"
-                                                className="text-muted-foreground"
-                                            >
-                                                Nema dostupnih modula.
-                                            </Typography>
-                                        ) : (
-                                            groupedModules[kind].map(
-                                                (module) => (
-                                                    <button
-                                                        key={module.key}
-                                                        type="button"
-                                                        onClick={() =>
-                                                            addModule(module)
-                                                        }
-                                                        className="rounded-md border bg-background p-3 text-left transition-colors hover:border-primary/60 hover:bg-muted"
-                                                    >
-                                                        <Row
-                                                            spacing={2}
-                                                            className="items-start"
-                                                        >
-                                                            <Add className="mt-0.5 size-4 shrink-0" />
-                                                            <Stack spacing={1}>
-                                                                <Typography
-                                                                    level="body2"
-                                                                    semiBold
-                                                                >
-                                                                    {
-                                                                        module.title
-                                                                    }
-                                                                </Typography>
-                                                                <Typography
-                                                                    level="body3"
-                                                                    className="text-muted-foreground"
-                                                                >
-                                                                    {
-                                                                        module.description
-                                                                    }
-                                                                </Typography>
-                                                                <Typography
-                                                                    level="body3"
-                                                                    className="text-muted-foreground"
-                                                                >
-                                                                    {module.key}
-                                                                </Typography>
-                                                            </Stack>
-                                                        </Row>
-                                                    </button>
-                                                ),
-                                            )
-                                        )}
-                                    </Stack>
-                                ))}
-                            </Stack>
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>Postavke modula</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            {!selectedNode || !selectedModule ? (
-                                <Typography
-                                    level="body2"
-                                    className="text-muted-foreground"
-                                >
-                                    Odaberite modul u grafu.
-                                </Typography>
-                            ) : (
-                                <Stack spacing={3}>
-                                    <Stack spacing={1}>
-                                        <Typography level="body2" semiBold>
-                                            {selectedModule.title}
-                                        </Typography>
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            {selectedModule.description}
-                                        </Typography>
-                                        <Row spacing={1} className="flex-wrap">
-                                            <Chip size="sm" variant="soft">
-                                                {kindLabel(selectedModule.kind)}
-                                            </Chip>
-                                            {selectedModule.mutatesData ? (
-                                                <Chip
-                                                    size="sm"
-                                                    color="warning"
-                                                    variant="soft"
-                                                >
-                                                    Mijenja podatke
-                                                </Chip>
-                                            ) : null}
-                                            {selectedModule.dryRunSupported ? (
-                                                <Chip
-                                                    size="sm"
-                                                    color="info"
-                                                    variant="soft"
-                                                >
-                                                    Dry-run
-                                                </Chip>
-                                            ) : null}
-                                        </Row>
-                                    </Stack>
-
-                                    {selectedModule.configFields.length ===
-                                    0 ? (
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            Modul nema konfiguracijskih polja.
-                                        </Typography>
-                                    ) : null}
-
-                                    {selectedModule.configFields.map(
-                                        (field) => {
-                                            const value =
-                                                selectedNode.data.config[
-                                                    field.key
-                                                ];
-
-                                            if (field.type === 'select') {
-                                                return (
-                                                    <SelectItems
-                                                        key={field.key}
-                                                        label={field.label}
-                                                        value={
-                                                            typeof value ===
-                                                            'string'
-                                                                ? value
-                                                                : ''
-                                                        }
-                                                        items={
-                                                            field.options?.map(
-                                                                (option) => ({
-                                                                    value: option.value,
-                                                                    label: option.label,
-                                                                }),
-                                                            ) ?? []
-                                                        }
-                                                        helperText={
-                                                            field.description
-                                                        }
-                                                        onValueChange={(
-                                                            nextValue,
-                                                        ) =>
-                                                            updateSelectedConfig(
-                                                                field.key,
-                                                                nextValue,
-                                                            )
-                                                        }
-                                                    />
-                                                );
-                                            }
-
-                                            if (field.type === 'boolean') {
-                                                return (
-                                                    <Checkbox
-                                                        key={field.key}
-                                                        label={field.label}
-                                                        checked={value === true}
-                                                        onCheckedChange={(
-                                                            checked,
-                                                        ) =>
-                                                            updateSelectedConfig(
-                                                                field.key,
-                                                                checked ===
-                                                                    true,
-                                                            )
-                                                        }
-                                                    />
-                                                );
-                                            }
-
-                                            if (field.type === 'json') {
-                                                return (
-                                                    <Stack
-                                                        key={field.key}
-                                                        spacing={1}
-                                                    >
-                                                        <label
-                                                            className="text-sm font-medium"
-                                                            htmlFor={`automation-config-${field.key}`}
-                                                        >
-                                                            {field.label}
-                                                        </label>
-                                                        <textarea
-                                                            id={`automation-config-${field.key}`}
-                                                            value={jsonFieldValue(
-                                                                value,
-                                                            )}
-                                                            onChange={(
-                                                                event,
-                                                            ) => {
-                                                                try {
-                                                                    updateSelectedConfig(
-                                                                        field.key,
-                                                                        parseJsonField(
-                                                                            event
-                                                                                .target
-                                                                                .value,
-                                                                        ),
-                                                                    );
-                                                                    setJsonError(
-                                                                        null,
-                                                                    );
-                                                                } catch (error) {
-                                                                    setJsonError(
-                                                                        error instanceof
-                                                                            Error
-                                                                            ? error.message
-                                                                            : 'Invalid JSON.',
-                                                                    );
-                                                                }
-                                                            }}
-                                                            className="min-h-28 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                                                        />
-                                                        {field.description ? (
-                                                            <Typography
-                                                                level="body3"
-                                                                className="text-muted-foreground"
-                                                            >
-                                                                {
-                                                                    field.description
-                                                                }
-                                                            </Typography>
-                                                        ) : null}
-                                                    </Stack>
-                                                );
-                                            }
-
-                                            return (
-                                                <Input
-                                                    key={field.key}
-                                                    label={field.label}
-                                                    helperText={
-                                                        field.description
-                                                    }
-                                                    placeholder={
-                                                        field.placeholder
-                                                    }
-                                                    type={
-                                                        field.type === 'number'
-                                                            ? 'number'
-                                                            : 'text'
-                                                    }
-                                                    value={
-                                                        typeof value ===
-                                                            'string' ||
-                                                        typeof value ===
-                                                            'number'
-                                                            ? value
-                                                            : ''
-                                                    }
-                                                    onChange={(event) =>
-                                                        updateSelectedConfig(
-                                                            field.key,
-                                                            field.type ===
-                                                                'number'
-                                                                ? event.target.value.trim()
-                                                                    ? Number(
-                                                                          event
-                                                                              .target
-                                                                              .value,
-                                                                      )
-                                                                    : undefined
-                                                                : event.target
-                                                                      .value,
-                                                        )
-                                                    }
-                                                    fullWidth
-                                                />
-                                            );
-                                        },
-                                    )}
-
-                                    {selectedModule.inputDescription ? (
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            Ulaz:{' '}
-                                            {selectedModule.inputDescription}
-                                        </Typography>
-                                    ) : null}
-                                    {selectedModule.outputDescription ? (
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            Izlaz:{' '}
-                                            {selectedModule.outputDescription}
-                                        </Typography>
-                                    ) : null}
-                                    {jsonError ? (
-                                        <Typography
-                                            level="body3"
-                                            className="text-red-700 dark:text-red-300"
-                                        >
-                                            {jsonError}
-                                        </Typography>
-                                    ) : null}
-                                </Stack>
-                            )}
-                        </CardContent>
-                    </Card>
-                </Stack>
-            </div>
-        </Stack>
+            <AutomationSlidePanel
+                open={Boolean(activePanel)}
+                title={panelTitle(activePanel)}
+                description={panelDescription(activePanel)}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setActivePanel(null);
+                    }
+                }}
+            >
+                {activePanel === 'details' ? detailPanel : null}
+                {activePanel === 'modules' ? modulesPanel : null}
+                {activePanel === 'settings' ? settingsPanel : null}
+                {activePanel === 'testing' ? testPanel : null}
+            </AutomationSlidePanel>
+        </>
     );
 }

--- a/apps/app/app/admin/automations/AutomationRunsTable.tsx
+++ b/apps/app/app/admin/automations/AutomationRunsTable.tsx
@@ -1,0 +1,455 @@
+'use client';
+
+import type {
+    AutomationJsonObject,
+    AutomationModuleKind,
+    AutomationRunStatus,
+    AutomationStepStatus,
+} from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { Stack } from '@gredice/ui/Stack';
+import { Table } from '@gredice/ui/Table';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { Route } from 'next';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
+import { AutomationSlidePanel } from './AutomationSlidePanel';
+import { ReplayAutomationRunButton } from './AutomationTestPanel';
+import { automationRunStatusMeta } from './presentation';
+
+export type AutomationRunStatusFilter =
+    | 'withoutSkipped'
+    | 'all'
+    | AutomationRunStatus;
+
+export type AutomationRunsTableRun = {
+    run: {
+        id: number;
+        status: AutomationRunStatus;
+        dryRun: boolean;
+        attempt: number;
+        maxAttempts: number;
+        sourceEventType: string | null;
+        sourceAggregateId: string | null;
+        input: AutomationJsonObject;
+        output: AutomationJsonObject;
+        errorMessage: string | null;
+        startedAt: string | null;
+        completedAt: string | null;
+        createdAt: string;
+    };
+    steps: Array<{
+        id: number;
+        nodeId: string;
+        moduleKey: string;
+        moduleKind: AutomationModuleKind;
+        status: AutomationStepStatus;
+        input: AutomationJsonObject;
+        output: AutomationJsonObject;
+        errorMessage: string | null;
+        startedAt: string | null;
+        completedAt: string | null;
+        createdAt: string;
+    }>;
+};
+
+function RunStatusChip({ status }: { status: AutomationRunStatus }) {
+    const meta = automationRunStatusMeta(status);
+    return (
+        <Chip color={meta.color} size="sm" variant="soft">
+            {meta.label}
+        </Chip>
+    );
+}
+
+function formatDuration(startedAt: string | null, completedAt: string | null) {
+    if (!startedAt || !completedAt) {
+        return '-';
+    }
+
+    const startedAtMs = new Date(startedAt).getTime();
+    const completedAtMs = new Date(completedAt).getTime();
+
+    if (Number.isNaN(startedAtMs) || Number.isNaN(completedAtMs)) {
+        return '-';
+    }
+
+    return `${Math.max(0, completedAtMs - startedAtMs)} ms`;
+}
+
+function JsonPreview({ value }: { value: unknown }) {
+    return (
+        <pre className="max-h-72 overflow-auto rounded-md bg-muted p-3 text-xs">
+            {JSON.stringify(value, null, 2)}
+        </pre>
+    );
+}
+
+function DateTimeValue({ value }: { value: string | null }) {
+    if (!value) {
+        return <span>-</span>;
+    }
+
+    return <LocalDateTime>{value}</LocalDateTime>;
+}
+
+function DetailItem({
+    children,
+    label,
+}: {
+    children: ReactNode;
+    label: string;
+}) {
+    return (
+        <>
+            <dt className="text-muted-foreground">{label}</dt>
+            <dd className="min-w-0 break-words">{children}</dd>
+        </>
+    );
+}
+
+export function AutomationRunsTable({
+    currentStatusFilter,
+    runs,
+    statusOptions,
+}: {
+    currentStatusFilter: AutomationRunStatusFilter;
+    runs: AutomationRunsTableRun[];
+    statusOptions: AutomationRunStatus[];
+}) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const [selectedRunId, setSelectedRunId] = useState<number | null>(null);
+    const selectedRun = useMemo(
+        () => runs.find(({ run }) => run.id === selectedRunId) ?? null,
+        [runs, selectedRunId],
+    );
+    const filterItems = useMemo<
+        Array<{ value: AutomationRunStatusFilter; label: string }>
+    >(
+        () => [
+            { value: 'withoutSkipped', label: 'Svi osim preskočenih' },
+            { value: 'all', label: 'Svi statusi' },
+            ...statusOptions.map((status) => ({
+                value: status,
+                label: automationRunStatusMeta(status).label,
+            })),
+        ],
+        [statusOptions],
+    );
+
+    function updateStatusFilter(nextFilter: AutomationRunStatusFilter) {
+        const nextSearchParams = new URLSearchParams(searchParams.toString());
+        if (nextFilter === 'withoutSkipped') {
+            nextSearchParams.delete('runStatus');
+        } else {
+            nextSearchParams.set('runStatus', nextFilter);
+        }
+
+        const queryString = nextSearchParams.toString();
+        setSelectedRunId(null);
+        router.replace(
+            (queryString ? `${pathname}?${queryString}` : pathname) as Route,
+        );
+    }
+
+    return (
+        <>
+            <div className="min-w-0 overflow-hidden rounded-md border bg-background">
+                <div className="flex flex-col gap-3 border-b px-4 py-3 sm:flex-row sm:items-end sm:justify-between">
+                    <Stack spacing={1}>
+                        <Typography level="h5" component="h2">
+                            Izvršavanja
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Preskočena izvođenja su skrivena dok ih ne uključite
+                            filtrom.
+                        </Typography>
+                    </Stack>
+                    <SelectItems<AutomationRunStatusFilter>
+                        className="w-full sm:w-64"
+                        label="Status"
+                        value={currentStatusFilter}
+                        items={filterItems}
+                        searchable={false}
+                        onValueChange={updateStatusFilter}
+                    />
+                </div>
+                <Table>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.Head>Status</Table.Head>
+                            <Table.Head>Event</Table.Head>
+                            <Table.Head>Trajanje</Table.Head>
+                            <Table.Head>Greška</Table.Head>
+                            <Table.Head>Vrijeme</Table.Head>
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {runs.length === 0 ? (
+                            <Table.Row>
+                                <Table.Cell colSpan={5}>
+                                    <NoDataPlaceholder>
+                                        Automatizacija nema izvođenja za
+                                        odabrani filter.
+                                    </NoDataPlaceholder>
+                                </Table.Cell>
+                            </Table.Row>
+                        ) : null}
+                        {runs.map(({ run, steps }) => (
+                            <Table.Row
+                                key={run.id}
+                                aria-selected={selectedRunId === run.id}
+                                className={cx(
+                                    'cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+                                    selectedRunId === run.id && 'bg-muted/70',
+                                )}
+                                onClick={() => setSelectedRunId(run.id)}
+                                onKeyDown={(event) => {
+                                    if (
+                                        event.key === 'Enter' ||
+                                        event.key === ' '
+                                    ) {
+                                        event.preventDefault();
+                                        setSelectedRunId(run.id);
+                                    }
+                                }}
+                                role="button"
+                                tabIndex={0}
+                            >
+                                <Table.Cell>
+                                    <Stack spacing={1}>
+                                        <RunStatusChip status={run.status} />
+                                        {run.dryRun ? (
+                                            <Chip
+                                                size="sm"
+                                                color="info"
+                                                variant="soft"
+                                            >
+                                                Dry-run
+                                            </Chip>
+                                        ) : null}
+                                    </Stack>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Stack spacing={1}>
+                                        <Typography level="body3">
+                                            {run.sourceEventType ?? '-'}
+                                        </Typography>
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            {run.sourceAggregateId ?? '-'}
+                                        </Typography>
+                                    </Stack>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {formatDuration(
+                                        run.startedAt,
+                                        run.completedAt,
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {run.errorMessage ? (
+                                        <Typography
+                                            level="body3"
+                                            className="text-red-700 dark:text-red-300"
+                                        >
+                                            {run.errorMessage}
+                                        </Typography>
+                                    ) : (
+                                        '-'
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Stack spacing={1}>
+                                        <LocalDateTime>
+                                            {run.createdAt}
+                                        </LocalDateTime>
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            {steps.length} koraka
+                                        </Typography>
+                                    </Stack>
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table>
+            </div>
+
+            <AutomationSlidePanel
+                open={Boolean(selectedRun)}
+                title="Detalji izvođenja"
+                description={
+                    selectedRun
+                        ? `#${selectedRun.run.id} · ${
+                              automationRunStatusMeta(selectedRun.run.status)
+                                  .label
+                          }`
+                        : undefined
+                }
+                widthClassName="max-w-[560px]"
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setSelectedRunId(null);
+                    }
+                }}
+            >
+                {selectedRun ? (
+                    <Stack spacing={5}>
+                        <Stack spacing={3}>
+                            <Row spacing={1} className="flex-wrap">
+                                <RunStatusChip
+                                    status={selectedRun.run.status}
+                                />
+                                {selectedRun.run.dryRun ? (
+                                    <Chip size="sm" color="info" variant="soft">
+                                        Dry-run
+                                    </Chip>
+                                ) : null}
+                            </Row>
+                            <dl className="grid grid-cols-[8rem_minmax(0,1fr)] gap-x-3 gap-y-2 text-sm">
+                                <DetailItem label="Event">
+                                    {selectedRun.run.sourceEventType ?? '-'}
+                                </DetailItem>
+                                <DetailItem label="Aggregate">
+                                    {selectedRun.run.sourceAggregateId ?? '-'}
+                                </DetailItem>
+                                <DetailItem label="Pokušaj">
+                                    {selectedRun.run.attempt} /{' '}
+                                    {selectedRun.run.maxAttempts}
+                                </DetailItem>
+                                <DetailItem label="Trajanje">
+                                    {formatDuration(
+                                        selectedRun.run.startedAt,
+                                        selectedRun.run.completedAt,
+                                    )}
+                                </DetailItem>
+                                <DetailItem label="Kreirano">
+                                    <DateTimeValue
+                                        value={selectedRun.run.createdAt}
+                                    />
+                                </DetailItem>
+                                <DetailItem label="Početak">
+                                    <DateTimeValue
+                                        value={selectedRun.run.startedAt}
+                                    />
+                                </DetailItem>
+                                <DetailItem label="Završetak">
+                                    <DateTimeValue
+                                        value={selectedRun.run.completedAt}
+                                    />
+                                </DetailItem>
+                            </dl>
+                            {selectedRun.run.errorMessage ? (
+                                <Typography
+                                    level="body2"
+                                    className="text-red-700 dark:text-red-300"
+                                >
+                                    {selectedRun.run.errorMessage}
+                                </Typography>
+                            ) : null}
+                            {selectedRun.run.status === 'failed' ? (
+                                <ReplayAutomationRunButton
+                                    runId={selectedRun.run.id}
+                                />
+                            ) : null}
+                        </Stack>
+
+                        <Stack spacing={2}>
+                            <Typography level="body2" semiBold>
+                                Podaci izvođenja
+                            </Typography>
+                            <details>
+                                <summary className="cursor-pointer text-sm font-medium">
+                                    Input
+                                </summary>
+                                <JsonPreview value={selectedRun.run.input} />
+                            </details>
+                            <details>
+                                <summary className="cursor-pointer text-sm font-medium">
+                                    Output
+                                </summary>
+                                <JsonPreview value={selectedRun.run.output} />
+                            </details>
+                        </Stack>
+
+                        <Stack spacing={3}>
+                            <Typography level="body2" semiBold>
+                                Koraci
+                            </Typography>
+                            {selectedRun.steps.length === 0 ? (
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Nema zabilježenih koraka.
+                                </Typography>
+                            ) : null}
+                            {selectedRun.steps.map((step) => (
+                                <section
+                                    key={step.id}
+                                    className="rounded-md border bg-background p-3"
+                                >
+                                    <Stack spacing={2}>
+                                        <Row spacing={2} className="flex-wrap">
+                                            <Typography level="body2" semiBold>
+                                                {step.nodeId}
+                                            </Typography>
+                                            <Chip size="sm" variant="soft">
+                                                {step.status}
+                                            </Chip>
+                                            <Chip size="sm" variant="soft">
+                                                {step.moduleKind}
+                                            </Chip>
+                                        </Row>
+                                        <Typography
+                                            level="body3"
+                                            className="break-all text-muted-foreground"
+                                        >
+                                            {step.moduleKey}
+                                        </Typography>
+                                        {step.errorMessage ? (
+                                            <Typography
+                                                level="body3"
+                                                className="text-red-700 dark:text-red-300"
+                                            >
+                                                {step.errorMessage}
+                                            </Typography>
+                                        ) : null}
+                                        <details>
+                                            <summary className="cursor-pointer text-xs font-medium">
+                                                Input
+                                            </summary>
+                                            <JsonPreview value={step.input} />
+                                        </details>
+                                        <details>
+                                            <summary className="cursor-pointer text-xs font-medium">
+                                                Output
+                                            </summary>
+                                            <JsonPreview value={step.output} />
+                                        </details>
+                                    </Stack>
+                                </section>
+                            ))}
+                        </Stack>
+                    </Stack>
+                ) : null}
+            </AutomationSlidePanel>
+        </>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationSlidePanel.tsx
+++ b/apps/app/app/admin/automations/AutomationSlidePanel.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { IconButton } from '@gredice/ui/IconButton';
+import { Close } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+
+type AutomationSlidePanelProps = {
+    children: ReactNode;
+    open: boolean;
+    title: string;
+    description?: string;
+    widthClassName?: string;
+    onOpenChange(open: boolean): void;
+};
+
+export function AutomationSlidePanel({
+    children,
+    description,
+    onOpenChange,
+    open,
+    title,
+    widthClassName,
+}: AutomationSlidePanelProps) {
+    return (
+        <>
+            <button
+                type="button"
+                aria-label="Zatvori panel"
+                aria-hidden={!open || undefined}
+                className={cx(
+                    'fixed inset-0 z-40 bg-black/20 opacity-0 transition-opacity duration-200',
+                    open
+                        ? 'pointer-events-auto opacity-100'
+                        : 'pointer-events-none',
+                )}
+                onClick={() => onOpenChange(false)}
+                tabIndex={open ? 0 : -1}
+            />
+            <aside
+                aria-hidden={!open || undefined}
+                className={cx(
+                    'fixed inset-y-0 right-0 z-50 flex w-full max-w-[440px] translate-x-full flex-col border-l bg-background shadow-xl transition-transform duration-300 ease-out motion-reduce:transition-none',
+                    open
+                        ? 'pointer-events-auto translate-x-0'
+                        : 'pointer-events-none',
+                    widthClassName,
+                )}
+                inert={!open || undefined}
+            >
+                <div className="flex shrink-0 items-start justify-between gap-4 border-b px-5 py-4">
+                    <Stack spacing={1} className="min-w-0">
+                        <Typography level="h5" component="h2">
+                            {title}
+                        </Typography>
+                        {description ? (
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                {description}
+                            </Typography>
+                        ) : null}
+                    </Stack>
+                    <IconButton
+                        type="button"
+                        size="sm"
+                        variant="plain"
+                        aria-label="Zatvori panel"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        <Close className="size-4" />
+                    </IconButton>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+                    {children}
+                </div>
+            </aside>
+        </>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationTestPanel.tsx
+++ b/apps/app/app/admin/automations/AutomationTestPanel.tsx
@@ -23,12 +23,19 @@ export type RecentAutomationEvent = {
     createdAt: string;
 };
 
+export type AutomationTestTriggerMode =
+    | 'domainEvent'
+    | 'schedule'
+    | 'unsupported';
+
 export function AutomationTestPanel({
     automationId,
     recentEvents,
+    triggerMode,
     triggerEventType,
 }: {
     automationId: number;
+    triggerMode: AutomationTestTriggerMode;
     triggerEventType: string | null;
     recentEvents: RecentAutomationEvent[];
 }) {
@@ -49,48 +56,70 @@ export function AutomationTestPanel({
             </CardHeader>
             <CardContent>
                 <Stack spacing={3}>
-                    <SelectItems
-                        label="Ulazni event"
-                        value={selectedEventId}
-                        placeholder="Sintetički event"
-                        items={[
-                            { value: '', label: 'Sintetički event' },
-                            ...recentEvents.map((event) => ({
-                                value: event.id.toString(),
-                                label: `#${event.id} ${event.aggregateId}`,
-                                content: `#${event.id} ${event.aggregateId}`,
-                            })),
-                        ]}
-                        onValueChange={setSelectedEventId}
-                    />
-                    {!selectedEventId ? (
+                    {triggerMode === 'domainEvent' ? (
                         <>
-                            <Input
-                                label="Aggregate ID"
-                                value={aggregateId}
-                                placeholder="raisedBedId|positionIndex"
-                                onChange={(event) =>
-                                    setAggregateId(event.target.value)
-                                }
-                                fullWidth
+                            <SelectItems
+                                label="Ulazni event"
+                                value={selectedEventId}
+                                placeholder="Sintetički event"
+                                items={[
+                                    { value: '', label: 'Sintetički event' },
+                                    ...recentEvents.map((event) => ({
+                                        value: event.id.toString(),
+                                        label: `#${event.id} ${event.aggregateId}`,
+                                        content: `#${event.id} ${event.aggregateId}`,
+                                    })),
+                                ]}
+                                onValueChange={setSelectedEventId}
                             />
-                            <Stack spacing={1}>
-                                <label
-                                    className="text-sm font-medium"
-                                    htmlFor="automation-test-event-data"
-                                >
-                                    Event data
-                                </label>
-                                <textarea
-                                    id="automation-test-event-data"
-                                    value={eventDataJson}
-                                    onChange={(event) =>
-                                        setEventDataJson(event.target.value)
-                                    }
-                                    className="min-h-28 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                                />
-                            </Stack>
+                            {!selectedEventId ? (
+                                <>
+                                    <Input
+                                        label="Aggregate ID"
+                                        value={aggregateId}
+                                        placeholder="raisedBedId|positionIndex"
+                                        onChange={(event) =>
+                                            setAggregateId(event.target.value)
+                                        }
+                                        fullWidth
+                                    />
+                                    <Stack spacing={1}>
+                                        <label
+                                            className="text-sm font-medium"
+                                            htmlFor="automation-test-event-data"
+                                        >
+                                            Event data
+                                        </label>
+                                        <textarea
+                                            id="automation-test-event-data"
+                                            value={eventDataJson}
+                                            onChange={(event) =>
+                                                setEventDataJson(
+                                                    event.target.value,
+                                                )
+                                            }
+                                            className="min-h-28 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                        />
+                                    </Stack>
+                                </>
+                            ) : null}
                         </>
+                    ) : null}
+                    {triggerMode === 'schedule' ? (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Test će koristiti sintetički mjesečni schedule run.
+                        </Typography>
+                    ) : null}
+                    {triggerMode === 'unsupported' ? (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Ovaj tip triggera još nema testni ulaz.
+                        </Typography>
                     ) : null}
                     <Checkbox
                         label="Dry-run"
@@ -101,7 +130,11 @@ export function AutomationTestPanel({
                     />
                     <Button
                         type="button"
-                        disabled={isPending || !triggerEventType}
+                        disabled={
+                            isPending ||
+                            triggerMode === 'unsupported' ||
+                            (triggerMode === 'domainEvent' && !triggerEventType)
+                        }
                         startDecorator={<Play className="size-4" />}
                         onClick={() =>
                             startTransition(async () => {
@@ -142,7 +175,7 @@ export function AutomationTestPanel({
                             ))}
                         </Stack>
                     ) : null}
-                    {!triggerEventType ? (
+                    {triggerMode === 'domainEvent' && !triggerEventType ? (
                         <Typography
                             level="body3"
                             className="text-muted-foreground"

--- a/apps/app/app/admin/automations/AutomationTestPanel.tsx
+++ b/apps/app/app/admin/automations/AutomationTestPanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Input } from '@gredice/ui/Input';
 import { Play } from '@gredice/ui/icons';
@@ -50,142 +49,120 @@ export function AutomationTestPanel({
     const [isPending, startTransition] = useTransition();
 
     return (
-        <Card>
-            <CardHeader>
-                <CardTitle>Testiranje</CardTitle>
-            </CardHeader>
-            <CardContent>
-                <Stack spacing={3}>
-                    {triggerMode === 'domainEvent' ? (
+        <Stack spacing={3}>
+            {triggerMode === 'domainEvent' ? (
+                <>
+                    <SelectItems
+                        label="Ulazni event"
+                        value={selectedEventId}
+                        placeholder="Sintetički event"
+                        items={[
+                            { value: '', label: 'Sintetički event' },
+                            ...recentEvents.map((event) => ({
+                                value: event.id.toString(),
+                                label: `#${event.id} ${event.aggregateId}`,
+                                content: `#${event.id} ${event.aggregateId}`,
+                            })),
+                        ]}
+                        onValueChange={setSelectedEventId}
+                    />
+                    {!selectedEventId ? (
                         <>
-                            <SelectItems
-                                label="Ulazni event"
-                                value={selectedEventId}
-                                placeholder="Sintetički event"
-                                items={[
-                                    { value: '', label: 'Sintetički event' },
-                                    ...recentEvents.map((event) => ({
-                                        value: event.id.toString(),
-                                        label: `#${event.id} ${event.aggregateId}`,
-                                        content: `#${event.id} ${event.aggregateId}`,
-                                    })),
-                                ]}
-                                onValueChange={setSelectedEventId}
+                            <Input
+                                label="Aggregate ID"
+                                value={aggregateId}
+                                placeholder="raisedBedId|positionIndex"
+                                onChange={(event) =>
+                                    setAggregateId(event.target.value)
+                                }
+                                fullWidth
                             />
-                            {!selectedEventId ? (
-                                <>
-                                    <Input
-                                        label="Aggregate ID"
-                                        value={aggregateId}
-                                        placeholder="raisedBedId|positionIndex"
-                                        onChange={(event) =>
-                                            setAggregateId(event.target.value)
-                                        }
-                                        fullWidth
-                                    />
-                                    <Stack spacing={1}>
-                                        <label
-                                            className="text-sm font-medium"
-                                            htmlFor="automation-test-event-data"
-                                        >
-                                            Event data
-                                        </label>
-                                        <textarea
-                                            id="automation-test-event-data"
-                                            value={eventDataJson}
-                                            onChange={(event) =>
-                                                setEventDataJson(
-                                                    event.target.value,
-                                                )
-                                            }
-                                            className="min-h-28 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                                        />
-                                    </Stack>
-                                </>
-                            ) : null}
+                            <Stack spacing={1}>
+                                <label
+                                    className="text-sm font-medium"
+                                    htmlFor="automation-test-event-data"
+                                >
+                                    Event data
+                                </label>
+                                <textarea
+                                    id="automation-test-event-data"
+                                    value={eventDataJson}
+                                    onChange={(event) =>
+                                        setEventDataJson(event.target.value)
+                                    }
+                                    className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                />
+                            </Stack>
                         </>
                     ) : null}
-                    {triggerMode === 'schedule' ? (
+                </>
+            ) : null}
+            {triggerMode === 'schedule' ? (
+                <Typography level="body3" className="text-muted-foreground">
+                    Test će koristiti sintetički mjesečni schedule run.
+                </Typography>
+            ) : null}
+            {triggerMode === 'unsupported' ? (
+                <Typography level="body3" className="text-muted-foreground">
+                    Ovaj tip triggera još nema testni ulaz.
+                </Typography>
+            ) : null}
+            <Checkbox
+                label="Dry-run"
+                checked={dryRun}
+                onCheckedChange={(checked) => setDryRun(checked === true)}
+            />
+            <Button
+                type="button"
+                disabled={
+                    isPending ||
+                    triggerMode === 'unsupported' ||
+                    (triggerMode === 'domainEvent' && !triggerEventType)
+                }
+                startDecorator={<Play className="size-4" />}
+                onClick={() =>
+                    startTransition(async () => {
+                        const runResult = await runAutomationTestAction({
+                            automationId,
+                            eventId: selectedEventId
+                                ? Number(selectedEventId)
+                                : null,
+                            aggregateId,
+                            eventDataJson,
+                            dryRun,
+                        });
+                        setResult(runResult);
+                        router.refresh();
+                    })
+                }
+            >
+                Pokreni test
+            </Button>
+            {result?.ok ? (
+                <Typography level="body2" className="text-green-700">
+                    Test run #{result.runId} završen je statusom {result.status}
+                    .
+                </Typography>
+            ) : null}
+            {result && !result.ok ? (
+                <Stack spacing={1}>
+                    {result.errors.map((error) => (
                         <Typography
-                            level="body3"
-                            className="text-muted-foreground"
+                            key={error}
+                            level="body2"
+                            className="text-red-700 dark:text-red-300"
                         >
-                            Test će koristiti sintetički mjesečni schedule run.
+                            {error}
                         </Typography>
-                    ) : null}
-                    {triggerMode === 'unsupported' ? (
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground"
-                        >
-                            Ovaj tip triggera još nema testni ulaz.
-                        </Typography>
-                    ) : null}
-                    <Checkbox
-                        label="Dry-run"
-                        checked={dryRun}
-                        onCheckedChange={(checked) =>
-                            setDryRun(checked === true)
-                        }
-                    />
-                    <Button
-                        type="button"
-                        disabled={
-                            isPending ||
-                            triggerMode === 'unsupported' ||
-                            (triggerMode === 'domainEvent' && !triggerEventType)
-                        }
-                        startDecorator={<Play className="size-4" />}
-                        onClick={() =>
-                            startTransition(async () => {
-                                const runResult = await runAutomationTestAction(
-                                    {
-                                        automationId,
-                                        eventId: selectedEventId
-                                            ? Number(selectedEventId)
-                                            : null,
-                                        aggregateId,
-                                        eventDataJson,
-                                        dryRun,
-                                    },
-                                );
-                                setResult(runResult);
-                                router.refresh();
-                            })
-                        }
-                    >
-                        Pokreni test
-                    </Button>
-                    {result?.ok ? (
-                        <Typography level="body2" className="text-green-700">
-                            Test run #{result.runId} završen je statusom{' '}
-                            {result.status}.
-                        </Typography>
-                    ) : null}
-                    {result && !result.ok ? (
-                        <Stack spacing={1}>
-                            {result.errors.map((error) => (
-                                <Typography
-                                    key={error}
-                                    level="body2"
-                                    className="text-red-700 dark:text-red-300"
-                                >
-                                    {error}
-                                </Typography>
-                            ))}
-                        </Stack>
-                    ) : null}
-                    {triggerMode === 'domainEvent' && !triggerEventType ? (
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground"
-                        >
-                            Trigger nema konfiguriran tip eventa.
-                        </Typography>
-                    ) : null}
+                    ))}
                 </Stack>
-            </CardContent>
-        </Card>
+            ) : null}
+            {triggerMode === 'domainEvent' && !triggerEventType ? (
+                <Typography level="body3" className="text-muted-foreground">
+                    Trigger nema konfiguriran tip eventa.
+                </Typography>
+            ) : null}
+        </Stack>
     );
 }
 

--- a/apps/app/app/admin/automations/[automationId]/page.tsx
+++ b/apps/app/app/admin/automations/[automationId]/page.tsx
@@ -1,5 +1,6 @@
 import {
     type AutomationGraph,
+    automationModuleKeys,
     getAutomationDefinitionById,
     getAutomationModuleMetadata,
     listAutomationRunSteps,
@@ -51,6 +52,12 @@ function getTriggerEventType(graph: AutomationGraph) {
     return typeof eventType === 'string' && eventType.trim().length > 0
         ? eventType.trim()
         : null;
+}
+
+function getTriggerModuleKey(graph: AutomationGraph) {
+    return (
+        graph.nodes.find((node) => node.kind === 'trigger')?.moduleKey ?? null
+    );
 }
 
 function formatDuration(startedAt: Date | null, completedAt: Date | null) {
@@ -116,15 +123,24 @@ export default async function AutomationDetailPage({
     const modules = getAutomationModuleMetadata();
     const modulesByKey = moduleMetadataByKey(modules);
     const triggerEventType = getTriggerEventType(definition.graph);
+    const triggerModuleKey = getTriggerModuleKey(definition.graph);
+    const triggerMode =
+        triggerModuleKey === automationModuleKeys.triggerDomainEvent
+            ? 'domainEvent'
+            : triggerModuleKey === automationModuleKeys.triggerScheduleMonthly
+              ? 'schedule'
+              : 'unsupported';
     const [runs, recentEvents] = await Promise.all([
         listAutomationRuns({
             automationDefinitionId: definition.id,
             limit: 25,
         }),
-        listRecentDomainEvents({
-            eventTypes: triggerEventType ? [triggerEventType] : undefined,
-            limit: 20,
-        }),
+        triggerMode === 'domainEvent' && triggerEventType
+            ? listRecentDomainEvents({
+                  eventTypes: [triggerEventType],
+                  limit: 20,
+              })
+            : Promise.resolve([]),
     ]);
     const runsWithSteps = await Promise.all(
         runs.map(async (run) => ({
@@ -262,6 +278,7 @@ export default async function AutomationDetailPage({
                 </Stack>
                 <AutomationTestPanel
                     automationId={definition.id}
+                    triggerMode={triggerMode}
                     triggerEventType={triggerEventType}
                     recentEvents={recentAutomationEvents}
                 />

--- a/apps/app/app/admin/automations/[automationId]/page.tsx
+++ b/apps/app/app/admin/automations/[automationId]/page.tsx
@@ -1,6 +1,8 @@
 import {
     type AutomationGraph,
+    type AutomationRunStatus,
     automationModuleKeys,
+    automationRunStatusValues,
     getAutomationDefinitionById,
     getAutomationModuleMetadata,
     listAutomationRunSteps,
@@ -8,40 +10,28 @@ import {
     listRecentDomainEvents,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardOverflow,
-    CardTitle,
-} from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import { notFound } from 'next/navigation';
 import {
     AdminPageHeader,
     AdminPageTitle,
 } from '../../../../components/admin/navigation';
-import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../../lib/auth/auth';
 import { AutomationFlowEditor } from '../AutomationFlowEditor';
 import {
+    type AutomationRunStatusFilter,
+    AutomationRunsTable,
+    type AutomationRunsTableRun,
+} from '../AutomationRunsTable';
+import {
     AutomationTestPanel,
     type RecentAutomationEvent,
-    ReplayAutomationRunButton,
 } from '../AutomationTestPanel';
 import { updateAutomationStatusAction } from '../actions';
-import {
-    automationActionSummary,
-    automationRunStatusMeta,
-    automationStatusMeta,
-    automationTriggerSummary,
-    moduleMetadataByKey,
-} from '../presentation';
+import { automationStatusMeta } from '../presentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -60,20 +50,42 @@ function getTriggerModuleKey(graph: AutomationGraph) {
     );
 }
 
-function formatDuration(startedAt: Date | null, completedAt: Date | null) {
-    if (!startedAt || !completedAt) {
-        return '-';
-    }
-
-    return `${Math.max(0, completedAt.getTime() - startedAt.getTime())} ms`;
+function firstSearchParam(value: string | string[] | undefined) {
+    return Array.isArray(value) ? value[0] : value;
 }
 
-function JsonPreview({ value }: { value: unknown }) {
-    return (
-        <pre className="max-h-72 overflow-auto rounded-md bg-muted p-3 text-xs">
-            {JSON.stringify(value, null, 2)}
-        </pre>
+function normalizeRunStatusFilter(
+    value: string | undefined,
+): AutomationRunStatusFilter {
+    if (value === 'all') {
+        return 'all';
+    }
+
+    const status = automationRunStatusValues.find(
+        (candidate) => candidate === value,
     );
+
+    return status ?? 'withoutSkipped';
+}
+
+function statusesForRunFilter(
+    filter: AutomationRunStatusFilter,
+): AutomationRunStatus | AutomationRunStatus[] | undefined {
+    if (filter === 'all') {
+        return undefined;
+    }
+
+    if (filter === 'withoutSkipped') {
+        return automationRunStatusValues.filter(
+            (status) => status !== 'skipped',
+        );
+    }
+
+    return filter;
+}
+
+function dateToIso(value: Date | null) {
+    return value ? value.toISOString() : null;
 }
 
 function StatusChip({
@@ -89,26 +101,16 @@ function StatusChip({
     );
 }
 
-function RunStatusChip({
-    status,
-}: {
-    status: Parameters<typeof automationRunStatusMeta>[0];
-}) {
-    const meta = automationRunStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
-}
-
 export default async function AutomationDetailPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ automationId: string }>;
+    searchParams?: Promise<{ runStatus?: string | string[] }>;
 }) {
     await auth(['admin']);
     const { automationId } = await params;
+    const resolvedSearchParams = searchParams ? await searchParams : {};
     const id = Number(automationId);
 
     if (!Number.isInteger(id) || id <= 0) {
@@ -121,7 +123,6 @@ export default async function AutomationDetailPage({
     }
 
     const modules = getAutomationModuleMetadata();
-    const modulesByKey = moduleMetadataByKey(modules);
     const triggerEventType = getTriggerEventType(definition.graph);
     const triggerModuleKey = getTriggerModuleKey(definition.graph);
     const triggerMode =
@@ -130,9 +131,14 @@ export default async function AutomationDetailPage({
             : triggerModuleKey === automationModuleKeys.triggerScheduleMonthly
               ? 'schedule'
               : 'unsupported';
+    const currentRunStatusFilter = normalizeRunStatusFilter(
+        firstSearchParam(resolvedSearchParams.runStatus),
+    );
+    const runStatusFilter = statusesForRunFilter(currentRunStatusFilter);
     const [runs, recentEvents] = await Promise.all([
         listAutomationRuns({
             automationDefinitionId: definition.id,
+            status: runStatusFilter,
             limit: 25,
         }),
         triggerMode === 'domainEvent' && triggerEventType
@@ -147,6 +153,38 @@ export default async function AutomationDetailPage({
             run,
             steps: await listAutomationRunSteps(run.id),
         })),
+    );
+    const tableRuns: AutomationRunsTableRun[] = runsWithSteps.map(
+        ({ run, steps }) => ({
+            run: {
+                id: run.id,
+                status: run.status,
+                dryRun: run.dryRun,
+                attempt: run.attempt,
+                maxAttempts: run.maxAttempts,
+                sourceEventType: run.sourceEventType,
+                sourceAggregateId: run.sourceAggregateId,
+                input: run.input,
+                output: run.output,
+                errorMessage: run.errorMessage,
+                startedAt: dateToIso(run.startedAt),
+                completedAt: dateToIso(run.completedAt),
+                createdAt: run.createdAt.toISOString(),
+            },
+            steps: steps.map((step) => ({
+                id: step.id,
+                nodeId: step.nodeId,
+                moduleKey: step.moduleKey,
+                moduleKind: step.moduleKind,
+                status: step.status,
+                input: step.input,
+                output: step.output,
+                errorMessage: step.errorMessage,
+                startedAt: dateToIso(step.startedAt),
+                completedAt: dateToIso(step.completedAt),
+                createdAt: step.createdAt.toISOString(),
+            })),
+        }),
     );
     const recentAutomationEvents: RecentAutomationEvent[] = recentEvents.map(
         (event) => ({
@@ -213,269 +251,29 @@ export default async function AutomationDetailPage({
                 </Typography>
             </Stack>
 
-            <div className="grid gap-4 lg:grid-cols-3">
-                <Card>
-                    <CardContent>
-                        <Typography level="body3" secondary>
-                            Trigger
-                        </Typography>
-                        <Typography level="body2">
-                            {automationTriggerSummary(
-                                definition.graph,
-                                modulesByKey,
-                            )}
-                        </Typography>
-                    </CardContent>
-                </Card>
-                <Card>
-                    <CardContent>
-                        <Typography level="body3" secondary>
-                            Akcije
-                        </Typography>
-                        <Typography level="body2">
-                            {automationActionSummary(
-                                definition.graph,
-                                modulesByKey,
-                            )}
-                        </Typography>
-                    </CardContent>
-                </Card>
-                <Card>
-                    <CardContent>
-                        <Typography level="body3" secondary>
-                            Zadnji run
-                        </Typography>
-                        {runs[0] ? (
-                            <Row spacing={2}>
-                                <RunStatusChip status={runs[0].status} />
-                                <LocalDateTime>
-                                    {runs[0].createdAt}
-                                </LocalDateTime>
-                            </Row>
-                        ) : (
-                            <Typography
-                                level="body2"
-                                className="text-muted-foreground"
-                            >
-                                Nema izvođenja
-                            </Typography>
-                        )}
-                    </CardContent>
-                </Card>
-            </div>
-
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
-                <Stack spacing={4}>
-                    <AutomationFlowEditor
+            <AutomationFlowEditor
+                automationId={definition.id}
+                initialKey={definition.key}
+                initialName={definition.name}
+                initialDescription={definition.description}
+                initialStatus={definition.status}
+                initialGraph={definition.graph}
+                modules={modules}
+                testPanel={
+                    <AutomationTestPanel
                         automationId={definition.id}
-                        initialKey={definition.key}
-                        initialName={definition.name}
-                        initialDescription={definition.description}
-                        initialStatus={definition.status}
-                        initialGraph={definition.graph}
-                        modules={modules}
+                        triggerMode={triggerMode}
+                        triggerEventType={triggerEventType}
+                        recentEvents={recentAutomationEvents}
                     />
-                </Stack>
-                <AutomationTestPanel
-                    automationId={definition.id}
-                    triggerMode={triggerMode}
-                    triggerEventType={triggerEventType}
-                    recentEvents={recentAutomationEvents}
-                />
-            </div>
+                }
+            />
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Run log</CardTitle>
-                </CardHeader>
-                <CardOverflow>
-                    <div className="overflow-auto">
-                        <Table>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.Head>ID</Table.Head>
-                                    <Table.Head>Status</Table.Head>
-                                    <Table.Head>Izvor</Table.Head>
-                                    <Table.Head>Event</Table.Head>
-                                    <Table.Head>Trajanje</Table.Head>
-                                    <Table.Head>Greška</Table.Head>
-                                    <Table.Head>Vrijeme</Table.Head>
-                                    <Table.Head>Detalji</Table.Head>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {runsWithSteps.length === 0 ? (
-                                    <Table.Row>
-                                        <Table.Cell colSpan={8}>
-                                            <NoDataPlaceholder>
-                                                Automatizacija još nema runova.
-                                            </NoDataPlaceholder>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                ) : null}
-                                {runsWithSteps.map(({ run, steps }) => (
-                                    <Table.Row key={run.id}>
-                                        <Table.Cell>#{run.id}</Table.Cell>
-                                        <Table.Cell>
-                                            <Stack spacing={1}>
-                                                <RunStatusChip
-                                                    status={run.status}
-                                                />
-                                                {run.dryRun ? (
-                                                    <Chip
-                                                        size="sm"
-                                                        color="info"
-                                                        variant="soft"
-                                                    >
-                                                        Dry-run
-                                                    </Chip>
-                                                ) : null}
-                                            </Stack>
-                                        </Table.Cell>
-                                        <Table.Cell>{run.source}</Table.Cell>
-                                        <Table.Cell>
-                                            <Stack spacing={1}>
-                                                <Typography level="body3">
-                                                    {run.sourceEventType ?? '-'}
-                                                </Typography>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-muted-foreground"
-                                                >
-                                                    {run.sourceAggregateId ??
-                                                        '-'}
-                                                </Typography>
-                                            </Stack>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {formatDuration(
-                                                run.startedAt,
-                                                run.completedAt,
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {run.errorMessage ? (
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-red-700 dark:text-red-300"
-                                                >
-                                                    {run.errorMessage}
-                                                </Typography>
-                                            ) : (
-                                                '-'
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <LocalDateTime>
-                                                {run.createdAt}
-                                            </LocalDateTime>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <details className="min-w-80">
-                                                <summary className="cursor-pointer text-sm font-medium text-primary">
-                                                    {steps.length} koraka
-                                                </summary>
-                                                <Stack
-                                                    spacing={3}
-                                                    className="pt-3"
-                                                >
-                                                    {run.status === 'failed' ? (
-                                                        <ReplayAutomationRunButton
-                                                            runId={run.id}
-                                                        />
-                                                    ) : null}
-                                                    {steps.map((step) => (
-                                                        <Card
-                                                            key={step.id}
-                                                            variant="secondary"
-                                                        >
-                                                            <CardContent>
-                                                                <Stack
-                                                                    spacing={2}
-                                                                >
-                                                                    <Row
-                                                                        spacing={
-                                                                            2
-                                                                        }
-                                                                        className="flex-wrap"
-                                                                    >
-                                                                        <Typography
-                                                                            level="body2"
-                                                                            semiBold
-                                                                        >
-                                                                            {
-                                                                                step.nodeId
-                                                                            }
-                                                                        </Typography>
-                                                                        <Chip
-                                                                            size="sm"
-                                                                            variant="soft"
-                                                                        >
-                                                                            {
-                                                                                step.status
-                                                                            }
-                                                                        </Chip>
-                                                                        <Chip
-                                                                            size="sm"
-                                                                            variant="soft"
-                                                                        >
-                                                                            {
-                                                                                step.moduleKind
-                                                                            }
-                                                                        </Chip>
-                                                                    </Row>
-                                                                    <Typography
-                                                                        level="body3"
-                                                                        className="text-muted-foreground"
-                                                                    >
-                                                                        {
-                                                                            step.moduleKey
-                                                                        }
-                                                                    </Typography>
-                                                                    {step.errorMessage ? (
-                                                                        <Typography
-                                                                            level="body3"
-                                                                            className="text-red-700 dark:text-red-300"
-                                                                        >
-                                                                            {
-                                                                                step.errorMessage
-                                                                            }
-                                                                        </Typography>
-                                                                    ) : null}
-                                                                    <details>
-                                                                        <summary className="cursor-pointer text-xs font-medium">
-                                                                            Input
-                                                                        </summary>
-                                                                        <JsonPreview
-                                                                            value={
-                                                                                step.input
-                                                                            }
-                                                                        />
-                                                                    </details>
-                                                                    <details>
-                                                                        <summary className="cursor-pointer text-xs font-medium">
-                                                                            Output
-                                                                        </summary>
-                                                                        <JsonPreview
-                                                                            value={
-                                                                                step.output
-                                                                            }
-                                                                        />
-                                                                    </details>
-                                                                </Stack>
-                                                            </CardContent>
-                                                        </Card>
-                                                    ))}
-                                                </Stack>
-                                            </details>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                ))}
-                            </Table.Body>
-                        </Table>
-                    </div>
-                </CardOverflow>
-            </Card>
+            <AutomationRunsTable
+                currentStatusFilter={currentRunStatusFilter}
+                runs={tableRuns}
+                statusOptions={[...automationRunStatusValues]}
+            />
         </Stack>
     );
 }

--- a/apps/app/app/admin/automations/actions.ts
+++ b/apps/app/app/admin/automations/actions.ts
@@ -7,6 +7,7 @@ import {
     type AutomationJsonObject,
     type AutomationModuleKind,
     automationDefinitionStatusValues,
+    automationModuleKeys,
     createAutomationDefinition,
     createAutomationRun,
     executeAutomationRun,
@@ -120,6 +121,12 @@ function getTriggerEventType(graph: AutomationGraph) {
     return typeof eventType === 'string' && eventType.trim().length > 0
         ? eventType.trim()
         : null;
+}
+
+function getTriggerModuleKey(graph: AutomationGraph) {
+    return (
+        graph.nodes.find((node) => node.kind === 'trigger')?.moduleKey ?? null
+    );
 }
 
 function parseEventDataJson(value: string | undefined) {
@@ -242,8 +249,14 @@ export async function runAutomationTestAction(
         return { ok: false, errors: validation.errors };
     }
 
+    const triggerModuleKey = getTriggerModuleKey(definition.graph);
     const eventType = getTriggerEventType(definition.graph);
-    if (!eventType) {
+    const isDomainEventTrigger =
+        triggerModuleKey === automationModuleKeys.triggerDomainEvent;
+    const isMonthlyScheduleTrigger =
+        triggerModuleKey === automationModuleKeys.triggerScheduleMonthly;
+
+    if (isDomainEventTrigger && !eventType) {
         return {
             ok: false,
             errors: ['Automation trigger event type is missing.'],
@@ -251,33 +264,75 @@ export async function runAutomationTestAction(
     }
 
     try {
-        const sourceEvent = payload.eventId
-            ? await getDomainEventById(payload.eventId)
-            : null;
+        const sourceEvent =
+            isDomainEventTrigger && payload.eventId
+                ? await getDomainEventById(payload.eventId)
+                : null;
 
-        if (payload.eventId && !sourceEvent) {
+        if (isDomainEventTrigger && payload.eventId && !sourceEvent) {
             return { ok: false, errors: ['Source event was not found.'] };
         }
 
-        const input = sourceEvent
-            ? {
-                  eventId: sourceEvent.id,
-                  eventType: sourceEvent.type,
-                  aggregateId: sourceEvent.aggregateId,
-                  data: isRecord(sourceEvent.data) ? sourceEvent.data : {},
-                  createdAt: sourceEvent.createdAt.toISOString(),
-              }
-            : {
-                  eventType,
-                  aggregateId: payload.aggregateId?.trim() || 'manual-test',
-                  data: parseEventDataJson(payload.eventDataJson),
-                  createdAt: new Date().toISOString(),
-              };
+        let input: AutomationJsonObject;
+        let sourceEventType: string | null = eventType;
+        let sourceAggregateId: string | null = null;
+
+        if (isMonthlyScheduleTrigger) {
+            const now = new Date();
+            const trigger = definition.graph.nodes.find(
+                (node) => node.kind === 'trigger',
+            );
+            const dayOfMonth = trigger?.config.dayOfMonth;
+            const timeZone = trigger?.config.timeZone;
+            const occurrenceKey = `test:${definition.id}:${now.getTime()}`;
+
+            sourceEventType = 'automation.schedule.monthly';
+            sourceAggregateId = occurrenceKey;
+            input = {
+                scheduleType: 'monthly',
+                triggerModuleKey: automationModuleKeys.triggerScheduleMonthly,
+                occurrenceKey,
+                period: now.toISOString().slice(0, 7),
+                occurrenceDate: now.toISOString().slice(0, 10),
+                dayOfMonth: typeof dayOfMonth === 'number' ? dayOfMonth : null,
+                timeZone:
+                    typeof timeZone === 'string' && timeZone.trim().length > 0
+                        ? timeZone.trim()
+                        : 'Europe/Zagreb',
+                enqueuedAt: now.toISOString(),
+            };
+        } else if (isDomainEventTrigger) {
+            input = sourceEvent
+                ? {
+                      eventId: sourceEvent.id,
+                      eventType: sourceEvent.type,
+                      aggregateId: sourceEvent.aggregateId,
+                      data: isRecord(sourceEvent.data) ? sourceEvent.data : {},
+                      createdAt: sourceEvent.createdAt.toISOString(),
+                  }
+                : {
+                      eventType,
+                      aggregateId: payload.aggregateId?.trim() || 'manual-test',
+                      data: parseEventDataJson(payload.eventDataJson),
+                      createdAt: new Date().toISOString(),
+                  };
+            sourceAggregateId =
+                typeof input.aggregateId === 'string'
+                    ? input.aggregateId
+                    : null;
+        } else {
+            return {
+                ok: false,
+                errors: ['Automation trigger type cannot be tested yet.'],
+            };
+        }
 
         const run = await createAutomationRun({
             automationDefinition: definition,
             source: 'test',
             sourceEvent,
+            sourceEventType,
+            sourceAggregateId,
             input,
             dryRun: payload.dryRun,
             manualRequestedByUserId: userId,

--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -5,6 +5,8 @@ import type {
     AutomationRunStatus,
 } from '@gredice/storage';
 
+const triggerScheduleMonthlyModuleKey = 'trigger.scheduleMonthly';
+
 type ChipColor =
     | 'primary'
     | 'secondary'
@@ -66,6 +68,19 @@ export function automationTriggerSummary(
     }
 
     const module = modules.get(trigger.moduleKey);
+    if (trigger.moduleKey === triggerScheduleMonthlyModuleKey) {
+        const dayOfMonth = trigger.config.dayOfMonth;
+        const timeZone = trigger.config.timeZone;
+        const dayText =
+            typeof dayOfMonth === 'number' ? dayOfMonth.toString() : '?';
+        const timeZoneText =
+            typeof timeZone === 'string' && timeZone.trim().length > 0
+                ? timeZone
+                : 'Europe/Zagreb';
+
+        return `${module?.title ?? trigger.moduleKey}: day ${dayText} (${timeZoneText})`;
+    }
+
     const eventType = trigger.config.eventType;
     const eventTypeText =
         typeof eventType === 'string' && eventType.trim().length > 0

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,9 +1,10 @@
 # Automations
 
 Automations are configurable, trusted server-side workflows that react to
-Gredice domain events. The MVP covers the existing planting workflow where a
-`raisedBedField.plantUpdate` event with `data.status = "sowed"` queues seasonal
-watering operations asynchronously.
+Gredice domain events or scheduled occurrences. The first workflows cover the
+existing planting flow where a `raisedBedField.plantUpdate` event with
+`data.status = "sowed"` queues seasonal watering operations asynchronously, and
+monthly schedules that can create recurring farm operations.
 
 ## Ownership
 
@@ -36,13 +37,15 @@ context.
 
 ## Runner Lifecycle
 
-`runAutomations()` in `packages/storage/src/automations/runner.ts` performs three
+`runAutomations()` in `packages/storage/src/automations/runner.ts` performs four
 bounded phases:
 
 1. Ensure default automation definitions exist.
-2. Read new domain events after the cursor and enqueue matching enabled
+2. Enqueue due scheduled automation runs, using deterministic occurrence keys so
+   repeated cron ticks do not duplicate the same period.
+3. Read new domain events after the cursor and enqueue matching enabled
    automation runs.
-3. Recover stale running jobs, claim due queued/retryable runs, and execute them
+4. Recover stale running jobs, claim due queued/retryable runs, and execute them
    through the graph executor.
 
 When defaults are first installed, the runner initializes the event cursor to
@@ -71,6 +74,7 @@ MVP modules:
 
 - `trigger.domainEvent`: starts from a stored domain event and filters by event
   type.
+- `trigger.scheduleMonthly`: starts once per month on the configured local day.
 - `condition.eventDataEquals`: compares a value in event data.
 - `condition.operationMatches`: checks operation status, entity id, or
   operation application.
@@ -78,6 +82,9 @@ MVP modules:
 - `action.queueSeasonalSowingOfferOperations`: queues seasonal free watering
   operations.
 - `action.createOperation`: creates an operation for the event context.
+- `action.createFarmInventoryOperations`: creates accepted, scheduled farm-level
+  operations for every active farm from a JSON list in the automation
+  definition.
 - `action.updateRaisedBedFieldPlantStatus`: writes a
   `raisedBedField.plantUpdate` event for an operation target.
 - `action.log`: records a no-op step for diagnostics.

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -11,7 +11,7 @@ import { getRaisedBed } from '../repositories/gardensRepo';
 import {
     acceptOperation,
     createOperation,
-    getFarmAcceptedOperations,
+    getFarmAcceptedOperationsByScheduleRange,
     getOperationById,
 } from '../repositories/operationsRepo';
 import { queueSeasonalSowingOfferOperations } from '../repositories/seasonalOffersRepo';
@@ -935,13 +935,12 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
         const repairedScheduledOperationIds: number[] = [];
 
         for (const farm of activeFarms) {
-            const existingOperations = await getFarmAcceptedOperations(
-                farm.id,
-                {
+            const existingOperations =
+                await getFarmAcceptedOperationsByScheduleRange({
+                    farmId: farm.id,
                     from,
                     to,
-                },
-            );
+                });
             const existingOperationsByKey = new Map(
                 existingOperations.flatMap((operation) => {
                     if (

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -6,9 +6,12 @@ import {
     knownEvents,
     knownEventTypes,
 } from '../repositories/events';
+import { getFarms } from '../repositories/farmsRepo';
 import { getRaisedBed } from '../repositories/gardensRepo';
 import {
+    acceptOperation,
     createOperation,
+    getFarmAcceptedOperations,
     getOperationById,
 } from '../repositories/operationsRepo';
 import { queueSeasonalSowingOfferOperations } from '../repositories/seasonalOffersRepo';
@@ -21,24 +24,31 @@ import {
 } from './types';
 
 const domainEventTriggerKey = 'trigger.domainEvent';
+const scheduleMonthlyTriggerKey = 'trigger.scheduleMonthly';
 const eventDataEqualsConditionKey = 'condition.eventDataEquals';
 const operationMatchesConditionKey = 'condition.operationMatches';
 const plantStatusEqualsConditionKey = 'condition.plantStatusEquals';
 const queueSeasonalSowingOfferOperationsActionKey =
     'action.queueSeasonalSowingOfferOperations';
 const createOperationActionKey = 'action.createOperation';
+const createFarmInventoryOperationsActionKey =
+    'action.createFarmInventoryOperations';
 const updateRaisedBedFieldPlantStatusActionKey =
     'action.updateRaisedBedFieldPlantStatus';
 const logActionKey = 'action.log';
+const monthlyScheduleEventType = 'automation.schedule.monthly';
+const defaultScheduleTimeZone = 'Europe/Zagreb';
 
 export const automationModuleKeys = {
     triggerDomainEvent: domainEventTriggerKey,
+    triggerScheduleMonthly: scheduleMonthlyTriggerKey,
     conditionEventDataEquals: eventDataEqualsConditionKey,
     conditionOperationMatches: operationMatchesConditionKey,
     conditionPlantStatusEquals: plantStatusEqualsConditionKey,
     actionQueueSeasonalSowingOfferOperations:
         queueSeasonalSowingOfferOperationsActionKey,
     actionCreateOperation: createOperationActionKey,
+    actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
     actionUpdateRaisedBedFieldPlantStatus:
         updateRaisedBedFieldPlantStatusActionKey,
     actionLog: logActionKey,
@@ -72,6 +82,179 @@ function getNumber(config: AutomationJsonObject, key: string) {
 function requiredString(config: AutomationJsonObject, key: string) {
     const value = getString(config, key);
     return value ? [] : [`${key} is required.`];
+}
+
+function isValidTimeZone(timeZone: string) {
+    try {
+        new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date());
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function getTimeZoneDateParts(date: Date, timeZone: string) {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+    const parts = Object.fromEntries(
+        formatter
+            .formatToParts(date)
+            .filter((part) => part.type !== 'literal')
+            .map((part) => [part.type, part.value]),
+    );
+    const year = Number(parts.year);
+    const month = Number(parts.month);
+    const day = Number(parts.day);
+
+    if (
+        !Number.isInteger(year) ||
+        !Number.isInteger(month) ||
+        !Number.isInteger(day)
+    ) {
+        throw new Error(`Unable to resolve date parts for ${timeZone}.`);
+    }
+
+    return {
+        year,
+        month,
+        day,
+        dateKey: `${parts.year}-${parts.month}-${parts.day}`,
+        periodKey: `${parts.year}-${parts.month}`,
+    };
+}
+
+function validateMonthlyScheduleConfig(config: AutomationJsonObject) {
+    const errors: string[] = [];
+    const dayOfMonth = getNumber(config, 'dayOfMonth');
+    const timeZone = getString(config, 'timeZone') ?? defaultScheduleTimeZone;
+
+    if (
+        !Number.isInteger(dayOfMonth) ||
+        dayOfMonth === undefined ||
+        dayOfMonth < 1 ||
+        dayOfMonth > 31
+    ) {
+        errors.push('dayOfMonth must be an integer from 1 to 31.');
+    }
+
+    if (!isValidTimeZone(timeZone)) {
+        errors.push('timeZone must be a valid IANA time zone.');
+    }
+
+    return errors;
+}
+
+export function getMonthlyScheduleOccurrence(
+    node: AutomationGraphNode,
+    now = new Date(),
+) {
+    const dayOfMonth = getNumber(node.config, 'dayOfMonth');
+    const timeZone =
+        getString(node.config, 'timeZone') ?? defaultScheduleTimeZone;
+
+    if (
+        !Number.isInteger(dayOfMonth) ||
+        dayOfMonth === undefined ||
+        dayOfMonth < 1 ||
+        dayOfMonth > 31 ||
+        !isValidTimeZone(timeZone)
+    ) {
+        return null;
+    }
+
+    const parts = getTimeZoneDateParts(now, timeZone);
+    if (parts.day !== dayOfMonth) {
+        return null;
+    }
+
+    const occurrenceKey = `${scheduleMonthlyTriggerKey}:${timeZone}:${parts.periodKey}:day-${dayOfMonth}`;
+
+    return {
+        eventType: monthlyScheduleEventType,
+        aggregateId: occurrenceKey,
+        input: {
+            scheduleType: 'monthly',
+            triggerModuleKey: scheduleMonthlyTriggerKey,
+            occurrenceKey,
+            period: parts.periodKey,
+            occurrenceDate: parts.dateKey,
+            dayOfMonth,
+            timeZone,
+            enqueuedAt: now.toISOString(),
+        } satisfies AutomationJsonObject,
+    };
+}
+
+type FarmInventoryOperationConfig = {
+    entityId: number;
+    entityTypeName: string;
+    scheduledInDays: number;
+};
+
+function parseFarmInventoryOperationConfigs(
+    value: unknown,
+): FarmInventoryOperationConfig[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.flatMap((item) => {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+            return [];
+        }
+
+        const entityId = Reflect.get(item, 'entityId');
+        const entityTypeName = Reflect.get(item, 'entityTypeName');
+        const scheduledInDays = Reflect.get(item, 'scheduledInDays');
+        const hasScheduledInDays = Reflect.has(item, 'scheduledInDays');
+        if (
+            typeof entityId !== 'number' ||
+            !Number.isInteger(entityId) ||
+            entityId <= 0
+        ) {
+            return [];
+        }
+        if (
+            hasScheduledInDays &&
+            (typeof scheduledInDays !== 'number' ||
+                !Number.isInteger(scheduledInDays))
+        ) {
+            return [];
+        }
+
+        return [
+            {
+                entityId,
+                entityTypeName:
+                    typeof entityTypeName === 'string' &&
+                    entityTypeName.trim().length > 0
+                        ? entityTypeName.trim()
+                        : 'operation',
+                scheduledInDays:
+                    typeof scheduledInDays === 'number' ? scheduledInDays : 0,
+            },
+        ];
+    });
+}
+
+function validateFarmInventoryOperationsConfig(config: AutomationJsonObject) {
+    const operations = config.operations;
+    if (!Array.isArray(operations) || operations.length === 0) {
+        return ['operations must be a non-empty JSON array.'];
+    }
+
+    const validOperations = parseFarmInventoryOperationConfigs(operations);
+    if (validOperations.length !== operations.length) {
+        return [
+            'Each operation must include a positive integer entityId. Optional fields: entityTypeName, integer scheduledInDays.',
+        ];
+    }
+
+    return [];
 }
 
 function readPath(source: AutomationJsonObject, path: string): unknown {
@@ -125,6 +308,40 @@ function success(output: AutomationJsonObject = {}) {
         status: 'succeeded',
         output,
     } satisfies AutomationModuleResult;
+}
+
+function addUtcDays(date: Date, days: number) {
+    const nextDate = new Date(date);
+    nextDate.setUTCDate(nextDate.getUTCDate() + days);
+    return nextDate;
+}
+
+function toUtcDayKey(date: Date) {
+    return date.toISOString().slice(0, 10);
+}
+
+function getScheduleReferenceDate(input: AutomationJsonObject) {
+    const enqueuedAt = input.enqueuedAt;
+    if (typeof enqueuedAt === 'string') {
+        const date = new Date(enqueuedAt);
+        if (!Number.isNaN(date.getTime())) {
+            return date;
+        }
+    }
+
+    return new Date();
+}
+
+function farmOperationKey({
+    entityId,
+    entityTypeName,
+    scheduledDate,
+}: {
+    entityId: number;
+    entityTypeName: string;
+    scheduledDate: Date;
+}) {
+    return `${entityTypeName}:${entityId}:${toUtcDayKey(scheduledDate)}`;
 }
 
 function parseRaisedBedFieldAggregateId(aggregateId: string) {
@@ -190,6 +407,67 @@ const triggerDomainEventModule: AutomationModule = {
             eventType: context.event.type,
             aggregateId: context.event.aggregateId,
             data: context.event.data,
+        });
+    },
+};
+
+const triggerScheduleMonthlyModule: AutomationModule = {
+    key: scheduleMonthlyTriggerKey,
+    kind: 'trigger',
+    title: 'Monthly schedule',
+    description:
+        'Starts an automation once per month on the configured local day.',
+    category: 'Schedules',
+    configFields: [
+        {
+            key: 'dayOfMonth',
+            label: 'Day of month',
+            type: 'number',
+            required: true,
+            placeholder: '1',
+        },
+        {
+            key: 'timeZone',
+            label: 'Time zone',
+            type: 'string',
+            required: false,
+            placeholder: defaultScheduleTimeZone,
+        },
+    ],
+    inputDescription:
+        'A scheduled monthly occurrence generated by the automation runner.',
+    outputDescription: 'The monthly occurrence key and configured local date.',
+    dryRunSupported: true,
+    mutatesData: false,
+    retryable: false,
+    validateConfig: validateMonthlyScheduleConfig,
+    execute: async (context, node) => {
+        const input = context.run.input;
+        const scheduleType = input.scheduleType;
+        const triggerModuleKey = input.triggerModuleKey;
+        const occurrenceKey = input.occurrenceKey;
+
+        if (
+            scheduleType !== 'monthly' ||
+            triggerModuleKey !== scheduleMonthlyTriggerKey ||
+            typeof occurrenceKey !== 'string'
+        ) {
+            return skip('Automation run is not a monthly schedule occurrence.');
+        }
+
+        const dayOfMonth = getNumber(node.config, 'dayOfMonth');
+        const timeZone =
+            getString(node.config, 'timeZone') ?? defaultScheduleTimeZone;
+
+        return success({
+            occurrenceKey,
+            period: typeof input.period === 'string' ? input.period : null,
+            occurrenceDate:
+                typeof input.occurrenceDate === 'string'
+                    ? input.occurrenceDate
+                    : null,
+            dayOfMonth: dayOfMonth ?? null,
+            timeZone,
         });
     },
 };
@@ -599,6 +877,195 @@ const createOperationActionModule: AutomationModule = {
     },
 };
 
+const createFarmInventoryOperationsActionModule: AutomationModule = {
+    key: createFarmInventoryOperationsActionKey,
+    kind: 'action',
+    title: 'Create farm inventory operations',
+    description:
+        'Creates configured inventory task operations for every active farm.',
+    category: 'Operations',
+    configFields: [
+        {
+            key: 'operations',
+            label: 'Operations',
+            type: 'json',
+            required: true,
+            description:
+                'JSON array: [{"entityId": 123, "entityTypeName": "operation", "scheduledInDays": 0}]',
+        },
+    ],
+    inputDescription: 'A monthly schedule occurrence.',
+    outputDescription: 'Created operation ids and skipped existing counts.',
+    dryRunSupported: true,
+    mutatesData: true,
+    retryable: true,
+    validateConfig: validateFarmInventoryOperationsConfig,
+    execute: async (context, node) => {
+        const operationConfigs = parseFarmInventoryOperationConfigs(
+            node.config.operations,
+        );
+        if (operationConfigs.length === 0) {
+            throw new AutomationModuleExecutionError(
+                'Farm inventory operation action is missing operations config.',
+                'invalid_config',
+            );
+        }
+
+        const referenceDate = getScheduleReferenceDate(context.run.input);
+        const scheduledDates = operationConfigs.map((operationConfig) =>
+            addUtcDays(referenceDate, operationConfig.scheduledInDays),
+        );
+        const from = new Date(
+            Math.min(...scheduledDates.map((date) => date.getTime())),
+        );
+        const to = addUtcDays(
+            new Date(Math.max(...scheduledDates.map((date) => date.getTime()))),
+            1,
+        );
+        const activeFarms = (await getFarms()).filter(
+            (farm) => !farm.isDeleted,
+        );
+
+        if (activeFarms.length === 0) {
+            return skip('No active farms were found.');
+        }
+
+        let skippedExistingCount = 0;
+        const createdOperationIds: number[] = [];
+        const repairedScheduledOperationIds: number[] = [];
+
+        for (const farm of activeFarms) {
+            const existingOperations = await getFarmAcceptedOperations(
+                farm.id,
+                {
+                    from,
+                    to,
+                },
+            );
+            const existingOperationsByKey = new Map(
+                existingOperations.flatMap((operation) => {
+                    if (
+                        operation.status === 'canceled' ||
+                        operation.status === 'failed'
+                    ) {
+                        return [];
+                    }
+
+                    return [
+                        [
+                            farmOperationKey({
+                                entityId: operation.entityId,
+                                entityTypeName: operation.entityTypeName,
+                                scheduledDate:
+                                    operation.scheduledDate ??
+                                    operation.timestamp,
+                            }),
+                            operation,
+                        ],
+                    ];
+                }),
+            );
+            const existingOperationKeys = new Set(
+                existingOperationsByKey.keys(),
+            );
+
+            for (const operationConfig of operationConfigs) {
+                const scheduledDate = addUtcDays(
+                    referenceDate,
+                    operationConfig.scheduledInDays,
+                );
+                const operationKey = farmOperationKey({
+                    entityId: operationConfig.entityId,
+                    entityTypeName: operationConfig.entityTypeName,
+                    scheduledDate,
+                });
+                const existingOperation =
+                    existingOperationsByKey.get(operationKey);
+
+                if (
+                    existingOperation ||
+                    existingOperationKeys.has(operationKey)
+                ) {
+                    skippedExistingCount += 1;
+                    if (
+                        existingOperation &&
+                        !existingOperation.scheduledDate &&
+                        !context.dryRun
+                    ) {
+                        await createEvent(
+                            knownEvents.operations.scheduledV1(
+                                existingOperation.id.toString(),
+                                {
+                                    scheduledDate: scheduledDate.toISOString(),
+                                },
+                            ),
+                        );
+                        repairedScheduledOperationIds.push(
+                            existingOperation.id,
+                        );
+                    }
+                    continue;
+                }
+
+                if (context.dryRun) {
+                    continue;
+                }
+
+                const operationId = await createOperation({
+                    entityId: operationConfig.entityId,
+                    entityTypeName: operationConfig.entityTypeName,
+                    farmId: farm.id,
+                    timestamp: scheduledDate,
+                });
+                await acceptOperation(operationId);
+                await createEvent(
+                    knownEvents.operations.scheduledV1(operationId.toString(), {
+                        scheduledDate: scheduledDate.toISOString(),
+                    }),
+                );
+                createdOperationIds.push(operationId);
+                existingOperationKeys.add(operationKey);
+            }
+        }
+
+        if (context.dryRun) {
+            return success({
+                dryRun: true,
+                farmCount: activeFarms.length,
+                operationCount: operationConfigs.length,
+                projectedCreateCount:
+                    activeFarms.length * operationConfigs.length -
+                    skippedExistingCount,
+                skippedExistingCount,
+            });
+        }
+
+        if (
+            createdOperationIds.length === 0 &&
+            repairedScheduledOperationIds.length === 0
+        ) {
+            return skip(
+                'All configured farm inventory operations already exist.',
+                {
+                    farmCount: activeFarms.length,
+                    operationCount: operationConfigs.length,
+                    skippedExistingCount,
+                },
+            );
+        }
+
+        return success({
+            createdOperationIds,
+            createdCount: createdOperationIds.length,
+            repairedScheduledOperationIds,
+            repairedScheduledCount: repairedScheduledOperationIds.length,
+            skippedExistingCount,
+            farmCount: activeFarms.length,
+            operationCount: operationConfigs.length,
+        });
+    },
+};
+
 const updateRaisedBedFieldPlantStatusActionModule: AutomationModule = {
     key: updateRaisedBedFieldPlantStatusActionKey,
     kind: 'action',
@@ -719,11 +1186,13 @@ const logActionModule: AutomationModule = {
 
 export const automationModules = [
     triggerDomainEventModule,
+    triggerScheduleMonthlyModule,
     eventDataEqualsConditionModule,
     operationMatchesConditionModule,
     plantStatusEqualsConditionModule,
     queueSeasonalSowingOfferOperationsActionModule,
     createOperationActionModule,
+    createFarmInventoryOperationsActionModule,
     updateRaisedBedFieldPlantStatusActionModule,
     logActionModule,
 ] as const satisfies readonly AutomationModule[];

--- a/packages/storage/src/automations/runner.ts
+++ b/packages/storage/src/automations/runner.ts
@@ -1,14 +1,17 @@
 import {
     advanceAutomationEventCursor,
     claimDueAutomationRuns,
+    createAutomationRun,
     enqueueAutomationRunsForEvent,
     getAutomationEventCursor,
     getRunnableAutomationEventTypes,
     listDomainEventsAfterId,
+    listEnabledAutomationDefinitionsForTriggerModule,
     recoverStaleAutomationRuns,
 } from '../repositories/automationsRepo';
 import { ensureDefaultAutomationDefinitions } from './defaults';
 import { executeAutomationRun } from './executor';
+import { automationModuleKeys, getMonthlyScheduleOccurrence } from './modules';
 
 const defaultEventBatchLimit = 500;
 const defaultRunBatchLimit = 25;
@@ -16,7 +19,10 @@ const defaultStaleRunMinutes = 15;
 
 export type AutomationRunnerResult = {
     scannedEvents: number;
+    scannedSchedules: number;
     enqueuedRuns: number;
+    enqueuedEventRuns: number;
+    enqueuedScheduledRuns: number;
     claimedRuns: number;
     succeeded: number;
     skipped: number;
@@ -25,6 +31,53 @@ export type AutomationRunnerResult = {
     recoveredStaleRuns: number;
     failedStaleRuns: number;
 };
+
+export async function enqueueAutomationRunsFromSchedules({
+    now = new Date(),
+    limit = 500,
+}: {
+    now?: Date;
+    limit?: number;
+} = {}) {
+    await ensureDefaultAutomationDefinitions();
+    const definitions = await listEnabledAutomationDefinitionsForTriggerModule(
+        automationModuleKeys.triggerScheduleMonthly,
+    );
+    let enqueuedRuns = 0;
+
+    for (const definition of definitions.slice(0, limit)) {
+        const trigger = definition.graph.nodes.find(
+            (node) =>
+                node.kind === 'trigger' &&
+                node.moduleKey === automationModuleKeys.triggerScheduleMonthly,
+        );
+        if (!trigger) {
+            continue;
+        }
+
+        const occurrence = getMonthlyScheduleOccurrence(trigger, now);
+        if (!occurrence) {
+            continue;
+        }
+
+        const run = await createAutomationRun({
+            automationDefinition: definition,
+            source: 'schedule',
+            sourceEventType: occurrence.eventType,
+            sourceAggregateId: occurrence.aggregateId,
+            input: occurrence.input,
+        });
+
+        if (run) {
+            enqueuedRuns += 1;
+        }
+    }
+
+    return {
+        scannedSchedules: Math.min(definitions.length, limit),
+        enqueuedRuns,
+    };
+}
 
 export async function enqueueAutomationRunsFromDomainEvents({
     limit = defaultEventBatchLimit,
@@ -109,13 +162,18 @@ export async function processDueAutomationRuns({
 
 export async function runAutomations({
     eventBatchLimit = defaultEventBatchLimit,
+    scheduleBatchLimit,
     runBatchLimit = defaultRunBatchLimit,
     lockedBy = 'automation-runner',
 }: {
     eventBatchLimit?: number;
+    scheduleBatchLimit?: number;
     runBatchLimit?: number;
     lockedBy?: string;
 } = {}): Promise<AutomationRunnerResult> {
+    const scheduleResult = await enqueueAutomationRunsFromSchedules({
+        limit: scheduleBatchLimit,
+    });
     const enqueueResult = await enqueueAutomationRunsFromDomainEvents({
         limit: eventBatchLimit,
     });
@@ -126,7 +184,10 @@ export async function runAutomations({
 
     return {
         scannedEvents: enqueueResult.scannedEvents,
-        enqueuedRuns: enqueueResult.enqueuedRuns,
+        scannedSchedules: scheduleResult.scannedSchedules,
+        enqueuedRuns: enqueueResult.enqueuedRuns + scheduleResult.enqueuedRuns,
+        enqueuedEventRuns: enqueueResult.enqueuedRuns,
+        enqueuedScheduledRuns: scheduleResult.enqueuedRuns,
         ...processResult,
     };
 }

--- a/packages/storage/src/migrations/0042_aberrant_mystique.sql
+++ b/packages/storage/src/migrations/0042_aberrant_mystique.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."automation_run_source" ADD VALUE 'schedule' BEFORE 'test';--> statement-breakpoint
+CREATE UNIQUE INDEX "automation_runs_definition_source_schedule_idx" ON "automation_runs" USING btree ("automation_definition_id","source_aggregate_id") WHERE "automation_runs"."source_event_type" = 'automation.schedule.monthly';

--- a/packages/storage/src/migrations/meta/0042_snapshot.json
+++ b/packages/storage/src/migrations/meta/0042_snapshot.json
@@ -1,0 +1,10291 @@
+{
+  "id": "f9bda2e9-b0c5-4a03-afec-3c23b48211d9",
+  "prevId": "26fa6363-1515-481a-a368-976219f5997e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_achievements": {
+      "name": "account_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "achievement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_value": {
+          "name": "progress_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_granted_at": {
+          "name": "reward_granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_by_user_id": {
+          "name": "denied_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_achievements_account_id_idx": {
+          "name": "account_achievements_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_status_idx": {
+          "name": "account_achievements_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_account_key_uq": {
+          "name": "account_achievements_account_key_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_achievements_account_id_accounts_id_fk": {
+          "name": "account_achievements_account_id_accounts_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_approved_by_user_id_users_id_fk": {
+          "name": "account_achievements_approved_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_denied_by_user_id_users_id_fk": {
+          "name": "account_achievements_denied_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "denied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_definitions": {
+      "name": "automation_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_definition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "trigger_module_key": {
+          "name": "trigger_module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_type": {
+          "name": "trigger_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_definitions_key_idx": {
+          "name": "automation_definitions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_status_idx": {
+          "name": "automation_definitions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_trigger_event_type_idx": {
+          "name": "automation_definitions_trigger_event_type_idx",
+          "columns": [
+            {
+              "expression": "trigger_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_updated_at_idx": {
+          "name": "automation_definitions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_definitions_created_by_user_id_users_id_fk": {
+          "name": "automation_definitions_created_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_definitions_updated_by_user_id_users_id_fk": {
+          "name": "automation_definitions_updated_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_event_cursors": {
+      "name": "automation_event_cursors",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_run_steps": {
+      "name": "automation_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_kind": {
+          "name": "module_kind",
+          "type": "automation_module_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_run_steps_run_node_idx": {
+          "name": "automation_run_steps_run_node_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_run_id_idx": {
+          "name": "automation_run_steps_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_status_idx": {
+          "name": "automation_run_steps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_run_steps_run_id_automation_runs_id_fk": {
+          "name": "automation_run_steps_run_id_automation_runs_id_fk",
+          "tableFrom": "automation_run_steps",
+          "tableTo": "automation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_definition_id": {
+          "name": "automation_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_key": {
+          "name": "automation_definition_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_name": {
+          "name": "automation_definition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "automation_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_type": {
+          "name": "source_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_aggregate_id": {
+          "name": "source_aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_requested_by_user_id": {
+          "name": "manual_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_snapshot": {
+          "name": "graph_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_runs_definition_source_event_idx": {
+          "name": "automation_runs_definition_source_event_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source\" = 'event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_source_schedule_idx": {
+          "name": "automation_runs_definition_source_schedule_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source_event_type\" = 'automation.schedule.monthly'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_id_idx": {
+          "name": "automation_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_status_next_run_at_idx": {
+          "name": "automation_runs_status_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_type_idx": {
+          "name": "automation_runs_source_event_type_idx",
+          "columns": [
+            {
+              "expression": "source_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_id_idx": {
+          "name": "automation_runs_source_event_id_idx",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_created_at_idx": {
+          "name": "automation_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_definition_id_automation_definitions_id_fk": {
+          "name": "automation_runs_automation_definition_id_automation_definitions_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automation_definitions",
+          "columnsFrom": [
+            "automation_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "automation_runs_source_event_id_events_id_fk": {
+          "name": "automation_runs_source_event_id_events_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_runs_manual_requested_by_user_id_users_id_fk": {
+          "name": "automation_runs_manual_requested_by_user_id_users_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "manual_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definition_categories": {
+      "name": "attribute_definition_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_adc_entity_type_name_idx": {
+          "name": "cms_adc_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_order_idx": {
+          "name": "cms_adc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_is_deleted_idx": {
+          "name": "cms_adc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definitions": {
+      "name": "attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display": {
+          "name": "display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_ad_category_idx": {
+          "name": "cms_ad_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_entity_type_name_idx": {
+          "name": "cms_ad_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_order_idx": {
+          "name": "cms_ad_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_is_deleted_idx": {
+          "name": "cms_ad_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_values": {
+      "name": "attribute_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_av_attribute_definition_id_idx": {
+          "name": "cms_av_attribute_definition_id_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_type_name_idx": {
+          "name": "cms_av_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_id_idx": {
+          "name": "cms_av_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_order_idx": {
+          "name": "cms_av_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_is_deleted_idx": {
+          "name": "cms_av_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attribute_values_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "attribute_values_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attribute_values_entity_id_entities_id_fk": {
+          "name": "attribute_values_entity_id_entities_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_page_revisions": {
+      "name": "cms_page_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_page_id": {
+          "name": "cms_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_slug": {
+          "name": "previous_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_slug": {
+          "name": "next_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_title": {
+          "name": "previous_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_title": {
+          "name": "next_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content": {
+          "name": "next_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_title": {
+          "name": "previous_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_title": {
+          "name": "next_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_description": {
+          "name": "previous_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_description": {
+          "name": "next_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_url": {
+          "name": "previous_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_url": {
+          "name": "next_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_canonical_path": {
+          "name": "previous_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_canonical_path": {
+          "name": "next_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_no_index": {
+          "name": "previous_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_no_index": {
+          "name": "next_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_published_at": {
+          "name": "previous_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_published_at": {
+          "name": "next_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_page_revisions_page_id_idx": {
+          "name": "cms_page_revisions_page_id_idx",
+          "columns": [
+            {
+              "expression": "cms_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_action_idx": {
+          "name": "cms_page_revisions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_created_at_idx": {
+          "name": "cms_page_revisions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_page_revisions_cms_page_id_cms_pages_id_fk": {
+          "name": "cms_page_revisions_cms_page_id_cms_pages_id_fk",
+          "tableFrom": "cms_page_revisions",
+          "tableTo": "cms_pages",
+          "columnsFrom": [
+            "cms_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_pages": {
+      "name": "cms_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_index": {
+          "name": "no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_pages_slug_active_uq": {
+          "name": "cms_pages_slug_active_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cms_pages\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_state_idx": {
+          "name": "cms_pages_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_published_at_idx": {
+          "name": "cms_pages_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_is_deleted_idx": {
+          "name": "cms_pages_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_e_entity_type_name_idx": {
+          "name": "cms_e_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_parent_id_idx": {
+          "name": "cms_e_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_hierarchy_order_idx": {
+          "name": "cms_e_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_state_idx": {
+          "name": "cms_e_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_is_deleted_idx": {
+          "name": "cms_e_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_parent_id_entities_id_fk": {
+          "name": "entities_parent_id_entities_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_revisions": {
+      "name": "entity_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_value": {
+          "name": "next_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_er_entity_id_idx": {
+          "name": "cms_er_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_entity_type_name_idx": {
+          "name": "cms_er_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_action_idx": {
+          "name": "cms_er_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_revisions_entity_id_entities_id_fk": {
+          "name": "entity_revisions_entity_id_entities_id_fk",
+          "tableFrom": "entity_revisions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_search_documents": {
+      "name": "entity_search_documents",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category": {
+          "name": "public_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category_label": {
+          "name": "public_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cms_esd_entity_type_idx": {
+          "name": "cms_esd_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_public_category_idx": {
+          "name": "cms_esd_public_category_idx",
+          "columns": [
+            {
+              "expression": "public_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_state_idx": {
+          "name": "cms_esd_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_published_at_idx": {
+          "name": "cms_esd_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_search_vector_idx": {
+          "name": "cms_esd_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_search_documents_entity_id_entities_id_fk": {
+          "name": "entity_search_documents_entity_id_entities_id_fk",
+          "tableFrom": "entity_search_documents",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_type_categories": {
+      "name": "entity_type_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_etc_order_idx": {
+          "name": "cms_etc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_etc_is_deleted_idx": {
+          "name": "cms_etc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_root": {
+          "name": "is_root",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_et_category_id_idx": {
+          "name": "cms_et_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_order_idx": {
+          "name": "cms_et_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_parent_id_idx": {
+          "name": "cms_et_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_hierarchy_order_idx": {
+          "name": "cms_et_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_deleted_idx": {
+          "name": "cms_et_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_root_idx": {
+          "name": "cms_et_is_root_idx",
+          "columns": [
+            {
+              "expression": "is_root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_types_category_id_entity_type_categories_id_fk": {
+          "name": "entity_types_category_id_entity_type_categories_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_type_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_parent_id_entity_types_id_fk": {
+          "name": "entity_types_parent_id_entity_types_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_types",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_addresses": {
+      "name": "delivery_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_addresses_account_id_idx": {
+          "name": "delivery_addresses_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_is_default_idx": {
+          "name": "delivery_addresses_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_deleted_at_idx": {
+          "name": "delivery_addresses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_addresses_account_id_accounts_id_fk": {
+          "name": "delivery_addresses_account_id_accounts_id_fk",
+          "tableFrom": "delivery_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_requests": {
+      "name": "delivery_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_requests_operation_id_idx": {
+          "name": "delivery_requests_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_requests_created_at_idx": {
+          "name": "delivery_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_requests_operation_id_operations_id_fk": {
+          "name": "delivery_requests_operation_id_operations_id_fk",
+          "tableFrom": "delivery_requests",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pickup_locations_is_active_idx": {
+          "name": "pickup_locations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_slots": {
+      "name": "time_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "time_slots_location_id_idx": {
+          "name": "time_slots_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_type_idx": {
+          "name": "time_slots_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_start_at_idx": {
+          "name": "time_slots_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_status_idx": {
+          "name": "time_slots_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_unique_slot_idx": {
+          "name": "time_slots_unique_slot_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_slots_location_id_pickup_locations_id_fk": {
+          "name": "time_slots_location_id_pickup_locations_id_fk",
+          "tableFrom": "time_slots",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_messages": {
+      "name": "email_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'acs'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_messages_status_idx": {
+          "name": "email_messages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_created_idx": {
+          "name": "email_messages_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_provider_message_idx": {
+          "name": "email_messages_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_e_type_idx": {
+          "name": "events_e_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_aggregate_id_idx": {
+          "name": "events_e_aggregate_id_idx",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_created_at_idx": {
+          "name": "events_e_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farms": {
+      "name": "farms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snow_accumulation": {
+          "name": "snow_accumulation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "farms_f_is_deleted_idx": {
+          "name": "farms_f_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_pos_settings": {
+      "name": "fiscalization_pos_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_id": {
+          "name": "pos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_pos_settings_pos_id_idx": {
+          "name": "fiscalization_pos_settings_pos_id_idx",
+          "columns": [
+            {
+              "expression": "pos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_active_idx": {
+          "name": "fiscalization_pos_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_deleted_idx": {
+          "name": "fiscalization_pos_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_user_settings": {
+      "name": "fiscalization_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_vat": {
+          "name": "use_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receipt_number_on_device": {
+          "name": "receipt_number_on_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'educ'"
+        },
+        "cert_base64": {
+          "name": "cert_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cert_password": {
+          "name": "cert_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_user_settings_is_active_idx": {
+          "name": "fiscalization_user_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_user_settings_is_deleted_idx": {
+          "name": "fiscalization_user_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_blocks": {
+      "name": "garden_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gb_garden_id_idx": {
+          "name": "garden_gb_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gb_is_deleted_idx": {
+          "name": "garden_gb_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_blocks_garden_id_gardens_id_fk": {
+          "name": "garden_blocks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_blocks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_stacks": {
+      "name": "garden_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gs_garden_id_idx": {
+          "name": "garden_gs_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gs_is_deleted_idx": {
+          "name": "garden_gs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_stacks_garden_id_gardens_id_fk": {
+          "name": "garden_stacks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_stacks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gardens": {
+      "name": "gardens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_g_account_id_idx": {
+          "name": "garden_g_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_farm_id_idx": {
+          "name": "garden_g_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_deleted_idx": {
+          "name": "garden_g_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_sandbox_idx": {
+          "name": "garden_g_is_sandbox_idx",
+          "columns": [
+            {
+              "expression": "is_sandbox",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gardens_account_id_accounts_id_fk": {
+          "name": "gardens_account_id_accounts_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gardens_farm_id_farms_id_fk": {
+          "name": "gardens_farm_id_farms_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_fields": {
+      "name": "raised_bed_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_fields_raised_bed_id_idx": {
+          "name": "raised_bed_fields_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_fields_is_deleted_idx": {
+          "name": "raised_bed_fields_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_fields_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_fields_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_fields",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_sensors": {
+      "name": "raised_bed_sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "sensor_signalco_id": {
+          "name": "sensor_signalco_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_sensors_raised_bed_id_idx": {
+          "name": "raised_bed_sensors_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_sensors_is_deleted_idx": {
+          "name": "raised_bed_sensors_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_sensors_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_sensors_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_sensors",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_beds": {
+      "name": "raised_beds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vertical'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "physical_id": {
+          "name": "physical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_beds_account_id_idx": {
+          "name": "raised_beds_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_garden_id_idx": {
+          "name": "raised_beds_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_block_id_idx": {
+          "name": "raised_beds_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_is_deleted_idx": {
+          "name": "raised_beds_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_beds_account_id_accounts_id_fk": {
+          "name": "raised_beds_account_id_accounts_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_garden_id_gardens_id_fk": {
+          "name": "raised_beds_garden_id_gardens_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_block_id_garden_blocks_id_fk": {
+          "name": "raised_beds_block_id_garden_blocks_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_configs": {
+      "name": "inventory_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_tracking_type": {
+          "name": "default_tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "status_attribute_name": {
+          "name": "status_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "empty_status_value": {
+          "name": "empty_status_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_attribute_name": {
+          "name": "amount_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_configs_entity_type_name_idx": {
+          "name": "inv_configs_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_configs_is_deleted_idx": {
+          "name": "inv_configs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_events": {
+      "name": "inventory_item_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_quantity": {
+          "name": "previous_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_quantity": {
+          "name": "new_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_item_events_inventory_item_id_idx": {
+          "name": "inv_item_events_inventory_item_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_item_events_is_deleted_idx": {
+          "name": "inv_item_events_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_events_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_item_events_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_item_events",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_field_definitions": {
+      "name": "inventory_item_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_field_defs_inventory_config_id_idx": {
+          "name": "inv_field_defs_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_field_defs_is_deleted_idx": {
+          "name": "inv_field_defs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_item_field_definitions",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_fields": {
+          "name": "additional_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_items_inventory_config_id_idx": {
+          "name": "inv_items_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_entity_id_idx": {
+          "name": "inv_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_is_deleted_idx": {
+          "name": "inv_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_tracking_type_idx": {
+          "name": "inv_items_tracking_type_idx",
+          "columns": [
+            {
+              "expression": "tracking_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_items_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_items_entity_id_entities_id_fk": {
+          "name": "inventory_items_entity_id_entities_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.00'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_id_idx": {
+          "name": "invoice_items_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_id_idx": {
+          "name": "invoice_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_type_idx": {
+          "name": "invoice_items_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_name": {
+          "name": "bill_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_email": {
+          "name": "bill_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_to_address": {
+          "name": "bill_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_country": {
+          "name": "bill_to_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_account_id_idx": {
+          "name": "invoices_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_transaction_id_idx": {
+          "name": "invoices_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_issue_date_idx": {
+          "name": "invoices_issue_date_idx",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_due_date_idx": {
+          "name": "invoices_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_is_deleted_idx": {
+          "name": "invoices_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_account_id_accounts_id_fk": {
+          "name": "invoices_account_id_accounts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_transaction_id_transactions_id_fk": {
+          "name": "invoices_transaction_id_transactions_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_receipt_number": {
+          "name": "year_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_reference": {
+          "name": "payment_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jir": {
+          "name": "jir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zki": {
+          "name": "zki",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_status": {
+          "name": "cis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cis_reference": {
+          "name": "cis_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_error_message": {
+          "name": "cis_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_timestamp": {
+          "name": "cis_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_response": {
+          "name": "cis_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "business_pin": {
+          "name": "business_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_address": {
+          "name": "business_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_pin": {
+          "name": "customer_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "receipts_invoice_id_idx": {
+          "name": "receipts_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_receipt_number_idx": {
+          "name": "receipts_receipt_number_idx",
+          "columns": [
+            {
+              "expression": "receipt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_jir_idx": {
+          "name": "receipts_jir_idx",
+          "columns": [
+            {
+              "expression": "jir",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_zki_idx": {
+          "name": "receipts_zki_idx",
+          "columns": [
+            {
+              "expression": "zki",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_cis_status_idx": {
+          "name": "receipts_cis_status_idx",
+          "columns": [
+            {
+              "expression": "cis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_issued_at_idx": {
+          "name": "receipts_issued_at_idx",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_business_pin_idx": {
+          "name": "receipts_business_pin_idx",
+          "columns": [
+            {
+              "expression": "business_pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_is_deleted_idx": {
+          "name": "receipts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_invoice_id_invoices_id_fk": {
+          "name": "receipts_invoice_id_invoices_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_year_receipt_number_unique": {
+          "name": "receipts_year_receipt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "newsletter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_campaigns": {
+      "name": "notification_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_action_url": {
+          "name": "safe_action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "delivery_metadata": {
+          "name": "delivery_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "failures": {
+          "name": "failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_user_id": {
+          "name": "cancelled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_campaigns_status_idx": {
+          "name": "notification_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_scheduled_at_idx": {
+          "name": "notification_campaigns_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_created_by_user_id_idx": {
+          "name": "notification_campaigns_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_category_idx": {
+          "name": "notification_campaigns_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_event_type_idx": {
+          "name": "notification_campaigns_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_campaigns_created_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_created_from_account_id_accounts_id_fk": {
+          "name": "notification_campaigns_created_from_account_id_accounts_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_cancelled_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_cancelled_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "cancelled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_attempts": {
+      "name": "notification_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_code": {
+          "name": "provider_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_body": {
+          "name": "provider_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_subscription_id": {
+          "name": "push_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_attempts_notification_id_idx": {
+          "name": "notification_delivery_attempts_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_attempts_status_idx": {
+          "name": "notification_delivery_attempts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_attempts_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_attempts_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_user_id_users_id_fk": {
+          "name": "notification_delivery_attempts_user_id_users_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_account_id_accounts_id_fk": {
+          "name": "notification_delivery_attempts_account_id_accounts_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk": {
+          "name": "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "web_push_subscriptions",
+          "columnsFrom": [
+            "push_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_events": {
+      "name": "notification_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_attempt_id": {
+          "name": "delivery_attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_delivery_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_events_attempt_id_idx": {
+          "name": "notification_delivery_events_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "delivery_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk": {
+          "name": "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notification_delivery_attempts",
+          "columnsFrom": [
+            "delivery_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_events_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_events_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_email_log": {
+      "name": "notification_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_email_log_user_id_users_id_fk": {
+          "name": "notification_email_log_user_id_users_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_email_log_notification_id_notifications_id_fk": {
+          "name": "notification_email_log_notification_id_notifications_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_user_channel_preferences": {
+      "name": "notification_user_channel_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "notification_preference_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours_start_minute": {
+          "name": "quiet_hours_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end_minute": {
+          "name": "quiet_hours_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_start_minute": {
+          "name": "delivery_window_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_end_minute": {
+          "name": "delivery_window_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_frequency": {
+          "name": "digest_frequency",
+          "type": "notification_digest_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_channel_preferences_global_unique_idx": {
+          "name": "notification_user_channel_preferences_global_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_channel_preferences_account_unique_idx": {
+          "name": "notification_user_channel_preferences_account_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'account'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_channel_preferences_user_id_users_id_fk": {
+          "name": "notification_user_channel_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_user_channel_preferences_account_id_accounts_id_fk": {
+          "name": "notification_user_channel_preferences_account_id_accounts_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_user_channel_preferences_scope_account_id_check": {
+          "name": "notification_user_channel_preferences_scope_account_id_check",
+          "value": "(scope = 'global' and account_id is null) or (scope = 'account' and account_id is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_where": {
+          "name": "read_where",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_account_id_idx": {
+          "name": "notifications_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_readAt_idx": {
+          "name": "notifications_readAt_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_category_idx": {
+          "name": "notifications_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_campaign_id_idx": {
+          "name": "notifications_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_garden_id_gardens_id_fk": {
+          "name": "notifications_garden_id_gardens_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_raised_bed_id_raised_beds_id_fk": {
+          "name": "notifications_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_block_id_garden_blocks_id_fk": {
+          "name": "notifications_block_id_garden_blocks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_digest": {
+          "name": "daily_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_push_subscriptions": {
+      "name": "web_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_label": {
+          "name": "device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_version": {
+          "name": "browser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "push_permission_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "web_push_subscriptions_endpoint_unique_idx": {
+          "name": "web_push_subscriptions_endpoint_unique_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_user_id_idx": {
+          "name": "web_push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_account_id_idx": {
+          "name": "web_push_subscriptions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_device_id_idx": {
+          "name": "web_push_subscriptions_device_id_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "web_push_subscriptions_account_id_accounts_id_fk": {
+          "name": "web_push_subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "web_push_subscriptions_user_id_users_id_fk": {
+          "name": "web_push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_accepted": {
+          "name": "is_accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "operations_entity_id_idx": {
+          "name": "operations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_entity_type_name_idx": {
+          "name": "operations_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_account_id_idx": {
+          "name": "operations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_farm_id_idx": {
+          "name": "operations_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_garden_id_idx": {
+          "name": "operations_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_id_idx": {
+          "name": "operations_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_field_id_idx": {
+          "name": "operations_raised_bed_field_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_timestamp_idx": {
+          "name": "operations_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_deleted_idx": {
+          "name": "operations_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_accepted_idx": {
+          "name": "operations_is_accepted_idx",
+          "columns": [
+            {
+              "expression": "is_accepted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_requests": {
+      "name": "farmer_payout_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "farmer_note": {
+          "name": "farmer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_reference": {
+          "name": "bank_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_requests_farm_id_idx": {
+          "name": "farmer_payout_requests_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_user_id_idx": {
+          "name": "farmer_payout_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_status_idx": {
+          "name": "farmer_payout_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_requests_farm_id_farms_id_fk": {
+          "name": "farmer_payout_requests_farm_id_farms_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_receipt_id_receipts_id_fk": {
+          "name": "farmer_payout_requests_receipt_id_receipts_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_approved_by_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_approved_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operation_prices": {
+      "name": "operation_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operation_prices_farm_type_null_unique": {
+          "name": "operation_prices_farm_type_null_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_type_entity_unique": {
+          "name": "operation_prices_farm_type_entity_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_id_idx": {
+          "name": "operation_prices_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operation_prices_farm_id_farms_id_fk": {
+          "name": "operation_prices_farm_id_farms_id_fk",
+          "tableFrom": "operation_prices",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_token_hash_idx": {
+          "name": "refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_cart_items": {
+      "name": "shopping_cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_cart_items_cart_id_idx": {
+          "name": "shopping_cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_entity_id_idx": {
+          "name": "shopping_cart_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_garden_id_idx": {
+          "name": "shopping_cart_items_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_raised_bed_id_idx": {
+          "name": "shopping_cart_items_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_is_deleted_idx": {
+          "name": "shopping_cart_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_status_idx": {
+          "name": "shopping_cart_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_cart_items_cart_id_shopping_carts_id_fk": {
+          "name": "shopping_cart_items_cart_id_shopping_carts_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_garden_id_gardens_id_fk": {
+          "name": "shopping_cart_items_garden_id_gardens_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_raised_bed_id_raised_beds_id_fk": {
+          "name": "shopping_cart_items_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_carts": {
+      "name": "shopping_carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_carts_account_id_idx": {
+          "name": "shopping_carts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_is_deleted_idx": {
+          "name": "shopping_carts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_status_idx": {
+          "name": "shopping_carts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_carts_account_id_accounts_id_fk": {
+          "name": "shopping_carts_account_id_accounts_id_fk",
+          "tableFrom": "shopping_carts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "social_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "default_destination": {
+          "name": "default_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_destinations": {
+          "name": "allowed_destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_reference": {
+          "name": "credential_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_provider_account_key_idx": {
+          "name": "social_accounts_provider_account_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_provider_idx": {
+          "name": "social_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_status_idx": {
+          "name": "social_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "post_type": {
+          "name": "post_type",
+          "type": "social_post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_submission_id": {
+          "name": "provider_submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_permalink": {
+          "name": "provider_permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_metadata": {
+          "name": "failure_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_provider_idx": {
+          "name": "social_posts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_queued_at_idx": {
+          "name": "social_posts_queued_at_idx",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_provider_destination_idx": {
+          "name": "social_posts_provider_destination_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "transactions_account_id_idx": {
+          "name": "transactions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_garden_id_idx": {
+          "name": "transactions_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_payment_id_idx": {
+          "name": "transactions_stripe_payment_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_is_deleted_idx": {
+          "name": "transactions_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_garden_id_gardens_id_fk": {
+          "name": "transactions_garden_id_gardens_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "account_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_invitations_account_id_idx": {
+          "name": "account_invitations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_email_idx": {
+          "name": "account_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_token_idx": {
+          "name": "account_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_id_fk": {
+          "name": "account_invitations_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_invitations_invited_by_user_id_users_id_fk": {
+          "name": "account_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_users": {
+      "name": "account_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_au_account_id_idx": {
+          "name": "users_au_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_au_user_id_idx": {
+          "name": "users_au_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_users_account_id_accounts_id_fk": {
+          "name": "account_users_account_id_accounts_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_users_user_id_users_id_fk": {
+          "name": "account_users_user_id_users_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street1": {
+          "name": "address_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street2": {
+          "name": "address_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farm_users": {
+      "name": "farm_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farm_users_farm_id_idx": {
+          "name": "farm_users_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_user_id_idx": {
+          "name": "farm_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_farm_user_unique": {
+          "name": "farm_users_farm_user_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farm_users_farm_id_farms_id_fk": {
+          "name": "farm_users_farm_id_farms_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farm_users_user_id_users_id_fk": {
+          "name": "farm_users_user_id_users_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_logins": {
+      "name": "user_logins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_id": {
+          "name": "login_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_data": {
+          "name": "login_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_ul_user_id_idx": {
+          "name": "users_ul_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_type_idx": {
+          "name": "users_ul_login_type_idx",
+          "columns": [
+            {
+              "expression": "login_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_id_idx": {
+          "name": "users_ul_login_id_idx",
+          "columns": [
+            {
+              "expression": "login_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_logins_user_id_users_id_fk": {
+          "name": "user_logins_user_id_users_id_fk",
+          "tableFrom": "user_logins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_day": {
+          "name": "birthday_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_month": {
+          "name": "birthday_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_year": {
+          "name": "birthday_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_last_updated_at": {
+          "name": "birthday_last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_u_username_idx": {
+          "name": "users_u_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_history": {
+      "name": "weather_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rain": {
+          "name": "rain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_speed": {
+          "name": "wind_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rainy": {
+          "name": "rainy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snowy": {
+          "name": "snowy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cloudy": {
+          "name": "cloudy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foggy": {
+          "name": "foggy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thundery": {
+          "name": "thundery",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_recorded_at_idx": {
+          "name": "weather_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_status": {
+      "name": "achievement_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.automation_definition_status": {
+      "name": "automation_definition_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "enabled",
+        "disabled",
+        "archived"
+      ]
+    },
+    "public.automation_module_kind": {
+      "name": "automation_module_kind",
+      "schema": "public",
+      "values": [
+        "trigger",
+        "filter",
+        "condition",
+        "action"
+      ]
+    },
+    "public.automation_run_source": {
+      "name": "automation_run_source",
+      "schema": "public",
+      "values": [
+        "event",
+        "manual",
+        "schedule",
+        "test",
+        "replay"
+      ]
+    },
+    "public.automation_run_status": {
+      "name": "automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed",
+        "retrying",
+        "canceled"
+      ]
+    },
+    "public.automation_step_status": {
+      "name": "automation_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed",
+        "bounced"
+      ]
+    },
+    "public.newsletter_status": {
+      "name": "newsletter_status",
+      "schema": "public",
+      "values": [
+        "subscribed",
+        "unsubscribed",
+        "pending"
+      ]
+    },
+    "public.notification_delivery_status": {
+      "name": "notification_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "dropped"
+      ]
+    },
+    "public.notification_delivery_event_type": {
+      "name": "notification_delivery_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "opened",
+        "clicked",
+        "dismissed",
+        "unsubscribed"
+      ]
+    },
+    "public.notification_digest_frequency": {
+      "name": "notification_digest_frequency",
+      "schema": "public",
+      "values": [
+        "off",
+        "hourly",
+        "daily",
+        "weekly"
+      ]
+    },
+    "public.notification_campaign_status": {
+      "name": "notification_campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "queued",
+        "sending",
+        "sent",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email",
+        "push",
+        "sms"
+      ]
+    },
+    "public.notification_preference_scope": {
+      "name": "notification_preference_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "account"
+      ]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "critical"
+      ]
+    },
+    "public.push_permission_state": {
+      "name": "push_permission_state",
+      "schema": "public",
+      "values": [
+        "default",
+        "granted",
+        "denied"
+      ]
+    },
+    "public.social_account_status": {
+      "name": "social_account_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disabled",
+        "needs_reauth"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "scheduled",
+        "submitting",
+        "submitted",
+        "published",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.social_post_type": {
+      "name": "social_post_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "link",
+        "image",
+        "video",
+        "reel",
+        "story",
+        "carousel",
+        "other"
+      ]
+    },
+    "public.social_provider": {
+      "name": "social_provider",
+      "schema": "public",
+      "values": [
+        "reddit",
+        "instagram",
+        "facebook",
+        "google_business",
+        "x",
+        "tiktok",
+        "threads",
+        "linkedin",
+        "whatsapp"
+      ]
+    },
+    "public.account_invitation_status": {
+      "name": "account_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1780168963649,
       "tag": "0041_chunky_eternity",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1780397292635,
+      "tag": "0042_aberrant_mystique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/automationsRepo.ts
+++ b/packages/storage/src/repositories/automationsRepo.ts
@@ -50,6 +50,8 @@ export type CreateAutomationRunInput = {
     automationDefinition: SelectAutomationDefinition;
     source: AutomationRunSource;
     sourceEvent?: DomainEventRow | null;
+    sourceEventType?: string | null;
+    sourceAggregateId?: string | null;
     parentRunId?: number | null;
     dryRun?: boolean;
     input?: AutomationJsonObject;
@@ -287,29 +289,72 @@ export function listEnabledAutomationDefinitionsForEventType(
     });
 }
 
+export function listEnabledAutomationDefinitionsForTriggerModule(
+    triggerModuleKey: string,
+): Promise<SelectAutomationDefinition[]> {
+    return storage()
+        .select()
+        .from(automationDefinitions)
+        .where(
+            and(
+                eq(automationDefinitions.status, 'enabled'),
+                eq(automationDefinitions.triggerModuleKey, triggerModuleKey),
+            ),
+        )
+        .orderBy(desc(automationDefinitions.updatedAt))
+        .limit(500);
+}
+
 export async function createAutomationRun(
     input: CreateAutomationRunInput,
 ): Promise<SelectAutomationRun | null> {
     const definition = input.automationDefinition;
     const sourceEvent = input.sourceEvent ?? null;
+    const sourceEventType = input.sourceEventType ?? sourceEvent?.type ?? null;
+    const sourceAggregateId =
+        input.sourceAggregateId ?? sourceEvent?.aggregateId ?? null;
+    const values = {
+        automationDefinitionId: definition.id,
+        automationDefinitionKey: definition.key,
+        automationDefinitionName: definition.name,
+        source: input.source,
+        sourceEventId: sourceEvent?.id ?? null,
+        sourceEventType,
+        sourceAggregateId,
+        parentRunId: input.parentRunId ?? null,
+        dryRun: input.dryRun ?? input.source === 'test',
+        maxAttempts: input.maxAttempts ?? defaultRunMaxAttempts,
+        nextRunAt: input.nextRunAt ?? new Date(),
+        manualRequestedByUserId: input.manualRequestedByUserId ?? null,
+        graphSnapshot: definition.graph,
+        input: input.input ?? {},
+    };
+
+    if (input.source === 'schedule' && !sourceAggregateId) {
+        throw new Error(
+            'Scheduled automation runs require a sourceAggregateId.',
+        );
+    }
+
+    if (input.source === 'schedule') {
+        const [created] = await storage()
+            .insert(automationRuns)
+            .values(values)
+            .onConflictDoNothing({
+                target: [
+                    automationRuns.automationDefinitionId,
+                    automationRuns.sourceAggregateId,
+                ],
+                where: sql`${automationRuns.sourceEventType} = 'automation.schedule.monthly'`,
+            })
+            .returning();
+
+        return created ?? null;
+    }
+
     const [created] = await storage()
         .insert(automationRuns)
-        .values({
-            automationDefinitionId: definition.id,
-            automationDefinitionKey: definition.key,
-            automationDefinitionName: definition.name,
-            source: input.source,
-            sourceEventId: sourceEvent?.id ?? null,
-            sourceEventType: sourceEvent?.type ?? null,
-            sourceAggregateId: sourceEvent?.aggregateId ?? null,
-            parentRunId: input.parentRunId ?? null,
-            dryRun: input.dryRun ?? input.source === 'test',
-            maxAttempts: input.maxAttempts ?? defaultRunMaxAttempts,
-            nextRunAt: input.nextRunAt ?? new Date(),
-            manualRequestedByUserId: input.manualRequestedByUserId ?? null,
-            graphSnapshot: definition.graph,
-            input: input.input ?? {},
-        })
+        .values(values)
         .onConflictDoNothing({
             target: [
                 automationRuns.automationDefinitionId,

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -763,6 +763,63 @@ export async function getFarmAcceptedOperations(
     return operationsWithAggregates;
 }
 
+export async function getFarmAcceptedOperationsByScheduleRange({
+    farmId,
+    from,
+    to,
+}: {
+    farmId: number;
+    from: Date;
+    to: Date;
+}) {
+    const scheduledDateExpression = sql<string>`${events.data} ->> 'scheduledDate'`;
+    const scheduledRows = await storage()
+        .selectDistinct({ id: operations.id })
+        .from(operations)
+        .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .leftJoin(gardens, eq(gardens.id, operationGardenIdExpression()))
+        .innerJoin(
+            events,
+            and(
+                sql`${events.aggregateId} = cast(${operations.id} as text)`,
+                eq(events.type, knownEventTypes.operations.schedule),
+            ),
+        )
+        .where(
+            and(
+                eq(operationFarmIdExpression(), farmId),
+                eq(operations.isAccepted, true),
+                eq(operations.isDeleted, false),
+                operationLocationIntegrityWhere(),
+                gte(scheduledDateExpression, from.toISOString()),
+                lte(scheduledDateExpression, to.toISOString()),
+            ),
+        );
+    const timestampRows = await storage()
+        .selectDistinct({ id: operations.id })
+        .from(operations)
+        .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .leftJoin(gardens, eq(gardens.id, operationGardenIdExpression()))
+        .where(
+            and(
+                eq(operationFarmIdExpression(), farmId),
+                eq(operations.isAccepted, true),
+                eq(operations.isDeleted, false),
+                operationLocationIntegrityWhere(),
+                gte(operations.timestamp, from),
+                lte(operations.timestamp, to),
+            ),
+        );
+    const operationIds = Array.from(
+        new Set([
+            ...scheduledRows.map((row) => row.id),
+            ...timestampRows.map((row) => row.id),
+        ]),
+    );
+
+    return getOperationsByIds(operationIds);
+}
+
 export async function getFarmUserAcceptedOperationById(
     userId: string,
     id: number,

--- a/packages/storage/src/schema/automationsSchema.ts
+++ b/packages/storage/src/schema/automationsSchema.ts
@@ -56,6 +56,7 @@ export const automationRunStatusEnum = pgEnum(
 export const automationRunSourceValues = [
     'event',
     'manual',
+    'schedule',
     'test',
     'replay',
 ] as const;
@@ -213,6 +214,11 @@ export const automationRuns = pgTable(
         uniqueIndex('automation_runs_definition_source_event_idx')
             .on(table.automationDefinitionId, table.sourceEventId)
             .where(sql`${table.source} = 'event'`),
+        uniqueIndex('automation_runs_definition_source_schedule_idx')
+            .on(table.automationDefinitionId, table.sourceAggregateId)
+            .where(
+                sql`${table.sourceEventType} = 'automation.schedule.monthly'`,
+            ),
         index('automation_runs_definition_id_idx').on(
             table.automationDefinitionId,
         ),

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    acceptOperation,
     automationEventCursors,
     automationModuleKeys,
     claimDueAutomationRuns,
@@ -19,7 +20,7 @@ import {
     getAutomationEventCursor,
     getAutomationRunWithSteps,
     getEvents,
-    getFarmAcceptedOperations,
+    getFarmAcceptedOperationsByScheduleRange,
     getFarms,
     getOperations,
     getRaisedBed,
@@ -370,6 +371,20 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
             scheduledInDays: 2,
         },
     ];
+    const preexistingFarm = activeFarms[0];
+    assert.ok(preexistingFarm);
+    const preexistingOperationId = await createOperation({
+        entityId: operationConfigs[0].entityId,
+        entityTypeName: operationConfigs[0].entityTypeName,
+        farmId: preexistingFarm.id,
+        timestamp: new Date('2026-05-01T08:00:00.000Z'),
+    });
+    await acceptOperation(preexistingOperationId);
+    await createEvent(
+        knownEvents.operations.scheduledV1(preexistingOperationId.toString(), {
+            scheduledDate: referenceDate.toISOString(),
+        }),
+    );
     const graph = {
         nodes: [
             {
@@ -426,7 +441,8 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
         ).toISOString(),
     );
     for (const farm of activeFarms) {
-        const farmOperations = await getFarmAcceptedOperations(farm.id, {
+        const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+            farmId: farm.id,
             from: referenceDate,
             to: addUtcDays(referenceDate, 3),
         });
@@ -439,7 +455,18 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
             )
             .sort((left, right) => left.entityId - right.entityId);
 
-        assert.strictEqual(inventoryOperations.length, operationConfigs.length);
+        assert.strictEqual(
+            inventoryOperations.length,
+            operationConfigs.length,
+            `Expected ${operationConfigs.length} inventory operations for farm ${farm.id}, got ${JSON.stringify(
+                inventoryOperations.map((operation) => ({
+                    id: operation.id,
+                    entityId: operation.entityId,
+                    scheduledDate: operation.scheduledDate?.toISOString(),
+                    timestamp: operation.timestamp.toISOString(),
+                })),
+            )}`,
+        );
         assert.deepStrictEqual(
             inventoryOperations.map((operation) =>
                 operation.scheduledDate?.toISOString(),
@@ -454,6 +481,13 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
                 (operation) => operation.farmId === farm.id,
             ),
         );
+        if (farm.id === preexistingFarm.id) {
+            assert.ok(
+                inventoryOperations.some(
+                    (operation) => operation.id === preexistingOperationId,
+                ),
+            );
+        }
     }
 
     const [firstRun] = await listAutomationRuns({
@@ -475,7 +509,8 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
 
     assert.strictEqual(replayResult.status, 'skipped');
     for (const farm of activeFarms) {
-        const farmOperations = await getFarmAcceptedOperations(farm.id, {
+        const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+            farmId: farm.id,
             from: referenceDate,
             to: addUtcDays(referenceDate, 3),
         });

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -9,14 +9,18 @@ import {
     createAutomationDefinition,
     createAutomationRun,
     createEvent,
+    createFarm,
     createOperation,
     enqueueAutomationRunsFromDomainEvents,
+    enqueueAutomationRunsFromSchedules,
     ensureDefaultAutomationDefinitions,
     executeAutomationRun,
     FREE_WATERING_OPERATION_ID,
     getAutomationEventCursor,
     getAutomationRunWithSteps,
     getEvents,
+    getFarmAcceptedOperations,
+    getFarms,
     getOperations,
     getRaisedBed,
     knownEvents,
@@ -29,6 +33,7 @@ import {
     seasonalSowedWateringAutomationGraph,
     startAutomationRun,
     storage,
+    updateAutomationDefinition,
     upsertRaisedBedField,
     validateAutomationGraph,
 } from '@gredice/storage';
@@ -83,6 +88,12 @@ async function getScheduledFreeWateringDates(
         )
         .map((operation) => operation.scheduledDate?.toISOString())
         .sort();
+}
+
+function addUtcDays(date: Date, days: number) {
+    const nextDate = new Date(date);
+    nextDate.setUTCDate(nextDate.getUTCDate() + days);
+    return nextDate;
 }
 
 test('automation definitions persist graph trigger metadata and event-run idempotency', async () => {
@@ -259,6 +270,223 @@ test('automation graph validation waits for all incoming dependencies', () => {
             'queue-seasonal-waterings',
         ],
     );
+});
+
+test('monthly schedule automation enqueues once per configured period', async () => {
+    createTestDb();
+    const graph = {
+        nodes: [
+            {
+                id: 'trigger',
+                moduleKey: automationModuleKeys.triggerScheduleMonthly,
+                kind: 'trigger' as const,
+                position: { x: 0, y: 0 },
+                config: {
+                    dayOfMonth: 1,
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'log',
+                moduleKey: automationModuleKeys.actionLog,
+                kind: 'action' as const,
+                position: { x: 280, y: 0 },
+                config: {
+                    message: 'Monthly schedule reached log action.',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-log',
+                source: 'trigger',
+                target: 'log',
+            },
+        ],
+    };
+    const definition = await createAutomationDefinition({
+        key: 'test.monthly-schedule',
+        name: 'Monthly schedule',
+        status: 'enabled',
+        graph,
+    });
+
+    const firstResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-01T08:00:00.000Z'),
+    });
+    const duplicateResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-01T09:00:00.000Z'),
+    });
+    const offDayResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-02T08:00:00.000Z'),
+    });
+
+    assert.strictEqual(firstResult.enqueuedRuns, 1);
+    assert.strictEqual(duplicateResult.enqueuedRuns, 0);
+    assert.strictEqual(offDayResult.enqueuedRuns, 0);
+
+    const runs = await listAutomationRuns({
+        automationDefinitionId: definition.id,
+    });
+    assert.strictEqual(runs.length, 1);
+    assert.strictEqual(runs[0]?.source, 'schedule');
+    assert.strictEqual(
+        runs[0]?.sourceAggregateId,
+        'trigger.scheduleMonthly:Europe/Zagreb:2026-06:day-1',
+    );
+    for (const run of runs) {
+        await completeAutomationRun({
+            id: run.id,
+            status: 'skipped',
+            output: { testCleanup: true },
+        });
+    }
+    await updateAutomationDefinition(definition.id, { status: 'disabled' });
+});
+
+test('monthly farm inventory automation creates accepted scheduled farm tasks', async () => {
+    createTestDb();
+    await createFarm({
+        name: 'Automation Inventory Farm A',
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    await createFarm({
+        name: 'Automation Inventory Farm B',
+        latitude: 46.1,
+        longitude: 16.2,
+    });
+    const activeFarms = (await getFarms()).filter((farm) => !farm.isDeleted);
+    const referenceDate = new Date('2026-07-01T08:00:00.000Z');
+    const operationConfigs = [
+        {
+            entityId: 9_910_001,
+            entityTypeName: 'operation',
+            scheduledInDays: 0,
+        },
+        {
+            entityId: 9_910_002,
+            entityTypeName: 'operation',
+            scheduledInDays: 2,
+        },
+    ];
+    const graph = {
+        nodes: [
+            {
+                id: 'trigger',
+                moduleKey: automationModuleKeys.triggerScheduleMonthly,
+                kind: 'trigger' as const,
+                position: { x: 0, y: 0 },
+                config: {
+                    dayOfMonth: 1,
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-inventory-operations',
+                moduleKey:
+                    automationModuleKeys.actionCreateFarmInventoryOperations,
+                kind: 'action' as const,
+                position: { x: 300, y: 0 },
+                config: {
+                    operations: operationConfigs,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-create-inventory-operations',
+                source: 'trigger',
+                target: 'create-inventory-operations',
+            },
+        ],
+    };
+    const definition = await createAutomationDefinition({
+        key: 'test.monthly-farm-inventory',
+        name: 'Monthly farm inventory',
+        status: 'enabled',
+        graph,
+    });
+
+    const enqueueResult = await enqueueAutomationRunsFromSchedules({
+        now: referenceDate,
+    });
+    assert.strictEqual(enqueueResult.enqueuedRuns, 1);
+
+    const processResult = await processDueAutomationRuns({
+        limit: 10,
+        lockedBy: 'automations-test',
+    });
+    assert.strictEqual(processResult.succeeded, 1);
+
+    const expectedScheduledDates = operationConfigs.map((operationConfig) =>
+        addUtcDays(
+            referenceDate,
+            operationConfig.scheduledInDays,
+        ).toISOString(),
+    );
+    for (const farm of activeFarms) {
+        const farmOperations = await getFarmAcceptedOperations(farm.id, {
+            from: referenceDate,
+            to: addUtcDays(referenceDate, 3),
+        });
+        const inventoryOperations = farmOperations
+            .filter((operation) =>
+                operationConfigs.some(
+                    (operationConfig) =>
+                        operationConfig.entityId === operation.entityId,
+                ),
+            )
+            .sort((left, right) => left.entityId - right.entityId);
+
+        assert.strictEqual(inventoryOperations.length, operationConfigs.length);
+        assert.deepStrictEqual(
+            inventoryOperations.map((operation) =>
+                operation.scheduledDate?.toISOString(),
+            ),
+            expectedScheduledDates,
+        );
+        assert.ok(
+            inventoryOperations.every((operation) => operation.isAccepted),
+        );
+        assert.ok(
+            inventoryOperations.every(
+                (operation) => operation.farmId === farm.id,
+            ),
+        );
+    }
+
+    const [firstRun] = await listAutomationRuns({
+        automationDefinitionId: definition.id,
+    });
+    assert.ok(firstRun);
+    const replayRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'replay',
+        input: firstRun.input,
+    });
+    assert.ok(replayRun);
+    const startedReplay = await startAutomationRun(replayRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedReplay);
+
+    const replayResult = await executeAutomationRun(startedReplay);
+
+    assert.strictEqual(replayResult.status, 'skipped');
+    for (const farm of activeFarms) {
+        const farmOperations = await getFarmAcceptedOperations(farm.id, {
+            from: referenceDate,
+            to: addUtcDays(referenceDate, 3),
+        });
+        const inventoryOperations = farmOperations.filter((operation) =>
+            operationConfigs.some(
+                (operationConfig) =>
+                    operationConfig.entityId === operation.entityId,
+            ),
+        );
+        assert.strictEqual(inventoryOperations.length, operationConfigs.length);
+    }
 });
 
 test('default sowed automation queues seasonal watering operations through executor', async () => {


### PR DESCRIPTION
## Summary
- add monthly scheduled automation support, including schedule-run enqueueing and execution metadata
- add a farm inventory operations action that creates scheduled accepted farm tasks from configured operations JSON
- dedupe farm inventory tasks by scheduled operation date so manually-created or earlier accepted tasks are not duplicated
- refresh the admin automation detail UI around a larger workflow canvas with slide-out panels for details, modules, module settings, and testing
- replace the inline run log with `Izvršavanja`, status filtering, and row-click run details

## Testing
- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `pnpm --filter app exec biome check --write app/admin/automations/AutomationFlowEditor.tsx app/admin/automations/AutomationTestPanel.tsx app/admin/automations/AutomationRunsTable.tsx app/admin/automations/AutomationSlidePanel.tsx 'app/admin/automations/[automationId]/page.tsx'`
- `pnpm --filter @gredice/storage exec biome check --write src/automations/modules.ts src/repositories/operationsRepo.ts tests/automationsRepo.node.spec.ts`
- `pnpm --filter app build`
- `git diff --check`

## Notes
- Browser smoke reached `/admin/automations/1` locally, but local auth redirected to the login dialog.
- Full app `tsc --noEmit` still reports existing unrelated errors outside the touched automation files; filtering the output showed no remaining errors for the automation files touched in this PR.
