### PR TITLE
Remove approvals headers and link raised-bed icons

### DIFF
--- a/apps/app/app/admin/approvals/RaisedBedTaskLink.tsx
+++ b/apps/app/app/admin/approvals/RaisedBedTaskLink.tsx
@@ -1,0 +1,28 @@
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
+import Link from 'next/link';
+import { KnownPages } from '../../../src/KnownPages';
+
+export function RaisedBedTaskLink({
+    raisedBedId,
+    physicalId,
+}: {
+    raisedBedId: number;
+    physicalId?: string | null;
+}) {
+    const label = physicalId ? `Gredica ${physicalId}` : 'Gredica';
+
+    return (
+        <Link
+            href={KnownPages.RaisedBed(raisedBedId)}
+            aria-label={`Otvori detalje: ${label}`}
+            title={`Otvori detalje: ${label}`}
+            className="inline-flex h-8 min-w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
+        >
+            <RaisedBedIcon
+                physicalId={physicalId ?? null}
+                containerClassName="h-8 min-w-8"
+                className="size-7"
+            />
+        </Link>
+    );
+}

--- a/apps/app/app/admin/approvals/page.tsx
+++ b/apps/app/app/admin/approvals/page.tsx
@@ -1,12 +1,6 @@
 import { plantFieldStatusLabel } from '@gredice/js/plants';
 import { Button } from '@gredice/ui/Button';
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardOverflow,
-    CardTitle,
-} from '@gredice/ui/Card';
+import { Card, CardOverflow } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
@@ -25,6 +19,7 @@ import {
     approveSchedulePlantingTaskAction,
     rejectApprovalRequestAction,
 } from '../../(actions)/approvalActions';
+import { RaisedBedTaskLink } from './RaisedBedTaskLink';
 
 export const dynamic = 'force-dynamic';
 
@@ -52,25 +47,8 @@ export default async function AdminApprovalsPage() {
     const tasks = await getPendingAdminApprovalTasks();
 
     return (
-        <Stack spacing={6}>
-            <Stack spacing={2}>
-                <Typography level="h4" component="h1">
-                    Odobrenja
-                </Typography>
-                <Typography level="body2" className="text-muted-foreground">
-                    Zahtjevi farmera i završeni rasporedni zadaci koji čekaju
-                    administrativnu potvrdu.
-                </Typography>
-            </Stack>
+        <Stack spacing={4}>
             <Card>
-                <CardHeader>
-                    <CardTitle>Zahtjevi na čekanju</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Typography level="body2">
-                        Ukupno {tasks.length} zahtjeva čeka odobrenje.
-                    </Typography>
-                </CardContent>
                 <CardOverflow>
                     <div className="overflow-auto">
                         <Table>
@@ -107,20 +85,36 @@ export default async function AdminApprovalsPage() {
                                                 </Chip>
                                             </Table.Cell>
                                             <Table.Cell>
-                                                <Stack spacing={1}>
-                                                    <Typography
-                                                        level="body2"
-                                                        semiBold
-                                                    >
-                                                        {task.title}
-                                                    </Typography>
-                                                    <Typography
-                                                        level="body3"
-                                                        className="text-muted-foreground"
-                                                    >
-                                                        {task.description}
-                                                    </Typography>
-                                                </Stack>
+                                                <Row
+                                                    spacing={3}
+                                                    alignItems="start"
+                                                >
+                                                    {task.raisedBedId !=
+                                                    null ? (
+                                                        <RaisedBedTaskLink
+                                                            raisedBedId={
+                                                                task.raisedBedId
+                                                            }
+                                                            physicalId={
+                                                                task.raisedBedPhysicalId
+                                                            }
+                                                        />
+                                                    ) : null}
+                                                    <Stack spacing={1}>
+                                                        <Typography
+                                                            level="body2"
+                                                            semiBold
+                                                        >
+                                                            {task.title}
+                                                        </Typography>
+                                                        <Typography
+                                                            level="body3"
+                                                            className="text-muted-foreground"
+                                                        >
+                                                            {task.description}
+                                                        </Typography>
+                                                    </Stack>
+                                                </Row>
                                             </Table.Cell>
                                             <Table.Cell>
                                                 {task.kind ===

--- a/apps/app/src/approvalTasks.ts
+++ b/apps/app/src/approvalTasks.ts
@@ -16,6 +16,7 @@ type ApprovalTaskBase = {
     accountId?: string | null;
     gardenId?: number | null;
     raisedBedId?: number | null;
+    raisedBedPhysicalId?: string | null;
     positionIndex?: number | null;
 };
 
@@ -57,20 +58,10 @@ function plantSortName(
     );
 }
 
-function raisedBedLabel(input: {
-    raisedBedName?: string | null;
-    physicalId?: string | null;
-    raisedBedId: number;
-    positionIndex?: number | null;
-}) {
-    const base =
-        input.raisedBedName ??
-        (input.physicalId ? `Gredica ${input.physicalId}` : null) ??
-        `Gredica #${input.raisedBedId}`;
-
-    return input.positionIndex === null || input.positionIndex === undefined
-        ? base
-        : `${base}, polje ${input.positionIndex + 1}`;
+function raisedBedFieldLabel(positionIndex?: number | null) {
+    return positionIndex === null || positionIndex === undefined
+        ? null
+        : `Polje ${positionIndex + 1}`;
 }
 
 function approvalRequestRequesterLabel(requestedBy: string) {
@@ -101,23 +92,19 @@ function buildPlantStatusRequestTask(
         request.target.requestedStatus,
     ).shortLabel;
     const plantName = plantSortName(plantSortsById, request.target.plantSortId);
-    const targetLabel = raisedBedLabel({
-        raisedBedName: raisedBed?.name,
-        physicalId: raisedBed?.physicalId,
-        raisedBedId: request.target.raisedBedId,
-        positionIndex: request.target.positionIndex,
-    });
+    const fieldLabel = raisedBedFieldLabel(request.target.positionIndex);
 
     return {
         id: `approval:${request.id}`,
         kind: 'plantStatusRequest',
         requestId: request.id,
         title: 'Promjena stanja biljke',
-        description: `${targetLabel}: ${plantName}, ${currentStatusLabel} → ${requestedStatusLabel}`,
+        description: `${fieldLabel ? `${fieldLabel}: ` : ''}${plantName}, ${currentStatusLabel} → ${requestedStatusLabel}`,
         receivedAt: request.requestedAt,
         accountId: request.target.accountId,
         gardenId: request.target.gardenId,
         raisedBedId: request.target.raisedBedId,
+        raisedBedPhysicalId: raisedBed?.physicalId,
         positionIndex: request.target.positionIndex,
         currentStatus: request.target.currentStatus,
         requestedStatus: request.target.requestedStatus,
@@ -166,23 +153,20 @@ export async function getPendingAdminApprovalTasks() {
                 operationsById.get(operation.entityId),
                 `Radnja #${operation.entityId}`,
             );
-            const raisedBed = operation.raisedBedId
-                ? raisedBedsById.get(operation.raisedBedId)
-                : undefined;
-            const targetLabel = operation.raisedBedId
-                ? raisedBedLabel({
-                      raisedBedName: raisedBed?.name,
-                      physicalId: raisedBed?.physicalId,
-                      raisedBedId: operation.raisedBedId,
-                  })
-                : 'Farma';
+            const raisedBed =
+                operation.raisedBedId != null
+                    ? raisedBedsById.get(operation.raisedBedId)
+                    : undefined;
 
             return {
                 id: `operation:${operation.id}`,
                 kind: 'scheduleOperationVerification',
                 operationId: operation.id,
                 title: 'Verifikacija radnje',
-                description: `${operationName} • ${targetLabel}`,
+                description:
+                    operation.raisedBedId != null
+                        ? operationName
+                        : `${operationName} • Farma`,
                 receivedAt:
                     operation.completedAt ??
                     operation.scheduledDate ??
@@ -190,6 +174,7 @@ export async function getPendingAdminApprovalTasks() {
                 accountId: operation.accountId,
                 gardenId: operation.gardenId,
                 raisedBedId: operation.raisedBedId,
+                raisedBedPhysicalId: raisedBed?.physicalId,
                 positionIndex: null,
                 completedBy: operation.completedBy,
             };
@@ -202,22 +187,22 @@ export async function getPendingAdminApprovalTasks() {
                 (field) =>
                     field.active && field.plantStatus === 'pendingVerification',
             )
-            .map((field) => ({
-                id: `planting:${field.id}`,
-                kind: 'schedulePlantingVerification',
-                raisedBedId: raisedBed.id,
-                positionIndex: field.positionIndex,
-                title: 'Verifikacija sijanja',
-                description: `${raisedBedLabel({
-                    raisedBedName: raisedBed.name,
-                    physicalId: raisedBed.physicalId,
+            .map((field) => {
+                const fieldLabel = raisedBedFieldLabel(field.positionIndex);
+
+                return {
+                    id: `planting:${field.id}`,
+                    kind: 'schedulePlantingVerification',
                     raisedBedId: raisedBed.id,
                     positionIndex: field.positionIndex,
-                })}: ${plantSortName(plantSortsById, field.plantSortId)}`,
-                receivedAt: field.plantSowDate ?? field.updatedAt,
-                accountId: raisedBed.accountId,
-                gardenId: raisedBed.gardenId,
-            })),
+                    title: 'Verifikacija sijanja',
+                    description: `${fieldLabel ? `${fieldLabel}: ` : ''}${plantSortName(plantSortsById, field.plantSortId)}`,
+                    receivedAt: field.plantSowDate ?? field.updatedAt,
+                    accountId: raisedBed.accountId,
+                    gardenId: raisedBed.gardenId,
+                    raisedBedPhysicalId: raisedBed.physicalId,
+                };
+            }),
     );
 
     return [...plantStatusTasks, ...operationTasks, ...plantingTasks].sort(


### PR DESCRIPTION
## Summary
- Removed the page and card header/subheader copy from the admin approvals screen.
- Reworked approval rows so the raised bed is shown as a linked icon with its physical identifier instead of text in the request column.
- Extended approval task data to carry the raised bed physical id for rendering.

## Testing
- Lint and formatting passed for the changed files.
- Touched-file TypeScript diagnostics were clean.
- Local browser verification reached the admin login screen, so the approvals table could not be visually inspected without auth.