### PR TITLE
GRE-187: Reschedule planned diary operations

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -4,6 +4,7 @@ import {
     RAISED_BED_ABANDON_OPERATION_ENTITY_ID,
     RAISED_BED_OPERATION_ENTITY_TYPE_NAME,
 } from '@gredice/js/raisedBeds';
+import { notifyOperationUpdate } from '@gredice/notifications';
 import { signalcoClient } from '@gredice/signalco';
 import {
     abandonRaisedBed,
@@ -20,6 +21,7 @@ import {
     deleteGardenStack,
     deleteSandboxGardenCompletely,
     GardenBoxInventoryLimitError,
+    GardenDiaryRescheduleError,
     getAccount,
     getAccountGardens,
     getEvents,
@@ -38,6 +40,8 @@ import {
     getSandboxGardenDeletionCandidate,
     knownEvents,
     knownEventTypes,
+    rescheduleGardenDiaryOperation,
+    rescheduleGardenDiaryRaisedBedField,
     sowSandboxField,
     spendSunflowers,
     storage,
@@ -47,7 +51,7 @@ import {
     updateGardenStack,
     updateRaisedBed,
 } from '@gredice/storage';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
@@ -106,6 +110,10 @@ const storeBlockInGardenBoxBodySchema = z.object({
     blockIndex: z.number().int().min(0),
 });
 
+const rescheduleDiaryItemBodySchema = z.object({
+    scheduledDate: z.string().trim().min(1),
+});
+
 function normalizeAnalysisImageUrls(body: AnalyzeImageBody) {
     const imageUrls = body.imageUrls?.length
         ? body.imageUrls
@@ -118,6 +126,20 @@ function normalizeAnalysisImageUrls(body: AnalyzeImageBody) {
 
 function getAnalysisReferenceDate(body: AnalyzeImageBody) {
     return normalizeAnalysisReferenceDate(body.referenceDate);
+}
+
+function diaryRescheduleErrorResponse(
+    context: Context,
+    error: GardenDiaryRescheduleError,
+) {
+    switch (error.statusCode) {
+        case 400:
+            return context.json({ error: error.message }, 400);
+        case 404:
+            return context.json({ error: error.message }, 404);
+        case 409:
+            return context.json({ error: error.message }, 409);
+    }
 }
 
 const aiTextStreamResponseInit = {
@@ -553,6 +575,65 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 nextCursor: operationsPage.nextCursor,
                 total: operationsPage.total,
             });
+        },
+    )
+    .post(
+        '/:gardenId/operations/:operationId/reschedule',
+        describeRoute({
+            description:
+                'Reschedule a planned in-game diary operation for the current user',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                operationId: z.string(),
+            }),
+        ),
+        zValidator('json', rescheduleDiaryItemBodySchema),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, operationId } = context.req.valid('param');
+            const { scheduledDate } = context.req.valid('json');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            const operationIdNumber = Number.parseInt(operationId, 10);
+
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+            if (Number.isNaN(operationIdNumber)) {
+                return context.json({ error: 'Invalid operation ID' }, 400);
+            }
+
+            const { accountId } = context.get('authContext');
+
+            try {
+                const result = await rescheduleGardenDiaryOperation({
+                    accountId,
+                    gardenId: gardenIdNumber,
+                    operationId: operationIdNumber,
+                    scheduledDate,
+                });
+
+                await notifyOperationUpdate(operationIdNumber, 'rescheduled', {
+                    scheduledDate: result.scheduledDate.toISOString(),
+                });
+
+                return context.json(
+                    { scheduledDate: result.scheduledDate.toISOString() },
+                    200,
+                );
+            } catch (error) {
+                if (error instanceof GardenDiaryRescheduleError) {
+                    return diaryRescheduleErrorResponse(context, error);
+                }
+
+                console.error('Error rescheduling diary operation:', error);
+                return context.json(
+                    { error: 'Failed to reschedule operation' },
+                    500,
+                );
+            }
         },
     )
     .get(
@@ -2503,6 +2584,71 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 type,
                 values: history.data?.values || [],
             });
+        },
+    )
+    .post(
+        '/:gardenId/raised-beds/:raisedBedId/fields/:positionIndex/reschedule',
+        describeRoute({
+            description:
+                'Reschedule a planned in-game diary raised-bed field sowing for the current user',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                raisedBedId: z.string(),
+                positionIndex: z.string(),
+            }),
+        ),
+        zValidator('json', rescheduleDiaryItemBodySchema),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, raisedBedId, positionIndex } =
+                context.req.valid('param');
+            const { scheduledDate } = context.req.valid('json');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            const raisedBedIdNumber = Number.parseInt(raisedBedId, 10);
+            const positionIndexNumber = Number.parseInt(positionIndex, 10);
+
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+            if (Number.isNaN(raisedBedIdNumber)) {
+                return context.json({ error: 'Invalid raised bed ID' }, 400);
+            }
+            if (Number.isNaN(positionIndexNumber) || positionIndexNumber < 0) {
+                return context.json({ error: 'Invalid position index' }, 400);
+            }
+
+            const { accountId } = context.get('authContext');
+
+            try {
+                const result = await rescheduleGardenDiaryRaisedBedField({
+                    accountId,
+                    gardenId: gardenIdNumber,
+                    raisedBedId: raisedBedIdNumber,
+                    positionIndex: positionIndexNumber,
+                    scheduledDate,
+                });
+
+                return context.json(
+                    { scheduledDate: result.scheduledDate.toISOString() },
+                    200,
+                );
+            } catch (error) {
+                if (error instanceof GardenDiaryRescheduleError) {
+                    return diaryRescheduleErrorResponse(context, error);
+                }
+
+                console.error(
+                    'Error rescheduling diary raised bed field:',
+                    error,
+                );
+                return context.json(
+                    { error: 'Failed to reschedule raised bed field' },
+                    500,
+                );
+            }
         },
     )
     .patch(

--- a/apps/garden/tests/RaisedBedDiaryStory.tsx
+++ b/apps/garden/tests/RaisedBedDiaryStory.tsx
@@ -15,6 +15,13 @@ type DiaryEntry = {
     timestamp: Date;
     imageUrls?: string[] | null;
     isMarkdown?: boolean;
+    rescheduleTarget?: {
+        type: 'operation';
+        operationId: number;
+        raisedBedId: number;
+        raisedBedFieldId: number | null;
+        scheduledDate: string;
+    };
 };
 
 const singleImageUrls = ['/web-app-manifest-192x192.png'];
@@ -28,14 +35,32 @@ const imageUrls = [
 const longWord =
     'SuperdugacakNazivDnevnickogUnosaBezRazmakaKojiMoraOstatiUnutarListe';
 
+function todayUtcIso() {
+    const today = new Date();
+    return new Date(
+        Date.UTC(
+            today.getUTCFullYear(),
+            today.getUTCMonth(),
+            today.getUTCDate(),
+        ),
+    ).toISOString();
+}
+
 const diaryEntries: DiaryEntry[] = [
     {
         id: 1,
         name: `${longWord} 1`,
         description: `${longWord} with a long description and enough words to wrap inside a narrow mobile raised bed diary card.`,
         status: 'Planirano',
-        timestamp: new Date('2026-05-13T12:00:00.000Z'),
+        timestamp: new Date('2040-01-05T00:00:00.000Z'),
         imageUrls: singleImageUrls,
+        rescheduleTarget: {
+            type: 'operation',
+            operationId: 1,
+            raisedBedId: TEST_RAISED_BED_ID,
+            raisedBedFieldId: null,
+            scheduledDate: '2040-01-05T00:00:00.000Z',
+        },
     },
     {
         id: 2,
@@ -52,8 +77,15 @@ const diaryEntries: DiaryEntry[] = [
         name: 'Watering and checkup',
         description:
             'Shorter entry without images keeps the same row constraints.',
-        status: 'Novo',
-        timestamp: new Date('2026-05-11T12:00:00.000Z'),
+        status: 'Planirano',
+        timestamp: new Date(todayUtcIso()),
+        rescheduleTarget: {
+            type: 'operation',
+            operationId: 3,
+            raisedBedId: TEST_RAISED_BED_ID,
+            raisedBedFieldId: null,
+            scheduledDate: todayUtcIso(),
+        },
     },
 ];
 

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Locator } from '@playwright/test';
+import { getMinimumDiaryRescheduleDateInput } from '../../../packages/game/src/hooks/useRescheduleDiaryEntry';
 import { RaisedBedDiaryOverflowStory } from './RaisedBedDiaryStory';
 
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
@@ -68,4 +69,26 @@ test('single-image diary entries keep text close to the thumbnail', async ({
     const textGap = (contentBox?.x ?? 0) - imageRight;
 
     expect(textGap).toBeLessThanOrEqual(24);
+});
+
+test('future planned diary entries expose the in-game reschedule action', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const rescheduleButtons = page.getByRole('button', {
+        name: 'Prerasporedi',
+    });
+    await expect(rescheduleButtons).toHaveCount(1);
+
+    await rescheduleButtons.first().click();
+
+    const dateInput = page.getByLabel('Novi datum');
+    await expect(dateInput).toBeVisible();
+    await expect(dateInput).toHaveAttribute(
+        'min',
+        getMinimumDiaryRescheduleDateInput(),
+    );
 });

--- a/packages/game/src/hooks/useRescheduleDiaryEntry.ts
+++ b/packages/game/src/hooks/useRescheduleDiaryEntry.ts
@@ -1,0 +1,212 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGardensKeys } from './useGardens';
+import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
+import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
+
+export type DiaryRescheduleTarget =
+    | {
+          type: 'operation';
+          operationId: number;
+          raisedBedId: number | null;
+          raisedBedFieldId: number | null;
+          positionIndex?: number;
+          scheduledDate: string;
+      }
+    | {
+          type: 'raisedBedFieldPlant';
+          raisedBedId: number;
+          positionIndex: number;
+          scheduledDate: string;
+      };
+
+const mutationKey = ['gardens', 'diary', 'reschedule'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+async function getResponseErrorMessage(response: Response) {
+    const fallbackMessage = 'Preraspoređivanje nije uspjelo.';
+    const text = await response.text();
+    if (!text.trim()) {
+        return fallbackMessage;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(text);
+        if (
+            isRecord(parsed) &&
+            typeof parsed.error === 'string' &&
+            parsed.error.trim()
+        ) {
+            return parsed.error;
+        }
+    } catch {
+        return text;
+    }
+
+    return fallbackMessage;
+}
+
+function startOfUtcDay(date: Date) {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+}
+
+function getMinimumRescheduleDate(referenceDate = new Date()) {
+    const tomorrow = startOfUtcDay(referenceDate);
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    return tomorrow;
+}
+
+export function formatDiaryRescheduleDateInput(date: Date) {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+export function getMinimumDiaryRescheduleDateInput(referenceDate = new Date()) {
+    return formatDiaryRescheduleDateInput(
+        getMinimumRescheduleDate(referenceDate),
+    );
+}
+
+export function isDiaryRescheduleTargetEligible(
+    target: DiaryRescheduleTarget | undefined,
+    referenceDate = new Date(),
+): target is DiaryRescheduleTarget {
+    if (!target) {
+        return false;
+    }
+
+    const scheduledDate = new Date(target.scheduledDate);
+    if (Number.isNaN(scheduledDate.getTime())) {
+        return false;
+    }
+
+    return (
+        startOfUtcDay(scheduledDate).getTime() >=
+        getMinimumRescheduleDate(referenceDate).getTime()
+    );
+}
+
+async function rescheduleOperation({
+    gardenId,
+    scheduledDate,
+    target,
+}: {
+    gardenId: number;
+    scheduledDate: string;
+    target: Extract<DiaryRescheduleTarget, { type: 'operation' }>;
+}) {
+    const response = await clientAuthenticated().api.gardens[
+        ':gardenId'
+    ].operations[':operationId'].reschedule.$post({
+        param: {
+            gardenId: gardenId.toString(),
+            operationId: target.operationId.toString(),
+        },
+        json: {
+            scheduledDate,
+        },
+    });
+
+    if (response.status !== 200) {
+        throw new Error(await getResponseErrorMessage(response));
+    }
+}
+
+async function rescheduleRaisedBedFieldPlant({
+    gardenId,
+    scheduledDate,
+    target,
+}: {
+    gardenId: number;
+    scheduledDate: string;
+    target: Extract<DiaryRescheduleTarget, { type: 'raisedBedFieldPlant' }>;
+}) {
+    const response = await clientAuthenticated().api.gardens[':gardenId'][
+        'raised-beds'
+    ][':raisedBedId'].fields[':positionIndex'].reschedule.$post({
+        param: {
+            gardenId: gardenId.toString(),
+            raisedBedId: target.raisedBedId.toString(),
+            positionIndex: target.positionIndex.toString(),
+        },
+        json: {
+            scheduledDate,
+        },
+    });
+
+    if (response.status !== 200) {
+        throw new Error(await getResponseErrorMessage(response));
+    }
+}
+
+export function useRescheduleDiaryEntry(gardenId: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationKey,
+        mutationFn: ({
+            scheduledDate,
+            target,
+        }: {
+            scheduledDate: string;
+            target: DiaryRescheduleTarget;
+        }) => {
+            if (target.type === 'operation') {
+                return rescheduleOperation({
+                    gardenId,
+                    scheduledDate,
+                    target,
+                });
+            }
+
+            return rescheduleRaisedBedFieldPlant({
+                gardenId,
+                scheduledDate,
+                target,
+            });
+        },
+        onSuccess: async (_data, { target }) => {
+            if (target.raisedBedId) {
+                await queryClient.invalidateQueries({
+                    queryKey: raisedBedDiaryQueryKeys.byId(target.raisedBedId),
+                });
+            }
+
+            if (target.type === 'raisedBedFieldPlant') {
+                await queryClient.invalidateQueries({
+                    queryKey: raisedBedFieldDiaryQueryKeys.byId(
+                        target.raisedBedId,
+                        target.positionIndex,
+                    ),
+                });
+            }
+
+            if (
+                target.type === 'operation' &&
+                target.raisedBedId &&
+                typeof target.positionIndex === 'number'
+            ) {
+                await queryClient.invalidateQueries({
+                    queryKey: raisedBedFieldDiaryQueryKeys.byId(
+                        target.raisedBedId,
+                        target.positionIndex,
+                    ),
+                });
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: ['garden-operations', gardenId],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: useGardensKeys,
+            });
+        },
+    });
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -15,7 +15,12 @@ import ReactMarkdown from 'react-markdown';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
 import { useRaisedBedFieldDiaryEntries } from '../../hooks/useRaisedBedFieldDiaryEntries';
+import {
+    type DiaryRescheduleTarget,
+    isDiaryRescheduleTargetEligible,
+} from '../../hooks/useRescheduleDiaryEntry';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
+import { RaisedBedDiaryRescheduleAction } from './RaisedBedDiaryRescheduleAction';
 
 type DiaryEntry = {
     id: number;
@@ -25,6 +30,7 @@ type DiaryEntry = {
     timestamp: Date;
     imageUrls?: string[] | null;
     isMarkdown?: boolean;
+    rescheduleTarget?: DiaryRescheduleTarget;
 };
 
 type DiaryEntryAiHistory = {
@@ -116,6 +122,38 @@ function DiaryEntryImages({
 
 function diaryEntryImagesClassName(imageUrls?: string[] | null) {
     return cx('w-20 shrink-0', (imageUrls?.length ?? 0) > 1 && 'sm:w-44');
+}
+
+function diaryEntryActions({
+    aiAction,
+    entry,
+    gardenId,
+}: {
+    aiAction?: ReactNode;
+    entry: DiaryEntry;
+    gardenId: number;
+}) {
+    const rescheduleTarget = entry.rescheduleTarget;
+    const rescheduleAction = isDiaryRescheduleTargetEligible(
+        rescheduleTarget,
+    ) ? (
+        <RaisedBedDiaryRescheduleAction
+            entryName={entry.name}
+            gardenId={gardenId}
+            target={rescheduleTarget}
+        />
+    ) : null;
+
+    if (!aiAction && !rescheduleAction) {
+        return null;
+    }
+
+    return (
+        <Row spacing={2} className="flex-wrap items-center">
+            {rescheduleAction}
+            {aiAction}
+        </Row>
+    );
 }
 
 function DiaryList({
@@ -379,23 +417,32 @@ export function RaisedBedFieldDiary({
     const renderEntryAction =
         flags.raisedBedImageAI && !disableActions
             ? (entry: DiaryEntry, aiHistory?: DiaryEntryAiHistory) => {
-                  if (!entry.imageUrls?.length || entry.isMarkdown) {
-                      return null;
-                  }
+                  const aiAction =
+                      entry.imageUrls?.length && !entry.isMarkdown ? (
+                          <RaisedBedDiaryAiAction
+                              gardenId={gardenId}
+                              raisedBedId={raisedBedId}
+                              positionIndex={positionIndex}
+                              entryName={entry.name}
+                              imageUrls={entry.imageUrls}
+                              referenceDate={entry.timestamp}
+                              historyEntries={aiHistory?.entries}
+                          />
+                      ) : undefined;
 
-                  return (
-                      <RaisedBedDiaryAiAction
-                          gardenId={gardenId}
-                          raisedBedId={raisedBedId}
-                          positionIndex={positionIndex}
-                          entryName={entry.name}
-                          imageUrls={entry.imageUrls}
-                          referenceDate={entry.timestamp}
-                          historyEntries={aiHistory?.entries}
-                      />
-                  );
+                  return diaryEntryActions({
+                      aiAction,
+                      entry,
+                      gardenId,
+                  });
               }
-            : undefined;
+            : !disableActions
+              ? (entry: DiaryEntry) =>
+                    diaryEntryActions({
+                        entry,
+                        gardenId,
+                    })
+              : undefined;
 
     return (
         <DiaryList
@@ -422,22 +469,29 @@ export function RaisedBedDiary({
     const flags = useGameFlags();
     const renderEntryAction = flags.raisedBedImageAI
         ? (entry: DiaryEntry, aiHistory?: DiaryEntryAiHistory) => {
-              if (!entry.imageUrls?.length || entry.isMarkdown) {
-                  return null;
-              }
+              const aiAction =
+                  entry.imageUrls?.length && !entry.isMarkdown ? (
+                      <RaisedBedDiaryAiAction
+                          gardenId={gardenId}
+                          raisedBedId={raisedBedId}
+                          entryName={entry.name}
+                          imageUrls={entry.imageUrls}
+                          referenceDate={entry.timestamp}
+                          historyEntries={aiHistory?.entries}
+                      />
+                  ) : undefined;
 
-              return (
-                  <RaisedBedDiaryAiAction
-                      gardenId={gardenId}
-                      raisedBedId={raisedBedId}
-                      entryName={entry.name}
-                      imageUrls={entry.imageUrls}
-                      referenceDate={entry.timestamp}
-                      historyEntries={aiHistory?.entries}
-                  />
-              );
+              return diaryEntryActions({
+                  aiAction,
+                  entry,
+                  gardenId,
+              });
           }
-        : undefined;
+        : (entry: DiaryEntry) =>
+              diaryEntryActions({
+                  entry,
+                  gardenId,
+              });
 
     return (
         <DiaryList

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -1,0 +1,135 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Input } from '@gredice/ui/Input';
+import { Calendar } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { type FormEvent, useState } from 'react';
+import {
+    type DiaryRescheduleTarget,
+    formatDiaryRescheduleDateInput,
+    getMinimumDiaryRescheduleDateInput,
+    useRescheduleDiaryEntry,
+} from '../../hooks/useRescheduleDiaryEntry';
+
+export function RaisedBedDiaryRescheduleAction({
+    entryName,
+    gardenId,
+    target,
+}: {
+    entryName: string;
+    gardenId: number;
+    target: DiaryRescheduleTarget;
+}) {
+    const [open, setOpen] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const mutation = useRescheduleDiaryEntry(gardenId);
+    const minimumDate = getMinimumDiaryRescheduleDateInput();
+    const defaultDate = formatDiaryRescheduleDateInput(
+        new Date(target.scheduledDate),
+    );
+    const currentValue = defaultDate >= minimumDate ? defaultDate : minimumDate;
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setErrorMessage(null);
+
+        const formData = new FormData(event.currentTarget);
+        const scheduledDate = formData.get('scheduledDate');
+        if (typeof scheduledDate !== 'string' || !scheduledDate) {
+            setErrorMessage('Odaberi novi datum.');
+            return;
+        }
+
+        try {
+            await mutation.mutateAsync({
+                scheduledDate,
+                target,
+            });
+            setOpen(false);
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : 'Preraspoređivanje nije uspjelo.',
+            );
+        }
+    }
+
+    return (
+        <Modal
+            title={`Prerasporedi ${entryName}`}
+            open={open}
+            onOpenChange={(nextOpen) => {
+                setOpen(nextOpen);
+                if (!nextOpen) {
+                    setErrorMessage(null);
+                }
+            }}
+            trigger={
+                <Button
+                    type="button"
+                    size="xs"
+                    variant="soft"
+                    startDecorator={<Calendar className="size-3.5 shrink-0" />}
+                >
+                    Prerasporedi
+                </Button>
+            }
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack spacing={4}>
+                    <Stack spacing={1}>
+                        <Typography level="h5">Prerasporedi</Typography>
+                        <Typography level="body2" secondary>
+                            Odaberi novi datum za {entryName}.
+                        </Typography>
+                    </Stack>
+
+                    {errorMessage ? (
+                        <Alert color="danger">
+                            <Typography level="body2">
+                                {errorMessage}
+                            </Typography>
+                        </Alert>
+                    ) : null}
+
+                    <Input
+                        type="date"
+                        label="Novi datum"
+                        name="scheduledDate"
+                        defaultValue={currentValue}
+                        min={minimumDate}
+                        disabled={mutation.isPending}
+                        fullWidth
+                        required
+                    />
+
+                    <Row spacing={2} className="justify-end">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={mutation.isPending}
+                            onClick={() => setOpen(false)}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={mutation.isPending}
+                            disabled={mutation.isPending}
+                            startDecorator={
+                                <Calendar className="size-4 shrink-0" />
+                            }
+                        >
+                            Spremi
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -38,6 +38,7 @@ export * from './repositories/eventsRepo';
 export * from './repositories/farmsRepo';
 export * from './repositories/feedbacksRepo';
 export * from './repositories/fiscalizationRepo';
+export * from './repositories/gardenDiaryRescheduleRepo';
 export * from './repositories/gardensRepo';
 export * from './repositories/inventoryManagementRepo';
 export * from './repositories/inventoryRepo';

--- a/packages/storage/src/repositories/gardenDiaryRescheduleRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryRescheduleRepo.ts
@@ -1,0 +1,225 @@
+import { isRaisedBedAbandoned } from '@gredice/js/raisedBeds';
+import { createEvent, knownEvents } from './eventsRepo';
+import { getRaisedBed } from './gardensRepo';
+import { getOperationsByIds } from './operationsRepo';
+
+export type GardenDiaryRescheduleStatusCode = 400 | 404 | 409;
+
+export class GardenDiaryRescheduleError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: GardenDiaryRescheduleStatusCode,
+    ) {
+        super(message);
+        this.name = 'GardenDiaryRescheduleError';
+    }
+}
+
+const reschedulableFieldPlantStatuses = new Set(['new', 'planned']);
+
+export function startOfUtcDay(date: Date) {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+}
+
+export function getMinimumDiaryRescheduleDate(referenceDate = new Date()) {
+    const tomorrow = startOfUtcDay(referenceDate);
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    return tomorrow;
+}
+
+export function isDiaryRescheduleDateAllowed(
+    scheduledDate: Date,
+    referenceDate = new Date(),
+) {
+    return (
+        startOfUtcDay(scheduledDate).getTime() >=
+        getMinimumDiaryRescheduleDate(referenceDate).getTime()
+    );
+}
+
+export function normalizeDiaryRescheduleDate(
+    scheduledDate: string,
+    referenceDate = new Date(),
+) {
+    const parsedDate = new Date(scheduledDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+        throw new GardenDiaryRescheduleError('Invalid scheduled date.', 400);
+    }
+
+    const normalizedDate = startOfUtcDay(parsedDate);
+    if (!isDiaryRescheduleDateAllowed(normalizedDate, referenceDate)) {
+        throw new GardenDiaryRescheduleError(
+            'Scheduled date must be tomorrow or later.',
+            400,
+        );
+    }
+
+    return normalizedDate;
+}
+
+export function isReschedulableFieldPlantStatus(status?: string | null) {
+    return !status || reschedulableFieldPlantStatuses.has(status);
+}
+
+function assertExistingScheduledDateCanMove(
+    scheduledDate: Date | undefined,
+    referenceDate: Date,
+) {
+    if (!scheduledDate) {
+        throw new GardenDiaryRescheduleError(
+            'Only scheduled planned items can be rescheduled.',
+            409,
+        );
+    }
+
+    if (!isDiaryRescheduleDateAllowed(scheduledDate, referenceDate)) {
+        throw new GardenDiaryRescheduleError(
+            'Items scheduled for today or earlier cannot be rescheduled.',
+            409,
+        );
+    }
+}
+
+async function operationBelongsToGarden({
+    accountId,
+    gardenId,
+    operation,
+}: {
+    accountId: string;
+    gardenId: number;
+    operation: Awaited<ReturnType<typeof getOperationsByIds>>[number];
+}) {
+    if (operation.accountId !== accountId) {
+        return false;
+    }
+
+    if (operation.gardenId === gardenId && !operation.raisedBedId) {
+        return true;
+    }
+
+    if (!operation.raisedBedId) {
+        return operation.gardenId === gardenId;
+    }
+
+    const raisedBed = await getRaisedBed(operation.raisedBedId);
+    return (
+        Boolean(raisedBed) &&
+        raisedBed?.accountId === accountId &&
+        raisedBed.gardenId === gardenId
+    );
+}
+
+export async function rescheduleGardenDiaryOperation({
+    accountId,
+    gardenId,
+    operationId,
+    scheduledDate,
+    referenceDate = new Date(),
+}: {
+    accountId: string;
+    gardenId: number;
+    operationId: number;
+    scheduledDate: string;
+    referenceDate?: Date;
+}) {
+    const [operation] = await getOperationsByIds([operationId]);
+    if (
+        !operation ||
+        !(await operationBelongsToGarden({ accountId, gardenId, operation }))
+    ) {
+        throw new GardenDiaryRescheduleError('Operation not found.', 404);
+    }
+
+    if (operation.status !== 'planned') {
+        throw new GardenDiaryRescheduleError(
+            'Only planned operations can be rescheduled.',
+            409,
+        );
+    }
+
+    assertExistingScheduledDateCanMove(operation.scheduledDate, referenceDate);
+
+    const normalizedDate = normalizeDiaryRescheduleDate(
+        scheduledDate,
+        referenceDate,
+    );
+
+    await createEvent(
+        knownEvents.operations.scheduledV1(operationId.toString(), {
+            scheduledDate: normalizedDate.toISOString(),
+        }),
+    );
+
+    return {
+        operationId,
+        scheduledDate: normalizedDate,
+    };
+}
+
+export async function rescheduleGardenDiaryRaisedBedField({
+    accountId,
+    gardenId,
+    raisedBedId,
+    positionIndex,
+    scheduledDate,
+    referenceDate = new Date(),
+}: {
+    accountId: string;
+    gardenId: number;
+    raisedBedId: number;
+    positionIndex: number;
+    scheduledDate: string;
+    referenceDate?: Date;
+}) {
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (
+        !raisedBed ||
+        raisedBed.accountId !== accountId ||
+        raisedBed.gardenId !== gardenId
+    ) {
+        throw new GardenDiaryRescheduleError('Raised bed not found.', 404);
+    }
+
+    if (isRaisedBedAbandoned(raisedBed.status)) {
+        throw new GardenDiaryRescheduleError('Raised bed is abandoned.', 409);
+    }
+
+    const field = raisedBed.fields.find(
+        (candidate) =>
+            candidate.positionIndex === positionIndex && candidate.active,
+    );
+    if (!field?.plantSortId) {
+        throw new GardenDiaryRescheduleError('Plant field not found.', 404);
+    }
+
+    if (!isReschedulableFieldPlantStatus(field.plantStatus)) {
+        throw new GardenDiaryRescheduleError(
+            'Only planned plant fields can be rescheduled.',
+            409,
+        );
+    }
+
+    assertExistingScheduledDateCanMove(field.plantScheduledDate, referenceDate);
+
+    const normalizedDate = normalizeDiaryRescheduleDate(
+        scheduledDate,
+        referenceDate,
+    );
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantScheduleV1(
+            `${raisedBedId.toString()}|${positionIndex.toString()}`,
+            {
+                scheduledDate: normalizedDate.toISOString(),
+            },
+        ),
+    );
+
+    return {
+        positionIndex,
+        raisedBedId,
+        scheduledDate: normalizedDate,
+    };
+}

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -2831,6 +2831,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
             status: operationStatusToLabel(op.status),
             timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
             imageUrls: op.imageUrls,
+            rescheduleTarget: operationDiaryRescheduleTarget(op),
         }))
         .filter((op) => op.name)
         .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
@@ -3319,19 +3320,107 @@ export async function getRaisedBedFieldDiaryEntries(
             status: operationStatusToLabel(op.status),
             timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
             imageUrls: op.imageUrls,
+            rescheduleTarget: operationDiaryRescheduleTarget(op, positionIndex),
         }))
         .filter((op) => op.name)
         .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
 
-    return [...raisedBedsEventDiaryEntries, ...operationsDiaryEntries].sort(
-        (a, b) => {
-            const aTime =
-                a.timestamp instanceof Date ? a.timestamp.getTime() : 0;
-            const bTime =
-                b.timestamp instanceof Date ? b.timestamp.getTime() : 0;
-            return bTime - aTime;
-        },
+    const plannedFieldDiaryEntry = fieldPlantDiaryEntry(
+        raisedBedId,
+        positionIndex,
+        fields,
     );
+
+    return [
+        ...raisedBedsEventDiaryEntries,
+        ...operationsDiaryEntries,
+        ...(plannedFieldDiaryEntry ? [plannedFieldDiaryEntry] : []),
+    ].sort((a, b) => {
+        const aTime = a.timestamp instanceof Date ? a.timestamp.getTime() : 0;
+        const bTime = b.timestamp instanceof Date ? b.timestamp.getTime() : 0;
+        return bTime - aTime;
+    });
+}
+
+type DiaryRescheduleTarget =
+    | {
+          type: 'operation';
+          operationId: number;
+          raisedBedId: number | null;
+          raisedBedFieldId: number | null;
+          positionIndex?: number;
+          scheduledDate: string;
+      }
+    | {
+          type: 'raisedBedFieldPlant';
+          raisedBedId: number;
+          positionIndex: number;
+          scheduledDate: string;
+      };
+
+type DiaryOperation = Awaited<ReturnType<typeof getOperations>>[number];
+type RaisedBedFieldWithEvents = Awaited<
+    ReturnType<typeof getRaisedBedFieldsWithEvents>
+>[number];
+
+const fieldPlantRescheduleStatuses = new Set(['new', 'planned']);
+
+function operationDiaryRescheduleTarget(
+    operation: DiaryOperation,
+    positionIndex?: number,
+): DiaryRescheduleTarget | undefined {
+    if (operation.status !== 'planned' || !operation.scheduledDate) {
+        return undefined;
+    }
+
+    return {
+        type: 'operation',
+        operationId: operation.id,
+        raisedBedId: operation.raisedBedId,
+        raisedBedFieldId: operation.raisedBedFieldId,
+        ...(positionIndex !== undefined ? { positionIndex } : {}),
+        scheduledDate: operation.scheduledDate.toISOString(),
+    };
+}
+
+function isPlannedFieldPlant(field: RaisedBedFieldWithEvents) {
+    return (
+        field.active &&
+        Boolean(field.plantSortId) &&
+        Boolean(field.plantScheduledDate) &&
+        (!field.plantStatus ||
+            fieldPlantRescheduleStatuses.has(field.plantStatus))
+    );
+}
+
+function fieldPlantDiaryEntry(
+    raisedBedId: number,
+    positionIndex: number,
+    fields: RaisedBedFieldWithEvents[],
+) {
+    const field = fields.find(
+        (candidate) =>
+            candidate.positionIndex === positionIndex &&
+            isPlannedFieldPlant(candidate),
+    );
+    if (!field?.plantScheduledDate) {
+        return null;
+    }
+
+    return {
+        id: -field.id,
+        name: 'Planirano sijanje',
+        description: 'Sijanje biljke je planirano za odabrani datum.',
+        status: 'Planirano',
+        timestamp: field.plantScheduledDate,
+        imageUrls: undefined,
+        rescheduleTarget: {
+            type: 'raisedBedFieldPlant',
+            raisedBedId,
+            positionIndex,
+            scheduledDate: field.plantScheduledDate.toISOString(),
+        } satisfies DiaryRescheduleTarget,
+    };
 }
 
 export async function getRaisedBedAiHistoryEntries(raisedBedId: number) {

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createAccount,
+    createEvent,
+    createOperation,
+    GardenDiaryRescheduleError,
+    getOperationById,
+    getRaisedBed,
+    getRaisedBedDiaryEntries,
+    getRaisedBedFieldDiaryEntries,
+    knownEvents,
+    rescheduleGardenDiaryOperation,
+    rescheduleGardenDiaryRaisedBedField,
+    upsertRaisedBedField,
+} from '@gredice/storage';
+import {
+    createTestBlock,
+    createTestGarden,
+    createTestRaisedBed,
+    ensureFarmId,
+} from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+async function createDiaryRescheduleContext() {
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'diary-reschedule-block');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    return {
+        accountId,
+        gardenId,
+        raisedBedId,
+    };
+}
+
+async function createScheduledOperation({
+    accountId,
+    gardenId,
+    raisedBedId,
+    scheduledDate,
+}: {
+    accountId: string;
+    gardenId: number;
+    raisedBedId: number;
+    scheduledDate: string;
+}) {
+    const operationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+
+    await createEvent(
+        knownEvents.operations.scheduledV1(operationId.toString(), {
+            scheduledDate,
+        }),
+    );
+
+    return operationId;
+}
+
+async function createScheduledField({
+    raisedBedId,
+    positionIndex,
+    scheduledDate,
+}: {
+    raisedBedId: number;
+    positionIndex: number;
+    scheduledDate: string;
+}) {
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex,
+    });
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|${positionIndex.toString()}`,
+            {
+                plantSortId: '101',
+                scheduledDate,
+            },
+        ),
+    );
+}
+
+test('rescheduleGardenDiaryOperation moves planned future operations', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await rescheduleGardenDiaryOperation({
+        accountId,
+        gardenId,
+        operationId,
+        scheduledDate: '2026-06-05',
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const operation = await getOperationById(operationId);
+    assert.equal(
+        operation.scheduledDate?.toISOString(),
+        '2026-06-05T00:00:00.000Z',
+    );
+});
+
+test('rescheduleGardenDiaryOperation rejects items scheduled for today', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-03T00:00:00.000Z',
+    });
+
+    await assert.rejects(
+        () =>
+            rescheduleGardenDiaryOperation({
+                accountId,
+                gardenId,
+                operationId,
+                scheduledDate: '2026-06-04',
+                referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+            }),
+        (error) =>
+            error instanceof GardenDiaryRescheduleError &&
+            error.statusCode === 409,
+    );
+});
+
+test('rescheduleGardenDiaryRaisedBedField moves planned future sowing', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    await createScheduledField({
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await rescheduleGardenDiaryRaisedBedField({
+        accountId,
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-06',
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.equal(
+        field?.plantScheduledDate?.toISOString(),
+        '2026-06-06T00:00:00.000Z',
+    );
+});
+
+test('rescheduleGardenDiaryRaisedBedField rejects today as the new date', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    await createScheduledField({
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await assert.rejects(
+        () =>
+            rescheduleGardenDiaryRaisedBedField({
+                accountId,
+                gardenId,
+                raisedBedId,
+                positionIndex: 0,
+                scheduledDate: '2026-06-03',
+                referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+            }),
+        (error) =>
+            error instanceof GardenDiaryRescheduleError &&
+            error.statusCode === 400,
+    );
+});
+
+test('diary entries expose operation and field reschedule targets', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+    await createScheduledField({
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-05T00:00:00.000Z',
+    });
+
+    const raisedBedEntries = await getRaisedBedDiaryEntries(raisedBedId);
+    const operationEntry = raisedBedEntries.find(
+        (entry) => entry.id === operationId,
+    );
+    assert.deepEqual(operationEntry?.rescheduleTarget, {
+        type: 'operation',
+        operationId,
+        raisedBedId,
+        raisedBedFieldId: null,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    const fieldEntries = await getRaisedBedFieldDiaryEntries(raisedBedId, 0);
+    const plannedFieldEntry = fieldEntries.find(
+        (entry) => entry.name === 'Planirano sijanje',
+    );
+    assert.deepEqual(plannedFieldEntry?.rescheduleTarget, {
+        type: 'raisedBedFieldPlant',
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-05T00:00:00.000Z',
+    });
+});


### PR DESCRIPTION
## Summary

- Add user-facing in-game diary rescheduling for planned operations and planned field sowing entries.
- Add API endpoints and storage repository logic to move eligible planned work to a new date.
- Expose reschedule targets in raised bed and field diary responses, with UI affordance only for items scheduled tomorrow or later.
- Add focused storage and garden component tests for the eligibility and modal behavior.

## Linear

https://linear.app/gredice/issue/GRE-187/diary-reschedule-planned-operation-or-plant-field

## Validation

- `pnpm --filter @gredice/game exec biome check src/hooks/useRescheduleDiaryEntry.ts src/hud/raisedBed/RaisedBedDiary.tsx src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx`
- `pnpm --filter @gredice/storage exec biome check src/repositories/gardenDiaryRescheduleRepo.ts src/repositories/gardensRepo.ts src/index.ts tests/gardenDiaryRescheduleRepo.node.spec.ts`
- `pnpm --filter api exec biome check 'app/api/[...route]/gardensRoutes.ts'`
- `pnpm --filter garden exec biome check tests/RaisedBedDiaryStory.tsx tests/raised-bed-diary.spec.tsx`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm build --filter api`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden test:run tests/raised-bed-diary.spec.tsx`
- `pnpm --filter @gredice/storage test:node gardenDiaryRescheduleRepo.node.spec.ts`
- `git diff --check`