### PR TITLE
Open plant details from raised-bed notifications

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -46,6 +46,20 @@ function normalizeCompletionNotes(notes?: string) {
     return normalizedNotes;
 }
 
+function buildRaisedBedNotificationLink(
+    raisedBedName: string | null | undefined,
+    positionIndex: number | null | undefined,
+) {
+    if (!raisedBedName) {
+        return undefined;
+    }
+
+    return getRaisedBedCloseupUrl(
+        raisedBedName,
+        typeof positionIndex === 'number' ? { positionIndex } : undefined,
+    );
+}
+
 async function assertRaisedBedAllowsNewOperation(raisedBedId?: number) {
     if (!raisedBedId) {
         return;
@@ -113,7 +127,7 @@ export async function createOperationAction(formData: FormData) {
             ? new Date(formData.get('timestamp') as string)
             : undefined,
     };
-    await assertRaisedBedAllowsNewOperation(operation.raisedBedId);
+    await assertRaisedBedAllowsNewOperation(operation.raisedBedId ?? undefined);
     const operationId = await createOperation(operation);
     if (scheduledDate) {
         await createEvent(
@@ -610,15 +624,15 @@ async function buildOperationCompletionNotification(
                 `Raised bed with ID ${operation.raisedBedId} not found.`,
             );
         } else {
-            if (raisedBed.name) {
-                linkUrl = getRaisedBedCloseupUrl(raisedBed.name);
-            }
-
             const positionIndex = operation.raisedBedFieldId
                 ? raisedBed.fields.find(
                       (field) => field.id === operation.raisedBedFieldId,
                   )?.positionIndex
                 : null;
+            linkUrl = buildRaisedBedNotificationLink(
+                raisedBed.name,
+                positionIndex,
+            );
             if (typeof positionIndex === 'number') {
                 content = `Danas je na gredici **${raisedBed.name}** za polje **${positionIndex + 1}** odrađeno **${operationData?.information?.label}**.`;
             } else {
@@ -833,6 +847,7 @@ export async function cancelOperationAction(formData: FormData) {
     const operationData = await getEntityFormatted<EntityStandardized>(
         operation.entityId,
     );
+    let linkUrl: string | undefined;
 
     // Calculate refund amount (operation price in sunflowers - multiplied by 1000 as per checkout logic)
     const refundAmount = operationData?.prices?.perOperation
@@ -858,6 +873,10 @@ export async function cancelOperationAction(formData: FormData) {
             } else {
                 content = `Radnja **${operationData?.information?.label}** na gredici **${raisedBed.name}** je otkazana.`;
             }
+            linkUrl = buildRaisedBedNotificationLink(
+                raisedBed.name,
+                positionIndex,
+            );
         }
     }
 
@@ -897,6 +916,7 @@ export async function cancelOperationAction(formData: FormData) {
                   raisedBedId: operation.raisedBedId,
                   header,
                   content,
+                  linkUrl,
                   timestamp: new Date(),
               })
             : undefined,

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -144,7 +144,9 @@ async function applyRaisedBedFieldPlantUpdate({
                     header,
                     content,
                     linkUrl: raisedBed.name
-                        ? getRaisedBedCloseupUrl(raisedBed.name)
+                        ? getRaisedBedCloseupUrl(raisedBed.name, {
+                              positionIndex,
+                          })
                         : undefined,
                     timestamp: new Date(),
                 });
@@ -538,6 +540,11 @@ export async function cancelRaisedBedFieldAction(formData: FormData) {
                   raisedBedId: raisedBed.id,
                   header,
                   content,
+                  linkUrl: raisedBed.name
+                      ? getRaisedBedCloseupUrl(raisedBed.name, {
+                            positionIndex,
+                        })
+                      : undefined,
                   timestamp: new Date(),
               })
             : undefined,

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import type { ShoppingCartItemData } from '../../hooks/useShoppingCart';
+import { useRaisedBedFieldDetailsParam } from '../../useUrlState';
 import {
     findRaisedBedOccupiedField,
     getRaisedBedFieldPlantHistory,
@@ -26,17 +28,55 @@ export function RaisedBedFieldItem({
 }) {
     const { data: garden, isLoading: isGardenLoading } = useCurrentGarden();
     const { enablePlantHistoryFlag } = useGameFlags();
+    const [fieldDetailsParam, setFieldDetailsParam] =
+        useRaisedBedFieldDetailsParam();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
+
+    const field = findRaisedBedOccupiedField(raisedBed?.fields, positionIndex);
+    const plantHistory = getRaisedBedFieldPlantHistory(
+        raisedBed?.fields,
+        positionIndex,
+    );
+    const visiblePlantHistory = enablePlantHistoryFlag ? plantHistory : [];
+    const hasField = Boolean(field);
+    const focusedPositionIndex =
+        typeof fieldDetailsParam === 'number' && fieldDetailsParam > 0
+            ? fieldDetailsParam - 1
+            : null;
+    const isFieldDetailsFocused = focusedPositionIndex === positionIndex;
+    const focusedHistoryEntry =
+        isFieldDetailsFocused && !hasField && plantHistory.length > 0
+            ? plantHistory[plantHistory.length - 1]
+            : null;
+
+    useEffect(() => {
+        if (
+            !isFieldDetailsFocused ||
+            isGardenLoading ||
+            hasField ||
+            focusedHistoryEntry
+        ) {
+            return;
+        }
+
+        void setFieldDetailsParam(null);
+    }, [
+        focusedHistoryEntry,
+        hasField,
+        isFieldDetailsFocused,
+        isGardenLoading,
+        setFieldDetailsParam,
+    ]);
+
+    function handleFieldDetailsOpenChange(open: boolean) {
+        if (!open && isFieldDetailsFocused) {
+            void setFieldDetailsParam(null);
+        }
+    }
+
     if (!raisedBed) {
         return null;
     }
-
-    const field = findRaisedBedOccupiedField(raisedBed.fields, positionIndex);
-    const plantHistory = getRaisedBedFieldPlantHistory(
-        raisedBed.fields,
-        positionIndex,
-    );
-    const hasField = Boolean(field);
 
     if (isGardenLoading) {
         return (
@@ -49,21 +89,39 @@ export function RaisedBedFieldItem({
 
     if (!hasField) {
         return (
-            <RaisedBedFieldItemEmpty
-                cartPlantItem={cartPlantItem}
-                gardenId={gardenId}
-                plantHistory={enablePlantHistoryFlag ? plantHistory : []}
-                isCartPending={isCartPending}
-                raisedBedId={raisedBedId}
-                positionIndex={positionIndex}
-                isDragging={isDragging}
-            />
+            <>
+                <RaisedBedFieldItemEmpty
+                    cartPlantItem={cartPlantItem}
+                    gardenId={gardenId}
+                    plantHistory={visiblePlantHistory}
+                    isCartPending={isCartPending}
+                    raisedBedId={raisedBedId}
+                    positionIndex={positionIndex}
+                    isDragging={isDragging}
+                />
+                {focusedHistoryEntry && (
+                    <RaisedBedFieldItemPlanted
+                        fieldOverride={focusedHistoryEntry}
+                        isHistorical
+                        onOpenChange={handleFieldDetailsOpenChange}
+                        open
+                        positionIndex={positionIndex}
+                        raisedBedId={raisedBedId}
+                        triggerOverride={null}
+                        triggerVariant="avatar"
+                    />
+                )}
+            </>
         );
     }
 
     return (
         <RaisedBedFieldItemPlanted
-            plantHistory={enablePlantHistoryFlag ? plantHistory : []}
+            onOpenChange={
+                isFieldDetailsFocused ? handleFieldDetailsOpenChange : undefined
+            }
+            open={isFieldDetailsFocused ? true : undefined}
+            plantHistory={visiblePlantHistory}
             raisedBedId={raisedBedId}
             positionIndex={positionIndex}
         />

--- a/packages/game/src/useRaisedBedCloseup.tsx
+++ b/packages/game/src/useRaisedBedCloseup.tsx
@@ -2,21 +2,37 @@ import { decodeUriComponentSafe } from '@gredice/js/uri';
 import { useEffect, useMemo } from 'react';
 import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { useGameState } from './useGameState';
-import { useRaisedBedCloseupParam } from './useUrlState';
+import {
+    useRaisedBedCloseupParam,
+    useRaisedBedCloseupParams,
+    useRaisedBedFieldDetailsParam,
+} from './useUrlState';
 
 export function useRemoveRaisedBedCloseupParam() {
-    const [, setGredica] = useRaisedBedCloseupParam();
-    return { mutate: () => setGredica(null) };
+    const [, setRaisedBedCloseupParams] = useRaisedBedCloseupParams();
+    return {
+        mutate: () => setRaisedBedCloseupParams({ gredica: null, polje: null }),
+    };
 }
 
 export function useSetRaisedBedCloseupParam() {
-    const [, setGredica] = useRaisedBedCloseupParam();
-    return { mutate: (value: string) => setGredica(value) };
+    const [, setRaisedBedCloseupParams] = useRaisedBedCloseupParams();
+    return {
+        mutate: (value: string, positionIndex?: number | null) =>
+            setRaisedBedCloseupParams({
+                gredica: value,
+                polje:
+                    typeof positionIndex === 'number'
+                        ? positionIndex + 1
+                        : null,
+            }),
+    };
 }
 
 export function useRaisedBedCloseup() {
     const { data: garden } = useCurrentGarden();
     const [raisedBedParam, setRaisedBedParam] = useRaisedBedCloseupParam();
+    const [, setFieldDetailsParam] = useRaisedBedFieldDetailsParam();
     const setView = useGameState((state) => state.setView);
     const closeupBlock = useGameState((state) => state.closeupBlock);
     const view = useGameState((state) => state.view);
@@ -53,6 +69,7 @@ export function useRaisedBedCloseup() {
                 setView({ view: 'normal' });
             }
             setRaisedBedParam(null);
+            setFieldDetailsParam(null);
             return;
         }
 
@@ -65,6 +82,7 @@ export function useRaisedBedCloseup() {
                 setView({ view: 'normal' });
             }
             setRaisedBedParam(null);
+            setFieldDetailsParam(null);
             return;
         }
 
@@ -80,6 +98,7 @@ export function useRaisedBedCloseup() {
         closeupBlock?.id,
         garden,
         raisedBedParam,
+        setFieldDetailsParam,
         setRaisedBedParam,
         setView,
         view,

--- a/packages/game/src/useUrlState.tsx
+++ b/packages/game/src/useUrlState.tsx
@@ -47,6 +47,20 @@ export function useRaisedBedCloseupParam() {
     return useQueryState('gredica', parseAsString);
 }
 
+const raisedBedCloseupParamParsers = {
+    gredica: parseAsString,
+    polje: parseAsInteger,
+};
+
+export function useRaisedBedCloseupParams() {
+    return useQueryStates(raisedBedCloseupParamParsers);
+}
+
+// Raised bed field details parameter (Croatian: "polje" = field)
+export function useRaisedBedFieldDetailsParam() {
+    return useQueryState('polje', parseAsInteger);
+}
+
 // Gift box modal parameter (Croatian: "poklon-kutija" = gift box)
 export function useGiftBoxParam() {
     return useQueryState('poklon-kutija', parseAsString);
@@ -63,6 +77,7 @@ export const urlStateSerializer = createSerializer({
     ruksak: parseAsBoolean,
     'ruksak-kartica': parseAsString,
     gredica: parseAsString,
+    polje: parseAsInteger,
     'poklon-kutija': parseAsString,
     vrt: parseAsInteger,
 });

--- a/packages/js/src/urls/gardenUrls.ts
+++ b/packages/js/src/urls/gardenUrls.ts
@@ -38,6 +38,18 @@ export function getGardenBaseUrl(): string {
  * @example
  * getRaisedBedCloseupUrl('Moja gredica') // => 'https://vrt.gredice.com?gredica=Moja%20gredica'
  */
-export function getRaisedBedCloseupUrl(raisedBedName: string): string {
-    return `${getGardenBaseUrl()}?gredica=${encodeURIComponent(raisedBedName)}`;
+export function getRaisedBedCloseupUrl(
+    raisedBedName: string,
+    options?: { positionIndex?: number | null },
+): string {
+    const params = [`gredica=${encodeURIComponent(raisedBedName)}`];
+    if (
+        typeof options?.positionIndex === 'number' &&
+        Number.isInteger(options.positionIndex) &&
+        options.positionIndex >= 0
+    ) {
+        params.push(`polje=${(options.positionIndex + 1).toString()}`);
+    }
+
+    return `${getGardenBaseUrl()}?${params.join('&')}`;
 }


### PR DESCRIPTION
## Summary
- Added field-focus query handling so raised-bed notifications can open the plant details modal while still entering closeup view.
- Updated raised-bed notification links to carry the field position when available, covering plant status and operation notifications.
- Kept closeup cleanup consistent by clearing field focus when the raised-bed closeup is removed.

## Testing
- `@gredice/game` typecheck passed.
- Biome checks passed for the touched files.
- `app` action files were rechecked with the touched-file scope and no new errors remained there.