### PR TITLE
Add debug indexes and move label date header

### DIFF
--- a/apps/app/app/debug/page.tsx
+++ b/apps/app/app/debug/page.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+
+const debugGroups = [
+    {
+        title: 'Shared UI',
+        pages: [
+            {
+                href: '/debug/select-items',
+                title: 'SelectItems mobile debug',
+                description:
+                    'Manual mobile check for SelectItems open and close behavior.',
+            },
+        ],
+    },
+] as const;
+
+export default function AdminDebugIndexPage() {
+    return (
+        <main className="min-h-screen w-full bg-background px-4 py-6 text-foreground sm:px-6 sm:py-8">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+                <header>
+                    <h1 className="text-2xl font-bold">Debug</h1>
+                    <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                        Available admin debug pages.
+                    </p>
+                </header>
+
+                {debugGroups.map((group) => (
+                    <section key={group.title} className="flex flex-col gap-3">
+                        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+                            {group.title}
+                        </h2>
+                        <div className="grid gap-3 md:grid-cols-2">
+                            {group.pages.map((page) => (
+                                <Link
+                                    key={page.href}
+                                    href={page.href}
+                                    className="rounded-lg border bg-card p-4 shadow-xs transition-colors hover:border-primary/50 hover:bg-muted/30"
+                                >
+                                    <span className="block text-base font-semibold">
+                                        {page.title}
+                                    </span>
+                                    <span className="mt-1 block text-sm text-muted-foreground">
+                                        {page.description}
+                                    </span>
+                                    <span className="mt-3 block break-all font-mono text-xs text-muted-foreground">
+                                        {page.href}
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+                    </section>
+                ))}
+            </div>
+        </main>
+    );
+}

--- a/apps/farm/app/debug/labels/HarvestLabelDebugPage.tsx
+++ b/apps/farm/app/debug/labels/HarvestLabelDebugPage.tsx
@@ -22,6 +22,7 @@ const DEFAULT_LABEL_DATA: HarvestLabelData = {
     fieldIndex: 4,
     operationLabel: 'Berba',
     plantSortName: 'Salata Batavia',
+    dateLabel: '02.06.2026.',
 };
 
 const LABEL_SAMPLES: Array<{
@@ -39,6 +40,7 @@ const LABEL_SAMPLES: Array<{
             fieldIndex: 2,
             operationLabel: 'Berba',
             plantSortName: 'Mladi špinat',
+            dateLabel: '02.06.2026.',
         },
     },
     {
@@ -48,6 +50,7 @@ const LABEL_SAMPLES: Array<{
             fieldIndex: 7,
             operationLabel: 'Berba zrelih plodova',
             plantSortName: 'Cherry rajčica',
+            dateLabel: '02.06.2026.',
         },
     },
 ];
@@ -139,6 +142,16 @@ export function HarvestLabelDebugPage() {
                                         setLabelData((current) => ({
                                             ...current,
                                             plantSortName: value,
+                                        }))
+                                    }
+                                />
+                                <DebugTextInput
+                                    label="Datum"
+                                    value={labelData.dateLabel ?? ''}
+                                    onChange={(value) =>
+                                        setLabelData((current) => ({
+                                            ...current,
+                                            dateLabel: value,
                                         }))
                                     }
                                 />

--- a/apps/farm/app/debug/page.tsx
+++ b/apps/farm/app/debug/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { HomeButton } from '../../components/HomeButton';
+
+const debugGroups = [
+    {
+        title: 'Labels',
+        pages: [
+            {
+                href: '/debug/labels',
+                title: 'Harvest label preview',
+                description:
+                    'Farm label canvas preview with fixed printer profile and editable label content.',
+            },
+        ],
+    },
+] as const;
+
+export default function FarmDebugIndexPage() {
+    if (process.env.NODE_ENV !== 'development') {
+        notFound();
+    }
+
+    return (
+        <main className="min-h-screen w-full bg-muted px-4 py-6 text-foreground sm:px-6 sm:py-8">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+                <header className="flex flex-col gap-4">
+                    <HomeButton />
+                    <div>
+                        <h1 className="text-2xl font-bold">Debug</h1>
+                        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                            Available farm debug pages.
+                        </p>
+                    </div>
+                </header>
+
+                {debugGroups.map((group) => (
+                    <section key={group.title} className="flex flex-col gap-3">
+                        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+                            {group.title}
+                        </h2>
+                        <div className="grid gap-3 md:grid-cols-2">
+                            {group.pages.map((page) => (
+                                <Link
+                                    key={page.href}
+                                    href={page.href}
+                                    className="rounded-lg border bg-background p-4 shadow-xs transition-colors hover:border-primary/50 hover:bg-muted/20"
+                                >
+                                    <span className="block text-base font-semibold">
+                                        {page.title}
+                                    </span>
+                                    <span className="mt-1 block text-sm text-muted-foreground">
+                                        {page.description}
+                                    </span>
+                                    <span className="mt-3 block break-all font-mono text-xs text-muted-foreground">
+                                        {page.href}
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+                    </section>
+                ))}
+            </div>
+        </main>
+    );
+}

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -204,9 +204,9 @@ async function FarmerDashboard() {
                                     size="lg"
                                     fullWidth
                                     className="h-24 flex-col text-center text-base"
-                                    href="/debug/labels"
+                                    href="/debug"
                                 >
-                                    Etiketa
+                                    Debug
                                 </Button>
                             )}
                         </div>

--- a/apps/farm/app/schedule/FieldOperationPrintModal.tsx
+++ b/apps/farm/app/schedule/FieldOperationPrintModal.tsx
@@ -60,6 +60,7 @@ function getLabelPreviewItems(labels: FieldOperationLabelData[]) {
             label.fieldLabel,
             label.detailLabel,
             label.plantSortName,
+            label.dateLabel ?? '',
         ].join('|');
         const count = keyCounts.get(baseKey) ?? 0;
         keyCounts.set(baseKey, count + 1);

--- a/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
+++ b/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
@@ -13,6 +13,7 @@ interface ScheduleLabelPrintSectionProps {
     dayDataPromise: Promise<FarmScheduleDayData>;
     operationsDataPromise: ReturnType<typeof getFarmScheduleOperationsData>;
     plantSortsPromise: ReturnType<typeof getFarmSchedulePlantSorts>;
+    date: Date;
 }
 
 function formatLabelCount(count: number) {
@@ -46,6 +47,7 @@ export async function ScheduleLabelPrintSection({
     dayDataPromise,
     operationsDataPromise,
     plantSortsPromise,
+    date,
 }: ScheduleLabelPrintSectionProps) {
     const [dayData, operationsData, plantSorts] = await Promise.all([
         dayDataPromise,
@@ -56,6 +58,7 @@ export async function ScheduleLabelPrintSection({
         dayData,
         plantSorts,
         operationsData,
+        date,
     );
 
     if (printData.labels.length === 0) {

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -45,6 +45,7 @@ async function FarmScheduleContent({ date }: { date: Date }) {
                             dayDataPromise={dayDataPromise}
                             operationsDataPromise={operationsDataPromise}
                             plantSortsPromise={plantSortsPromise}
+                            date={date}
                         />
                     </Suspense>
                 </div>

--- a/apps/farm/app/schedule/scheduleLabels.ts
+++ b/apps/farm/app/schedule/scheduleLabels.ts
@@ -43,6 +43,12 @@ function formatPieceCountLabel(count: number) {
     return `${count} ${count === 1 ? 'KOMAD' : 'KOMADA'}`;
 }
 
+function formatScheduleLabelDate(date: Date) {
+    const day = date.getDate().toString().padStart(2, '0');
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    return `${day}.${month}.${date.getFullYear()}.`;
+}
+
 function formatFieldRange(fields: SowingLabelField[]) {
     const positions = fields.map((field) => field.physicalPositionIndex);
     const firstPosition = positions.at(0);
@@ -63,12 +69,14 @@ function addSowingLabel(
     fields: SowingLabelField[],
     plantCount: number,
     plantSortName: string,
+    dateLabel: string,
 ) {
     labels.push({
         raisedBedPhysicalId: physicalId,
         fieldLabel: formatFieldRange(fields),
         detailLabel: formatPieceCountLabel(plantCount),
         plantSortName,
+        dateLabel,
     });
 }
 
@@ -76,6 +84,7 @@ function buildSowingLabelsForFields(
     fields: SowingLabelField[],
     physicalId: string,
     plantSortById: Map<number, EntityStandardized>,
+    dateLabel: string,
 ) {
     const labels: FieldOperationLabelData[] = [];
     let activeFields: SowingLabelField[] = [];
@@ -98,6 +107,7 @@ function buildSowingLabelsForFields(
             activeFields,
             activePlantCount,
             activePlantSortName,
+            dateLabel,
         );
         activeFields = [];
         activePlantSortId = null;
@@ -149,6 +159,7 @@ function buildSowingLabelsForFields(
                     [field],
                     labelPlantCount,
                     plantSortName,
+                    dateLabel,
                 );
                 remainingPlants -= labelPlantCount;
             }
@@ -172,6 +183,7 @@ function buildSowingLabelsForFields(
 function buildSowingLabels(
     dayData: FarmScheduleDayData,
     plantSortById: Map<number, EntityStandardized>,
+    dateLabel: string,
 ) {
     const affectedRaisedBedIds = [
         ...new Set(dayData.scheduledFields.map((field) => field.raisedBedId)),
@@ -208,7 +220,12 @@ function buildSowingLabels(
             );
 
         labels.push(
-            ...buildSowingLabelsForFields(fields, physicalId, plantSortById),
+            ...buildSowingLabelsForFields(
+                fields,
+                physicalId,
+                plantSortById,
+                dateLabel,
+            ),
         );
     }
 
@@ -258,7 +275,8 @@ function buildHarvestFieldLabel(
     raisedBeds: FarmRaisedBed[],
     plantSortById: Map<number, EntityStandardized>,
     detailLabel: string,
-) {
+    dateLabel: string,
+): FieldOperationLabelData | null {
     const plantSortName = field.plantSortId
         ? plantSortById.get(field.plantSortId)?.information?.name
         : undefined;
@@ -272,6 +290,7 @@ function buildHarvestFieldLabel(
         fieldLabel: getFieldPhysicalPositionIndex(field, raisedBeds).toString(),
         detailLabel,
         plantSortName,
+        dateLabel,
     };
 }
 
@@ -280,6 +299,7 @@ function buildOperationLabels(
     operationData: EntityStandardized | undefined,
     groupedRaisedBeds: FarmRaisedBed[],
     plantSortById: Map<number, EntityStandardized>,
+    dateLabel: string,
 ) {
     if (
         !shouldPrintOperationLabel(operationData) ||
@@ -310,6 +330,7 @@ function buildOperationLabels(
             groupedRaisedBeds,
             plantSortById,
             detailLabel,
+            dateLabel,
         );
         return label ? [label] : [];
     }
@@ -329,6 +350,7 @@ function buildOperationLabels(
                 groupedRaisedBeds,
                 plantSortById,
                 detailLabel,
+                dateLabel,
             ),
         )
         .filter((label): label is FieldOperationLabelData => label !== null);
@@ -365,6 +387,7 @@ function buildHarvestLabels(
     dayData: FarmScheduleDayData,
     plantSortById: Map<number, EntityStandardized>,
     operationDataById: Map<number, EntityStandardized>,
+    dateLabel: string,
 ) {
     const affectedRaisedBedIds = [
         ...new Set(
@@ -395,6 +418,7 @@ function buildHarvestLabels(
                 operationDataById.get(operation.entityId),
                 raisedBedGroup.raisedBeds,
                 plantSortById,
+                dateLabel,
             ),
         );
     }
@@ -406,14 +430,17 @@ export function buildScheduleLabelPrintData(
     dayData: FarmScheduleDayData,
     plantSorts: EntityStandardized[] | null | undefined,
     operationsData: EntityStandardized[] | null | undefined,
+    date: Date,
 ) {
     const plantSortById = getEntityById(plantSorts);
     const operationDataById = getEntityById(operationsData);
-    const sowingLabels = buildSowingLabels(dayData, plantSortById);
+    const dateLabel = formatScheduleLabelDate(date);
+    const sowingLabels = buildSowingLabels(dayData, plantSortById, dateLabel);
     const harvestLabels = buildHarvestLabels(
         dayData,
         plantSortById,
         operationDataById,
+        dateLabel,
     );
 
     return {

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -33,6 +33,12 @@ const debugGroups = [
                 description:
                     'Animal behavior scene with spawn presets, entity placement, and debug controls.',
             },
+            {
+                href: '/debug/profile/game',
+                title: 'Game profile viewer',
+                description:
+                    'Mocked garden scene profiles for weather, season, quality, and HUD checks.',
+            },
         ],
     },
     {

--- a/packages/label-printer/src/harvestLabelCanvas.ts
+++ b/packages/label-printer/src/harvestLabelCanvas.ts
@@ -207,9 +207,20 @@ export function renderFieldOperationLabel(
 	const topFieldText = sanitizeText(data.fieldLabel);
 	const detailText = sanitizeText(data.detailLabel);
 	const plantSortName = sanitizeText(data.plantSortName);
+	const dateLabel = data.dateLabel ? sanitizeText(data.dateLabel) : "";
 	const detailTop = Math.round(height * 0.58);
 	const plantTop = Math.round(height * 0.75);
 	const bottomMaxWidth = width - paddingX * 2;
+	const dateFontSize = dateLabel
+		? fitSingleLineFont(
+				context,
+				dateLabel,
+				width * 0.28,
+				Math.round(height * 0.085),
+				Math.round(height * 0.06),
+				500,
+			)
+		: 0;
 	const headerMaxWidth = Math.max(
 		width * 0.25,
 		rightColumnX - headerLabelX - Math.round(width * 0.08),
@@ -260,12 +271,18 @@ export function renderFieldOperationLabel(
 		Math.round(height * 0.12),
 		800,
 	);
+	const fieldBaseline = headerTop + bedFontSize + headerLineHeight;
 	context.font = `800 ${fieldFontSize}px ${FONT_FAMILY}`;
-	context.fillText(
-		topFieldText,
-		rightColumnX,
-		headerTop + bedFontSize + headerLineHeight,
-	);
+	context.fillText(topFieldText, rightColumnX, fieldBaseline);
+
+	if (dateLabel) {
+		context.font = `500 ${dateFontSize}px ${FONT_FAMILY}`;
+		context.fillText(
+			dateLabel,
+			rightColumnX,
+			fieldBaseline + dateFontSize + Math.round(height * 0.015),
+		);
+	}
 
 	const detailFontSize = fitSingleLineFont(
 		context,
@@ -311,6 +328,7 @@ export function renderHarvestLabel(
 			fieldLabel: data.fieldIndex.toString(),
 			detailLabel: data.operationLabel ?? "BERBA",
 			plantSortName: data.plantSortName,
+			dateLabel: data.dateLabel,
 		},
 		preset,
 	);

--- a/packages/label-printer/src/types.ts
+++ b/packages/label-printer/src/types.ts
@@ -5,6 +5,7 @@ export type FieldOperationLabelData = {
 	fieldLabel: string;
 	detailLabel: string;
 	plantSortName: string;
+	dateLabel?: string;
 };
 
 export type HarvestLabelData = {
@@ -12,6 +13,7 @@ export type HarvestLabelData = {
 	fieldIndex: number;
 	plantSortName: string;
 	operationLabel?: string;
+	dateLabel?: string;
 };
 
 export type HarvestLabelPreset = {


### PR DESCRIPTION
## Summary
- add `/debug` index pages for farm and admin, and include the missing garden debug profile route in the garden index
- point the farm dashboard debug shortcut at the new farm debug index
- keep label dates in the shared renderer, but place them under the field number so long operation and plant names get the full width
- expose the date on the farm label debug page and pass the schedule date through the farm print flow

## Testing
- `pnpm --filter @gredice/label-printer lint`
- `pnpm exec tsc -p packages/label-printer/tsconfig.json --noEmit --pretty false`
- `pnpm --filter farm build`
- browser smoke-tested the three `/debug` index pages and the farm label preview