### PR TITLE
Add special entity debug rewards in the debug HUD

### DIFF
--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -4,6 +4,7 @@ import { Button } from '@gredice/ui/Button';
 import { DebugPanel, DebugPanelSection } from '@gredice/ui/DebugControls';
 import { IconButton } from '@gredice/ui/IconButton';
 import {
+    AI,
     Cloud,
     Custom,
     Desktop,
@@ -35,16 +36,25 @@ import type {
     ReactNode,
     PointerEvent as ReactPointerEvent,
 } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Vector3 } from 'three';
+import { useBlockData } from '../hooks/useBlockData';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useLiveTime } from '../hooks/useLiveTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
+import { animateSunflowerPointToHud } from '../indicators/SunflowerTransfer/useSunflowerTransferAnimation';
 import {
     type GameProfileMetadata,
     readGameProfileMetadata,
 } from '../scene/gameProfileMetadata';
-import { type AnimalDebugEntry, useGameState } from '../useGameState';
+import { useGameState } from '../useGameState';
 import { clampTimeOfDay, createDateForGameTimeOfDay } from '../utils/timeOfDay';
 import { TimeOfDayVisualization } from './components/TimeOfDayVisualization';
+import {
+    getSpecialEntityDebugEntries,
+    type SpecialEntityDebugEntry,
+    SUNFLOWER_SPECIAL_ENTITY_REWARD_AMOUNT,
+} from './specialEntityDebug';
 
 type IconType = ComponentType<{ className?: string }>;
 
@@ -106,7 +116,7 @@ function formatTemperature(value: number | null | undefined) {
         : 'n/a';
 }
 
-function formatAnimalPosition(position: AnimalDebugEntry['position']) {
+function formatDebugPosition(position: { x: number; y: number; z: number }) {
     return `${formatMetric(position.x)}, ${formatMetric(position.y)}, ${formatMetric(position.z)}`;
 }
 
@@ -287,10 +297,47 @@ export function DebugHud() {
     );
     const gameQualitySetting = useGameState((s) => s.gameQualitySetting);
     const setGameQualitySetting = useGameState((s) => s.setGameQualitySetting);
+    const gameCamera = useGameState((s) => s.gameCamera);
     const frameStats = useFrameStats();
     const profileSnapshot = useProfileHudSnapshot();
 
+    const { data: blockData } = useBlockData();
+    const { data: garden } = useCurrentGarden();
     const { data: weather } = useWeatherNow();
+    const specialEntityDebugEntries = useMemo(
+        () =>
+            getSpecialEntityDebugEntries({
+                blockData,
+                stacks: garden?.stacks,
+            }),
+        [blockData, garden?.stacks],
+    );
+
+    const forceSunflowerReward = useCallback(
+        (entry: SpecialEntityDebugEntry) => {
+            if (!gameCamera) {
+                return;
+            }
+
+            const target = gameCamera.projectToScreen(
+                new Vector3(
+                    entry.position.x,
+                    entry.position.y,
+                    entry.position.z,
+                ),
+            );
+
+            if (!target) {
+                return;
+            }
+
+            animateSunflowerPointToHud({
+                amount: SUNFLOWER_SPECIAL_ENTITY_REWARD_AMOUNT,
+                from: target,
+            });
+        },
+        [gameCamera],
+    );
 
     const panelWrapperRef = useRef<HTMLDivElement>(null);
     const panelSizeRef = useRef({ width: 0, height: 0 });
@@ -835,13 +882,13 @@ export function DebugHud() {
                                                     blocked
                                                     {entry.pathfinding
                                                         .nextWaypoint
-                                                        ? ` · next ${formatAnimalPosition(entry.pathfinding.nextWaypoint)}`
+                                                        ? ` · next ${formatDebugPosition(entry.pathfinding.nextWaypoint)}`
                                                         : ''}
                                                 </div>
                                             ) : null}
                                             <div className="inline-flex items-center gap-1 font-mono text-muted-foreground">
                                                 <MapPin className="size-3 shrink-0" />
-                                                {formatAnimalPosition(
+                                                {formatDebugPosition(
                                                     entry.position,
                                                 )}
                                             </div>
@@ -877,6 +924,59 @@ export function DebugHud() {
                                                     )}
                                                 </div>
                                             ) : null}
+                                        </div>
+                                    ))}
+                                </Stack>
+                            )}
+                        </DebugPanelSection>
+                        <DebugPanelSection title="Special entities" icon={AI}>
+                            {specialEntityDebugEntries.length === 0 ? (
+                                <Typography
+                                    level="body3"
+                                    secondary
+                                    className="italic"
+                                >
+                                    No active special entities
+                                </Typography>
+                            ) : (
+                                <Stack spacing={1}>
+                                    {specialEntityDebugEntries.map((entry) => (
+                                        <div
+                                            key={entry.id}
+                                            className="rounded-md border border-border/50 bg-card/60 p-1.5 text-[11px] leading-tight"
+                                        >
+                                            <div className="flex items-center justify-between gap-2">
+                                                <span className="inline-flex min-w-0 items-center gap-1 font-medium">
+                                                    <AI className="size-3 shrink-0 text-muted-foreground" />
+                                                    <span className="truncate">
+                                                        {entry.label}
+                                                    </span>
+                                                </span>
+                                                <span className="shrink-0 rounded bg-muted px-1 font-mono">
+                                                    {entry.kind}
+                                                </span>
+                                            </div>
+                                            <div className="mt-0.5 truncate text-muted-foreground">
+                                                {entry.blockName} ·{' '}
+                                                {entry.blockId}
+                                            </div>
+                                            <div className="inline-flex items-center gap-1 font-mono text-muted-foreground">
+                                                <MapPin className="size-3 shrink-0" />
+                                                {formatDebugPosition(
+                                                    entry.position,
+                                                )}
+                                            </div>
+                                            <Button
+                                                size="xs"
+                                                className="mt-1.5 h-6 px-1.5 text-[10px]"
+                                                disabled={!gameCamera}
+                                                variant="outlined"
+                                                onClick={() =>
+                                                    forceSunflowerReward(entry)
+                                                }
+                                            >
+                                                Spawn reward
+                                            </Button>
                                         </div>
                                     ))}
                                 </Stack>

--- a/packages/game/src/hud/specialEntityDebug.ts
+++ b/packages/game/src/hud/specialEntityDebug.ts
@@ -1,0 +1,145 @@
+import type { Stack } from '../types/Stack';
+
+export const SUNFLOWER_SPECIAL_ENTITY_REWARD_AMOUNT = 1000;
+
+export type SpecialEntityBlockData = {
+    attributes?: {
+        height?: number | null;
+    };
+    information: {
+        label?: string | null;
+        name: string;
+    };
+};
+
+export type SpecialEntityDebugEntry = {
+    blockId: string;
+    blockName: string;
+    id: string;
+    kind: 'sunflower';
+    label: string;
+    position: {
+        x: number;
+        y: number;
+        z: number;
+    };
+};
+
+const explicitSunflowerEntityNames = new Set([
+    'SpecialSunflower',
+    'Special_Sunflower',
+    'Sunflower',
+    'SunflowerReward',
+    'Sunflower_Reward',
+]);
+
+function matchesSunflowerEntityText(value: string | null | undefined) {
+    const normalized = value?.toLowerCase();
+    return (
+        Boolean(normalized?.includes('sunflower')) ||
+        Boolean(normalized?.includes('suncokret'))
+    );
+}
+
+function isSunflowerSpecialEntity({
+    blockData,
+    blockName,
+}: {
+    blockData: SpecialEntityBlockData | undefined;
+    blockName: string;
+}) {
+    return (
+        explicitSunflowerEntityNames.has(blockName) ||
+        matchesSunflowerEntityText(blockName) ||
+        matchesSunflowerEntityText(blockData?.information.label)
+    );
+}
+
+function resolveBlockDataByName(blockData: SpecialEntityBlockData[] | null) {
+    const blockDataByName = new Map<string, SpecialEntityBlockData>();
+
+    for (const block of blockData ?? []) {
+        blockDataByName.set(block.information.name, block);
+    }
+
+    return blockDataByName;
+}
+
+function resolveBlockHeight(blockData: SpecialEntityBlockData | undefined) {
+    const height = blockData?.attributes?.height;
+    return typeof height === 'number' && Number.isFinite(height) ? height : 0;
+}
+
+function resolveSpecialEntityPositionY({
+    blockDataByName,
+    blockIndex,
+    stack,
+}: {
+    blockDataByName: Map<string, SpecialEntityBlockData>;
+    blockIndex: number;
+    stack: Stack;
+}) {
+    let y = 0;
+
+    for (let index = 0; index < blockIndex; index += 1) {
+        const block = stack.blocks[index];
+        if (!block) {
+            continue;
+        }
+        y += resolveBlockHeight(blockDataByName.get(block.name));
+    }
+
+    const block = stack.blocks[blockIndex];
+    const blockHeight = block
+        ? resolveBlockHeight(blockDataByName.get(block.name))
+        : 0;
+
+    return y + Math.max(blockHeight, 0.8) / 2;
+}
+
+export function getSpecialEntityDebugEntries({
+    blockData,
+    stacks,
+}: {
+    blockData?: SpecialEntityBlockData[] | null;
+    stacks: Stack[] | undefined;
+}) {
+    const blockDataByName = resolveBlockDataByName(blockData ?? null);
+    const entries: SpecialEntityDebugEntry[] = [];
+
+    for (const stack of stacks ?? []) {
+        stack.blocks.forEach((block, blockIndex) => {
+            const blockDataEntry = blockDataByName.get(block.name);
+            if (
+                !isSunflowerSpecialEntity({
+                    blockData: blockDataEntry,
+                    blockName: block.name,
+                })
+            ) {
+                return;
+            }
+
+            entries.push({
+                blockId: block.id,
+                blockName: block.name,
+                id: `sunflower:${block.id}`,
+                kind: 'sunflower',
+                label: blockDataEntry?.information.label ?? 'Sunflower',
+                position: {
+                    x: stack.position.x,
+                    y: resolveSpecialEntityPositionY({
+                        blockDataByName,
+                        blockIndex,
+                        stack,
+                    }),
+                    z: stack.position.z,
+                },
+            });
+        });
+    }
+
+    return entries.sort((left, right) => {
+        const labelComparison = left.label.localeCompare(right.label);
+        return labelComparison || left.blockId.localeCompare(right.blockId);
+    });
+}

--- a/packages/game/src/hud/specialEntityDebug.unit.ts
+++ b/packages/game/src/hud/specialEntityDebug.unit.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { Vector3 } from 'three';
+import type { Stack } from '../types/Stack';
+import {
+    getSpecialEntityDebugEntries,
+    type SpecialEntityBlockData,
+} from './specialEntityDebug';
+
+function blockData(
+    name: string,
+    label: string,
+    height: number,
+): SpecialEntityBlockData {
+    return {
+        attributes: { height },
+        information: { label, name },
+    };
+}
+
+test('finds sunflower special entities by block name', () => {
+    const stacks: Stack[] = [
+        {
+            position: new Vector3(2, 0, -1),
+            blocks: [{ id: 'sunflower-1', name: 'Sunflower', rotation: 0 }],
+        },
+    ];
+
+    const entries = getSpecialEntityDebugEntries({
+        stacks,
+        blockData: [blockData('Sunflower', 'Sunflower', 1.4)],
+    });
+
+    assert.deepEqual(entries, [
+        {
+            blockId: 'sunflower-1',
+            blockName: 'Sunflower',
+            id: 'sunflower:sunflower-1',
+            kind: 'sunflower',
+            label: 'Sunflower',
+            position: { x: 2, y: 0.7, z: -1 },
+        },
+    ]);
+});
+
+test('finds sunflower special entities by localized block label', () => {
+    const stacks: Stack[] = [
+        {
+            position: new Vector3(0, 0, 3),
+            blocks: [
+                { id: 'ground-1', name: 'Block_Grass', rotation: 0 },
+                { id: 'reward-1', name: 'Special_Reward', rotation: 0 },
+            ],
+        },
+    ];
+
+    const entries = getSpecialEntityDebugEntries({
+        stacks,
+        blockData: [
+            blockData('Block_Grass', 'Grass', 0.4),
+            blockData('Special_Reward', 'Suncokret', 1.2),
+        ],
+    });
+
+    assert.deepEqual(entries, [
+        {
+            blockId: 'reward-1',
+            blockName: 'Special_Reward',
+            id: 'sunflower:reward-1',
+            kind: 'sunflower',
+            label: 'Suncokret',
+            position: { x: 0, y: 1, z: 3 },
+        },
+    ]);
+});
+
+test('ignores non-sunflower entities', () => {
+    const stacks: Stack[] = [
+        {
+            position: new Vector3(0, 0, 0),
+            blocks: [{ id: 'tree-1', name: 'Tree', rotation: 0 }],
+        },
+    ];
+
+    assert.deepEqual(
+        getSpecialEntityDebugEntries({
+            stacks,
+            blockData: [blockData('Tree', 'Tree', 1.8)],
+        }),
+        [],
+    );
+});

--- a/packages/game/src/indicators/SunflowerTransfer/useSunflowerTransferAnimation.ts
+++ b/packages/game/src/indicators/SunflowerTransfer/useSunflowerTransferAnimation.ts
@@ -71,6 +71,21 @@ function getElementCenter(element: HTMLElement): Point {
     };
 }
 
+function getFallbackHudTarget(): Point {
+    if (typeof window === 'undefined') {
+        return { x: 0, y: 0 };
+    }
+
+    const isMobile = window.innerWidth < 768;
+    const horizontalOffset = isMobile ? 80 : 120;
+    const verticalOffset = isMobile ? 110 : 80;
+
+    return {
+        x: Math.max(window.innerWidth - horizontalOffset, 0),
+        y: Math.max(verticalOffset, 0),
+    };
+}
+
 function getParticleCount(amount: number) {
     if (!Number.isFinite(amount) || amount <= 0) {
         return 3;
@@ -269,6 +284,26 @@ export function animateSunflowerHudToPoint({
         amount,
         from: getElementCenter(hudElement),
         to,
+    });
+}
+
+export function animateSunflowerPointToHud({
+    amount = 0,
+    from,
+}: {
+    amount?: number;
+    from: Point;
+}) {
+    if (getPrefersReducedMotion() || typeof document === 'undefined') {
+        return;
+    }
+
+    const hudElement = document.querySelector<HTMLElement>(HUD_TARGET_SELECTOR);
+
+    startSunflowerTransfer({
+        amount,
+        from,
+        to: hudElement ? getElementCenter(hudElement) : getFallbackHudTarget(),
     });
 }
 


### PR DESCRIPTION
**Summary**
- Added a new `Special entities` section to the game debug HUD that surfaces sunflower-like scene entities when they exist.
- Wired a `Spawn reward` action to trigger the sunflower reward animation from the entity position back to the HUD.
- Added a small helper plus unit coverage for sunflower special-entity detection.

**Testing**
- `@gredice/game` unit tests passed, including the new special-entity helper tests.
- `@gredice/game` typecheck passed.
- `garden` and `www` typechecks passed.