### PR TITLE
Normalize raised-bed card sizing in admin details

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -158,8 +158,8 @@ export default async function RaisedBedPage({
                             </Stack>
                         </Alert>
                     )}
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                        <Card className="h-fit">
+                    <div className="grid grid-cols-1 items-stretch gap-4 lg:grid-cols-2">
+                        <Card>
                             <CardHeader>
                                 <CardTitle>Polja</CardTitle>
                             </CardHeader>

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -9,7 +9,7 @@ type RaisedBedFieldCardGridProps = {
 };
 
 export const raisedBedFieldCardSelectClassName =
-    '[&_[role=combobox]]:h-8 [&_[role=combobox]]:!bg-background/80 [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:ring-1 [&_[role=combobox]]:ring-border/70 [&_[role=combobox]]:backdrop-blur-md [&_[role=combobox]]:hover:!bg-background/90';
+    'w-full min-w-0 [&_[role=combobox]]:h-8 [&_[role=combobox]]:!bg-background/80 [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:ring-1 [&_[role=combobox]]:ring-border/70 [&_[role=combobox]]:backdrop-blur-md [&_[role=combobox]]:hover:!bg-background/90 [&_[role=combobox]>span]:min-w-0';
 
 export const raisedBedFieldCardButtonClassName =
     '!bg-background/80 text-foreground ring-1 ring-border/70 backdrop-blur-md hover:!bg-background/90 hover:text-foreground';
@@ -23,7 +23,7 @@ export function RaisedBedFieldCardGrid({
     return (
         <div
             className={cx(
-                'grid grid-cols-3 gap-0 overflow-hidden rounded-lg border-r border-b',
+                'grid grid-cols-3 auto-rows-fr gap-0 overflow-hidden rounded-lg border-r border-b',
                 className,
             )}
         >
@@ -56,7 +56,7 @@ export function RaisedBedFieldCard({
     return (
         <div
             className={cx(
-                'relative flex h-full min-h-56 flex-col overflow-hidden border-l border-t bg-muted/40',
+                'relative flex aspect-[4/3] min-h-48 min-w-0 flex-col overflow-hidden border-l border-t bg-muted/40',
                 className,
             )}
         >
@@ -66,21 +66,21 @@ export function RaisedBedFieldCard({
                 </div>
             )}
             <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-background/55 via-background/10 to-background/70" />
-            <div className="relative z-10 flex items-start justify-between gap-1.5 p-2">
+            <div className="relative z-10 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-1.5 p-2">
                 <div className="min-w-0">{locationControl}</div>
-                <div>{fieldBadge}</div>
+                <div className="shrink-0">{fieldBadge}</div>
             </div>
             {historyControl && (
                 <div className="absolute left-2 top-11 z-10">
                     {historyControl}
                 </div>
             )}
-            <div className="relative z-10 mt-auto flex flex-col gap-0.5 px-2 pb-2 pt-8">
-                {plantSortControl}
+            <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-8">
+                <div className="min-w-0">{plantSortControl}</div>
                 {(statusControl || datesControl) && (
                     <Stack spacing={0.5}>
                         {statusControl ? (
-                            <div>
+                            <div className="min-w-0">
                                 {statusControl}
                                 {datesControl}
                             </div>


### PR DESCRIPTION
## Summary
- Make raised-bed field tiles use a stable aspect ratio and shared row sizing so the grid lines up consistently
- Constrain select/header content so long labels truncate instead of forcing uneven card widths
- Let the raised-bed details card stretch with the surrounding two-column layout instead of fitting to content

## Testing
- UI smoke check in the local app reached the raised-beds route, but authenticated visual verification was blocked by the login screen
- `pnpm --filter app build` passed