### PR TITLE
Add AI analytics type filters and operation metadata

### DIFF
--- a/apps/app/app/admin/ai-analytics/AiAnalyticsFilters.tsx
+++ b/apps/app/app/admin/ai-analytics/AiAnalyticsFilters.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { AI } from '@gredice/ui/icons';
+import {
+    type FilterOption,
+    TableFilter,
+} from '../../../components/shared/filters';
+import { aiAnalyticsOperationTypeOptions } from './aiAnalyticsPresentation';
+
+const AI_OPERATION_TYPE_FILTER_OPTIONS: FilterOption = {
+    key: 'type',
+    label: 'Tip AI operacije',
+    icon: <AI className="size-4" />,
+    options: [
+        { value: '', label: 'Sve AI operacije' },
+        ...aiAnalyticsOperationTypeOptions,
+    ],
+};
+
+export function AiAnalyticsFilters() {
+    return (
+        <TableFilter
+            filters={[AI_OPERATION_TYPE_FILTER_OPTIONS]}
+            defaultValues={{ type: '' }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/ai-analytics/AiAnalyticsTable.tsx
+++ b/apps/app/app/admin/ai-analytics/AiAnalyticsTable.tsx
@@ -16,21 +16,33 @@ import {
     estimateAiAnalysisCostUsd,
     formatAiCostUsd,
 } from '../../../src/ai/aiAnalyticsCost';
+import type { AiAnalyticsOperationType } from './aiAnalyticsPresentation';
 
 export type AiAnalyticsRow = {
     id: number;
     createdAt: string;
+    type: AiAnalyticsOperationType;
+    typeLabel: string;
     raisedBedName: string;
     raisedBedPhysicalId: string | null;
     positionIndex: number | null;
+    sourceEventType: string | null;
+    sourceAggregateId: string | null;
+    automationRunId: number | null;
     data: {
-        markdown: string;
-        imageUrl: string;
-        imageUrls?: string[];
-        model?: string | null;
-        inputTokens?: number | null;
-        outputTokens?: number | null;
-        totalTokens?: number | null;
+        markdown?: string | undefined;
+        imageUrl?: string | undefined;
+        imageUrls?: string[] | undefined;
+        model?: string | null | undefined;
+        inputTokens?: number | null | undefined;
+        outputTokens?: number | null | undefined;
+        totalTokens?: number | null | undefined;
+        summary?: string | undefined;
+        source?: string | undefined;
+        imageCount?: number | null | undefined;
+        proposalCount?: number | null | undefined;
+        acceptedProposalCount?: number | null | undefined;
+        requestCount?: number | null | undefined;
     } | null;
 };
 
@@ -81,18 +93,25 @@ function RaisedBedCell({ row }: { row: AiAnalyticsRow }) {
 
 function AiAnalysisDetails({ row }: { row: AiAnalyticsRow }) {
     const images = imageItems(row);
-    const markdown = row.data?.markdown.trim();
+    const markdown = row.data?.markdown?.trim();
+    const summary = row.data?.summary?.trim();
+    const generatedContent = markdown || summary;
+    const imageCount = row.data?.imageCount ?? images.length;
 
     return (
         <Stack spacing={4}>
             <Stack spacing={1} className="pr-6">
                 <Typography level="h4" semiBold>
-                    AI analiza
+                    {row.typeLabel}
                 </Typography>
                 <RaisedBedCell row={row} />
             </Stack>
 
-            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
+                <Stack spacing={0}>
+                    <Typography level="body3">Tip</Typography>
+                    <Typography level="body2">{row.typeLabel}</Typography>
+                </Stack>
                 <Stack spacing={0}>
                     <Typography level="body3">Model</Typography>
                     <Typography level="body2">
@@ -119,13 +138,47 @@ function AiAnalysisDetails({ row }: { row: AiAnalyticsRow }) {
                 </Stack>
             </div>
 
+            {(row.data?.source ||
+                row.data?.proposalCount != null ||
+                row.data?.requestCount != null ||
+                row.automationRunId != null) && (
+                <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                    <Stack spacing={0}>
+                        <Typography level="body3">Izvor</Typography>
+                        <Typography level="body2">
+                            {row.data?.source ?? row.sourceEventType ?? 'Ručno'}
+                        </Typography>
+                    </Stack>
+                    <Stack spacing={0}>
+                        <Typography level="body3">Prijedlozi</Typography>
+                        <Typography level="body2">
+                            {formatTokens(row.data?.proposalCount)}
+                        </Typography>
+                    </Stack>
+                    <Stack spacing={0}>
+                        <Typography level="body3">Zahtjevi</Typography>
+                        <Typography level="body2">
+                            {formatTokens(row.data?.requestCount)}
+                        </Typography>
+                    </Stack>
+                    <Stack spacing={0}>
+                        <Typography level="body3">Automation run</Typography>
+                        <Typography level="body2">
+                            {row.automationRunId
+                                ? `#${row.automationRunId}`
+                                : '-'}
+                        </Typography>
+                    </Stack>
+                </div>
+            )}
+
             <Stack spacing={2}>
                 <Typography level="body2" semiBold>
                     Generirani sadržaj
                 </Typography>
-                {markdown ? (
+                {generatedContent ? (
                     <Markdown className="rounded-md border bg-muted/20 p-3">
-                        {markdown}
+                        {generatedContent}
                     </Markdown>
                 ) : (
                     <NoDataPlaceholder>Nema sadržaja</NoDataPlaceholder>
@@ -144,7 +197,13 @@ function AiAnalysisDetails({ row }: { row: AiAnalyticsRow }) {
                         previewVariant="carousel"
                     />
                 ) : (
-                    <NoDataPlaceholder>Nema priloženih slika</NoDataPlaceholder>
+                    <NoDataPlaceholder>
+                        {imageCount > 0
+                            ? `Analizirano slika: ${imageCount.toLocaleString(
+                                  'hr-HR',
+                              )}`
+                            : 'Nema priloženih slika'}
+                    </NoDataPlaceholder>
                 )}
             </Stack>
         </Stack>
@@ -162,6 +221,7 @@ export function AiAnalyticsTable({ rows }: { rows: AiAnalyticsRow[] }) {
                         <Table.Header>
                             <Table.Row>
                                 <Table.Head>Gredica | Polje</Table.Head>
+                                <Table.Head>Tip</Table.Head>
                                 <Table.Head>Model</Table.Head>
                                 <Table.Head className="text-right">
                                     Ulazni tokeni
@@ -181,9 +241,9 @@ export function AiAnalyticsTable({ rows }: { rows: AiAnalyticsRow[] }) {
                         <Table.Body>
                             {rows.length === 0 && (
                                 <Table.Row>
-                                    <Table.Cell colSpan={7}>
+                                    <Table.Cell colSpan={8}>
                                         <NoDataPlaceholder>
-                                            Nema AI analiza
+                                            Nema AI operacija
                                         </NoDataPlaceholder>
                                     </Table.Cell>
                                 </Table.Row>
@@ -207,6 +267,9 @@ export function AiAnalyticsTable({ rows }: { rows: AiAnalyticsRow[] }) {
                                 >
                                     <Table.Cell>
                                         <RaisedBedCell row={row} />
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        <Chip size="sm">{row.typeLabel}</Chip>
                                     </Table.Cell>
                                     <Table.Cell>
                                         <Chip size="sm">

--- a/apps/app/app/admin/ai-analytics/aiAnalyticsPresentation.ts
+++ b/apps/app/app/admin/ai-analytics/aiAnalyticsPresentation.ts
@@ -1,0 +1,37 @@
+import type { AiAnalyticsOperationType } from '@gredice/storage';
+
+export type { AiAnalyticsOperationType };
+
+export const aiAnalyticsOperationTypeOptions: Array<{
+    value: AiAnalyticsOperationType;
+    label: string;
+}> = [
+    { value: 'raisedBedImageAnalysis', label: 'Analiza gredice' },
+    { value: 'raisedBedFieldImageAnalysis', label: 'Analiza polja' },
+    {
+        value: 'raisedBedImagePlantStatusReview',
+        label: 'Pregled statusa biljaka',
+    },
+];
+
+const aiAnalyticsOperationTypeLabels = new Map(
+    aiAnalyticsOperationTypeOptions.map((option) => [
+        option.value,
+        option.label,
+    ]),
+);
+
+export function isAiAnalyticsOperationType(
+    value: string | undefined,
+): value is AiAnalyticsOperationType {
+    return Boolean(
+        value &&
+            aiAnalyticsOperationTypeOptions.some(
+                (option) => option.value === value,
+            ),
+    );
+}
+
+export function aiAnalyticsOperationTypeLabel(type: AiAnalyticsOperationType) {
+    return aiAnalyticsOperationTypeLabels.get(type) ?? type;
+}

--- a/apps/app/app/admin/ai-analytics/page.tsx
+++ b/apps/app/app/admin/ai-analytics/page.tsx
@@ -1,4 +1,6 @@
 import {
+    type AiAnalyticsOperation,
+    type AiAnalyticsOperationType,
     getAiAnalysisEvents,
     getAiAnalysisTotals,
     getRaisedBedMetadataByIds,
@@ -11,7 +13,12 @@ import {
     formatAiCostUsd,
     sumAiAnalysisCostUsd,
 } from '../../../src/ai/aiAnalyticsCost';
+import { AiAnalyticsFilters } from './AiAnalyticsFilters';
 import { type AiAnalyticsRow, AiAnalyticsTable } from './AiAnalyticsTable';
+import {
+    aiAnalyticsOperationTypeLabel,
+    isAiAnalyticsOperationType,
+} from './aiAnalyticsPresentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,23 +38,58 @@ function parseRaisedBedAggregateId(aggregateId: string) {
     };
 }
 
-export default async function AiAnalyticsPage() {
+function parseOperationTypeFilter(
+    value: string | string[] | undefined,
+): AiAnalyticsOperationType | undefined {
+    const normalized = typeof value === 'string' ? value : undefined;
+    return isAiAnalyticsOperationType(normalized) ? normalized : undefined;
+}
+
+function getRaisedBedReference(event: AiAnalyticsOperation) {
+    const raisedBedId = event.data?.raisedBedId;
+    if (typeof raisedBedId === 'number') {
+        return {
+            raisedBedId,
+            positionIndex:
+                typeof event.data?.focusPositionIndex === 'number'
+                    ? event.data.focusPositionIndex
+                    : null,
+        };
+    }
+
+    return parseRaisedBedAggregateId(event.aggregateId);
+}
+
+export default async function AiAnalyticsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ type?: string | string[] }>;
+}) {
     await auth(['admin']);
+    const params = await searchParams;
+    const selectedOperationType = parseOperationTypeFilter(params.type);
+    const operationTypes = selectedOperationType
+        ? [selectedOperationType]
+        : undefined;
 
     const now = new Date();
     const last30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
     const last24h = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
     const [events, totals30d, totals24h] = await Promise.all([
-        getAiAnalysisEvents(),
-        getAiAnalysisTotals({ from: last30d }),
-        getAiAnalysisTotals({ from: last24h }),
+        getAiAnalysisEvents({ operationTypes }),
+        getAiAnalysisTotals({ from: last30d, operationTypes }),
+        getAiAnalysisTotals({ from: last24h, operationTypes }),
     ]);
-    const raisedBedIds = events
-        .map(
-            (event) => parseRaisedBedAggregateId(event.aggregateId).raisedBedId,
-        )
-        .filter((raisedBedId): raisedBedId is number => raisedBedId != null);
+    const raisedBedIds = Array.from(
+        new Set(
+            events
+                .map((event) => getRaisedBedReference(event).raisedBedId)
+                .filter(
+                    (raisedBedId): raisedBedId is number => raisedBedId != null,
+                ),
+        ),
+    );
     const raisedBeds = await getRaisedBedMetadataByIds(raisedBedIds);
     const raisedBedsById = new Map(
         raisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
@@ -67,23 +109,28 @@ export default async function AiAnalyticsPage() {
     );
     const totalCostUsd = sumAiAnalysisCostUsd(events);
     const rows: AiAnalyticsRow[] = events.map((event) => {
-        const { raisedBedId, positionIndex } = parseRaisedBedAggregateId(
-            event.aggregateId,
-        );
+        const { raisedBedId, positionIndex } = getRaisedBedReference(event);
         const raisedBed =
             raisedBedId == null ? undefined : raisedBedsById.get(raisedBedId);
         const raisedBedName =
             raisedBed?.name?.trim() ||
             (raisedBed?.physicalId
                 ? `Gredica ${raisedBed.physicalId}`
-                : 'Nepoznata gredica');
+                : raisedBedId != null
+                  ? `Gredica #${raisedBedId}`
+                  : 'Nepoznata gredica');
 
         return {
             id: event.id,
             createdAt: event.createdAt.toISOString(),
+            type: event.aiOperationType,
+            typeLabel: aiAnalyticsOperationTypeLabel(event.aiOperationType),
             raisedBedName,
             raisedBedPhysicalId: raisedBed?.physicalId ?? null,
             positionIndex,
+            sourceEventType: event.sourceEventType ?? null,
+            sourceAggregateId: event.sourceAggregateId ?? null,
+            automationRunId: event.automationRunId ?? null,
             data: event.data
                 ? {
                       markdown: event.data.markdown,
@@ -93,6 +140,12 @@ export default async function AiAnalyticsPage() {
                       inputTokens: event.data.inputTokens,
                       outputTokens: event.data.outputTokens,
                       totalTokens: event.data.totalTokens,
+                      summary: event.data.summary,
+                      source: event.data.source,
+                      imageCount: event.data.imageCount,
+                      proposalCount: event.data.proposalCount,
+                      acceptedProposalCount: event.data.acceptedProposalCount,
+                      requestCount: event.data.requestCount,
                   }
                 : null,
         };
@@ -105,7 +158,7 @@ export default async function AiAnalyticsPage() {
                     <CardOverflow>
                         <Stack className="p-2">
                             <Typography level="body3">
-                                Ukupno zahtjeva
+                                Ukupno operacija
                             </Typography>
                             <Typography level="h4" semiBold>
                                 {events.length}
@@ -198,6 +251,7 @@ export default async function AiAnalyticsPage() {
                     </CardOverflow>
                 </Card>
             </div>
+            <AiAnalyticsFilters />
             <AiAnalyticsTable rows={rows} />
         </Stack>
     );

--- a/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
@@ -171,40 +171,40 @@ function PlantSortSelect({ field }: { field: MockField }) {
     );
 }
 
-function StatusSelect({ field }: { field: MockField }) {
+function StatusDateButton({ field }: { field: MockField }) {
     if (!field.status) {
         return undefined;
     }
 
-    return (
-        <SelectItems
-            value={field.status}
-            items={statusItems}
-            onValueChange={() => {}}
-            variant="plain"
-            className={raisedBedFieldCardSelectClassName}
-        />
-    );
-}
-
-function DatesButton({ date }: { date?: string }) {
-    if (!date) {
-        return undefined;
-    }
+    const statusItem = statusItems.find((item) => item.value === field.status);
 
     return (
         <Button
             color="neutral"
             size="sm"
-            startDecorator={<Calendar className="size-3.5" />}
-            title="Prikazi datume biljke"
+            startDecorator={
+                statusItem?.icon ? (
+                    <span aria-hidden="true">{statusItem.icon}</span>
+                ) : undefined
+            }
+            endDecorator={
+                field.date ? (
+                    <span className="ml-auto inline-flex items-center gap-1 text-muted-foreground">
+                        <Calendar className="size-3.5" />
+                        {field.date}
+                    </span>
+                ) : undefined
+            }
+            title="Promijeni stanje i datum biljke"
             variant="plain"
             className={cx(
-                'h-8 shrink-0 justify-start px-2 text-muted-foreground hover:text-foreground',
+                'h-8 w-full justify-start px-2 text-foreground',
                 raisedBedFieldCardButtonClassName,
             )}
         >
-            {date}
+            <span className="truncate">
+                {statusItem?.label ?? field.status}
+            </span>
         </Button>
     );
 }
@@ -226,10 +226,7 @@ function MockRaisedBedFieldCard({ field }: { field: MockField }) {
             historyControl={field.hasHistory ? <HistoryButton /> : undefined}
             plantSortControl={<PlantSortSelect field={field} />}
             statusControl={
-                field.status ? <StatusSelect field={field} /> : undefined
-            }
-            datesControl={
-                field.date ? <DatesButton date={field.date} /> : undefined
+                field.status ? <StatusDateButton field={field} /> : undefined
             }
         />
     );

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -5,8 +5,14 @@ export { knownEvents } from './knownEvents';
 
 // Constants
 export { knownEventTypes } from './knownEventTypes';
+export type {
+    AiAnalyticsOperation,
+    AiAnalyticsOperationData,
+    AiAnalyticsOperationType,
+} from './queries';
 // Query functions
 export {
+    aiAnalyticsOperationTypes,
     countAiRequestEventsSince,
     countEventsSince,
     createEvent,

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -15,21 +15,75 @@ import {
     bustDeliveryRequestsCache,
     bustScheduleCache,
 } from '../../cache/scheduleCache';
-import { events } from '../../schema';
+import { automationRunSteps, automationRuns, events } from '../../schema';
 import { storage } from '../../storage';
 import { knownEventTypes } from './knownEventTypes';
-import type {
-    Event,
-    RaisedBedFieldAiAnalysisPayload,
-    UserBirthdayRewardPayload,
-} from './types';
+import type { AiRequestKind, Event, UserBirthdayRewardPayload } from './types';
 
 type DatabaseClient = ReturnType<typeof storage>;
+
+export type AiAnalyticsOperationType =
+    | 'raisedBedImageAnalysis'
+    | 'raisedBedFieldImageAnalysis'
+    | 'raisedBedImagePlantStatusReview';
+
+export const aiAnalyticsOperationTypes: AiAnalyticsOperationType[] = [
+    'raisedBedImageAnalysis',
+    'raisedBedFieldImageAnalysis',
+    'raisedBedImagePlantStatusReview',
+];
+
+export type AiAnalyticsOperationData = {
+    markdown?: string;
+    imageUrl?: string;
+    imageUrls?: string[];
+    model?: string | null;
+    analyzedAt?: string;
+    referenceDate?: string;
+    accountId?: string;
+    aiRequestKind?: AiRequestKind;
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+    totalTokens?: number | null;
+    source?: string;
+    summary?: string;
+    raisedBedId?: number | null;
+    operationId?: number | null;
+    focusPositionIndex?: number | null;
+    imageCount?: number | null;
+    skippedInvalidImageCount?: number | null;
+    proposalCount?: number | null;
+    acceptedProposalCount?: number | null;
+    requestCount?: number | null;
+};
+
+export type AiAnalyticsOperation = {
+    id: number;
+    type: string;
+    version: number;
+    aggregateId: string;
+    data: AiAnalyticsOperationData | null;
+    createdAt: Date;
+    aiOperationType: AiAnalyticsOperationType;
+    source: 'domainEvent' | 'automationRunStep';
+    automationRunId?: number | null;
+    sourceEventType?: string | null;
+    sourceAggregateId?: string | null;
+};
+
+type AiAnalysisEventsFilter = {
+    from?: Date;
+    to?: Date;
+    operationTypes?: AiAnalyticsOperationType[];
+};
 
 const aiAnalysisEventTypes = [
     knownEventTypes.raisedBeds.aiAnalysis,
     knownEventTypes.raisedBedFields.aiAnalysis,
 ];
+
+const aiPlantStatusReviewModuleKey =
+    'action.createPlantStatusRequestsFromImageAnalysis';
 
 const scheduleInvalidatingEventTypes = new Set<string>([
     knownEventTypes.operations.assign,
@@ -66,6 +120,108 @@ function eventTypeFilter(type: string | string[]) {
     return Array.isArray(type)
         ? inArray(events.type, type)
         : eq(events.type, type);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function optionalString(value: unknown) {
+    return typeof value === 'string' && value.trim().length > 0
+        ? value
+        : undefined;
+}
+
+function optionalNumber(value: unknown) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function optionalStringArray(value: unknown) {
+    return Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === 'string')
+        : undefined;
+}
+
+function optionalAiRequestKind(value: unknown): AiRequestKind | undefined {
+    return value === 'raisedBedImageAnalysis' ? value : undefined;
+}
+
+function normalizeAiAnalyticsData(
+    value: unknown,
+): AiAnalyticsOperationData | null {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const markdown = optionalString(value.markdown);
+    const imageUrl = optionalString(value.imageUrl);
+    const imageUrls = optionalStringArray(value.imageUrls);
+    const model = optionalString(value.model);
+    const analyzedAt = optionalString(value.analyzedAt);
+    const referenceDate = optionalString(value.referenceDate);
+    const accountId = optionalString(value.accountId);
+    const aiRequestKind = optionalAiRequestKind(value.aiRequestKind);
+    const source = optionalString(value.source);
+    const summary = optionalString(value.summary);
+
+    return {
+        ...(markdown ? { markdown } : {}),
+        ...(imageUrl ? { imageUrl } : {}),
+        ...(imageUrls ? { imageUrls } : {}),
+        ...(model ? { model } : {}),
+        ...(analyzedAt ? { analyzedAt } : {}),
+        ...(referenceDate ? { referenceDate } : {}),
+        ...(accountId ? { accountId } : {}),
+        ...(aiRequestKind ? { aiRequestKind } : {}),
+        inputTokens: optionalNumber(value.inputTokens),
+        outputTokens: optionalNumber(value.outputTokens),
+        totalTokens: optionalNumber(value.totalTokens),
+        ...(source ? { source } : {}),
+        ...(summary ? { summary } : {}),
+        raisedBedId: optionalNumber(value.raisedBedId),
+        operationId: optionalNumber(value.operationId),
+        focusPositionIndex: optionalNumber(value.focusPositionIndex),
+        imageCount: optionalNumber(value.imageCount),
+        skippedInvalidImageCount: optionalNumber(
+            value.skippedInvalidImageCount,
+        ),
+        proposalCount: optionalNumber(value.proposalCount),
+        acceptedProposalCount: optionalNumber(value.acceptedProposalCount),
+        requestCount: optionalNumber(value.requestCount),
+    };
+}
+
+function aiAnalysisEventTypesForFilter(
+    operationTypes?: AiAnalyticsOperationType[],
+) {
+    if (!operationTypes?.length) {
+        return aiAnalysisEventTypes;
+    }
+
+    const eventTypes: string[] = [];
+    if (operationTypes.includes('raisedBedImageAnalysis')) {
+        eventTypes.push(knownEventTypes.raisedBeds.aiAnalysis);
+    }
+    if (operationTypes.includes('raisedBedFieldImageAnalysis')) {
+        eventTypes.push(knownEventTypes.raisedBedFields.aiAnalysis);
+    }
+
+    return eventTypes;
+}
+
+function includesAutomationAiAnalysisType(
+    operationTypes?: AiAnalyticsOperationType[],
+) {
+    return (
+        !operationTypes?.length ||
+        operationTypes.includes('raisedBedImagePlantStatusReview')
+    );
+}
+
+function aiOperationTypeForDomainEvent(type: string): AiAnalyticsOperationType {
+    return type === knownEventTypes.raisedBedFields.aiAnalysis
+        ? 'raisedBedFieldImageAnalysis'
+        : 'raisedBedImageAnalysis';
 }
 
 async function bustReadModelCachesForEvent(event: Event) {
@@ -265,36 +421,169 @@ export async function createEvent(
     await bustReadModelCachesForEvent({ type, version, aggregateId, data });
 }
 
-export async function getAiAnalysisEvents(filter?: { from?: Date; to?: Date }) {
+async function getDomainAiAnalysisEvents(
+    filter?: AiAnalysisEventsFilter,
+): Promise<AiAnalyticsOperation[]> {
+    const eventTypes = aiAnalysisEventTypesForFilter(filter?.operationTypes);
+    if (eventTypes.length === 0) {
+        return [];
+    }
+
     const results = await storage().query.events.findMany({
         where: and(
-            inArray(events.type, aiAnalysisEventTypes),
+            inArray(events.type, eventTypes),
             filter?.from ? gte(events.createdAt, filter.from) : undefined,
             filter?.to ? lte(events.createdAt, filter.to) : undefined,
         ),
-        orderBy: [desc(events.createdAt)],
+        orderBy: [desc(events.createdAt), desc(events.id)],
     });
 
     return results.map((event) => ({
-        ...event,
-        data: event.data as RaisedBedFieldAiAnalysisPayload | null,
+        id: event.id,
+        type: event.type,
+        version: event.version,
+        aggregateId: event.aggregateId,
+        data: normalizeAiAnalyticsData(event.data),
+        createdAt: event.createdAt,
+        aiOperationType: aiOperationTypeForDomainEvent(event.type),
+        source: 'domainEvent',
     }));
 }
 
-export async function getAiAnalysisTotals(filter?: { from?: Date; to?: Date }) {
-    const whereConditions = [
-        inArray(events.type, aiAnalysisEventTypes),
-        ...(filter?.from ? [gte(events.createdAt, filter.from)] : []),
-        ...(filter?.to ? [lte(events.createdAt, filter.to)] : []),
-    ];
+async function getAutomationAiAnalysisEvents(
+    filter?: AiAnalysisEventsFilter,
+): Promise<AiAnalyticsOperation[]> {
+    if (!includesAutomationAiAnalysisType(filter?.operationTypes)) {
+        return [];
+    }
+
+    const results = await storage()
+        .select({
+            id: automationRunSteps.id,
+            runId: automationRunSteps.runId,
+            output: automationRunSteps.output,
+            completedAt: automationRunSteps.completedAt,
+            createdAt: automationRunSteps.createdAt,
+            sourceEventType: automationRuns.sourceEventType,
+            sourceAggregateId: automationRuns.sourceAggregateId,
+        })
+        .from(automationRunSteps)
+        .innerJoin(
+            automationRuns,
+            eq(automationRunSteps.runId, automationRuns.id),
+        )
+        .where(
+            and(
+                eq(automationRunSteps.moduleKey, aiPlantStatusReviewModuleKey),
+                eq(automationRunSteps.status, 'succeeded'),
+                eq(automationRuns.dryRun, false),
+                sql<boolean>`${automationRunSteps.output}->>'model' is not null`,
+                filter?.from
+                    ? gte(automationRunSteps.completedAt, filter.from)
+                    : undefined,
+                filter?.to
+                    ? lte(automationRunSteps.completedAt, filter.to)
+                    : undefined,
+            ),
+        )
+        .orderBy(
+            desc(automationRunSteps.completedAt),
+            desc(automationRunSteps.id),
+        );
+
+    return results.map((row) => ({
+        id: row.id,
+        type: aiPlantStatusReviewModuleKey,
+        version: 1,
+        aggregateId:
+            row.sourceAggregateId ??
+            normalizeAiAnalyticsData(row.output)?.raisedBedId?.toString() ??
+            row.runId.toString(),
+        data: normalizeAiAnalyticsData(row.output),
+        createdAt: row.completedAt ?? row.createdAt,
+        aiOperationType: 'raisedBedImagePlantStatusReview',
+        source: 'automationRunStep',
+        automationRunId: row.runId,
+        sourceEventType: row.sourceEventType,
+        sourceAggregateId: row.sourceAggregateId,
+    }));
+}
+
+export async function getAiAnalysisEvents(
+    filter?: AiAnalysisEventsFilter,
+): Promise<AiAnalyticsOperation[]> {
+    const [domainEvents, automationEvents] = await Promise.all([
+        getDomainAiAnalysisEvents(filter),
+        getAutomationAiAnalysisEvents(filter),
+    ]);
+
+    return [...domainEvents, ...automationEvents].sort((a, b) => {
+        const dateDifference = b.createdAt.getTime() - a.createdAt.getTime();
+        if (dateDifference !== 0) {
+            return dateDifference;
+        }
+        return b.id - a.id;
+    });
+}
+
+async function getDomainAiAnalysisCount(filter?: AiAnalysisEventsFilter) {
+    const eventTypes = aiAnalysisEventTypesForFilter(filter?.operationTypes);
+    if (eventTypes.length === 0) {
+        return 0;
+    }
 
     const result = await storage()
         .select({ count: count() })
         .from(events)
-        .where(and(...whereConditions));
+        .where(
+            and(
+                inArray(events.type, eventTypes),
+                filter?.from ? gte(events.createdAt, filter.from) : undefined,
+                filter?.to ? lte(events.createdAt, filter.to) : undefined,
+            ),
+        );
+
+    return result[0]?.count ?? 0;
+}
+
+async function getAutomationAiAnalysisCount(filter?: AiAnalysisEventsFilter) {
+    if (!includesAutomationAiAnalysisType(filter?.operationTypes)) {
+        return 0;
+    }
+
+    const result = await storage()
+        .select({ count: count() })
+        .from(automationRunSteps)
+        .innerJoin(
+            automationRuns,
+            eq(automationRunSteps.runId, automationRuns.id),
+        )
+        .where(
+            and(
+                eq(automationRunSteps.moduleKey, aiPlantStatusReviewModuleKey),
+                eq(automationRunSteps.status, 'succeeded'),
+                eq(automationRuns.dryRun, false),
+                sql<boolean>`${automationRunSteps.output}->>'model' is not null`,
+                filter?.from
+                    ? gte(automationRunSteps.completedAt, filter.from)
+                    : undefined,
+                filter?.to
+                    ? lte(automationRunSteps.completedAt, filter.to)
+                    : undefined,
+            ),
+        );
+
+    return result[0]?.count ?? 0;
+}
+
+export async function getAiAnalysisTotals(filter?: AiAnalysisEventsFilter) {
+    const [domainCount, automationCount] = await Promise.all([
+        getDomainAiAnalysisCount(filter),
+        getAutomationAiAnalysisCount(filter),
+    ]);
 
     return {
-        count: result[0]?.count ?? 0,
+        count: domainCount + automationCount,
     };
 }
 

--- a/packages/storage/tests/eventsRepo.node.spec.ts
+++ b/packages/storage/tests/eventsRepo.node.spec.ts
@@ -3,6 +3,8 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     countAiRequestEventsSince,
+    createAutomationDefinition,
+    createAutomationRun,
     createEvent,
     getAiAnalysisEvents,
     getAiAnalysisTotals,
@@ -12,8 +14,12 @@ import {
     getLatestEventsByAggregateIdPrefix,
     knownEvents,
     knownEventTypes,
+    recordAutomationRunStep,
 } from '@gredice/storage';
 import { createTestDb } from './testDb';
+
+const aiPlantStatusReviewModuleKey =
+    'action.createPlantStatusRequestsFromImageAnalysis';
 
 function aiAnalysisData(
     overrides: Partial<
@@ -245,9 +251,10 @@ test('countAiRequestEventsSince counts account-kind events with legacy aggregate
     assert.strictEqual(count, 2);
 });
 
-test('AI analysis analytics includes raised-bed and field events', async () => {
+test('AI analysis analytics includes raised-bed, field, and automation operations', async () => {
     createTestDb();
-    const raisedBedAggregateId = `raised-bed-${randomUUID()}`;
+    const raisedBedId = 8123;
+    const raisedBedAggregateId = raisedBedId.toString();
     const fieldAggregateId = `${raisedBedAggregateId}|0`;
     const from = new Date('2036-03-01T00:00:00.000Z');
     const to = new Date('2036-03-31T23:59:59.999Z');
@@ -276,6 +283,42 @@ test('AI analysis analytics includes raised-bed and field events', async () => {
         ),
         createdAt: new Date('2036-03-04T12:00:00.000Z'),
     });
+    const automationDefinition = await createAutomationDefinition({
+        key: `test-ai-analytics-${randomUUID()}`,
+        name: 'AI analytics plant status review',
+        status: 'enabled',
+    });
+    const automationRun = await createAutomationRun({
+        automationDefinition,
+        source: 'event',
+        sourceEventType: knownEventTypes.raisedBeds.aiAnalysis,
+        sourceAggregateId: raisedBedAggregateId,
+        dryRun: false,
+    });
+    assert.ok(automationRun);
+    await recordAutomationRunStep({
+        runId: automationRun.id,
+        nodeId: 'review-plant-statuses',
+        moduleKey: aiPlantStatusReviewModuleKey,
+        moduleKind: 'action',
+        status: 'succeeded',
+        output: {
+            source: 'raisedBedAiAnalysis',
+            raisedBedId,
+            imageCount: 2,
+            model: 'plant-status-model',
+            summary: 'Plants look ready for review.',
+            proposalCount: 2,
+            acceptedProposalCount: 1,
+            requestCount: 1,
+            inputTokens: 300,
+            outputTokens: 150,
+            totalTokens: 450,
+            analyzedAt: '2036-03-05T12:00:00.000Z',
+        },
+        startedAt: new Date('2036-03-05T11:59:00.000Z'),
+        completedAt: new Date('2036-03-05T12:00:00.000Z'),
+    });
     await createEvent({
         ...knownEvents.accounts.sunflowersEarnedV1(
             `unrelated-account-${randomUUID()}`,
@@ -292,23 +335,40 @@ test('AI analysis analytics includes raised-bed and field events', async () => {
     assert.deepStrictEqual(
         events.map((event) => event.type),
         [
+            aiPlantStatusReviewModuleKey,
             knownEventTypes.raisedBedFields.aiAnalysis,
             knownEventTypes.raisedBeds.aiAnalysis,
         ],
     );
     assert.deepStrictEqual(
+        events.map((event) => event.aiOperationType),
+        [
+            'raisedBedImagePlantStatusReview',
+            'raisedBedFieldImageAnalysis',
+            'raisedBedImageAnalysis',
+        ],
+    );
+    assert.deepStrictEqual(
         events.map((event) => event.aggregateId),
-        [fieldAggregateId, raisedBedAggregateId],
+        [raisedBedAggregateId, fieldAggregateId, raisedBedAggregateId],
     );
 
     const allTotals = await getAiAnalysisTotals({ from, to });
-    assert.strictEqual(allTotals.count, 2);
+    assert.strictEqual(allTotals.count, 3);
 
     const filteredTotals = await getAiAnalysisTotals({
         from: new Date('2036-03-04T00:00:00.000Z'),
         to,
     });
-    assert.strictEqual(filteredTotals.count, 1);
+    assert.strictEqual(filteredTotals.count, 2);
+
+    const plantStatusReviewEvents = await getAiAnalysisEvents({
+        from,
+        to,
+        operationTypes: ['raisedBedImagePlantStatusReview'],
+    });
+    assert.strictEqual(plantStatusReviewEvents.length, 1);
+    assert.strictEqual(plantStatusReviewEvents[0]?.data?.totalTokens, 450);
 });
 
 test('getLatestEvents can list multiple event types for an aggregate', async () => {


### PR DESCRIPTION
## Summary
- Add an AI operation type filter to the admin analytics view and wire it through totals and event queries
- Merge domain AI analysis events with automation-run review steps into one analytics feed
- Expand the table details to show operation type, source metadata, and richer generated-content stats

## Testing
- Added and updated node tests for mixed AI analytics sources, filtering, and totals
- Not run (not requested)