### PR TITLE
GRE-187: Polish operation card reschedule UI

### DIFF
--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -46,16 +46,26 @@ test.describe('Garden operations HUD', () => {
         await expect(page.getByText('Planirano', { exact: true })).toHaveCount(
             0,
         );
+        await expect(page.getByText('Zakazano: 22. svibnja 2026.')).toHaveCount(
+            0,
+        );
+        const operationDateButton = page.getByRole('button', {
+            name: '22. svibnja 2026.',
+        });
+        await expect(operationDateButton).toBeVisible();
         await expect(
-            page.getByText('Zakazano: 22. svibnja 2026.'),
+            page.locator('[data-operation-media="plant"]').first(),
         ).toBeVisible();
         await expect(page.getByText('Sadnja', { exact: true })).toBeVisible();
         await expect(page.getByText('Sadnja: Klasični bosiljak')).toBeVisible();
         await expect(
             page.getByLabel('Raised Bed 1 › Polje 6').first(),
         ).toBeVisible();
+        await expect(page.getByText('Zakazano: 23. svibnja 2026.')).toHaveCount(
+            0,
+        );
         await expect(
-            page.getByText('Zakazano: 23. svibnja 2026.'),
+            page.getByRole('button', { name: '23. svibnja 2026.' }),
         ).toBeVisible();
         await expect(page.getByLabel('Tijek radnje')).toHaveCount(0);
         await expect(page.locator('.animate-progress')).toHaveCount(0);
@@ -64,11 +74,11 @@ test.describe('Garden operations HUD', () => {
         await expect(page.getByText('Nema nedovršenih radnji.')).toHaveCount(0);
 
         const rescheduleButtons = page.getByRole('button', {
-            name: 'Prerasporedi',
+            name: /svibnja 2026\./,
         });
         await expect(rescheduleButtons).toHaveCount(2);
 
-        await rescheduleButtons.first().click();
+        await operationDateButton.click();
         await expect(
             page.getByText('Novi datum', { exact: true }),
         ).toBeVisible();

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -844,7 +844,15 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             dialog.getByText('Površinsko zalijevanje gredice (20L)'),
         ).toBeVisible();
-        await dialog.getByRole('button', { name: 'Prerasporedi' }).click();
+        await expect(dialog.getByText('Zakazano:')).toHaveCount(0);
+        await expect(
+            dialog.locator('[data-operation-media="plant"]').first(),
+        ).toBeVisible();
+        await expect(
+            dialog.locator('[data-operation-media-badge]').first(),
+        ).toBeVisible();
+
+        await dialog.getByRole('button', { name: '20. svibnja 2026.' }).click();
 
         await expect(
             page.getByText('Novi datum', { exact: true }),

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -198,6 +198,15 @@ function formatDate(value?: string | null) {
     });
 }
 
+function formatCompactDate(value?: string | null) {
+    if (!value) return null;
+    return new Date(value).toLocaleDateString('hr-HR', {
+        day: 'numeric',
+        month: 'numeric',
+        year: 'numeric',
+    });
+}
+
 function formatDateTime(value?: string | null) {
     if (!value) return null;
     return new Date(value).toLocaleString('hr-HR');
@@ -558,6 +567,33 @@ function getOperationFieldPositionIndex(
     return undefined;
 }
 
+function getOperationField(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+) {
+    if (operation.raisedBedFieldId == null) {
+        return null;
+    }
+
+    for (const raisedBed of garden?.raisedBeds ?? []) {
+        const field = raisedBed.fields.find(
+            (candidate) => candidate.id === operation.raisedBedFieldId,
+        );
+        if (field) {
+            return field;
+        }
+    }
+
+    return null;
+}
+
+function getOperationFieldPlantSortId(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+) {
+    return getOperationField(operation, garden)?.plantSortId ?? null;
+}
+
 export function getGardenOperationRescheduleTarget(
     operation: GardenOperationHudItem,
     garden: CurrentGardenData | null | undefined,
@@ -601,6 +637,52 @@ export function getGardenOperationRescheduleTarget(
     return null;
 }
 
+function getOperationDisplayStatus(
+    operation: GardenOperationHudItem,
+    referenceDate: Date,
+): OperationDisplayStatus {
+    return isScheduledUnassignedOperation(operation, referenceDate)
+        ? 'scheduled'
+        : operation.status;
+}
+
+function getLatestStatusHistoryDate(operation: GardenOperationHudItem) {
+    return operation.statusHistory.reduce<string | null>((latest, entry) => {
+        const entryTime = new Date(entry.changedAt).getTime();
+        if (!Number.isFinite(entryTime)) {
+            return latest;
+        }
+
+        if (!latest || entryTime > new Date(latest).getTime()) {
+            return entry.changedAt;
+        }
+
+        return latest;
+    }, null);
+}
+
+function getOperationDisplayStatusDate(
+    operation: GardenOperationHudItem,
+    displayStatus: OperationDisplayStatus,
+) {
+    if (displayStatus === 'scheduled') {
+        return operation.scheduledDate;
+    }
+
+    const matchingHistoryDate = [...operation.statusHistory]
+        .reverse()
+        .find((entry) => entry.status === operation.status)?.changedAt;
+
+    return (
+        matchingHistoryDate ??
+        operation.verifiedAt ??
+        operation.completedAt ??
+        operation.canceledAt ??
+        operation.scheduledAt ??
+        getLatestStatusHistoryDate(operation)
+    );
+}
+
 export function canRescheduleGardenOperation(
     operation: GardenOperationHudItem,
     garden: CurrentGardenData | null | undefined,
@@ -617,11 +699,13 @@ export function GardenOperationRescheduleAction({
     garden,
     operation,
     referenceDate,
+    triggerLabel,
 }: {
     entryName: string;
     garden: CurrentGardenData | null | undefined;
     operation: GardenOperationHudItem;
     referenceDate: Date;
+    triggerLabel?: ReactNode;
 }) {
     if (!garden) {
         return null;
@@ -637,6 +721,7 @@ export function GardenOperationRescheduleAction({
             entryName={entryName}
             gardenId={garden.id}
             target={target}
+            triggerLabel={triggerLabel}
         />
     );
 }
@@ -701,6 +786,29 @@ function StatusBadge({
                 {config.label}
             </Typography>
         </Row>
+    );
+}
+
+function OperationStatusSummary({
+    operation,
+    status,
+}: {
+    operation: GardenOperationHudItem;
+    status: OperationDisplayStatus;
+}) {
+    const statusDate = formatCompactDate(
+        getOperationDisplayStatusDate(operation, status),
+    );
+
+    return (
+        <Stack spacing={0.25} className="shrink-0 items-end">
+            <StatusBadge status={status} />
+            {statusDate && (
+                <Typography level="body3" secondary noWrap>
+                    {statusDate}
+                </Typography>
+            )}
+        </Stack>
     );
 }
 
@@ -856,23 +964,36 @@ function OperationProgress({
     return (
         <SegmentedProgress
             aria-label="Tijek radnje"
-            className={cx('w-full min-w-0 max-w-full px-4 pb-6', className)}
+            className={cx('w-full min-w-0 max-w-full pb-6', className)}
             segments={segments}
         />
     );
 }
 
-function OperationDates({ operation }: { operation: GardenOperationItem }) {
+function OperationSchedule({
+    operation,
+    scheduleAction,
+}: {
+    operation: GardenOperationItem;
+    scheduleAction?: ReactNode;
+}) {
     const scheduledDate = formatDate(operation.scheduledDate);
 
     if (!scheduledDate) {
         return null;
     }
 
+    if (scheduleAction) {
+        return <div className="w-fit max-w-full">{scheduleAction}</div>;
+    }
+
     return (
-        <Typography level="body3" secondary>
-            Zakazano: {scheduledDate}
-        </Typography>
+        <Row spacing={1} className="w-fit max-w-full text-muted-foreground">
+            <Calendar aria-hidden className="size-3.5 shrink-0" />
+            <Typography level="body3" secondary noWrap>
+                {scheduledDate}
+            </Typography>
+        </Row>
     );
 }
 
@@ -936,12 +1057,13 @@ function OperationTargetLabel({
     return (
         <Row
             spacing={1}
-            className="min-w-0 max-w-full items-center"
+            className="min-w-0 max-w-full items-center flex-wrap gap-y-0.5"
             aria-label={targetDetails.fallbackLabel}
         >
-            <Row spacing={1} className="min-w-0 flex-1 items-center">
+            <Row spacing={1} className="min-w-0 items-center">
                 <RaisedBedIcon
                     physicalId={targetDetails.raisedBedPhysicalId}
+                    containerClassName="h-6 w-6 min-w-6 overflow-visible"
                     className={cx(
                         'size-5 text-tertiary-foreground',
                         iconClassName,
@@ -1004,23 +1126,87 @@ function getActiveOperationName({
     return `Radnja #${operation.id}`;
 }
 
+function OperationMedia({
+    operationData,
+    plantSortData,
+    targetPlantSortData,
+}: {
+    operationData?: OperationData;
+    plantSortData?: PlantSortData;
+    targetPlantSortData?: PlantSortData;
+}) {
+    const primaryPlantSort = plantSortData ?? targetPlantSortData;
+    const shouldShowOperationBadge = Boolean(
+        operationData && targetPlantSortData,
+    );
+
+    if (primaryPlantSort) {
+        return (
+            <div
+                className="relative size-12 shrink-0"
+                data-operation-media="plant"
+            >
+                <div className="flex size-12 items-center justify-center overflow-hidden rounded-lg bg-card">
+                    <PlantOrSortImage
+                        plantSort={primaryPlantSort}
+                        alt={primaryPlantSort.information.name}
+                        width={44}
+                        height={44}
+                    />
+                </div>
+                {shouldShowOperationBadge && operationData && (
+                    <span
+                        className="-right-1 -top-1 absolute flex size-6 items-center justify-center rounded-full border bg-background text-foreground shadow-xs"
+                        data-operation-media-badge
+                    >
+                        <OperationImage operation={operationData} size={18} />
+                    </span>
+                )}
+            </div>
+        );
+    }
+
+    if (operationData) {
+        return (
+            <div
+                className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-card"
+                data-operation-media="operation"
+            >
+                <OperationImage operation={operationData} size={40} />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-card">
+            <Typography level="body3" secondary>
+                🌱
+            </Typography>
+        </div>
+    );
+}
+
 export function GardenOperationCard({
     operation,
     operationName,
     operationData,
     plantSortData,
+    targetPlantSortData,
     currentGarden,
     referenceDate,
     progressClassName,
+    scheduleAction,
     action,
 }: {
     operation: GardenOperationHudItem;
     operationName?: string;
     operationData?: OperationData;
     plantSortData?: PlantSortData;
+    targetPlantSortData?: PlantSortData;
     currentGarden?: CurrentGardenData | null;
     referenceDate: Date;
     progressClassName?: string;
+    scheduleAction?: ReactNode;
     action?: ReactNode;
 }) {
     const resolvedOperationName = getActiveOperationName({
@@ -1029,10 +1215,8 @@ export function GardenOperationCard({
         plantSortName: plantSortData?.information.name,
     });
     const targetDetails = getOperationTargetDetails(operation, currentGarden);
-    const isScheduledUnassigned = isScheduledUnassignedOperation(
-        operation,
-        referenceDate,
-    );
+    const displayStatus = getOperationDisplayStatus(operation, referenceDate);
+    const isScheduledUnassigned = displayStatus === 'scheduled';
 
     return (
         <div
@@ -1044,52 +1228,44 @@ export function GardenOperationCard({
                 alignItems="start"
                 className="w-full min-w-0 max-w-full"
             >
-                <div className="size-12 rounded-lg bg-card flex items-center justify-center overflow-hidden shrink-0">
-                    {plantSortData ? (
-                        <PlantOrSortImage
-                            plantSort={plantSortData}
-                            alt={plantSortData.information.name}
-                            width={40}
-                            height={40}
-                        />
-                    ) : operationData ? (
-                        <OperationImage operation={operationData} size={40} />
-                    ) : (
-                        <Typography level="body3" secondary>
-                            🌱
-                        </Typography>
-                    )}
-                </div>
+                <OperationMedia
+                    operationData={operationData}
+                    plantSortData={plantSortData}
+                    targetPlantSortData={targetPlantSortData}
+                />
                 <Stack
                     spacing={1.5}
                     className="min-w-0 max-w-full flex-1 overflow-hidden"
                 >
-                    <Stack spacing={0.5}>
+                    <Stack spacing={0.75}>
                         <Row
                             spacing={1}
                             alignItems="start"
-                            className="min-w-0 max-w-full flex-wrap gap-y-1"
+                            className="min-w-0 max-w-full gap-y-1"
                         >
-                            <Typography
-                                level="body2"
-                                semiBold
-                                noWrap
-                                className="min-w-0 flex-1"
-                            >
-                                {resolvedOperationName}
-                            </Typography>
-                            <StatusBadge
-                                status={
-                                    isScheduledUnassigned
-                                        ? 'scheduled'
-                                        : operation.status
-                                }
-                                className="shrink-0"
+                            <Stack spacing={0.5} className="min-w-0 flex-1">
+                                <Typography
+                                    level="body2"
+                                    semiBold
+                                    noWrap
+                                    className="min-w-0"
+                                >
+                                    {resolvedOperationName}
+                                </Typography>
+                                <OperationTargetLabel
+                                    targetDetails={targetDetails}
+                                />
+                            </Stack>
+                            <OperationStatusSummary
+                                operation={operation}
+                                status={displayStatus}
                             />
                         </Row>
-                        <OperationTargetLabel targetDetails={targetDetails} />
                     </Stack>
-                    <OperationDates operation={operation} />
+                    <OperationSchedule
+                        operation={operation}
+                        scheduleAction={scheduleAction}
+                    />
                     <OperationEvidence operation={operation} />
                     {!isScheduledUnassigned && (
                         <OperationProgress
@@ -1280,6 +1456,17 @@ function HistoryModal({
                                               )
                                             : undefined
                                     }
+                                    targetPlantSortData={
+                                        operation.entityTypeName ===
+                                        cartOperationEntityType
+                                            ? (plantSortById.get(
+                                                  getOperationFieldPlantSortId(
+                                                      operation,
+                                                      currentGarden,
+                                                  ) ?? 0,
+                                              ) ?? undefined)
+                                            : undefined
+                                    }
                                     currentGarden={currentGarden}
                                     referenceDate={referenceDate}
                                     progressClassName="md:max-w-80"
@@ -1354,8 +1541,28 @@ export function GardenOperationsHud() {
             ),
         [sowingOperations],
     );
-    const { data: sowingPlantSorts } = useSorts(
-        sowingPlantSortIds.length > 0 ? sowingPlantSortIds : undefined,
+    const fieldPlantSortIds = useMemo(
+        () =>
+            Array.from(
+                new Set(
+                    (currentGarden?.raisedBeds ?? []).flatMap((raisedBed) =>
+                        raisedBed.fields.flatMap((field) =>
+                            typeof field.plantSortId === 'number'
+                                ? [field.plantSortId]
+                                : [],
+                        ),
+                    ),
+                ),
+            ),
+        [currentGarden],
+    );
+    const operationPlantSortIds = useMemo(
+        () =>
+            Array.from(new Set([...sowingPlantSortIds, ...fieldPlantSortIds])),
+        [fieldPlantSortIds, sowingPlantSortIds],
+    );
+    const { data: operationPlantSorts } = useSorts(
+        operationPlantSortIds.length > 0 ? operationPlantSortIds : undefined,
     );
 
     const pendingOperations = useMemo(
@@ -1402,12 +1609,12 @@ export function GardenOperationsHud() {
     const plantSortById = useMemo(
         () =>
             new Map(
-                (sowingPlantSorts ?? []).map((plantSort) => [
+                (operationPlantSorts ?? []).map((plantSort) => [
                     plantSort.id,
                     plantSort,
                 ]),
             ),
-        [sowingPlantSorts],
+        [operationPlantSorts],
     );
     const cartOperations = useMemo(() => {
         if (!currentGarden) {
@@ -1555,24 +1762,31 @@ export function GardenOperationsHud() {
                                             : undefined;
                                     const operationName =
                                         operationData?.information.label;
+                                    const scheduledDateLabel = formatDate(
+                                        operation.scheduledDate,
+                                    );
                                     const entryName = getActiveOperationName({
                                         operation,
                                         operationName,
                                         plantSortName:
                                             plantSortData?.information.name,
                                     });
-                                    const action = canRescheduleGardenOperation(
-                                        operation,
-                                        currentGarden,
-                                        referenceDate,
-                                    ) ? (
-                                        <GardenOperationRescheduleAction
-                                            entryName={entryName}
-                                            garden={currentGarden}
-                                            operation={operation}
-                                            referenceDate={referenceDate}
-                                        />
-                                    ) : undefined;
+                                    const scheduleAction =
+                                        canRescheduleGardenOperation(
+                                            operation,
+                                            currentGarden,
+                                            referenceDate,
+                                        ) && scheduledDateLabel ? (
+                                            <GardenOperationRescheduleAction
+                                                entryName={entryName}
+                                                garden={currentGarden}
+                                                operation={operation}
+                                                referenceDate={referenceDate}
+                                                triggerLabel={
+                                                    scheduledDateLabel
+                                                }
+                                            />
+                                        ) : undefined;
 
                                     return (
                                         <GardenOperationCard
@@ -1581,9 +1795,20 @@ export function GardenOperationsHud() {
                                             operationName={operationName}
                                             operationData={operationData}
                                             plantSortData={plantSortData}
+                                            targetPlantSortData={
+                                                operation.entityTypeName ===
+                                                cartOperationEntityType
+                                                    ? (plantSortById.get(
+                                                          getOperationFieldPlantSortId(
+                                                              operation,
+                                                              currentGarden,
+                                                          ) ?? 0,
+                                                      ) ?? undefined)
+                                                    : undefined
+                                            }
                                             currentGarden={currentGarden}
                                             referenceDate={referenceDate}
-                                            action={action}
+                                            scheduleAction={scheduleAction}
                                         />
                                     );
                                 })}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -6,7 +6,7 @@ import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, type ReactNode, useState } from 'react';
 import {
     type DiaryRescheduleTarget,
     formatDiaryRescheduleDateInput,
@@ -18,10 +18,12 @@ export function RaisedBedDiaryRescheduleAction({
     entryName,
     gardenId,
     target,
+    triggerLabel = 'Prerasporedi',
 }: {
     entryName: string;
     gardenId: number;
     target: DiaryRescheduleTarget;
+    triggerLabel?: ReactNode;
 }) {
     const [open, setOpen] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -75,7 +77,7 @@ export function RaisedBedDiaryRescheduleAction({
                     variant="soft"
                     startDecorator={<Calendar className="size-3.5 shrink-0" />}
                 >
-                    Prerasporedi
+                    {triggerLabel}
                 </Button>
             }
         >

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -45,6 +45,20 @@ function buildFieldPositionById(
     );
 }
 
+function buildFieldPlantSortIdById(
+    garden: ReturnType<typeof useCurrentGarden>['data'],
+) {
+    return new Map(
+        (garden?.raisedBeds ?? []).flatMap((raisedBed) =>
+            raisedBed.fields.flatMap((field) =>
+                typeof field.plantSortId === 'number'
+                    ? [[field.id, field.plantSortId] as const]
+                    : [],
+            ),
+        ),
+    );
+}
+
 function filterOperationsByTarget({
     operations,
     raisedBedId,
@@ -154,6 +168,10 @@ export function RaisedBedOperationHistoryList({
         () => buildFieldPositionById(currentGarden),
         [currentGarden],
     );
+    const fieldPlantSortIdById = useMemo(
+        () => buildFieldPlantSortIdById(currentGarden),
+        [currentGarden],
+    );
     const history = useGardenOperations({
         includeCompleted: true,
         pageSize: 20,
@@ -190,16 +208,27 @@ export function RaisedBedOperationHistoryList({
         () =>
             Array.from(
                 new Set(
-                    operations
-                        .filter(
-                            (operation) =>
-                                operation.entityTypeName ===
-                                cartPlantSortEntityType,
-                        )
-                        .map((operation) => operation.entityId),
+                    operations.flatMap((operation) => {
+                        if (
+                            operation.entityTypeName === cartPlantSortEntityType
+                        ) {
+                            return [operation.entityId];
+                        }
+
+                        return operation.raisedBedFieldId
+                            ? [
+                                  fieldPlantSortIdById.get(
+                                      operation.raisedBedFieldId,
+                                  ),
+                              ].filter(
+                                  (plantSortId): plantSortId is number =>
+                                      typeof plantSortId === 'number',
+                              )
+                            : [];
+                    }),
                 ),
             ),
-        [operations],
+        [fieldPlantSortIdById, operations],
     );
     const { data: sowingPlantSorts } = useSorts(
         sowingPlantSortIds.length > 0 ? sowingPlantSortIds : undefined,
@@ -266,6 +295,16 @@ export function RaisedBedOperationHistoryList({
                         ? plantSortById.get(operation.entityId)
                         : undefined;
                 const operationName = operationData?.information.label;
+                const scheduledDateLabel = operation.scheduledDate
+                    ? new Date(operation.scheduledDate).toLocaleDateString(
+                          'hr-HR',
+                          {
+                              day: 'numeric',
+                              month: 'long',
+                              year: 'numeric',
+                          },
+                      )
+                    : null;
                 const entryName =
                     operationName ??
                     plantSortData?.information.name ??
@@ -288,6 +327,7 @@ export function RaisedBedOperationHistoryList({
                             garden={currentGarden}
                             operation={operation}
                             referenceDate={referenceDate}
+                            triggerLabel={scheduledDateLabel}
                         />
                     ) : null;
                 const aiAction =
@@ -309,13 +349,11 @@ export function RaisedBedOperationHistoryList({
                             })}
                         />
                     ) : undefined;
-                const action =
-                    rescheduleAction || aiAction ? (
-                        <Row spacing={2} className="flex-wrap justify-end">
-                            {rescheduleAction}
-                            {aiAction}
-                        </Row>
-                    ) : undefined;
+                const action = aiAction ? (
+                    <Row spacing={2} className="flex-wrap justify-end">
+                        {aiAction}
+                    </Row>
+                ) : undefined;
 
                 return (
                     <GardenOperationCard
@@ -324,9 +362,20 @@ export function RaisedBedOperationHistoryList({
                         operationName={operationName}
                         operationData={operationData}
                         plantSortData={plantSortData}
+                        targetPlantSortData={
+                            operation.entityTypeName === 'operation' &&
+                            operation.raisedBedFieldId
+                                ? (plantSortById.get(
+                                      fieldPlantSortIdById.get(
+                                          operation.raisedBedFieldId,
+                                      ) ?? 0,
+                                  ) ?? undefined)
+                                : undefined
+                        }
                         currentGarden={currentGarden}
                         referenceDate={referenceDate}
                         progressClassName="md:max-w-80"
+                        scheduleAction={rescheduleAction ?? undefined}
                         action={action}
                     />
                 );


### PR DESCRIPTION
## Summary
- Move future-operation rescheduling onto the scheduled-date button and remove the duplicated `Zakazano:` label from operation cards.
- Align operation card progress with the text column, tighten the raised-bed/field target label, and avoid clipping the raised-bed icon.
- Show status-change dates under the status badge and render field operations with the plant image plus an operation badge when operation artwork is available.

## Validation
- `pnpm --filter garden exec biome check --write tests/garden-operations-hud.spec.tsx tests/raised-bed-field-hud.spec.tsx`
- `pnpm --filter @gredice/game exec biome check src/hud/GardenOperationsHud.tsx src/hud/raisedBed/RaisedBedOperationHistoryList.tsx src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx`
- `pnpm --filter garden exec biome check tests/garden-operations-hud.spec.tsx tests/raised-bed-field-hud.spec.tsx`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter garden test:run tests/garden-operations-hud.spec.tsx tests/raised-bed-field-hud.spec.tsx`
- `git diff --check`