### PR TITLE
Add dates to recent raised-bed image gallery

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -3,10 +3,11 @@ import {
     RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
     RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE,
 } from '@gredice/js/raisedBeds';
-import { getRaisedBed } from '@gredice/storage';
+import { getRaisedBed, getRaisedBedDiaryEntries } from '@gredice/storage';
 import { Alert } from '@gredice/ui/Alert';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
+import { ImageGallery } from '@gredice/ui/ImageGallery';
 import { Warning } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -37,6 +38,45 @@ import { RaisedBedStatusSelect } from './RaisedBedStatusSelect';
 
 export const dynamic = 'force-dynamic';
 
+const RECENT_RAISED_BED_IMAGE_LIMIT = 12;
+const recentRaisedBedImageDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    dateStyle: 'short',
+});
+
+function recentRaisedBedImages(
+    entries: Awaited<ReturnType<typeof getRaisedBedDiaryEntries>>,
+    raisedBedId: number,
+) {
+    const seen = new Set<string>();
+
+    return entries
+        .flatMap((entry) =>
+            (entry.imageUrls ?? []).flatMap((url, index) => {
+                const trimmedUrl = url.trim();
+
+                if (!trimmedUrl || seen.has(trimmedUrl)) {
+                    return [];
+                }
+
+                seen.add(trimmedUrl);
+
+                return {
+                    src: trimmedUrl,
+                    alt: `${entry.name || 'Slika gredice'} ${raisedBedId}-${
+                        index + 1
+                    }`,
+                    dateLabel:
+                        entry.timestamp instanceof Date
+                            ? recentRaisedBedImageDateFormatter.format(
+                                  entry.timestamp,
+                              )
+                            : undefined,
+                };
+            }),
+        )
+        .slice(0, RECENT_RAISED_BED_IMAGE_LIMIT);
+}
+
 export default async function RaisedBedPage({
     params,
     searchParams,
@@ -51,6 +91,10 @@ export default async function RaisedBedPage({
     if (!raisedBed) {
         notFound();
     }
+    const recentImages = recentRaisedBedImages(
+        await getRaisedBedDiaryEntries(raisedBed.id),
+        raisedBed.id,
+    );
     const raisedBedTitle =
         raisedBed.name || `Gredica ${raisedBed.physicalId ?? raisedBed.id}`;
     const isAbandoned = isRaisedBedAbandoned(raisedBed.status);
@@ -137,6 +181,23 @@ export default async function RaisedBedPage({
                     heading="Gredica"
                 />
                 <EntityDetailsPropertiesLayout properties={propertiesPanel}>
+                    {recentImages.length > 0 && (
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Nedavne slike</CardTitle>
+                            </CardHeader>
+                            <CardOverflow>
+                                <Row className="w-full px-2 pb-2" spacing={4}>
+                                    <ImageGallery
+                                        images={recentImages}
+                                        previewWidth={240}
+                                        previewHeight={160}
+                                        previewVariant="carousel"
+                                    />
+                                </Row>
+                            </CardOverflow>
+                        </Card>
+                    )}
                     {isAbandoned && (
                         <Alert
                             color="warning"

--- a/packages/ui/src/ImageGallery/ImageGallery.tsx
+++ b/packages/ui/src/ImageGallery/ImageGallery.tsx
@@ -20,6 +20,7 @@ import { cx } from '../utils';
 interface ImageGalleryItem {
     src: string;
     alt: string;
+    dateLabel?: string;
 }
 
 interface ImageGalleryProps {
@@ -417,6 +418,11 @@ export function ImageGallery({
                                 sizes={`${previewWidth}px`}
                                 className="h-full w-full object-cover"
                             />
+                            {image.dateLabel && (
+                                <span className="absolute inset-x-0 bottom-0 z-10 bg-black/55 px-2 py-1 text-left text-[11px] leading-none text-white/90 backdrop-blur-sm">
+                                    {image.dateLabel}
+                                </span>
+                            )}
                             <div className="absolute inset-0 bg-white/30 opacity-0 transition-opacity group-hover:opacity-100" />
                         </PreviewComponent>
                     ))}


### PR DESCRIPTION
## Summary
- Show the recent raised-bed image gallery at the top of the raised-bed admin page
- Add a small date label to each preview image using the source diary entry timestamp
- Keep the existing gallery behavior intact for all other callers

## Testing
- `pnpm --filter app exec biome check --write app/admin/raised-beds/'[raisedBedId]'/page.tsx ../../packages/ui/src/ImageGallery/ImageGallery.tsx`
- Verified the updated gallery and overlay wiring in the touched files