### PR TITLE
Streamline automation detail controls

### DIFF
--- a/apps/app/app/admin/automations/AutomationActionsMenu.tsx
+++ b/apps/app/app/admin/automations/AutomationActionsMenu.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import type { AutomationDefinitionStatus } from '@gredice/storage';
+import { ArchiveIcon } from '@gredice/ui/ArchiveIcon';
+import { IconButton } from '@gredice/ui/IconButton';
+import { MoreHorizontal, ToggleLeft, ToggleRight } from '@gredice/ui/icons';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@gredice/ui/Menu';
+
+export function AutomationActionsMenu({
+    disabled,
+    onStatusChange,
+    status,
+}: {
+    disabled?: boolean;
+    onStatusChange(status: AutomationDefinitionStatus): void;
+    status: AutomationDefinitionStatus;
+}) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <IconButton
+                    disabled={disabled}
+                    size="sm"
+                    title="Više opcija"
+                    variant="plain"
+                >
+                    <MoreHorizontal className="size-4" />
+                </IconButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+                {status === 'enabled' ? (
+                    <DropdownMenuItem
+                        disabled={disabled}
+                        onSelect={() => onStatusChange('disabled')}
+                        startDecorator={<ToggleLeft className="size-4" />}
+                    >
+                        Isključi
+                    </DropdownMenuItem>
+                ) : (
+                    <DropdownMenuItem
+                        disabled={disabled}
+                        onSelect={() => onStatusChange('enabled')}
+                        startDecorator={<ToggleRight className="size-4" />}
+                    >
+                        Uključi
+                    </DropdownMenuItem>
+                )}
+                {status !== 'archived' ? (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            className="text-red-700 focus:bg-red-50 focus:text-red-700 dark:text-red-300 dark:focus:bg-red-950"
+                            disabled={disabled}
+                            onSelect={() => onStatusChange('archived')}
+                            startDecorator={<ArchiveIcon className="size-4" />}
+                        >
+                            Arhiviraj
+                        </DropdownMenuItem>
+                    </>
+                ) : null}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationFlowEditor.tsx
+++ b/apps/app/app/admin/automations/AutomationFlowEditor.tsx
@@ -10,19 +10,13 @@ import type {
     AutomationModuleKind,
     AutomationModuleMetadata,
 } from '@gredice/storage';
+import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Button } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
-import {
-    Add,
-    Configuration,
-    Delete,
-    Layers,
-    Play,
-    Save,
-    Settings,
-} from '@gredice/ui/icons';
+import { Add, Configuration, Play, Settings } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
@@ -42,8 +36,18 @@ import {
 } from '@xyflow/react';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
-import { useMemo, useState, useTransition } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    useTransition,
+} from 'react';
+import { AdminPageHeader } from '../../../components/admin/navigation';
+import { AdminBreadcrumbLevelSelector } from '../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { KnownPages } from '../../../src/KnownPages';
+import { AutomationActionsMenu } from './AutomationActionsMenu';
 import { AutomationSlidePanel } from './AutomationSlidePanel';
 import {
     type AutomationSaveResult,
@@ -60,6 +64,7 @@ type FlowNodeData = Record<string, unknown> & {
 
 type FlowNode = Node<FlowNodeData>;
 type AutomationEditorPanel = 'details' | 'modules' | 'settings' | 'testing';
+type AutosaveStatus = 'saved' | 'unsaved' | 'saving' | 'failed';
 
 type AutomationFlowEditorProps = {
     automationId?: number;
@@ -71,13 +76,6 @@ type AutomationFlowEditorProps = {
     modules: AutomationModuleMetadata[];
     testPanel?: ReactNode;
 };
-
-const definitionStatusItems = [
-    { value: 'draft', label: 'Skica' },
-    { value: 'enabled', label: 'Uključena' },
-    { value: 'disabled', label: 'Isključena' },
-    { value: 'archived', label: 'Arhivirana' },
-] satisfies Array<{ value: AutomationDefinitionStatus; label: string }>;
 
 function kindLabel(kind: AutomationModuleKind) {
     switch (kind) {
@@ -211,7 +209,7 @@ function panelTitle(panel: AutomationEditorPanel | null) {
         case 'settings':
             return 'Postavke modula';
         case 'testing':
-            return 'Testiranje';
+            return 'Pokreni';
         default:
             return '';
     }
@@ -220,30 +218,56 @@ function panelTitle(panel: AutomationEditorPanel | null) {
 function panelDescription(panel: AutomationEditorPanel | null) {
     switch (panel) {
         case 'details':
-            return 'Naziv, ključ, status i opis automatizacije.';
+            return 'Naziv i ključ automatizacije.';
         case 'modules':
             return 'Dodajte triggere, uvjete i akcije u dijagram.';
         case 'settings':
             return 'Konfiguracija trenutno odabranog modula.';
         case 'testing':
-            return 'Pokrenite probno izvođenje iz sintetičkog ili postojećeg ulaza.';
+            return 'Pokrenite workflow iz sintetičkog ili postojećeg ulaza.';
         default:
             return undefined;
     }
 }
 
+function automationDraftSnapshot({
+    description,
+    graph,
+    key,
+    name,
+    status,
+}: {
+    description: string;
+    graph: AutomationGraph;
+    key: string;
+    name: string;
+    status: AutomationDefinitionStatus;
+}) {
+    return JSON.stringify({
+        description,
+        graph,
+        key,
+        name,
+        status,
+    });
+}
+
+function autosaveLabel(status: AutosaveStatus) {
+    switch (status) {
+        case 'failed':
+            return 'Spremanje nije uspjelo.';
+        case 'saving':
+            return 'Spremanje...';
+        case 'unsaved':
+            return 'Nespremljene promjene';
+        case 'saved':
+            return 'Spremljeno';
+    }
+}
+
 function SaveResultNotice({ result }: { result: AutomationSaveResult }) {
     if (result.ok) {
-        return (
-            <div
-                role="status"
-                className="rounded-md border border-green-200 bg-green-50 p-3 text-green-800 dark:border-green-900 dark:bg-green-950 dark:text-green-200"
-            >
-                <Typography level="body2">
-                    Automatizacija je spremljena.
-                </Typography>
-            </div>
-        );
+        return null;
     }
 
     return (
@@ -273,12 +297,15 @@ export function AutomationFlowEditor({
     testPanel,
 }: AutomationFlowEditorProps) {
     const router = useRouter();
+    const [currentAutomationId, setCurrentAutomationId] =
+        useState(automationId);
+    const [definitionKey, setDefinitionKey] = useState(initialKey);
     const modulesByKey = useMemo(
         () => new Map(modules.map((module) => [module.key, module])),
         [modules],
     );
     const [name, setName] = useState(initialName);
-    const [description, setDescription] = useState(initialDescription ?? '');
+    const description = initialDescription ?? '';
     const [status, setStatus] =
         useState<AutomationDefinitionStatus>(initialStatus);
     const [activePanel, setActivePanel] =
@@ -297,6 +324,11 @@ export function AutomationFlowEditor({
     );
     const [result, setResult] = useState<AutomationSaveResult | null>(null);
     const [jsonError, setJsonError] = useState<string | null>(null);
+    const [autosaveStatus, setAutosaveStatus] =
+        useState<AutosaveStatus>('saved');
+    const [lastSavedSnapshot, setLastSavedSnapshot] = useState<string | null>(
+        null,
+    );
     const [isPending, startTransition] = useTransition();
     const selectedNode = nodes.find((node) => node.id === selectedNodeId);
     const selectedModule = selectedNode
@@ -304,11 +336,27 @@ export function AutomationFlowEditor({
         : null;
     const automationKey = useMemo(
         () =>
-            automationId
-                ? initialKey
-                : slugify(name) || initialKey || 'nova-automatizacija',
-        [automationId, initialKey, name],
+            currentAutomationId
+                ? definitionKey || initialKey || 'automatizacija'
+                : slugify(name) ||
+                  definitionKey ||
+                  initialKey ||
+                  'nova-automatizacija',
+        [currentAutomationId, definitionKey, initialKey, name],
     );
+    const draftGraph = useMemo(() => flowToGraph(nodes, edges), [nodes, edges]);
+    const saveSnapshot = useMemo(
+        () =>
+            automationDraftSnapshot({
+                description,
+                graph: draftGraph,
+                key: automationKey,
+                name,
+                status,
+            }),
+        [automationKey, description, draftGraph, name, status],
+    );
+    const latestSaveSnapshot = useRef(saveSnapshot);
     const groupedModules = useMemo(
         () =>
             modules.reduce<
@@ -327,6 +375,16 @@ export function AutomationFlowEditor({
             ),
         [modules],
     );
+
+    useEffect(() => {
+        latestSaveSnapshot.current = saveSnapshot;
+    }, [saveSnapshot]);
+
+    useEffect(() => {
+        if (lastSavedSnapshot === null) {
+            setLastSavedSnapshot(saveSnapshot);
+        }
+    }, [lastSavedSnapshot, saveSnapshot]);
 
     function selectNode(nodeId: string | null) {
         setSelectedNodeId(nodeId);
@@ -347,6 +405,7 @@ export function AutomationFlowEditor({
                 currentEdges,
             ),
         );
+        setResult(null);
     };
 
     function openPanel(panel: AutomationEditorPanel) {
@@ -384,25 +443,6 @@ export function AutomationFlowEditor({
         setResult(null);
     }
 
-    function removeSelectedNode() {
-        if (!selectedNodeId) {
-            return;
-        }
-
-        setNodes((current) =>
-            current.filter((node) => node.id !== selectedNodeId),
-        );
-        setEdges((current) =>
-            current.filter(
-                (edge) =>
-                    edge.source !== selectedNodeId &&
-                    edge.target !== selectedNodeId,
-            ),
-        );
-        setSelectedNodeId(null);
-        setResult(null);
-    }
-
     function updateSelectedConfig(key: string, value: unknown) {
         if (!selectedNodeId) {
             return;
@@ -427,19 +467,100 @@ export function AutomationFlowEditor({
         setResult(null);
     }
 
-    function save() {
-        setJsonError(null);
-        startTransition(async () => {
+    const saveDraft = useCallback(
+        async ({
+            requireLatest = false,
+            snapshot,
+            statusOverride,
+        }: {
+            requireLatest?: boolean;
+            snapshot?: string;
+            statusOverride?: AutomationDefinitionStatus;
+        } = {}) => {
+            const draftStatus = statusOverride ?? status;
+            const draftSnapshot =
+                snapshot ??
+                automationDraftSnapshot({
+                    description,
+                    graph: draftGraph,
+                    key: automationKey,
+                    name,
+                    status: draftStatus,
+                });
+
+            setJsonError(null);
+            setAutosaveStatus('saving');
+
             const saveResult = await saveAutomationDefinitionAction({
-                id: automationId,
+                id: currentAutomationId,
                 key: automationKey,
                 name,
                 description,
-                status,
-                graph: flowToGraph(nodes, edges),
+                status: draftStatus,
+                graph: draftGraph,
             });
 
-            setResult(saveResult);
+            if (requireLatest && latestSaveSnapshot.current !== draftSnapshot) {
+                return saveResult;
+            }
+
+            if (saveResult.ok) {
+                setResult(null);
+                setAutosaveStatus('saved');
+                setLastSavedSnapshot(draftSnapshot);
+                setCurrentAutomationId(saveResult.automationId);
+                setDefinitionKey(automationKey);
+            } else {
+                setResult(saveResult);
+                setAutosaveStatus('failed');
+            }
+
+            return saveResult;
+        },
+        [
+            automationKey,
+            currentAutomationId,
+            description,
+            draftGraph,
+            name,
+            status,
+        ],
+    );
+
+    useEffect(() => {
+        if (!currentAutomationId || lastSavedSnapshot === null || jsonError) {
+            return;
+        }
+
+        if (saveSnapshot === lastSavedSnapshot) {
+            setAutosaveStatus('saved');
+            return;
+        }
+
+        setAutosaveStatus('unsaved');
+
+        const timeout = window.setTimeout(() => {
+            void saveDraft({
+                requireLatest: true,
+                snapshot: saveSnapshot,
+            });
+        }, 700);
+
+        return () => window.clearTimeout(timeout);
+    }, [
+        currentAutomationId,
+        jsonError,
+        lastSavedSnapshot,
+        saveDraft,
+        saveSnapshot,
+    ]);
+
+    function save() {
+        startTransition(async () => {
+            const saveResult = await saveDraft({
+                snapshot: saveSnapshot,
+            });
+
             if (saveResult.ok) {
                 router.replace(KnownPages.Automation(saveResult.automationId));
                 router.refresh();
@@ -447,7 +568,78 @@ export function AutomationFlowEditor({
         });
     }
 
+    function changeDefinitionStatus(nextStatus: AutomationDefinitionStatus) {
+        setStatus(nextStatus);
+        setResult(null);
+
+        const nextSnapshot = automationDraftSnapshot({
+            description,
+            graph: draftGraph,
+            key: automationKey,
+            name,
+            status: nextStatus,
+        });
+
+        startTransition(() => {
+            void saveDraft({
+                snapshot: nextSnapshot,
+                statusOverride: nextStatus,
+            });
+        });
+    }
+
     const statusMeta = automationStatusMeta(status);
+    const canAutosave = Boolean(currentAutomationId);
+
+    const header = currentAutomationId ? (
+        <AdminPageHeader
+            breadcrumbs={
+                <Row spacing={2} className="min-w-0 items-center">
+                    <div className="min-w-0">
+                        <Breadcrumbs
+                            items={[
+                                {
+                                    label: <AdminBreadcrumbLevelSelector />,
+                                    href: KnownPages.Automations,
+                                },
+                                { label: name },
+                            ]}
+                        />
+                    </div>
+                    <Chip
+                        className="shrink-0"
+                        color={statusMeta.color}
+                        size="sm"
+                        variant="soft"
+                    >
+                        {statusMeta.label}
+                    </Chip>
+                </Row>
+            }
+            actions={
+                <Row spacing={2} className="items-center">
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant={
+                            activePanel === 'details' ? 'soft' : 'outlined'
+                        }
+                        aria-pressed={activePanel === 'details'}
+                        onClick={() => openPanel('details')}
+                        startDecorator={<Settings className="size-4" />}
+                    >
+                        Detalji
+                    </Button>
+                    <AutomationActionsMenu
+                        disabled={isPending}
+                        onStatusChange={changeDefinitionStatus}
+                        status={status}
+                    />
+                </Row>
+            }
+            heading={name}
+        />
+    ) : null;
 
     const detailPanel = (
         <Stack spacing={4}>
@@ -471,42 +663,17 @@ export function AutomationFlowEditor({
                 }
                 fullWidth
             />
-            <SelectItems<AutomationDefinitionStatus>
-                className="w-full"
-                label="Status"
-                value={status}
-                items={definitionStatusItems}
-                onValueChange={(nextStatus) => {
-                    setStatus(nextStatus);
-                    setResult(null);
-                }}
-            />
-            <Stack spacing={1}>
-                <label
-                    className="text-sm font-medium"
-                    htmlFor="automation-description"
+            {!currentAutomationId ? (
+                <Button
+                    type="button"
+                    disabled={isPending}
+                    loading={isPending}
+                    onClick={save}
+                    startDecorator={<Add className="size-4" />}
                 >
-                    Opis
-                </label>
-                <textarea
-                    id="automation-description"
-                    value={description}
-                    onChange={(event) => {
-                        setDescription(event.target.value);
-                        setResult(null);
-                    }}
-                    className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                />
-            </Stack>
-            <Button
-                type="button"
-                disabled={isPending}
-                loading={isPending}
-                onClick={save}
-                startDecorator={<Save className="size-4" />}
-            >
-                Spremi
-            </Button>
+                    Kreiraj
+                </Button>
+            ) : null}
         </Stack>
     );
 
@@ -738,52 +905,48 @@ export function AutomationFlowEditor({
 
     return (
         <>
+            {header}
             <Stack spacing={3}>
                 {result ? <SaveResultNotice result={result} /> : null}
 
                 <div className="min-w-0 overflow-hidden rounded-md border bg-background">
-                    <div className="flex flex-col gap-3 border-b px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
-                        <Row spacing={2} className="min-w-0 flex-wrap">
-                            <Chip
-                                color={statusMeta.color}
-                                size="sm"
-                                variant="soft"
-                            >
-                                {statusMeta.label}
-                            </Chip>
-                            <Typography level="body2" secondary>
-                                {nodes.length} modula, {edges.length} veza
-                            </Typography>
-                        </Row>
-                        <Row spacing={2} className="flex-wrap">
-                            <Button
-                                type="button"
-                                size="sm"
-                                variant={
-                                    activePanel === 'details'
-                                        ? 'soft'
-                                        : 'outlined'
-                                }
-                                aria-pressed={activePanel === 'details'}
-                                onClick={() => openPanel('details')}
-                                startDecorator={<Settings className="size-4" />}
-                            >
-                                Detalji
-                            </Button>
-                            <Button
-                                type="button"
-                                size="sm"
-                                variant={
-                                    activePanel === 'modules'
-                                        ? 'soft'
-                                        : 'outlined'
-                                }
-                                aria-pressed={activePanel === 'modules'}
-                                onClick={() => openPanel('modules')}
-                                startDecorator={<Layers className="size-4" />}
-                            >
-                                Moduli
-                            </Button>
+                    <div className="flex flex-col gap-3 border-b px-4 py-3 lg:flex-row lg:items-center">
+                        <div className="min-w-0 flex-1">
+                            {canAutosave ? (
+                                <Typography
+                                    level="body3"
+                                    className={
+                                        autosaveStatus === 'failed'
+                                            ? 'text-red-700 dark:text-red-300'
+                                            : 'text-muted-foreground'
+                                    }
+                                >
+                                    {autosaveLabel(autosaveStatus)}
+                                </Typography>
+                            ) : null}
+                        </div>
+                        <Row
+                            spacing={2}
+                            className="ml-auto flex-wrap justify-end"
+                        >
+                            {!currentAutomationId ? (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant={
+                                        activePanel === 'details'
+                                            ? 'soft'
+                                            : 'outlined'
+                                    }
+                                    aria-pressed={activePanel === 'details'}
+                                    onClick={() => openPanel('details')}
+                                    startDecorator={
+                                        <Settings className="size-4" />
+                                    }
+                                >
+                                    Detalji
+                                </Button>
+                            ) : null}
                             <Button
                                 type="button"
                                 size="sm"
@@ -813,30 +976,19 @@ export function AutomationFlowEditor({
                                     onClick={() => openPanel('testing')}
                                     startDecorator={<Play className="size-4" />}
                                 >
-                                    Testiranje
+                                    Pokreni
                                 </Button>
                             ) : null}
-                            <Button
+                            <IconButton
                                 type="button"
                                 size="sm"
-                                variant="outlined"
-                                color="danger"
-                                disabled={!selectedNodeId}
-                                onClick={removeSelectedNode}
-                                startDecorator={<Delete className="size-4" />}
+                                variant="plain"
+                                title="Dodaj modul"
+                                aria-pressed={activePanel === 'modules'}
+                                onClick={() => openPanel('modules')}
                             >
-                                Ukloni
-                            </Button>
-                            <Button
-                                type="button"
-                                size="sm"
-                                disabled={isPending}
-                                loading={isPending}
-                                onClick={save}
-                                startDecorator={<Save className="size-4" />}
-                            >
-                                Spremi
-                            </Button>
+                                <Add className="size-4" />
+                            </IconButton>
                         </Row>
                     </div>
                     <div className="h-[calc(100vh-260px)] min-h-[560px]">

--- a/apps/app/app/admin/automations/AutomationTestPanel.tsx
+++ b/apps/app/app/admin/automations/AutomationTestPanel.tsx
@@ -101,12 +101,12 @@ export function AutomationTestPanel({
             ) : null}
             {triggerMode === 'schedule' ? (
                 <Typography level="body3" className="text-muted-foreground">
-                    Test će koristiti sintetički mjesečni schedule run.
+                    Pokretanje će koristiti sintetički mjesečni schedule run.
                 </Typography>
             ) : null}
             {triggerMode === 'unsupported' ? (
                 <Typography level="body3" className="text-muted-foreground">
-                    Ovaj tip triggera još nema testni ulaz.
+                    Ovaj tip triggera još nema ulaz za pokretanje.
                 </Typography>
             ) : null}
             <Checkbox
@@ -138,12 +138,11 @@ export function AutomationTestPanel({
                     })
                 }
             >
-                Pokreni test
+                Pokreni
             </Button>
             {result?.ok ? (
                 <Typography level="body2" className="text-green-700">
-                    Test run #{result.runId} završen je statusom {result.status}
-                    .
+                    Run #{result.runId} završen je statusom {result.status}.
                 </Typography>
             ) : null}
             {result && !result.ok ? (

--- a/apps/app/app/admin/automations/[automationId]/page.tsx
+++ b/apps/app/app/admin/automations/[automationId]/page.tsx
@@ -9,16 +9,9 @@ import {
     listAutomationRuns,
     listRecentDomainEvents,
 } from '@gredice/storage';
-import { Button } from '@gredice/ui/Button';
-import { Chip } from '@gredice/ui/Chip';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { notFound } from 'next/navigation';
-import {
-    AdminPageHeader,
-    AdminPageTitle,
-} from '../../../../components/admin/navigation';
+import { AdminPageTitle } from '../../../../components/admin/navigation';
 import { auth } from '../../../../lib/auth/auth';
 import { AutomationFlowEditor } from '../AutomationFlowEditor';
 import {
@@ -30,8 +23,6 @@ import {
     AutomationTestPanel,
     type RecentAutomationEvent,
 } from '../AutomationTestPanel';
-import { updateAutomationStatusAction } from '../actions';
-import { automationStatusMeta } from '../presentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -86,19 +77,6 @@ function statusesForRunFilter(
 
 function dateToIso(value: Date | null) {
     return value ? value.toISOString() : null;
-}
-
-function StatusChip({
-    status,
-}: {
-    status: Parameters<typeof automationStatusMeta>[0];
-}) {
-    const meta = automationStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
 }
 
 export default async function AutomationDetailPage({
@@ -194,63 +172,10 @@ export default async function AutomationDetailPage({
             createdAt: event.createdAt.toISOString(),
         }),
     );
-    const enableAutomationAction = async () => {
-        'use server';
-        await updateAutomationStatusAction(definition.id, 'enabled');
-    };
-    const disableAutomationAction = async () => {
-        'use server';
-        await updateAutomationStatusAction(definition.id, 'disabled');
-    };
-    const archiveAutomationAction = async () => {
-        'use server';
-        await updateAutomationStatusAction(definition.id, 'archived');
-    };
 
     return (
         <Stack spacing={5}>
             <AdminPageTitle title={definition.name} />
-            <AdminPageHeader
-                actions={
-                    <Row spacing={2}>
-                        {definition.status === 'enabled' ? (
-                            <form action={disableAutomationAction}>
-                                <Button type="submit" variant="outlined">
-                                    Isključi
-                                </Button>
-                            </form>
-                        ) : (
-                            <form action={enableAutomationAction}>
-                                <Button type="submit">Uključi</Button>
-                            </form>
-                        )}
-                        {definition.status !== 'archived' ? (
-                            <form action={archiveAutomationAction}>
-                                <Button
-                                    type="submit"
-                                    variant="outlined"
-                                    color="danger"
-                                >
-                                    Arhiviraj
-                                </Button>
-                            </form>
-                        ) : null}
-                    </Row>
-                }
-            />
-
-            <Stack spacing={1}>
-                <Row spacing={2} className="flex-wrap">
-                    <Typography level="h4" component="h1">
-                        {definition.name}
-                    </Typography>
-                    <StatusChip status={definition.status} />
-                </Row>
-                <Typography level="body2" className="text-muted-foreground">
-                    {definition.description || definition.key}
-                </Typography>
-            </Stack>
-
             <AutomationFlowEditor
                 automationId={definition.id}
                 initialKey={definition.key}


### PR DESCRIPTION
## Summary
- Moved the automation name into breadcrumbs and kept a single workflow status chip in the header.
- Reworked the editor controls: removed the save button for existing definitions, added debounced autosave, and moved status/archive actions into a `...` menu.
- Simplified the workflow UI by removing the duplicate status, description, counts, and delete action, and renamed the run/test copy to `Pokreni`.

## Testing
- `pnpm lint --filter app` passed.
- `pnpm --filter app exec next typegen` passed.
- Browser smoke test reached the local app, but the automation page redirected to login because admin auth/API services were not available in this environment.