### PR TITLE
[Weather] Add regional weather alert notifications

### DIFF
--- a/apps/api/app/api/[...route]/data/weatherRoutes.ts
+++ b/apps/api/app/api/[...route]/data/weatherRoutes.ts
@@ -11,12 +11,18 @@ import {
     cacheControlPresets,
     setCacheControl,
 } from '../../../../lib/http/cacheControl';
+import {
+    filterWeatherAlertsForFarm,
+    getDhmzWeatherAlerts,
+    resolveWeatherAlertRegionCode,
+} from '../../../../lib/weather/alerts';
 import { getBjelovarForecast } from '../../../../lib/weather/forecast';
 import { populateWeatherFromSymbol } from '../../../../lib/weather/populateWeatherFromSymbol';
 import {
     fallbackWeatherNow,
     findClosestForecastEntry,
     pickFarmSnowAccumulation,
+    pickWeatherFarm,
 } from '../../../../lib/weather/weatherNowContract';
 
 // import { signalcoClient } from '@gredice/signalco';
@@ -66,13 +72,30 @@ const app = new Hono()
 
             const farmId = context.req.query('farmId');
             const farms = await getFarms();
+            const farm = pickWeatherFarm(farms, farmId);
             const snowAccumulation = pickFarmSnowAccumulation(farms, farmId);
+            const alerts = await grediceCached(
+                grediceCacheKeys.weatherAlertsCroatia,
+                getDhmzWeatherAlerts,
+                30 * 60,
+            )
+                .then((sourceAlerts) =>
+                    filterWeatherAlertsForFarm(sourceAlerts ?? [], farm),
+                )
+                .catch((error) => {
+                    console.warn('Weather alerts unavailable for now route', {
+                        error,
+                        farmId,
+                    });
+                    return [];
+                });
 
             if (!forecast || forecast.length === 0) {
                 setCacheControl(context, cacheControlPresets.weatherShortTerm);
                 return context.json({
                     ...fallbackWeatherNow,
                     snowAccumulation,
+                    alerts,
                 });
             }
 
@@ -82,6 +105,7 @@ const app = new Hono()
                 return context.json({
                     ...fallbackWeatherNow,
                     snowAccumulation,
+                    alerts,
                 });
             }
             setCacheControl(context, cacheControlPresets.weatherShortTerm);
@@ -97,9 +121,32 @@ const app = new Hono()
                 ...populateWeatherFromSymbol(closestEntry.symbol),
                 source: 'forecast' as const,
                 isStale: false,
+                alerts,
             };
 
             return context.json(weather);
+        },
+    )
+    .get(
+        '/alerts',
+        describeRoute({
+            description: 'Get regional weather alerts for a farm',
+        }),
+        async (context) => {
+            const farmId = context.req.query('farmId');
+            const farms = await getFarms();
+            const farm = pickWeatherFarm(farms, farmId);
+            const sourceAlerts = await grediceCached(
+                grediceCacheKeys.weatherAlertsCroatia,
+                getDhmzWeatherAlerts,
+                30 * 60,
+            );
+            const alerts = filterWeatherAlertsForFarm(sourceAlerts ?? [], farm);
+            setCacheControl(context, cacheControlPresets.weatherShortTerm);
+            return context.json({
+                alerts,
+                regionCode: resolveWeatherAlertRegionCode(farm),
+            });
         },
     )
     .get(

--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -696,6 +696,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 id: garden.id,
                 name: garden.name,
                 isSandbox: garden.isSandbox,
+                farmId: garden.farmId,
                 latitude: garden.farm.latitude,
                 longitude: garden.farm.longitude,
                 stacks,

--- a/apps/api/app/api/internal/cron/update-farm-weather/route.ts
+++ b/apps/api/app/api/internal/cron/update-farm-weather/route.ts
@@ -1,5 +1,6 @@
 import { getFarms, insertWeatherHistory, updateFarm } from '@gredice/storage';
 import type { NextRequest } from 'next/server';
+import { notifyWeatherRiskAlerts } from '../../../../../lib/weather/alertNotifications';
 import { getBjelovarForecast } from '../../../../../lib/weather/forecast';
 import { populateWeatherFromSymbol } from '../../../../../lib/weather/populateWeatherFromSymbol';
 
@@ -148,10 +149,20 @@ export async function GET(request: NextRequest) {
             }
         }
 
+        const weatherAlertNotifications = await notifyWeatherRiskAlerts().catch(
+            (error) => {
+                console.warn('Failed to create weather alert notifications', {
+                    error,
+                });
+                return null;
+            },
+        );
+
         return Response.json({
             success: true,
             updatedFarms: updates.length,
             updates,
+            weatherAlertNotifications,
             weather: {
                 temperature,
                 snowy: weather.snowy,

--- a/apps/api/lib/weather/alertNotifications.ts
+++ b/apps/api/lib/weather/alertNotifications.ts
@@ -1,0 +1,119 @@
+import {
+    createNotification,
+    gardens,
+    grediceCached,
+    grediceCacheKeys,
+    notifications,
+    storage,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import {
+    type DhmzWeatherAlert,
+    filterWeatherAlertsForFarm,
+    getDhmzWeatherAlerts,
+} from './alerts';
+
+export type WeatherAlertNotificationResult = {
+    gardensScanned: number;
+    alertsMatched: number;
+    notificationsCreated: number;
+    duplicatesSkipped: number;
+};
+
+function formatAlertWindow(alert: DhmzWeatherAlert) {
+    const formatter = new Intl.DateTimeFormat('hr-HR', {
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        month: '2-digit',
+        timeZone: 'Europe/Zagreb',
+    });
+    return `${formatter.format(new Date(alert.onset))} - ${formatter.format(new Date(alert.expires))}`;
+}
+
+function collapseKeyForWeatherAlert(gardenId: number, alert: DhmzWeatherAlert) {
+    return `weather-risk:${gardenId}:${alert.deduplicationKey}`;
+}
+
+function weatherAlertContent(alert: DhmzWeatherAlert) {
+    const instruction = alert.instruction ? ` ${alert.instruction}` : '';
+    return `${alert.description} Vrijedi ${formatAlertWindow(alert)}.${instruction}`;
+}
+
+async function notificationExists(accountId: string, collapseKey: string) {
+    const existing = await storage().query.notifications.findFirst({
+        where: and(
+            eq(notifications.accountId, accountId),
+            eq(notifications.collapseKey, collapseKey),
+        ),
+    });
+    return Boolean(existing);
+}
+
+export async function notifyWeatherRiskAlerts({
+    now = new Date(),
+}: {
+    now?: Date;
+} = {}): Promise<WeatherAlertNotificationResult> {
+    const sourceAlerts = await grediceCached(
+        grediceCacheKeys.weatherAlertsCroatia,
+        getDhmzWeatherAlerts,
+        30 * 60,
+    );
+    const gardenRows = await storage().query.gardens.findMany({
+        where: eq(gardens.isDeleted, false),
+        with: {
+            farm: true,
+        },
+    });
+
+    let alertsMatched = 0;
+    let notificationsCreated = 0;
+    let duplicatesSkipped = 0;
+
+    for (const garden of gardenRows) {
+        const alerts = filterWeatherAlertsForFarm(sourceAlerts, garden.farm, {
+            now,
+        });
+        alertsMatched += alerts.length;
+
+        for (const alert of alerts) {
+            const collapseKey = collapseKeyForWeatherAlert(garden.id, alert);
+            if (await notificationExists(garden.accountId, collapseKey)) {
+                duplicatesSkipped += 1;
+                continue;
+            }
+
+            await createNotification({
+                accountId: garden.accountId,
+                gardenId: garden.id,
+                header: alert.event,
+                content: weatherAlertContent(alert),
+                category: 'weather_alerts',
+                type: 'weather_risk_alert',
+                primaryChannel: 'push',
+                priority: 'high',
+                collapseKey,
+                threadKey: `weather-risk:${garden.id}`,
+                metadata: {
+                    alertId: alert.id,
+                    awarenessLevel: alert.awarenessLevel?.id ?? null,
+                    awarenessType: alert.awarenessType?.id ?? null,
+                    expires: alert.expires,
+                    onset: alert.onset,
+                    regionCode: alert.area.regionCode,
+                    source: alert.source,
+                },
+                timestamp: now,
+            });
+            notificationsCreated += 1;
+        }
+    }
+
+    return {
+        gardensScanned: gardenRows.length,
+        alertsMatched,
+        notificationsCreated,
+        duplicatesSkipped,
+    };
+}

--- a/apps/api/lib/weather/alerts.node.spec.ts
+++ b/apps/api/lib/weather/alerts.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     filterWeatherAlertsForFarm,
+    getDhmzWeatherAlerts,
     parseDhmzCapAlertXml,
     resolveWeatherAlertRegionCode,
 } from './alerts';
@@ -96,6 +97,57 @@ describe('parseDhmzCapAlertXml', () => {
         assert.equal(
             croatianAlert.description,
             'Lokalno mogući izraženiji pljuskovi s grmljavinom.',
+        );
+    });
+});
+
+describe('getDhmzWeatherAlerts', () => {
+    it('falls back to the misspelled DHMZ tomorrow feed candidate', async () => {
+        const requestedUrls: string[] = [];
+        const fetchAlerts: typeof fetch = async (input) => {
+            const url = input.toString();
+            requestedUrls.push(url);
+
+            if (
+                url.endsWith('/cap_hr_today.xml') ||
+                url.endsWith('/cap_hr_day_after_tomorrow.xml')
+            ) {
+                return new Response('<alert />', {
+                    headers: {
+                        'content-type': 'text/xml',
+                    },
+                    status: 200,
+                });
+            }
+
+            if (url.endsWith('/cap_hr_tomorrow.xml')) {
+                return new Response('', { status: 404 });
+            }
+
+            if (url.endsWith('/cap_hr_tmorrow.xml')) {
+                return new Response(sampleCapXml, {
+                    headers: {
+                        'content-type': 'text/xml',
+                    },
+                    status: 200,
+                });
+            }
+
+            throw new Error(`Unexpected weather alert URL: ${url}`);
+        };
+
+        const alerts = await getDhmzWeatherAlerts(fetchAlerts);
+
+        assert.deepEqual(requestedUrls, [
+            'https://meteo.hr/upozorenja/cap_hr_today.xml',
+            'https://meteo.hr/upozorenja/cap_hr_tomorrow.xml',
+            'https://meteo.hr/upozorenja/cap_hr_day_after_tomorrow.xml',
+            'https://meteo.hr/upozorenja/cap_hr_tmorrow.xml',
+        ]);
+        assert.equal(alerts.length, 2);
+        assert.equal(
+            alerts[0]?.sourceUrl,
+            'https://meteo.hr/upozorenja/cap_hr_tmorrow.xml',
         );
     });
 });

--- a/apps/api/lib/weather/alerts.node.spec.ts
+++ b/apps/api/lib/weather/alerts.node.spec.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    filterWeatherAlertsForFarm,
+    parseDhmzCapAlertXml,
+    resolveWeatherAlertRegionCode,
+} from './alerts';
+
+const sampleCapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>2.49.0.0.191.0.HR.test.LDZM</identifier>
+  <sender>https://meteo.hr</sender>
+  <sent>2026-06-02T17:46:47+02:00</sent>
+  <status>Actual</status>
+  <msgType>Alert</msgType>
+  <scope>Public</scope>
+  <info>
+    <language>hr</language>
+    <category>Met</category>
+    <event>Žuto upozorenje za grmljavinsku oluju</event>
+    <urgency>Future</urgency>
+    <severity>Moderate</severity>
+    <certainty>Likely</certainty>
+    <onset>2026-06-03T12:00:00+02:00</onset>
+    <expires>2026-06-03T20:00:00+02:00</expires>
+    <senderName>DHMZ Državni hidrometeorološki zavod</senderName>
+    <description>Lokalno mogući izraženiji pljuskovi s grmljavinom.</description>
+    <instruction>Budite na oprezu na otvorenim terenima.</instruction>
+    <parameter>
+      <valueName>awareness_level</valueName>
+      <value>2; yellow; Moderate</value>
+    </parameter>
+    <parameter>
+      <valueName>awareness_type</valueName>
+      <value>3; Thunderstorm</value>
+    </parameter>
+    <area>
+      <areaDesc>Zagrebačka regija</areaDesc>
+      <geocode>
+        <valueName>EMMA_ID</valueName>
+        <value>HR002</value>
+      </geocode>
+    </area>
+  </info>
+  <info>
+    <language>en</language>
+    <category>Met</category>
+    <event>Yellow thunderstorm warning</event>
+    <urgency>Future</urgency>
+    <severity>Moderate</severity>
+    <certainty>Likely</certainty>
+    <onset>2026-06-03T12:00:00+02:00</onset>
+    <expires>2026-06-03T20:00:00+02:00</expires>
+    <senderName>DHMZ Državni hidrometeorološki zavod</senderName>
+    <description>Locally possible severe thundershowers.</description>
+    <parameter>
+      <valueName>awareness_level</valueName>
+      <value>2; yellow; Moderate</value>
+    </parameter>
+    <parameter>
+      <valueName>awareness_type</valueName>
+      <value>3; Thunderstorm</value>
+    </parameter>
+    <area>
+      <areaDesc>Zagreb region</areaDesc>
+      <geocode>
+        <valueName>EMMA_ID</valueName>
+        <value>HR002</value>
+      </geocode>
+    </area>
+  </info>
+</alert>`;
+
+const bjelovarFarm = {
+    latitude: 45.9,
+    longitude: 16.84,
+};
+
+describe('parseDhmzCapAlertXml', () => {
+    it('normalizes CAP warning fields', async () => {
+        const alerts = await parseDhmzCapAlertXml(
+            sampleCapXml,
+            'https://example.com/cap.xml',
+        );
+
+        assert.equal(alerts.length, 2);
+        const croatianAlert = alerts.find((alert) => alert.language === 'hr');
+        assert.ok(croatianAlert);
+        assert.equal(
+            croatianAlert.event,
+            'Žuto upozorenje za grmljavinsku oluju',
+        );
+        assert.equal(croatianAlert.area.regionCode, 'HR002');
+        assert.equal(croatianAlert.awarenessLevel?.color, 'yellow');
+        assert.equal(croatianAlert.awarenessType?.id, '3');
+        assert.equal(
+            croatianAlert.description,
+            'Lokalno mogući izraženiji pljuskovi s grmljavinom.',
+        );
+    });
+});
+
+describe('filterWeatherAlertsForFarm', () => {
+    it('uses the nearest land warning region and preferred language', async () => {
+        const alerts = await parseDhmzCapAlertXml(sampleCapXml);
+        const filtered = filterWeatherAlertsForFarm(alerts, bjelovarFarm, {
+            now: new Date('2026-06-03T08:00:00+02:00'),
+        });
+
+        assert.equal(resolveWeatherAlertRegionCode(bjelovarFarm), 'HR002');
+        assert.equal(filtered.length, 1);
+        assert.equal(filtered[0]?.language, 'hr');
+    });
+
+    it('falls back to another source language when preferred text is missing', async () => {
+        const alerts = (await parseDhmzCapAlertXml(sampleCapXml)).filter(
+            (alert) => alert.language === 'en',
+        );
+        const filtered = filterWeatherAlertsForFarm(alerts, bjelovarFarm, {
+            now: new Date('2026-06-03T08:00:00+02:00'),
+        });
+
+        assert.equal(filtered.length, 1);
+        assert.equal(filtered[0]?.language, 'en');
+    });
+});

--- a/apps/api/lib/weather/alerts.ts
+++ b/apps/api/lib/weather/alerts.ts
@@ -1,10 +1,13 @@
 import { parseStringPromise } from 'xml2js';
 
-const dhmzCapUrls = [
-    'https://meteo.hr/upozorenja/cap_hr_today.xml',
-    'https://meteo.hr/upozorenja/cap_hr_tomorrow.xml',
-    'https://meteo.hr/upozorenja/cap_hr_day_after_tomorrow.xml',
-] as const;
+const dhmzCapUrlGroups = [
+    ['https://meteo.hr/upozorenja/cap_hr_today.xml'],
+    [
+        'https://meteo.hr/upozorenja/cap_hr_tomorrow.xml',
+        'https://meteo.hr/upozorenja/cap_hr_tmorrow.xml',
+    ],
+    ['https://meteo.hr/upozorenja/cap_hr_day_after_tomorrow.xml'],
+];
 
 const defaultAlertRegionCode = 'HR002';
 
@@ -333,29 +336,44 @@ export async function parseDhmzCapAlertXml(
     });
 }
 
+async function fetchDhmzWeatherAlertsFromUrlGroup(
+    urls: string[],
+    fetchFn: typeof fetch,
+): Promise<DhmzWeatherAlert[]> {
+    let lastFailure: unknown = null;
+
+    for (const url of urls) {
+        try {
+            const response = await fetchFn(url);
+            if (!response.ok) {
+                lastFailure = {
+                    status: response.status,
+                    url,
+                };
+                continue;
+            }
+
+            return await parseDhmzCapAlertXml(await response.text(), url);
+        } catch (error) {
+            lastFailure = error;
+        }
+    }
+
+    console.warn('Failed to fetch DHMZ weather alerts feed', {
+        error: lastFailure,
+        url: urls[0],
+        fallbackUrls: urls.slice(1),
+    });
+    return [];
+}
+
 export async function getDhmzWeatherAlerts(
     fetchFn: typeof fetch = fetch,
 ): Promise<DhmzWeatherAlert[]> {
     const parsedGroups = await Promise.all(
-        dhmzCapUrls.map(async (url) => {
-            try {
-                const response = await fetchFn(url);
-                if (!response.ok) {
-                    console.warn('DHMZ weather alerts feed unavailable', {
-                        status: response.status,
-                        url,
-                    });
-                    return [];
-                }
-                return await parseDhmzCapAlertXml(await response.text(), url);
-            } catch (error) {
-                console.warn('Failed to fetch DHMZ weather alerts feed', {
-                    error,
-                    url,
-                });
-                return [];
-            }
-        }),
+        dhmzCapUrlGroups.map((urls) =>
+            fetchDhmzWeatherAlertsFromUrlGroup(urls, fetchFn),
+        ),
     );
 
     const alertsByKey = new Map<string, DhmzWeatherAlert>();

--- a/apps/api/lib/weather/alerts.ts
+++ b/apps/api/lib/weather/alerts.ts
@@ -1,0 +1,449 @@
+import { parseStringPromise } from 'xml2js';
+
+const dhmzCapUrls = [
+    'https://meteo.hr/upozorenja/cap_hr_today.xml',
+    'https://meteo.hr/upozorenja/cap_hr_tomorrow.xml',
+    'https://meteo.hr/upozorenja/cap_hr_day_after_tomorrow.xml',
+] as const;
+
+const defaultAlertRegionCode = 'HR002';
+
+type WeatherAlertFarm = {
+    latitude: number;
+    longitude: number;
+};
+
+type WeatherAlertRegion = {
+    code: string;
+    nameHr: string;
+    latitude: number;
+    longitude: number;
+};
+
+const landAlertRegions: WeatherAlertRegion[] = [
+    {
+        code: 'HR001',
+        nameHr: 'Kninska regija',
+        latitude: 44.04,
+        longitude: 16.2,
+    },
+    {
+        code: 'HR002',
+        nameHr: 'Zagrebacka regija',
+        latitude: 45.81,
+        longitude: 16.0,
+    },
+    {
+        code: 'HR003',
+        nameHr: 'Karlovacka regija',
+        latitude: 45.49,
+        longitude: 15.55,
+    },
+    {
+        code: 'HR004',
+        nameHr: 'Gospicka regija',
+        latitude: 44.55,
+        longitude: 15.37,
+    },
+    {
+        code: 'HR005',
+        nameHr: 'Osjecka regija',
+        latitude: 45.55,
+        longitude: 18.7,
+    },
+    {
+        code: 'HR006',
+        nameHr: 'Rijecka regija',
+        latitude: 45.33,
+        longitude: 14.45,
+    },
+    {
+        code: 'HR007',
+        nameHr: 'Dubrovacka regija',
+        latitude: 42.65,
+        longitude: 18.09,
+    },
+    {
+        code: 'HR008',
+        nameHr: 'Splitska regija',
+        latitude: 43.51,
+        longitude: 16.44,
+    },
+];
+
+const awarenessTypeLabelsHr: Record<string, string> = {
+    '1': 'vjetar',
+    '2': 'snijeg i poledica',
+    '3': 'grmljavinsku oluju',
+    '4': 'maglu',
+    '5': 'visoku temperaturu',
+    '6': 'nisku temperaturu',
+    '7': 'obalni dogadaj',
+    '8': 'opasnost od pozara',
+    '9': 'lavine',
+    '10': 'kisu',
+    '11': 'poplave',
+    '12': 'kisu i poplave',
+    '13': 'morsku grmljavinsku oluju',
+};
+
+export type WeatherAlertLanguage = 'hr' | 'en';
+
+export type WeatherAlertAwareness = {
+    id: string;
+    color: string | null;
+    label: string | null;
+};
+
+export type WeatherAlertType = {
+    id: string;
+    label: string;
+};
+
+export type WeatherAlertArea = {
+    name: string;
+    regionCode: string;
+};
+
+export type DhmzWeatherAlert = {
+    id: string;
+    source: 'dhmz-cap';
+    sourceUrl: string;
+    language: string;
+    event: string;
+    description: string;
+    instruction: string | null;
+    urgency: string | null;
+    severity: string | null;
+    certainty: string | null;
+    onset: string;
+    expires: string;
+    sent: string | null;
+    senderName: string | null;
+    awarenessLevel: WeatherAlertAwareness | null;
+    awarenessType: WeatherAlertType | null;
+    area: WeatherAlertArea;
+    deduplicationKey: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function arrayFromUnknown(value: unknown): unknown[] {
+    if (Array.isArray(value)) return value;
+    if (value == null) return [];
+    return [value];
+}
+
+function firstString(value: unknown): string | null {
+    if (typeof value === 'string') return value;
+    const first = arrayFromUnknown(value)[0];
+    return typeof first === 'string' ? first : null;
+}
+
+function field(record: Record<string, unknown>, key: string): unknown {
+    return record[key];
+}
+
+function stringField(record: Record<string, unknown>, key: string) {
+    return firstString(field(record, key));
+}
+
+function normalizeText(value: string | null) {
+    const normalized = value?.replace(/\s+/g, ' ').trim();
+    return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function parseParameter(
+    info: Record<string, unknown>,
+    valueName: string,
+): string | null {
+    for (const item of arrayFromUnknown(field(info, 'parameter'))) {
+        if (!isRecord(item)) continue;
+        if (stringField(item, 'valueName') === valueName) {
+            return normalizeText(stringField(item, 'value'));
+        }
+    }
+    return null;
+}
+
+function parseAwarenessLevel(
+    value: string | null,
+): WeatherAlertAwareness | null {
+    if (!value) return null;
+    const [id, color, label] = value.split(';').map((part) => part.trim());
+    if (!id) return null;
+    return {
+        id,
+        color: color || null,
+        label: label || null,
+    };
+}
+
+function parseAwarenessType(value: string | null): WeatherAlertType | null {
+    if (!value) return null;
+    const [id, label] = value.split(';').map((part) => part.trim());
+    if (!id) return null;
+    return {
+        id,
+        label: label || awarenessTypeLabelsHr[id] || id,
+    };
+}
+
+function parseArea(area: unknown): WeatherAlertArea | null {
+    if (!isRecord(area)) return null;
+    const areaName = normalizeText(stringField(area, 'areaDesc'));
+    if (!areaName) return null;
+
+    for (const geocode of arrayFromUnknown(field(area, 'geocode'))) {
+        if (!isRecord(geocode)) continue;
+        if (stringField(geocode, 'valueName') !== 'EMMA_ID') continue;
+        const regionCode = normalizeText(stringField(geocode, 'value'));
+        if (regionCode) {
+            return {
+                name: areaName,
+                regionCode,
+            };
+        }
+    }
+
+    return null;
+}
+
+function fallbackCroatianEvent(alertType: WeatherAlertType | null) {
+    if (!alertType) return 'Vremensko upozorenje';
+    const label = awarenessTypeLabelsHr[alertType.id] ?? alertType.label;
+    return `Upozorenje za ${label}`;
+}
+
+function severityRank(
+    alert: Pick<DhmzWeatherAlert, 'awarenessLevel' | 'severity'>,
+) {
+    const awarenessLevel = Number(alert.awarenessLevel?.id);
+    if (Number.isFinite(awarenessLevel)) return awarenessLevel;
+
+    switch (alert.severity?.toLowerCase()) {
+        case 'extreme':
+            return 4;
+        case 'severe':
+            return 3;
+        case 'moderate':
+            return 2;
+        case 'minor':
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+function alertSortKey(alert: DhmzWeatherAlert) {
+    return [
+        String(4 - severityRank(alert)).padStart(2, '0'),
+        alert.onset,
+        alert.expires,
+        alert.id,
+    ].join(':');
+}
+
+export async function parseDhmzCapAlertXml(
+    xml: string,
+    sourceUrl = 'dhmz-cap',
+): Promise<DhmzWeatherAlert[]> {
+    return parseStringPromise(xml).then((data: unknown) => {
+        if (!isRecord(data) || !isRecord(data.alert)) return [];
+        const alert = data.alert;
+        const identifier =
+            normalizeText(stringField(alert, 'identifier')) ?? sourceUrl;
+        const sent = normalizeText(stringField(alert, 'sent'));
+        const parsedAlerts: DhmzWeatherAlert[] = [];
+
+        for (const infoItem of arrayFromUnknown(field(alert, 'info'))) {
+            if (!isRecord(infoItem)) continue;
+
+            const language = normalizeText(stringField(infoItem, 'language'));
+            const urgency = normalizeText(stringField(infoItem, 'urgency'));
+            const severity = normalizeText(stringField(infoItem, 'severity'));
+            const certainty = normalizeText(stringField(infoItem, 'certainty'));
+            const onset = normalizeText(stringField(infoItem, 'onset'));
+            const expires = normalizeText(stringField(infoItem, 'expires'));
+            if (!onset || !expires) continue;
+
+            const awarenessLevel = parseAwarenessLevel(
+                parseParameter(infoItem, 'awareness_level'),
+            );
+            const awarenessType = parseAwarenessType(
+                parseParameter(infoItem, 'awareness_type'),
+            );
+            const event =
+                normalizeText(stringField(infoItem, 'event')) ??
+                fallbackCroatianEvent(awarenessType);
+            const description =
+                normalizeText(stringField(infoItem, 'description')) ?? event;
+            const instruction = normalizeText(
+                stringField(infoItem, 'instruction'),
+            );
+            const senderName = normalizeText(
+                stringField(infoItem, 'senderName'),
+            );
+
+            for (const areaItem of arrayFromUnknown(field(infoItem, 'area'))) {
+                const area = parseArea(areaItem);
+                if (!area) continue;
+                const typeKey = awarenessType?.id ?? event;
+                const levelKey = awarenessLevel?.id ?? severity ?? 'unknown';
+                const deduplicationKey = [
+                    area.regionCode,
+                    typeKey,
+                    levelKey,
+                    onset,
+                    expires,
+                ].join(':');
+                parsedAlerts.push({
+                    id: [
+                        identifier,
+                        language ?? 'unknown',
+                        area.regionCode,
+                        typeKey,
+                        onset,
+                        expires,
+                    ].join(':'),
+                    source: 'dhmz-cap',
+                    sourceUrl,
+                    language: language ?? 'unknown',
+                    event,
+                    description,
+                    instruction,
+                    urgency,
+                    severity,
+                    certainty,
+                    onset,
+                    expires,
+                    sent,
+                    senderName,
+                    awarenessLevel,
+                    awarenessType,
+                    area,
+                    deduplicationKey,
+                });
+            }
+        }
+
+        return parsedAlerts;
+    });
+}
+
+export async function getDhmzWeatherAlerts(
+    fetchFn: typeof fetch = fetch,
+): Promise<DhmzWeatherAlert[]> {
+    const parsedGroups = await Promise.all(
+        dhmzCapUrls.map(async (url) => {
+            try {
+                const response = await fetchFn(url);
+                if (!response.ok) {
+                    console.warn('DHMZ weather alerts feed unavailable', {
+                        status: response.status,
+                        url,
+                    });
+                    return [];
+                }
+                return await parseDhmzCapAlertXml(await response.text(), url);
+            } catch (error) {
+                console.warn('Failed to fetch DHMZ weather alerts feed', {
+                    error,
+                    url,
+                });
+                return [];
+            }
+        }),
+    );
+
+    const alertsByKey = new Map<string, DhmzWeatherAlert>();
+    for (const alert of parsedGroups.flat()) {
+        alertsByKey.set(alert.id, alert);
+    }
+
+    return Array.from(alertsByKey.values()).sort((left, right) =>
+        alertSortKey(left).localeCompare(alertSortKey(right)),
+    );
+}
+
+function configuredRegionCode() {
+    const configured = process.env.GREDICE_WEATHER_ALERT_REGION_CODE?.trim();
+    if (!configured) return null;
+    return configured.toUpperCase();
+}
+
+function distanceSquaredToRegion(
+    farm: WeatherAlertFarm,
+    region: WeatherAlertRegion,
+) {
+    const latitudeDistance = farm.latitude - region.latitude;
+    const longitudeDistance =
+        (farm.longitude - region.longitude) *
+        Math.cos((farm.latitude * Math.PI) / 180);
+    return (
+        latitudeDistance * latitudeDistance +
+        longitudeDistance * longitudeDistance
+    );
+}
+
+export function resolveWeatherAlertRegionCode(
+    farm?: WeatherAlertFarm | null,
+): string {
+    const configured = configuredRegionCode();
+    if (configured) return configured;
+    if (!farm) return defaultAlertRegionCode;
+
+    const nearestRegion = landAlertRegions.reduce<WeatherAlertRegion | null>(
+        (nearest, region) => {
+            if (!nearest) return region;
+            return distanceSquaredToRegion(farm, region) <
+                distanceSquaredToRegion(farm, nearest)
+                ? region
+                : nearest;
+        },
+        null,
+    );
+
+    return nearestRegion?.code ?? defaultAlertRegionCode;
+}
+
+export function filterWeatherAlertsForFarm(
+    alerts: DhmzWeatherAlert[],
+    farm?: WeatherAlertFarm | null,
+    options: {
+        horizonHours?: number;
+        language?: WeatherAlertLanguage;
+        now?: Date;
+    } = {},
+): DhmzWeatherAlert[] {
+    const now = options.now ?? new Date();
+    const horizonMs = (options.horizonHours ?? 72) * 60 * 60 * 1000;
+    const regionCode = resolveWeatherAlertRegionCode(farm);
+    const language = options.language ?? 'hr';
+    const relevantAlerts = alerts.filter((alert) => {
+        const onsetMs = new Date(alert.onset).getTime();
+        const expiresMs = new Date(alert.expires).getTime();
+        return (
+            alert.area.regionCode === regionCode &&
+            Number.isFinite(onsetMs) &&
+            Number.isFinite(expiresMs) &&
+            expiresMs > now.getTime() &&
+            onsetMs <= now.getTime() + horizonMs
+        );
+    });
+    const localizedAlerts = relevantAlerts.filter(
+        (alert) => alert.language === language,
+    );
+    const selectedAlerts =
+        localizedAlerts.length > 0 ? localizedAlerts : relevantAlerts;
+
+    return selectedAlerts.sort((left, right) =>
+        alertSortKey(left).localeCompare(alertSortKey(right)),
+    );
+}
+
+export function mostImportantWeatherAlert(alerts: DhmzWeatherAlert[]) {
+    return alerts[0] ?? null;
+}

--- a/apps/api/lib/weather/weatherNowContract.node.spec.ts
+++ b/apps/api/lib/weather/weatherNowContract.node.spec.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
     findClosestForecastEntry,
     pickFarmSnowAccumulation,
+    pickWeatherFarm,
 } from './weatherNowContract';
 
 describe('findClosestForecastEntry', () => {
@@ -89,5 +90,16 @@ describe('pickFarmSnowAccumulation', () => {
     it('falls back to first farm when id is missing or invalid', () => {
         assert.equal(pickFarmSnowAccumulation(farms), 1);
         assert.equal(pickFarmSnowAccumulation(farms, 'missing'), 1);
+    });
+
+    it('uses the same selected farm for alert region matching', () => {
+        assert.deepEqual(pickWeatherFarm(farms, '2'), {
+            id: 2,
+            snowAccumulation: 4,
+        });
+        assert.deepEqual(pickWeatherFarm(farms, 'missing'), {
+            id: 1,
+            snowAccumulation: 1,
+        });
     });
 });

--- a/apps/api/lib/weather/weatherNowContract.ts
+++ b/apps/api/lib/weather/weatherNowContract.ts
@@ -85,11 +85,18 @@ export function pickFarmSnowAccumulation(
     farms: Array<{ id: number | string; snowAccumulation: number }>,
     farmId?: string,
 ): number {
+    return pickWeatherFarm(farms, farmId)?.snowAccumulation ?? 0;
+}
+
+export function pickWeatherFarm<T extends { id: number | string }>(
+    farms: T[],
+    farmId?: string,
+): T | undefined {
     if (farmId) {
         const farm = farms.find(
             (currentFarm) => String(currentFarm.id) === farmId,
         );
-        if (farm) return farm.snowAccumulation;
+        if (farm) return farm;
     }
-    return farms[0]?.snowAccumulation ?? 0;
+    return farms[0];
 }

--- a/apps/garden/tests/WeatherHudStory.tsx
+++ b/apps/garden/tests/WeatherHudStory.tsx
@@ -1,10 +1,20 @@
 import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
+import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
+import { useGardensKeys } from '../../../packages/game/src/hooks/useGardens';
 import { WeatherHud } from '../../../packages/game/src/hud/WeatherHud';
 import {
     createGameState,
     GameStateContext,
 } from '../../../packages/game/src/useGameState';
+
+const currentGarden = {
+    id: 1,
+    name: 'Test',
+    isSandbox: false,
+    createdAt: '2026-06-01T00:00:00.000Z',
+};
 
 function createWeatherHudQueryClient() {
     const queryClient = new ReactQuery.QueryClient({
@@ -13,7 +23,18 @@ function createWeatherHudQueryClient() {
         },
     });
 
-    queryClient.setQueryData(['weather', 'now'], {
+    queryClient.setQueryData(useGardensKeys, [currentGarden]);
+    queryClient.setQueryData(currentGardenKeys('summer', currentGarden.id), {
+        id: currentGarden.id,
+        name: currentGarden.name,
+        isSandbox: currentGarden.isSandbox,
+        farmId: 1,
+        stacks: [],
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [],
+    });
+    queryClient.setQueryData(['weather', 'now', 1], {
+        alerts: [],
         cloudy: 0.1,
         foggy: 0,
         measuredTemperature: 20,
@@ -46,9 +67,11 @@ function WeatherHudTestProviders({ children }: PropsWithChildren) {
 
     return (
         <ReactQuery.QueryClientProvider client={queryClient}>
-            <GameStateContext.Provider value={gameStore}>
-                {children}
-            </GameStateContext.Provider>
+            <NuqsTestingAdapter>
+                <GameStateContext.Provider value={gameStore}>
+                    {children}
+                </GameStateContext.Provider>
+            </NuqsTestingAdapter>
         </ReactQuery.QueryClientProvider>
     );
 }

--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -32,6 +32,15 @@ const defaultPreferences = [
         scope: 'global',
     },
     {
+        category: 'weather_alerts',
+        channel: 'push',
+        digestFrequency: 'off',
+        enabled: true,
+        quietHoursEndMinute: null,
+        quietHoursStartMinute: null,
+        scope: 'global',
+    },
+    {
         category: 'reminders',
         channel: 'push',
         digestFrequency: 'weekly',

--- a/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
@@ -10,6 +10,7 @@ import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Calendar, Timer } from '@gredice/ui/icons';
 import { SelectItems } from '@gredice/ui/SelectItems';
+import { Stack } from '@gredice/ui/Stack';
 import { cx } from '@gredice/ui/utils';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
@@ -226,10 +227,16 @@ function MockRaisedBedFieldCard({ field }: { field: MockField }) {
             historyControl={field.hasHistory ? <HistoryButton /> : undefined}
             plantSortControl={<PlantSortSelect field={field} />}
             statusControl={
-                field.status ? <StatusSelect field={field} /> : undefined
-            }
-            datesControl={
-                field.date ? <DatesButton date={field.date} /> : undefined
+                field.status || field.date ? (
+                    <Stack spacing={0.5}>
+                        {field.status ? (
+                            <StatusSelect field={field} />
+                        ) : undefined}
+                        {field.date ? (
+                            <DatesButton date={field.date} />
+                        ) : undefined}
+                    </Stack>
+                ) : undefined
             }
         />
     );

--- a/docs/notification-preference-matrix.md
+++ b/docs/notification-preference-matrix.md
@@ -14,7 +14,7 @@ schema/API/UI/router/bulk implementation for:
 
 Every notification must carry the following dimensions:
 
-- `domain`: `garden` | `account_security` | `billing_order_delivery` | `reminders` | `digests` | `admin_campaigns` | `promotional`
+- `domain`: `garden` | `weather_alerts` | `account_security` | `billing_order_delivery` | `reminders` | `digests` | `admin_campaigns` | `promotional`
 - `eventType`: stable machine key for a concrete trigger.
 - `priority`: `critical` | `high` | `normal` | `low`.
 - `audienceType`: `single_user` | `segment` | `all_users`.
@@ -51,7 +51,8 @@ Per eventType, each channel gets one of:
 | `billing_order_delivery` | `delivery_status_changed`, `delivery_delay`, `delivery_ready` | high | ❌ | ✅ | ❌ | ✅ | default_on | default_on | default_on | never | never |
 | `billing_order_delivery` | `order_confirmation` | high | ✅ | ❌ | ❌ | ❌ | required | required | default_on | never | never |
 | `garden` | `operation_scheduled`, `operation_rescheduled`, `operation_completed`, `operation_canceled` | high | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_on | default_on | never |
-| `garden` | `garden_health_alert`, `weather_risk_alert` | high | ❌ | ✅ | ❌ | ❌ | default_on | default_on | default_on | never | never |
+| `garden` | `garden_health_alert` | high | ❌ | ✅ | ❌ | ❌ | default_on | default_on | default_on | never | never |
+| `weather_alerts` | `weather_risk_alert` | high | ❌ | ✅ | ❌ | ❌ | default_on | default_on | default_on | never | never |
 | `garden` | `harvest_ready`, `harvest_window_ending` | normal | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_on | default_on | never |
 | `reminders` | `task_reminder`, `cart_abandonment_reminder`, `subscription_renewal_reminder` | normal | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_off | default_on | never |
 | `digests` | `daily_digest`, `weekly_digest`, `monthly_digest` | low | ❌ | ✅ | ❌ | ✅ | default_on | default_on | never | required | never |
@@ -76,6 +77,7 @@ Garden settings currently expose domain-level controls for the canonical
 preference categories that are safe to adjust from the customer UI:
 
 - `garden`
+- `weather_alerts`
 - `reminders`
 - `admin_campaigns`
 - `promotional`

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -31,8 +31,9 @@ export const currentGardenKeys = (
 
 type useCurrentGardenResponse = Omit<
     GardenResponse,
-    'stacks' | 'latitude' | 'longitude' | 'createdAt' | 'updatedAt'
+    'stacks' | 'farmId' | 'latitude' | 'longitude' | 'createdAt' | 'updatedAt'
 > & {
+    farmId?: number | null;
     stacks: Stack[];
     location: {
         lat: number;
@@ -848,6 +849,7 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
                 id: garden.id,
                 name: garden.name,
                 isSandbox: garden.isSandbox,
+                farmId: garden.farmId,
                 stacks,
                 location: {
                     lat: garden.latitude,

--- a/packages/game/src/hooks/useWeatherNow.ts
+++ b/packages/game/src/hooks/useWeatherNow.ts
@@ -2,15 +2,19 @@ import { clientPublic } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
 import { useGameState } from '../useGameState';
 
-export function useWeatherNow(enabled = true) {
+export function useWeatherNow(enabled = true, farmId?: number | null) {
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );
 
     return useQuery({
-        queryKey: ['weather', 'now'],
+        queryKey: ['weather', 'now', farmId ?? null],
         queryFn: async () => {
-            const response = await clientPublic().api.data.weather.now.$get();
+            const query: Record<string, string> = {};
+            if (farmId != null) query.farmId = farmId.toString();
+            const response = await clientPublic().api.data.weather.now.$get({
+                query,
+            });
             if (!response.ok) {
                 console.debug('Weather data unavailable', {
                     status: response.status,

--- a/packages/game/src/hud/WeatherHud.tsx
+++ b/packages/game/src/hud/WeatherHud.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
+import { Warning } from '@gredice/ui/icons';
 import { Popper } from '@gredice/ui/Popper';
 import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useLiveTime } from '../hooks/useLiveTime';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
 import { useWeatherNow } from '../hooks/useWeatherNow';
@@ -21,7 +23,9 @@ const timePopperClassName =
 export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
     const currentTime = useLiveTime();
     const weatherEnabled = !noWeather;
-    const { data: weatherData } = useWeatherNow(weatherEnabled);
+    const { data: currentGarden } = useCurrentGarden();
+    const farmId = currentGarden?.farmId;
+    const { data: weatherData } = useWeatherNow(weatherEnabled, farmId);
     const { data: forecastData } = useWeatherForecast(weatherEnabled);
     if (!weatherEnabled) return null;
     // TODO: Add loading indicator
@@ -30,6 +34,7 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
 
     const WeatherIcon =
         weatherData?.symbol != null ? weatherIcons[weatherData.symbol] : null;
+    const hasAlerts = (weatherData?.alerts?.length ?? 0) > 0;
     const formattedTime = currentTime?.toLocaleTimeString('hr-HR', {
         hour: '2-digit',
         minute: '2-digit',
@@ -53,6 +58,9 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
                                     {WeatherIcon && (
                                         <WeatherIcon.day className="size-6" />
                                     )}
+                                    {hasAlerts && (
+                                        <Warning className="size-4 shrink-0 text-amber-600" />
+                                    )}
                                     <Typography
                                         level="body2"
                                         className="text-base pl-0.5"
@@ -68,7 +76,7 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
                             </Button>
                         }
                     >
-                        <WeatherNowDetails />
+                        <WeatherNowDetails farmId={farmId} />
                     </Popper>
                 )}
                 {weatherData && (forecastData || formattedTime) && (

--- a/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
+++ b/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
@@ -1,3 +1,4 @@
+import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Divider } from '@gredice/ui/Divider';
 import {
@@ -12,6 +13,7 @@ import {
     Empty,
     Navigate,
     Snowflake,
+    Warning,
     Wind,
 } from '@gredice/ui/icons';
 import { Link } from '@gredice/ui/Link';
@@ -41,8 +43,28 @@ export const windDirectionIcons: Record<string, FC> = {
     NW: ArrowUpLeft,
 };
 
-export function WeatherNowDetails() {
-    const { data } = useWeatherNow();
+function formatAlertDateTime(value: string) {
+    return new Date(value).toLocaleString('hr-HR', {
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        month: '2-digit',
+    });
+}
+
+function alertLevelLabel(alert: {
+    awarenessLevel?: { color?: string | null; label?: string | null } | null;
+    severity?: string | null;
+}) {
+    const color = alert.awarenessLevel?.color;
+    if (color === 'yellow') return 'Žuto upozorenje';
+    if (color === 'orange') return 'Narančasto upozorenje';
+    if (color === 'red') return 'Crveno upozorenje';
+    return alert.awarenessLevel?.label ?? alert.severity ?? 'Upozorenje';
+}
+
+export function WeatherNowDetails({ farmId }: { farmId?: number | null } = {}) {
+    const { data } = useWeatherNow(true, farmId);
     // TODO: Add loading indicator
     // TODO: Add error message
 
@@ -64,6 +86,7 @@ export function WeatherNowDetails() {
     // Chance of rain is a number between 0 and 1,
     // chance is 100 when there is 10 or more mm of rain
     const rainChance = data.rain > 10 ? 1 : 10 / data.rain;
+    const alerts = data.alerts ?? [];
 
     return (
         <Stack
@@ -164,6 +187,46 @@ export function WeatherNowDetails() {
                             )}
                         </div>
                     </Row>
+                    {alerts.length > 0 && (
+                        <Stack className="col-span-full px-4 pb-4" spacing={2}>
+                            {alerts.map((alert) => (
+                                <Alert
+                                    key={alert.id}
+                                    color="warning"
+                                    className="p-3"
+                                    startDecorator={
+                                        <Warning className="size-4" />
+                                    }
+                                >
+                                    <Stack spacing={1}>
+                                        <div>
+                                            <Typography semiBold>
+                                                {alert.event}
+                                            </Typography>
+                                            <Typography level="body3" secondary>
+                                                {alertLevelLabel(alert)} ·{' '}
+                                                {formatAlertDateTime(
+                                                    alert.onset,
+                                                )}{' '}
+                                                -{' '}
+                                                {formatAlertDateTime(
+                                                    alert.expires,
+                                                )}
+                                            </Typography>
+                                        </div>
+                                        <Typography level="body3">
+                                            {alert.description}
+                                        </Typography>
+                                        {alert.instruction && (
+                                            <Typography level="body3" secondary>
+                                                {alert.instruction}
+                                            </Typography>
+                                        )}
+                                    </Stack>
+                                </Alert>
+                            ))}
+                        </Stack>
+                    )}
                     <div className="border-l block md:hidden">
                         <Button
                             variant="plain"
@@ -196,6 +259,18 @@ export function WeatherNowDetails() {
                         />
                         <span>DHMZ</span>
                     </Link>
+                    {alerts.length > 0 && (
+                        <>
+                            <span>•</span>
+                            <Link
+                                href="https://meteoalarm.org"
+                                target="_blank"
+                                className="flex gap-1 items-center"
+                            >
+                                <span>MeteoAlarm</span>
+                            </Link>
+                        </>
+                    )}
                     <span>•</span>
                     <Link
                         href="https://signalco.io"

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -87,10 +87,20 @@ const categoryPreferences: NotificationPreferenceItem[] = [
         channel: 'push',
         defaultEnabled: true,
         description:
-            'Radovi u vrtu, promjene termina i berba. Hitna upozorenja o vrtu ostaju odmah vidljiva.',
+            'Radovi u vrtu, promjene termina, berba i zdravstvena upozorenja o vrtu.',
         digestEligible: true,
         label: 'Radovi i berba u vrtu',
         quietHoursEligible: true,
+    },
+    {
+        category: 'weather_alerts',
+        channel: 'push',
+        defaultEnabled: true,
+        description:
+            'Upozorenja za grmljavinu, vjetar, kišu, snijeg, poledicu i druge vremenske rizike za regiju vrta.',
+        digestEligible: false,
+        label: 'Vremenska upozorenja',
+        quietHoursEligible: false,
     },
     {
         category: 'reminders',

--- a/packages/storage/src/cache/grediceCached.ts
+++ b/packages/storage/src/cache/grediceCached.ts
@@ -2,6 +2,7 @@ import { bustRedisCached, redisCached, redisCachedInfo } from './redisCache';
 
 export const grediceCacheKeys = {
     forecastBjelovar: 'forecastBjelovar',
+    weatherAlertsCroatia: 'weatherAlertsCroatia',
     airSensorOpgIb: 'airSensorOpgIb',
 };
 

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -202,6 +202,27 @@ const notificationRolloutPreferenceDefaults: NotificationRolloutPreferenceDefaul
             required: false,
         },
         {
+            category: 'weather_alerts',
+            channel: 'in_app',
+            defaultEnabled: true,
+            digestEligible: false,
+            required: false,
+        },
+        {
+            category: 'weather_alerts',
+            channel: 'email',
+            defaultEnabled: true,
+            digestEligible: false,
+            required: false,
+        },
+        {
+            category: 'weather_alerts',
+            channel: 'push',
+            defaultEnabled: true,
+            digestEligible: false,
+            required: false,
+        },
+        {
             category: 'reminders',
             channel: 'in_app',
             defaultEnabled: true,

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -1227,6 +1227,29 @@ test('backfillNotificationRolloutDefaults limits subscription updates with batch
     assert.ok(result.deniedSubscriptionsDisabled >= 1);
     assert.ok(result.deviceLabelsBackfilled >= 1);
 
+    const weatherAlertPreferences = await storage()
+        .select({
+            channel: notificationUserChannelPreferences.channel,
+            enabled: notificationUserChannelPreferences.enabled,
+        })
+        .from(notificationUserChannelPreferences)
+        .where(
+            eq(notificationUserChannelPreferences.category, 'weather_alerts'),
+        );
+    assert.deepEqual(
+        weatherAlertPreferences
+            .map((preference) => ({
+                channel: preference.channel,
+                enabled: preference.enabled,
+            }))
+            .sort((left, right) => left.channel.localeCompare(right.channel)),
+        [
+            { channel: 'email', enabled: true },
+            { channel: 'in_app', enabled: true },
+            { channel: 'push', enabled: true },
+        ],
+    );
+
     const subscriptions = await storage()
         .select({
             id: webPushSubscriptions.id,


### PR DESCRIPTION
## Summary
- add DHMZ CAP alert fetching/parsing for today, tomorrow, and day-after-tomorrow feeds
- expose farm-region alerts through current weather and a dedicated weather alerts endpoint
- show weather warnings in the Garden HUD and details panel with localized alert text
- add default-on `weather_alerts` notification preferences and emit deduplicated `weather_risk_alert` notifications from the weather cron

## Tracking
Closes #3164
Closes #3167
Closes #3168
Closes #3169

## Validation
- `pnpm --filter api test:node`
- `pnpm --filter @gredice/storage test:node`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/weather-hud.spec.tsx tests/notifications-tab.spec.tsx`
- live DHMZ CAP smoke parse returned active alerts; Bjelovar-like coordinates resolve to `HR002` with Croatian alert text

## Notes
- Direct `apps/api` package `tsc` still reports an unrelated existing optional-argument typing issue in `lib/notifications/webPushSender.node.spec.ts`.
- Local browser smoke requires API env such as `POSTGRES_URL`; without it, the dev API returns storage-backed 500s as expected.