### PR TITLE
fix(js): export package metadata

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "exports": {
+        "./package.json": "./package.json",
         "./*": "./src/*/index.ts"
     },
     "scripts": {


### PR DESCRIPTION
### Motivation
- Storybook and package tooling logged `unable to find package.json for @gredice/js` because the package `exports` map exposed subpaths but did not expose the package metadata (`./package.json`).

### Description
- Add `"./package.json": "./package.json"` to `packages/js/package.json` `exports` while preserving the existing `"./*": "./src/*/index.ts"` wildcard export.

### Testing
- Ran `pnpm build --filter=storybook`, which completed successfully and no longer showed the `unable to find package.json for @gredice/js` warning; the run still showed an environment Node engine warning and existing Vite plugin/chunk-size warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a200f33d7b8832fa686effc7285cd8e)