### PR TITLE
Add animal pathfinding and target debug toggles

### DIFF
--- a/packages/game/src/entities/animals/AnimalDebugIndicators.tsx
+++ b/packages/game/src/entities/animals/AnimalDebugIndicators.tsx
@@ -1,0 +1,100 @@
+import { Line } from '@react-three/drei';
+import { forwardRef, useMemo } from 'react';
+import type { Group } from 'three';
+import { DoubleSide } from 'three';
+
+export type AnimalDebugPathPoint = [x: number, y: number, z: number];
+
+export const AnimalTargetDebugMarker = forwardRef<
+    Group,
+    {
+        color: string;
+    }
+>(({ color }, ref) => (
+    <group ref={ref} visible={false} raycast={() => undefined}>
+        <mesh position={[0, 0.08, 0]} renderOrder={1000}>
+            <sphereGeometry args={[0.045, 12, 8]} />
+            <meshBasicMaterial
+                color={color}
+                depthTest={false}
+                depthWrite={false}
+                opacity={0.9}
+                transparent
+            />
+        </mesh>
+        <mesh position={[0, 0.11, 0]} renderOrder={1000}>
+            <cylinderGeometry args={[0.01, 0.01, 0.22, 6]} />
+            <meshBasicMaterial
+                color={color}
+                depthTest={false}
+                depthWrite={false}
+                opacity={0.7}
+                transparent
+            />
+        </mesh>
+        <mesh rotation={[Math.PI / 2, 0, 0]} renderOrder={1000}>
+            <ringGeometry args={[0.13, 0.16, 32]} />
+            <meshBasicMaterial
+                color={color}
+                depthTest={false}
+                depthWrite={false}
+                opacity={0.75}
+                side={DoubleSide}
+                transparent
+            />
+        </mesh>
+    </group>
+));
+
+AnimalTargetDebugMarker.displayName = 'AnimalTargetDebugMarker';
+
+export function AnimalPathDebugIndicator({
+    color,
+    points,
+    visible,
+}: {
+    color: string;
+    points: AnimalDebugPathPoint[];
+    visible: boolean;
+}) {
+    const linePoints = useMemo<AnimalDebugPathPoint[]>(
+        () => points.map((point) => [point[0], point[1] + 0.035, point[2]]),
+        [points],
+    );
+
+    if (!visible || linePoints.length < 2) {
+        return null;
+    }
+
+    return (
+        <group raycast={() => undefined}>
+            <Line
+                color={color}
+                depthTest={false}
+                lineWidth={1.8}
+                opacity={0.86}
+                points={linePoints}
+                renderOrder={1000}
+                transparent
+            />
+            {linePoints.map((point, index) => (
+                <mesh
+                    key={`${point[0]}:${point[1]}:${point[2]}`}
+                    position={point}
+                    renderOrder={1001}
+                >
+                    <sphereGeometry
+                        args={[index === 0 ? 0.035 : 0.027, 10, 8]}
+                    />
+                    <meshBasicMaterial
+                        color={color}
+                        depthTest={false}
+                        depthWrite={false}
+                        opacity={index === 0 ? 0.95 : 0.78}
+                        transparent
+                    />
+                </mesh>
+            ))}
+        </group>
+    );
+}

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -27,6 +27,7 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { AnimalTargetDebugMarker } from '../animals/AnimalDebugIndicators';
 import { getCactusVariantConfig } from '../Cactus';
 import { getBlockSurfaceDecorations } from '../groundDecorations/getBlockSurfaceDecorations';
 import { resolveGroundDecorationSurface } from '../groundDecorations/groundDecorationConfig';
@@ -1154,11 +1155,15 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     const { enableDebugHudFlag = false } = useGameFlags();
     const clock = useThree((state) => state.clock);
     const groupRef = useRef<Group>(null);
+    const targetDebugRef = useRef<Group>(null);
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<BeeRuntimeState | null>(null);
     const lastAnimalDebugUpdateRef = useRef(0);
     const lastDebugCommandSequenceRef = useRef(0);
     const lastDisturbanceSequenceRef = useRef(0);
+    const animalTargetsDebugVisible = useGameState(
+        (state) => state.animalTargetsDebugVisible,
+    );
     const animalDebugCommand = useGameState(
         (state) => state.animalDebugCommand,
     );
@@ -1203,6 +1208,24 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
 
         return () => removeAnimalDebugEntry(habitat.id);
     }, [enableDebugHudFlag, habitat.id, removeAnimalDebugEntry]);
+
+    useEffect(() => {
+        if (!animalTargetsDebugVisible && targetDebugRef.current) {
+            targetDebugRef.current.visible = false;
+        }
+    }, [animalTargetsDebugVisible]);
+
+    const syncDebugTarget = (runtime: BeeRuntimeState | null) => {
+        const targetDebug = targetDebugRef.current;
+        if (!targetDebug) {
+            return;
+        }
+
+        targetDebug.visible = animalTargetsDebugVisible && runtime !== null;
+        if (targetDebug.visible && runtime) {
+            targetDebug.position.copy(runtime.target.position);
+        }
+    };
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
@@ -1315,6 +1338,8 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
             }
         }
 
+        syncDebugTarget(runtime);
+
         if (runtime.phase === 'moving') {
             const progress = MathUtils.clamp(
                 (now - runtime.startedAt) / runtime.duration,
@@ -1413,15 +1438,18 @@ function Bee({ habitat }: { habitat: BeeHabitat }) {
     });
 
     return (
-        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
-        <group
-            ref={groupRef}
-            scale={beeScale}
-            onPointerDown={handlePointerDown}
-            onClick={handleClick}
-        >
-            <primitive object={beeModel.scene} />
-        </group>
+        <>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive */}
+            <group
+                ref={groupRef}
+                scale={beeScale}
+                onPointerDown={handlePointerDown}
+                onClick={handleClick}
+            >
+                <primitive object={beeModel.scene} />
+            </group>
+            <AnimalTargetDebugMarker ref={targetDebugRef} color="#facc15" />
+        </>
     );
 }
 

--- a/packages/game/src/entities/birds/Birds.tsx
+++ b/packages/game/src/entities/birds/Birds.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../useGameState';
 import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { AnimalTargetDebugMarker } from '../animals/AnimalDebugIndicators';
 import { waterBlockName } from '../waterBlockFoam';
 import {
     type BirdBehavior,
@@ -1515,6 +1516,7 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     const gltf = useGameGLTF('BirdSmall');
     const clock = useThree((state) => state.clock);
     const groupRef = useRef<Group>(null);
+    const targetDebugRef = useRef<Group>(null);
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<BirdRuntimeState | null>(null);
     const flappingRef = useRef(false);
@@ -1523,6 +1525,9 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     const lastDisturbanceSequenceRef = useRef(0);
     const [isFlapping, setIsFlapping] = useState(false);
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const animalTargetsDebugVisible = useGameState(
+        (state) => state.animalTargetsDebugVisible,
+    );
     const animalDebugCommand = useGameState(
         (state) => state.animalDebugCommand,
     );
@@ -1592,6 +1597,24 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     useEffect(() => {
         return () => removeAnimalDebugEntry(habitat.id);
     }, [habitat.id, removeAnimalDebugEntry]);
+
+    useEffect(() => {
+        if (!animalTargetsDebugVisible && targetDebugRef.current) {
+            targetDebugRef.current.visible = false;
+        }
+    }, [animalTargetsDebugVisible]);
+
+    const syncDebugTarget = (runtime: BirdRuntimeState | null) => {
+        const targetDebug = targetDebugRef.current;
+        if (!targetDebug) {
+            return;
+        }
+
+        targetDebug.visible = animalTargetsDebugVisible && runtime !== null;
+        if (targetDebug.visible && runtime) {
+            targetDebug.position.copy(runtime.target.position);
+        }
+    };
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
@@ -1743,6 +1766,8 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
                 runtimeRef.current = runtime;
             }
         }
+
+        syncDebugTarget(runtime);
 
         if (runtime.phase === 'circling') {
             const progress = MathUtils.clamp(
@@ -2009,15 +2034,18 @@ function Bird({ habitat }: { habitat: BirdHabitat }) {
     });
 
     return (
-        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
-        <group
-            ref={groupRef}
-            scale={birdScale}
-            onPointerDown={handlePointerDown}
-            onClick={handleClick}
-        >
-            <primitive object={birdModel.scene} />
-        </group>
+        <>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive */}
+            <group
+                ref={groupRef}
+                scale={birdScale}
+                onPointerDown={handlePointerDown}
+                onClick={handleClick}
+            >
+                <primitive object={birdModel.scene} />
+            </group>
+            <AnimalTargetDebugMarker ref={targetDebugRef} color="#fb7185" />
+        </>
     );
 }
 

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -17,6 +17,11 @@ import {
 import { getStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import {
+    type AnimalDebugPathPoint,
+    AnimalPathDebugIndicator,
+    AnimalTargetDebugMarker,
+} from '../animals/AnimalDebugIndicators';
+import {
     type CatBehavior,
     type CatWeather,
     getCatActivityRange,
@@ -1063,6 +1068,18 @@ function roundCatDebugPoint(point: Vector3) {
     };
 }
 
+function catDebugPathPoint(point: Vector3) {
+    return [
+        roundCatDebugCoordinate(point.x),
+        roundCatDebugCoordinate(point.y),
+        roundCatDebugCoordinate(point.z),
+    ] satisfies AnimalDebugPathPoint;
+}
+
+function catDebugPathKey(path: Vector3[]) {
+    return path.map((point) => catDebugPathPoint(point).join(':')).join('|');
+}
+
 function nextPathWaypoint(runtime: MovingCatState, position: Vector3) {
     return (
         runtime.path.find(
@@ -1157,14 +1174,25 @@ function Cat({
     const { enableDebugHudFlag = false } = useGameFlags();
     const clock = useThree((state) => state.clock);
     const groupRef = useRef<Group>(null);
+    const targetDebugRef = useRef<Group>(null);
     const randomRef = useRef(createRandom(habitat.seed));
     const runtimeRef = useRef<CatRuntimeState | null>(null);
     const lastAnimalDebugUpdateRef = useRef(0);
     const lastDebugCommandSequenceRef = useRef(0);
+    const pathDebugKeyRef = useRef('');
     const activeAnimationRef = useRef<CatAnimationName>('Cat_LyingIdle');
     const [activeAnimation, setActiveAnimation] =
         useState<CatAnimationName>('Cat_LyingIdle');
+    const [pathDebugPoints, setPathDebugPoints] = useState<
+        AnimalDebugPathPoint[]
+    >([]);
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const animalPathfindingDebugVisible = useGameState(
+        (state) => state.animalPathfindingDebugVisible,
+    );
+    const animalTargetsDebugVisible = useGameState(
+        (state) => state.animalTargetsDebugVisible,
+    );
     const animalDebugCommand = useGameState(
         (state) => state.animalDebugCommand,
     );
@@ -1219,6 +1247,43 @@ function Cat({
 
         return () => removeAnimalDebugEntry(habitat.id);
     }, [enableDebugHudFlag, habitat.id, removeAnimalDebugEntry]);
+
+    useEffect(() => {
+        if (!animalTargetsDebugVisible && targetDebugRef.current) {
+            targetDebugRef.current.visible = false;
+        }
+    }, [animalTargetsDebugVisible]);
+
+    useEffect(() => {
+        if (!animalPathfindingDebugVisible) {
+            pathDebugKeyRef.current = '';
+            setPathDebugPoints([]);
+        }
+    }, [animalPathfindingDebugVisible]);
+
+    const syncDebugIndicators = (runtime: CatRuntimeState | null) => {
+        const targetDebug = targetDebugRef.current;
+        if (targetDebug) {
+            targetDebug.visible = animalTargetsDebugVisible && runtime !== null;
+            if (targetDebug.visible && runtime) {
+                targetDebug.position.copy(runtime.target.position);
+            }
+        }
+
+        const nextPathDebugKey =
+            animalPathfindingDebugVisible && runtime?.phase === 'moving'
+                ? catDebugPathKey(runtime.path)
+                : '';
+
+        if (nextPathDebugKey !== pathDebugKeyRef.current) {
+            pathDebugKeyRef.current = nextPathDebugKey;
+            setPathDebugPoints(
+                animalPathfindingDebugVisible && runtime?.phase === 'moving'
+                    ? runtime.path.map(catDebugPathPoint)
+                    : [],
+            );
+        }
+    };
 
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
         event.stopPropagation();
@@ -1355,6 +1420,8 @@ function Cat({
             }
         }
 
+        syncDebugIndicators(runtime);
+
         if (runtime.phase === 'moving') {
             setAnimation(getCatAnimationName(runtime));
             syncWalkAnimationSpeed(runtime);
@@ -1476,15 +1543,23 @@ function Cat({
     });
 
     return (
-        // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
-        <group
-            ref={groupRef}
-            scale={catScale}
-            onPointerDown={handlePointerDown}
-            onClick={handleClick}
-        >
-            <primitive object={catModel} />
-        </group>
+        <>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive */}
+            <group
+                ref={groupRef}
+                scale={catScale}
+                onPointerDown={handlePointerDown}
+                onClick={handleClick}
+            >
+                <primitive object={catModel} />
+            </group>
+            <AnimalTargetDebugMarker ref={targetDebugRef} color="#38bdf8" />
+            <AnimalPathDebugIndicator
+                color="#38bdf8"
+                points={pathDebugPoints}
+                visible={animalPathfindingDebugVisible}
+            />
+        </>
     );
 }
 

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -285,6 +285,18 @@ export function DebugHud() {
     const setEntityRenderModeDebugVisible = useGameState(
         (s) => s.setEntityRenderModeDebugVisible,
     );
+    const animalPathfindingDebugVisible = useGameState(
+        (s) => s.animalPathfindingDebugVisible,
+    );
+    const setAnimalPathfindingDebugVisible = useGameState(
+        (s) => s.setAnimalPathfindingDebugVisible,
+    );
+    const animalTargetsDebugVisible = useGameState(
+        (s) => s.animalTargetsDebugVisible,
+    );
+    const setAnimalTargetsDebugVisible = useGameState(
+        (s) => s.setAnimalTargetsDebugVisible,
+    );
     const gameQualitySetting = useGameState((s) => s.gameQualitySetting);
     const setGameQualitySetting = useGameState((s) => s.setGameQualitySetting);
     const frameStats = useFrameStats();
@@ -921,6 +933,44 @@ export function DebugHud() {
                                     }
                                 >
                                     Render modes
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    className="flex-1"
+                                    startDecorator={
+                                        <Graph className="size-3.5" />
+                                    }
+                                    variant={
+                                        animalPathfindingDebugVisible
+                                            ? 'solid'
+                                            : 'outlined'
+                                    }
+                                    onClick={() =>
+                                        setAnimalPathfindingDebugVisible(
+                                            !animalPathfindingDebugVisible,
+                                        )
+                                    }
+                                >
+                                    Pathfinding
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    className="flex-1"
+                                    startDecorator={
+                                        <MapPin className="size-3.5" />
+                                    }
+                                    variant={
+                                        animalTargetsDebugVisible
+                                            ? 'solid'
+                                            : 'outlined'
+                                    }
+                                    onClick={() =>
+                                        setAnimalTargetsDebugVisible(
+                                            !animalTargetsDebugVisible,
+                                        )
+                                    }
+                                >
+                                    Animal targets
                                 </Button>
                             </Row>
                             {entityRenderModeDebugVisible && (

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -199,6 +199,10 @@ export type GameState = {
     setEditHitboxDebugVisible: (visible: boolean) => void;
     entityRenderModeDebugVisible: boolean;
     setEntityRenderModeDebugVisible: (visible: boolean) => void;
+    animalPathfindingDebugVisible: boolean;
+    setAnimalPathfindingDebugVisible: (visible: boolean) => void;
+    animalTargetsDebugVisible: boolean;
+    setAnimalTargetsDebugVisible: (visible: boolean) => void;
     weather?: WeatherOverride;
     setWeather: (weather: WeatherOverride | undefined) => void;
     clearEnvironmentOverrides: () => void;
@@ -482,6 +486,12 @@ export function createGameState({
         entityRenderModeDebugVisible: false,
         setEntityRenderModeDebugVisible: (entityRenderModeDebugVisible) =>
             set({ entityRenderModeDebugVisible }),
+        animalPathfindingDebugVisible: false,
+        setAnimalPathfindingDebugVisible: (animalPathfindingDebugVisible) =>
+            set({ animalPathfindingDebugVisible }),
+        animalTargetsDebugVisible: false,
+        setAnimalTargetsDebugVisible: (animalTargetsDebugVisible) =>
+            set({ animalTargetsDebugVisible }),
         setWeather: (weather) => set({ weather }),
         clearEnvironmentOverrides: () => {
             const referenceTime = new Date();


### PR DESCRIPTION
## Summary
- Added Scene debug toggles for animal pathfinding and animal target markers.
- Wired shared debug visibility state into cats, birds, and bees.
- Added reusable animal debug indicator components for target markers and cat path lines.

## Testing
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- Local browser smoke test on `/debug/animals` confirmed the new Scene controls render, toggle correctly, and the cat pathfinding overlay appears during movement with no console errors.