### PR TITLE
Deduplicate weather warning notifications

### DIFF
--- a/apps/api/lib/weather/alertNotifications.node.spec.ts
+++ b/apps/api/lib/weather/alertNotifications.node.spec.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    filterWeatherAlertsForNotifications,
+    weatherAlertNotificationCollapseKey,
+    weatherAlertNotificationLookupCollapseKeys,
+} from './alertNotifications';
+import type { DhmzWeatherAlert } from './alerts';
+
+const bjelovarFarm = {
+    latitude: 45.9,
+    longitude: 16.84,
+};
+
+const yellowAlert = {
+    id: 'yellow-alert',
+    source: 'dhmz-cap',
+    sourceUrl: 'https://example.com/cap.xml',
+    language: 'hr',
+    event: 'Zuto upozorenje za kisu',
+    description: 'Mjestimice obilna kisa.',
+    instruction: 'Budite na oprezu.',
+    urgency: 'Future',
+    severity: 'Moderate',
+    certainty: 'Likely',
+    onset: '2026-06-04T00:00:00+02:00',
+    expires: '2026-06-05T00:00:00+02:00',
+    sent: '2026-06-03T17:46:47+02:00',
+    senderName: 'DHMZ',
+    awarenessLevel: {
+        id: '2',
+        color: 'yellow',
+        label: 'Moderate',
+    },
+    awarenessType: {
+        id: '10',
+        label: 'Rain',
+    },
+    area: {
+        name: 'Zagrebacka regija',
+        regionCode: 'HR002',
+    },
+    deduplicationKey:
+        'HR002:10:2:2026-06-04T00:00:00+02:00:2026-06-05T00:00:00+02:00',
+} satisfies DhmzWeatherAlert;
+
+const greenNoWarningAlert = {
+    ...yellowAlert,
+    id: 'green-no-warning-alert',
+    event: 'Zeleno upozorenje za vjetar',
+    description: 'Nema upozorenja!',
+    instruction: null,
+    severity: 'Minor',
+    awarenessLevel: {
+        id: '1',
+        color: 'green',
+        label: 'Minor',
+    },
+    awarenessType: {
+        id: '1',
+        label: 'Wind',
+    },
+    deduplicationKey:
+        'HR002:1:1:2026-06-04T00:00:00+02:00:2026-06-05T00:00:00+02:00',
+} satisfies DhmzWeatherAlert;
+
+const duplicateYellowAlert = {
+    ...yellowAlert,
+    id: 'duplicate-yellow-alert',
+    sourceUrl: 'https://example.com/duplicate-cap.xml',
+} satisfies DhmzWeatherAlert;
+
+describe('filterWeatherAlertsForNotifications', () => {
+    it('does not select green no-warning CAP records for notifications', () => {
+        const alerts = filterWeatherAlertsForNotifications({
+            farm: bjelovarFarm,
+            now: new Date('2026-06-03T18:00:00+02:00'),
+            sourceAlerts: [greenNoWarningAlert],
+        });
+
+        assert.equal(alerts.length, 0);
+    });
+
+    it('keeps real warnings when green no-warning records are present', () => {
+        const alerts = filterWeatherAlertsForNotifications({
+            farm: bjelovarFarm,
+            now: new Date('2026-06-03T18:00:00+02:00'),
+            sourceAlerts: [greenNoWarningAlert, yellowAlert],
+        });
+
+        assert.deepEqual(
+            alerts.map((alert) => alert.id),
+            ['yellow-alert'],
+        );
+    });
+
+    it('deduplicates repeated CAP records for the same warning', () => {
+        const alerts = filterWeatherAlertsForNotifications({
+            farm: bjelovarFarm,
+            now: new Date('2026-06-03T18:00:00+02:00'),
+            sourceAlerts: [yellowAlert, duplicateYellowAlert],
+        });
+
+        assert.equal(alerts.length, 1);
+        assert.equal(alerts[0]?.deduplicationKey, yellowAlert.deduplicationKey);
+    });
+});
+
+describe('weather alert notification collapse keys', () => {
+    it('uses an account-level warning key and keeps legacy garden keys for lookup', () => {
+        assert.equal(
+            weatherAlertNotificationCollapseKey(yellowAlert),
+            `weather-risk:${yellowAlert.deduplicationKey}`,
+        );
+        assert.deepEqual(
+            weatherAlertNotificationLookupCollapseKeys(42, yellowAlert),
+            [
+                `weather-risk:${yellowAlert.deduplicationKey}`,
+                `weather-risk:42:${yellowAlert.deduplicationKey}`,
+            ],
+        );
+    });
+});

--- a/apps/api/lib/weather/alertNotifications.node.spec.ts
+++ b/apps/api/lib/weather/alertNotifications.node.spec.ts
@@ -107,16 +107,17 @@ describe('filterWeatherAlertsForNotifications', () => {
 });
 
 describe('weather alert notification collapse keys', () => {
-    it('uses an account-level warning key and keeps legacy garden keys for lookup', () => {
+    it('uses an account-level warning key and keeps all account legacy garden keys for lookup', () => {
         assert.equal(
             weatherAlertNotificationCollapseKey(yellowAlert),
             `weather-risk:${yellowAlert.deduplicationKey}`,
         );
         assert.deepEqual(
-            weatherAlertNotificationLookupCollapseKeys(42, yellowAlert),
+            weatherAlertNotificationLookupCollapseKeys([42, 43], yellowAlert),
             [
                 `weather-risk:${yellowAlert.deduplicationKey}`,
                 `weather-risk:42:${yellowAlert.deduplicationKey}`,
+                `weather-risk:43:${yellowAlert.deduplicationKey}`,
             ],
         );
     });

--- a/apps/api/lib/weather/alertNotifications.ts
+++ b/apps/api/lib/weather/alertNotifications.ts
@@ -6,11 +6,13 @@ import {
     notifications,
     storage,
 } from '@gredice/storage';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import {
     type DhmzWeatherAlert,
     filterWeatherAlertsForFarm,
     getDhmzWeatherAlerts,
+    isWeatherWarningAlert,
+    type WeatherAlertFarm,
 } from './alerts';
 
 export type WeatherAlertNotificationResult = {
@@ -31,8 +33,27 @@ function formatAlertWindow(alert: DhmzWeatherAlert) {
     return `${formatter.format(new Date(alert.onset))} - ${formatter.format(new Date(alert.expires))}`;
 }
 
-function collapseKeyForWeatherAlert(gardenId: number, alert: DhmzWeatherAlert) {
+export function weatherAlertNotificationCollapseKey(
+    alert: Pick<DhmzWeatherAlert, 'deduplicationKey'>,
+) {
+    return `weather-risk:${alert.deduplicationKey}`;
+}
+
+function legacyWeatherAlertNotificationCollapseKey(
+    gardenId: number,
+    alert: Pick<DhmzWeatherAlert, 'deduplicationKey'>,
+) {
     return `weather-risk:${gardenId}:${alert.deduplicationKey}`;
+}
+
+export function weatherAlertNotificationLookupCollapseKeys(
+    gardenId: number,
+    alert: Pick<DhmzWeatherAlert, 'deduplicationKey'>,
+) {
+    return [
+        weatherAlertNotificationCollapseKey(alert),
+        legacyWeatherAlertNotificationCollapseKey(gardenId, alert),
+    ];
 }
 
 function weatherAlertContent(alert: DhmzWeatherAlert) {
@@ -40,11 +61,40 @@ function weatherAlertContent(alert: DhmzWeatherAlert) {
     return `${alert.description} Vrijedi ${formatAlertWindow(alert)}.${instruction}`;
 }
 
-async function notificationExists(accountId: string, collapseKey: string) {
+function dedupeWeatherAlertsByWarning(alerts: DhmzWeatherAlert[]) {
+    const seenAlertKeys = new Set<string>();
+    const dedupedAlerts: DhmzWeatherAlert[] = [];
+
+    for (const alert of alerts) {
+        if (seenAlertKeys.has(alert.deduplicationKey)) continue;
+        seenAlertKeys.add(alert.deduplicationKey);
+        dedupedAlerts.push(alert);
+    }
+
+    return dedupedAlerts;
+}
+
+export function filterWeatherAlertsForNotifications({
+    farm,
+    now,
+    sourceAlerts,
+}: {
+    farm?: WeatherAlertFarm | null;
+    now: Date;
+    sourceAlerts: DhmzWeatherAlert[];
+}) {
+    return dedupeWeatherAlertsByWarning(
+        filterWeatherAlertsForFarm(sourceAlerts, farm, { now }).filter(
+            isWeatherWarningAlert,
+        ),
+    );
+}
+
+async function notificationExists(accountId: string, collapseKeys: string[]) {
     const existing = await storage().query.notifications.findFirst({
         where: and(
             eq(notifications.accountId, accountId),
-            eq(notifications.collapseKey, collapseKey),
+            inArray(notifications.collapseKey, collapseKeys),
         ),
     });
     return Boolean(existing);
@@ -70,16 +120,34 @@ export async function notifyWeatherRiskAlerts({
     let alertsMatched = 0;
     let notificationsCreated = 0;
     let duplicatesSkipped = 0;
+    const processedNotificationKeys = new Set<string>();
 
     for (const garden of gardenRows) {
-        const alerts = filterWeatherAlertsForFarm(sourceAlerts, garden.farm, {
+        const alerts = filterWeatherAlertsForNotifications({
+            farm: garden.farm,
             now,
+            sourceAlerts,
         });
         alertsMatched += alerts.length;
 
         for (const alert of alerts) {
-            const collapseKey = collapseKeyForWeatherAlert(garden.id, alert);
-            if (await notificationExists(garden.accountId, collapseKey)) {
+            const collapseKey = weatherAlertNotificationCollapseKey(alert);
+            const accountNotificationKey = `${garden.accountId}:${collapseKey}`;
+            if (processedNotificationKeys.has(accountNotificationKey)) {
+                duplicatesSkipped += 1;
+                continue;
+            }
+            processedNotificationKeys.add(accountNotificationKey);
+
+            if (
+                await notificationExists(
+                    garden.accountId,
+                    weatherAlertNotificationLookupCollapseKeys(
+                        garden.id,
+                        alert,
+                    ),
+                )
+            ) {
                 duplicatesSkipped += 1;
                 continue;
             }

--- a/apps/api/lib/weather/alertNotifications.ts
+++ b/apps/api/lib/weather/alertNotifications.ts
@@ -47,12 +47,14 @@ function legacyWeatherAlertNotificationCollapseKey(
 }
 
 export function weatherAlertNotificationLookupCollapseKeys(
-    gardenId: number,
+    gardenIds: number[],
     alert: Pick<DhmzWeatherAlert, 'deduplicationKey'>,
 ) {
     return [
         weatherAlertNotificationCollapseKey(alert),
-        legacyWeatherAlertNotificationCollapseKey(gardenId, alert),
+        ...gardenIds.map((gardenId) =>
+            legacyWeatherAlertNotificationCollapseKey(gardenId, alert),
+        ),
     ];
 }
 
@@ -121,6 +123,13 @@ export async function notifyWeatherRiskAlerts({
     let notificationsCreated = 0;
     let duplicatesSkipped = 0;
     const processedNotificationKeys = new Set<string>();
+    const accountGardenIds = new Map<string, number[]>();
+
+    for (const garden of gardenRows) {
+        const gardenIds = accountGardenIds.get(garden.accountId) ?? [];
+        gardenIds.push(garden.id);
+        accountGardenIds.set(garden.accountId, gardenIds);
+    }
 
     for (const garden of gardenRows) {
         const alerts = filterWeatherAlertsForNotifications({
@@ -143,7 +152,7 @@ export async function notifyWeatherRiskAlerts({
                 await notificationExists(
                     garden.accountId,
                     weatherAlertNotificationLookupCollapseKeys(
-                        garden.id,
+                        accountGardenIds.get(garden.accountId) ?? [garden.id],
                         alert,
                     ),
                 )

--- a/apps/api/lib/weather/alerts.node.spec.ts
+++ b/apps/api/lib/weather/alerts.node.spec.ts
@@ -72,6 +72,43 @@ const sampleCapXml = `<?xml version="1.0" encoding="UTF-8"?>
   </info>
 </alert>`;
 
+const greenCapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>2.49.0.0.191.0.HR.green-test.LDZM</identifier>
+  <sender>https://meteo.hr</sender>
+  <sent>2026-06-03T17:46:47+02:00</sent>
+  <status>Actual</status>
+  <msgType>Alert</msgType>
+  <scope>Public</scope>
+  <info>
+    <language>hr</language>
+    <category>Met</category>
+    <event>Zeleno upozorenje za vjetar</event>
+    <urgency>Future</urgency>
+    <severity>Minor</severity>
+    <certainty>Likely</certainty>
+    <onset>2026-06-04T00:00:00+02:00</onset>
+    <expires>2026-06-05T00:00:00+02:00</expires>
+    <senderName>DHMZ Državni hidrometeorološki zavod</senderName>
+    <description>Nema upozorenja!</description>
+    <parameter>
+      <valueName>awareness_level</valueName>
+      <value>1; green; Minor</value>
+    </parameter>
+    <parameter>
+      <valueName>awareness_type</valueName>
+      <value>1; Wind</value>
+    </parameter>
+    <area>
+      <areaDesc>Zagrebačka regija</areaDesc>
+      <geocode>
+        <valueName>EMMA_ID</valueName>
+        <value>HR002</value>
+      </geocode>
+    </area>
+  </info>
+</alert>`;
+
 const bjelovarFarm = {
     latitude: 45.9,
     longitude: 16.84,
@@ -174,5 +211,30 @@ describe('filterWeatherAlertsForFarm', () => {
 
         assert.equal(filtered.length, 1);
         assert.equal(filtered[0]?.language, 'en');
+    });
+
+    it('excludes green no-warning CAP entries', async () => {
+        const alerts = await parseDhmzCapAlertXml(greenCapXml);
+        const filtered = filterWeatherAlertsForFarm(alerts, bjelovarFarm, {
+            now: new Date('2026-06-03T18:00:00+02:00'),
+        });
+
+        assert.equal(filtered.length, 0);
+    });
+
+    it('keeps real warnings when green entries are present', async () => {
+        const alerts = [
+            ...(await parseDhmzCapAlertXml(sampleCapXml)),
+            ...(await parseDhmzCapAlertXml(greenCapXml)),
+        ];
+        const filtered = filterWeatherAlertsForFarm(alerts, bjelovarFarm, {
+            now: new Date('2026-06-03T08:00:00+02:00'),
+        });
+
+        assert.equal(filtered.length, 1);
+        assert.equal(
+            filtered[0]?.event,
+            'Žuto upozorenje za grmljavinsku oluju',
+        );
     });
 });

--- a/apps/api/lib/weather/alerts.ts
+++ b/apps/api/lib/weather/alerts.ts
@@ -11,7 +11,7 @@ const dhmzCapUrlGroups = [
 
 const defaultAlertRegionCode = 'HR002';
 
-type WeatherAlertFarm = {
+export type WeatherAlertFarm = {
     latitude: number;
     longitude: number;
 };
@@ -240,6 +240,23 @@ function severityRank(
     }
 }
 
+export function isWeatherWarningAlert(
+    alert: Pick<DhmzWeatherAlert, 'awarenessLevel' | 'severity'>,
+) {
+    const color = alert.awarenessLevel?.color?.toLowerCase();
+    if (color === 'green') return false;
+    if (color === 'yellow' || color === 'orange' || color === 'red') {
+        return true;
+    }
+
+    const awarenessLevel = Number(alert.awarenessLevel?.id);
+    if (Number.isFinite(awarenessLevel)) return awarenessLevel > 1;
+
+    const severity = alert.severity?.toLowerCase();
+    if (severity === 'minor') return false;
+    return true;
+}
+
 function alertSortKey(alert: DhmzWeatherAlert) {
     return [
         String(4 - severityRank(alert)).padStart(2, '0'),
@@ -445,6 +462,7 @@ export function filterWeatherAlertsForFarm(
         const expiresMs = new Date(alert.expires).getTime();
         return (
             alert.area.regionCode === regionCode &&
+            isWeatherWarningAlert(alert) &&
             Number.isFinite(onsetMs) &&
             Number.isFinite(expiresMs) &&
             expiresMs > now.getTime() &&


### PR DESCRIPTION
## Summary
- Filter out green/no-warning DHMZ alerts before notification creation.
- Collapse weather notifications by alert `deduplicationKey` instead of `gardenId` so the same warning is only sent once per account.
- Keep legacy collapse-key lookup so existing garden-scoped notifications still suppress repeats after deploy.
- Add unit coverage for green no-warning alerts, repeated CAP records, and notification collapse keys.

## Testing
- `pnpm --filter api test:node` passed with the new weather alert and notification tests.
- `pnpm --filter api lint` passed with only pre-existing unrelated Biome warnings.
- `git diff --check` passed.