### PR TITLE
Add reciprocal plant relationship read model

### DIFF
--- a/packages/storage/src/@types/EntityStandardized.ts
+++ b/packages/storage/src/@types/EntityStandardized.ts
@@ -38,6 +38,10 @@ export type EntityStandardized = {
     image?: {
         cover?: { url?: string };
     };
+    relationships?: {
+        companions?: EntityRelationshipEntry[];
+        antagonists?: EntityRelationshipEntry[];
+    };
     prices?: {
         perPlant?: number;
         perOperation?: number;
@@ -48,5 +52,17 @@ export type EntityStandardized = {
         completionAttachImagesRequired?: boolean;
         completionAttachNotes?: boolean;
         completionAttachNotesRequired?: boolean;
+    };
+};
+
+export type EntityRelationshipEntry = {
+    id: number;
+    slug: string;
+    displayName: string;
+    kind: 'companion' | 'antagonist';
+    image?: {
+        cover: {
+            url: string;
+        };
     };
 };

--- a/packages/storage/src/helpers/plantRelationships.ts
+++ b/packages/storage/src/helpers/plantRelationships.ts
@@ -1,0 +1,413 @@
+import { slugify } from '@gredice/js/slug';
+import { and, eq, inArray, or } from 'drizzle-orm';
+import {
+    attributeDefinitions,
+    attributeValues,
+    entities,
+    type SelectAttributeDefinition,
+    type SelectAttributeValue,
+    type SelectEntity,
+    type SelectEntityType,
+    storage,
+} from '..';
+
+export const plantRelationshipAttributeConfigs = [
+    {
+        category: 'relationships',
+        name: 'companions',
+        label: 'Companion plants',
+        kind: 'companion',
+    },
+    {
+        category: 'relationships',
+        name: 'antagonists',
+        label: 'Antagonistic plants',
+        kind: 'antagonist',
+    },
+] as const;
+
+export type PlantRelationshipKind =
+    (typeof plantRelationshipAttributeConfigs)[number]['kind'];
+export type PlantRelationshipAttributeName =
+    (typeof plantRelationshipAttributeConfigs)[number]['name'];
+
+export type PlantRelationshipDefinition = SelectAttributeDefinition & {
+    name: PlantRelationshipAttributeName;
+};
+
+type PlantRelationshipAttribute = SelectAttributeValue & {
+    attributeDefinition: SelectAttributeDefinition;
+};
+
+type PlantRelationshipEntity = SelectEntity & {
+    attributes: PlantRelationshipAttribute[];
+    entityType: SelectEntityType;
+};
+
+export type PlantRelationshipEntry = {
+    id: number;
+    slug: string;
+    displayName: string;
+    kind: PlantRelationshipKind;
+    image?: {
+        cover: {
+            url: string;
+        };
+    };
+};
+
+export type PlantRelationshipReadModel = Partial<
+    Record<PlantRelationshipAttributeName, PlantRelationshipEntry[]>
+>;
+
+const plantRelationshipConfigByName = new Map(
+    plantRelationshipAttributeConfigs.map((config) => [config.name, config]),
+);
+
+function parseEntityRefId(value: string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const trimmedValue = value.trim();
+    if (!/^\d+$/.test(trimmedValue)) {
+        return null;
+    }
+
+    return Number.parseInt(trimmedValue, 10);
+}
+
+export function isPlantRelationshipAttributeDefinition(
+    definition: Pick<
+        SelectAttributeDefinition,
+        'entityTypeName' | 'category' | 'name' | 'dataType'
+    >,
+): definition is PlantRelationshipDefinition {
+    return (
+        definition.entityTypeName === 'plant' &&
+        definition.category === 'relationships' &&
+        definition.dataType === 'ref:plant' &&
+        plantRelationshipAttributeConfigs.some(
+            (config) => config.name === definition.name,
+        )
+    );
+}
+
+export async function getPlantRelationshipDefinitions() {
+    const definitions = await storage().query.attributeDefinitions.findMany({
+        where: and(
+            eq(attributeDefinitions.isDeleted, false),
+            eq(attributeDefinitions.entityTypeName, 'plant'),
+            eq(attributeDefinitions.category, 'relationships'),
+            eq(attributeDefinitions.dataType, 'ref:plant'),
+            inArray(
+                attributeDefinitions.name,
+                plantRelationshipAttributeConfigs.map((config) => config.name),
+            ),
+        ),
+    });
+
+    return definitions.filter(isPlantRelationshipAttributeDefinition);
+}
+
+function plantRelationshipConfigForDefinition(
+    definition: SelectAttributeDefinition,
+) {
+    if (!isPlantRelationshipAttributeDefinition(definition)) {
+        return null;
+    }
+    return plantRelationshipConfigByName.get(definition.name) ?? null;
+}
+
+function entityNameFromAttributes(entity: PlantRelationshipEntity) {
+    return (
+        entity.attributes.find(
+            (attribute) =>
+                attribute.attributeDefinition.category === 'information' &&
+                attribute.attributeDefinition.name === 'name',
+        )?.value ?? null
+    );
+}
+
+function entityDisplayNameFromAttributes(entity: PlantRelationshipEntity) {
+    const label = entity.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinition.category === 'information' &&
+            attribute.attributeDefinition.name === 'label',
+    )?.value;
+    const name = entityNameFromAttributes(entity);
+    return label ?? name ?? `${entity.entityType.label} ${entity.id}`;
+}
+
+function parseJson(value: string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(value) as unknown;
+    } catch {
+        return null;
+    }
+}
+
+function imageUrlFromParsed(value: unknown): string | null {
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const url = imageUrlFromParsed(item);
+            if (url) {
+                return url;
+            }
+        }
+        return null;
+    }
+
+    if (typeof value !== 'object' || value === null) {
+        return null;
+    }
+
+    if ('url' in value && typeof value.url === 'string') {
+        const url = value.url.trim();
+        return url.length > 0 ? url : null;
+    }
+
+    return (
+        ('cover' in value ? imageUrlFromParsed(value.cover) : null) ??
+        ('image' in value ? imageUrlFromParsed(value.image) : null) ??
+        ('images' in value ? imageUrlFromParsed(value.images) : null)
+    );
+}
+
+function entityCoverImage(entity: PlantRelationshipEntity) {
+    for (const attribute of entity.attributes) {
+        if (
+            attribute.attributeDefinition.dataType !== 'image' &&
+            !attribute.attributeDefinition.dataType.startsWith('json')
+        ) {
+            continue;
+        }
+
+        const url = imageUrlFromParsed(parseJson(attribute.value));
+        if (url) {
+            return { cover: { url } };
+        }
+    }
+
+    return undefined;
+}
+
+function shallowPlantRelationshipEntry(
+    entity: PlantRelationshipEntity,
+    kind: PlantRelationshipKind,
+): PlantRelationshipEntry {
+    const displayName = entityDisplayNameFromAttributes(entity);
+    const image = entityCoverImage(entity);
+    return {
+        id: entity.id,
+        slug: slugify(displayName),
+        displayName,
+        kind,
+        ...(image ? { image } : {}),
+    };
+}
+
+function addRelationshipTarget(
+    relationships: Map<
+        PlantRelationshipAttributeName,
+        Map<number, PlantRelationshipEntry>
+    >,
+    sourcePlantId: number,
+    targetPlantId: number | null,
+    targetPlantsById: Map<number, PlantRelationshipEntity>,
+    definition: SelectAttributeDefinition,
+) {
+    if (targetPlantId === null || targetPlantId === sourcePlantId) {
+        return;
+    }
+
+    const targetPlant = targetPlantsById.get(targetPlantId);
+    const config = plantRelationshipConfigForDefinition(definition);
+    if (!targetPlant || !config) {
+        return;
+    }
+
+    const entries = relationships.get(config.name) ?? new Map();
+    if (!entries.has(targetPlant.id)) {
+        entries.set(
+            targetPlant.id,
+            shallowPlantRelationshipEntry(targetPlant, config.kind),
+        );
+    }
+    relationships.set(config.name, entries);
+}
+
+export async function buildPlantRelationshipReadModel(
+    sourcePlant: PlantRelationshipEntity,
+    publishedPlants: PlantRelationshipEntity[],
+): Promise<PlantRelationshipReadModel | null> {
+    if (sourcePlant.entityTypeName !== 'plant') {
+        return null;
+    }
+
+    const publishedPlantsById = new Map(
+        publishedPlants.map((plant) => [plant.id, plant]),
+    );
+    const relationships = new Map<
+        PlantRelationshipAttributeName,
+        Map<number, PlantRelationshipEntry>
+    >();
+
+    for (const attribute of sourcePlant.attributes) {
+        if (
+            !isPlantRelationshipAttributeDefinition(
+                attribute.attributeDefinition,
+            )
+        ) {
+            continue;
+        }
+
+        addRelationshipTarget(
+            relationships,
+            sourcePlant.id,
+            parseEntityRefId(attribute.value),
+            publishedPlantsById,
+            attribute.attributeDefinition,
+        );
+    }
+
+    for (const plant of publishedPlants) {
+        if (plant.id === sourcePlant.id) {
+            continue;
+        }
+
+        for (const attribute of plant.attributes) {
+            if (
+                !isPlantRelationshipAttributeDefinition(
+                    attribute.attributeDefinition,
+                )
+            ) {
+                continue;
+            }
+
+            const targetPlantId = parseEntityRefId(attribute.value);
+            if (targetPlantId !== sourcePlant.id) {
+                continue;
+            }
+
+            addRelationshipTarget(
+                relationships,
+                sourcePlant.id,
+                plant.id,
+                publishedPlantsById,
+                attribute.attributeDefinition,
+            );
+        }
+    }
+
+    if (relationships.size === 0) {
+        return null;
+    }
+
+    return Object.fromEntries(
+        Array.from(relationships.entries()).map(([name, entries]) => [
+            name,
+            Array.from(entries.values()).sort((a, b) =>
+                a.displayName.localeCompare(b.displayName),
+            ),
+        ]),
+    );
+}
+
+export async function getPlantRelationshipLinkedEntityIds(entityId: number) {
+    const definitions = await getPlantRelationshipDefinitions();
+    if (definitions.length === 0) {
+        return [];
+    }
+
+    const relationshipValues = await storage().query.attributeValues.findMany({
+        where: and(
+            eq(attributeValues.isDeleted, false),
+            inArray(
+                attributeValues.attributeDefinitionId,
+                definitions.map((definition) => definition.id),
+            ),
+            or(
+                eq(attributeValues.entityId, entityId),
+                eq(attributeValues.value, String(entityId)),
+            ),
+        ),
+        columns: {
+            entityId: true,
+            value: true,
+        },
+    });
+
+    const linkedIds = new Set<number>();
+    for (const relationshipValue of relationshipValues) {
+        if (relationshipValue.entityId !== entityId) {
+            linkedIds.add(relationshipValue.entityId);
+        }
+
+        const targetId = parseEntityRefId(relationshipValue.value);
+        if (targetId !== null && targetId !== entityId) {
+            linkedIds.add(targetId);
+        }
+    }
+
+    if (linkedIds.size === 0) {
+        return [];
+    }
+
+    const linkedPlants = await storage().query.entities.findMany({
+        where: and(
+            inArray(entities.id, Array.from(linkedIds)),
+            eq(entities.entityTypeName, 'plant'),
+            eq(entities.isDeleted, false),
+        ),
+        columns: {
+            id: true,
+        },
+    });
+
+    return linkedPlants.map((plant) => plant.id);
+}
+
+export async function getPlantRelationshipMutationEntityIds(input: {
+    entityId: number | undefined;
+    entityTypeName: string | undefined | null;
+    attributeDefinition: SelectAttributeDefinition | undefined | null;
+    previousValue?: string | null;
+    nextValue?: string | null;
+}) {
+    if (
+        !input.entityId ||
+        input.entityTypeName !== 'plant' ||
+        !input.attributeDefinition ||
+        !isPlantRelationshipAttributeDefinition(input.attributeDefinition)
+    ) {
+        return [];
+    }
+
+    const entityIds = new Set<number>([input.entityId]);
+    const previousTargetId = parseEntityRefId(input.previousValue);
+    const nextTargetId = parseEntityRefId(input.nextValue);
+    if (previousTargetId !== null && previousTargetId !== input.entityId) {
+        entityIds.add(previousTargetId);
+    }
+    if (nextTargetId !== null && nextTargetId !== input.entityId) {
+        entityIds.add(nextTargetId);
+    }
+
+    const existingPlants = await storage().query.entities.findMany({
+        where: and(
+            inArray(entities.id, Array.from(entityIds)),
+            eq(entities.entityTypeName, 'plant'),
+            eq(entities.isDeleted, false),
+        ),
+        columns: {
+            id: true,
+        },
+    });
+
+    return existingPlants.map((plant) => plant.id);
+}

--- a/packages/storage/src/repositories/attributeValuesRepo.ts
+++ b/packages/storage/src/repositories/attributeValuesRepo.ts
@@ -6,26 +6,38 @@ import {
     bustCachedByPrefixes,
     cacheKeys,
 } from '../cache/directoriesCached';
+import { getPlantRelationshipMutationEntityIds } from '../helpers/plantRelationships';
 import {
     attributeValues,
     entityRevisions,
     type InsertAttributeValue,
 } from '../schema';
 
-async function refreshEntitySearchDocumentAfterMutation(
-    entityId: number | undefined,
+async function refreshEntitySearchDocumentsAfterMutation(
+    entityIds: (number | undefined)[],
 ) {
-    if (!entityId) {
+    const ids = Array.from(
+        new Set(
+            entityIds.filter((entityId): entityId is number =>
+                Boolean(entityId),
+            ),
+        ),
+    );
+    if (ids.length === 0) {
         return;
     }
     try {
         const { refreshImpactedEntitySearchDocuments } = await import(
             './entitySearchRepo'
         );
-        await refreshImpactedEntitySearchDocuments(entityId);
+        await Promise.all(
+            ids.map((entityId) =>
+                refreshImpactedEntitySearchDocuments(entityId),
+            ),
+        );
     } catch (error) {
         console.error('Failed to refresh entity search document', {
-            entityId,
+            entityIds: ids,
             error,
         });
     }
@@ -36,15 +48,13 @@ export async function upsertAttributeValue(
     actor?: { id?: string; name?: string },
 ) {
     let value = attributeValue.value;
+    const definition = await getAttributeDefinition(
+        attributeValue.attributeDefinitionId,
+    );
 
     // Handle default value - assign default value if value is not provided
-    if (!value) {
-        const definition = await getAttributeDefinition(
-            attributeValue.attributeDefinitionId,
-        );
-        if (definition?.defaultValue) {
-            value = definition.defaultValue;
-        }
+    if (!value && definition?.defaultValue) {
+        value = definition.defaultValue;
     }
 
     const existingValue = attributeValue.id
@@ -52,6 +62,13 @@ export async function upsertAttributeValue(
               where: eq(attributeValues.id, attributeValue.id),
           })
         : undefined;
+    const relationshipEntityIds = await getPlantRelationshipMutationEntityIds({
+        entityId: attributeValue.entityId,
+        entityTypeName: attributeValue.entityTypeName,
+        attributeDefinition: definition,
+        previousValue: existingValue?.value,
+        nextValue: value,
+    });
 
     await Promise.all([
         storage()
@@ -93,6 +110,9 @@ export async function upsertAttributeValue(
                   cacheKeys.entityTypeName(attributeValue.entityTypeName),
               )
             : undefined,
+        ...relationshipEntityIds
+            .filter((entityId) => entityId !== attributeValue.entityId)
+            .map((entityId) => bustCached(cacheKeys.entity(entityId))),
         bustCachedByPrefixes(['dashboard:admin:']),
         // Bust cache if value exists
         attributeValue.id
@@ -121,7 +141,11 @@ export async function upsertAttributeValue(
             : undefined,
     ]);
 
-    await refreshEntitySearchDocumentAfterMutation(attributeValue.entityId);
+    await refreshEntitySearchDocumentsAfterMutation(
+        relationshipEntityIds.length
+            ? relationshipEntityIds
+            : [attributeValue.entityId],
+    );
 }
 
 export async function deleteAttributeValue(
@@ -130,6 +154,16 @@ export async function deleteAttributeValue(
 ) {
     const existingValue = await storage().query.attributeValues.findFirst({
         where: eq(attributeValues.id, id),
+    });
+    const definition = existingValue
+        ? await getAttributeDefinition(existingValue.attributeDefinitionId)
+        : undefined;
+    const relationshipEntityIds = await getPlantRelationshipMutationEntityIds({
+        entityId: existingValue?.entityId,
+        entityTypeName: existingValue?.entityTypeName,
+        attributeDefinition: definition,
+        previousValue: existingValue?.value,
+        nextValue: null,
     });
 
     await Promise.all([
@@ -150,6 +184,9 @@ export async function deleteAttributeValue(
                   nextValue: null,
               })
             : undefined,
+        ...relationshipEntityIds
+            .filter((entityId) => entityId !== existingValue?.entityId)
+            .map((entityId) => bustCached(cacheKeys.entity(entityId))),
         storage()
             .select()
             .from(attributeValues)
@@ -173,5 +210,9 @@ export async function deleteAttributeValue(
             }),
     ]);
 
-    await refreshEntitySearchDocumentAfterMutation(existingValue?.entityId);
+    await refreshEntitySearchDocumentsAfterMutation(
+        relationshipEntityIds.length
+            ? relationshipEntityIds
+            : [existingValue?.entityId],
+    );
 }

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -21,18 +21,32 @@ import {
     directoriesCached,
 } from '../cache/directoriesCached';
 import { getEntityCompleteness } from '../helpers/entityCompleteness';
+import {
+    buildPlantRelationshipReadModel,
+    getPlantRelationshipDefinitions,
+    getPlantRelationshipLinkedEntityIds,
+    isPlantRelationshipAttributeDefinition,
+} from '../helpers/plantRelationships';
 
 const entityCacheTtl = 60 * 60; // 1 hour
 
-async function refreshEntitySearchDocumentAfterMutation(entityId: number) {
+async function refreshEntitySearchDocumentsAfterMutation(entityIds: number[]) {
+    const ids = Array.from(new Set(entityIds));
+    if (ids.length === 0) {
+        return;
+    }
     try {
         const { refreshImpactedEntitySearchDocuments } = await import(
             './entitySearchRepo'
         );
-        await refreshImpactedEntitySearchDocuments(entityId);
+        await Promise.all(
+            ids.map((entityId) =>
+                refreshImpactedEntitySearchDocuments(entityId),
+            ),
+        );
     } catch (error) {
         console.error('Failed to refresh entity search document', {
-            entityId,
+            entityIds: ids,
             error,
         });
     }
@@ -257,8 +271,16 @@ interface EntityWithAttributesAndType extends SelectEntity {
     attributes: EntityAttribute[];
     entityType: SelectEntityType;
 }
-interface EntityTypeCache {
-    [key: string]: Promise<EntityWithAttributesAndType[]>;
+interface EntityExpansionCache {
+    entitiesByType: Record<string, Promise<EntityWithAttributesAndType[]>>;
+    plantRelationshipDefinitions?: Promise<
+        import('../helpers/plantRelationships').PlantRelationshipDefinition[]
+    >;
+    plantRelationshipPublishedPlants?: Promise<EntityWithAttributesAndType[]>;
+}
+
+function createEntityExpansionCache(): EntityExpansionCache {
+    return { entitiesByType: {} };
 }
 
 export type IncomingEntityLinkGroup = {
@@ -277,7 +299,7 @@ export type IncomingEntityLinkGroup = {
 // Update expandEntity to accept a cache
 async function expandEntity(
     entityRaw: EntityWithAttributesAndType | undefined,
-    cache: EntityTypeCache = {},
+    cache: EntityExpansionCache = createEntityExpansionCache(),
 ) {
     if (!entityRaw) {
         return null;
@@ -304,7 +326,10 @@ async function expandEntity(
         updatedAt: entityRaw.updatedAt,
         slug: slugify(entityDisplayNameFromAttributes(entityRaw)),
     };
-    return await expandEntityAttributes(entity, entityRaw.attributes, cache);
+    return await expandEntityAttributes(entity, entityRaw.attributes, cache, {
+        includePlantRelationships: true,
+        sourceEntity: entityRaw,
+    });
 }
 
 // Update expandEntityAttributes to accept a cache
@@ -313,11 +338,22 @@ async function expandEntityAttributes<T extends Record<string, unknown>>(
     attributes: (SelectAttributeValue & {
         attributeDefinition: SelectAttributeDefinition;
     })[],
-    cache: EntityTypeCache = {},
+    cache: EntityExpansionCache = createEntityExpansionCache(),
+    options: {
+        includePlantRelationships?: boolean;
+        sourceEntity?: EntityWithAttributesAndType;
+    } = {},
 ) {
     const expandedEntity = { ...entity };
     // Prepare all attribute expansion promises
     const attributePromises = attributes.map(async (attribute) => {
+        if (
+            isPlantRelationshipAttributeDefinition(
+                attribute.attributeDefinition,
+            )
+        ) {
+            return;
+        }
         // Create category object if it doesn't exist
         if (
             expandedEntity[attribute.attributeDefinition.category] === undefined
@@ -357,6 +393,32 @@ async function expandEntityAttributes<T extends Record<string, unknown>>(
         }
     });
     await Promise.all(attributePromises);
+
+    if (options.includePlantRelationships && options.sourceEntity) {
+        if (!cache.plantRelationshipDefinitions) {
+            cache.plantRelationshipDefinitions =
+                getPlantRelationshipDefinitions();
+        }
+        const definitions = await cache.plantRelationshipDefinitions;
+        if (!cache.plantRelationshipPublishedPlants) {
+            cache.plantRelationshipPublishedPlants = getEntitiesRaw(
+                'plant',
+                'published',
+            ) as Promise<EntityWithAttributesAndType[]>;
+        }
+        const publishedPlants = await cache.plantRelationshipPublishedPlants;
+        const plantRelationships = definitions.length
+            ? await buildPlantRelationshipReadModel(
+                  options.sourceEntity,
+                  publishedPlants,
+              )
+            : null;
+        if (plantRelationships) {
+            (expandedEntity as Record<string, unknown>).relationships =
+                plantRelationships;
+        }
+    }
+
     return expandedEntity;
 }
 
@@ -364,7 +426,7 @@ async function expandEntityAttributes<T extends Record<string, unknown>>(
 async function expandValue(
     value: string | null | undefined,
     attributeDefinition: SelectAttributeDefinition,
-    cache: EntityTypeCache = {},
+    cache: EntityExpansionCache = createEntityExpansionCache(),
 ) {
     if (value === null || value === undefined) {
         return null;
@@ -415,7 +477,7 @@ async function expandValue(
 async function resolveRef(
     value: string | null,
     attributeDefinition: SelectAttributeDefinition,
-    cache: EntityTypeCache = {},
+    cache: EntityExpansionCache = createEntityExpansionCache(),
 ) {
     const refId = parseEntityRefId(value);
     if (refId === null) {
@@ -424,13 +486,13 @@ async function resolveRef(
 
     const refEntityTypeName = attributeDefinition.dataType.split(':')[1];
     const cacheKey = `${refEntityTypeName}:published`;
-    if (!cache[cacheKey]) {
-        cache[cacheKey] = getEntitiesRaw(
+    if (!cache.entitiesByType[cacheKey]) {
+        cache.entitiesByType[cacheKey] = getEntitiesRaw(
             refEntityTypeName,
             'published',
         ) as Promise<EntityWithAttributesAndType[]>;
     }
-    const refEntitiesByType = await cache[cacheKey];
+    const refEntitiesByType = await cache.entitiesByType[cacheKey];
     const refEntity = refEntitiesByType.find((e) => e.id === refId);
     if (!refEntity) {
         return null;
@@ -447,7 +509,7 @@ export async function getEntitiesFormatted<T>(entityTypeName: string) {
     return directoriesCached(
         cacheKeys.entityTypeName(entityTypeName),
         async () => {
-            const cache: EntityTypeCache = {};
+            const cache = createEntityExpansionCache();
             const entities = (await getEntitiesRaw(
                 entityTypeName,
                 'published',
@@ -464,7 +526,7 @@ export async function getEntityFormatted<T>(id: number) {
     return directoriesCached(
         cacheKeys.entity(id),
         async () => {
-            const cache: EntityTypeCache = {};
+            const cache = createEntityExpansionCache();
             const entity = (await getEntityRaw(id)) as
                 | EntityWithAttributesAndType
                 | undefined;
@@ -850,7 +912,20 @@ export async function updateEntity(
         bustCachedByPrefixes(['dashboard:admin:']),
     ]);
 
-    await refreshEntitySearchDocumentAfterMutation(entity.id);
+    const linkedPlantRelationshipEntityIds =
+        previousEntity.entityTypeName === 'plant'
+            ? await getPlantRelationshipLinkedEntityIds(entity.id)
+            : [];
+    await Promise.all(
+        linkedPlantRelationshipEntityIds.map((linkedEntityId) =>
+            bustCached(cacheKeys.entity(linkedEntityId)),
+        ),
+    );
+
+    await refreshEntitySearchDocumentsAfterMutation([
+        entity.id,
+        ...linkedPlantRelationshipEntityIds,
+    ]);
 }
 
 export async function deleteEntity(
@@ -883,7 +958,20 @@ export async function deleteEntity(
         bustCachedByPrefixes(['dashboard:admin:']),
     ]);
 
-    await refreshEntitySearchDocumentAfterMutation(id);
+    const linkedPlantRelationshipEntityIds =
+        entity.entityTypeName === 'plant'
+            ? await getPlantRelationshipLinkedEntityIds(id)
+            : [];
+    await Promise.all(
+        linkedPlantRelationshipEntityIds.map((linkedEntityId) =>
+            bustCached(cacheKeys.entity(linkedEntityId)),
+        ),
+    );
+
+    await refreshEntitySearchDocumentsAfterMutation([
+        id,
+        ...linkedPlantRelationshipEntityIds,
+    ]);
 }
 
 export async function getEntityRevisions(entityId: number) {

--- a/packages/storage/tests/entitiesRepo.node.spec.ts
+++ b/packages/storage/tests/entitiesRepo.node.spec.ts
@@ -5,6 +5,7 @@ import {
     createAttributeDefinition,
     createEntity,
     deleteAttributeValue,
+    deleteEntity,
     getEntitiesFormatted,
     getEntityIncomingLinks,
     getEntityRaw,
@@ -209,4 +210,210 @@ test('CMS entity variants inherit parent attributes and allow override reset', a
     variant = formattedEntities.find((entity) => entity.id === variantEntityId);
     assert.equal(variant?.information.name, 'Base name');
     assert.equal(variant?.information.description, 'Base description');
+});
+type FormattedPlantRelationshipEntry = {
+    id: number;
+    slug: string;
+    displayName: string;
+    kind: 'companion' | 'antagonist';
+    image?: {
+        cover: {
+            url: string;
+        };
+    };
+};
+
+type FormattedPlant = {
+    id: number;
+    information: {
+        name: string;
+    };
+    relationships?: {
+        companions?: FormattedPlantRelationshipEntry[];
+        antagonists?: FormattedPlantRelationshipEntry[];
+    };
+};
+
+async function createPlantRelationshipTestDirectory(suffix: string) {
+    await upsertEntityType({ name: 'plant', label: 'Plant' });
+
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Name',
+        entityTypeName: 'plant',
+        dataType: 'text',
+    });
+    const companionDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'companions',
+        label: 'Companion plants',
+        entityTypeName: 'plant',
+        dataType: 'ref:plant',
+        multiple: true,
+    });
+    const antagonistDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'antagonists',
+        label: 'Antagonistic plants',
+        entityTypeName: 'plant',
+        dataType: 'ref:plant',
+        multiple: true,
+    });
+
+    async function createPlant(
+        name: string,
+        state: 'draft' | 'published' = 'published',
+    ) {
+        const id = await createEntity('plant');
+        await upsertAttributeValue({
+            attributeDefinitionId: nameDefinitionId,
+            entityTypeName: 'plant',
+            entityId: id,
+            value: `${name} ${suffix}`,
+        });
+        if (state === 'published') {
+            await updateEntity({
+                id,
+                entityTypeName: 'plant',
+                state: 'published',
+            });
+        }
+        return id;
+    }
+
+    return {
+        companionDefinitionId,
+        antagonistDefinitionId,
+        createPlant,
+    };
+}
+
+test('plant companion relationships are reciprocal in formatted output', async () => {
+    createTestDb();
+    const suffix = randomUUID();
+    const { companionDefinitionId, createPlant } =
+        await createPlantRelationshipTestDirectory(suffix);
+
+    const tomatoId = await createPlant('Tomato');
+    const basilId = await createPlant('Basil');
+    await upsertAttributeValue({
+        attributeDefinitionId: companionDefinitionId,
+        entityTypeName: 'plant',
+        entityId: tomatoId,
+        value: String(basilId),
+    });
+
+    const formattedPlants = await getEntitiesFormatted<FormattedPlant>('plant');
+    const tomato = formattedPlants.find((plant) => plant.id === tomatoId);
+    const basil = formattedPlants.find((plant) => plant.id === basilId);
+
+    assert.deepEqual(
+        tomato?.relationships?.companions?.map((plant) => ({
+            id: plant.id,
+            displayName: plant.displayName,
+            kind: plant.kind,
+        })),
+        [{ id: basilId, displayName: `Basil ${suffix}`, kind: 'companion' }],
+    );
+    assert.deepEqual(
+        basil?.relationships?.companions?.map((plant) => ({
+            id: plant.id,
+            displayName: plant.displayName,
+            kind: plant.kind,
+        })),
+        [{ id: tomatoId, displayName: `Tomato ${suffix}`, kind: 'companion' }],
+    );
+});
+
+test('plant antagonist relationships are reciprocal in formatted output', async () => {
+    createTestDb();
+    const suffix = randomUUID();
+    const { antagonistDefinitionId, createPlant } =
+        await createPlantRelationshipTestDirectory(suffix);
+
+    const tomatoId = await createPlant('Tomato');
+    const walnutId = await createPlant('Walnut');
+    await upsertAttributeValue({
+        attributeDefinitionId: antagonistDefinitionId,
+        entityTypeName: 'plant',
+        entityId: tomatoId,
+        value: String(walnutId),
+    });
+
+    const formattedPlants = await getEntitiesFormatted<FormattedPlant>('plant');
+    const tomato = formattedPlants.find((plant) => plant.id === tomatoId);
+    const walnut = formattedPlants.find((plant) => plant.id === walnutId);
+
+    assert.deepEqual(
+        tomato?.relationships?.antagonists?.map((plant) => ({
+            id: plant.id,
+            displayName: plant.displayName,
+            kind: plant.kind,
+        })),
+        [{ id: walnutId, displayName: `Walnut ${suffix}`, kind: 'antagonist' }],
+    );
+    assert.deepEqual(
+        walnut?.relationships?.antagonists?.map((plant) => ({
+            id: plant.id,
+            displayName: plant.displayName,
+            kind: plant.kind,
+        })),
+        [{ id: tomatoId, displayName: `Tomato ${suffix}`, kind: 'antagonist' }],
+    );
+});
+
+test('plant relationship read model filters self-links, duplicates, missing, draft, and deleted targets', async () => {
+    createTestDb();
+    const suffix = randomUUID();
+    const { companionDefinitionId, createPlant } =
+        await createPlantRelationshipTestDirectory(suffix);
+
+    const tomatoId = await createPlant('Tomato');
+    const basilId = await createPlant('Basil');
+    const draftId = await createPlant('Draft', 'draft');
+    const deletedId = await createPlant('Deleted');
+    await deleteEntity(deletedId);
+
+    for (const value of [
+        String(tomatoId),
+        String(basilId),
+        String(basilId),
+        String(draftId),
+        String(deletedId),
+        '999999999',
+    ]) {
+        await upsertAttributeValue({
+            attributeDefinitionId: companionDefinitionId,
+            entityTypeName: 'plant',
+            entityId: tomatoId,
+            value,
+        });
+    }
+
+    await upsertAttributeValue({
+        attributeDefinitionId: companionDefinitionId,
+        entityTypeName: 'plant',
+        entityId: basilId,
+        value: String(tomatoId),
+    });
+
+    const formattedPlants = await getEntitiesFormatted<FormattedPlant>('plant');
+    const tomato = formattedPlants.find((plant) => plant.id === tomatoId);
+    const basil = formattedPlants.find((plant) => plant.id === basilId);
+
+    assert.deepEqual(
+        tomato?.relationships?.companions?.map((plant) => plant.id),
+        [basilId],
+    );
+    assert.deepEqual(
+        basil?.relationships?.companions?.map((plant) => plant.id),
+        [tomatoId],
+    );
+    assert.equal(
+        tomato?.relationships?.companions?.some((plant) =>
+            [tomatoId, draftId, deletedId, 999999999].includes(plant.id),
+        ),
+        false,
+    );
 });


### PR DESCRIPTION
### Motivation
- Represent companion and antagonistic plant links as plant-level symmetric relationships that can be authored once and read from both plants without recursively expanding `ref:plant` trees.
- Provide a stable, shallow read model safe for public formatted entity payloads and avoid infinite recursion when plants reference each other.

### Description
- Add `packages/storage/src/helpers/plantRelationships.ts` to define configured plant relationship attributes (`relationships.companions` and `relationships.antagonists`), utilities `getPlantRelationshipDefinitions`, `buildPlantRelationshipReadModel`, `getPlantRelationshipLinkedEntityIds`, and `getPlantRelationshipMutationEntityIds`, and produce shallow `PlantRelationshipEntry` objects (id, slug, displayName, optional cover image, and kind).
- Update entity expansion in `packages/storage/src/repositories/entitiesRepo.ts` to skip expanding plant relationship `ref:plant` attributes and instead attach a `relationships` read model produced by `buildPlantRelationshipReadModel`, using an expansion cache to avoid repeated queries.
- Update `packages/storage/src/repositories/attributeValuesRepo.ts` to compute impacted entity ids for plant relationship mutations via `getPlantRelationshipMutationEntityIds`, bust caches for linked peers, and refresh impacted search/read documents when relationship attribute values are added/updated/deleted.
- Extend standardized types in `packages/storage/src/@types/EntityStandardized.ts` to include a `relationships` section and add `EntityRelationshipEntry` type, and add tests in `packages/storage/tests/entitiesRepo.node.spec.ts` that assert reciprocal companions, reciprocal antagonists, and filtering of self/duplicate/missing/draft/deleted links.

### Testing
- Ran formatter/lint checks with `pnpm --filter @gredice/storage exec biome check --write ...` against the new helper, updated repos, types and tests and the check completed (auto-fixes applied where safe).
- Ran storage unit tests with `pnpm --filter @gredice/storage test -- tests/entitiesRepo.node.spec.ts` and all new and existing assertions in that test file passed (5 tests, 0 failures).
- Attempted package `tsc` runs for stricter type-checking; full workspace `tsc` surfaced unrelated pre-existing type errors in scripts and other storage sources, so a full `pnpm --filter @gredice/storage typecheck` was not executed here (storage package has no `typecheck` script).  The new functionality compiles and the targeted tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201203a688832fb40e811c5af7be6f)