### PR TITLE
Add historical weather date to AI image analysis

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -64,6 +64,7 @@ import {
     AI_REQUEST_WEEKLY_LIMIT_PER_ACTIVE_RAISED_BED,
     type AiRequestKind,
     getRaisedBedImageAnalysisWeeklyLimit,
+    normalizeAnalysisReferenceDate,
     RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND,
     streamRaisedBedImageAnalysis,
     validateImageUrls,
@@ -88,6 +89,7 @@ const analyzeImageBodySchema = z
     .object({
         imageUrl: z.url().optional(),
         imageUrls: z.array(z.url()).min(1).optional(),
+        referenceDate: z.iso.datetime().optional(),
     })
     .refine((body) => Boolean(body.imageUrl || body.imageUrls?.length), {
         message: 'At least one image URL is required',
@@ -112,6 +114,10 @@ function normalizeAnalysisImageUrls(body: AnalyzeImageBody) {
           : [];
 
     return Array.from(new Set(imageUrls));
+}
+
+function getAnalysisReferenceDate(body: AnalyzeImageBody) {
+    return normalizeAnalysisReferenceDate(body.referenceDate);
 }
 
 const aiTextStreamResponseInit = {
@@ -2229,9 +2235,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
         authValidator(['user', 'admin']),
         async (context) => {
             const { gardenId, raisedBedId } = context.req.valid('param');
-            const imageUrls = normalizeAnalysisImageUrls(
-                context.req.valid('json'),
-            );
+            const body = context.req.valid('json');
+            const imageUrls = normalizeAnalysisImageUrls(body);
+            const referenceDate = getAnalysisReferenceDate(body);
             const firstImageUrl = imageUrls[0];
             if (!firstImageUrl) {
                 return context.json({ error: 'Image URL is required' }, 400);
@@ -2294,6 +2300,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     gardenId: gardenIdNumber,
                     raisedBed,
                     imageUrls,
+                    referenceDate,
                 },
                 async (analysis) => {
                     await createEvent(
@@ -2305,6 +2312,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                 imageUrls,
                                 model: analysis.model,
                                 analyzedAt: analysis.analyzedAt,
+                                referenceDate:
+                                    referenceDate?.toISOString() ?? undefined,
                                 accountId,
                                 aiRequestKind:
                                     RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND,
@@ -2794,9 +2803,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
         async (context) => {
             const { gardenId, raisedBedId, positionIndex } =
                 context.req.valid('param');
-            const imageUrls = normalizeAnalysisImageUrls(
-                context.req.valid('json'),
-            );
+            const body = context.req.valid('json');
+            const imageUrls = normalizeAnalysisImageUrls(body);
+            const referenceDate = getAnalysisReferenceDate(body);
             const firstImageUrl = imageUrls[0];
             if (!firstImageUrl) {
                 return context.json({ error: 'Image URL is required' }, 400);
@@ -2881,6 +2890,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     raisedBed,
                     positionIndex: positionIndexNumber,
                     imageUrls,
+                    referenceDate,
                 },
                 async (analysis) => {
                     await createEvent(
@@ -2892,6 +2902,8 @@ const app = new Hono<{ Variables: AuthVariables }>()
                                 imageUrls,
                                 model: analysis.model,
                                 analyzedAt: analysis.analyzedAt,
+                                referenceDate:
+                                    referenceDate?.toISOString() ?? undefined,
                                 accountId,
                                 aiRequestKind:
                                     RAISED_BED_IMAGE_ANALYSIS_REQUEST_KIND,

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
@@ -1,9 +1,31 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getRaisedBedImageAnalysisWeeklyLimit } from './raisedBedAiAnalysisService';
+import {
+    getRaisedBedImageAnalysisWeeklyLimit,
+    getWeatherHistoryDayRange,
+    normalizeAnalysisReferenceDate,
+} from './raisedBedAiAnalysisService';
 
 test('getRaisedBedImageAnalysisWeeklyLimit grants 5 requests per active raised bed', () => {
     assert.strictEqual(getRaisedBedImageAnalysisWeeklyLimit(0), 0);
     assert.strictEqual(getRaisedBedImageAnalysisWeeklyLimit(1), 5);
     assert.strictEqual(getRaisedBedImageAnalysisWeeklyLimit(3), 15);
+});
+
+test('normalizeAnalysisReferenceDate parses valid dates and rejects invalid values', () => {
+    const parsed = normalizeAnalysisReferenceDate('2026-05-12T12:00:00.000Z');
+
+    assert.strictEqual(parsed?.toISOString(), '2026-05-12T12:00:00.000Z');
+    assert.strictEqual(normalizeAnalysisReferenceDate('not-a-date'), null);
+    assert.strictEqual(normalizeAnalysisReferenceDate(null), null);
+});
+
+test('getWeatherHistoryDayRange resolves the Zagreb local weather day', () => {
+    const range = getWeatherHistoryDayRange(
+        new Date('2026-05-12T12:00:00.000Z'),
+    );
+
+    assert.strictEqual(range.date, '2026-05-12');
+    assert.strictEqual(range.from.toISOString(), '2026-05-11T22:00:00.000Z');
+    assert.strictEqual(range.to.toISOString(), '2026-05-12T21:59:59.999Z');
 });

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -1,8 +1,11 @@
+import { TZDate, tz } from '@date-fns/tz';
 import {
     getEntitiesFormatted,
     getOperations,
+    getWeatherHistory,
     grediceCached,
     grediceCacheKeys,
+    type SelectWeatherHistory,
 } from '@gredice/storage';
 import { streamText } from 'ai';
 import { validateHostedImageUrl } from '../http/safeUrls';
@@ -12,6 +15,7 @@ import { findClosestForecastEntry } from '../weather/weatherNowContract';
 const FORECAST_CACHE_TTL_SECONDS = 60 * 60;
 const RAISED_BED_FIELDS_PER_BLOCK = 9;
 const RAISED_BED_COLUMNS = 3;
+const WEATHER_CONTEXT_TIME_ZONE = 'Europe/Zagreb';
 const GREENHOUSE_SEEDLING_STATUSES = new Set([
     'pendingVerification',
     'sowed',
@@ -64,7 +68,21 @@ export function validateImageUrls(imageUrls: string[]): string | null {
     return null;
 }
 
-function daysSince(date: Date | string | null | undefined) {
+export function normalizeAnalysisReferenceDate(
+    date: Date | string | null | undefined,
+) {
+    if (!date) {
+        return null;
+    }
+
+    const dateValue = date instanceof Date ? date : new Date(date);
+    return Number.isNaN(dateValue.getTime()) ? null : dateValue;
+}
+
+function daysSince(
+    date: Date | string | null | undefined,
+    referenceDate = new Date(),
+) {
     if (!date) {
         return null;
     }
@@ -77,7 +95,7 @@ function daysSince(date: Date | string | null | undefined) {
     const oneDayMs = 1000 * 60 * 60 * 24;
     return Math.max(
         0,
-        Math.floor((Date.now() - dateValue.getTime()) / oneDayMs),
+        Math.floor((referenceDate.getTime() - dateValue.getTime()) / oneDayMs),
     );
 }
 
@@ -111,8 +129,41 @@ type WeatherDayContext = {
     windStrength: number;
 };
 
+type WeatherObservationContext = {
+    recordedAt: string;
+    minutesFromReference: number;
+    temperatureC: number | null;
+    rainMm: number;
+    symbol: number | null;
+    windDirection: string | null;
+    windSpeed: number;
+    rainy: number;
+    snowy: number;
+    cloudy: number;
+    foggy: number;
+    thundery: number;
+};
+
+type HistoricalWeatherContext = {
+    date: string;
+    timeZone: string;
+    from: string;
+    to: string;
+    observationCount: number;
+    closestObservation: WeatherObservationContext | null;
+    dailySummary: {
+        minTemperatureC: number | null;
+        maxTemperatureC: number | null;
+        totalRainMm: number;
+        maxWindSpeed: number;
+    } | null;
+    observations: WeatherObservationContext[];
+};
+
 type WeatherContext = {
     location: string;
+    referenceDate: string;
+    historical: HistoricalWeatherContext | null;
     now: {
         temperatureC: number | null;
         rainMm: number;
@@ -145,44 +196,204 @@ function isCurrentlyGreenhouseSeedling(field: {
     );
 }
 
-async function buildWeatherContext(): Promise<WeatherContext | null> {
-    try {
-        const forecast = await grediceCached(
-            grediceCacheKeys.forecastBjelovar,
-            getBjelovarForecast,
-            FORECAST_CACHE_TTL_SECONDS,
-        );
-        if (!forecast || forecast.length === 0) {
-            return null;
-        }
+function formatLocalDateKey(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
 
-        const closestEntry = findClosestForecastEntry(forecast, Date.now());
+    return `${year}-${month}-${day}`;
+}
 
-        return {
-            location: 'Bjelovar, HR',
-            now: closestEntry
-                ? {
-                      temperatureC: closestEntry.temperature,
-                      rainMm: closestEntry.rain,
-                      symbol: closestEntry.symbol,
-                      windDirection: closestEntry.windDirection,
-                      windStrength: closestEntry.windStrength,
-                  }
-                : null,
-            forecast: forecast.slice(0, 5).map((day) => ({
-                date: day.date,
-                minTemperatureC: day.minTemp,
-                maxTemperatureC: day.maxTemp,
-                rainMm: day.rain,
-                symbol: day.symbol,
-                windDirection: day.windDirection,
-                windStrength: day.windStrength,
-            })),
-        };
-    } catch (error) {
-        console.warn('Failed to load weather context for AI analysis:', error);
+export function getWeatherHistoryDayRange(referenceDate: Date) {
+    const localReferenceDate = tz(WEATHER_CONTEXT_TIME_ZONE)(referenceDate);
+    const start = new TZDate(
+        localReferenceDate.getFullYear(),
+        localReferenceDate.getMonth(),
+        localReferenceDate.getDate(),
+        0,
+        0,
+        0,
+        0,
+        WEATHER_CONTEXT_TIME_ZONE,
+    );
+    const nextStart = new TZDate(
+        localReferenceDate.getFullYear(),
+        localReferenceDate.getMonth(),
+        localReferenceDate.getDate() + 1,
+        0,
+        0,
+        0,
+        0,
+        WEATHER_CONTEXT_TIME_ZONE,
+    );
+
+    return {
+        date: formatLocalDateKey(localReferenceDate),
+        from: new Date(start.getTime()),
+        to: new Date(nextStart.getTime() - 1),
+    };
+}
+
+function toWeatherObservationContext(
+    row: SelectWeatherHistory,
+    referenceDate: Date,
+): WeatherObservationContext {
+    return {
+        recordedAt: row.recordedAt.toISOString(),
+        minutesFromReference: Math.round(
+            Math.abs(row.recordedAt.getTime() - referenceDate.getTime()) /
+                (1000 * 60),
+        ),
+        temperatureC: row.temperature,
+        rainMm: row.rain,
+        symbol: row.symbol,
+        windDirection: row.windDirection,
+        windSpeed: row.windSpeed,
+        rainy: row.rainy,
+        snowy: row.snowy,
+        cloudy: row.cloudy,
+        foggy: row.foggy,
+        thundery: row.thundery,
+    };
+}
+
+function buildWeatherDailySummary(rows: SelectWeatherHistory[]) {
+    if (rows.length === 0) {
         return null;
     }
+
+    const temperatures = rows
+        .map((row) => row.temperature)
+        .filter((value): value is number => typeof value === 'number');
+
+    return {
+        minTemperatureC:
+            temperatures.length > 0 ? Math.min(...temperatures) : null,
+        maxTemperatureC:
+            temperatures.length > 0 ? Math.max(...temperatures) : null,
+        totalRainMm: rows.reduce((sum, row) => sum + row.rain, 0),
+        maxWindSpeed: rows.reduce(
+            (maxWindSpeed, row) => Math.max(maxWindSpeed, row.windSpeed),
+            0,
+        ),
+    };
+}
+
+async function buildHistoricalWeatherContext(
+    referenceDate: Date,
+): Promise<HistoricalWeatherContext | null> {
+    const range = getWeatherHistoryDayRange(referenceDate);
+    const rows = await getWeatherHistory(range.from, range.to);
+    if (rows.length === 0) {
+        return {
+            date: range.date,
+            timeZone: WEATHER_CONTEXT_TIME_ZONE,
+            from: range.from.toISOString(),
+            to: range.to.toISOString(),
+            observationCount: 0,
+            closestObservation: null,
+            dailySummary: null,
+            observations: [],
+        };
+    }
+
+    const closestRow = rows.reduce((closest, row) => {
+        const closestDistance = Math.abs(
+            closest.recordedAt.getTime() - referenceDate.getTime(),
+        );
+        const rowDistance = Math.abs(
+            row.recordedAt.getTime() - referenceDate.getTime(),
+        );
+
+        return rowDistance < closestDistance ? row : closest;
+    }, rows[0]);
+    const observations = rows.map((row) =>
+        toWeatherObservationContext(row, referenceDate),
+    );
+
+    return {
+        date: range.date,
+        timeZone: WEATHER_CONTEXT_TIME_ZONE,
+        from: range.from.toISOString(),
+        to: range.to.toISOString(),
+        observationCount: rows.length,
+        closestObservation: toWeatherObservationContext(
+            closestRow,
+            referenceDate,
+        ),
+        dailySummary: buildWeatherDailySummary(rows),
+        observations,
+    };
+}
+
+async function buildForecastContext() {
+    const forecast = await grediceCached(
+        grediceCacheKeys.forecastBjelovar,
+        getBjelovarForecast,
+        FORECAST_CACHE_TTL_SECONDS,
+    );
+    const closestEntry = forecast
+        ? findClosestForecastEntry(forecast, Date.now())
+        : null;
+
+    return {
+        now: closestEntry
+            ? {
+                  temperatureC: closestEntry.temperature,
+                  rainMm: closestEntry.rain,
+                  symbol: closestEntry.symbol,
+                  windDirection: closestEntry.windDirection,
+                  windStrength: closestEntry.windStrength,
+              }
+            : null,
+        forecast: (forecast ?? []).slice(0, 5).map((day) => ({
+            date: day.date,
+            minTemperatureC: day.minTemp,
+            maxTemperatureC: day.maxTemp,
+            rainMm: day.rain,
+            symbol: day.symbol,
+            windDirection: day.windDirection,
+            windStrength: day.windStrength,
+        })),
+    };
+}
+
+async function buildWeatherContext(
+    referenceDate: Date,
+): Promise<WeatherContext> {
+    const [historyResult, forecastResult] = await Promise.allSettled([
+        buildHistoricalWeatherContext(referenceDate),
+        buildForecastContext(),
+    ]);
+
+    if (historyResult.status === 'rejected') {
+        console.warn(
+            'Failed to load historical weather context for AI analysis:',
+            historyResult.reason,
+        );
+    }
+
+    if (forecastResult.status === 'rejected') {
+        console.warn(
+            'Failed to load forecast weather context for AI analysis:',
+            forecastResult.reason,
+        );
+    }
+
+    return {
+        location: 'Bjelovar, HR',
+        referenceDate: referenceDate.toISOString(),
+        historical:
+            historyResult.status === 'fulfilled' ? historyResult.value : null,
+        now:
+            forecastResult.status === 'fulfilled'
+                ? forecastResult.value.now
+                : null,
+        forecast:
+            forecastResult.status === 'fulfilled'
+                ? forecastResult.value.forecast
+                : [],
+    };
 }
 
 type AnalysisParams = {
@@ -191,6 +402,7 @@ type AnalysisParams = {
     raisedBed: RaisedBedAnalysisTarget;
     imageUrls: string[];
     positionIndex?: number;
+    referenceDate?: Date | string | null;
 };
 
 async function buildAnalysisMessages({
@@ -199,7 +411,10 @@ async function buildAnalysisMessages({
     raisedBed,
     imageUrls,
     positionIndex,
+    referenceDate: inputReferenceDate,
 }: AnalysisParams) {
+    const referenceDate =
+        normalizeAnalysisReferenceDate(inputReferenceDate) ?? new Date();
     const [plantSorts, operations, operationsData, weather] = await Promise.all(
         [
             getEntitiesFormatted<{
@@ -211,7 +426,7 @@ async function buildAnalysisMessages({
                 id: string;
                 information?: { label?: string; name?: string };
             }>('operation'),
-            buildWeatherContext(),
+            buildWeatherContext(referenceDate),
         ],
     );
 
@@ -250,11 +465,14 @@ async function buildAnalysisMessages({
                     ? ('greenhouse' as const)
                     : ('raisedBed' as const),
                 isGreenhouseSeedling,
-                daysFromSowing: daysSince(field.plantSowDate),
-                daysFromGrowth: daysSince(field.plantGrowthDate),
-                daysFromReady: daysSince(field.plantReadyDate),
-                daysFromHarvest: daysSince(field.plantHarvestedDate),
-                daysFromDead: daysSince(field.plantDeadDate),
+                daysFromSowing: daysSince(field.plantSowDate, referenceDate),
+                daysFromGrowth: daysSince(field.plantGrowthDate, referenceDate),
+                daysFromReady: daysSince(field.plantReadyDate, referenceDate),
+                daysFromHarvest: daysSince(
+                    field.plantHarvestedDate,
+                    referenceDate,
+                ),
+                daysFromDead: daysSince(field.plantDeadDate, referenceDate),
                 needsRemoval: Boolean(field.toBeRemoved),
                 isAnalyzedField:
                     typeof positionIndex === 'number' &&
@@ -278,6 +496,7 @@ async function buildAnalysisMessages({
     const rows = Math.max(1, Math.ceil(totalFields / RAISED_BED_COLUMNS));
     const orientation = raisedBed.orientation ?? 'vertical';
     const nowIso = new Date().toISOString();
+    const referenceDateIso = referenceDate.toISOString();
     const analyzedPositionLabel =
         typeof positionIndex === 'number'
             ? toPositionLabel(positionIndex)
@@ -296,7 +515,7 @@ async function buildAnalysisMessages({
                 '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
                 '- U JSON kontekstu vrijednost `positionLabel` koristi ovo brojanje (1-bazirano), dok `positionIndex` ostaje 0-bazirana interna oznaka (`positionLabel = positionIndex + 1`).',
                 '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
-                '- Koristi `weather` kontekst (trenutno stanje i prognozu) i `currentDate` pri preporukama za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
+                '- Koristi `analysisReferenceDate` i `weather.historical` za vremenske uvjete na dan fotografija. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
             ].join('\n'),
         },
         {
@@ -319,6 +538,7 @@ async function buildAnalysisMessages({
                         JSON.stringify(
                             {
                                 currentDate: nowIso,
+                                analysisReferenceDate: referenceDateIso,
                                 weather,
                                 raisedBed: {
                                     orientation,

--- a/packages/game/src/hooks/aiAnalysisReferenceDate.ts
+++ b/packages/game/src/hooks/aiAnalysisReferenceDate.ts
@@ -1,0 +1,11 @@
+export function serializeAiAnalysisReferenceDate(
+    referenceDate: Date | string | null | undefined,
+) {
+    if (!referenceDate) {
+        return undefined;
+    }
+
+    return referenceDate instanceof Date
+        ? referenceDate.toISOString()
+        : referenceDate;
+}

--- a/packages/game/src/hooks/aiAnalysisReferenceDate.unit.ts
+++ b/packages/game/src/hooks/aiAnalysisReferenceDate.unit.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { serializeAiAnalysisReferenceDate } from './aiAnalysisReferenceDate';
+
+test('serializeAiAnalysisReferenceDate serializes dates for API requests', () => {
+    assert.strictEqual(
+        serializeAiAnalysisReferenceDate(new Date('2026-05-12T12:00:00.000Z')),
+        '2026-05-12T12:00:00.000Z',
+    );
+    assert.strictEqual(
+        serializeAiAnalysisReferenceDate('2026-05-12T12:00:00.000Z'),
+        '2026-05-12T12:00:00.000Z',
+    );
+    assert.strictEqual(serializeAiAnalysisReferenceDate(null), undefined);
+});

--- a/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
@@ -4,6 +4,7 @@ import {
     AiAnalysisRequestError,
     getAiAnalysisErrorMessage,
 } from './aiAnalysisError';
+import { serializeAiAnalysisReferenceDate } from './aiAnalysisReferenceDate';
 import { queryKeys as raisedBedAiHistoryQueryKeys } from './useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
 
@@ -18,13 +19,17 @@ export function useRaisedBedAiAnalysis() {
             gardenId,
             raisedBedId,
             imageUrls,
+            referenceDate,
             onChunk,
         }: {
             gardenId: number;
             raisedBedId: number;
             imageUrls: string[];
+            referenceDate?: Date | string | null;
             onChunk?: (accumulated: string) => void;
         }) => {
+            const serializedReferenceDate =
+                serializeAiAnalysisReferenceDate(referenceDate);
             const response = await client({
                 auth: 'authenticated',
             }).api.gardens[':gardenId']['raised-beds'][':raisedBedId'][
@@ -36,6 +41,9 @@ export function useRaisedBedAiAnalysis() {
                 },
                 json: {
                     imageUrls,
+                    ...(serializedReferenceDate
+                        ? { referenceDate: serializedReferenceDate }
+                        : {}),
                 },
             });
 

--- a/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
@@ -4,6 +4,7 @@ import {
     AiAnalysisRequestError,
     getAiAnalysisErrorMessage,
 } from './aiAnalysisError';
+import { serializeAiAnalysisReferenceDate } from './aiAnalysisReferenceDate';
 import { queryKeys as raisedBedAiHistoryQueryKeys } from './useRaisedBedAiHistory';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
 
@@ -19,14 +20,18 @@ export function useRaisedBedFieldAiAnalysis() {
             raisedBedId,
             positionIndex,
             imageUrls,
+            referenceDate,
             onChunk,
         }: {
             gardenId: number;
             raisedBedId: number;
             positionIndex: number;
             imageUrls: string[];
+            referenceDate?: Date | string | null;
             onChunk?: (accumulated: string) => void;
         }) => {
+            const serializedReferenceDate =
+                serializeAiAnalysisReferenceDate(referenceDate);
             const response = await client({
                 auth: 'authenticated',
             }).api.gardens[':gardenId']['raised-beds'][':raisedBedId'].fields[
@@ -39,6 +44,9 @@ export function useRaisedBedFieldAiAnalysis() {
                 },
                 json: {
                     imageUrls,
+                    ...(serializedReferenceDate
+                        ? { referenceDate: serializedReferenceDate }
+                        : {}),
                 },
             });
 

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -390,6 +390,7 @@ export function RaisedBedFieldDiary({
                           positionIndex={positionIndex}
                           entryName={entry.name}
                           imageUrls={entry.imageUrls}
+                          referenceDate={entry.timestamp}
                           historyEntries={aiHistory?.entries}
                       />
                   );
@@ -431,6 +432,7 @@ export function RaisedBedDiary({
                       raisedBedId={raisedBedId}
                       entryName={entry.name}
                       imageUrls={entry.imageUrls}
+                      referenceDate={entry.timestamp}
                       historyEntries={aiHistory?.entries}
                   />
               );

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
@@ -19,6 +19,7 @@ type RaisedBedDiaryAiActionProps = {
     entryName: string;
     imageUrls: string[];
     positionIndex?: number;
+    referenceDate?: Date | string | null;
     historyEntries?: Array<{
         id: number;
         description: string | undefined;
@@ -35,6 +36,7 @@ export function RaisedBedDiaryAiAction({
     entryName,
     imageUrls,
     positionIndex,
+    referenceDate,
     historyEntries,
 }: RaisedBedDiaryAiActionProps) {
     const [open, setOpen] = useState(false);
@@ -138,6 +140,7 @@ export function RaisedBedDiaryAiAction({
                     raisedBedId,
                     positionIndex,
                     imageUrls,
+                    referenceDate,
                     onChunk,
                 },
                 callbacks,
@@ -148,6 +151,7 @@ export function RaisedBedDiaryAiAction({
                     gardenId,
                     raisedBedId,
                     imageUrls,
+                    referenceDate,
                     onChunk,
                 },
                 callbacks,

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -113,6 +113,17 @@ function getAiHistoryForOperation({
         : undefined;
 }
 
+function getOperationReferenceDate(operation: GardenOperationItem) {
+    return (
+        operation.completedAt ??
+        operation.verifiedAt ??
+        operation.canceledAt ??
+        operation.scheduledAt ??
+        operation.scheduledDate ??
+        operation.createdAt
+    );
+}
+
 export function RaisedBedOperationHistoryList({
     raisedBedId,
     positionIndex,
@@ -274,6 +285,7 @@ export function RaisedBedOperationHistoryList({
                                 operation.targetLabel
                             }
                             imageUrls={operation.imageUrls}
+                            referenceDate={getOperationReferenceDate(operation)}
                             historyEntries={getAiHistoryForOperation({
                                 imageUrls: operation.imageUrls,
                                 entries: aiHistoryEntries,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -205,6 +205,7 @@ export type RaisedBedFieldAiAnalysisPayload = {
     imageUrls?: string[];
     model: string;
     analyzedAt: string;
+    referenceDate?: string;
     accountId?: string;
     aiRequestKind?: AiRequestKind;
     inputTokens?: number;


### PR DESCRIPTION
## Summary
- Add an optional analysis reference date to raised-bed image analysis requests.
- Use the stored historical weather table for the photo day and pass that context into the AI prompt.
- Thread the originating diary or operation timestamp through the UI so analysis uses the correct day.
- Persist the reference date on AI analysis events for later inspection.

## Testing
- Unit tests added for reference-date parsing and Zagreb-local weather day range resolution.
- `api` node tests passed for the raised-bed AI analysis service.
- `@gredice/game` unit tests passed for the new reference-date serializer.
- UI/package lint and game typecheck passed; broader `api` and `storage` typechecks still have unrelated pre-existing failures elsewhere.