### PR TITLE
Add a jobs queue view to the automations admin page

### DIFF
--- a/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
+++ b/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
@@ -1,0 +1,285 @@
+import type {
+    AutomationRunSource,
+    AutomationRunStatus,
+    SelectAutomationRun,
+} from '@gredice/storage';
+import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Table } from '@gredice/ui/Table';
+import { Typography } from '@gredice/ui/Typography';
+import Link from 'next/link';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
+import { KnownPages } from '../../../src/KnownPages';
+import { automationRunStatusMeta } from './presentation';
+
+type AutomationJobQueueRun = Pick<
+    SelectAutomationRun,
+    | 'id'
+    | 'automationDefinitionId'
+    | 'automationDefinitionKey'
+    | 'automationDefinitionName'
+    | 'source'
+    | 'sourceEventType'
+    | 'sourceAggregateId'
+    | 'parentRunId'
+    | 'status'
+    | 'dryRun'
+    | 'attempt'
+    | 'maxAttempts'
+    | 'nextRunAt'
+    | 'lockedAt'
+    | 'lockedBy'
+    | 'errorMessage'
+    | 'startedAt'
+    | 'completedAt'
+    | 'createdAt'
+    | 'updatedAt'
+>;
+
+function renderRunStatusChip(status: AutomationRunStatus) {
+    const meta = automationRunStatusMeta(status);
+    return (
+        <Chip color={meta.color} size="sm" variant="soft">
+            {meta.label}
+        </Chip>
+    );
+}
+
+function sourceLabel(source: AutomationRunSource) {
+    switch (source) {
+        case 'event':
+            return 'Event';
+        case 'manual':
+            return 'Ručno';
+        case 'schedule':
+            return 'Raspored';
+        case 'test':
+            return 'Test';
+        case 'replay':
+            return 'Replay';
+    }
+}
+
+function renderDateTimeValue(value: Date | null) {
+    if (!value) {
+        return <span>-</span>;
+    }
+
+    return <LocalDateTime>{value}</LocalDateTime>;
+}
+
+function renderQueueTiming(run: AutomationJobQueueRun) {
+    if (run.status === 'queued' || run.status === 'retrying') {
+        return (
+            <Stack spacing={1}>
+                <Typography level="body3" className="text-muted-foreground">
+                    Sljedeće
+                </Typography>
+                <LocalDateTime>{run.nextRunAt}</LocalDateTime>
+            </Stack>
+        );
+    }
+
+    if (run.status === 'running') {
+        return (
+            <Stack spacing={1}>
+                <Typography level="body3" className="text-muted-foreground">
+                    Zaključano
+                </Typography>
+                {renderDateTimeValue(run.lockedAt)}
+                {run.lockedBy ? (
+                    <Typography
+                        level="body3"
+                        className="break-all text-muted-foreground"
+                    >
+                        {run.lockedBy}
+                    </Typography>
+                ) : null}
+            </Stack>
+        );
+    }
+
+    if (run.completedAt) {
+        return (
+            <Stack spacing={1}>
+                <Typography level="body3" className="text-muted-foreground">
+                    Završeno
+                </Typography>
+                <LocalDateTime>{run.completedAt}</LocalDateTime>
+            </Stack>
+        );
+    }
+
+    return (
+        <Typography level="body3" className="text-muted-foreground">
+            -
+        </Typography>
+    );
+}
+
+export function AutomationJobsQueueTable({
+    runs,
+}: {
+    runs: AutomationJobQueueRun[];
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Red poslova</CardTitle>
+                <Typography level="body3" className="text-muted-foreground">
+                    Automatizacijski poslovi s trenutnim statusom, pokušajima i
+                    podacima za obradu.
+                </Typography>
+            </CardHeader>
+            <CardOverflow>
+                <div className="overflow-auto">
+                    <Table>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.Head>Job</Table.Head>
+                                <Table.Head>Status</Table.Head>
+                                <Table.Head>Izvor</Table.Head>
+                                <Table.Head>Pokušaji</Table.Head>
+                                <Table.Head>Obrada</Table.Head>
+                                <Table.Head>Vrijeme</Table.Head>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {runs.length === 0 ? (
+                                <Table.Row>
+                                    <Table.Cell colSpan={6}>
+                                        <NoDataPlaceholder>
+                                            Nema poslova za odabrane filtere.
+                                        </NoDataPlaceholder>
+                                    </Table.Cell>
+                                </Table.Row>
+                            ) : null}
+                            {runs.map((run) => (
+                                <Table.Row key={run.id}>
+                                    <Table.Cell>
+                                        <Stack spacing={1}>
+                                            <Link
+                                                href={KnownPages.Automation(
+                                                    run.automationDefinitionId,
+                                                )}
+                                                className="font-medium text-primary hover:underline"
+                                            >
+                                                #{run.id}{' '}
+                                                {run.automationDefinitionName}
+                                            </Link>
+                                            <Typography
+                                                level="body3"
+                                                className="break-all text-muted-foreground"
+                                            >
+                                                {run.automationDefinitionKey}
+                                            </Typography>
+                                            {run.parentRunId ? (
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-muted-foreground"
+                                                >
+                                                    Parent #{run.parentRunId}
+                                                </Typography>
+                                            ) : null}
+                                        </Stack>
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <Stack spacing={1}>
+                                            <Row
+                                                spacing={1}
+                                                className="flex-wrap"
+                                            >
+                                                {renderRunStatusChip(
+                                                    run.status,
+                                                )}
+                                                {run.dryRun ? (
+                                                    <Chip
+                                                        size="sm"
+                                                        color="info"
+                                                        variant="soft"
+                                                    >
+                                                        Dry-run
+                                                    </Chip>
+                                                ) : null}
+                                            </Row>
+                                            {run.errorMessage ? (
+                                                <Typography
+                                                    level="body3"
+                                                    className="max-w-80 break-words text-red-700 dark:text-red-300"
+                                                >
+                                                    {run.errorMessage}
+                                                </Typography>
+                                            ) : null}
+                                        </Stack>
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <Stack spacing={1}>
+                                            <Chip size="sm" variant="soft">
+                                                {sourceLabel(run.source)}
+                                            </Chip>
+                                            <Typography level="body3">
+                                                {run.sourceEventType ?? '-'}
+                                            </Typography>
+                                            <Typography
+                                                level="body3"
+                                                className="break-all text-muted-foreground"
+                                            >
+                                                {run.sourceAggregateId ?? '-'}
+                                            </Typography>
+                                        </Stack>
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <Typography level="body3">
+                                            {run.attempt} / {run.maxAttempts}
+                                        </Typography>
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        {renderQueueTiming(run)}
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <Stack spacing={1}>
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Kreirano
+                                            </Typography>
+                                            <LocalDateTime>
+                                                {run.createdAt}
+                                            </LocalDateTime>
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Ažurirano
+                                            </Typography>
+                                            <LocalDateTime>
+                                                {run.updatedAt}
+                                            </LocalDateTime>
+                                            {run.startedAt ? (
+                                                <>
+                                                    <Typography
+                                                        level="body3"
+                                                        className="text-muted-foreground"
+                                                    >
+                                                        Početak
+                                                    </Typography>
+                                                    <LocalDateTime>
+                                                        {run.startedAt}
+                                                    </LocalDateTime>
+                                                </>
+                                            ) : null}
+                                        </Stack>
+                                    </Table.Cell>
+                                </Table.Row>
+                            ))}
+                        </Table.Body>
+                    </Table>
+                </div>
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/automations/page.tsx
+++ b/apps/app/app/admin/automations/page.tsx
@@ -28,6 +28,7 @@ import { AdminPageHeader } from '../../../components/admin/navigation';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
+import { AutomationJobsQueueTable } from './AutomationJobsQueueTable';
 import {
     automationActionSummary,
     automationRunStatusMeta,
@@ -108,6 +109,12 @@ export default async function AutomationsPage({
             limit: 300,
         }),
     ]);
+    const queuedRunsCount = runs.filter(
+        (run) => run.status === 'queued' || run.status === 'retrying',
+    ).length;
+    const runningRunsCount = runs.filter(
+        (run) => run.status === 'running',
+    ).length;
     const runsByDefinitionId = new Map<number, typeof runs>();
 
     for (const run of runs) {
@@ -228,7 +235,7 @@ export default async function AutomationsPage({
                 </CardContent>
             </Card>
 
-            <div className="grid gap-4 md:grid-cols-4">
+            <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
                 <Card>
                     <CardContent>
                         <Typography level="body3" secondary>
@@ -255,9 +262,25 @@ export default async function AutomationsPage({
                 <Card>
                     <CardContent>
                         <Typography level="body3" secondary>
-                            Recent runs
+                            Poslovi
                         </Typography>
                         <Typography level="h4">{runs.length}</Typography>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent>
+                        <Typography level="body3" secondary>
+                            Čeka
+                        </Typography>
+                        <Typography level="h4">{queuedRunsCount}</Typography>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent>
+                        <Typography level="body3" secondary>
+                            U tijeku
+                        </Typography>
+                        <Typography level="h4">{runningRunsCount}</Typography>
                     </CardContent>
                 </Card>
                 <Card>
@@ -274,6 +297,8 @@ export default async function AutomationsPage({
                     </CardContent>
                 </Card>
             </div>
+
+            <AutomationJobsQueueTable runs={runs} />
 
             <Card>
                 <CardHeader>

--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -38,7 +38,7 @@ export function automationRunStatusMeta(status: AutomationRunStatus): {
 } {
     switch (status) {
         case 'queued':
-            return { label: 'U redu', color: 'neutral' };
+            return { label: 'U redu čekanja', color: 'neutral' };
         case 'running':
             return { label: 'Izvodi se', color: 'info' };
         case 'succeeded':

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -123,7 +123,8 @@ snapshot reaches the runner.
 Admins manage automations in `apps/app` at `/admin/automations`.
 
 - The list page shows definition status, trigger summary, action summary, latest
-  run status, recent failed-run count, and filters for definition status,
+  run status, recent failed-run count, a jobs queue table with run state,
+  attempts, timing, and source context, and filters for definition status,
   trigger event type, run status, and failed-only runs.
 - The detail page shows the editor, test controls, and expandable run logs with
   per-step input/output/error snapshots.


### PR DESCRIPTION
## Summary
- Add a queue table to `/admin/automations` that lists automation runs with status, source, attempts, timing, errors, and linked definition context.
- Update the summary cards to surface queued and running job counts, and rename the queued status label to `U redu čekanja`.
- Refresh the automations docs to describe the new queue view.

## Testing
- `pnpm lint --filter app` passed.
- `pnpm build --filter app` passed.
- `git diff --check` passed.
- Local browser smoke check reached the `/admin/automations` route without console errors; the session was unauthenticated, so it rendered the login screen instead of the queue table.