### PR TITLE
Make shared chips size to content by default

### DIFF
--- a/apps/app/app/admin/communication/emails/EmailStatusBadge.tsx
+++ b/apps/app/app/admin/communication/emails/EmailStatusBadge.tsx
@@ -22,7 +22,7 @@ export function EmailStatusBadge({ status }: { status: EmailStatus }) {
     const { label, color } = getStatusMetadata(status);
 
     return (
-        <Chip color={color} className="w-fit">
+        <Chip color={color}>
             {label}
         </Chip>
     );

--- a/apps/app/app/admin/communication/emails/[emailId]/page.tsx
+++ b/apps/app/app/admin/communication/emails/[emailId]/page.tsx
@@ -104,7 +104,7 @@ export default async function EmailDetailPage({
                     </DetailItem>
                     <DetailItem label="Tip">
                         {email.messageType ? (
-                            <Chip className="w-fit">{email.messageType}</Chip>
+                            <Chip>{email.messageType}</Chip>
                         ) : (
                             <NoDataPlaceholder>Nije određeno</NoDataPlaceholder>
                         )}

--- a/apps/app/app/admin/communication/emails/page.tsx
+++ b/apps/app/app/admin/communication/emails/page.tsx
@@ -222,7 +222,7 @@ export default async function EmailsPage({
                                         </Table.Cell>
                                         <Table.Cell>
                                             {email.messageType ? (
-                                                <Chip className="w-fit">
+                                                <Chip>
                                                     {email.messageType}
                                                 </Chip>
                                             ) : (

--- a/apps/app/app/admin/delivery/components/DeliveryRequestModeChip.tsx
+++ b/apps/app/app/admin/delivery/components/DeliveryRequestModeChip.tsx
@@ -7,7 +7,7 @@ export function DeliveryRequestModeChip({
     mode: string | null | undefined;
 }) {
     return (
-        <Chip color="primary" className="w-fit">
+        <Chip color="primary">
             {getDeliveryRequestModeLabel(mode)}
         </Chip>
     );

--- a/apps/app/app/admin/delivery/components/DeliveryRequestStatusChip.tsx
+++ b/apps/app/app/admin/delivery/components/DeliveryRequestStatusChip.tsx
@@ -6,7 +6,7 @@ import {
 
 export function DeliveryRequestStatusChip({ status }: { status: string }) {
     return (
-        <Chip color={getDeliveryRequestStatusColor(status)} className="w-fit">
+        <Chip color={getDeliveryRequestStatusColor(status)}>
             {getDeliveryRequestStatusLabel(status)}
         </Chip>
     );

--- a/apps/app/app/admin/delivery/slots/TimeSlotsTable.tsx
+++ b/apps/app/app/admin/delivery/slots/TimeSlotsTable.tsx
@@ -93,7 +93,7 @@ export async function TimeSlotsTable({
                     return (
                         <Table.Row key={slot.id}>
                             <Table.Cell>
-                                <Chip color="primary" className="w-fit">
+                                <Chip color="primary">
                                     {getTypeLabel(slot.type)}
                                 </Chip>
                             </Table.Cell>
@@ -114,7 +114,6 @@ export async function TimeSlotsTable({
                             <Table.Cell>
                                 <Chip
                                     color={getStatusColor(slot.status)}
-                                    className="w-fit"
                                 >
                                     {getStatusLabel(slot.status)}
                                 </Chip>

--- a/apps/app/app/admin/invoices/InvoicesTable.tsx
+++ b/apps/app/app/admin/invoices/InvoicesTable.tsx
@@ -92,13 +92,12 @@ export async function InvoicesTable({
                         <Table.Cell>
                             <Chip
                                 color={getStatusColor(invoice.status)}
-                                className="w-fit"
                             >
                                 {getStatusLabel(invoice.status)}
                             </Chip>
                         </Table.Cell>
                         <Table.Cell>
-                            <Chip color="success" className="w-fit">
+                            <Chip color="success">
                                 {invoice.totalAmount}
                                 {invoice.currency === 'eur'
                                     ? '€'
@@ -126,7 +125,6 @@ export async function InvoicesTable({
                                         startDecorator={
                                             <ExternalLink className="size-4 shrink-0" />
                                         }
-                                        className="w-fit"
                                     >
                                         #{invoice.transactionId}
                                     </Chip>

--- a/apps/app/app/admin/receipts/page.tsx
+++ b/apps/app/app/admin/receipts/page.tsx
@@ -108,7 +108,6 @@ export default async function ReceiptsPage() {
                                             color={getCisStatusColor(
                                                 receipt.cisStatus,
                                             )}
-                                            className="w-fit"
                                         >
                                             {getCisStatusLabel(
                                                 receipt.cisStatus,
@@ -116,7 +115,7 @@ export default async function ReceiptsPage() {
                                         </Chip>
                                     </Table.Cell>
                                     <Table.Cell>
-                                        <Chip className="w-fit">
+                                        <Chip>
                                             {receipt.totalAmount}
                                             {receipt.currency === 'eur'
                                                 ? '€'

--- a/apps/app/app/admin/shopping-carts/ShoppingCartsTable.tsx
+++ b/apps/app/app/admin/shopping-carts/ShoppingCartsTable.tsx
@@ -54,7 +54,7 @@ export async function ShoppingCartsTable({
                 {shoppingCarts.map((cart) => {
                     const user = cart.account?.accountUsers.at(0)?.user;
                     const itemCount = (
-                        <Chip className="w-fit">
+                        <Chip>
                             {cart.items.length} stavke
                         </Chip>
                     );
@@ -110,7 +110,6 @@ export async function ShoppingCartsTable({
                             </Table.Cell>
                             <Table.Cell>
                                 <Chip
-                                    className="w-fit"
                                     color={
                                         cart.status === 'paid'
                                             ? 'success'

--- a/apps/app/app/admin/transactions/TransactionsTable.tsx
+++ b/apps/app/app/admin/transactions/TransactionsTable.tsx
@@ -84,14 +84,14 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                                 </Table.Cell>
                             )}
                             <Table.Cell>
-                                <Chip color="info" className="w-fit">
+                                <Chip color="info">
                                     <Typography component="span" noWrap>
                                         {transaction.status}
                                     </Typography>
                                 </Chip>
                             </Table.Cell>
                             <Table.Cell>
-                                <Chip color="success" className="w-fit">
+                                <Chip color="success">
                                     <Typography component="span" noWrap>
                                         €{(transaction.amount / 100).toFixed(2)}
                                     </Typography>
@@ -100,13 +100,13 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                             <Table.Cell>
                                 <Row spacing={2}>
                                     {hasNoInvoices ? (
-                                        <Chip color="error" className="w-fit">
+                                        <Chip color="error">
                                             <Typography component="span" noWrap>
                                                 Bez ponuda
                                             </Typography>
                                         </Chip>
                                     ) : (
-                                        <Chip color="success" className="w-fit">
+                                        <Chip color="success">
                                             <Typography component="span" noWrap>
                                                 📋 {invoiceCount} ponuda
                                             </Typography>
@@ -127,7 +127,6 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                                         )}
                                     >
                                         <Chip
-                                            className="w-fit"
                                             color={
                                                 isTest ? 'warning' : 'neutral'
                                             }

--- a/apps/app/app/admin/transactions/[transactionId]/page.tsx
+++ b/apps/app/app/admin/transactions/[transactionId]/page.tsx
@@ -60,11 +60,11 @@ export default async function TransactionDetailsPage({
             label: 'Računi',
             value:
                 invoiceCount === 0 ? (
-                    <Chip color="success" className="w-fit">
+                    <Chip color="success">
                         Bez računa - dostupna za fakturiranje
                     </Chip>
                 ) : (
-                    <Chip color="neutral" className="w-fit">
+                    <Chip color="neutral">
                         {invoiceCount} račun{invoiceCount > 1 ? 'a' : ''}
                     </Chip>
                 ),

--- a/apps/app/components/admin/tables/TransactionsTable.tsx
+++ b/apps/app/components/admin/tables/TransactionsTable.tsx
@@ -84,14 +84,14 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                                 </Table.Cell>
                             )}
                             <Table.Cell>
-                                <Chip color="info" className="w-fit">
+                                <Chip color="info">
                                     <Typography component="span" noWrap>
                                         {transaction.status}
                                     </Typography>
                                 </Chip>
                             </Table.Cell>
                             <Table.Cell>
-                                <Chip color="success" className="w-fit">
+                                <Chip color="success">
                                     <Typography component="span" noWrap>
                                         €{(transaction.amount / 100).toFixed(2)}
                                     </Typography>
@@ -100,13 +100,13 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                             <Table.Cell>
                                 <Row spacing={2}>
                                     {hasNoInvoices ? (
-                                        <Chip color="error" className="w-fit">
+                                        <Chip color="error">
                                             <Typography component="span" noWrap>
                                                 Bez ponuda
                                             </Typography>
                                         </Chip>
                                     ) : (
-                                        <Chip color="success" className="w-fit">
+                                        <Chip color="success">
                                             <Typography component="span" noWrap>
                                                 📋 {invoiceCount} ponuda
                                             </Typography>
@@ -127,7 +127,6 @@ export async function TransactionsTable({ accountId }: { accountId?: string }) {
                                         )}
                                     >
                                         <Chip
-                                            className="w-fit"
                                             color={
                                                 isTest ? 'warning' : 'neutral'
                                             }

--- a/apps/app/components/shared/attributes/typed/SelectEntity.tsx
+++ b/apps/app/components/shared/attributes/typed/SelectEntity.tsx
@@ -66,7 +66,7 @@ export function SelectEntity({
                 />
             </div>
             {selectedEntity?.state === 'draft' ? (
-                <Chip color="neutral" className="w-fit">
+                <Chip color="neutral">
                     Draft
                 </Chip>
             ) : null}

--- a/apps/www/app/biljke/CalendarInfoChip.tsx
+++ b/apps/www/app/biljke/CalendarInfoChip.tsx
@@ -10,7 +10,7 @@ export function CalendarInfoChip({ className }: { className?: string }) {
             color="neutral"
             size="sm"
             href={sowingCalendarHref}
-            className={cx('w-fit shrink-0 whitespace-nowrap', className)}
+            className={cx('shrink-0 whitespace-nowrap', className)}
             title="Saznaj više o kalendaru sijanja i rasta biljaka"
         >
             <Info className="size-4 shrink-0" />

--- a/packages/game/src/hud/raisedBed/PlantStageSection.tsx
+++ b/packages/game/src/hud/raisedBed/PlantStageSection.tsx
@@ -156,7 +156,7 @@ function StageDurationDetails({
                     aria-label={`${label}: ${durationText}`}
                     title={`${label}: ${durationText}`}
                 >
-                    <Chip className="w-fit cursor-pointer" size="sm">
+                    <Chip className="cursor-pointer" size="sm">
                         {durationText}
                     </Chip>
                 </button>

--- a/packages/ui/src/Chip/Chip.tsx
+++ b/packages/ui/src/Chip/Chip.tsx
@@ -121,7 +121,7 @@ export const Chip = forwardRef<HTMLElement, ChipProps>(function Chip(
         </>
     );
     const mergedClassName = cx(
-        'm-0 inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full border font-medium whitespace-nowrap transition-colors',
+        'm-0 inline-flex w-fit max-w-full min-w-0 shrink-0 items-center gap-1 rounded-full border font-medium whitespace-nowrap transition-colors',
         variantColorClassNames[variant][color],
         sizeClassNames[size],
         disabled && 'pointer-events-none opacity-50',


### PR DESCRIPTION
## Summary
- Make the shared `Chip` component use content width by default so badges no longer stretch in flex/table layouts.
- Remove now-duplicated `w-fit` overrides from chip consumers across admin, delivery, invoices, receipts, transactions, and related UI.
- Keep the existing shared chip behavior consistent for both plain and linked chips.

## Testing
- Typecheck passed for the affected workspaces: `@gredice/ui`, `app`, `@gredice/game`, and `www`.
- `git diff --check` passed.