### PR TITLE
GRE-187: Show reschedule on operation cards

### DIFF
--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -62,6 +62,19 @@ test.describe('Garden operations HUD', () => {
         await expect(page.getByText(/^Kreirano:/)).toHaveCount(0);
         await expect(page.getByText(/Sljedeći korak/)).toHaveCount(0);
         await expect(page.getByText('Nema nedovršenih radnji.')).toHaveCount(0);
+
+        const rescheduleButtons = page.getByRole('button', {
+            name: 'Prerasporedi',
+        });
+        await expect(rescheduleButtons).toHaveCount(2);
+
+        await rescheduleButtons.first().click();
+        await expect(
+            page.getByText('Novi datum', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Spremi' }),
+        ).toBeVisible();
     });
 
     test('shows completed sowing tasks in operation history', async ({

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -805,6 +805,55 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeLessThanOrEqual(1);
     });
 
+    test('diary tab allows rescheduling future active operation cards', async ({
+        mount,
+        page,
+    }) => {
+        const scenario = plantedGrowingWithOperationHistoryScenario();
+        const operation = scenario.operationHistoryItems?.[0];
+
+        if (!operation) {
+            throw new Error('Expected operation history item.');
+        }
+
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={{
+                    ...scenario,
+                    operationHistoryItems: [
+                        {
+                            ...operation,
+                            scheduledDate: '2026-05-20T00:00:00.000Z',
+                            scheduledAt: '2026-05-19T00:00:00.000Z',
+                            completedAt: null,
+                            verifiedAt: null,
+                            imageUrls: [],
+                            completionNotes: null,
+                        },
+                    ],
+                }}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
+
+        await expect(
+            dialog.getByText('Površinsko zalijevanje gredice (20L)'),
+        ).toBeVisible();
+        await dialog.getByRole('button', { name: 'Prerasporedi' }).click();
+
+        await expect(
+            page.getByText('Novi datum', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Spremi' }),
+        ).toBeVisible();
+    });
+
     test('raised bed diary operation history does not overflow the modal', async ({
         mount,
         page,

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -43,11 +43,16 @@ import { useLiveTime } from '../hooks/useLiveTime';
 import { useOperations } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
 import {
+    type DiaryRescheduleTarget,
+    isDiaryRescheduleTargetEligible,
+} from '../hooks/useRescheduleDiaryEntry';
+import {
     type ShoppingCartItemData,
     useShoppingCart,
 } from '../hooks/useShoppingCart';
 import { ScrollView } from '../shared-ui/ScrollView';
 import { useShoppingCartOpenParam } from '../useUrlState';
+import { RaisedBedDiaryRescheduleAction } from './raisedBed/RaisedBedDiaryRescheduleAction';
 
 type OperationData = NonNullable<
     ReturnType<typeof useOperations>['data']
@@ -112,6 +117,11 @@ const hiddenFromActive = new Set<GardenOperationStatus>([
     'completed',
     'failed',
     'canceled',
+]);
+const reschedulableActiveStatuses = new Set<GardenOperationStatus>([
+    'planned',
+    'assigned',
+    'confirmed',
 ]);
 const cartOperationEntityType = 'operation' as const;
 export const cartPlantSortEntityType = 'plantSort' as const;
@@ -526,6 +536,109 @@ function getOperationTargetDetails(
         raisedBedPhysicalId: raisedBed.physicalId,
         fallbackLabel: formatRaisedBedTargetLabel(raisedBed.name, fieldLabel),
     };
+}
+
+function getOperationFieldPositionIndex(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+) {
+    if (operation.raisedBedFieldId == null) {
+        return undefined;
+    }
+
+    for (const raisedBed of garden?.raisedBeds ?? []) {
+        const field = raisedBed.fields.find(
+            (candidate) => candidate.id === operation.raisedBedFieldId,
+        );
+        if (field) {
+            return field.positionIndex;
+        }
+    }
+
+    return undefined;
+}
+
+export function getGardenOperationRescheduleTarget(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+): DiaryRescheduleTarget | null {
+    if (
+        !operation.scheduledDate ||
+        !reschedulableActiveStatuses.has(operation.status) ||
+        operation.completedAt ||
+        operation.verifiedAt ||
+        operation.canceledAt
+    ) {
+        return null;
+    }
+
+    const positionIndex = getOperationFieldPositionIndex(operation, garden);
+
+    if (operation.entityTypeName === cartOperationEntityType) {
+        return {
+            type: 'operation',
+            operationId: operation.id,
+            raisedBedId: operation.raisedBedId,
+            raisedBedFieldId: operation.raisedBedFieldId,
+            positionIndex,
+            scheduledDate: operation.scheduledDate,
+        };
+    }
+
+    if (
+        operation.entityTypeName === cartPlantSortEntityType &&
+        operation.raisedBedId &&
+        typeof positionIndex === 'number'
+    ) {
+        return {
+            type: 'raisedBedFieldPlant',
+            raisedBedId: operation.raisedBedId,
+            positionIndex,
+            scheduledDate: operation.scheduledDate,
+        };
+    }
+
+    return null;
+}
+
+export function canRescheduleGardenOperation(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+    referenceDate: Date,
+) {
+    const target = getGardenOperationRescheduleTarget(operation, garden);
+    return Boolean(
+        target && isDiaryRescheduleTargetEligible(target, referenceDate),
+    );
+}
+
+export function GardenOperationRescheduleAction({
+    entryName,
+    garden,
+    operation,
+    referenceDate,
+}: {
+    entryName: string;
+    garden: CurrentGardenData | null | undefined;
+    operation: GardenOperationHudItem;
+    referenceDate: Date;
+}) {
+    if (!garden) {
+        return null;
+    }
+
+    const target = getGardenOperationRescheduleTarget(operation, garden);
+    if (!target || !isDiaryRescheduleTargetEligible(target, referenceDate)) {
+        return null;
+    }
+
+    return (
+        <RaisedBedDiaryRescheduleAction
+            entryName={entryName}
+            gardenId={garden.id}
+            target={target}
+        />
+    );
 }
 
 function getCartOperationTargetDetails(
@@ -1425,38 +1538,55 @@ export function GardenOperationsHud() {
                                 )}
                                 {cartOperations.length > 0 &&
                                     pendingOperations.length > 0 && <Divider />}
-                                {pendingOperations.map((operation) => (
-                                    <GardenOperationCard
-                                        key={`${operation.entityTypeName}-${operation.id}`}
-                                        operation={operation}
-                                        operationName={
-                                            operation.entityTypeName ===
-                                            cartOperationEntityType
-                                                ? operationDataById.get(
-                                                      operation.entityId,
-                                                  )?.information.label
-                                                : undefined
-                                        }
-                                        operationData={
-                                            operation.entityTypeName ===
-                                            cartOperationEntityType
-                                                ? operationDataById.get(
-                                                      operation.entityId,
-                                                  )
-                                                : undefined
-                                        }
-                                        plantSortData={
-                                            operation.entityTypeName ===
-                                            cartPlantSortEntityType
-                                                ? plantSortById.get(
-                                                      operation.entityId,
-                                                  )
-                                                : undefined
-                                        }
-                                        currentGarden={currentGarden}
-                                        referenceDate={referenceDate}
-                                    />
-                                ))}
+                                {pendingOperations.map((operation) => {
+                                    const operationData =
+                                        operation.entityTypeName ===
+                                        cartOperationEntityType
+                                            ? operationDataById.get(
+                                                  operation.entityId,
+                                              )
+                                            : undefined;
+                                    const plantSortData =
+                                        operation.entityTypeName ===
+                                        cartPlantSortEntityType
+                                            ? plantSortById.get(
+                                                  operation.entityId,
+                                              )
+                                            : undefined;
+                                    const operationName =
+                                        operationData?.information.label;
+                                    const entryName = getActiveOperationName({
+                                        operation,
+                                        operationName,
+                                        plantSortName:
+                                            plantSortData?.information.name,
+                                    });
+                                    const action = canRescheduleGardenOperation(
+                                        operation,
+                                        currentGarden,
+                                        referenceDate,
+                                    ) ? (
+                                        <GardenOperationRescheduleAction
+                                            entryName={entryName}
+                                            garden={currentGarden}
+                                            operation={operation}
+                                            referenceDate={referenceDate}
+                                        />
+                                    ) : undefined;
+
+                                    return (
+                                        <GardenOperationCard
+                                            key={`${operation.entityTypeName}-${operation.id}`}
+                                            operation={operation}
+                                            operationName={operationName}
+                                            operationData={operationData}
+                                            plantSortData={plantSortData}
+                                            currentGarden={currentGarden}
+                                            referenceDate={referenceDate}
+                                            action={action}
+                                        />
+                                    );
+                                })}
                             </>
                         )}
                         <div ref={pendingRef} className="h-1" />

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -1,6 +1,7 @@
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
+import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
 import { useMemo } from 'react';
@@ -16,8 +17,10 @@ import { useSorts } from '../../hooks/usePlantSorts';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import {
     buildSowingOperationItems,
+    canRescheduleGardenOperation,
     cartPlantSortEntityType,
     GardenOperationCard,
+    GardenOperationRescheduleAction,
     sortNewestFirst,
 } from '../GardenOperationsHud';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
@@ -263,13 +266,31 @@ export function RaisedBedOperationHistoryList({
                         ? plantSortById.get(operation.entityId)
                         : undefined;
                 const operationName = operationData?.information.label;
+                const entryName =
+                    operationName ??
+                    plantSortData?.information.name ??
+                    operation.targetLabel;
                 const actionRaisedBedId = operation.raisedBedId ?? raisedBedId;
                 const actionPositionIndex =
                     positionIndex ??
                     (operation.raisedBedFieldId
                         ? fieldPositionById.get(operation.raisedBedFieldId)
                         : undefined);
-                const action =
+                const rescheduleAction =
+                    !disableActions &&
+                    canRescheduleGardenOperation(
+                        operation,
+                        currentGarden,
+                        referenceDate,
+                    ) ? (
+                        <GardenOperationRescheduleAction
+                            entryName={entryName}
+                            garden={currentGarden}
+                            operation={operation}
+                            referenceDate={referenceDate}
+                        />
+                    ) : null;
+                const aiAction =
                     flags.raisedBedImageAI &&
                     !disableActions &&
                     currentGarden &&
@@ -279,11 +300,7 @@ export function RaisedBedOperationHistoryList({
                             gardenId={currentGarden.id}
                             raisedBedId={actionRaisedBedId}
                             positionIndex={actionPositionIndex}
-                            entryName={
-                                operationName ??
-                                plantSortData?.information.name ??
-                                operation.targetLabel
-                            }
+                            entryName={entryName}
                             imageUrls={operation.imageUrls}
                             referenceDate={getOperationReferenceDate(operation)}
                             historyEntries={getAiHistoryForOperation({
@@ -291,6 +308,13 @@ export function RaisedBedOperationHistoryList({
                                 entries: aiHistoryEntries,
                             })}
                         />
+                    ) : undefined;
+                const action =
+                    rescheduleAction || aiAction ? (
+                        <Row spacing={2} className="flex-wrap justify-end">
+                            {rescheduleAction}
+                            {aiAction}
+                        </Row>
                     ) : undefined;
 
                 return (


### PR DESCRIPTION
## Summary

- Show the `Prerasporedi` action on active future scheduled operation cards, including the raised-bed/field `Dnevnik` tab shown in-game and the global operations HUD.
- Reuse the GRE-187 reschedule endpoint/hook from the merged implementation, while keeping completed, canceled, failed, today, and past operations ineligible.
- Add component coverage for the operation-card button and date modal in both operation-card surfaces.

## Context

Follow-up to #3238. The first PR exposed rescheduling for diary-entry rows, but the visible in-game operation cards in the `Dnevnik`/`Radnje` surfaces render through `GardenOperationCard`, so future scheduled cards displayed as `Potvrđeno` did not show the action.

## Validation

- `pnpm --filter @gredice/game exec biome check src/hud/GardenOperationsHud.tsx src/hud/raisedBed/RaisedBedOperationHistoryList.tsx`
- `pnpm --filter garden exec biome check tests/garden-operations-hud.spec.tsx tests/raised-bed-field-hud.spec.tsx`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter garden test:run tests/garden-operations-hud.spec.tsx tests/raised-bed-field-hud.spec.tsx`
- `git diff --check`