### PR TITLE
Dodaj višestruki odabir i brisanje obavijesti

### DIFF
--- a/apps/app/components/notifications/(actions)/notificationActions.ts
+++ b/apps/app/components/notifications/(actions)/notificationActions.ts
@@ -1,17 +1,137 @@
 'use server';
 import 'server-only';
-import { deleteNotification as storageDeleteNotification } from '@gredice/storage';
+import {
+    type SelectNotification,
+    deleteNotifications as storageDeleteNotifications,
+} from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
+import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
+
+export type DeleteNotificationsContext = {
+    accountId?: string;
+    userId?: string | null;
+    gardenId?: number;
+    raisedBedId?: number;
+};
+
+type DeletedNotification = Pick<
+    SelectNotification,
+    'accountId' | 'gardenId' | 'raisedBedId' | 'userId'
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseString(value: unknown) {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed || undefined;
+}
+
+function parseInteger(value: unknown) {
+    return typeof value === 'number' && Number.isInteger(value)
+        ? value
+        : undefined;
+}
+
+function parseNotificationIds(value: unknown) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const ids = new Set<string>();
+    for (const item of value) {
+        const id = parseString(item);
+        if (id) {
+            ids.add(id);
+        }
+    }
+
+    return Array.from(ids);
+}
+
+function parseContext(value: unknown): DeleteNotificationsContext {
+    if (!isRecord(value)) {
+        return {};
+    }
+
+    return {
+        accountId: parseString(value.accountId),
+        userId: parseString(value.userId),
+        gardenId: parseInteger(value.gardenId),
+        raisedBedId: parseInteger(value.raisedBedId),
+    };
+}
+
+function revalidateNotificationPaths(
+    context: DeleteNotificationsContext,
+    deletedNotifications: DeletedNotification[],
+) {
+    const accountIds = new Set<string>();
+    const userIds = new Set<string>();
+    const gardenIds = new Set<number>();
+    const raisedBedIds = new Set<number>();
+
+    if (context.accountId) accountIds.add(context.accountId);
+    if (context.userId) userIds.add(context.userId);
+    if (context.gardenId) gardenIds.add(context.gardenId);
+    if (context.raisedBedId) raisedBedIds.add(context.raisedBedId);
+
+    for (const notification of deletedNotifications) {
+        accountIds.add(notification.accountId);
+        if (notification.userId) userIds.add(notification.userId);
+        if (notification.gardenId) gardenIds.add(notification.gardenId);
+        if (notification.raisedBedId)
+            raisedBedIds.add(notification.raisedBedId);
+    }
+
+    revalidatePath(KnownPages.Notifications);
+
+    for (const accountId of accountIds) {
+        revalidatePath(KnownPages.Account(accountId));
+    }
+    for (const userId of userIds) {
+        revalidatePath(KnownPages.User(userId));
+    }
+    for (const gardenId of gardenIds) {
+        revalidatePath(KnownPages.Garden(gardenId));
+    }
+    for (const raisedBedId of raisedBedIds) {
+        revalidatePath(KnownPages.RaisedBed(raisedBedId));
+    }
+}
 
 export async function deleteNotification(
     accountId: string,
     userId: string | null | undefined,
     id: string,
 ) {
-    await storageDeleteNotification(id);
-    revalidatePath(KnownPages.Account(accountId));
-    if (userId) {
-        revalidatePath(KnownPages.User(userId));
+    return deleteNotifications([id], { accountId, userId });
+}
+
+export async function deleteNotifications(
+    notificationIds: unknown,
+    contextValue: unknown,
+) {
+    await auth(['admin']);
+
+    const ids = parseNotificationIds(notificationIds);
+    if (ids.length === 0) {
+        return {
+            success: false,
+            deletedCount: 0,
+            error: 'No notifications selected',
+        };
     }
+
+    const context = parseContext(contextValue);
+    const deletedNotifications = await storageDeleteNotifications(ids);
+    revalidateNotificationPaths(context, deletedNotifications);
+
+    return { success: true, deletedCount: deletedNotifications.length };
 }

--- a/apps/app/components/notifications/NotificationsTable.tsx
+++ b/apps/app/components/notifications/NotificationsTable.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Checkbox } from '@gredice/ui/Checkbox';
+import { Chip } from '@gredice/ui/Chip';
+import { IconButton } from '@gredice/ui/IconButton';
+import { ImageViewer } from '@gredice/ui/ImageViewer';
+import { Delete } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Markdown } from '@gredice/ui/Markdown';
+import { Row } from '@gredice/ui/Row';
+import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
+import { Stack } from '@gredice/ui/Stack';
+import { Table } from '@gredice/ui/Table';
+import { Typography } from '@gredice/ui/Typography';
+import Link from 'next/link';
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import { KnownPages } from '../../src/KnownPages';
+import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
+
+export type NotificationTableRow = {
+    id: string;
+    accountId: string | null;
+    accountLabel: string | null;
+    blockId: string | null;
+    content: string;
+    createdAt: string;
+    gardenId: number | null;
+    gardenName: string | null;
+    header: string;
+    imageUrl: string | null;
+    linkUrl: string | null;
+    raisedBedId: number | null;
+    raisedBedPhysicalId: string | null;
+    readAt: string | null;
+    timestamp: string;
+    userId: string | null;
+};
+
+export type NotificationDeleteContext = {
+    accountId?: string;
+    userId?: string | null;
+    gardenId?: number;
+    raisedBedId?: number;
+};
+
+type DeleteNotificationsResult = {
+    success: boolean;
+    deletedCount: number;
+    error?: string;
+};
+
+type NotificationsTableProps = {
+    deleteContext: NotificationDeleteContext;
+    deleteNotificationsAction: (
+        notificationIds: string[],
+        context: NotificationDeleteContext,
+    ) => Promise<DeleteNotificationsResult>;
+    notifications: NotificationTableRow[];
+    showAccountColumn: boolean;
+};
+
+function buildDeleteConfirmMessage(count: number) {
+    return count === 1
+        ? 'Da li ste sigurni da želite obrisati odabranu obavijest?'
+        : `Da li ste sigurni da želite obrisati ${count} odabrane obavijesti?`;
+}
+
+function getCreatedTimestampDistance(row: NotificationTableRow) {
+    return Math.abs(
+        new Date(row.createdAt).getTime() - new Date(row.timestamp).getTime(),
+    );
+}
+
+export function NotificationsTable({
+    deleteContext,
+    deleteNotificationsAction,
+    notifications,
+    showAccountColumn,
+}: NotificationsTableProps) {
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [isPending, startTransition] = useTransition();
+    const selectedCount = selectedIds.size;
+    const hasNotifications = notifications.length > 0;
+    const allSelected =
+        hasNotifications && selectedCount === notifications.length;
+    const headerChecked = allSelected
+        ? true
+        : selectedCount > 0
+          ? 'indeterminate'
+          : false;
+    const emptyStateColumnCount = showAccountColumn ? 9 : 8;
+
+    const selectedNotificationIds = useMemo(
+        () => notifications.map((notification) => notification.id),
+        [notifications],
+    );
+
+    useEffect(() => {
+        const visibleIds = new Set(selectedNotificationIds);
+        setSelectedIds((current) => {
+            const next = new Set<string>();
+            for (const id of current) {
+                if (visibleIds.has(id)) {
+                    next.add(id);
+                }
+            }
+            return next.size === current.size ? current : next;
+        });
+    }, [selectedNotificationIds]);
+
+    function setNotificationSelected(id: string, selected: boolean) {
+        setSelectedIds((current) => {
+            const next = new Set(current);
+            if (selected) {
+                next.add(id);
+            } else {
+                next.delete(id);
+            }
+            return next;
+        });
+    }
+
+    function setAllSelected(selected: boolean) {
+        setSelectedIds(selected ? new Set(selectedNotificationIds) : new Set());
+    }
+
+    function handleDelete(ids: string[]) {
+        if (ids.length === 0) {
+            return;
+        }
+
+        if (!confirm(buildDeleteConfirmMessage(ids.length))) {
+            return;
+        }
+
+        startTransition(async () => {
+            try {
+                const result = await deleteNotificationsAction(
+                    ids,
+                    deleteContext,
+                );
+                if (!result.success) {
+                    alert('Došlo je do greške pri brisanju obavijesti.');
+                    return;
+                }
+
+                setSelectedIds((current) => {
+                    const next = new Set(current);
+                    for (const id of ids) {
+                        next.delete(id);
+                    }
+                    return next;
+                });
+            } catch (error) {
+                console.error('Error deleting notifications:', error);
+                alert('Došlo je do greške pri brisanju obavijesti.');
+            }
+        });
+    }
+
+    return (
+        <Stack spacing={2}>
+            <Row justifyContent="space-between" className="px-4 pt-3">
+                <Typography level="body2">Odabrano: {selectedCount}</Typography>
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outlined"
+                    color="danger"
+                    startDecorator={<Delete className="size-4" />}
+                    disabled={selectedCount === 0 || isPending}
+                    loading={isPending}
+                    onClick={() => handleDelete(Array.from(selectedIds))}
+                >
+                    Obriši odabrane
+                </Button>
+            </Row>
+            <Table>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.Head className="w-12">
+                            <Checkbox
+                                aria-label="Odaberi sve obavijesti"
+                                checked={headerChecked}
+                                disabled={!hasNotifications || isPending}
+                                onCheckedChange={(checked) =>
+                                    setAllSelected(checked === true)
+                                }
+                            />
+                        </Table.Head>
+                        <Table.Head>Sadržaj</Table.Head>
+                        <Table.Head>Link</Table.Head>
+                        <Table.Head>Mjesto</Table.Head>
+                        {showAccountColumn && <Table.Head>Račun</Table.Head>}
+                        <Table.Head>Korisnik</Table.Head>
+                        <Table.Head>Pročitano</Table.Head>
+                        <Table.Head>Datum</Table.Head>
+                        <Table.Head>Akcije</Table.Head>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {!hasNotifications && (
+                        <Table.Row>
+                            <Table.Cell colSpan={emptyStateColumnCount}>
+                                <NoDataPlaceholder>
+                                    Nema obavjesti
+                                </NoDataPlaceholder>
+                            </Table.Cell>
+                        </Table.Row>
+                    )}
+                    {notifications.map((notification) => {
+                        const isSelected = selectedIds.has(notification.id);
+
+                        return (
+                            <Table.Row key={notification.id}>
+                                <Table.Cell>
+                                    <Checkbox
+                                        aria-label={`Odaberi obavijest ${notification.header}`}
+                                        checked={isSelected}
+                                        disabled={isPending}
+                                        onCheckedChange={(checked) =>
+                                            setNotificationSelected(
+                                                notification.id,
+                                                checked === true,
+                                            )
+                                        }
+                                    />
+                                </Table.Cell>
+                                <Table.Cell className="max-w-xs whitespace-pre-wrap">
+                                    <Row spacing={4}>
+                                        {notification.imageUrl && (
+                                            <div className="shrink-0 aspect-square">
+                                                <ImageViewer
+                                                    src={notification.imageUrl}
+                                                    alt={notification.header}
+                                                    previewWidth={80}
+                                                    previewHeight={80}
+                                                />
+                                            </div>
+                                        )}
+                                        <Stack>
+                                            <Typography level="body2" bold>
+                                                {notification.header}
+                                            </Typography>
+                                            <Markdown>
+                                                {notification.content}
+                                            </Markdown>
+                                        </Stack>
+                                    </Row>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    {notification.linkUrl ? (
+                                        <a
+                                            href={notification.linkUrl}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-primary underline"
+                                        >
+                                            Otvori
+                                        </a>
+                                    ) : (
+                                        '-'
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Stack>
+                                        {notification.gardenId && (
+                                            <Link
+                                                href={KnownPages.Garden(
+                                                    notification.gardenId,
+                                                )}
+                                                className="text-primary underline"
+                                            >
+                                                {notification.gardenName ??
+                                                    'N/A'}
+                                            </Link>
+                                        )}
+                                        {notification.raisedBedId && (
+                                            <RaisedBedLabel
+                                                physicalId={
+                                                    notification.raisedBedPhysicalId
+                                                }
+                                            />
+                                        )}
+                                        {notification.blockId && (
+                                            <span>
+                                                Blok: {notification.blockId}
+                                            </span>
+                                        )}
+                                    </Stack>
+                                </Table.Cell>
+                                {showAccountColumn && (
+                                    <Table.Cell>
+                                        {notification.accountId ? (
+                                            <Link
+                                                href={KnownPages.Account(
+                                                    notification.accountId,
+                                                )}
+                                                className="text-primary underline"
+                                            >
+                                                {notification.accountLabel ??
+                                                    notification.accountId}
+                                            </Link>
+                                        ) : (
+                                            '-'
+                                        )}
+                                    </Table.Cell>
+                                )}
+                                <Table.Cell>
+                                    {notification.userId ? (
+                                        <Link
+                                            href={KnownPages.User(
+                                                notification.userId,
+                                            )}
+                                            className="text-primary underline"
+                                        >
+                                            {notification.userId}
+                                        </Link>
+                                    ) : (
+                                        '-'
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Chip
+                                        color={
+                                            notification.readAt
+                                                ? 'success'
+                                                : 'neutral'
+                                        }
+                                        size="sm"
+                                        className="w-fit"
+                                    >
+                                        {notification.readAt
+                                            ? 'Pročitano'
+                                            : 'Nepročitano'}
+                                    </Chip>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Typography level="body3">
+                                        <LocalDateTime>
+                                            {notification.createdAt}
+                                        </LocalDateTime>
+                                    </Typography>
+                                    {getCreatedTimestampDistance(notification) >
+                                        1000 && (
+                                        <Typography level="body3">
+                                            <LocalDateTime>
+                                                {notification.timestamp}
+                                            </LocalDateTime>
+                                        </Typography>
+                                    )}
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <IconButton
+                                        type="button"
+                                        title="Obriši obavijest"
+                                        size="sm"
+                                        color="danger"
+                                        disabled={isPending}
+                                        onClick={() =>
+                                            handleDelete([notification.id])
+                                        }
+                                    >
+                                        <Delete className="size-5" />
+                                    </IconButton>
+                                </Table.Cell>
+                            </Table.Row>
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </Stack>
+    );
+}

--- a/apps/app/components/notifications/NotificationsTableCard.tsx
+++ b/apps/app/components/notifications/NotificationsTableCard.tsx
@@ -7,27 +7,18 @@ import {
     getNotificationsByUser,
 } from '@gredice/storage';
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
-import { Chip } from '@gredice/ui/Chip';
-import { ImageViewer } from '@gredice/ui/ImageViewer';
-import { Delete } from '@gredice/ui/icons';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
-import { Markdown } from '@gredice/ui/Markdown';
 import { Row } from '@gredice/ui/Row';
-import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
-import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
-import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import Link from 'next/link';
-import { KnownPages } from '../../src/KnownPages';
 import {
     scrollableTableCardClassName,
     scrollableTableCardOverflowClassName,
 } from '../admin/cards/tableCardLayout';
-import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
-import { ServerActionIconButton } from '../shared/ServerActionIconButton';
-import { deleteNotification } from './(actions)/notificationActions';
+import { deleteNotifications } from './(actions)/notificationActions';
 import { NotificationCreateModal } from './NotificationCreateModal';
+import {
+    NotificationsTable,
+    type NotificationTableRow,
+} from './NotificationsTable';
 
 type NotificationTableCardProps = {
     accountId?: string;
@@ -103,194 +94,48 @@ export async function NotificationsTableCard({
             return true;
         },
     );
-    const emptyStateColumnCount = showAccountColumn ? 8 : 7;
+
+    const gardenNames = new Map(
+        gardens.map((garden) => [garden.id, garden.name]),
+    );
+    const raisedBedPhysicalIds = new Map(
+        raisedBeds.map((raisedBed) => [raisedBed.id, raisedBed.physicalId]),
+    );
+    const tableRows: NotificationTableRow[] = filteredNotifications.map(
+        (notification) => ({
+            id: notification.id,
+            accountId: notification.accountId,
+            accountLabel: notification.accountId
+                ? accountLabels[notification.accountId] ||
+                  notification.accountId
+                : null,
+            blockId: notification.blockId,
+            content: notification.content,
+            createdAt: notification.createdAt.toISOString(),
+            gardenId: notification.gardenId,
+            gardenName: notification.gardenId
+                ? (gardenNames.get(notification.gardenId) ?? null)
+                : null,
+            header: notification.header,
+            imageUrl: notification.imageUrl,
+            linkUrl: notification.linkUrl,
+            raisedBedId: notification.raisedBedId,
+            raisedBedPhysicalId: notification.raisedBedId
+                ? (raisedBedPhysicalIds.get(notification.raisedBedId) ?? null)
+                : null,
+            readAt: notification.readAt?.toISOString() ?? null,
+            timestamp: notification.timestamp.toISOString(),
+            userId: notification.userId,
+        }),
+    );
 
     const tableContent = (
-        <Table>
-            <Table.Header>
-                <Table.Row>
-                    <Table.Head>Sadržaj</Table.Head>
-                    <Table.Head>Link</Table.Head>
-                    <Table.Head>Mjesto</Table.Head>
-                    {showAccountColumn && <Table.Head>Račun</Table.Head>}
-                    <Table.Head>Korisnik</Table.Head>
-                    <Table.Head>Pročitano</Table.Head>
-                    <Table.Head>Datum</Table.Head>
-                    <Table.Head>Akcije</Table.Head>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {filteredNotifications.length === 0 && (
-                    <Table.Row>
-                        <Table.Cell colSpan={emptyStateColumnCount}>
-                            <NoDataPlaceholder>
-                                Nema obavjesti
-                            </NoDataPlaceholder>
-                        </Table.Cell>
-                    </Table.Row>
-                )}
-                {filteredNotifications.map((notification) => {
-                    const notificationRaisedBed = notification.raisedBedId
-                        ? raisedBeds.find(
-                              (rb) => rb.id === notification.raisedBedId,
-                          )
-                        : null;
-
-                    return (
-                        <Table.Row key={notification.id}>
-                            <Table.Cell className="max-w-xs whitespace-pre-wrap">
-                                <Row spacing={4}>
-                                    {notification.imageUrl && (
-                                        <div className="shrink-0 aspect-square">
-                                            <ImageViewer
-                                                src={notification.imageUrl}
-                                                alt={notification.header}
-                                                previewWidth={80}
-                                                previewHeight={80}
-                                            />
-                                        </div>
-                                    )}
-                                    <Stack>
-                                        <Typography level="body2" bold>
-                                            {notification.header}
-                                        </Typography>
-                                        <Markdown>
-                                            {notification.content}
-                                        </Markdown>
-                                    </Stack>
-                                </Row>
-                            </Table.Cell>
-                            <Table.Cell>
-                                {notification.linkUrl ? (
-                                    <a
-                                        href={notification.linkUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="text-primary underline"
-                                    >
-                                        Otvori
-                                    </a>
-                                ) : (
-                                    '-'
-                                )}
-                            </Table.Cell>
-                            <Table.Cell>
-                                <Stack>
-                                    {notification.gardenId && (
-                                        <Link
-                                            href={KnownPages.Garden(
-                                                notification.gardenId,
-                                            )}
-                                            className="text-primary underline"
-                                        >
-                                            {gardens.find(
-                                                (garden) =>
-                                                    garden.id ===
-                                                    notification.gardenId,
-                                            )?.name ?? 'N/A'}
-                                        </Link>
-                                    )}
-                                    {notification.raisedBedId && (
-                                        <RaisedBedLabel
-                                            physicalId={
-                                                notificationRaisedBed?.physicalId ??
-                                                null
-                                            }
-                                        />
-                                    )}
-                                    {notification.blockId && (
-                                        <span>
-                                            Blok: {notification.blockId}
-                                        </span>
-                                    )}
-                                </Stack>
-                            </Table.Cell>
-                            {showAccountColumn && (
-                                <Table.Cell>
-                                    {notification.accountId ? (
-                                        <Link
-                                            href={KnownPages.Account(
-                                                notification.accountId,
-                                            )}
-                                            className="text-primary underline"
-                                        >
-                                            {accountLabels[
-                                                notification.accountId
-                                            ] || notification.accountId}
-                                        </Link>
-                                    ) : (
-                                        '-'
-                                    )}
-                                </Table.Cell>
-                            )}
-                            <Table.Cell>
-                                {notification.userId ? (
-                                    <Link
-                                        href={KnownPages.User(
-                                            notification.userId,
-                                        )}
-                                        className="text-primary underline"
-                                    >
-                                        {notification.userId}
-                                    </Link>
-                                ) : (
-                                    '-'
-                                )}
-                            </Table.Cell>
-                            <Table.Cell>
-                                <Chip
-                                    color={
-                                        notification.readAt
-                                            ? 'success'
-                                            : 'neutral'
-                                    }
-                                    size="sm"
-                                    className="w-fit"
-                                >
-                                    {notification.readAt
-                                        ? 'Pročitano'
-                                        : 'Nepročitano'}
-                                </Chip>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <Typography level="body3">
-                                    <LocalDateTime>
-                                        {notification.createdAt}
-                                    </LocalDateTime>
-                                </Typography>
-                                {Math.abs(
-                                    new Date(notification.createdAt).getTime() -
-                                        new Date(
-                                            notification.timestamp,
-                                        ).getTime(),
-                                ) > 1000 && (
-                                    <Typography level="body3">
-                                        <LocalDateTime>
-                                            {notification.timestamp}
-                                        </LocalDateTime>
-                                    </Typography>
-                                )}
-                            </Table.Cell>
-                            <Table.Cell>
-                                {accountId && (
-                                    <ServerActionIconButton
-                                        title="Obriši obavijest"
-                                        onClick={deleteNotification.bind(
-                                            null,
-                                            accountId,
-                                            null,
-                                            notification.id,
-                                        )}
-                                    >
-                                        <Delete className="size-5" />
-                                    </ServerActionIconButton>
-                                )}
-                            </Table.Cell>
-                        </Table.Row>
-                    );
-                })}
-            </Table.Body>
-        </Table>
+        <NotificationsTable
+            deleteContext={{ accountId, userId, gardenId, raisedBedId }}
+            deleteNotificationsAction={deleteNotifications}
+            notifications={tableRows}
+            showAccountColumn={showAccountColumn}
+        />
     );
 
     if (!showCard) {

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -1784,6 +1784,23 @@ export function deleteNotification(id: string) {
     return storage().delete(notifications).where(eq(notifications.id, id));
 }
 
+export function deleteNotifications(ids: string[]) {
+    if (ids.length === 0) {
+        return Promise.resolve([]);
+    }
+
+    return storage()
+        .delete(notifications)
+        .where(inArray(notifications.id, ids))
+        .returning({
+            id: notifications.id,
+            accountId: notifications.accountId,
+            userId: notifications.userId,
+            gardenId: notifications.gardenId,
+            raisedBedId: notifications.raisedBedId,
+        });
+}
+
 export async function notificationsDigest({
     markSent = true,
     targetHour,


### PR DESCRIPTION
## Summary
- Dodaje višestruki odabir u tablicu obavijesti u `apps/app`.
- Uvodi pojedinačno i bulk brisanje kroz admin server action, uz admin autentikaciju i revalidaciju pogođenih stranica.
- Premješta render tablice u client komponentu i zadržava dohvat podataka na serveru.

## Testing
- `pnpm build --filter app` uspješno prošao.
- Biome formatiranje/provjera prošli na izmijenjenim datotekama.
- Lokalni browser smoke je dosegnuo admin login gate; tablica nije bila dostupna bez autentikacije, ali nije bilo konzolnih grešaka.