### PR TITLE
Prevent automation save from overwriting keys

### DIFF
--- a/apps/app/app/admin/automations/AutomationFlowEditor.tsx
+++ b/apps/app/app/admin/automations/AutomationFlowEditor.tsx
@@ -302,9 +302,12 @@ export function AutomationFlowEditor({
     const selectedModule = selectedNode
         ? modulesByKey.get(selectedNode.data.moduleKey)
         : null;
-    const generatedKey = useMemo(
-        () => slugify(name) || initialKey || 'nova-automatizacija',
-        [initialKey, name],
+    const automationKey = useMemo(
+        () =>
+            automationId
+                ? initialKey
+                : slugify(name) || initialKey || 'nova-automatizacija',
+        [automationId, initialKey, name],
     );
     const groupedModules = useMemo(
         () =>
@@ -429,7 +432,7 @@ export function AutomationFlowEditor({
         startTransition(async () => {
             const saveResult = await saveAutomationDefinitionAction({
                 id: automationId,
-                key: generatedKey,
+                key: automationKey,
                 name,
                 description,
                 status,
@@ -459,9 +462,13 @@ export function AutomationFlowEditor({
             />
             <Input
                 label="Ključ"
-                value={generatedKey}
+                value={automationKey}
                 readOnly
-                helperText="Automatski se generira iz naziva."
+                helperText={
+                    automationId
+                        ? 'Postojeći ključ ostaje nepromijenjen.'
+                        : 'Automatski se generira iz naziva.'
+                }
                 fullWidth
             />
             <SelectItems<AutomationDefinitionStatus>

--- a/apps/app/app/admin/automations/actions.ts
+++ b/apps/app/app/admin/automations/actions.ts
@@ -12,6 +12,7 @@ import {
     createAutomationRun,
     executeAutomationRun,
     getAutomationDefinitionById,
+    getAutomationDefinitionByKey,
     getAutomationRunById,
     getDomainEventById,
     listAutomationRunSteps,
@@ -149,6 +150,23 @@ function revalidateAutomationPages(automationId?: number) {
     }
 }
 
+function automationKeyExistsMessage(key: string) {
+    return `Automation key "${key}" already exists.`;
+}
+
+function isAutomationKeyUniqueConstraintError(error: unknown) {
+    if (!isRecord(error)) {
+        return false;
+    }
+
+    const candidate = isRecord(error.cause) ? error.cause : error;
+
+    return (
+        candidate.code === '23505' &&
+        candidate.constraint === 'automation_definitions_key_idx'
+    );
+}
+
 export async function saveAutomationDefinitionAction(
     payload: SaveAutomationDefinitionPayload,
 ): Promise<AutomationSaveResult> {
@@ -178,6 +196,17 @@ export async function saveAutomationDefinitionAction(
         return { ok: false, errors };
     }
 
+    const existingDefinition = await getAutomationDefinitionByKey(key);
+    if (
+        existingDefinition &&
+        (!payload.id || existingDefinition.id !== payload.id)
+    ) {
+        return {
+            ok: false,
+            errors: [automationKeyExistsMessage(key)],
+        };
+    }
+
     const input = {
         key,
         name,
@@ -187,12 +216,24 @@ export async function saveAutomationDefinitionAction(
         updatedByUserId: userId,
     };
 
-    const definition = payload.id
-        ? await updateAutomationDefinition(payload.id, input)
-        : await createAutomationDefinition({
-              ...input,
-              createdByUserId: userId,
-          });
+    let definition: Awaited<ReturnType<typeof updateAutomationDefinition>>;
+    try {
+        definition = payload.id
+            ? await updateAutomationDefinition(payload.id, input)
+            : await createAutomationDefinition({
+                  ...input,
+                  createdByUserId: userId,
+              });
+    } catch (error) {
+        if (isAutomationKeyUniqueConstraintError(error)) {
+            return {
+                ok: false,
+                errors: [automationKeyExistsMessage(key)],
+            };
+        }
+
+        throw error;
+    }
 
     if (!definition) {
         return {


### PR DESCRIPTION
## Summary
- Preserve the existing automation key when editing an automation instead of regenerating it from the name.
- Add a preflight key-uniqueness check on save and convert the Postgres unique-constraint race into a normal validation error.
- Keep the automation editor’s key field accurate for new vs existing definitions.

## Testing
- Biome check passed for the two changed automation files.
- `git diff --check` passed.
- App-wide TypeScript validation was not useful here because the workspace already has unrelated existing type errors.