### PR TITLE
Use standard sandbox stacks in entity debug views

### DIFF
--- a/apps/garden/app/debug/entities/EntityGridViewerDynamic.tsx
+++ b/apps/garden/app/debug/entities/EntityGridViewerDynamic.tsx
@@ -5,7 +5,11 @@ import { useEffect, useState } from 'react';
 type EntityGridViewerComponent =
     typeof import('@gredice/game').EntityGridViewer;
 
-export function EntityGridViewerDynamic() {
+export function EntityGridViewerDynamic({
+    storageKey,
+}: {
+    storageKey: string;
+}) {
     const [EntityGridViewer, setEntityGridViewer] =
         useState<EntityGridViewerComponent | null>(null);
 
@@ -32,6 +36,11 @@ export function EntityGridViewerDynamic() {
     }
 
     return (
-        <EntityGridViewer className="h-full w-full" debugHud showBackground />
+        <EntityGridViewer
+            className="h-full w-full"
+            debugHud
+            localSandboxStorageKey={storageKey}
+            showBackground
+        />
     );
 }

--- a/apps/garden/app/debug/entities/[entityName]/EntityViewerDynamic.tsx
+++ b/apps/garden/app/debug/entities/[entityName]/EntityViewerDynamic.tsx
@@ -2,30 +2,27 @@
 
 import { useEffect, useState } from 'react';
 
-type EntityViewerComponent = typeof import('@gredice/game').EntityViewer;
+type EntitySandboxViewerComponent =
+    typeof import('@gredice/game').EntitySandboxViewer;
 
 export function EntityViewerDynamic({
     entityName,
-    noControl,
     rotation,
-    staticEnvironment,
-    zoom,
+    storageKey,
 }: {
     entityName: string;
-    noControl?: boolean;
     rotation?: number;
-    staticEnvironment?: boolean;
-    zoom?: number;
+    storageKey: string;
 }) {
-    const [EntityViewer, setEntityViewer] =
-        useState<EntityViewerComponent | null>(null);
+    const [EntitySandboxViewer, setEntitySandboxViewer] =
+        useState<EntitySandboxViewerComponent | null>(null);
 
     useEffect(() => {
         let isMounted = true;
 
         void import('@gredice/game').then((mod) => {
             if (isMounted) {
-                setEntityViewer(() => mod.EntityViewer);
+                setEntitySandboxViewer(() => mod.EntitySandboxViewer);
             }
         });
 
@@ -34,7 +31,7 @@ export function EntityViewerDynamic({
         };
     }, []);
 
-    if (!EntityViewer) {
+    if (!EntitySandboxViewer) {
         return (
             <div className="flex h-full items-center justify-center text-sm text-neutral-700">
                 Loading entity scene...
@@ -43,15 +40,12 @@ export function EntityViewerDynamic({
     }
 
     return (
-        <EntityViewer
+        <EntitySandboxViewer
             className="h-full w-full"
             debugHud
             entityName={entityName}
-            noControl={noControl}
+            localSandboxStorageKey={storageKey}
             rotation={rotation}
-            showBackground
-            staticEnvironment={staticEnvironment}
-            zoom={zoom}
         />
     );
 }

--- a/apps/garden/app/debug/entities/[entityName]/page.tsx
+++ b/apps/garden/app/debug/entities/[entityName]/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import { SandboxDebugActions } from '../../sandbox/SandboxDebugActions';
+import { getEntitySandboxStorageKey } from '../entitySandboxStorage';
 import { EntityViewerDynamic } from './EntityViewerDynamic';
 
 type EntityDebugParams = Promise<{ entityName: string }>;
@@ -25,10 +27,8 @@ export default async function DebugEntityPage({
     searchParams: EntityDebugSearchParams;
 }) {
     const [{ entityName }, query] = await Promise.all([params, searchParams]);
-    const zoom = resolveNumber(firstValue(query.zoom));
     const rotation = resolveNumber(firstValue(query.rotation));
-    const staticEnvironment = firstValue(query.static) === '1';
-    const noControl = firstValue(query.controls) === '0';
+    const storageKey = getEntitySandboxStorageKey(entityName);
 
     return (
         <main className="flex h-screen w-screen flex-col bg-[#e7e2cc]">
@@ -38,7 +38,7 @@ export default async function DebugEntityPage({
                         {entityName}
                     </h1>
                     <p className="text-sm text-neutral-400">
-                        Single entity debug view
+                        Single block sandbox scene
                     </p>
                 </div>
                 <nav className="flex items-center gap-3 text-sm">
@@ -56,14 +56,13 @@ export default async function DebugEntityPage({
                     </Link>
                 </nav>
             </header>
-            <div className="min-h-0 flex-1">
+            <div className="relative min-h-0 flex-1">
                 <EntityViewerDynamic
                     entityName={entityName}
-                    noControl={noControl}
                     rotation={rotation}
-                    staticEnvironment={staticEnvironment}
-                    zoom={zoom}
+                    storageKey={storageKey}
                 />
+                <SandboxDebugActions storageKey={storageKey} />
             </div>
         </main>
     );

--- a/apps/garden/app/debug/entities/entitySandboxStorage.ts
+++ b/apps/garden/app/debug/entities/entitySandboxStorage.ts
@@ -1,0 +1,5 @@
+export const entityGridSandboxStorageKey = 'gredice.debug.entities.sandbox.v1';
+
+export function getEntitySandboxStorageKey(entityName: string) {
+    return `gredice.debug.entity.${encodeURIComponent(entityName)}.sandbox.v1`;
+}

--- a/apps/garden/app/debug/entities/page.tsx
+++ b/apps/garden/app/debug/entities/page.tsx
@@ -1,18 +1,21 @@
+import { SandboxDebugActions } from '../sandbox/SandboxDebugActions';
 import { EntityGridViewerDynamic } from './EntityGridViewerDynamic';
+import { entityGridSandboxStorageKey } from './entitySandboxStorage';
 
 export default function DebugEntitiesPage() {
     return (
         <div className="flex h-screen w-screen flex-col bg-[#e7e2cc]">
             <div className="border-b border-neutral-700 bg-neutral-950 p-4">
-                <h1 className="text-xl font-bold text-white">
-                    Entity Debug View
-                </h1>
+                <h1 className="text-xl font-bold text-white">Entity Sandbox</h1>
                 <p className="text-neutral-400 text-sm">
-                    Displaying all entities/blocks
+                    Displaying sandbox blocks in positioned stacks
                 </p>
             </div>
-            <div className="flex-1">
-                <EntityGridViewerDynamic />
+            <div className="relative min-h-0 flex-1">
+                <EntityGridViewerDynamic
+                    storageKey={entityGridSandboxStorageKey}
+                />
+                <SandboxDebugActions storageKey={entityGridSandboxStorageKey} />
             </div>
         </div>
     );

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -7,14 +7,15 @@ const debugGroups = [
         pages: [
             {
                 href: '/debug/entities',
-                title: 'Entity grid',
-                description: 'All registered garden entities in one 3D scene.',
+                title: 'Entity sandbox',
+                description:
+                    'Sandbox scene with all placeable debug blocks in separate stacks.',
             },
             {
-                href: '/debug/entities/FireflyJar?zoom=130&static=1',
-                title: 'Single entity viewer',
+                href: '/debug/entities/FireflyJar',
+                title: 'Single entity sandbox',
                 description:
-                    'One entity rendered with EntityViewer. Replace the path segment with any entity name.',
+                    'One block rendered through the standard sandbox scene. Replace the path segment with any block name.',
             },
         ],
     },

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -48,6 +48,7 @@ import {
     resolveGameQualityProfile,
 } from './scene/gameQuality';
 import { Scene } from './scene/Scene';
+import type { Stack } from './types/Stack';
 import {
     type GameState,
     type MockGardenProfile,
@@ -73,6 +74,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     mockGarden?: boolean;
     mockGardenProfile?: MockGardenProfile;
     localSandboxStorageKey?: string;
+    localSandboxInitialStacks?: Stack[];
     winterMode?: WinterMode;
     weather?: Partial<GameState['weather']>;
     deferDetails?: boolean;

--- a/packages/game/src/GameSceneWrapper.tsx
+++ b/packages/game/src/GameSceneWrapper.tsx
@@ -22,6 +22,7 @@ export function GameSceneWrapper({
     mockGarden,
     mockGardenProfile,
     localSandboxStorageKey,
+    localSandboxInitialStacks,
     winterMode,
     ...rest
 }: GameSceneProps) {
@@ -35,6 +36,7 @@ export function GameSceneWrapper({
             initialQualitySetting,
             isMock: mockGarden || false,
             localSandboxStorageKey,
+            localSandboxInitialStacks,
             mockGardenProfile,
             winterMode: winterMode ?? 'summer',
         });

--- a/packages/game/src/hooks/useBlockDelete.ts
+++ b/packages/game/src/hooks/useBlockDelete.ts
@@ -35,7 +35,12 @@ export function useBlockDelete() {
         (state) => state.localSandboxStorageKey,
     );
     const winterMode = useGameState((state) => state.winterMode);
-    const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
+    const gardenQueryKey = currentGardenKeys(
+        winterMode,
+        garden?.id,
+        undefined,
+        localSandboxStorageKey,
+    );
 
     return useMutation({
         mutationKey,

--- a/packages/game/src/hooks/useBlockMove.ts
+++ b/packages/game/src/hooks/useBlockMove.ts
@@ -128,7 +128,12 @@ export function useBlockMove() {
         (state) => state.localSandboxStorageKey,
     );
     const winterMode = useGameState((state) => state.winterMode);
-    const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
+    const gardenQueryKey = currentGardenKeys(
+        winterMode,
+        garden?.id,
+        undefined,
+        localSandboxStorageKey,
+    );
 
     return useMutation({
         mutationKey,

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -92,7 +92,12 @@ export function useBlockPlace() {
     const queueBlockPlacementDropAnimation = useGameState(
         (state) => state.queueBlockPlacementDropAnimation,
     );
-    const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
+    const gardenQueryKey = currentGardenKeys(
+        winterMode,
+        garden?.id,
+        undefined,
+        localSandboxStorageKey,
+    );
 
     return useMutation({
         mutationKey,

--- a/packages/game/src/hooks/useBlockRecycle.ts
+++ b/packages/game/src/hooks/useBlockRecycle.ts
@@ -44,7 +44,12 @@ export function useBlockRecycle() {
     );
     const { data: shoppingCart } = useShoppingCart(!localSandboxStorageKey);
     const winterMode = useGameState((state) => state.winterMode);
-    const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
+    const gardenQueryKey = currentGardenKeys(
+        winterMode,
+        garden?.id,
+        undefined,
+        localSandboxStorageKey,
+    );
 
     return useMutation({
         mutationKey,

--- a/packages/game/src/hooks/useBlockRotate.ts
+++ b/packages/game/src/hooks/useBlockRotate.ts
@@ -14,7 +14,12 @@ export function useBlockRotate() {
         (state) => state.localSandboxStorageKey,
     );
     const winterMode = useGameState((state) => state.winterMode);
-    const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
+    const gardenQueryKey = currentGardenKeys(
+        winterMode,
+        garden?.id,
+        undefined,
+        localSandboxStorageKey,
+    );
 
     return useMutation({
         mutationFn: async ({

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -21,11 +21,15 @@ export const currentGardenKeys = (
     winterMode: WinterMode,
     gardenId?: number | null,
     mockGardenProfile?: MockGardenProfile,
+    localSandboxStorageKey?: string | null,
 ) => [
     ...useGardensKeys,
     'current',
     winterMode,
     ...(gardenId != null ? [gardenId] : []),
+    ...(localSandboxStorageKey
+        ? ['local-sandbox', localSandboxStorageKey]
+        : []),
     ...(mockGardenProfile != null ? [mockGardenProfile] : []),
 ];
 
@@ -750,6 +754,9 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
     );
+    const localSandboxInitialStacks = useGameState(
+        (state) => state.localSandboxInitialStacks,
+    );
     const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
     const winterMode = useGameState((state) => state.winterMode);
     const isLocalSandbox = localSandboxStorageKey !== null;
@@ -771,10 +778,13 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
             winterMode,
             currentGardenId,
             isMock ? mockGardenProfile : undefined,
+            localSandboxStorageKey,
         ),
         queryFn: async () => {
             if (localSandboxStorageKey) {
-                return loadLocalSandboxGarden(localSandboxStorageKey);
+                return loadLocalSandboxGarden(localSandboxStorageKey, {
+                    stacks: localSandboxInitialStacks ?? undefined,
+                });
             }
 
             if (isMock) {

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -26,6 +26,12 @@ export { useSpriteAtlasManifest } from './sprites/useSpriteAtlasManifest';
 export { useSpriteAtlasTexture } from './sprites/useSpriteAtlasTexture';
 export type { EntityGridViewerProps } from './viewers/EntityGridViewer';
 export { EntityGridViewer } from './viewers/EntityGridViewer';
+export type { EntitySandboxViewerProps } from './viewers/EntitySandboxViewer';
+export {
+    EntitySandboxViewer,
+    entitySandboxStorageKey,
+    getEntitySandboxStorageKey,
+} from './viewers/EntitySandboxViewer';
 export type { EntityViewerProps } from './viewers/EntityViewer';
 export { EntityViewer } from './viewers/EntityViewer';
 export type { PlantPerformanceViewerProps } from './viewers/PlantPerformanceViewer';

--- a/packages/game/src/localSandboxBlockData.ts
+++ b/packages/game/src/localSandboxBlockData.ts
@@ -1,6 +1,6 @@
 import type { BlockData } from '@gredice/client';
 
-const localSandboxBlockNames = [
+export const localSandboxBlockNames = [
     'Raised_Bed',
     'Bucket',
     'WateringCan',
@@ -71,7 +71,7 @@ const localSandboxBlockNames = [
     'Block_Snow_Reverse_Corner',
 ] as const;
 
-type LocalSandboxBlockName = (typeof localSandboxBlockNames)[number];
+export type LocalSandboxBlockName = (typeof localSandboxBlockNames)[number];
 
 const createdAt = new Date(0).toISOString();
 

--- a/packages/game/src/localSandboxGarden.ts
+++ b/packages/game/src/localSandboxGarden.ts
@@ -27,6 +27,11 @@ type StoredLocalSandboxGarden = {
     }>;
 };
 
+type LocalSandboxGardenOptions = {
+    name?: string;
+    stacks?: Stack[];
+};
+
 function createDefaultLocalSandboxStacks(): Stack[] {
     const stacks: Stack[] = [];
 
@@ -48,12 +53,27 @@ function createDefaultLocalSandboxStacks(): Stack[] {
     return stacks;
 }
 
-export function createDefaultLocalSandboxGarden(): LocalSandboxGarden {
+function cloneSandboxStacks(stacks: Stack[]): Stack[] {
+    return stacks.map((stack) => ({
+        position: stack.position.clone(),
+        blocks: stack.blocks.map((block) => ({ ...block })),
+    }));
+}
+
+function resolveDefaultLocalSandboxStacks(stacks: Stack[] | undefined) {
+    return stacks?.length
+        ? cloneSandboxStacks(stacks)
+        : createDefaultLocalSandboxStacks();
+}
+
+export function createDefaultLocalSandboxGarden(
+    options: LocalSandboxGardenOptions = {},
+): LocalSandboxGarden {
     return {
         id: localSandboxGardenId,
-        name: 'Debug sandbox',
+        name: options.name ?? 'Debug sandbox',
         isSandbox: true,
-        stacks: createDefaultLocalSandboxStacks(),
+        stacks: resolveDefaultLocalSandboxStacks(options.stacks),
         location: { lat: 45.739, lon: 16.572 },
         raisedBeds: [],
     };
@@ -100,6 +120,7 @@ function normalizeStoredBlocks(blocks: unknown): Block[] {
 
 function normalizeStoredGarden(
     storedGarden: StoredLocalSandboxGarden,
+    options: LocalSandboxGardenOptions = {},
 ): LocalSandboxGarden {
     const stacks =
         storedGarden.stacks?.flatMap((stack) => {
@@ -118,28 +139,35 @@ function normalizeStoredGarden(
         }) ?? [];
 
     return {
-        ...createDefaultLocalSandboxGarden(),
-        stacks: stacks.length > 0 ? stacks : createDefaultLocalSandboxStacks(),
+        ...createDefaultLocalSandboxGarden(options),
+        stacks:
+            stacks.length > 0
+                ? stacks
+                : resolveDefaultLocalSandboxStacks(options.stacks),
     };
 }
 
-export function loadLocalSandboxGarden(storageKey: string): LocalSandboxGarden {
+export function loadLocalSandboxGarden(
+    storageKey: string,
+    options: LocalSandboxGardenOptions = {},
+): LocalSandboxGarden {
     if (typeof window === 'undefined') {
-        return createDefaultLocalSandboxGarden();
+        return createDefaultLocalSandboxGarden(options);
     }
 
     try {
         const storedValue = window.localStorage.getItem(storageKey);
         if (!storedValue) {
-            return createDefaultLocalSandboxGarden();
+            return createDefaultLocalSandboxGarden(options);
         }
 
         return normalizeStoredGarden(
             JSON.parse(storedValue) as StoredLocalSandboxGarden,
+            options,
         );
     } catch (error) {
         console.warn('Failed to load local sandbox garden', error);
-        return createDefaultLocalSandboxGarden();
+        return createDefaultLocalSandboxGarden(options);
     }
 }
 
@@ -173,9 +201,12 @@ export function persistLocalSandboxGarden(
     }
 }
 
-export function resetLocalSandboxGarden(storageKey: string) {
+export function resetLocalSandboxGarden(
+    storageKey: string,
+    options: LocalSandboxGardenOptions = {},
+) {
     if (typeof window === 'undefined') {
-        return createDefaultLocalSandboxGarden();
+        return createDefaultLocalSandboxGarden(options);
     }
 
     try {
@@ -184,7 +215,7 @@ export function resetLocalSandboxGarden(storageKey: string) {
         console.warn('Failed to reset local sandbox garden', error);
     }
 
-    return createDefaultLocalSandboxGarden();
+    return createDefaultLocalSandboxGarden(options);
 }
 
 export function createLocalSandboxBlockId(blockName: string) {

--- a/packages/game/src/localSandboxGarden.unit.ts
+++ b/packages/game/src/localSandboxGarden.unit.ts
@@ -70,6 +70,34 @@ test('persists local sandbox stacks in local storage', () => {
     });
 });
 
+test('loads provided default local sandbox stacks when storage is empty', () => {
+    withLocalStorage(() => {
+        const initialStacks = [
+            {
+                position: new Vector3(-2, 0, 1),
+                blocks: [
+                    {
+                        id: 'debug-firefly',
+                        name: 'FireflyJar',
+                        rotation: 1,
+                    },
+                ],
+            },
+        ];
+
+        const garden = loadLocalSandboxGarden('test-local-sandbox', {
+            stacks: initialStacks,
+        });
+
+        assert.equal(garden.stacks.length, 1);
+        assert.notEqual(garden.stacks[0], initialStacks[0]);
+        assert.equal(garden.stacks[0]?.position.x, -2);
+        assert.equal(garden.stacks[0]?.position.z, 1);
+        assert.equal(garden.stacks[0]?.blocks[0]?.name, 'FireflyJar');
+        assert.equal(garden.stacks[0]?.blocks[0]?.rotation, 1);
+    });
+});
+
 test('falls back to a playable default local sandbox', () => {
     const garden = createDefaultLocalSandboxGarden();
 

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -19,6 +19,7 @@ import {
 } from './scene/gameQuality';
 import { defaultWaterColors, type WaterColors } from './scene/waterColors';
 import type { Block } from './types/Block';
+import type { Stack } from './types/Stack';
 import { getAudioConfig } from './utils/audioConfig';
 import {
     isDayNightCycleDisabled,
@@ -136,6 +137,7 @@ export type GameState = {
     spriteBaseUrl: string;
     audio: GameAudio;
     localSandboxStorageKey: string | null;
+    localSandboxInitialStacks: Stack[] | null;
     freezeTime?: Date | null;
     setFreezeTime: (freezeTime: Date | null) => void;
     dayNightCycleDisabled: boolean;
@@ -229,6 +231,7 @@ export function createGameState({
     initialQualitySetting,
     isMock,
     localSandboxStorageKey,
+    localSandboxInitialStacks,
     mockGardenProfile,
     winterMode,
 }: {
@@ -239,6 +242,7 @@ export function createGameState({
     initialQualitySetting?: GameQualitySetting;
     isMock: boolean;
     localSandboxStorageKey?: string;
+    localSandboxInitialStacks?: Stack[];
     mockGardenProfile?: MockGardenProfile;
     winterMode?: WinterMode;
 }) {
@@ -259,6 +263,7 @@ export function createGameState({
         spriteBaseUrl: spriteBaseUrl ?? appBaseUrl,
         audio: createGameAudio(getAudioConfig()),
         localSandboxStorageKey: localSandboxStorageKey ?? null,
+        localSandboxInitialStacks: localSandboxInitialStacks ?? null,
         freezeTime,
         setFreezeTime: (freezeTime) => {
             const referenceTime = freezeTime ?? new Date();

--- a/packages/game/src/viewers/EntityGridViewer.tsx
+++ b/packages/game/src/viewers/EntityGridViewer.tsx
@@ -1,172 +1,38 @@
 'use client';
 
-import { Html, OrbitControls } from '@react-three/drei';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useRef } from 'react';
-import { MOUSE, Vector3 } from 'three';
-import { v4 as uuidv4 } from 'uuid';
-import { EntityFactory } from '../entities/EntityFactory';
-import { entityNameMap } from '../entities/entityNameMap';
-import { GameFlagsContext } from '../GameFlagsContext';
-import { DebugHud } from '../hud/DebugHud';
-import { ParticleSystemProvider } from '../particles/ParticleSystem';
-import { Environment } from '../scene/Environment';
-import { Scene } from '../scene/Scene';
-import type { Block } from '../types/Block';
-import {
-    createGameState,
-    GameStateContext,
-    type GameStateStore,
-    useDisposeGameStateStore,
-} from '../useGameState';
+import type { HTMLAttributes } from 'react';
+import { EntitySandboxViewer } from './EntitySandboxViewer';
 
-export type EntityGridViewerProps = {
-    className?: string;
+export type EntityGridViewerProps = HTMLAttributes<HTMLDivElement> & {
     /**
-     * Number of columns in the grid
-     * @default 6
+     * Number of columns in the sandbox layout.
+     * @default 9
      */
     columns?: number;
     /**
-     * Spacing between entities
-     * @default 5
+     * Kept for compatibility with older debug links. The standard sandbox scene
+     * uses normal stack positions instead of custom spacing.
      */
     spacing?: number;
     /**
-     * Zoom level of the camera
-     * @default 28
+     * Kept for compatibility with older debug links. Camera zoom is handled by
+     * the standard game scene.
      */
     zoom?: number;
     debugHud?: boolean;
+    localSandboxStorageKey?: string;
     showBackground?: boolean;
 };
 
 export function EntityGridViewer({
-    className,
-    columns = 6,
-    spacing = 5,
-    zoom = 28,
-    debugHud,
-    showBackground,
+    spacing: _spacing,
+    zoom: _zoom,
+    showBackground: _showBackground,
+    ...props
 }: EntityGridViewerProps) {
-    const storeRef = useRef<GameStateStore>(null);
-    if (!storeRef.current) {
-        storeRef.current = createGameState({
-            appBaseUrl: '',
-            dayNightCycleDisabled: false,
-            freezeTime: new Date(2024, 5, 21, 12, 0, 0),
-            isMock: true,
-            winterMode: 'summer',
-        });
-    }
-    useDisposeGameStateStore(storeRef.current);
+    void _spacing;
+    void _zoom;
+    void _showBackground;
 
-    const client = new QueryClient();
-
-    const entityNames = Object.keys(entityNameMap);
-    const entities = entityNames.map((entityName, index) => {
-        const col = index % columns;
-        const row = Math.floor(index / columns);
-
-        let variant: number | undefined;
-        if (entityName === 'PineAdvent') {
-            variant = 100;
-        }
-
-        const block: Block = {
-            id: uuidv4(),
-            name: entityName,
-            rotation: 0,
-            variant: variant,
-        };
-
-        const position = new Vector3(col * spacing, 0, row * spacing);
-        const stack = {
-            position,
-            blocks: [block],
-        };
-
-        return { entityName, stack, block, variant, position };
-    });
-
-    // Calculate camera position to center on the grid
-    const rows = Math.ceil(entityNames.length / columns);
-    const centerX = ((columns - 1) * spacing) / 2;
-    const centerZ = ((rows - 1) * spacing) / 2;
-
-    return (
-        <QueryClientProvider client={client}>
-            <GameStateContext.Provider value={storeRef.current}>
-                <GameFlagsContext.Provider
-                    value={{
-                        enableDebugHudFlag: debugHud,
-                        enableRainWetOverlayFlag: debugHud,
-                    }}
-                >
-                    <Scene
-                        position={[100, 100, 100]}
-                        zoom={zoom}
-                        className={className}
-                    >
-                        <ParticleSystemProvider>
-                            <Environment
-                                noBackground={!showBackground}
-                                noSound
-                                noWeather
-                            />
-                            <OrbitControls
-                                enableDamping
-                                screenSpacePanning={false}
-                                minZoom={10}
-                                maxZoom={120}
-                                mouseButtons={{
-                                    LEFT: MOUSE.PAN,
-                                    MIDDLE: MOUSE.DOLLY,
-                                    RIGHT: MOUSE.ROTATE,
-                                }}
-                            />
-                            <group position={[-centerX, 0, -centerZ]}>
-                                {entities.map(
-                                    ({
-                                        entityName,
-                                        stack,
-                                        block,
-                                        variant,
-                                        position,
-                                    }) => (
-                                        <group key={entityName}>
-                                            <EntityFactory
-                                                name={entityName}
-                                                stack={stack}
-                                                block={block}
-                                                rotation={0}
-                                                variant={variant}
-                                            />
-                                            <Html
-                                                position={[
-                                                    position.x + 0.5,
-                                                    -0.5,
-                                                    position.z + 0.5,
-                                                ]}
-                                                center
-                                                distanceFactor={15}
-                                                style={{
-                                                    pointerEvents: 'none',
-                                                }}
-                                            >
-                                                <div className="text-white text-xs bg-black/70 px-2 py-1 rounded whitespace-nowrap pointer-events-none">
-                                                    {entityName}
-                                                </div>
-                                            </Html>
-                                        </group>
-                                    ),
-                                )}
-                            </group>
-                        </ParticleSystemProvider>
-                    </Scene>
-                    {debugHud && <DebugHud />}
-                </GameFlagsContext.Provider>
-            </GameStateContext.Provider>
-        </QueryClientProvider>
-    );
+    return <EntitySandboxViewer {...props} />;
 }

--- a/packages/game/src/viewers/EntitySandboxViewer.tsx
+++ b/packages/game/src/viewers/EntitySandboxViewer.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { type HTMLAttributes, useMemo } from 'react';
+import { Vector3 } from 'three';
+import { GameSceneDynamic } from '../GameSceneDynamic';
+import { localSandboxBlockNames } from '../localSandboxBlockData';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+
+const defaultColumns = 9;
+
+export const entitySandboxStorageKey = 'gredice.debug.entities.sandbox.v1';
+
+export function getEntitySandboxStorageKey(entityName: string) {
+    return `gredice.debug.entity.${encodeURIComponent(entityName)}.sandbox.v1`;
+}
+
+function createEntitySandboxBlock(
+    name: string,
+    index: number,
+    rotation: number,
+): Block {
+    return {
+        id: `entity-sandbox:${name}:${index}`,
+        name,
+        rotation,
+        variant: name === 'PineAdvent' ? 100 : undefined,
+    };
+}
+
+function createEntitySandboxStacks({
+    blockNames,
+    columns,
+    rotation,
+}: {
+    blockNames: readonly string[];
+    columns: number;
+    rotation: number;
+}): Stack[] {
+    const safeColumns = Math.max(1, Math.floor(columns));
+    const rowCount = Math.ceil(blockNames.length / safeColumns);
+    const xOffset = Math.floor(safeColumns / 2);
+    const zOffset = Math.floor(rowCount / 2);
+
+    return blockNames.map((name, index) => {
+        const x = (index % safeColumns) - xOffset;
+        const z = Math.floor(index / safeColumns) - zOffset;
+
+        return {
+            position: new Vector3(x, 0, z),
+            blocks: [createEntitySandboxBlock(name, index, rotation)],
+        };
+    });
+}
+
+export type EntitySandboxViewerProps = HTMLAttributes<HTMLDivElement> & {
+    columns?: number;
+    debugHud?: boolean;
+    entityName?: string;
+    localSandboxStorageKey?: string;
+    rotation?: number;
+};
+
+export function EntitySandboxViewer({
+    className,
+    columns = defaultColumns,
+    debugHud,
+    entityName,
+    localSandboxStorageKey,
+    rotation = 0,
+    ...rest
+}: EntitySandboxViewerProps) {
+    const normalizedRotation = ((rotation % 4) + 4) % 4;
+    const blockNames = useMemo(
+        () => (entityName ? [entityName] : [...localSandboxBlockNames]),
+        [entityName],
+    );
+    const stacks = useMemo(
+        () =>
+            createEntitySandboxStacks({
+                blockNames,
+                columns,
+                rotation: normalizedRotation,
+            }),
+        [blockNames, columns, normalizedRotation],
+    );
+    const storageKey =
+        localSandboxStorageKey ??
+        (entityName
+            ? getEntitySandboxStorageKey(entityName)
+            : entitySandboxStorageKey);
+
+    return (
+        <GameSceneDynamic
+            className={className}
+            dayNightCycleDisabled={false}
+            deferDetails={false}
+            flags={{
+                enableDebugHudFlag: debugHud,
+                enableRainWetOverlayFlag: debugHud,
+            }}
+            key={storageKey}
+            localSandboxInitialStacks={stacks}
+            localSandboxStorageKey={storageKey}
+            noSound
+            zoom={entityName ? 'normal' : 'far'}
+            {...rest}
+        />
+    );
+}


### PR DESCRIPTION
## Summary
- Replace the custom entity grid and single-entity scene with the standard sandbox game scene
- Seed debug views with positioned block stacks, one block per stack, and keep reset controls
- Teach local sandbox loading to accept initial stacks and scope cache keys by sandbox storage key

## Testing
- Added unit coverage for loading sandbox gardens with provided default stacks
- Verified the updated debug routes locally with browser smoke checks on `/debug/entities` and `/debug/entities/FireflyJar`