### PR TITLE
Add real retry controls for failed automation runs

### DIFF
--- a/apps/app/app/admin/automations/AutomationRunsTable.tsx
+++ b/apps/app/app/admin/automations/AutomationRunsTable.tsx
@@ -20,7 +20,7 @@ import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { AutomationSlidePanel } from './AutomationSlidePanel';
-import { ReplayAutomationRunButton } from './AutomationTestPanel';
+import { AutomationRunRetryControls } from './AutomationTestPanel';
 import { automationRunStatusMeta } from './presentation';
 
 export type AutomationRunStatusFilter =
@@ -364,7 +364,7 @@ export function AutomationRunsTable({
                                 </Typography>
                             ) : null}
                             {selectedRun.run.status === 'failed' ? (
-                                <ReplayAutomationRunButton
+                                <AutomationRunRetryControls
                                     runId={selectedRun.run.id}
                                 />
                             ) : null}

--- a/apps/app/app/admin/automations/AutomationTestPanel.tsx
+++ b/apps/app/app/admin/automations/AutomationTestPanel.tsx
@@ -4,6 +4,7 @@ import { Button } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Input } from '@gredice/ui/Input';
 import { Play } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -12,6 +13,7 @@ import { useState, useTransition } from 'react';
 import {
     type AutomationRunActionResult,
     replayAutomationRunAction,
+    retryAutomationRunAction,
     runAutomationTestAction,
 } from './actions';
 
@@ -166,7 +168,7 @@ export function AutomationTestPanel({
     );
 }
 
-export function ReplayAutomationRunButton({ runId }: { runId: number }) {
+export function AutomationRunRetryControls({ runId }: { runId: number }) {
     const router = useRouter();
     const [result, setResult] = useState<AutomationRunActionResult | null>(
         null,
@@ -175,23 +177,50 @@ export function ReplayAutomationRunButton({ runId }: { runId: number }) {
 
     return (
         <Stack spacing={1}>
-            <Button
-                type="button"
-                size="sm"
-                variant="outlined"
-                disabled={isPending}
-                startDecorator={<Play className="size-4" />}
-                onClick={() =>
-                    startTransition(async () => {
-                        const replayResult =
-                            await replayAutomationRunAction(runId);
-                        setResult(replayResult);
-                        router.refresh();
-                    })
-                }
-            >
-                Replay
-            </Button>
+            <Row spacing={2} className="flex-wrap">
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outlined"
+                    disabled={isPending}
+                    startDecorator={<Play className="size-4" />}
+                    onClick={() =>
+                        startTransition(async () => {
+                            const replayResult =
+                                await replayAutomationRunAction(runId);
+                            setResult(replayResult);
+                            router.refresh();
+                        })
+                    }
+                >
+                    Replay dry-run
+                </Button>
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="solid"
+                    disabled={isPending}
+                    startDecorator={<Play className="size-4" />}
+                    onClick={() => {
+                        if (
+                            !confirm(
+                                'Retry will execute this automation for real. Continue?',
+                            )
+                        ) {
+                            return;
+                        }
+
+                        startTransition(async () => {
+                            const retryResult =
+                                await retryAutomationRunAction(runId);
+                            setResult(retryResult);
+                            router.refresh();
+                        });
+                    }}
+                >
+                    Retry
+                </Button>
+            </Row>
             {result?.ok ? (
                 <Typography level="body3" className="text-green-700">
                     Run #{result.runId}: {result.status}

--- a/apps/app/app/admin/automations/actions.ts
+++ b/apps/app/app/admin/automations/actions.ts
@@ -363,14 +363,28 @@ export async function runAutomationTestAction(
     }
 }
 
-export async function replayAutomationRunAction(
-    runId: number,
-    dryRun = true,
-): Promise<AutomationRunActionResult> {
+async function runAutomationRunAgain({
+    runId,
+    dryRun,
+    actionName,
+    lockedByScope,
+}: {
+    runId: number;
+    dryRun: boolean;
+    actionName: 'replay' | 'retry';
+    lockedByScope: 'app-admin-replay' | 'app-admin-retry';
+}): Promise<AutomationRunActionResult> {
     const { userId } = await auth(['admin']);
     const originalRun = await getAutomationRunById(runId);
     if (!originalRun) {
         return { ok: false, errors: ['Automation run was not found.'] };
+    }
+
+    if (actionName === 'retry' && originalRun.status !== 'failed') {
+        return {
+            ok: false,
+            errors: ['Only failed automation runs can be retried.'],
+        };
     }
 
     const definition = await getAutomationDefinitionById(
@@ -385,8 +399,13 @@ export async function replayAutomationRunAction(
         : null;
     const run = await createAutomationRun({
         automationDefinition: definition,
-        source: 'replay',
+        source: dryRun ? 'replay' : 'manual',
         sourceEvent,
+        sourceEventType: originalRun.sourceEventType,
+        sourceAggregateId:
+            originalRun.sourceEventType === 'automation.schedule.monthly'
+                ? null
+                : originalRun.sourceAggregateId,
         parentRunId: originalRun.id,
         input: originalRun.input,
         dryRun,
@@ -396,18 +415,40 @@ export async function replayAutomationRunAction(
     if (!run) {
         return {
             ok: false,
-            errors: ['Automation replay run was not created.'],
+            errors: [`Automation ${actionName} run was not created.`],
         };
     }
 
     const started =
         (await startAutomationRun(run.id, {
-            lockedBy: `app-admin-replay:${userId}`,
+            lockedBy: `${lockedByScope}:${userId}`,
         })) ?? run;
     const result = await executeAutomationRun(started);
 
     revalidateAutomationPages(definition.id);
     return { ok: true, runId: run.id, status: result.status };
+}
+
+export async function replayAutomationRunAction(
+    runId: number,
+): Promise<AutomationRunActionResult> {
+    return runAutomationRunAgain({
+        runId,
+        dryRun: true,
+        actionName: 'replay',
+        lockedByScope: 'app-admin-replay',
+    });
+}
+
+export async function retryAutomationRunAction(
+    runId: number,
+): Promise<AutomationRunActionResult> {
+    return runAutomationRunAgain({
+        runId,
+        dryRun: false,
+        actionName: 'retry',
+        lockedByScope: 'app-admin-retry',
+    });
 }
 
 export async function getAutomationRunStepsAction(runId: number) {


### PR DESCRIPTION
## Summary
- Adds a real retry action for failed automation runs in run details.
- Keeps replay as dry-run and separates it from the new retry path.
- Reuses the existing child-run flow with audit metadata and run refresh.

## Testing
- UI flow updated in the automation run details panel to expose both replay and retry controls.
- Not run (not requested)