### PR TITLE
[codex] Disable weather alert defaults and add HUD opt-in

### DIFF
--- a/apps/api/lib/weather/alerts.node.spec.ts
+++ b/apps/api/lib/weather/alerts.node.spec.ts
@@ -5,6 +5,7 @@ import {
     getDhmzWeatherAlerts,
     parseDhmzCapAlertXml,
     resolveWeatherAlertRegionCode,
+    weatherAlertSeverityScore,
 } from './alerts';
 
 const sampleCapXml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -215,6 +216,10 @@ describe('filterWeatherAlertsForFarm', () => {
 
     it('excludes green no-warning CAP entries', async () => {
         const alerts = await parseDhmzCapAlertXml(greenCapXml);
+        const firstAlert = alerts[0];
+        assert.ok(firstAlert);
+        assert.equal(weatherAlertSeverityScore(firstAlert), 1);
+
         const filtered = filterWeatherAlertsForFarm(alerts, bjelovarFarm, {
             now: new Date('2026-06-03T18:00:00+02:00'),
         });

--- a/apps/api/lib/weather/alerts.ts
+++ b/apps/api/lib/weather/alerts.ts
@@ -220,7 +220,7 @@ function fallbackCroatianEvent(alertType: WeatherAlertType | null) {
     return `Upozorenje za ${label}`;
 }
 
-function severityRank(
+export function weatherAlertSeverityScore(
     alert: Pick<DhmzWeatherAlert, 'awarenessLevel' | 'severity'>,
 ) {
     const awarenessLevel = Number(alert.awarenessLevel?.id);
@@ -245,21 +245,26 @@ export function isWeatherWarningAlert(
 ) {
     const color = alert.awarenessLevel?.color?.toLowerCase();
     if (color === 'green') return false;
+
+    const severityScore = weatherAlertSeverityScore(alert);
+    if (severityScore > 0) return severityScore >= 2;
+
     if (color === 'yellow' || color === 'orange' || color === 'red') {
         return true;
     }
 
-    const awarenessLevel = Number(alert.awarenessLevel?.id);
-    if (Number.isFinite(awarenessLevel)) return awarenessLevel > 1;
+    return false;
+}
 
-    const severity = alert.severity?.toLowerCase();
-    if (severity === 'minor') return false;
-    return true;
+export function isActionableWeatherAlert(
+    alert: Pick<DhmzWeatherAlert, 'awarenessLevel' | 'severity'>,
+) {
+    return isWeatherWarningAlert(alert);
 }
 
 function alertSortKey(alert: DhmzWeatherAlert) {
     return [
-        String(4 - severityRank(alert)).padStart(2, '0'),
+        String(4 - weatherAlertSeverityScore(alert)).padStart(2, '0'),
         alert.onset,
         alert.expires,
         alert.id,

--- a/packages/game/src/hooks/useNotificationPreferences.ts
+++ b/packages/game/src/hooks/useNotificationPreferences.ts
@@ -1,0 +1,60 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+type ApiClient = ReturnType<typeof clientAuthenticated>;
+
+export type NotificationPreferenceUpdate = NonNullable<
+    Parameters<ApiClient['api']['notifications']['preferences']['$put']>[0]
+>['json']['preferences'][number];
+
+export const notificationPreferencesKey = ['notifications', 'preferences'];
+
+export function useNotificationPreferences() {
+    return useQuery({
+        queryKey: notificationPreferencesKey,
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.notifications.preferences.$get();
+            if (!response.ok)
+                throw new Error('Postavke obavijesti nisu učitane');
+            return (await response.json()).preferences;
+        },
+    });
+}
+
+export function useSaveNotificationPreferences() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (preferences: NotificationPreferenceUpdate[]) => {
+            const response =
+                await clientAuthenticated().api.notifications.preferences.$put({
+                    json: { preferences },
+                });
+            if (!response.ok)
+                throw new Error('Postavke obavijesti nisu spremljene');
+        },
+        onSuccess: () =>
+            queryClient.invalidateQueries({
+                queryKey: notificationPreferencesKey,
+            }),
+    });
+}
+
+export function pushNotificationPreferenceUpdate({
+    category,
+    enabled,
+}: {
+    category: string;
+    enabled: boolean;
+}): NotificationPreferenceUpdate {
+    return {
+        scope: 'global',
+        category,
+        channel: 'push',
+        enabled,
+        quietHoursStartMinute: null,
+        quietHoursEndMinute: null,
+        digestFrequency: 'off',
+    };
+}

--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -36,6 +36,7 @@ import { KnownPages } from '../knownPages';
 import {
     type NotificationsFilter,
     notificationsFilterSearchParam,
+    notificationsViewSearchParam,
 } from '../notificationFilters';
 import { ProfileAvatar } from '../shared-ui/ProfileAvatar';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
@@ -55,6 +56,7 @@ function useOpenNotificationsOverview() {
                 Array.from(searchParams.entries()),
             );
             next.set('pregled', 'obavijesti');
+            next.set(notificationsViewSearchParam, 'notifications');
 
             if (filter === 'all') {
                 next.set(notificationsFilterSearchParam, filter);

--- a/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
+++ b/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
@@ -21,8 +21,16 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
-import { type FC, useState } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { type FC, useMemo, useState } from 'react';
+import {
+    pushNotificationPreferenceUpdate,
+    useNotificationPreferences,
+    useSaveNotificationPreferences,
+} from '../../../hooks/useNotificationPreferences';
+import { usePushPermissionOnboarding } from '../../../hooks/usePushPermissionOnboarding';
 import { useWeatherNow } from '../../../hooks/useWeatherNow';
+import { notificationsViewSearchParam } from '../../../notificationFilters';
 import { RainIcon } from './icons/RainIcon';
 import { WeatherForecastDays } from './WeatherForecastDetails';
 import { WeatherHistoryPanel } from './WeatherHistoryModal';
@@ -61,6 +69,125 @@ function alertLevelLabel(alert: {
     if (color === 'orange') return 'Narančasto upozorenje';
     if (color === 'red') return 'Crveno upozorenje';
     return alert.awarenessLevel?.label ?? alert.severity ?? 'Upozorenje';
+}
+
+function useNotificationSettingsHref() {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    return useMemo(() => {
+        const next = new URLSearchParams(Array.from(searchParams.entries()));
+        next.set('pregled', 'obavijesti');
+        next.set(notificationsViewSearchParam, 'settings');
+
+        const query = next.toString();
+        return `${pathname}${query ? `?${query}` : ''}`;
+    }, [pathname, searchParams]);
+}
+
+function WeatherAlertPreferencePrompt() {
+    const settingsHref = useNotificationSettingsHref();
+    const pushOnboarding = usePushPermissionOnboarding();
+    const preferencesQuery = useNotificationPreferences();
+    const savePreferencesMutation = useSaveNotificationPreferences();
+    const [localChoice, setLocalChoice] = useState<boolean | null>(null);
+
+    const weatherAlertPreference = preferencesQuery.data?.find(
+        (preference) =>
+            preference.scope === 'global' &&
+            preference.category === 'weather_alerts' &&
+            preference.channel === 'push',
+    );
+    const weatherAlertsEnabled =
+        weatherAlertPreference?.enabled ?? localChoice === true;
+    const hasWeatherAlertChoice =
+        Boolean(weatherAlertPreference) || localChoice !== null;
+    const busy =
+        preferencesQuery.isPending || savePreferencesMutation.isPending;
+
+    const saveWeatherAlertPreference = async (enabled: boolean) => {
+        if (enabled && pushOnboarding.canPrompt) {
+            await pushOnboarding.requestPermission().catch(() => undefined);
+        }
+        await savePreferencesMutation.mutateAsync([
+            pushNotificationPreferenceUpdate({
+                category: 'weather_alerts',
+                enabled,
+            }),
+        ]);
+        setLocalChoice(enabled);
+    };
+
+    if (preferencesQuery.isError) {
+        return null;
+    }
+
+    if (weatherAlertsEnabled) {
+        return (
+            <Typography
+                level="body3"
+                secondary
+                className="col-span-full px-4 pb-3 text-xs"
+            >
+                Vremenska upozorenja su uključena.{' '}
+                <Link href={settingsHref} className="underline">
+                    Postavke
+                </Link>
+            </Typography>
+        );
+    }
+
+    if (hasWeatherAlertChoice || preferencesQuery.isPending) {
+        return null;
+    }
+
+    return (
+        <Stack className="col-span-full px-4 pb-4" spacing={1}>
+            <div className="rounded border border-border/60 bg-muted/20 p-3">
+                <Stack spacing={2}>
+                    <Stack spacing={0.5}>
+                        <Typography level="body2" semiBold>
+                            Primati vremenska upozorenja?
+                        </Typography>
+                        <Typography level="body3" secondary>
+                            Samo žuta, narančasta i crvena upozorenja za regiju
+                            vrta.
+                        </Typography>
+                    </Stack>
+                    <Row justifyContent="end" spacing={2} className="flex-wrap">
+                        <Button
+                            size="sm"
+                            variant="plain"
+                            disabled={busy}
+                            onClick={() =>
+                                void saveWeatherAlertPreference(false).catch(
+                                    () => undefined,
+                                )
+                            }
+                        >
+                            Ne uključuj
+                        </Button>
+                        <Button
+                            size="sm"
+                            disabled={busy}
+                            onClick={() =>
+                                void saveWeatherAlertPreference(true).catch(
+                                    () => undefined,
+                                )
+                            }
+                        >
+                            Uključi
+                        </Button>
+                    </Row>
+                    {savePreferencesMutation.isError && (
+                        <Typography level="body3" secondary>
+                            Postavke obavijesti nisu spremljene.
+                        </Typography>
+                    )}
+                </Stack>
+            </div>
+        </Stack>
+    );
 }
 
 export function WeatherNowDetails({ farmId }: { farmId?: number | null } = {}) {
@@ -227,6 +354,7 @@ export function WeatherNowDetails({ farmId }: { farmId?: number | null } = {}) {
                             ))}
                         </Stack>
                     )}
+                    <WeatherAlertPreferencePrompt />
                     <div className="border-l block md:hidden">
                         <Button
                             variant="plain"

--- a/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
+++ b/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
@@ -22,7 +22,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { type FC, useMemo, useState } from 'react';
+import { type FC, useEffect, useMemo, useState } from 'react';
 import {
     pushNotificationPreferenceUpdate,
     useNotificationPreferences,
@@ -39,6 +39,24 @@ import {
     type WeatherPopoverView,
     WeatherViewToggle,
 } from './WeatherViewToggle';
+
+const weatherAlertPromptChoiceKey = 'game:weather-alerts:prompt-choice';
+
+function readWeatherAlertPromptChoice(): boolean | null {
+    if (typeof window === 'undefined') return null;
+    const value = window.localStorage.getItem(weatherAlertPromptChoiceKey);
+    if (value === 'enabled') return true;
+    if (value === 'disabled') return false;
+    return null;
+}
+
+function writeWeatherAlertPromptChoice(enabled: boolean) {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(
+        weatherAlertPromptChoiceKey,
+        enabled ? 'enabled' : 'disabled',
+    );
+}
 
 export const windDirectionIcons: Record<string, FC> = {
     N: ArrowUp,
@@ -91,6 +109,13 @@ function WeatherAlertPreferencePrompt() {
     const preferencesQuery = useNotificationPreferences();
     const savePreferencesMutation = useSaveNotificationPreferences();
     const [localChoice, setLocalChoice] = useState<boolean | null>(null);
+    const [storedChoice, setStoredChoice] = useState<
+        boolean | null | undefined
+    >(undefined);
+
+    useEffect(() => {
+        setStoredChoice(readWeatherAlertPromptChoice());
+    }, []);
 
     const weatherAlertPreference = preferencesQuery.data?.find(
         (preference) =>
@@ -99,9 +124,13 @@ function WeatherAlertPreferencePrompt() {
             preference.channel === 'push',
     );
     const weatherAlertsEnabled =
-        weatherAlertPreference?.enabled ?? localChoice === true;
+        weatherAlertPreference?.enabled === true || localChoice === true;
+    const hasStoredWeatherAlertChoice =
+        storedChoice !== undefined && storedChoice !== null;
     const hasWeatherAlertChoice =
-        Boolean(weatherAlertPreference) || localChoice !== null;
+        weatherAlertsEnabled ||
+        localChoice !== null ||
+        hasStoredWeatherAlertChoice;
     const busy =
         preferencesQuery.isPending || savePreferencesMutation.isPending;
 
@@ -115,6 +144,8 @@ function WeatherAlertPreferencePrompt() {
                 enabled,
             }),
         ]);
+        writeWeatherAlertPromptChoice(enabled);
+        setStoredChoice(enabled);
         setLocalChoice(enabled);
     };
 
@@ -137,7 +168,11 @@ function WeatherAlertPreferencePrompt() {
         );
     }
 
-    if (hasWeatherAlertChoice || preferencesQuery.isPending) {
+    if (
+        hasWeatherAlertChoice ||
+        preferencesQuery.isPending ||
+        storedChoice === undefined
+    ) {
         return null;
     }
 

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -9,7 +9,9 @@ import { Fragment, useEffect } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import {
     isNotificationsFilter,
+    isNotificationsView,
     notificationsFilterSearchParam,
+    notificationsViewSearchParam,
 } from '../notificationFilters';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { AccountUsersTab } from './components/AccountUsersTab';
@@ -115,10 +117,16 @@ export function OverviewModal() {
     const [notificationsFilterParam] = useSearchParam(
         notificationsFilterSearchParam,
     );
+    const [notificationsViewParam] = useSearchParam(
+        notificationsViewSearchParam,
+    );
     const { track } = useGameAnalytics();
     const notificationsFilter = isNotificationsFilter(notificationsFilterParam)
         ? notificationsFilterParam
         : 'unread';
+    const notificationsView = isNotificationsView(notificationsViewParam)
+        ? notificationsViewParam
+        : 'notifications';
 
     useEffect(() => {
         if (!settingsMode) {
@@ -192,7 +200,10 @@ export function OverviewModal() {
                     {settingsMode === 'dostava' && <DeliveryTab />}
                     {settingsMode === 'zvuk' && <SoundTab />}
                     {settingsMode === 'obavijesti' && (
-                        <NotificationsTab initialFilter={notificationsFilter} />
+                        <NotificationsTab
+                            initialFilter={notificationsFilter}
+                            initialView={notificationsView}
+                        />
                     )}
                     {settingsMode === 'suncokreti' && <SunflowersTab />}
                     {settingsMode === 'postignuca' && <AchievementsTab />}

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -13,15 +13,20 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useMarkAllNotificationsRead } from '../../hooks/useMarkAllNotificationsRead';
+import {
+    type NotificationPreferenceUpdate,
+    useNotificationPreferences,
+    useSaveNotificationPreferences,
+} from '../../hooks/useNotificationPreferences';
 import { usePushPermissionOnboarding } from '../../hooks/usePushPermissionOnboarding';
 import { NotificationList } from '../../hud/NotificationList';
-import type { NotificationsFilter } from '../../notificationFilters';
+import {
+    isNotificationsView,
+    type NotificationsFilter,
+    type NotificationsView,
+} from '../../notificationFilters';
 
 type ApiClient = ReturnType<typeof clientAuthenticated>;
-
-type NotificationPreferenceUpdate = NonNullable<
-    Parameters<ApiClient['api']['notifications']['preferences']['$put']>[0]
->['json']['preferences'][number];
 
 type PushDeviceUpdate = NonNullable<
     Parameters<ApiClient['api']['notifications']['devices'][':id']['$patch']>[0]
@@ -32,7 +37,6 @@ type DigestFrequency = NonNullable<
 >;
 type DigestPeriod = Exclude<DigestFrequency, 'off'>;
 
-type NotificationsView = 'notifications' | 'settings';
 type NotificationPreferenceItem = {
     category: string;
     channel: NotificationPreferenceUpdate['channel'];
@@ -43,7 +47,6 @@ type NotificationPreferenceItem = {
     quietHoursEligible: boolean;
 };
 
-const notificationPreferencesKey = ['notifications', 'preferences'];
 const notificationDevicesKey = ['notifications', 'devices'];
 const notificationPushStatusKey = ['notifications', 'push-status'];
 const defaultQuietHoursStartMinute = 22 * 60;
@@ -95,7 +98,7 @@ const categoryPreferences: NotificationPreferenceItem[] = [
     {
         category: 'weather_alerts',
         channel: 'push',
-        defaultEnabled: true,
+        defaultEnabled: false,
         description:
             'Upozorenja za grmljavinu, vjetar, kišu, snijeg, poledicu i druge vremenske rizike za regiju vrta.',
         digestEligible: false,
@@ -142,10 +145,6 @@ const digestFrequencyItems: Array<{
     { label: 'Dnevno', value: 'daily' },
     { label: 'Tjedno', value: 'weekly' },
 ];
-
-function isNotificationsView(value: string): value is NotificationsView {
-    return value === 'notifications' || value === 'settings';
-}
 
 function isDigestPeriod(value: string): value is DigestPeriod {
     return digestFrequencyItems.some((item) => item.value === value);
@@ -215,13 +214,15 @@ function pushStatusLabel(status: string | undefined) {
 
 type NotificationsTabProps = {
     initialFilter?: NotificationsFilter;
+    initialView?: NotificationsView;
 };
 
 export function NotificationsTab({
     initialFilter = 'unread',
+    initialView = 'notifications',
 }: NotificationsTabProps = {}) {
     const [activeView, setActiveView] =
-        useState<NotificationsView>('notifications');
+        useState<NotificationsView>(initialView);
     const [notificationsFilter, setNotificationsFilter] =
         useState<NotificationsFilter>(initialFilter);
     const [quietHoursEnabled, setQuietHoursEnabled] = useState(false);
@@ -243,16 +244,11 @@ export function NotificationsTab({
         setNotificationsFilter(initialFilter);
     }, [initialFilter]);
 
-    const preferencesQuery = useQuery({
-        queryKey: notificationPreferencesKey,
-        queryFn: async () => {
-            const response =
-                await clientAuthenticated().api.notifications.preferences.$get();
-            if (!response.ok)
-                throw new Error('Postavke obavijesti nisu učitane');
-            return (await response.json()).preferences;
-        },
-    });
+    useEffect(() => {
+        setActiveView(initialView);
+    }, [initialView]);
+
+    const preferencesQuery = useNotificationPreferences();
 
     const devicesQuery = useQuery({
         queryKey: notificationDevicesKey,
@@ -277,20 +273,7 @@ export function NotificationsTab({
         },
     });
 
-    const savePreferencesMutation = useMutation({
-        mutationFn: async (preferences: NotificationPreferenceUpdate[]) => {
-            const response =
-                await clientAuthenticated().api.notifications.preferences.$put({
-                    json: { preferences },
-                });
-            if (!response.ok)
-                throw new Error('Postavke obavijesti nisu spremljene');
-        },
-        onSuccess: () =>
-            queryClient.invalidateQueries({
-                queryKey: notificationPreferencesKey,
-            }),
-    });
+    const savePreferencesMutation = useSaveNotificationPreferences();
 
     const updateDeviceMutation = useMutation({
         mutationFn: async ({

--- a/packages/game/src/notificationFilters.ts
+++ b/packages/game/src/notificationFilters.ts
@@ -1,9 +1,17 @@
 export const notificationsFilterSearchParam = 'obavijestiFilter';
+export const notificationsViewSearchParam = 'obavijestiView';
 
 export type NotificationsFilter = 'unread' | 'all';
+export type NotificationsView = 'notifications' | 'settings';
 
 export function isNotificationsFilter(
     value: string | null | undefined,
 ): value is NotificationsFilter {
     return value === 'unread' || value === 'all';
+}
+
+export function isNotificationsView(
+    value: string | null | undefined,
+): value is NotificationsView {
+    return value === 'notifications' || value === 'settings';
 }

--- a/packages/storage/src/repositories/notificationsRepo.ts
+++ b/packages/storage/src/repositories/notificationsRepo.ts
@@ -204,21 +204,21 @@ const notificationRolloutPreferenceDefaults: NotificationRolloutPreferenceDefaul
         {
             category: 'weather_alerts',
             channel: 'in_app',
-            defaultEnabled: true,
+            defaultEnabled: false,
             digestEligible: false,
             required: false,
         },
         {
             category: 'weather_alerts',
             channel: 'email',
-            defaultEnabled: true,
+            defaultEnabled: false,
             digestEligible: false,
             required: false,
         },
         {
             category: 'weather_alerts',
             channel: 'push',
-            defaultEnabled: true,
+            defaultEnabled: false,
             digestEligible: false,
             required: false,
         },
@@ -345,6 +345,16 @@ function notificationPreferenceKey(preference: {
     channel: DeliveryChannel;
 }) {
     return `${preference.category}:${preference.channel}`;
+}
+
+function notificationPreferenceDefault(
+    category: string,
+    channel: DeliveryChannel,
+) {
+    return notificationRolloutPreferenceDefaults.find(
+        (preference) =>
+            preference.category === category && preference.channel === channel,
+    );
 }
 
 function notificationRolloutPreferenceRows({
@@ -940,16 +950,19 @@ function isInsideQuietHours(
 
 function decideDeliveryOutcome({
     channel,
+    defaultPreference,
     preference,
     hasPushSubscription,
     now,
 }: {
     channel: DeliveryChannel;
+    defaultPreference?: NotificationRolloutPreferenceDefault;
     preference?: SelectNotificationUserChannelPreference;
     hasPushSubscription: boolean;
     now: Date;
 }): NotificationDeliveryOutcomeDecision {
-    const required = preference?.required ?? false;
+    const required =
+        preference?.required ?? defaultPreference?.required ?? false;
     if (channel === 'push' && !hasPushSubscription) {
         return {
             channel,
@@ -958,7 +971,10 @@ function decideDeliveryOutcome({
             required,
         };
     }
-    if ((preference?.enabled ?? true) === false) {
+    if (
+        (preference?.enabled ?? defaultPreference?.defaultEnabled ?? true) ===
+        false
+    ) {
         return {
             channel,
             outcome: required ? 'required' : 'suppressed',
@@ -1437,6 +1453,10 @@ export async function routeNotificationDelivery(notificationId: string) {
                 return {
                     ...decideDeliveryOutcome({
                         channel,
+                        defaultPreference: notificationPreferenceDefault(
+                            notification.category,
+                            channel,
+                        ),
                         preference: accountPref ?? globalPref,
                         hasPushSubscription:
                             recipient.userId != null &&

--- a/packages/storage/tests/notificationsRepo.node.spec.ts
+++ b/packages/storage/tests/notificationsRepo.node.spec.ts
@@ -135,6 +135,68 @@ test('createNotification routes and queues deliverable push by default', async (
     );
 });
 
+test('weather alert notifications are suppressed when no preference opt-in exists', async () => {
+    createTestDb();
+    await ensureFarmId();
+    const userName = `push-weather-default-${randomUUID()}@example.com`;
+    const userId = await createUserWithPassword(userName, 'password');
+    const user = await getUser(userId);
+    assert.ok(user);
+    const accountId = user.accounts[0]?.accountId;
+    assert.ok(accountId);
+
+    await storage()
+        .insert(webPushSubscriptions)
+        .values({
+            id: randomUUID(),
+            accountId,
+            userId,
+            endpoint: `https://example.com/weather-${randomUUID()}`,
+            p256dh: 'k',
+            auth: 'a',
+            enabled: true,
+            permissionState: 'granted',
+        });
+
+    const notificationId = await createNotification({
+        accountId,
+        userId,
+        header: 'Weather alert',
+        content: 'Weather alerts default off',
+        category: 'weather_alerts',
+        timestamp: new Date(),
+    });
+
+    const attempts = await storage()
+        .select({
+            channel: notificationDeliveryAttempts.channel,
+            provider: notificationDeliveryAttempts.provider,
+            providerResponseCode:
+                notificationDeliveryAttempts.providerResponseCode,
+        })
+        .from(notificationDeliveryAttempts)
+        .where(eq(notificationDeliveryAttempts.notificationId, notificationId));
+
+    assert.deepEqual(
+        attempts
+            .filter((attempt) => attempt.provider === 'router')
+            .map((attempt) => ({
+                channel: attempt.channel,
+                reason: attempt.providerResponseCode,
+            }))
+            .sort((left, right) => left.channel.localeCompare(right.channel)),
+        [
+            { channel: 'email', reason: 'preference_disabled' },
+            { channel: 'in_app', reason: 'preference_disabled' },
+            { channel: 'push', reason: 'preference_disabled' },
+        ],
+    );
+    assert.equal(
+        attempts.some((attempt) => attempt.provider === 'web_push_queue'),
+        false,
+    );
+});
+
 test('createNotification expands account-wide push to account users', async () => {
     createTestDb();
     await ensureFarmId();
@@ -1244,9 +1306,9 @@ test('backfillNotificationRolloutDefaults limits subscription updates with batch
             }))
             .sort((left, right) => left.channel.localeCompare(right.channel)),
         [
-            { channel: 'email', enabled: true },
-            { channel: 'in_app', enabled: true },
-            { channel: 'push', enabled: true },
+            { channel: 'email', enabled: false },
+            { channel: 'in_app', enabled: false },
+            { channel: 'push', enabled: false },
         ],
     );
 


### PR DESCRIPTION
## Summary
- Expose a weather alert severity score and filter non-actionable green/level-1 DHMZ CAP alerts from farm weather alerts and notification selection.
- Default weather alert notification preferences to disabled, including delivery routing when no explicit preference exists.
- Add a weather HUD opt-in prompt that saves either enable or disable once, and link the enabled state to notification settings.

## Validation
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/weather/alerts.node.spec.ts`
- `pnpm --filter @gredice/storage test:node notificationsRepo.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter api lint` (passes with existing optional-chain warnings and Biome schema info)
- `pnpm --filter @gredice/storage lint` (passes with existing optional-chain warnings and Biome schema info)
- `pnpm --filter @gredice/game lint` (passes with Biome schema info)
- `git diff --cached --check`

## Browser verification
- Garden dev server loaded at `http://localhost:3801`, but authenticated weather HUD verification was blocked because the local API proxy target on `localhost:3805` was not running; `/debug/profile/game` did not include the customer weather HUD.