### PR TITLE
Refine raised-bed field card controls and Storybook preview

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
@@ -19,6 +19,7 @@ type RaisedBedFieldLocationSelectorProps = {
     sowingLocation: RaisedBedFieldSowingLocation;
     currentLocation: 'greenhouse' | 'raisedBed';
     greenhouseCurrentLocationEligible: boolean;
+    className?: string;
 };
 
 const locationLabels = {
@@ -41,6 +42,7 @@ export function RaisedBedFieldLocationSelector({
     sowingLocation,
     currentLocation,
     greenhouseCurrentLocationEligible,
+    className,
 }: RaisedBedFieldLocationSelectorProps) {
     const router = useRouter();
     const [isPending, startTransition] = useTransition();
@@ -93,6 +95,7 @@ export function RaisedBedFieldLocationSelector({
                     }
                     startDecorator={<span aria-hidden>{current.icon}</span>}
                     title="Promijeni trenutnu lokaciju biljke"
+                    className={className}
                     onClick={() => {}}
                 >
                     {current.label}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector.tsx
@@ -11,6 +11,7 @@ type RaisedBedFieldPlantSortSelectorProps = {
     plantSortId?: number | null;
     plantSorts: PlantSortData[];
     variant?: 'outlined' | 'plain';
+    className?: string;
 };
 
 export function RaisedBedFieldPlantSortSelector({
@@ -20,6 +21,7 @@ export function RaisedBedFieldPlantSortSelector({
     plantSortId,
     plantSorts,
     variant = 'outlined',
+    className,
 }: RaisedBedFieldPlantSortSelectorProps) {
     const items = plantSorts
         .map((sort) => ({
@@ -67,6 +69,7 @@ export function RaisedBedFieldPlantSortSelector({
             items={items}
             disabled={items.length === 0}
             variant={variant}
+            className={className}
         />
     );
 }

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector.tsx
@@ -9,14 +9,20 @@ export function RaisedBedFieldPlantStatusSelector({
     raisedBedId,
     positionIndex,
     status,
+    variant = 'outlined',
+    className,
 }: {
     raisedBedId: number;
     positionIndex: number;
     status: string;
+    variant?: 'outlined' | 'plain';
+    className?: string;
 }) {
     return (
         <SelectItems
             value={status}
+            variant={variant}
+            className={className}
             onValueChange={(newValue) => {
                 raisedBedFieldUpdatePlant({
                     raisedBedId,

--- a/apps/app/components/raised-beds/MoveRaisedBedFieldPlantModal.tsx
+++ b/apps/app/components/raised-beds/MoveRaisedBedFieldPlantModal.tsx
@@ -8,8 +8,10 @@ import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { useEffect, useState, useTransition } from 'react';
 import { moveRaisedBedFieldPlantAction } from '../../app/(actions)/raisedBedFieldsActions';
+import { raisedBedFieldCardButtonClassName } from './RaisedBedFieldCard';
 
 type MoveRaisedBedFieldPlantOption = {
     value: string;
@@ -79,9 +81,11 @@ export function MoveRaisedBedFieldPlantModal({
                         type="button"
                         title="Premjesti biljku"
                         disabled={targetOptions.length === 0}
-                        className="inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full bg-background/90 px-2 py-1 text-xs font-semibold text-foreground shadow transition-opacity hover:opacity-80 disabled:pointer-events-none disabled:opacity-50"
+                        className={cx(
+                            'inline-flex min-w-0 shrink-0 items-center rounded-full px-2 py-1 text-xs font-semibold transition-opacity hover:opacity-80 disabled:pointer-events-none disabled:opacity-50',
+                            raisedBedFieldCardButtonClassName,
+                        )}
                     >
-                        <Replace aria-hidden className="size-3.5 shrink-0" />#
                         {sourcePositionIndex + 1}
                     </button>
                 ) : triggerVariant === 'icon' ? (

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -1,0 +1,95 @@
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+
+type RaisedBedFieldCardGridProps = {
+    children: ReactNode;
+    className?: string;
+};
+
+export const raisedBedFieldCardSelectClassName =
+    '[&_[role=combobox]]:h-8 [&_[role=combobox]]:!bg-background/80 [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:ring-1 [&_[role=combobox]]:ring-border/70 [&_[role=combobox]]:backdrop-blur-md [&_[role=combobox]]:hover:!bg-background/90';
+
+export const raisedBedFieldCardButtonClassName =
+    '!bg-background/80 text-foreground ring-1 ring-border/70 backdrop-blur-md hover:!bg-background/90 hover:text-foreground';
+
+export const raisedBedFieldCardChipClassName = 'backdrop-blur-md';
+
+export function RaisedBedFieldCardGrid({
+    children,
+    className,
+}: RaisedBedFieldCardGridProps) {
+    return (
+        <div
+            className={cx(
+                'grid grid-cols-3 gap-0 overflow-hidden rounded-lg border-r border-b',
+                className,
+            )}
+        >
+            {children}
+        </div>
+    );
+}
+
+type RaisedBedFieldCardProps = {
+    datesControl?: ReactNode;
+    fieldBadge: ReactNode;
+    historyControl?: ReactNode;
+    image?: ReactNode;
+    locationControl?: ReactNode;
+    plantSortControl: ReactNode;
+    statusControl?: ReactNode;
+    className?: string;
+};
+
+export function RaisedBedFieldCard({
+    datesControl,
+    fieldBadge,
+    historyControl,
+    image,
+    locationControl,
+    plantSortControl,
+    statusControl,
+    className,
+}: RaisedBedFieldCardProps) {
+    return (
+        <div
+            className={cx(
+                'relative flex h-full min-h-56 flex-col overflow-hidden border-l border-t bg-muted/40',
+                className,
+            )}
+        >
+            {image ?? (
+                <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+                    <Typography level="body2">Nema slike</Typography>
+                </div>
+            )}
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-background/55 via-background/10 to-background/70" />
+            <div className="relative z-10 flex items-start justify-between gap-1.5 p-2">
+                <div className="min-w-0">{locationControl}</div>
+                <div>{fieldBadge}</div>
+            </div>
+            {historyControl && (
+                <div className="absolute left-2 top-11 z-10">
+                    {historyControl}
+                </div>
+            )}
+            <div className="relative z-10 mt-auto flex flex-col gap-0.5 px-2 pb-2 pt-8">
+                {plantSortControl}
+                {(statusControl || datesControl) && (
+                    <Stack spacing={0.5}>
+                        {statusControl ? (
+                            <div>
+                                {statusControl}
+                                {datesControl}
+                            </div>
+                        ) : (
+                            <div>{datesControl}</div>
+                        )}
+                    </Stack>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/app/components/raised-beds/RaisedBedFieldDatesPopover.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldDatesPopover.tsx
@@ -4,6 +4,7 @@ import { Button } from '@gredice/ui/Button';
 import { Calendar } from '@gredice/ui/icons';
 import { Popper } from '@gredice/ui/Popper';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { useEffect, useState } from 'react';
 
 export type RaisedBedFieldDateItem = {
@@ -15,6 +16,7 @@ export type RaisedBedFieldDateItem = {
 
 type RaisedBedFieldDatesPopoverProps = {
     items: RaisedBedFieldDateItem[];
+    className?: string;
 };
 
 function parseDate(value: string | null) {
@@ -47,6 +49,7 @@ function formatShortDate(value: string | null) {
 
 export function RaisedBedFieldDatesPopover({
     items,
+    className,
 }: RaisedBedFieldDatesPopoverProps) {
     const [mounted, setMounted] = useState(false);
     const currentItem = items.find((item) => item.current);
@@ -73,7 +76,10 @@ export function RaisedBedFieldDatesPopover({
                     startDecorator={<Calendar className="size-3.5" />}
                     title="Prikaži datume biljke"
                     variant="plain"
-                    className="h-10 shrink-0 px-2 text-muted-foreground hover:text-foreground"
+                    className={cx(
+                        'h-8 shrink-0 justify-start px-2 text-muted-foreground hover:text-foreground',
+                        className,
+                    )}
                 >
                     {triggerLabel}
                 </Button>

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -6,12 +6,18 @@ import {
 } from '@gredice/storage';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { RaisedBedFieldLocationSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector';
 import { RaisedBedFieldPlantSortSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector';
 import { RaisedBedFieldPlantStatusSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
 import { MoveRaisedBedFieldPlantModal } from './MoveRaisedBedFieldPlantModal';
+import {
+    RaisedBedFieldCard,
+    RaisedBedFieldCardGrid,
+    raisedBedFieldCardButtonClassName,
+    raisedBedFieldCardChipClassName,
+    raisedBedFieldCardSelectClassName,
+} from './RaisedBedFieldCard';
 import {
     type RaisedBedFieldDateItem,
     RaisedBedFieldDatesPopover,
@@ -174,8 +180,8 @@ export async function RaisedBedFieldsTable({
     }
 
     return (
-        <Stack spacing={6}>
-            <div className="grid gap-3 grid-cols-3">
+        <Stack spacing={0}>
+            <RaisedBedFieldCardGrid>
                 {orderedPositions.map((positionIndex) => {
                     const positionPlantCycles = [
                         ...(plantCyclesByPosition.get(positionIndex) ?? []),
@@ -294,7 +300,7 @@ export async function RaisedBedFieldsTable({
                         />
                     );
                 })}
-            </div>
+            </RaisedBedFieldCardGrid>
         </Stack>
     );
 }
@@ -379,94 +385,91 @@ function RaisedBedFieldTile({
         },
     ];
 
+    const image =
+        field?.active && sort ? (
+            <PlantOrSortImage
+                plantSort={sort}
+                alt={plantLabel}
+                fill
+                className="object-cover"
+                sizes="(min-width: 1536px) 14rem, (min-width: 1280px) 16rem, (min-width: 768px) 18rem, 50vw"
+            />
+        ) : undefined;
+    const locationControl =
+        field?.active && field.plantSortId ? (
+            <RaisedBedFieldLocationSelector
+                raisedBedId={raisedBedId}
+                positionIndex={positionIndex}
+                sowingLocation={field.sowingLocation}
+                currentLocation={getCurrentLocation(field)}
+                greenhouseCurrentLocationEligible={canFieldCurrentlyBeInGreenhouse(
+                    field,
+                )}
+                className={raisedBedFieldCardChipClassName}
+            />
+        ) : undefined;
+    const fieldBadge =
+        field?.active && activePlantCycle ? (
+            <MoveRaisedBedFieldPlantModal
+                raisedBedId={raisedBedId}
+                sourcePositionIndex={positionIndex}
+                sourcePlantPlaceEventId={activePlantCycle.plantPlaceEventId}
+                sourcePlantLabel={plantLabel}
+                targetOptions={moveTargetOptions}
+                triggerVariant="fieldIndex"
+            />
+        ) : (
+            <div
+                className={`rounded-full px-2 py-1 text-xs font-semibold ${raisedBedFieldCardButtonClassName}`}
+            >
+                {positionIndex + 1}
+            </div>
+        );
+    const historyControl =
+        removedFields.length > 0 ? (
+            <RaisedBedRemovedFieldsModal
+                raisedBedId={raisedBedId}
+                fields={removedFields}
+                targetOptions={moveTargetOptions}
+            />
+        ) : undefined;
+    const plantSortControl = (
+        <RaisedBedFieldPlantSortSelector
+            raisedBedId={raisedBedId}
+            positionIndex={positionIndex}
+            status={field?.plantStatus ?? null}
+            plantSortId={field?.plantSortId}
+            plantSorts={plantSorts}
+            variant="plain"
+            className={raisedBedFieldCardSelectClassName}
+        />
+    );
+    const statusControl =
+        field?.active && field.plantStatus ? (
+            <RaisedBedFieldPlantStatusSelector
+                raisedBedId={raisedBedId}
+                positionIndex={positionIndex}
+                status={field.plantStatus}
+                variant="plain"
+                className={raisedBedFieldCardSelectClassName}
+            />
+        ) : undefined;
+    const datesControl = field?.active ? (
+        <RaisedBedFieldDatesPopover
+            items={dateItems}
+            className={raisedBedFieldCardButtonClassName}
+        />
+    ) : undefined;
+
     return (
-        <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border bg-background shadow-xs">
-            <div className="relative min-h-52 flex-1 bg-muted/40">
-                {field?.active && sort ? (
-                    <PlantOrSortImage
-                        plantSort={sort}
-                        alt={plantLabel}
-                        fill
-                        className="object-cover"
-                        sizes="(min-width: 1536px) 14rem, (min-width: 1280px) 16rem, (min-width: 768px) 18rem, 50vw"
-                    />
-                ) : (
-                    <div className="flex h-full items-center justify-center text-muted-foreground">
-                        <Typography level="body2">Nema slike</Typography>
-                    </div>
-                )}
-                {removedFields.length > 0 && (
-                    <div className="absolute bottom-2 left-2">
-                        <RaisedBedRemovedFieldsModal
-                            raisedBedId={raisedBedId}
-                            fields={removedFields}
-                            targetOptions={moveTargetOptions}
-                        />
-                    </div>
-                )}
-                {field?.active && field.plantSortId && (
-                    <div className="absolute top-2 left-2">
-                        <RaisedBedFieldLocationSelector
-                            raisedBedId={raisedBedId}
-                            positionIndex={positionIndex}
-                            sowingLocation={field.sowingLocation}
-                            currentLocation={getCurrentLocation(field)}
-                            greenhouseCurrentLocationEligible={canFieldCurrentlyBeInGreenhouse(
-                                field,
-                            )}
-                        />
-                    </div>
-                )}
-                <div className="absolute bottom-2 right-2">
-                    {field?.active && activePlantCycle ? (
-                        <MoveRaisedBedFieldPlantModal
-                            raisedBedId={raisedBedId}
-                            sourcePositionIndex={positionIndex}
-                            sourcePlantPlaceEventId={
-                                activePlantCycle.plantPlaceEventId
-                            }
-                            sourcePlantLabel={plantLabel}
-                            targetOptions={moveTargetOptions}
-                            triggerVariant="fieldIndex"
-                        />
-                    ) : (
-                        <div className="rounded-full bg-background/90 px-2 py-1 text-xs font-semibold shadow">
-                            #{positionIndex + 1}
-                        </div>
-                    )}
-                </div>
-            </div>
-            <div className="flex flex-col gap-2 px-2 pb-2 pt-0">
-                <RaisedBedFieldPlantSortSelector
-                    raisedBedId={raisedBedId}
-                    positionIndex={positionIndex}
-                    status={field?.plantStatus ?? null}
-                    plantSortId={field?.plantSortId}
-                    plantSorts={plantSorts}
-                    variant="plain"
-                />
-                {field?.active && (
-                    <Stack spacing={2}>
-                        {field.plantStatus && (
-                            <div className="flex items-center gap-2">
-                                <div className="min-w-0 flex-1">
-                                    <RaisedBedFieldPlantStatusSelector
-                                        raisedBedId={raisedBedId}
-                                        positionIndex={positionIndex}
-                                        status={field.plantStatus}
-                                    />
-                                </div>
-                                <RaisedBedFieldDatesPopover items={dateItems} />
-                            </div>
-                        )}
-                        {!field.plantStatus && (
-                            <div className="flex justify-end">
-                                <RaisedBedFieldDatesPopover items={dateItems} />
-                            </div>
-                        )}
-                    </Stack>
-                )}
-            </div>
-        </div>
+        <RaisedBedFieldCard
+            image={image}
+            locationControl={locationControl}
+            fieldBadge={fieldBadge}
+            historyControl={historyControl}
+            plantSortControl={plantSortControl}
+            statusControl={statusControl}
+            datesControl={datesControl}
+        />
     );
 }

--- a/apps/app/components/raised-beds/RaisedBedRemovedFieldsModal.tsx
+++ b/apps/app/components/raised-beds/RaisedBedRemovedFieldsModal.tsx
@@ -10,6 +10,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { MoveRaisedBedFieldPlantModal } from './MoveRaisedBedFieldPlantModal';
+import { raisedBedFieldCardButtonClassName } from './RaisedBedFieldCard';
 
 export type RemovedFieldDetails = {
     id: number;
@@ -70,6 +71,7 @@ export function RaisedBedRemovedFieldsModal({
                     variant="plain"
                     size="sm"
                     title={`Povijest (${fields.length})`}
+                    className={raisedBedFieldCardButtonClassName}
                 >
                     <Timer className="size-4 shrink-0" />
                 </IconButton>

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -10,7 +10,10 @@ const localDomain = 'storybook.dev.gredice.test';
 
 const config: StorybookConfig = {
     stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(ts|tsx)'],
-    staticDirs: ['../public'],
+    staticDirs: [
+        '../public',
+        { from: '../../www/public/assets/plants', to: '/assets/plants' },
+    ],
     addons: [
         '@storybook/addon-docs',
         '@storybook/addon-a11y',
@@ -30,6 +33,7 @@ const config: StorybookConfig = {
                 '../../packages/ui/src/**/*.tsx',
                 '../../packages/game/src/hud/**/*.tsx',
                 '../app/components/admin/cards/FactCard.tsx',
+                '../app/components/raised-beds/RaisedBedFieldCard.tsx',
                 '../app/components/shared/ServerActionButton.tsx',
                 '../app/components/shared/ServerActionIconButton.tsx',
                 '../app/components/shared/fields/Field.tsx',

--- a/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
@@ -1,0 +1,291 @@
+import {
+    RaisedBedFieldCard,
+    RaisedBedFieldCardGrid,
+    raisedBedFieldCardButtonClassName,
+    raisedBedFieldCardChipClassName,
+    raisedBedFieldCardSelectClassName,
+} from '@apps/app/components/raised-beds/RaisedBedFieldCard';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Calendar, Timer } from '@gredice/ui/icons';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { cx } from '@gredice/ui/utils';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+type MockField = {
+    id: string;
+    number: number;
+    plant: string;
+    status?: string;
+    date?: string;
+    imageSrc?: string;
+    location?: 'greenhouse' | 'raisedBed';
+    hasHistory?: boolean;
+};
+
+const mockFields: MockField[] = [
+    {
+        id: 'tomato-saint',
+        number: 18,
+        plant: 'Rajcica saint...',
+        status: 'firstFruitSet',
+        date: '22. 05.',
+        imageSrc: '/assets/plants/tomato_mature.png',
+        location: 'greenhouse',
+        hasHistory: true,
+    },
+    {
+        id: 'tomato-mini-a',
+        number: 17,
+        plant: 'Rajcica mini...',
+        status: 'firstFruitSet',
+        date: '22. 05.',
+        imageSrc: '/assets/plants/tomato_growing.png',
+        location: 'greenhouse',
+    },
+    {
+        id: 'tomato-mini-b',
+        number: 16,
+        plant: 'Rajcica mini...',
+        status: 'firstFlowers',
+        date: '22. 05.',
+        imageSrc: '/assets/plants/tomato_growing.png',
+        location: 'greenhouse',
+    },
+    {
+        id: 'chili',
+        number: 15,
+        plant: 'Cili De...',
+        status: 'sprouted',
+        date: '22. 05.',
+        imageSrc: '/assets/plants/bellpepper_mature.png',
+        location: 'greenhouse',
+    },
+    {
+        id: 'bean-yellow',
+        number: 14,
+        plant: 'Grah mahuna...',
+        status: 'sprouted',
+        date: '29. 05.',
+        imageSrc: '/assets/plants/bean_mature.png',
+        location: 'raisedBed',
+    },
+    {
+        id: 'bean-green',
+        number: 13,
+        plant: 'Grah mahuna...',
+        status: 'sprouted',
+        date: '29. 05.',
+        imageSrc: '/assets/plants/greenbean_mature.png',
+        location: 'raisedBed',
+    },
+];
+
+const plantItems = mockFields.map((field) => ({
+    value: field.id,
+    label: field.plant,
+}));
+
+const statusItems = [
+    { value: 'new', label: 'Novo', icon: '🆕' },
+    { value: 'planned', label: 'Planirano', icon: '🗓️' },
+    { value: 'sprouted', label: 'Proklijalo', icon: '🌱' },
+    { value: 'firstFlowers', label: 'Prvi cvjetovi', icon: '🌸' },
+    { value: 'firstFruitSet', label: 'Prvi plodovi', icon: '🍅' },
+    { value: 'ready', label: 'Spremno', icon: '🥕' },
+];
+
+function FieldBadge({ number }: { number: number }) {
+    return (
+        <button
+            type="button"
+            title="Premjesti biljku"
+            className={cx(
+                'inline-flex min-w-0 shrink-0 items-center rounded-full px-2 py-1 text-xs font-semibold transition-opacity hover:opacity-80',
+                raisedBedFieldCardButtonClassName,
+            )}
+        >
+            {number}
+        </button>
+    );
+}
+
+function LocationChip({ location }: { location?: MockField['location'] }) {
+    if (!location) {
+        return null;
+    }
+
+    const isGreenhouse = location === 'greenhouse';
+
+    return (
+        <Chip
+            size="sm"
+            variant="solid"
+            color={isGreenhouse ? 'success' : 'neutral'}
+            startDecorator={
+                <span aria-hidden>{isGreenhouse ? '🏡' : '🪴'}</span>
+            }
+            title="Promijeni trenutnu lokaciju biljke"
+            className={raisedBedFieldCardChipClassName}
+        >
+            {isGreenhouse ? 'Staklenik' : 'Gredica'}
+        </Chip>
+    );
+}
+
+function HistoryButton() {
+    return (
+        <IconButton
+            variant="plain"
+            size="sm"
+            title="Povijest (2)"
+            className={raisedBedFieldCardButtonClassName}
+        >
+            <Timer className="size-4 shrink-0" />
+        </IconButton>
+    );
+}
+
+function PlantImage({ alt, src }: { alt: string; src: string }) {
+    return (
+        // biome-ignore lint/performance/noImgElement: Storybook serves stable local plant assets directly.
+        <img
+            alt={alt}
+            src={src}
+            className="absolute inset-0 size-full object-cover"
+        />
+    );
+}
+
+function PlantSortSelect({ field }: { field: MockField }) {
+    return (
+        <SelectItems
+            placeholder="Odaberi biljku"
+            value={field.imageSrc ? field.id : ''}
+            items={plantItems}
+            onValueChange={() => {}}
+            variant="plain"
+            className={raisedBedFieldCardSelectClassName}
+        />
+    );
+}
+
+function StatusSelect({ field }: { field: MockField }) {
+    if (!field.status) {
+        return undefined;
+    }
+
+    return (
+        <SelectItems
+            value={field.status}
+            items={statusItems}
+            onValueChange={() => {}}
+            variant="plain"
+            className={raisedBedFieldCardSelectClassName}
+        />
+    );
+}
+
+function DatesButton({ date }: { date?: string }) {
+    if (!date) {
+        return undefined;
+    }
+
+    return (
+        <Button
+            color="neutral"
+            size="sm"
+            startDecorator={<Calendar className="size-3.5" />}
+            title="Prikazi datume biljke"
+            variant="plain"
+            className={cx(
+                'h-8 shrink-0 justify-start px-2 text-muted-foreground hover:text-foreground',
+                raisedBedFieldCardButtonClassName,
+            )}
+        >
+            {date}
+        </Button>
+    );
+}
+
+function MockRaisedBedFieldCard({ field }: { field: MockField }) {
+    return (
+        <RaisedBedFieldCard
+            image={
+                field.imageSrc ? (
+                    <PlantImage alt={field.plant} src={field.imageSrc} />
+                ) : undefined
+            }
+            locationControl={
+                field.location ? (
+                    <LocationChip location={field.location} />
+                ) : undefined
+            }
+            fieldBadge={<FieldBadge number={field.number} />}
+            historyControl={field.hasHistory ? <HistoryButton /> : undefined}
+            plantSortControl={<PlantSortSelect field={field} />}
+            statusControl={
+                field.status ? <StatusSelect field={field} /> : undefined
+            }
+            datesControl={
+                field.date ? <DatesButton date={field.date} /> : undefined
+            }
+        />
+    );
+}
+
+const meta = {
+    title: 'apps/app/RaisedBeds/FieldCard',
+    component: RaisedBedFieldCard,
+    tags: ['autodocs'],
+    args: {
+        fieldBadge: <FieldBadge number={18} />,
+        plantSortControl: <PlantSortSelect field={mockFields[0]} />,
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Raised bed field cards show plant imagery with transparent admin controls for compact field management.',
+            },
+        },
+    },
+    render: () => (
+        <div className="w-40">
+            <MockRaisedBedFieldCard field={mockFields[0]} />
+        </div>
+    ),
+} satisfies Meta<typeof RaisedBedFieldCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FieldGrid: Story = {
+    render: () => (
+        <div className="w-[462px] max-w-[calc(100vw-3rem)]">
+            <RaisedBedFieldCardGrid>
+                {mockFields.map((field) => (
+                    <MockRaisedBedFieldCard key={field.id} field={field} />
+                ))}
+            </RaisedBedFieldCardGrid>
+        </div>
+    ),
+};
+
+export const EmptyField: Story = {
+    render: () => (
+        <div className="w-40">
+            <MockRaisedBedFieldCard
+                field={{
+                    id: 'empty',
+                    number: 12,
+                    plant: 'Prazno polje',
+                }}
+            />
+        </div>
+    ),
+};

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -42,6 +42,7 @@
         "../../packages/game/src/hud/**/*.tsx",
         "../../packages/game/src/utils/raisedBedFields.ts",
         "../app/components/admin/cards/FactCard.tsx",
+        "../app/components/raised-beds/RaisedBedFieldCard.tsx",
         "../app/components/shared/ServerActionButton.tsx",
         "../app/components/shared/ServerActionIconButton.tsx",
         "../app/components/shared/fields/Field.tsx",


### PR DESCRIPTION
## Summary
- Added a shared raised-bed field card shell and applied it to the admin table so the visual treatment stays consistent.
- Gave the card controls soft translucent backgrounds with blur, and tightened spacing between the plant, status, date, and history controls.
- Added a Storybook field-card story with local plant assets so the new look can be inspected without auth.

## Testing
- `pnpm typecheck --filter app`
- `pnpm typecheck --filter storybook`
- Biome checks on the touched app and Storybook files
- Local Storybook visual inspection of `apps-app-raisedbeds-fieldcard--field-grid`