### PR TITLE
Poboljšaj unos stanja i raspored galerije za uzdignute gredice

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -16,6 +16,7 @@ import {
     knownEvents,
     moveRaisedBedFieldPlantHistory,
     type RaisedBedFieldSowingLocation,
+    updateActiveRaisedBedFieldPlantStatusEventCreatedAt,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import type { EntityStandardized } from '../../lib/@types/EntityStandardized';
@@ -52,6 +53,11 @@ async function applyRaisedBedFieldPlantUpdate({
     const existingField = raisedBed.fields.find(
         (field) => field.positionIndex === positionIndex && field.active,
     );
+    const createdAt = timestamp ? new Date(timestamp) : undefined;
+    if (createdAt && Number.isNaN(createdAt.getTime())) {
+        throw new Error('Invalid plant status timestamp.');
+    }
+
     if (plantSortId && existingField?.plantSortId !== plantSortId) {
         await createEvent(
             knownEvents.raisedBedFields.plantReplaceSortV1(aggregateId, {
@@ -61,25 +67,32 @@ async function applyRaisedBedFieldPlantUpdate({
     }
 
     if (status) {
-        const createdAt = timestamp ? new Date(timestamp) : undefined;
-        if (createdAt && Number.isNaN(createdAt.getTime())) {
-            throw new Error('Invalid plant status timestamp.');
-        }
-
-        await createEvent({
-            ...knownEvents.raisedBedFields.plantUpdateV1(
-                aggregateId,
-                buildRaisedBedFieldPlantUpdatePayload(
+        const statusChanged = existingField?.plantStatus !== status;
+        if (!statusChanged) {
+            if (createdAt) {
+                await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
+                    raisedBedId: raisedBed.id,
+                    positionIndex,
                     status,
-                    existingField?.assignedUserIds,
+                    createdAt,
+                });
+            }
+        } else {
+            await createEvent({
+                ...knownEvents.raisedBedFields.plantUpdateV1(
+                    aggregateId,
+                    buildRaisedBedFieldPlantUpdatePayload(
+                        status,
+                        existingField?.assignedUserIds,
+                    ),
                 ),
-            ),
-            ...(createdAt ? { createdAt } : {}),
-        });
+                ...(createdAt ? { createdAt } : {}),
+            });
+        }
     }
 
     const sortIdToUse = plantSortId ?? existingField?.plantSortId;
-    if (sortIdToUse && status) {
+    if (sortIdToUse && status && existingField?.plantStatus !== status) {
         const sortData =
             await getEntityFormatted<EntityStandardized>(sortIdToUse);
         if (sortData) {
@@ -240,7 +253,7 @@ export async function verifyRaisedBedPlantingAction(
     const field = raisedBed.fields.find(
         (item) => item.positionIndex === positionIndex && item.active,
     );
-    if (!field || field.plantStatus !== 'pendingVerification') {
+    if (field?.plantStatus !== 'pendingVerification') {
         throw new Error('Sijanje ne čeka verifikaciju.');
     }
 

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -70,12 +70,18 @@ async function applyRaisedBedFieldPlantUpdate({
         const statusChanged = existingField?.plantStatus !== status;
         if (!statusChanged) {
             if (createdAt) {
-                await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
-                    raisedBedId: raisedBed.id,
-                    positionIndex,
-                    status,
-                    createdAt,
-                });
+                const updated =
+                    await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
+                        raisedBedId: raisedBed.id,
+                        positionIndex,
+                        status,
+                        createdAt,
+                    });
+                if (!updated) {
+                    throw new Error(
+                        'Datum stanja mora ostati u redoslijedu događaja biljke.',
+                    );
+                }
             }
         } else {
             await createEvent({

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector.tsx
@@ -98,7 +98,7 @@ export function RaisedBedFieldLocationSelector({
                     className={className}
                     onClick={() => {}}
                 >
-                    {current.label}
+                    <span className="min-w-0 truncate">{current.label}</span>
                 </Chip>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start">

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -182,21 +182,12 @@ export default async function RaisedBedPage({
                 />
                 <EntityDetailsPropertiesLayout properties={propertiesPanel}>
                     {recentImages.length > 0 && (
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>Nedavne slike</CardTitle>
-                            </CardHeader>
-                            <CardOverflow>
-                                <Row className="w-full px-2 pb-2" spacing={4}>
-                                    <ImageGallery
-                                        images={recentImages}
-                                        previewWidth={240}
-                                        previewHeight={160}
-                                        previewVariant="carousel"
-                                    />
-                                </Row>
-                            </CardOverflow>
-                        </Card>
+                        <ImageGallery
+                            images={recentImages}
+                            previewWidth={240}
+                            previewHeight={160}
+                            previewVariant="carousel"
+                        />
                     )}
                     {isAbandoned && (
                         <Alert

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import type { ReactNode } from 'react';
@@ -9,12 +8,13 @@ type RaisedBedFieldCardGridProps = {
 };
 
 export const raisedBedFieldCardSelectClassName =
-    'w-full min-w-0 [&_[role=combobox]]:h-8 [&_[role=combobox]]:!bg-background/80 [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:ring-1 [&_[role=combobox]]:ring-border/70 [&_[role=combobox]]:backdrop-blur-md [&_[role=combobox]]:hover:!bg-background/90 [&_[role=combobox]>span]:min-w-0';
+    'w-full min-w-0 [&_[role=combobox]]:h-8 [&_[role=combobox]]:min-w-0 [&_[role=combobox]]:gap-1.5 [&_[role=combobox]]:overflow-hidden [&_[role=combobox]]:!bg-background/80 [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:ring-1 [&_[role=combobox]]:ring-border/70 [&_[role=combobox]]:backdrop-blur-md [&_[role=combobox]]:hover:!bg-background/90 [&_[role=combobox]>span]:block [&_[role=combobox]>span]:min-w-0 [&_[role=combobox]>span]:truncate';
 
 export const raisedBedFieldCardButtonClassName =
-    '!bg-background/80 text-foreground ring-1 ring-border/70 backdrop-blur-md hover:!bg-background/90 hover:text-foreground';
+    'max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap !bg-background/80 text-foreground ring-1 ring-border/70 backdrop-blur-md hover:!bg-background/90 hover:text-foreground';
 
-export const raisedBedFieldCardChipClassName = 'backdrop-blur-md';
+export const raisedBedFieldCardChipClassName =
+    'min-w-0 max-w-full overflow-hidden backdrop-blur-md';
 
 export function RaisedBedFieldCardGrid({
     children,
@@ -76,9 +76,7 @@ export function RaisedBedFieldCard({
             <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-8">
                 <div className="min-w-0">{plantSortControl}</div>
                 {statusControl && (
-                    <Stack spacing={0.5}>
-                        <div className="min-w-0">{statusControl}</div>
-                    </Stack>
+                    <div className="min-w-0">{statusControl}</div>
                 )}
             </div>
         </div>

--- a/apps/app/components/raised-beds/RaisedBedFieldStatusDateChip.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldStatusDateChip.tsx
@@ -121,15 +121,24 @@ export function RaisedBedFieldStatusDateChip({
 
     function handleSave() {
         startTransition(async () => {
-            await raisedBedFieldUpdatePlant({
-                raisedBedId,
-                positionIndex,
-                status: selectedStatus,
-                timestamp: selectedDate
-                    ? dateInputToTimestamp(selectedDate)
-                    : undefined,
-            });
-            setOpen(false);
+            try {
+                await raisedBedFieldUpdatePlant({
+                    raisedBedId,
+                    positionIndex,
+                    status: selectedStatus,
+                    timestamp: selectedDate
+                        ? dateInputToTimestamp(selectedDate)
+                        : undefined,
+                });
+                setOpen(false);
+            } catch (error) {
+                console.error('Error updating plant status date:', error);
+                alert(
+                    error instanceof Error
+                        ? error.message
+                        : 'Spremanje stanja biljke nije uspjelo.',
+                );
+            }
         });
     }
 

--- a/apps/app/components/raised-beds/RaisedBedFieldStatusDateChip.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldStatusDateChip.tsx
@@ -45,6 +45,14 @@ function formatLocalDateInput(value: string | null) {
     return `${year}-${month}-${day}`;
 }
 
+function formatDateInputValue(date: Date) {
+    const year = date.getFullYear().toString();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}
+
 function formatShortDate(value: string | null) {
     const date = parseDate(value);
     if (!date) {
@@ -99,6 +107,18 @@ export function RaisedBedFieldStatusDateChip({
         setSelectedDate(formatLocalDateInput(date));
     }, [date, status]);
 
+    function resetForm() {
+        setSelectedStatus(status);
+        setSelectedDate(formatLocalDateInput(date));
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (nextOpen) {
+            resetForm();
+        }
+        setOpen(nextOpen);
+    }
+
     function handleSave() {
         startTransition(async () => {
             await raisedBedFieldUpdatePlant({
@@ -113,12 +133,21 @@ export function RaisedBedFieldStatusDateChip({
         });
     }
 
+    function handleStatusChange(nextStatus: string) {
+        setSelectedStatus(nextStatus);
+        setSelectedDate(
+            nextStatus === status
+                ? formatLocalDateInput(date)
+                : formatDateInputValue(new Date()),
+        );
+    }
+
     const dateLabel = mounted ? formatShortDate(date) : '...';
 
     return (
         <Popper
             open={open}
-            onOpenChange={setOpen}
+            onOpenChange={handleOpenChange}
             align="start"
             className="w-72 p-3"
             side="bottom"
@@ -136,13 +165,13 @@ export function RaisedBedFieldStatusDateChip({
                         <span aria-hidden="true">{statusItem.icon}</span>
                     }
                     endDecorator={
-                        <span className="ml-auto inline-flex items-center gap-1 text-muted-foreground">
-                            <Calendar className="size-3.5" />
-                            {dateLabel}
+                        <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-muted-foreground">
+                            <Calendar className="size-3.5 shrink-0" />
+                            <span>{dateLabel}</span>
                         </span>
                     }
                 >
-                    <span className="truncate">{statusItem.label}</span>
+                    <span className="min-w-0 truncate">{statusItem.label}</span>
                 </Button>
             }
         >
@@ -150,7 +179,7 @@ export function RaisedBedFieldStatusDateChip({
                 <SelectItems
                     label="Stanje"
                     value={selectedStatus}
-                    onValueChange={setSelectedStatus}
+                    onValueChange={handleStatusChange}
                     items={raisedBedFieldPlantStatusItems}
                 />
                 <Input

--- a/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
@@ -28,7 +28,7 @@ const mockFields: MockField[] = [
     {
         id: 'tomato-saint',
         number: 18,
-        plant: 'Rajcica saint...',
+        plant: 'Rajcica saint pierre dugi naziv',
         status: 'firstFruitSet',
         date: '22. 05.',
         imageSrc: '/assets/plants/tomato_mature.png',
@@ -47,8 +47,8 @@ const mockFields: MockField[] = [
     {
         id: 'tomato-mini-b',
         number: 16,
-        plant: 'Rajcica mini...',
-        status: 'firstFlowers',
+        plant: 'Luk Red Baron (lukovica)',
+        status: 'pendingVerification',
         date: '22. 05.',
         imageSrc: '/assets/plants/tomato_growing.png',
         location: 'greenhouse',
@@ -90,6 +90,7 @@ const plantItems = mockFields.map((field) => ({
 const statusItems = [
     { value: 'new', label: 'Novo', icon: '🆕' },
     { value: 'planned', label: 'Planirano', icon: '🗓️' },
+    { value: 'pendingVerification', label: 'Čeka verifikaciju', icon: '🔍' },
     { value: 'sprouted', label: 'Proklijalo', icon: '🌱' },
     { value: 'firstFlowers', label: 'Prvi cvjetovi', icon: '🌸' },
     { value: 'firstFruitSet', label: 'Prvi plodovi', icon: '🍅' },
@@ -129,7 +130,9 @@ function LocationChip({ location }: { location?: MockField['location'] }) {
             title="Promijeni trenutnu lokaciju biljke"
             className={raisedBedFieldCardChipClassName}
         >
-            {isGreenhouse ? 'Staklenik' : 'Gredica'}
+            <span className="min-w-0 truncate">
+                {isGreenhouse ? 'Staklenik' : 'Gredica'}
+            </span>
         </Chip>
     );
 }
@@ -171,40 +174,37 @@ function PlantSortSelect({ field }: { field: MockField }) {
     );
 }
 
-function StatusSelect({ field }: { field: MockField }) {
+function StatusDateButton({ field }: { field: MockField }) {
     if (!field.status) {
         return undefined;
     }
 
-    return (
-        <SelectItems
-            value={field.status}
-            items={statusItems}
-            onValueChange={() => {}}
-            variant="plain"
-            className={raisedBedFieldCardSelectClassName}
-        />
-    );
-}
-
-function DatesButton({ date }: { date?: string }) {
-    if (!date) {
-        return undefined;
-    }
+    const statusItem = statusItems.find((item) => item.value === field.status);
+    const label = statusItem?.label ?? field.status;
 
     return (
         <Button
             color="neutral"
             size="sm"
-            startDecorator={<Calendar className="size-3.5" />}
-            title="Prikazi datume biljke"
+            title="Promijeni stanje i datum biljke"
             variant="plain"
             className={cx(
-                'h-8 shrink-0 justify-start px-2 text-muted-foreground hover:text-foreground',
+                'h-8 w-full justify-start px-2 text-foreground',
                 raisedBedFieldCardButtonClassName,
             )}
+            startDecorator={
+                statusItem?.icon ? (
+                    <span aria-hidden="true">{statusItem.icon}</span>
+                ) : undefined
+            }
+            endDecorator={
+                <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-muted-foreground">
+                    <Calendar className="size-3.5 shrink-0" />
+                    <span>{field.date ?? 'Datum'}</span>
+                </span>
+            }
         >
-            {date}
+            <span className="min-w-0 truncate">{label}</span>
         </Button>
     );
 }
@@ -226,10 +226,7 @@ function MockRaisedBedFieldCard({ field }: { field: MockField }) {
             historyControl={field.hasHistory ? <HistoryButton /> : undefined}
             plantSortControl={<PlantSortSelect field={field} />}
             statusControl={
-                field.status ? <StatusSelect field={field} /> : undefined
-            }
-            datesControl={
-                field.date ? <DatesButton date={field.date} /> : undefined
+                field.status ? <StatusDateButton field={field} /> : undefined
             }
         />
     );

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -56,6 +56,7 @@ import {
     knownEvents,
     knownEventTypes,
     type RaisedBedFieldSowingLocation,
+    updateEventCreatedAt,
 } from './eventsRepo';
 import { getFarms } from './farmsRepo';
 import { processReferralRewardsForAccount } from './referralsRepo';
@@ -896,6 +897,70 @@ function summarizePlantCycles(
         .filter((plantCycle): plantCycle is RaisedBedFieldPlantCycle =>
             Boolean(plantCycle),
         );
+}
+
+function eventDataRecord(event: RaisedBedFieldPlantCycleEvent) {
+    return event.data && typeof event.data === 'object'
+        ? (event.data as Record<string, unknown>)
+        : {};
+}
+
+function plantUpdateEventStatus(event: RaisedBedFieldPlantCycleEvent) {
+    const data = eventDataRecord(event);
+
+    return event.type === knownEventTypes.raisedBedFields.plantUpdate &&
+        typeof data.status === 'string'
+        ? data.status
+        : undefined;
+}
+
+export async function updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
+    raisedBedId,
+    positionIndex,
+    status,
+    createdAt,
+}: {
+    raisedBedId: number;
+    positionIndex: number;
+    status: string;
+    createdAt: Date;
+}) {
+    const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
+    const plantEvents = await getEvents(
+        [...PLANT_CYCLE_EVENT_TYPES],
+        [aggregateId],
+        0,
+        100000,
+    );
+    const activePlantCycleEvents = splitPlantCycleEvents(plantEvents).find(
+        (plantCycleEvents) => {
+            const plantCycle = summarizePlantCycle(
+                aggregateId,
+                positionIndex,
+                plantCycleEvents,
+            );
+
+            return plantCycle?.active && plantCycle.plantStatus === status;
+        },
+    );
+    const targetEvent =
+        status === 'new'
+            ? activePlantCycleEvents?.find(
+                  (event) =>
+                      event.type === knownEventTypes.raisedBedFields.plantPlace,
+              )
+            : activePlantCycleEvents
+              ? [...activePlantCycleEvents]
+                    .reverse()
+                    .find((event) => plantUpdateEventStatus(event) === status)
+              : undefined;
+
+    if (!targetEvent) {
+        return false;
+    }
+
+    await updateEventCreatedAt(targetEvent.id, createdAt);
+    return true;
 }
 
 function plantCyclesOverlap(

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -914,6 +914,51 @@ function plantUpdateEventStatus(event: RaisedBedFieldPlantCycleEvent) {
         : undefined;
 }
 
+function comparePlantCycleEventOrder(
+    left: Pick<RaisedBedFieldPlantCycleEvent, 'createdAt' | 'id'>,
+    right: Pick<RaisedBedFieldPlantCycleEvent, 'createdAt' | 'id'>,
+) {
+    const timestampDifference =
+        left.createdAt.getTime() - right.createdAt.getTime();
+    if (timestampDifference !== 0) {
+        return timestampDifference;
+    }
+
+    return left.id - right.id;
+}
+
+function wouldKeepPlantCycleEventOrder({
+    plantCycleEvents,
+    targetEvent,
+    createdAt,
+}: {
+    plantCycleEvents: RaisedBedFieldPlantCycleEvent[];
+    targetEvent: RaisedBedFieldPlantCycleEvent;
+    createdAt: Date;
+}) {
+    const targetIndex = plantCycleEvents.findIndex(
+        (event) => event.id === targetEvent.id,
+    );
+    if (targetIndex < 0) {
+        return false;
+    }
+
+    const proposedEventOrder = {
+        createdAt,
+        id: targetEvent.id,
+    };
+    const previousEvent = plantCycleEvents[targetIndex - 1];
+    const nextEvent = plantCycleEvents[targetIndex + 1];
+
+    return (
+        (!previousEvent ||
+            comparePlantCycleEventOrder(proposedEventOrder, previousEvent) >=
+                0) &&
+        (!nextEvent ||
+            comparePlantCycleEventOrder(proposedEventOrder, nextEvent) <= 0)
+    );
+}
+
 export async function updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
     raisedBedId,
     positionIndex,
@@ -955,7 +1000,17 @@ export async function updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
                     .find((event) => plantUpdateEventStatus(event) === status)
               : undefined;
 
-    if (!targetEvent) {
+    if (!activePlantCycleEvents || !targetEvent) {
+        return false;
+    }
+
+    if (
+        !wouldKeepPlantCycleEventOrder({
+            plantCycleEvents: activePlantCycleEvents,
+            targetEvent,
+            createdAt,
+        })
+    ) {
         return false;
     }
 
@@ -977,13 +1032,10 @@ function plantCyclesOverlap(
         left: { createdAt: Date; eventId: number },
         right: { createdAt: Date; eventId: number },
     ) => {
-        const timestampDifference =
-            left.createdAt.getTime() - right.createdAt.getTime();
-        if (timestampDifference !== 0) {
-            return timestampDifference;
-        }
-
-        return left.eventId - right.eventId;
+        return comparePlantCycleEventOrder(
+            { createdAt: left.createdAt, id: left.eventId },
+            { createdAt: right.createdAt, id: right.eventId },
+        );
     };
 
     return (

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -1058,6 +1058,12 @@ test('active plant status date updates the existing status event', async () => {
         }),
         createdAt: new Date('2026-01-10T12:00:00.000Z'),
     });
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantScheduleV1(aggregateId, {
+            scheduledDate: null,
+        }),
+        createdAt: new Date('2026-01-15T12:00:00.000Z'),
+    });
 
     const eventsBefore = await getPlantEventsForAggregate(aggregateId);
     const sproutedEventBefore = eventsBefore.find((event) => {
@@ -1065,6 +1071,37 @@ test('active plant status date updates the existing status event', async () => {
         return data?.status === 'sprouted';
     });
     assert.ok(sproutedEventBefore);
+
+    const tooEarlyUpdated =
+        await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
+            raisedBedId,
+            positionIndex: 0,
+            status: 'sprouted',
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        });
+    const tooLateUpdated =
+        await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
+            raisedBedId,
+            positionIndex: 0,
+            status: 'sprouted',
+            createdAt: new Date('2026-01-16T12:00:00.000Z'),
+        });
+
+    assert.strictEqual(tooEarlyUpdated, false);
+    assert.strictEqual(tooLateUpdated, false);
+
+    const eventsAfterRejectedEdits =
+        await getPlantEventsForAggregate(aggregateId);
+    const sproutedEventAfterRejectedEdits = eventsAfterRejectedEdits.find(
+        (event) => {
+            const data = event.data as Record<string, unknown> | null;
+            return data?.status === 'sprouted';
+        },
+    );
+    assert.strictEqual(
+        sproutedEventAfterRejectedEdits?.createdAt.toISOString(),
+        '2026-01-10T12:00:00.000Z',
+    );
 
     const updated = await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
         raisedBedId,

--- a/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts
@@ -19,6 +19,7 @@ import {
     mergeRaisedBeds,
     moveRaisedBedFieldPlantHistory,
     storage,
+    updateActiveRaisedBedFieldPlantStatusEventCreatedAt,
     upsertOrRemoveCartItem,
     upsertRaisedBedField,
 } from '@gredice/storage';
@@ -1022,6 +1023,80 @@ test('raised bed field assignment metadata is projected for assign and unassign 
     assert.strictEqual(field.assignedUserId, null);
     assert.strictEqual(field.assignedBy, null);
     assert.strictEqual(field.assignedAt, undefined);
+});
+
+test('active plant status date updates the existing status event', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'block-status-date-edit');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+
+    const aggregateId = `${raisedBedId.toString()}|0`;
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantPlaceV1(aggregateId, {
+            plantSortId: '101',
+            scheduledDate: null,
+        }),
+        createdAt: new Date('2026-01-01T12:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'sowed',
+        }),
+        createdAt: new Date('2026-01-02T12:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'sprouted',
+        }),
+        createdAt: new Date('2026-01-10T12:00:00.000Z'),
+    });
+
+    const eventsBefore = await getPlantEventsForAggregate(aggregateId);
+    const sproutedEventBefore = eventsBefore.find((event) => {
+        const data = event.data as Record<string, unknown> | null;
+        return data?.status === 'sprouted';
+    });
+    assert.ok(sproutedEventBefore);
+
+    const updated = await updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
+        raisedBedId,
+        positionIndex: 0,
+        status: 'sprouted',
+        createdAt: new Date('2026-01-12T12:00:00.000Z'),
+    });
+
+    assert.strictEqual(updated, true);
+
+    const eventsAfter = await getPlantEventsForAggregate(aggregateId);
+    const sproutedEventsAfter = eventsAfter.filter((event) => {
+        const data = event.data as Record<string, unknown> | null;
+        return data?.status === 'sprouted';
+    });
+    assert.strictEqual(eventsAfter.length, eventsBefore.length);
+    assert.strictEqual(sproutedEventsAfter.length, 1);
+    assert.strictEqual(sproutedEventsAfter[0]?.id, sproutedEventBefore.id);
+    assert.strictEqual(
+        sproutedEventsAfter[0]?.createdAt.toISOString(),
+        '2026-01-12T12:00:00.000Z',
+    );
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.strictEqual(field?.plantStatus, 'sprouted');
+    assert.strictEqual(
+        field?.plantGrowthDate?.toISOString(),
+        '2026-01-12T12:00:00.000Z',
+    );
 });
 
 test('upsertRaisedBedField reuses the same row after a field is deleted and planted again', async () => {


### PR DESCRIPTION
## Sažetak
- zadržava datum postojećeg statusa kada se mijenja samo datum i ažurira odgovarajući event umjesto stvaranja novog
- pojednostavljuje prikaz kartica i selektora da dugi nazivi ostanu čitljivi bez prelijevanja
- uklanja nepotreban naslovni omotač oko nedavnih slika u detaljima gredice
- ažurira Storybook primjer za novu kompoziciju statusa i datuma

## Testiranje
- Dodani i izvršeni unit testovi za ažuriranje `createdAt` na aktivnom status eventu
- Nije pokrenuto (nije traženo)