### PR TITLE
docs: record HACCP public claim boundary

### DIFF
--- a/docs/haccp-public-claim-boundary.md
+++ b/docs/haccp-public-claim-boundary.md
@@ -1,0 +1,121 @@
+# HACCP-aligned public claim boundary
+
+This note records the publication boundary for the public harvest quality and
+safety page tracked in GRE-449. It is a documentation gate for public copy; it is
+not a legal certificate, sanitary inspection report, or replacement for review by
+the responsible Gredice/OPG owner.
+
+## Current service model
+
+Describe Gredice as a service that helps the customer plan, grow, care for,
+harvest, and receive delivery of the customer's harvest from their garden or
+raised bed. Public wording should keep the customer-harvest model visible and
+avoid presenting Gredice as the seller of its own finished, packaged, or
+ready-to-eat food product.
+
+## Regulatory context used for this boundary
+
+This boundary is intentionally phrased as use of internal procedures based on
+HACCP principles, not as certification. Croatian Ministry of Agriculture public
+guidance describes food business operators as primarily responsible for food in
+stages under their control and refers to self-control based on HACCP principles
+and good hygiene practice. Croatian Ministry of Health public FAQ guidance also
+points operators to hygiene requirements, procedures based on HACCP principles,
+and traceability evidence during inspection.
+
+Reference links:
+
+- https://poljoprivreda.gov.hr/istaknute-teme/hrana-111/sigurnost-hrane/smjernice/224
+- https://zdravlje.gov.hr/o-ministarstvu/djelokrug-1297/sanitarna-inspekcija/najcesca-pitanja-i-odgovori-2332/odjel-za-hranu-i-financiranje-sluzbenih-kontrola-hrane-2334/2334
+- https://sredisnjikatalogrh.gov.hr/srce-arhiva/263/135559/narodne-novine.nn.hr/clanci/sluzbeni/2015_06_68_1307.html
+
+## Approved public claim boundary
+
+The public page and FAQ may say that Gredice uses internal procedures based on:
+
+- good agricultural practice;
+- good hygiene practice;
+- traceability;
+- records;
+- corrective actions; and
+- HACCP principles.
+
+Use conservative wording such as:
+
+> Gredice uses internal procedures based on good agricultural practice, good
+> hygiene practice, traceability, records, corrective actions, and HACCP
+> principles to support the quality and safety of harvest planning, growing,
+> caring, harvesting, and delivery.
+
+In Croatian public copy, use similarly bounded wording:
+
+> Gredice koristi interne postupke temeljene na dobroj poljoprivrednoj praksi,
+> dobroj higijenskoj praksi, sljedivosti, evidencijama, korektivnim radnjama i
+> načelima HACCP-a kako bi podržao kvalitetu i sigurnost planiranja, uzgoja,
+> njege, berbe i dostave korisnikova uroda.
+
+## Claims to avoid
+
+Do not publish wording that states or implies any of the following unless the
+responsible owner separately approves a documented basis for that claim:
+
+- Gredice is HACCP certified.
+- Gredice has a HACCP certificate.
+- Gredice is fully HACCP compliant in all activities.
+- The harvest is ready-to-eat.
+- Gredice performs industrial food processing.
+- Gredice sells its own finished food product instead of supporting the
+  customer's harvest.
+- Washing, preparation, or consumer handling can be skipped.
+
+Avoid shorthand badges or headings such as `HACCP certified`, `HACCP compliant`,
+`ready to eat`, `certified safe food`, or equivalent Croatian phrases including
+`HACCP certificirano`, `HACCP certifikat`, `potpuna HACCP sukladnost`, and
+`spremno za jelo`.
+
+## Required user-facing reminder
+
+Every public quality or harvest-safety page that mentions these internal
+procedures should include a visible reminder:
+
+> Fresh harvest should be washed and prepared before consumption.
+
+Recommended Croatian wording:
+
+> Svježi urod treba oprati i pripremiti prije konzumacije.
+
+## Last-reviewed metadata and ownership
+
+The public page should show a visible `Last reviewed` / `Zadnji pregled` date so
+visitors and operators can tell when the claim boundary was last checked. Use the
+publication approval date, not the implementation date, and update it whenever
+public wording or the underlying procedures change.
+
+Suggested ownership:
+
+- **Business/OPG owner:** final approval of the public claim boundary and any
+  legal or sanitary review notes before publication.
+- **Website/content owner:** keeps the public page and FAQ aligned with the
+  approved wording and updates the visible review date after owner approval.
+- **Implementation owner:** blocks GRE-450, GRE-451, and related website work
+  until the approved wording and review date are confirmed.
+
+## Publication checklist
+
+Before the public page or FAQ goes live:
+
+1. Confirm the source pack wording is still limited to internal procedures based
+   on good practice, traceability, records, corrective actions, and HACCP
+   principles.
+2. Confirm no page, FAQ, metadata, structured data, image alt text, or social
+   preview copy implies certification, certificate ownership, full compliance,
+   ready-to-eat produce, industrial processing, or sale of Gredice's own finished
+   food product.
+3. Confirm the wash-and-prepare reminder is visible near the quality/safety
+   claims.
+4. Record the responsible Gredice/OPG owner approval in Linear or the project
+   document.
+5. Record any legal or sanitary reviewer notes in Linear or the project
+   document before unblocking website implementation.
+6. Publish or update the visible `Last reviewed` / `Zadnji pregled` date only
+   after owner approval.


### PR DESCRIPTION
### Motivation
- Record an explicit publication gate for the HACCP-aligned public harvest quality and safety page tracked in GRE-449.
- Ensure public copy remains conservative and does not imply HACCP certification, ready-to-eat produce, industrial processing, or sale of Gredice’s own finished food product.
- Provide clear allowed wording, Croatian translations, and a visible user-facing wash-and-prepare reminder to reduce legal and sanitary risk in public pages.
- Establish ownership and a publication checklist so website implementation work is blocked until responsible owner approval and any legal/sanitary notes are captured.

### Description
- Add `docs/haccp-public-claim-boundary.md` which records the service model, regulatory context, approved public claim boundary, and explicit claims to avoid.
- Include conservative example wording in English and Croatian and a required visible reminder: `Fresh harvest should be washed and prepared before consumption` / `Svježi urod treba oprati i pripremiti prije konzumacije`.
- Add a `Last reviewed` guidance and suggested owners for Business/OPG, Website/content, and Implementation responsibilities.
- Provide a six-point publication checklist and three Croatian regulatory reference links used to frame the boundary.

### Testing
- Run `git diff --check` to validate whitespace and simple diff issues, which completed without errors.
- No build, typecheck, or runtime changes were required because this is a documentation-only addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201224fcf8832fba8afeadd8bb187d)