### PR TITLE
Add animal pathfinding debug controls

### DIFF
--- a/apps/garden/app/debug/animals/AnimalDebugActions.tsx
+++ b/apps/garden/app/debug/animals/AnimalDebugActions.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Reset } from '@gredice/ui/icons';
+
+type StoredSandboxBlock = {
+    id: string;
+    name: string;
+    rotation: number;
+};
+
+type StoredSandboxStack = {
+    blocks: StoredSandboxBlock[];
+    position: {
+        x: number;
+        z: number;
+    };
+};
+
+type SandboxBounds = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
+const animalDebugStorageVersion = 1;
+
+function stackKey(x: number, z: number) {
+    return `${x}:${z}`;
+}
+
+function createGroundStacks(bounds: SandboxBounds) {
+    const stacks = new Map<string, StoredSandboxStack>();
+
+    for (let x = bounds.minX; x <= bounds.maxX; x += 1) {
+        for (let z = bounds.minZ; z <= bounds.maxZ; z += 1) {
+            stacks.set(stackKey(x, z), {
+                position: { x, z },
+                blocks: [
+                    {
+                        id: `animal-debug-ground:${x}:${z}`,
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                ],
+            });
+        }
+    }
+
+    return stacks;
+}
+
+function placeBlock(
+    stacks: Map<string, StoredSandboxStack>,
+    x: number,
+    z: number,
+    name: string,
+    rotation = 0,
+) {
+    const stack = stacks.get(stackKey(x, z));
+    if (!stack) {
+        return;
+    }
+
+    stack.blocks.push({
+        id: `animal-debug:${animalDebugStorageVersion}:${name}:${x}:${z}`,
+        name,
+        rotation,
+    });
+}
+
+function serializeStacks(stacks: Map<string, StoredSandboxStack>) {
+    return Array.from(stacks.values()).sort((left, right) => {
+        if (left.position.x !== right.position.x) {
+            return left.position.x - right.position.x;
+        }
+
+        return left.position.z - right.position.z;
+    });
+}
+
+function createCatPathfindingStacks() {
+    const stacks = createGroundStacks({
+        minX: -5,
+        maxX: 5,
+        minZ: -3,
+        maxZ: 3,
+    });
+
+    placeBlock(stacks, -4, 0, 'CatPillow');
+    placeBlock(stacks, 3, 0, 'Tree');
+    placeBlock(stacks, 2, -1, 'Stool');
+    placeBlock(stacks, 2, 1, 'Bucket');
+    placeBlock(stacks, -3, 2, 'StoneMedium');
+
+    for (let z = -3; z <= 1; z += 1) {
+        placeBlock(stacks, 0, z, z % 2 === 0 ? 'GardenBox' : 'Composter');
+    }
+
+    return serializeStacks(stacks);
+}
+
+function createBirdStacks() {
+    const stacks = createGroundStacks({
+        minX: -4,
+        maxX: 4,
+        minZ: -4,
+        maxZ: 4,
+    });
+
+    placeBlock(stacks, -3, -2, 'BirdHouse');
+    placeBlock(stacks, 2, 1, 'Tree');
+    placeBlock(stacks, -1, 1, 'Bush');
+    placeBlock(stacks, 0, 0, 'StoneLarge');
+    placeBlock(stacks, 3, -2, 'WaterWell');
+    placeBlock(stacks, -2, 2, 'Tulip');
+
+    return serializeStacks(stacks);
+}
+
+function createBeeStacks() {
+    const stacks = createGroundStacks({
+        minX: -4,
+        maxX: 4,
+        minZ: -4,
+        maxZ: 4,
+    });
+
+    placeBlock(stacks, -2, -1, 'Tulip');
+    placeBlock(stacks, 0, 1, 'Tulip');
+    placeBlock(stacks, 2, -2, 'Tulip');
+    placeBlock(stacks, 3, 2, 'CactusBarrel');
+    placeBlock(stacks, -3, 2, 'CactusPricklyPear');
+
+    return serializeStacks(stacks);
+}
+
+function createAllAnimalStacks() {
+    const stacks = createGroundStacks({
+        minX: -6,
+        maxX: 6,
+        minZ: -4,
+        maxZ: 4,
+    });
+
+    placeBlock(stacks, -5, 0, 'CatPillow');
+    placeBlock(stacks, 2, 0, 'Tree');
+    placeBlock(stacks, 3, -2, 'Stool');
+    placeBlock(stacks, 3, 2, 'Bucket');
+    placeBlock(stacks, -4, 3, 'StoneMedium');
+    for (let z = -4; z <= 1; z += 1) {
+        placeBlock(stacks, 0, z, z % 2 === 0 ? 'GardenBox' : 'Composter');
+    }
+
+    placeBlock(stacks, -5, -3, 'BirdHouse');
+    placeBlock(stacks, 2, 2, 'Bush');
+    placeBlock(stacks, 3, 3, 'WaterWell');
+    placeBlock(stacks, -2, -2, 'Tulip');
+    placeBlock(stacks, 1, -3, 'Tulip');
+    placeBlock(stacks, 5, -3, 'Tulip');
+    placeBlock(stacks, -3, 2, 'CactusPricklyPear');
+    placeBlock(stacks, 2, -1, 'CactusBarrel');
+
+    return serializeStacks(stacks);
+}
+
+function persistAnimalDebugStacks(
+    storageKey: string,
+    stacks: StoredSandboxStack[],
+) {
+    window.localStorage.setItem(storageKey, JSON.stringify({ stacks }));
+    window.location.reload();
+}
+
+export function AnimalDebugActions({ storageKey }: { storageKey: string }) {
+    const reset = () => {
+        window.localStorage.removeItem(storageKey);
+        window.location.reload();
+    };
+
+    return (
+        <div className="pointer-events-none absolute left-2 top-2 z-20 flex max-w-[calc(100vw-1rem)] flex-wrap gap-1.5">
+            <Button
+                className="pointer-events-auto rounded-full shadow-lg"
+                color="neutral"
+                onClick={() =>
+                    persistAnimalDebugStacks(
+                        storageKey,
+                        createAllAnimalStacks(),
+                    )
+                }
+                size="sm"
+                variant="soft"
+            >
+                All animals
+            </Button>
+            <Button
+                className="pointer-events-auto rounded-full shadow-lg"
+                color="neutral"
+                onClick={() =>
+                    persistAnimalDebugStacks(
+                        storageKey,
+                        createCatPathfindingStacks(),
+                    )
+                }
+                size="sm"
+                variant="soft"
+            >
+                Cat path
+            </Button>
+            <Button
+                className="pointer-events-auto rounded-full shadow-lg"
+                color="neutral"
+                onClick={() =>
+                    persistAnimalDebugStacks(storageKey, createBirdStacks())
+                }
+                size="sm"
+                variant="soft"
+            >
+                Birds
+            </Button>
+            <Button
+                className="pointer-events-auto rounded-full shadow-lg"
+                color="neutral"
+                onClick={() =>
+                    persistAnimalDebugStacks(storageKey, createBeeStacks())
+                }
+                size="sm"
+                variant="soft"
+            >
+                Bees
+            </Button>
+            <Button
+                className="pointer-events-auto rounded-full shadow-lg"
+                color="neutral"
+                onClick={reset}
+                size="sm"
+                startDecorator={<Reset className="size-4" />}
+                variant="soft"
+            >
+                Reset
+            </Button>
+        </div>
+    );
+}

--- a/apps/garden/app/debug/animals/page.tsx
+++ b/apps/garden/app/debug/animals/page.tsx
@@ -1,0 +1,39 @@
+import { GameScene } from '@gredice/game';
+import type { ComponentProps } from 'react';
+import { AnimalDebugActions } from './AnimalDebugActions';
+
+const animalDebugStorageKey = 'gredice.debug.sandbox.animals.v1';
+
+const animalDebugFlags = {
+    enableDebugHudFlag: true,
+    enableRainWetOverlayFlag: true,
+} satisfies NonNullable<ComponentProps<typeof GameScene>['flags']>;
+
+const animalDebugFreezeTime = new Date('2026-06-02T10:00:00+02:00');
+
+const animalDebugWeather = {
+    cloudy: 0,
+    rainy: 0,
+    snowy: 0,
+    foggy: 0,
+    thundery: 0,
+    windSpeed: 0,
+};
+
+export default function DebugAnimalsPage() {
+    return (
+        <main className="relative h-screen w-screen overflow-hidden bg-[#e7e2cc]">
+            <GameScene
+                className="h-full w-full"
+                dayNightCycleDisabled={false}
+                deferDetails={false}
+                flags={animalDebugFlags}
+                freezeTime={animalDebugFreezeTime}
+                localSandboxStorageKey={animalDebugStorageKey}
+                noSound
+                weather={animalDebugWeather}
+            />
+            <AnimalDebugActions storageKey={animalDebugStorageKey} />
+        </main>
+    );
+}

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -27,6 +27,12 @@ const debugGroups = [
                 description:
                     'Playable sandbox scene backed by browser local storage.',
             },
+            {
+                href: '/debug/animals',
+                title: 'Animal sandbox',
+                description:
+                    'Animal behavior scene with spawn presets, entity placement, and debug controls.',
+            },
         ],
     },
     {

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -126,6 +126,14 @@ type BeeRigParts = {
     wingRight: BeeRigNode;
 };
 
+const beeDebugBehaviors = [
+    'flower',
+    'raised-bed-flower',
+    'cactus-flower',
+    'ground-flower',
+    'wander',
+];
+
 const clearBeeWeather = {
     cloudy: 0,
     foggy: 0,
@@ -850,6 +858,32 @@ function chooseManualNextTarget({
     return pickCandidate(alternatives, random) ?? target;
 }
 
+function chooseDebugTarget({
+    behavior,
+    habitatCenter,
+    random,
+    targets,
+}: {
+    behavior: string;
+    habitatCenter: Vector3;
+    random: () => number;
+    targets: BeeTarget[];
+}) {
+    if (behavior === 'wander') {
+        return createWanderTarget(habitatCenter, random);
+    }
+
+    const exactTargets = targets.filter((target) => target.kind === behavior);
+    if (exactTargets.length > 0) {
+        return pickCandidate(exactTargets, random);
+    }
+
+    return (
+        pickCandidate(targets, random) ??
+        createWanderTarget(habitatCenter, random)
+    );
+}
+
 function makeMovingState({
     from,
     now,
@@ -1105,6 +1139,7 @@ function createBeeDebugEntry({
         behavior: runtime.target.kind,
         activity: getBeeDebugActivity(runtime),
         targetId: runtime.target.id,
+        debugBehaviors: beeDebugBehaviors,
         position: {
             x: roundBeeDebugCoordinate(group.position.x),
             y: roundBeeDebugCoordinate(group.position.y),
@@ -1122,7 +1157,11 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<BeeRuntimeState | null>(null);
     const lastAnimalDebugUpdateRef = useRef(0);
+    const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
+    const animalDebugCommand = useGameState(
+        (state) => state.animalDebugCommand,
+    );
     const setAnimalDebugEntry = useGameState(
         (state) => state.setAnimalDebugEntry,
     );
@@ -1213,6 +1252,37 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
             });
             runtimeRef.current = runtime;
             group.position.copy(foragePositionAt(runtime));
+        }
+
+        if (
+            animalDebugCommand &&
+            animalDebugCommand.sequence !==
+                lastDebugCommandSequenceRef.current &&
+            animalDebugCommand.species === 'Bee'
+        ) {
+            lastDebugCommandSequenceRef.current = animalDebugCommand.sequence;
+
+            if (
+                !animalDebugCommand.targetId ||
+                animalDebugCommand.targetId === habitat.id
+            ) {
+                const target = chooseDebugTarget({
+                    behavior: animalDebugCommand.behavior,
+                    habitatCenter: habitat.center,
+                    random,
+                    targets: habitat.targets,
+                });
+
+                if (target) {
+                    runtime = makeMovingState({
+                        from: group.position.clone(),
+                        now,
+                        random,
+                        target,
+                    });
+                    runtimeRef.current = runtime;
+                }
+            }
         }
 
         if (

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -137,6 +137,15 @@ type BirdRigParts = {
     walkPoseAmount: number;
 };
 
+const birdDebugBehaviors = [
+    'home',
+    'air',
+    'circle',
+    'tree',
+    'entity',
+    'ground',
+] satisfies BirdBehavior[];
+
 const birdScale = 0.28;
 const birdGroundLift = 0.02;
 const birdHousePerchYOffset = 1.3;
@@ -895,6 +904,72 @@ function chooseManualNextTarget({
     return pickCandidate(alternatives, random) ?? target;
 }
 
+function chooseDebugTarget({
+    behavior,
+    habitat,
+    random,
+    timeOfDay,
+}: {
+    behavior: string;
+    habitat: BirdHabitat;
+    random: () => number;
+    timeOfDay: number;
+}) {
+    const range = getBirdActivityRange(timeOfDay);
+
+    if (behavior === 'home') {
+        return habitat.home;
+    }
+
+    if (behavior === 'air') {
+        return createAirTarget({
+            anchors: getAirAnchorsInRange(habitat, range),
+            home: habitat.home,
+            index: 0,
+            random,
+        });
+    }
+
+    if (behavior === 'circle') {
+        const anchor = pickCandidate(
+            candidatesInRange(habitat.circleAnchors, habitat.home, range),
+            random,
+        );
+        return anchor
+            ? createCircleTarget({ anchor, home: habitat.home, random })
+            : habitat.home;
+    }
+
+    if (behavior === 'tree') {
+        return (
+            pickCandidate(
+                candidatesInRange(habitat.trees, habitat.home, range),
+                random,
+            ) ?? habitat.home
+        );
+    }
+
+    if (behavior === 'entity') {
+        return (
+            pickCandidate(
+                candidatesInRange(habitat.entities, habitat.home, range),
+                random,
+            ) ?? habitat.home
+        );
+    }
+
+    if (behavior === 'ground') {
+        return (
+            pickCandidate(
+                candidatesInRange(habitat.grounds, habitat.home, range),
+                random,
+            ) ?? habitat.home
+        );
+    }
+
+    return null;
+}
+
 function makeMovingState({
     airUntil,
     airWaypointIndex = 0,
@@ -1426,6 +1501,7 @@ function createBirdDebugEntry({
         behavior: runtime.target.behavior,
         activity: getBirdDebugActivity(runtime),
         targetId: runtime.target.id,
+        debugBehaviors: birdDebugBehaviors,
         position: {
             x: roundBirdDebugCoordinate(group.position.x),
             y: roundBirdDebugCoordinate(group.position.y),
@@ -1443,9 +1519,13 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     const runtimeRef = useRef<BirdRuntimeState | null>(null);
     const flappingRef = useRef(false);
     const lastAnimalDebugUpdateRef = useRef(0);
+    const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
     const [isFlapping, setIsFlapping] = useState(false);
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const animalDebugCommand = useGameState(
+        (state) => state.animalDebugCommand,
+    );
     const animalDisturbance = useGameState((state) => state.animalDisturbance);
     const setAnimalDebugEntry = useGameState(
         (state) => state.setAnimalDebugEntry,
@@ -1574,6 +1654,49 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
             group.position.copy(habitat.home.position);
             if (habitat.home.facingYaw !== undefined) {
                 group.rotation.y = habitat.home.facingYaw;
+            }
+        }
+
+        if (
+            animalDebugCommand &&
+            animalDebugCommand.sequence !==
+                lastDebugCommandSequenceRef.current &&
+            animalDebugCommand.species === 'Bird'
+        ) {
+            lastDebugCommandSequenceRef.current = animalDebugCommand.sequence;
+
+            if (
+                !animalDebugCommand.targetId ||
+                animalDebugCommand.targetId === habitat.id
+            ) {
+                const target = chooseDebugTarget({
+                    behavior: animalDebugCommand.behavior,
+                    habitat,
+                    random,
+                    timeOfDay,
+                });
+
+                if (target) {
+                    runtime =
+                        target.behavior !== 'air' &&
+                        target.behavior !== 'circle' &&
+                        group.position.distanceTo(target.position) < 0.08
+                            ? makeSettledState({
+                                  now,
+                                  random,
+                                  target,
+                                  timeOfDay,
+                              })
+                            : makeMovingState({
+                                  from: group.position.clone(),
+                                  now,
+                                  random,
+                                  takeoffLead: false,
+                                  target,
+                                  timeOfDay,
+                              });
+                    runtimeRef.current = runtime;
+                }
             }
         }
 

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -1258,7 +1258,8 @@ function Cat({
         runtimeRef.current = makeMovingState({
             blockedCells: habitat.blockedCells,
             from: group.position.clone(),
-            fromTarget: runtime.target,
+            fromTarget:
+                runtime.phase === 'settled' ? runtime.target : undefined,
             groundSurfaces: habitat.groundSurfaces,
             now,
             target,
@@ -1341,7 +1342,10 @@ function Cat({
                             : makeMovingState({
                                   blockedCells: habitat.blockedCells,
                                   from: group.position.clone(),
-                                  fromTarget: runtime.target,
+                                  fromTarget:
+                                      runtime.phase === 'settled'
+                                          ? runtime.target
+                                          : undefined,
                                   groundSurfaces: habitat.groundSurfaces,
                                   now,
                                   target,

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -25,6 +25,12 @@ import {
     pickCatBehavior,
     shouldCatSeekCover,
 } from './catBehavior';
+import {
+    type CatPathCell,
+    type CatPathResult,
+    type CatPathSurface,
+    findCatPath,
+} from './catPathfinding';
 
 type CatWeatherOverride = Partial<NonNullable<GameState['weather']>>;
 
@@ -37,14 +43,11 @@ type CatTarget = {
     walkPosition?: Vector3;
 };
 
-type CatGroundSurface = {
-    x: number;
-    y: number;
-    z: number;
-};
+type CatGroundSurface = CatPathSurface;
 
 type CatHabitat = {
     id: string;
+    blockedCells: CatPathCell[];
     covers: CatTarget[];
     groundSurfaces: CatGroundSurface[];
     lowEntities: CatTarget[];
@@ -58,6 +61,9 @@ type MovingCatState = {
     duration: number;
     from: Vector3;
     groundSurfaces: CatGroundSurface[];
+    path: Vector3[];
+    pathDistance: number;
+    pathfinding: CatPathResult;
     startedAt: number;
     target: CatTarget;
     to: Vector3;
@@ -76,6 +82,14 @@ type CatAnimationName =
     | 'Cat_Walk'
     | 'Cat_LyingIdle'
     | 'Cat_PreyWatch';
+
+const catDebugBehaviors = [
+    'pillow',
+    'roam',
+    'cover',
+    'low-entity',
+    'stalk-bird',
+] satisfies CatBehavior[];
 
 const clearCatWeather = {
     cloudy: 0,
@@ -296,6 +310,24 @@ function createCatGroundSurfaces(
     return surfaces;
 }
 
+function createCatBlockedCells(stacks: Stack[] | undefined) {
+    const blockedCells: CatPathCell[] = [];
+
+    for (const stack of stacks ?? []) {
+        const topBlock = stack.blocks.at(-1);
+        if (!topBlock || isGroundBlockName(topBlock.name)) {
+            continue;
+        }
+
+        blockedCells.push({
+            x: Math.round(stack.position.x),
+            z: Math.round(stack.position.z),
+        });
+    }
+
+    return blockedCells;
+}
+
 function targetForPillowBlock({
     block,
     blockData,
@@ -406,6 +438,7 @@ function createCatHabitats(
     stacks: Stack[] | undefined,
     blockData: BlockData[] | null | undefined,
 ) {
+    const blockedCells = createCatBlockedCells(stacks);
     const groundSurfaces = createCatGroundSurfaces(stacks, blockData);
     const pillows: CatTarget[] = [];
     const covers: CatTarget[] = [];
@@ -456,6 +489,7 @@ function createCatHabitats(
 
     return pillows.map((pillow) => ({
         id: `cat-${pillow.id}`,
+        blockedCells,
         covers,
         groundSurfaces,
         lowEntities,
@@ -465,10 +499,8 @@ function createCatHabitats(
     }));
 }
 
-function movementDuration(from: Vector3, to: Vector3) {
-    const horizontal = horizontalDistance(from, to);
-
-    return MathUtils.clamp(horizontal / catWalkSpeedBlocksPerSecond, 0.9, 8.5);
+function movementDuration(distance: number) {
+    return MathUtils.clamp(distance / catWalkSpeedBlocksPerSecond, 0.9, 8.5);
 }
 
 function movingCatHorizontalSpeed(runtime: MovingCatState) {
@@ -476,7 +508,61 @@ function movingCatHorizontalSpeed(runtime: MovingCatState) {
         return 0;
     }
 
-    return horizontalDistance(runtime.from, runtime.to) / runtime.duration;
+    return runtime.pathDistance / runtime.duration;
+}
+
+function pathHorizontalDistance(path: Vector3[]) {
+    let distance = 0;
+    for (let index = 1; index < path.length; index += 1) {
+        const previous = path[index - 1];
+        const current = path[index];
+        if (!previous || !current) {
+            continue;
+        }
+        distance += horizontalDistance(previous, current);
+    }
+    return distance;
+}
+
+function vectorFromPathPoint(point: CatPathSurface) {
+    return new Vector3(point.x, point.y, point.z);
+}
+
+function vectorPathFromResult(pathfinding: CatPathResult) {
+    return pathfinding.points.map(vectorFromPathPoint);
+}
+
+function pathPositionAtDistance(path: Vector3[], distance: number) {
+    if (path.length <= 0) {
+        return new Vector3();
+    }
+
+    const firstPoint = path[0];
+    if (!firstPoint || distance <= 0) {
+        return firstPoint?.clone() ?? new Vector3();
+    }
+
+    let remainingDistance = distance;
+    for (let index = 1; index < path.length; index += 1) {
+        const from = path[index - 1];
+        const to = path[index];
+        if (!from || !to) {
+            continue;
+        }
+
+        const segmentDistance = horizontalDistance(from, to);
+        if (segmentDistance <= 0.0001) {
+            continue;
+        }
+
+        if (remainingDistance <= segmentDistance) {
+            return from.clone().lerp(to, remainingDistance / segmentDistance);
+        }
+
+        remainingDistance -= segmentDistance;
+    }
+
+    return path[path.length - 1]?.clone() ?? new Vector3();
 }
 
 function catWalkAnimationTimeScale(
@@ -769,13 +855,75 @@ function chooseManualNextTarget({
     return pickCandidate(alternatives, random) ?? target;
 }
 
+function chooseDebugTarget({
+    behavior,
+    birdGroundEntries,
+    habitat,
+    random,
+    timeOfDay,
+    weather,
+}: {
+    behavior: string;
+    birdGroundEntries: AnimalDebugEntry[];
+    habitat: CatHabitat;
+    random: () => number;
+    timeOfDay: number;
+    weather: CatWeather | null | undefined;
+}) {
+    const range = getCatActivityRange(timeOfDay, weather);
+
+    if (behavior === 'pillow') {
+        return habitat.pillow;
+    }
+
+    if (behavior === 'roam') {
+        return createRoamTarget({ habitat, random, range });
+    }
+
+    if (behavior === 'cover') {
+        return (
+            pickCandidate(
+                candidatesInRange(habitat.covers, habitat.pillow, range),
+                random,
+            ) ?? habitat.pillow
+        );
+    }
+
+    if (behavior === 'low-entity') {
+        return (
+            pickCandidate(
+                candidatesInRange(habitat.lowEntities, habitat.pillow, range),
+                random,
+            ) ?? habitat.pillow
+        );
+    }
+
+    if (behavior === 'stalk-bird') {
+        return (
+            createStalkBirdTarget({
+                birdGroundTargets: getGroundBirdTargets({
+                    birdGroundEntries,
+                    habitat,
+                    range,
+                }),
+                habitat,
+                random,
+            }) ?? habitat.pillow
+        );
+    }
+
+    return null;
+}
+
 function makeMovingState({
+    blockedCells,
     from,
     fromTarget,
     groundSurfaces,
     now,
     target,
 }: {
+    blockedCells?: CatPathCell[];
     from: Vector3;
     fromTarget?: CatTarget;
     groundSurfaces?: CatGroundSurface[];
@@ -792,11 +940,26 @@ function makeMovingState({
         walkTo.y = getCatWalkYAt(walkTo, groundSurfaces);
     }
 
+    const pathfinding = findCatPath({
+        blockedCells: blockedCells ?? [],
+        from: walkFrom,
+        surfaces: resolvedGroundSurfaces,
+        to: walkTo,
+    });
+    const path = vectorPathFromResult(pathfinding);
+    const pathDistance = Math.max(
+        pathfinding.distance,
+        pathHorizontalDistance(path),
+    );
+
     return {
         phase: 'moving',
-        duration: movementDuration(walkFrom, walkTo),
+        duration: movementDuration(pathDistance),
         from: walkFrom,
         groundSurfaces: resolvedGroundSurfaces,
+        path,
+        pathDistance,
+        pathfinding,
         startedAt: now,
         target,
         to: walkTo,
@@ -804,10 +967,8 @@ function makeMovingState({
 }
 
 function movingPositionAt(runtime: MovingCatState, progress: number) {
-    const movementProgress = progress;
-    const position = runtime.from.clone().lerp(runtime.to, movementProgress);
-    const walkDistance =
-        horizontalDistance(runtime.from, runtime.to) * movementProgress;
+    const walkDistance = runtime.pathDistance * progress;
+    const position = pathPositionAtDistance(runtime.path, walkDistance);
     const walkPhase = (walkDistance / catWalkCycleDistance) * fullTurn;
 
     position.y = getCatWalkYAt(position, runtime.groundSurfaces);
@@ -894,6 +1055,22 @@ function roundCatDebugCoordinate(value: number) {
     return Math.round(value * 100) / 100;
 }
 
+function roundCatDebugPoint(point: Vector3) {
+    return {
+        x: roundCatDebugCoordinate(point.x),
+        y: roundCatDebugCoordinate(point.y),
+        z: roundCatDebugCoordinate(point.z),
+    };
+}
+
+function nextPathWaypoint(runtime: MovingCatState, position: Vector3) {
+    return (
+        runtime.path.find(
+            (point) => horizontalDistance(point, position) > 0.12,
+        ) ?? runtime.to
+    );
+}
+
 function createCatDebugEntry({
     group,
     habitat,
@@ -913,11 +1090,22 @@ function createCatDebugEntry({
         behavior: runtime.target.behavior,
         activity: getCatDebugActivity(runtime),
         targetId: runtime.target.id,
-        position: {
-            x: roundCatDebugCoordinate(group.position.x),
-            y: roundCatDebugCoordinate(group.position.y),
-            z: roundCatDebugCoordinate(group.position.z),
-        },
+        debugBehaviors: catDebugBehaviors,
+        pathfinding:
+            runtime.phase === 'moving'
+                ? {
+                      blockedCellCount: runtime.pathfinding.blockedCellCount,
+                      distance: roundCatDebugCoordinate(runtime.pathDistance),
+                      nextWaypoint: roundCatDebugPoint(
+                          nextPathWaypoint(runtime, group.position),
+                      ),
+                      status: runtime.pathfinding.status,
+                      targetCell: runtime.pathfinding.targetCell,
+                      visitedCellCount: runtime.pathfinding.visitedCellCount,
+                      waypointCount: runtime.path.length,
+                  }
+                : undefined,
+        position: roundCatDebugPoint(group.position),
         updatedAt: now,
     };
 }
@@ -972,10 +1160,14 @@ function Cat({
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<CatRuntimeState | null>(null);
     const lastAnimalDebugUpdateRef = useRef(0);
+    const lastDebugCommandSequenceRef = useRef(0);
     const activeAnimationRef = useRef<CatAnimationName>('Cat_LyingIdle');
     const [activeAnimation, setActiveAnimation] =
         useState<CatAnimationName>('Cat_LyingIdle');
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const animalDebugCommand = useGameState(
+        (state) => state.animalDebugCommand,
+    );
     const setAnimalDebugEntry = useGameState(
         (state) => state.setAnimalDebugEntry,
     );
@@ -1064,6 +1256,7 @@ function Cat({
         }
 
         runtimeRef.current = makeMovingState({
+            blockedCells: habitat.blockedCells,
             from: group.position.clone(),
             fromTarget: runtime.target,
             groundSurfaces: habitat.groundSurfaces,
@@ -1111,6 +1304,50 @@ function Cat({
             group.position.copy(habitat.pillow.position);
             if (habitat.pillow.facingYaw !== undefined) {
                 group.rotation.y = habitat.pillow.facingYaw;
+            }
+        }
+
+        if (
+            animalDebugCommand &&
+            animalDebugCommand.sequence !==
+                lastDebugCommandSequenceRef.current &&
+            animalDebugCommand.species === 'Cat'
+        ) {
+            lastDebugCommandSequenceRef.current = animalDebugCommand.sequence;
+
+            if (
+                !animalDebugCommand.targetId ||
+                animalDebugCommand.targetId === habitat.id
+            ) {
+                const target = chooseDebugTarget({
+                    behavior: animalDebugCommand.behavior,
+                    birdGroundEntries,
+                    habitat,
+                    random,
+                    timeOfDay,
+                    weather,
+                });
+
+                if (target) {
+                    runtime =
+                        group.position.distanceTo(target.position) < 0.08
+                            ? makeSettledState({
+                                  now,
+                                  random,
+                                  target,
+                                  timeOfDay,
+                                  weather,
+                              })
+                            : makeMovingState({
+                                  blockedCells: habitat.blockedCells,
+                                  from: group.position.clone(),
+                                  fromTarget: runtime.target,
+                                  groundSurfaces: habitat.groundSurfaces,
+                                  now,
+                                  target,
+                              });
+                    runtimeRef.current = runtime;
+                }
             }
         }
 
@@ -1207,6 +1444,7 @@ function Cat({
         }
 
         runtimeRef.current = makeMovingState({
+            blockedCells: habitat.blockedCells,
             from: group.position.clone(),
             fromTarget: runtime.target,
             groundSurfaces: habitat.groundSurfaces,

--- a/packages/game/src/entities/cats/catPathfinding.ts
+++ b/packages/game/src/entities/cats/catPathfinding.ts
@@ -1,0 +1,528 @@
+export type CatPathCell = {
+    x: number;
+    z: number;
+};
+
+export type CatPathPoint = CatPathCell & {
+    y: number;
+};
+
+export type CatPathSurface = CatPathPoint;
+
+export type CatPathStatus = 'direct' | 'path' | 'fallback';
+
+export type CatPathResult = {
+    blockedCellCount: number;
+    distance: number;
+    points: CatPathPoint[];
+    startCell: CatPathCell;
+    status: CatPathStatus;
+    targetCell: CatPathCell;
+    visitedCellCount: number;
+};
+
+type SearchNode = {
+    cell: CatPathCell;
+    costFromStart: number;
+    estimatedTotalCost: number;
+    previousKey: string | null;
+};
+
+const diagonalCost = Math.SQRT2;
+const directPathSampleStep = 0.18;
+const cardinalDirections = [
+    { x: 1, z: 0, cost: 1 },
+    { x: -1, z: 0, cost: 1 },
+    { x: 0, z: 1, cost: 1 },
+    { x: 0, z: -1, cost: 1 },
+];
+const diagonalDirections = [
+    { x: 1, z: 1, cost: diagonalCost },
+    { x: 1, z: -1, cost: diagonalCost },
+    { x: -1, z: 1, cost: diagonalCost },
+    { x: -1, z: -1, cost: diagonalCost },
+];
+const searchDirections = [...cardinalDirections, ...diagonalDirections];
+
+function cellKey(cell: CatPathCell) {
+    return `${cell.x}:${cell.z}`;
+}
+
+function roundCell(point: Pick<CatPathPoint, 'x' | 'z'>): CatPathCell {
+    return {
+        x: Math.round(point.x),
+        z: Math.round(point.z),
+    };
+}
+
+function horizontalDistance(
+    left: Pick<CatPathPoint, 'x' | 'z'>,
+    right: Pick<CatPathPoint, 'x' | 'z'>,
+) {
+    return Math.hypot(left.x - right.x, left.z - right.z);
+}
+
+function pointDistance(left: CatPathPoint, right: CatPathPoint) {
+    return horizontalDistance(left, right);
+}
+
+function pathDistance(points: CatPathPoint[]) {
+    let distance = 0;
+    for (let index = 1; index < points.length; index += 1) {
+        const previous = points[index - 1];
+        const current = points[index];
+        if (!previous || !current) {
+            continue;
+        }
+        distance += pointDistance(previous, current);
+    }
+    return distance;
+}
+
+function createSurfaceMap(
+    surfaces: CatPathSurface[],
+    from: CatPathPoint,
+    to: CatPathPoint,
+) {
+    const surfaceByKey = new Map<string, CatPathSurface>();
+
+    for (const surface of surfaces) {
+        surfaceByKey.set(cellKey(roundCell(surface)), surface);
+    }
+
+    const startCell = roundCell(from);
+    const targetCell = roundCell(to);
+    if (!surfaceByKey.has(cellKey(startCell))) {
+        surfaceByKey.set(cellKey(startCell), {
+            x: startCell.x,
+            y: from.y,
+            z: startCell.z,
+        });
+    }
+    if (!surfaceByKey.has(cellKey(targetCell))) {
+        surfaceByKey.set(cellKey(targetCell), {
+            x: targetCell.x,
+            y: to.y,
+            z: targetCell.z,
+        });
+    }
+
+    return surfaceByKey;
+}
+
+function isSameCell(left: CatPathCell, right: CatPathCell) {
+    return left.x === right.x && left.z === right.z;
+}
+
+function isTemporarilyAllowedCell(
+    cell: CatPathCell,
+    startCell: CatPathCell,
+    targetCell: CatPathCell,
+) {
+    return isSameCell(cell, startCell) || isSameCell(cell, targetCell);
+}
+
+function canWalkCell({
+    blockedKeys,
+    cell,
+    startCell,
+    surfaceByKey,
+    targetCell,
+}: {
+    blockedKeys: Set<string>;
+    cell: CatPathCell;
+    startCell: CatPathCell;
+    surfaceByKey: Map<string, CatPathSurface>;
+    targetCell: CatPathCell;
+}) {
+    const key = cellKey(cell);
+    if (!surfaceByKey.has(key)) {
+        return false;
+    }
+
+    return (
+        !blockedKeys.has(key) ||
+        isTemporarilyAllowedCell(cell, startCell, targetCell)
+    );
+}
+
+function directPathCrossesBlockedCell({
+    blockedKeys,
+    from,
+    startCell,
+    targetCell,
+    to,
+}: {
+    blockedKeys: Set<string>;
+    from: CatPathPoint;
+    startCell: CatPathCell;
+    targetCell: CatPathCell;
+    to: CatPathPoint;
+}) {
+    const distance = horizontalDistance(from, to);
+    const steps = Math.max(1, Math.ceil(distance / directPathSampleStep));
+
+    for (let step = 1; step < steps; step += 1) {
+        const progress = step / steps;
+        const cell = roundCell({
+            x: from.x + (to.x - from.x) * progress,
+            z: from.z + (to.z - from.z) * progress,
+        });
+
+        if (
+            !isTemporarilyAllowedCell(cell, startCell, targetCell) &&
+            blockedKeys.has(cellKey(cell))
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function heuristic(left: CatPathCell, right: CatPathCell) {
+    const dx = Math.abs(left.x - right.x);
+    const dz = Math.abs(left.z - right.z);
+    const diagonal = Math.min(dx, dz);
+    const straight = Math.max(dx, dz) - diagonal;
+    return diagonal * diagonalCost + straight;
+}
+
+function canWalkDiagonal({
+    blockedKeys,
+    cell,
+    direction,
+    startCell,
+    surfaceByKey,
+    targetCell,
+}: {
+    blockedKeys: Set<string>;
+    cell: CatPathCell;
+    direction: CatPathCell;
+    startCell: CatPathCell;
+    surfaceByKey: Map<string, CatPathSurface>;
+    targetCell: CatPathCell;
+}) {
+    if (direction.x === 0 || direction.z === 0) {
+        return true;
+    }
+
+    return (
+        canWalkCell({
+            blockedKeys,
+            cell: { x: cell.x + direction.x, z: cell.z },
+            startCell,
+            surfaceByKey,
+            targetCell,
+        }) &&
+        canWalkCell({
+            blockedKeys,
+            cell: { x: cell.x, z: cell.z + direction.z },
+            startCell,
+            surfaceByKey,
+            targetCell,
+        })
+    );
+}
+
+function findLowestCostOpenNode(
+    openKeys: Set<string>,
+    nodesByKey: Map<string, SearchNode>,
+) {
+    let selectedNode: SearchNode | null = null;
+    let selectedKey: string | null = null;
+
+    for (const key of openKeys) {
+        const node = nodesByKey.get(key);
+        if (!node) {
+            continue;
+        }
+
+        if (
+            !selectedNode ||
+            node.estimatedTotalCost < selectedNode.estimatedTotalCost ||
+            (node.estimatedTotalCost === selectedNode.estimatedTotalCost &&
+                node.costFromStart < selectedNode.costFromStart)
+        ) {
+            selectedNode = node;
+            selectedKey = key;
+        }
+    }
+
+    return selectedNode && selectedKey
+        ? { key: selectedKey, node: selectedNode }
+        : null;
+}
+
+function reconstructPath(
+    targetKey: string,
+    nodesByKey: Map<string, SearchNode>,
+) {
+    const cells: CatPathCell[] = [];
+    let currentKey: string | null = targetKey;
+
+    while (currentKey) {
+        const node = nodesByKey.get(currentKey);
+        if (!node) {
+            break;
+        }
+
+        cells.push(node.cell);
+        currentKey = node.previousKey;
+    }
+
+    return cells.reverse();
+}
+
+function findCellPath({
+    blockedKeys,
+    startCell,
+    surfaceByKey,
+    targetCell,
+}: {
+    blockedKeys: Set<string>;
+    startCell: CatPathCell;
+    surfaceByKey: Map<string, CatPathSurface>;
+    targetCell: CatPathCell;
+}) {
+    const startKey = cellKey(startCell);
+    const targetKey = cellKey(targetCell);
+    const openKeys = new Set([startKey]);
+    const closedKeys = new Set<string>();
+    const nodesByKey = new Map<string, SearchNode>([
+        [
+            startKey,
+            {
+                cell: startCell,
+                costFromStart: 0,
+                estimatedTotalCost: heuristic(startCell, targetCell),
+                previousKey: null,
+            },
+        ],
+    ]);
+
+    while (openKeys.size > 0) {
+        const current = findLowestCostOpenNode(openKeys, nodesByKey);
+        if (!current) {
+            break;
+        }
+
+        if (current.key === targetKey) {
+            return {
+                cells: reconstructPath(current.key, nodesByKey),
+                visitedCellCount: closedKeys.size + 1,
+            };
+        }
+
+        openKeys.delete(current.key);
+        closedKeys.add(current.key);
+
+        for (const direction of searchDirections) {
+            const neighborCell = {
+                x: current.node.cell.x + direction.x,
+                z: current.node.cell.z + direction.z,
+            };
+            const neighborKey = cellKey(neighborCell);
+
+            if (closedKeys.has(neighborKey)) {
+                continue;
+            }
+
+            if (
+                !canWalkCell({
+                    blockedKeys,
+                    cell: neighborCell,
+                    startCell,
+                    surfaceByKey,
+                    targetCell,
+                }) ||
+                !canWalkDiagonal({
+                    blockedKeys,
+                    cell: current.node.cell,
+                    direction,
+                    startCell,
+                    surfaceByKey,
+                    targetCell,
+                })
+            ) {
+                continue;
+            }
+
+            const candidateCost = current.node.costFromStart + direction.cost;
+            const existingNode = nodesByKey.get(neighborKey);
+            if (existingNode && candidateCost >= existingNode.costFromStart) {
+                continue;
+            }
+
+            nodesByKey.set(neighborKey, {
+                cell: neighborCell,
+                costFromStart: candidateCost,
+                estimatedTotalCost:
+                    candidateCost + heuristic(neighborCell, targetCell),
+                previousKey: current.key,
+            });
+            openKeys.add(neighborKey);
+        }
+    }
+
+    return {
+        cells: null,
+        visitedCellCount: closedKeys.size,
+    };
+}
+
+function simplifyCellPath(cells: CatPathCell[]) {
+    if (cells.length <= 2) {
+        return cells;
+    }
+
+    const simplified: CatPathCell[] = [];
+    let previousDirection: CatPathCell | null = null;
+
+    for (let index = 0; index < cells.length; index += 1) {
+        const previous = cells[index - 1];
+        const current = cells[index];
+        const next = cells[index + 1];
+        if (!current) {
+            continue;
+        }
+
+        if (!previous || !next) {
+            simplified.push(current);
+            continue;
+        }
+
+        const direction = {
+            x: Math.sign(current.x - previous.x),
+            z: Math.sign(current.z - previous.z),
+        };
+        const nextDirection = {
+            x: Math.sign(next.x - current.x),
+            z: Math.sign(next.z - current.z),
+        };
+        if (
+            !previousDirection ||
+            direction.x !== previousDirection.x ||
+            direction.z !== previousDirection.z ||
+            direction.x !== nextDirection.x ||
+            direction.z !== nextDirection.z
+        ) {
+            simplified.push(current);
+        }
+        previousDirection = direction;
+    }
+
+    return simplified;
+}
+
+function pointForCell(
+    cell: CatPathCell,
+    surfaceByKey: Map<string, CatPathSurface>,
+) {
+    const surface = surfaceByKey.get(cellKey(cell));
+    return {
+        x: cell.x,
+        y: surface?.y ?? 0,
+        z: cell.z,
+    };
+}
+
+function cellsToPoints({
+    cells,
+    from,
+    surfaceByKey,
+    to,
+}: {
+    cells: CatPathCell[];
+    from: CatPathPoint;
+    surfaceByKey: Map<string, CatPathSurface>;
+    to: CatPathPoint;
+}) {
+    const points: CatPathPoint[] = [from];
+    const simplifiedCells = simplifyCellPath(cells);
+
+    for (let index = 1; index < simplifiedCells.length - 1; index += 1) {
+        const cell = simplifiedCells[index];
+        if (cell) {
+            points.push(pointForCell(cell, surfaceByKey));
+        }
+    }
+
+    points.push(to);
+    return points;
+}
+
+export function findCatPath({
+    blockedCells,
+    from,
+    surfaces,
+    to,
+}: {
+    blockedCells: CatPathCell[];
+    from: CatPathPoint;
+    surfaces: CatPathSurface[];
+    to: CatPathPoint;
+}): CatPathResult {
+    const startCell = roundCell(from);
+    const targetCell = roundCell(to);
+    const surfaceByKey = createSurfaceMap(surfaces, from, to);
+    const blockedKeys = new Set(blockedCells.map(cellKey));
+    const blockedCellCount = blockedKeys.size;
+    const directPoints = [from, to];
+
+    if (
+        isSameCell(startCell, targetCell) ||
+        !directPathCrossesBlockedCell({
+            blockedKeys,
+            from,
+            startCell,
+            targetCell,
+            to,
+        })
+    ) {
+        return {
+            blockedCellCount,
+            distance: pathDistance(directPoints),
+            points: directPoints,
+            startCell,
+            status: 'direct',
+            targetCell,
+            visitedCellCount: 0,
+        };
+    }
+
+    const cellPath = findCellPath({
+        blockedKeys,
+        startCell,
+        surfaceByKey,
+        targetCell,
+    });
+    if (!cellPath.cells) {
+        return {
+            blockedCellCount,
+            distance: pathDistance(directPoints),
+            points: directPoints,
+            startCell,
+            status: 'fallback',
+            targetCell,
+            visitedCellCount: cellPath.visitedCellCount,
+        };
+    }
+
+    const pathPoints = cellsToPoints({
+        cells: cellPath.cells,
+        from,
+        surfaceByKey,
+        to,
+    });
+
+    return {
+        blockedCellCount,
+        distance: pathDistance(pathPoints),
+        points: pathPoints,
+        startCell,
+        status: 'path',
+        targetCell,
+        visitedCellCount: cellPath.visitedCellCount,
+    };
+}

--- a/packages/game/src/entities/cats/catPathfinding.unit.ts
+++ b/packages/game/src/entities/cats/catPathfinding.unit.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { CatPathCell, CatPathSurface } from './catPathfinding';
+import { findCatPath } from './catPathfinding';
+
+function createSurfaces({
+    maxX,
+    maxZ,
+    minX,
+    minZ,
+}: {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+}) {
+    const surfaces: CatPathSurface[] = [];
+
+    for (let x = minX; x <= maxX; x += 1) {
+        for (let z = minZ; z <= maxZ; z += 1) {
+            surfaces.push({ x, y: 0.42, z });
+        }
+    }
+
+    return surfaces;
+}
+
+test('keeps direct cat movement when no cells block the segment', () => {
+    const path = findCatPath({
+        blockedCells: [],
+        from: { x: -2, y: 0.42, z: 0 },
+        surfaces: createSurfaces({ minX: -2, maxX: 2, minZ: -1, maxZ: 1 }),
+        to: { x: 2, y: 0.42, z: 0 },
+    });
+
+    assert.equal(path.status, 'direct');
+    assert.equal(path.points.length, 2);
+    assert.equal(path.visitedCellCount, 0);
+});
+
+test('routes cats through an early passage instead of through blocking entities', () => {
+    const blockedCells: CatPathCell[] = [
+        { x: -1, z: 0 },
+        { x: 0, z: 0 },
+        { x: 1, z: 0 },
+    ];
+    const path = findCatPath({
+        blockedCells,
+        from: { x: -2, y: 0.42, z: 0 },
+        surfaces: createSurfaces({ minX: -2, maxX: 2, minZ: -1, maxZ: 1 }),
+        to: { x: 2, y: 0.42, z: 0 },
+    });
+
+    assert.equal(path.status, 'path');
+    assert.ok(path.visitedCellCount > 0);
+    assert.ok(path.points.length > 2);
+    assert.equal(
+        path.points.some(
+            (point) =>
+                blockedCells.some(
+                    (cell) =>
+                        Math.round(point.x) === cell.x &&
+                        Math.round(point.z) === cell.z,
+                ) &&
+                point.x !== -2 &&
+                point.x !== 2,
+        ),
+        false,
+    );
+});
+
+test('allows the cat to start or finish on an occupied target cell', () => {
+    const path = findCatPath({
+        blockedCells: [
+            { x: -2, z: 0 },
+            { x: 2, z: 0 },
+            { x: 0, z: 0 },
+        ],
+        from: { x: -2, y: 0.42, z: 0 },
+        surfaces: createSurfaces({ minX: -2, maxX: 2, minZ: -1, maxZ: 1 }),
+        to: { x: 2, y: 0.42, z: 0 },
+    });
+
+    assert.equal(path.status, 'path');
+    assert.deepEqual(path.startCell, { x: -2, z: 0 });
+    assert.deepEqual(path.targetCell, { x: 2, z: 0 });
+});
+
+test('falls back to direct movement when no walkable passage exists', () => {
+    const path = findCatPath({
+        blockedCells: [
+            { x: -1, z: -1 },
+            { x: -1, z: 0 },
+            { x: -1, z: 1 },
+            { x: 0, z: -1 },
+            { x: 0, z: 0 },
+            { x: 0, z: 1 },
+            { x: 1, z: -1 },
+            { x: 1, z: 0 },
+            { x: 1, z: 1 },
+        ],
+        from: { x: -2, y: 0.42, z: 0 },
+        surfaces: createSurfaces({ minX: -2, maxX: 2, minZ: -1, maxZ: 1 }),
+        to: { x: 2, y: 0.42, z: 0 },
+    });
+
+    assert.equal(path.status, 'fallback');
+    assert.equal(path.points.length, 2);
+});

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -270,6 +270,9 @@ export function DebugHud() {
         (s) => s.setDayNightCycleDisabled,
     );
     const animalDebugEntries = useGameState((s) => s.animalDebugEntries);
+    const triggerAnimalDebugBehavior = useGameState(
+        (s) => s.triggerAnimalDebugBehavior,
+    );
     const editHitboxDebugVisible = useGameState(
         (s) => s.editHitboxDebugVisible,
     );
@@ -809,12 +812,71 @@ export function DebugHud() {
                                                 {entry.behavior} →{' '}
                                                 {entry.targetId || 'none'}
                                             </div>
+                                            {entry.pathfinding ? (
+                                                <div className="mt-1 rounded bg-muted/70 px-1.5 py-1 font-mono text-[10px] text-muted-foreground">
+                                                    pathfinding{' '}
+                                                    {entry.pathfinding.status} ·{' '}
+                                                    {
+                                                        entry.pathfinding
+                                                            .waypointCount
+                                                    }{' '}
+                                                    wp ·{' '}
+                                                    {entry.pathfinding.distance}
+                                                    b ·{' '}
+                                                    {
+                                                        entry.pathfinding
+                                                            .visitedCellCount
+                                                    }{' '}
+                                                    checked ·{' '}
+                                                    {
+                                                        entry.pathfinding
+                                                            .blockedCellCount
+                                                    }{' '}
+                                                    blocked
+                                                    {entry.pathfinding
+                                                        .nextWaypoint
+                                                        ? ` · next ${formatAnimalPosition(entry.pathfinding.nextWaypoint)}`
+                                                        : ''}
+                                                </div>
+                                            ) : null}
                                             <div className="inline-flex items-center gap-1 font-mono text-muted-foreground">
                                                 <MapPin className="size-3 shrink-0" />
                                                 {formatAnimalPosition(
                                                     entry.position,
                                                 )}
                                             </div>
+                                            {entry.debugBehaviors?.length ? (
+                                                <div className="mt-1.5 flex flex-wrap gap-1">
+                                                    {entry.debugBehaviors.map(
+                                                        (behavior) => (
+                                                            <Button
+                                                                key={`${entry.id}-${behavior}`}
+                                                                size="xs"
+                                                                className="h-6 px-1.5 text-[10px]"
+                                                                variant={
+                                                                    entry.behavior ===
+                                                                    behavior
+                                                                        ? 'solid'
+                                                                        : 'outlined'
+                                                                }
+                                                                onClick={() =>
+                                                                    triggerAnimalDebugBehavior(
+                                                                        {
+                                                                            behavior,
+                                                                            species:
+                                                                                entry.species,
+                                                                            targetId:
+                                                                                entry.id,
+                                                                        },
+                                                                    )
+                                                                }
+                                                            >
+                                                                {behavior}
+                                                            </Button>
+                                                        ),
+                                                    )}
+                                                </div>
+                                            ) : null}
                                         </div>
                                     ))}
                                 </Stack>

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -62,6 +62,7 @@ export type BlockPlacementDropAnimation = {
 };
 
 export type AnimalDebugEntry = {
+    debugBehaviors?: string[];
     id: string;
     species: string;
     label: string;
@@ -74,7 +75,31 @@ export type AnimalDebugEntry = {
         y: number;
         z: number;
     };
+    pathfinding?: {
+        blockedCellCount: number;
+        distance: number;
+        nextWaypoint?: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        status: string;
+        targetCell?: {
+            x: number;
+            z: number;
+        };
+        visitedCellCount: number;
+        waypointCount: number;
+    };
     updatedAt: number;
+};
+
+export type AnimalDebugCommand = {
+    behavior: string;
+    createdAt: number;
+    sequence: number;
+    species: string;
+    targetId?: string | null;
 };
 
 export type AnimalDisturbance = {
@@ -151,6 +176,10 @@ export type GameState = {
     animalDebugEntries: AnimalDebugEntry[];
     setAnimalDebugEntry: (entry: AnimalDebugEntry) => void;
     removeAnimalDebugEntry: (id: string) => void;
+    animalDebugCommand: AnimalDebugCommand | null;
+    triggerAnimalDebugBehavior: (
+        command: Omit<AnimalDebugCommand, 'createdAt' | 'sequence'>,
+    ) => void;
     animalDisturbance: AnimalDisturbance | null;
     disturbAnimals: (
         disturbance: Omit<AnimalDisturbance, 'createdAt' | 'sequence'>,
@@ -396,6 +425,15 @@ export function createGameState({
                 animalDebugEntries: state.animalDebugEntries.filter(
                     (entry) => entry.id !== id,
                 ),
+            })),
+        animalDebugCommand: null,
+        triggerAnimalDebugBehavior: (command) =>
+            set((state) => ({
+                animalDebugCommand: {
+                    ...command,
+                    createdAt: Date.now(),
+                    sequence: (state.animalDebugCommand?.sequence ?? 0) + 1,
+                },
             })),
         animalDisturbance: null,
         disturbAnimals: (disturbance) =>


### PR DESCRIPTION
## Summary
- Add an animal sandbox entry under the garden debug routes.
- Add debug commands for bees, birds, and cats so behaviors can be triggered from the HUD.
- Surface richer debug data, including cat pathfinding details and selectable behavior buttons.
- Introduce cat pathfinding support and unit coverage for the pathfinding helper.

## Testing
- Unit tests added for cat pathfinding.
- UI testing not run (not requested).