### PR TITLE
Fix block pickup raycast ordering

### DIFF
--- a/packages/game/src/controls/BlockInteractionLayer.tsx
+++ b/packages/game/src/controls/BlockInteractionLayer.tsx
@@ -2,7 +2,7 @@
 
 import type { ThreeEvent } from '@react-three/fiber';
 import { useLayoutEffect, useMemo, useRef } from 'react';
-import { MeshBasicMaterial, type Vector3 } from 'three';
+import { type Mesh, MeshBasicMaterial, type Vector3 } from 'three';
 import { instancedBlockNames } from '../entities/EntityInstances';
 import { useBlockData } from '../hooks/useBlockData';
 import type { Stack } from '../types/Stack';
@@ -16,6 +16,7 @@ import {
 import {
     type BlockInteractionLayerTarget,
     getBlockInteractionLayerBounds,
+    hasCloserNonLayerIntersection,
     resolveBlockInteractionLayerTarget,
 } from './BlockInteractionResolver';
 
@@ -94,6 +95,7 @@ export function BlockInteractionLayer({
     const { data: blockData } = useBlockData();
     const registry = useBlockInteractionRegistry();
     const hoveredTargetKeyRef = useRef<string | null>(null);
+    const layerRef = useRef<Mesh>(null);
     const view = useGameState((state) => state.view);
     const editHitboxDebugVisible = useGameState(
         (state) => state.editHitboxDebugVisible,
@@ -142,6 +144,18 @@ export function BlockInteractionLayer({
             event.ray,
         );
         if (!resolvedLayerTarget) {
+            return null;
+        }
+
+        if (
+            layerRef.current &&
+            hasCloserNonLayerIntersection({
+                intersections: event.intersections,
+                layerObject: layerRef.current,
+                ray: event.ray,
+                resolvedHitPoint: resolvedLayerTarget.hitPoint,
+            })
+        ) {
             return null;
         }
 
@@ -231,6 +245,7 @@ export function BlockInteractionLayer({
     return (
         // biome-ignore lint/a11y/noStaticElementInteractions: Three.js mesh is the single block interaction plane.
         <mesh
+            ref={layerRef}
             frustumCulled={false}
             onClick={handleClick}
             onPointerDown={handlePointerDown}

--- a/packages/game/src/controls/BlockInteractionResolver.ts
+++ b/packages/game/src/controls/BlockInteractionResolver.ts
@@ -1,4 +1,4 @@
-import { Box3, type Ray, Vector3 } from 'three';
+import { Box3, type Object3D, type Ray, Vector3 } from 'three';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 
@@ -29,10 +29,16 @@ export type BlockInteractionLayerBounds = {
     width: number;
 };
 
+type BlockInteractionEventIntersection = {
+    distance: number;
+    object: Object3D;
+};
+
 const hitboxMin = new Vector3();
 const hitboxMax = new Vector3();
 const hitboxIntersection = new Vector3();
 const hitboxBounds = new Box3();
+const closerIntersectionEpsilon = 0.0001;
 
 export function getBlockInteractionRotatedHitboxFootprint(
     target: BlockInteractionLayerTarget,
@@ -134,4 +140,25 @@ export function resolveBlockInteractionLayerTarget(
               target: resolvedTarget,
           }
         : null;
+}
+
+export function hasCloserNonLayerIntersection({
+    intersections,
+    layerObject,
+    ray,
+    resolvedHitPoint,
+}: {
+    intersections: readonly BlockInteractionEventIntersection[];
+    layerObject: Object3D;
+    ray: Ray;
+    resolvedHitPoint: Vector3;
+}) {
+    const resolvedDistance = ray.origin.distanceTo(resolvedHitPoint);
+
+    return intersections.some(
+        (intersection) =>
+            intersection.object !== layerObject &&
+            intersection.distance + closerIntersectionEpsilon <
+                resolvedDistance,
+    );
 }

--- a/packages/game/src/controls/BlockInteractionResolver.unit.ts
+++ b/packages/game/src/controls/BlockInteractionResolver.unit.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Ray, Vector3 } from 'three';
+import { Object3D, Ray, Vector3 } from 'three';
 import {
     type BlockInteractionLayerTarget,
     getBlockInteractionLayerBounds,
     getBlockInteractionRotatedHitboxFootprint,
+    hasCloserNonLayerIntersection,
     resolveBlockInteractionLayerTarget,
 } from './BlockInteractionResolver';
 
@@ -172,6 +173,58 @@ describe('resolveBlockInteractionLayerTarget', () => {
                 height: 2.48,
                 width: 1.46,
             },
+        );
+    });
+});
+
+describe('hasCloserNonLayerIntersection', () => {
+    it('detects a foreground object closer than the resolved layer target', () => {
+        const layerObject = new Object3D();
+        const foregroundObject = new Object3D();
+        const ray = new Ray(new Vector3(0, 0, 0), new Vector3(0, 0, 1));
+
+        assert.equal(
+            hasCloserNonLayerIntersection({
+                intersections: [
+                    {
+                        distance: 1,
+                        object: layerObject,
+                    },
+                    {
+                        distance: 2,
+                        object: foregroundObject,
+                    },
+                ],
+                layerObject,
+                ray,
+                resolvedHitPoint: new Vector3(0, 0, 3),
+            }),
+            true,
+        );
+    });
+
+    it('ignores the layer receiver and farther intersections', () => {
+        const layerObject = new Object3D();
+        const backgroundObject = new Object3D();
+        const ray = new Ray(new Vector3(0, 0, 0), new Vector3(0, 0, 1));
+
+        assert.equal(
+            hasCloserNonLayerIntersection({
+                intersections: [
+                    {
+                        distance: 1,
+                        object: layerObject,
+                    },
+                    {
+                        distance: 4,
+                        object: backgroundObject,
+                    },
+                ],
+                layerObject,
+                ray,
+                resolvedHitPoint: new Vector3(0, 0, 3),
+            }),
+            false,
         );
     });
 });


### PR DESCRIPTION
## Summary
- Make the block interaction layer yield to nearer non-layer intersections so pickup targets behind foreground blocks are no longer selected first
- Add a shared resolver guard for comparing the resolved hit against the event intersections
- Cover the new behavior with unit tests for the foreground and background cases

## Testing
- `@gredice/game` unit tests passed
- `@gredice/game` typecheck passed
- `garden` and `www` typechecks passed
- `@gredice/game` lint passed