### PR TITLE
Strip markdown from web push notifications

### DIFF
--- a/apps/api/lib/notifications/webPushSender.node.spec.ts
+++ b/apps/api/lib/notifications/webPushSender.node.spec.ts
@@ -72,6 +72,37 @@ test('buildWebPushPayload serializes notification content without subscription s
     });
 });
 
+test('buildWebPushPayload strips unsupported Markdown from browser-visible text', () => {
+    const payload = buildWebPushPayload(
+        queuedAttempt({
+            actionLabel: '**Otvori obavijest**',
+            actionUrl: '/vrtovi/1',
+            content:
+                'U gredici **Zabavna Pahuljica** na poziciji **18** proklijala je biljka **Grah Borlotto lingua di fuoco nano**.',
+            header: '🌱 **Proklijala** je biljka Grah Borlotto!',
+        }),
+    );
+
+    assert.deepEqual(JSON.parse(payload), {
+        actions: [
+            {
+                action: 'open',
+                title: 'Otvori obavijest',
+                url: '/vrtovi/1',
+            },
+        ],
+        body: 'U gredici Zabavna Pahuljica na poziciji 18 proklijala je biljka Grah Borlotto lingua di fuoco nano.',
+        category: 'general',
+        deliveryAttemptId: 1,
+        icon: '/icon.png',
+        notificationId: 'notification-1',
+        requireInteraction: false,
+        tag: 'notification-1',
+        title: '🌱 Proklijala je biljka Grah Borlotto!',
+        url: '/',
+    });
+});
+
 test('processWebPushAttempts records accepted provider success', async () => {
     const accepted: QueuedWebPushAttempt[] = [];
     const failed: WebPushFailure[] = [];

--- a/apps/api/lib/notifications/webPushSender.ts
+++ b/apps/api/lib/notifications/webPushSender.ts
@@ -138,6 +138,30 @@ function normalizeUrgency(value: string | null): Urgency | undefined {
     }
 }
 
+function plainTextForWebPush(value: string) {
+    return value
+        .replace(/\r\n?/gu, '\n')
+        .replace(/!\[([^\]]*)\]\(([^)]*)\)/gu, '$1')
+        .replace(/\[([^\]]+)\]\(([^)]*)\)/gu, '$1')
+        .replace(/`([^`]+)`/gu, '$1')
+        .replace(/^#{1,6}\s+/gmu, '')
+        .replace(/^\s{0,3}[-*+]\s+/gmu, '')
+        .replace(/^\s{0,3}>\s?/gmu, '')
+        .replace(/(\*\*|__)(.*?)\1/gu, '$2')
+        .replace(/(^|[\s([{])\*([^*\n]+)\*(?=$|[\s)\]},.!?:;])/gmu, '$1$2')
+        .replace(/(^|[\s([{])_([^_\n]+)_(?=$|[\s)\]},.!?:;])/gmu, '$1$2')
+        .replace(/~~(.*?)~~/gu, '$1')
+        .replace(/\\([\\`*_{}[\]()#+\-.!>])/gu, '$1')
+        .replace(/[ \t]{2,}/gu, ' ')
+        .replace(/\n{3,}/gu, '\n\n')
+        .trim();
+}
+
+function plainTextForWebPushActionTitle(value: string | null) {
+    if (!value) return 'Otvori';
+    return plainTextForWebPush(value) || 'Otvori';
+}
+
 function webPushSubscription(attempt: QueuedWebPushAttempt): PushSubscription {
     return {
         endpoint: attempt.endpoint,
@@ -161,12 +185,14 @@ export function buildWebPushPayload(
             ? [
                   {
                       action: 'open',
-                      title: attempt.actionLabel ?? 'Otvori',
+                      title: plainTextForWebPushActionTitle(
+                          attempt.actionLabel,
+                      ),
                       url: actionUrl,
                   },
               ]
             : undefined,
-        body: attempt.content,
+        body: plainTextForWebPush(attempt.content),
         campaignId: undefined,
         category: attempt.category,
         deliveryAttemptId: attempt.attemptId,
@@ -181,7 +207,7 @@ export function buildWebPushPayload(
             attempt.threadKey ??
             attempt.collapseKey ??
             attempt.notificationId.slice(0, 64),
-        title: attempt.header,
+        title: plainTextForWebPush(attempt.header),
         url,
     });
 }


### PR DESCRIPTION
## Summary
- Clean browser-visible web push title, body, and action label text before sending notifications.
- Preserve the original stored notification content for in-app Markdown rendering.
- Add a regression test covering the unsupported Markdown case shown in the browser screenshot.

## Testing
- Unit test added for `buildWebPushPayload` Markdown stripping.
- `apps/api/lib/notifications/webPushSender.node.spec.ts` passed.
- `apps/api/lib/notifications/webPushSender.ts` and the new test passed Biome checks.