### PR TITLE
Fix breadcrumb dropdown navigation and menu overflow

### DIFF
--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -33,6 +33,7 @@ import {
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { AdminBreadcrumbSelectorLink } from './AdminBreadcrumbSelectorLink';
 import { AdminBreadcrumbSelectorTrigger } from './AdminBreadcrumbSelectorTrigger';
 import { adminBreadcrumbPages, adminPages } from './adminPages';
 
@@ -187,32 +188,40 @@ export function AdminBreadcrumbLevelSelector() {
         resolveCurrentTopLevel(pathname) ?? adminBreadcrumbPages[0];
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <AdminBreadcrumbSelectorTrigger>
-                    {currentTopLevel.label}
-                </AdminBreadcrumbSelectorTrigger>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-                {breadcrumbSections.map((section, index) => (
-                    <div key={section.title}>
-                        <DropdownMenuLabel className="text-muted-foreground text-xs">
-                            {section.title}
-                        </DropdownMenuLabel>
-                        {section.pages.map((page) => (
-                            <DropdownMenuItem key={page.href} href={page.href}>
-                                <div className="flex items-center gap-2">
-                                    {page.icon}
-                                    <span>{page.label}</span>
-                                </div>
-                            </DropdownMenuItem>
-                        ))}
-                        {index < breadcrumbSections.length - 1 && (
-                            <DropdownMenuSeparator />
-                        )}
-                    </div>
-                ))}
-            </DropdownMenuContent>
-        </DropdownMenu>
+        <span className="inline-flex min-w-0 items-center gap-0.5">
+            <AdminBreadcrumbSelectorLink href={currentTopLevel.href}>
+                {currentTopLevel.label}
+            </AdminBreadcrumbSelectorLink>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <AdminBreadcrumbSelectorTrigger
+                        aria-label={`Prikaži podizbornik za ${currentTopLevel.label}`}
+                    />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                    {breadcrumbSections.map((section, index) => (
+                        <div key={section.title}>
+                            <DropdownMenuLabel className="text-muted-foreground text-xs">
+                                {section.title}
+                            </DropdownMenuLabel>
+                            {section.pages.map((page) => (
+                                <DropdownMenuItem
+                                    key={page.href}
+                                    href={page.href}
+                                >
+                                    <div className="flex items-center gap-2">
+                                        {page.icon}
+                                        <span>{page.label}</span>
+                                    </div>
+                                </DropdownMenuItem>
+                            ))}
+                            {index < breadcrumbSections.length - 1 && (
+                                <DropdownMenuSeparator />
+                            )}
+                        </div>
+                    ))}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </span>
     );
 }

--- a/apps/app/components/admin/navigation/AdminBreadcrumbSelectorLink.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbSelectorLink.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Link } from '@gredice/ui/Link';
+import type { ReactNode } from 'react';
+import { adminBreadcrumbSelectorLinkClassName } from './adminBreadcrumbStyles';
+
+export function AdminBreadcrumbSelectorLink({
+    children,
+    href,
+}: {
+    children: ReactNode;
+    href: string;
+}) {
+    return (
+        <Link className={adminBreadcrumbSelectorLinkClassName} href={href}>
+            <span className="min-w-0 truncate">{children}</span>
+        </Link>
+    );
+}

--- a/apps/app/components/admin/navigation/AdminBreadcrumbSelectorTrigger.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbSelectorTrigger.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import { ArrowDown } from '@gredice/ui/icons';
-import { type ButtonHTMLAttributes, forwardRef, type ReactNode } from 'react';
+import { Down } from '@gredice/ui/icons';
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
 import { adminBreadcrumbSelectorTriggerClassName } from './adminBreadcrumbStyles';
 
 export const AdminBreadcrumbSelectorTrigger = forwardRef<
     HTMLButtonElement,
     ButtonHTMLAttributes<HTMLButtonElement> & {
-        children: ReactNode;
+        'aria-label': string;
     }
->(function AdminBreadcrumbSelectorTrigger(
-    { children, className, type, ...props },
-    ref,
-) {
+>(function AdminBreadcrumbSelectorTrigger({ className, type, ...props }, ref) {
     return (
         <button
             ref={ref}
@@ -22,8 +19,7 @@ export const AdminBreadcrumbSelectorTrigger = forwardRef<
                 .join(' ')}
             {...props}
         >
-            <span className="min-w-0 truncate">{children}</span>
-            <ArrowDown className="size-3 shrink-0" aria-hidden />
+            <Down className="size-3.5" aria-hidden />
         </button>
     );
 });

--- a/apps/app/components/admin/navigation/AdminDirectoryCategoryBreadcrumbSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminDirectoryCategoryBreadcrumbSelector.tsx
@@ -9,6 +9,7 @@ import {
 import { useContext } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
 import { EntityTypeIcon } from '../directories/EntityTypeIcon';
+import { AdminBreadcrumbSelectorLink } from './AdminBreadcrumbSelectorLink';
 import { AdminBreadcrumbSelectorTrigger } from './AdminBreadcrumbSelectorTrigger';
 import {
     findDirectoryBreadcrumbGroup,
@@ -29,38 +30,48 @@ export function AdminDirectoryCategoryBreadcrumbSelector({
         return null;
     }
 
-    return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <AdminBreadcrumbSelectorTrigger>
-                    {currentGroup.label}
-                </AdminBreadcrumbSelectorTrigger>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-                {groups.map((group) => {
-                    const firstEntityType = group.entityTypes[0];
-                    if (!firstEntityType) {
-                        return null;
-                    }
+    const firstCurrentGroupEntityType = currentGroup.entityTypes[0];
+    const currentGroupHref = firstCurrentGroupEntityType
+        ? KnownPages.DirectoryEntityType(firstCurrentGroupEntityType.name)
+        : KnownPages.Directories;
 
-                    return (
-                        <DropdownMenuItem
-                            key={group.key}
-                            href={KnownPages.DirectoryEntityType(
-                                firstEntityType.name,
-                            )}
-                        >
-                            <div className="flex items-center gap-2">
-                                <EntityTypeIcon
-                                    icon={group.icon}
-                                    className="size-4"
-                                />
-                                <span>{group.label}</span>
-                            </div>
-                        </DropdownMenuItem>
-                    );
-                })}
-            </DropdownMenuContent>
-        </DropdownMenu>
+    return (
+        <span className="inline-flex min-w-0 items-center gap-0.5">
+            <AdminBreadcrumbSelectorLink href={currentGroupHref}>
+                {currentGroup.label}
+            </AdminBreadcrumbSelectorLink>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <AdminBreadcrumbSelectorTrigger
+                        aria-label={`Prikaži podizbornik za ${currentGroup.label}`}
+                    />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                    {groups.map((group) => {
+                        const firstEntityType = group.entityTypes[0];
+                        if (!firstEntityType) {
+                            return null;
+                        }
+
+                        return (
+                            <DropdownMenuItem
+                                key={group.key}
+                                href={KnownPages.DirectoryEntityType(
+                                    firstEntityType.name,
+                                )}
+                            >
+                                <div className="flex items-center gap-2">
+                                    <EntityTypeIcon
+                                        icon={group.icon}
+                                        className="size-4"
+                                    />
+                                    <span>{group.label}</span>
+                                </div>
+                            </DropdownMenuItem>
+                        );
+                    })}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </span>
     );
 }

--- a/apps/app/components/admin/navigation/AdminDirectoryEntityTypeBreadcrumbSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminDirectoryEntityTypeBreadcrumbSelector.tsx
@@ -9,6 +9,7 @@ import {
 import { useContext } from 'react';
 import { KnownPages } from '../../../src/KnownPages';
 import { EntityTypeIcon } from '../directories/EntityTypeIcon';
+import { AdminBreadcrumbSelectorLink } from './AdminBreadcrumbSelectorLink';
 import { AdminBreadcrumbSelectorTrigger } from './AdminBreadcrumbSelectorTrigger';
 import {
     findDirectoryBreadcrumbEntityType,
@@ -37,32 +38,39 @@ export function AdminDirectoryEntityTypeBreadcrumbSelector({
     }
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <AdminBreadcrumbSelectorTrigger>
-                    {currentEntityType.label}
-                </AdminBreadcrumbSelectorTrigger>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-                {(currentGroup?.entityTypes ?? [currentEntityType]).map(
-                    (entityType) => (
-                        <DropdownMenuItem
-                            key={entityType.id}
-                            href={KnownPages.DirectoryEntityType(
-                                entityType.name,
-                            )}
-                        >
-                            <div className="flex items-center gap-2">
-                                <EntityTypeIcon
-                                    icon={entityType.icon}
-                                    className="size-4"
-                                />
-                                <span>{entityType.label}</span>
-                            </div>
-                        </DropdownMenuItem>
-                    ),
-                )}
-            </DropdownMenuContent>
-        </DropdownMenu>
+        <span className="inline-flex min-w-0 items-center gap-0.5">
+            <AdminBreadcrumbSelectorLink
+                href={KnownPages.DirectoryEntityType(currentEntityType.name)}
+            >
+                {currentEntityType.label}
+            </AdminBreadcrumbSelectorLink>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <AdminBreadcrumbSelectorTrigger
+                        aria-label={`Prikaži podizbornik za ${currentEntityType.label}`}
+                    />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                    {(currentGroup?.entityTypes ?? [currentEntityType]).map(
+                        (entityType) => (
+                            <DropdownMenuItem
+                                key={entityType.id}
+                                href={KnownPages.DirectoryEntityType(
+                                    entityType.name,
+                                )}
+                            >
+                                <div className="flex items-center gap-2">
+                                    <EntityTypeIcon
+                                        icon={entityType.icon}
+                                        className="size-4"
+                                    />
+                                    <span>{entityType.label}</span>
+                                </div>
+                            </DropdownMenuItem>
+                        ),
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </span>
     );
 }

--- a/apps/app/components/admin/navigation/adminBreadcrumbStyles.ts
+++ b/apps/app/components/admin/navigation/adminBreadcrumbStyles.ts
@@ -1,5 +1,8 @@
 export const adminBreadcrumbClassName =
     'text-muted-foreground text-sm font-medium';
 
+export const adminBreadcrumbSelectorLinkClassName =
+    'inline-flex min-w-0 max-w-full items-center rounded-xs text-inherit underline-offset-4 [font:inherit] outline-hidden transition-colors hover:text-foreground hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
 export const adminBreadcrumbSelectorTriggerClassName =
-    'inline-flex max-w-full items-center gap-1 rounded-xs text-inherit [font:inherit] outline-hidden transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+    'inline-flex size-5 shrink-0 items-center justify-center rounded-xs text-inherit outline-hidden transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';

--- a/apps/storybook/stories/packages/ui/primitives/Menu.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Menu.stories.tsx
@@ -83,3 +83,23 @@ export const ButtonTrigger: Story = {
         </DropdownMenu>
     ),
 };
+
+export const ScrollableContent: Story = {
+    render: (args) => (
+        <div className="flex h-72 items-end">
+            <DropdownMenu {...args}>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="outlined">Otvori dugi izbornik</Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-56">
+                    <DropdownMenuLabel>Odaberi stranicu</DropdownMenuLabel>
+                    {Array.from({ length: 24 }, (_, index) => (
+                        <DropdownMenuItem key={`page-${index + 1}`}>
+                            Stranica {index + 1}
+                        </DropdownMenuItem>
+                    ))}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    ),
+};

--- a/packages/ui/src/Menu/Menu.tsx
+++ b/packages/ui/src/Menu/Menu.tsx
@@ -52,7 +52,7 @@ export const DropdownMenuSubContent = forwardRef<
     return (
         <DropdownMenuPrimitive.SubContent
             className={cx(
-                'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+                'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-32 overflow-x-hidden overflow-y-auto overscroll-contain rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
                 className,
             )}
             ref={ref}
@@ -69,7 +69,7 @@ export const DropdownMenuContent = forwardRef<
         <DropdownMenuPrimitive.Portal>
             <DropdownMenuPrimitive.Content
                 className={cx(
-                    'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+                    'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-32 overflow-x-hidden overflow-y-auto overscroll-contain rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
                     className,
                 )}
                 ref={ref}


### PR DESCRIPTION
## Summary
- Make breadcrumb labels with subitems navigate to their route while keeping the chevron as the only dropdown trigger
- Reuse the admin breadcrumb selector pattern across top-level and directory breadcrumb selectors
- Update shared menu content to cap at available viewport height and scroll internally when content is tall
- Add a Storybook case that verifies the dropdown stays scrollable with long content

## Testing
- `pnpm typecheck --filter app`
- `pnpm typecheck --filter @gredice/ui`
- Storybook UI check of the new scrollable menu story confirmed the menu opens with internal scrolling instead of overflowing offscreen