### PR TITLE
Expand admin quick links and badge counts

### DIFF
--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -1,5 +1,11 @@
-import { getEntityTypes, getSetting, SettingsKeys } from '@gredice/storage';
+import {
+    getEntityTypes,
+    getPendingAchievementsCount,
+    getSetting,
+    SettingsKeys,
+} from '@gredice/storage';
 import { auth } from '../../../lib/auth/auth';
+import { getPendingAdminApprovalTaskCount } from '../../../src/approvalTasks';
 import {
     buildDashboardQuickActionOptions,
     getDashboardQuickActionsFromConfig,
@@ -17,19 +23,23 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
     const params = await searchParams;
     const selectedPeriod = params?.period || '7';
 
-    const [data, entityTypes, dashboardQuickActionsSetting] = await Promise.all(
-        [
-            getAnalyticsData(
-                selectedPeriod === 'custom'
-                    ? undefined
-                    : Number(selectedPeriod),
-                params?.from,
-                params?.to,
-            ),
-            getEntityTypes(),
-            getSetting(SettingsKeys.DashboardQuickActions),
-        ],
-    );
+    const [
+        data,
+        entityTypes,
+        dashboardQuickActionsSetting,
+        pendingAchievementsCount,
+        pendingApprovalTasksCount,
+    ] = await Promise.all([
+        getAnalyticsData(
+            selectedPeriod === 'custom' ? undefined : Number(selectedPeriod),
+            params?.from,
+            params?.to,
+        ),
+        getEntityTypes(),
+        getSetting(SettingsKeys.DashboardQuickActions),
+        getPendingAchievementsCount(),
+        getPendingAdminApprovalTaskCount(),
+    ]);
 
     const quickActionOptions = buildDashboardQuickActionOptions(
         entityTypes.map((entityType) => ({
@@ -58,6 +68,10 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
             initialAiData={data.ai}
             initialSunflowersData={data.sunflowers}
             initialQuickActions={quickActions}
+            initialQuickActionBadgeCounts={{
+                pendingAchievementsCount,
+                pendingApprovalTasksCount,
+            }}
             initialPeriod={selectedPeriod}
             initialFrom={params?.from}
             initialTo={params?.to}

--- a/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboardClient.tsx
@@ -4,7 +4,28 @@ import type { getAnalyticsTotals } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { Input } from '@gredice/ui/Input';
-import { Calendar, Euro, File, Hammer, Truck } from '@gredice/ui/icons';
+import {
+    AI,
+    Bank,
+    Calendar,
+    Cloud,
+    Euro,
+    Fence,
+    File,
+    Hammer,
+    Inbox,
+    Lightning,
+    Mail,
+    Map as MapIcon,
+    Megaphone,
+    Settings,
+    ShoppingCart,
+    SmileHappy,
+    Success,
+    Tally3,
+    Truck,
+    User,
+} from '@gredice/ui/icons';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
@@ -13,7 +34,11 @@ import { Typography } from '@gredice/ui/Typography';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import { formatAiCostUsd } from '../../../src/ai/aiAnalyticsCost';
-import type { DashboardQuickActionOption } from '../../../src/dashboardQuickActions';
+import {
+    type DashboardQuickActionBadgeCounts,
+    type DashboardQuickActionOption,
+    getDashboardQuickActionBadge,
+} from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
 import { FactCard } from '../cards/FactCard';
 import { EntityTypeIcon } from '../directories/EntityTypeIcon';
@@ -59,16 +84,54 @@ function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
     }
 
     switch (quickAction.href) {
+        case KnownPages.Accounts:
+            return <Bank className="size-4" />;
+        case KnownPages.Achievements:
+        case KnownPages.Sunflowers:
+            return <Success className="size-4" />;
+        case KnownPages.AiAnalytics:
+            return <AI className="size-4" />;
+        case KnownPages.Approvals:
+        case KnownPages.CommunicationInbox:
+            return <Inbox className="size-4" />;
+        case KnownPages.Automations:
+            return <Lightning className="size-4" />;
+        case KnownPages.CommunicationEmails:
+            return <Mail className="size-4" />;
+        case KnownPages.DeliveryRequests:
+        case KnownPages.DeliverySlots:
+            return <Truck className="size-4" />;
+        case KnownPages.FarmerPayouts:
+        case KnownPages.FarmerPrices:
+        case KnownPages.Transactions:
+            return <Euro className="size-4" />;
+        case KnownPages.Farms:
+            return <MapIcon className="size-4" />;
+        case KnownPages.Gardens:
+            return <Fence className="size-4" />;
+        case KnownPages.Inventory:
+        case KnownPages.SowingStatistics:
+            return <Tally3 className="size-4" />;
+        case KnownPages.Notifications:
+        case KnownPages.SocialPublishing:
+            return <Megaphone className="size-4" />;
+        case KnownPages.Occasions:
         case KnownPages.Schedule:
             return <Calendar className="size-4" />;
         case KnownPages.RaisedBeds:
-            return <RaisedBedIcon className="size-4" />;
+            return <RaisedBedIcon className="size-4" physicalId={null} />;
         case KnownPages.Operations:
             return <Hammer className="size-4" />;
-        case KnownPages.DeliveryRequests:
-            return <Truck className="size-4" />;
-        case KnownPages.Transactions:
-            return <Euro className="size-4" />;
+        case KnownPages.Settings:
+            return <Settings className="size-4" />;
+        case KnownPages.ShoppingCarts:
+            return <ShoppingCart className="size-4" />;
+        case KnownPages.Users:
+            return <User className="size-4" />;
+        case KnownPages.Weather:
+            return <Cloud className="size-4" />;
+        case KnownPages.Feedback:
+            return <SmileHappy className="size-4" />;
         default:
             return <File className="size-4" />;
     }
@@ -78,6 +141,7 @@ export function AdminDashboardClient({
     initialAnalyticsData,
     initialEntitiesData,
     initialQuickActions,
+    initialQuickActionBadgeCounts,
     initialPeriod = '7',
     initialOperationsDurationData,
     initialWeekdayRegistrations,
@@ -88,6 +152,7 @@ export function AdminDashboardClient({
 }: {
     initialAnalyticsData: Awaited<ReturnType<typeof getAnalyticsTotals>>;
     initialQuickActions: DashboardQuickActionOption[];
+    initialQuickActionBadgeCounts: DashboardQuickActionBadgeCounts;
     initialEntitiesData: EntityData[];
     initialPeriod?: string;
     initialOperationsDurationData: OperationsDurationData;
@@ -200,15 +265,27 @@ export function AdminDashboardClient({
     return (
         <Stack spacing={4}>
             <Row spacing={2} className="flex-wrap">
-                {initialQuickActions.map((quickAction) => (
-                    <Chip
-                        key={quickAction.id}
-                        href={quickAction.href}
-                        startDecorator={quickActionIcon(quickAction)}
-                    >
-                        {quickAction.label}
-                    </Chip>
-                ))}
+                {initialQuickActions.map((quickAction) => {
+                    const badge = getDashboardQuickActionBadge(
+                        quickAction,
+                        initialQuickActionBadgeCounts,
+                    );
+
+                    return (
+                        <Chip
+                            key={quickAction.id}
+                            href={quickAction.href}
+                            startDecorator={quickActionIcon(quickAction)}
+                        >
+                            {quickAction.label}
+                            {badge != null && badge > 0 ? (
+                                <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground">
+                                    {badge}
+                                </span>
+                            ) : null}
+                        </Chip>
+                    );
+                })}
             </Row>
             <Stack spacing={2}>
                 <Row justifyContent="space-between">

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -44,6 +44,7 @@ import { usePathname } from 'next/navigation';
 import type { CSSProperties } from 'react';
 import { useContext, useState } from 'react';
 import { reorderEntityType } from '../../../app/(actions)/entityActions';
+import { getDashboardQuickActionBadge } from '../../../src/dashboardQuickActions';
 import { KnownPages } from '../../../src/KnownPages';
 import { EntityTypeIcon } from '../directories/EntityTypeIcon';
 import { adminPages } from './adminPages';
@@ -71,18 +72,52 @@ function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
     }
 
     switch (quickAction.href) {
+        case KnownPages.Accounts:
+            return <Bank className="size-5" />;
+        case KnownPages.Achievements:
+        case KnownPages.Sunflowers:
+            return <Success className="size-5" />;
+        case KnownPages.AiAnalytics:
+            return <AI className="size-5" />;
+        case KnownPages.Approvals:
+        case KnownPages.CommunicationInbox:
+            return <Inbox className="size-5" />;
+        case KnownPages.Automations:
+            return <Lightning className="size-5" />;
+        case KnownPages.CommunicationEmails:
+            return <Mail className="size-5" />;
+        case KnownPages.DeliveryRequests:
+        case KnownPages.DeliverySlots:
+            return <Truck className="size-5" />;
+        case KnownPages.FarmerPayouts:
+        case KnownPages.FarmerPrices:
+        case KnownPages.Transactions:
+            return <Euro className="size-5" />;
+        case KnownPages.Farms:
+            return <MapIcon className="size-5" />;
+        case KnownPages.Gardens:
+            return <Fence className="size-5" />;
+        case KnownPages.Inventory:
+        case KnownPages.SowingStatistics:
+            return <Tally3 className="size-5" />;
+        case KnownPages.Notifications:
+        case KnownPages.SocialPublishing:
+            return <Megaphone className="size-5" />;
+        case KnownPages.Occasions:
         case KnownPages.Schedule:
             return <Calendar className="size-5" />;
         case KnownPages.RaisedBeds:
             return <RaisedBedIcon className="size-5" physicalId={null} />;
         case KnownPages.Operations:
             return <Hammer className="size-5" />;
-        case KnownPages.DeliveryRequests:
-            return <Truck className="size-5" />;
-        case KnownPages.Transactions:
-            return <Euro className="size-5" />;
-        case KnownPages.Sunflowers:
-            return <Success className="size-5" />;
+        case KnownPages.Settings:
+            return <Settings className="size-5" />;
+        case KnownPages.Users:
+            return <User className="size-5" />;
+        case KnownPages.Weather:
+            return <Cloud className="size-5" />;
+        case KnownPages.Feedback:
+            return <SmileHappy className="size-5" />;
         default:
             return <File className="size-5" />;
     }
@@ -200,6 +235,10 @@ export function Nav({
     const pendingAchievementsCount = navContext?.pendingAchievementsCount ?? 0;
     const pendingApprovalTasksCount =
         navContext?.pendingApprovalTasksCount ?? 0;
+    const quickActionBadgeCounts = {
+        pendingAchievementsCount,
+        pendingApprovalTasksCount,
+    };
     const quickActions = navContext?.quickActions || [];
     const hasDirectoryRecords =
         categorizedTypes.length > 0 ||
@@ -230,6 +269,10 @@ export function Nav({
                         label={quickAction.label}
                         icon={quickActionIcon(quickAction)}
                         onClick={onItemClick}
+                        badge={getDashboardQuickActionBadge(
+                            quickAction,
+                            quickActionBadgeCounts,
+                        )}
                         compact={compact}
                     />
                 ))}

--- a/apps/app/src/dashboardQuickActions.ts
+++ b/apps/app/src/dashboardQuickActions.ts
@@ -10,13 +10,96 @@ export type DashboardQuickActionOption = {
     icon?: string | null;
 };
 
+export type DashboardQuickActionBadgeCounts = {
+    pendingAchievementsCount: number;
+    pendingApprovalTasksCount: number;
+};
+
 type DashboardEntityTypeOption = {
     name: string;
     label: string;
     icon?: string | null;
 };
 
+type DashboardBuiltinQuickAction = {
+    key: string;
+    label: string;
+    href: Route;
+    description?: string;
+};
+
 const DASHBOARD_BUILTIN_QUICK_ACTIONS = [
+    {
+        key: 'directories',
+        label: 'Zapisi',
+        href: KnownPages.Directories,
+    },
+    {
+        key: 'directories-activity',
+        label: 'Aktivnosti',
+        href: KnownPages.DirectoriesActivity,
+    },
+    {
+        key: 'cms-pages',
+        label: 'Stranice',
+        href: KnownPages.CmsPages,
+    },
+    {
+        key: 'accounts',
+        label: 'Korisnički računi',
+        href: KnownPages.Accounts,
+    },
+    {
+        key: 'achievements',
+        label: 'Postignuća',
+        href: KnownPages.Achievements,
+    },
+    {
+        key: 'shopping-carts',
+        label: 'Košarice',
+        href: KnownPages.ShoppingCarts,
+    },
+    {
+        key: 'invoices',
+        label: 'Ponude',
+        href: KnownPages.Invoices,
+    },
+    {
+        key: 'transactions',
+        label: 'Transakcije',
+        href: KnownPages.Transactions,
+        description: 'Pregled nedavnih transakcija.',
+    },
+    {
+        key: 'sunflowers',
+        label: 'Suncokreti',
+        href: KnownPages.Sunflowers,
+    },
+    {
+        key: 'receipts',
+        label: 'Fiskalni računi',
+        href: KnownPages.Receipts,
+    },
+    {
+        key: 'users',
+        label: 'Korisnici',
+        href: KnownPages.Users,
+    },
+    {
+        key: 'farms',
+        label: 'Farme',
+        href: KnownPages.Farms,
+    },
+    {
+        key: 'weather',
+        label: 'Vrijeme',
+        href: KnownPages.Weather,
+    },
+    {
+        key: 'gardens',
+        label: 'Vrtovi',
+        href: KnownPages.Gardens,
+    },
     {
         key: 'schedule',
         label: 'Raspored',
@@ -42,12 +125,96 @@ const DASHBOARD_BUILTIN_QUICK_ACTIONS = [
         description: 'Pregled zahtjeva za dostavu.',
     },
     {
-        key: 'transactions',
-        label: 'Transakcije',
-        href: KnownPages.Transactions,
-        description: 'Pregled nedavnih transakcija.',
+        key: 'farmer-payouts',
+        label: 'Isplate farmera',
+        href: KnownPages.FarmerPayouts,
     },
-] as const;
+    {
+        key: 'farmer-prices',
+        label: 'Cijene radnji',
+        href: KnownPages.FarmerPrices,
+    },
+    {
+        key: 'inventory',
+        label: 'Zalihe',
+        href: KnownPages.Inventory,
+    },
+    {
+        key: 'occasions',
+        label: 'Prigode',
+        href: KnownPages.Occasions,
+    },
+    {
+        key: 'approvals',
+        label: 'Odobrenja',
+        href: KnownPages.Approvals,
+    },
+    {
+        key: 'automations',
+        label: 'Automatizacije',
+        href: KnownPages.Automations,
+    },
+    {
+        key: 'sowing-statistics',
+        label: 'Statistika sijanja',
+        href: KnownPages.SowingStatistics,
+    },
+    {
+        key: 'delivery-slots',
+        label: 'Dostava - Slotovi',
+        href: KnownPages.DeliverySlots,
+    },
+    {
+        key: 'communication-inbox',
+        label: 'Sandučić',
+        href: KnownPages.CommunicationInbox,
+    },
+    {
+        key: 'communication-emails',
+        label: 'Poslani emailovi',
+        href: KnownPages.CommunicationEmails,
+    },
+    {
+        key: 'communication-slack',
+        label: 'Slack',
+        href: KnownPages.CommunicationSlack,
+    },
+    {
+        key: 'notifications',
+        label: 'Obavijesti',
+        href: KnownPages.Notifications,
+    },
+    {
+        key: 'feedback',
+        label: 'Povratne informacije',
+        href: KnownPages.Feedback,
+    },
+    {
+        key: 'sensors',
+        label: 'Senzori',
+        href: KnownPages.Sensors,
+    },
+    {
+        key: 'cache',
+        label: 'Cache',
+        href: KnownPages.Cache,
+    },
+    {
+        key: 'ai-analytics',
+        label: 'AI analitika',
+        href: KnownPages.AiAnalytics,
+    },
+    {
+        key: 'settings',
+        label: 'Postavke',
+        href: KnownPages.Settings,
+    },
+    {
+        key: 'social-publishing',
+        label: 'Društvene objave',
+        href: KnownPages.SocialPublishing,
+    },
+] as const satisfies readonly DashboardBuiltinQuickAction[];
 
 type DashboardBuiltinQuickActionKey =
     (typeof DASHBOARD_BUILTIN_QUICK_ACTIONS)[number]['key'];
@@ -56,6 +223,12 @@ function isBuiltinQuickActionKey(
     value: string,
 ): value is DashboardBuiltinQuickActionKey {
     return DASHBOARD_BUILTIN_QUICK_ACTIONS.some((item) => item.key === value);
+}
+
+function getBuiltinQuickActionDescription(
+    item: DashboardBuiltinQuickAction,
+): string {
+    return item.description ?? `Otvara stranicu „${item.label}”.`;
 }
 
 export function encodeBuiltinQuickActionId(
@@ -106,7 +279,7 @@ export function buildDashboardQuickActionOptions(
             id: encodeBuiltinQuickActionId(item.key),
             label: item.label,
             href: item.href,
-            description: item.description,
+            description: getBuiltinQuickActionDescription(item),
         }));
 
     const entityOptions: DashboardQuickActionOption[] = entityTypes.map(
@@ -206,4 +379,18 @@ export function getQuickActionIdsFromConfig(config: unknown): string[] {
     return parseQuickActionConfig(config).map((action) =>
         toQuickActionId(action),
     );
+}
+
+export function getDashboardQuickActionBadge(
+    quickAction: Pick<DashboardQuickActionOption, 'href'>,
+    counts: DashboardQuickActionBadgeCounts,
+): number | undefined {
+    switch (quickAction.href) {
+        case KnownPages.Achievements:
+            return counts.pendingAchievementsCount;
+        case KnownPages.Approvals:
+            return counts.pendingApprovalTasksCount;
+        default:
+            return undefined;
+    }
 }


### PR DESCRIPTION
## Summary
- Expanded the dashboard quick-link catalog so more static admin pages are selectable, including `Odobrenja`.
- Added shared quick-link badge lookup so pending counts follow quick links in both the sidebar and dashboard.
- Kept the dashboard and settings screens on the same quick-link source of truth.

## Testing
- Biome check passed on the edited app files.
- Verified the quick-link helper resolves `builtin:approvals` to `/admin/approvals` and returns the pending approval badge count.
- Opened the admin app in the browser and confirmed the settings route compiles; deeper UI inspection was blocked by the admin login wall.