### PR TITLE
[codex] Move diary schedule action to card top

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -862,6 +862,142 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeVisible();
     });
 
+    test('diary tab disables same-day schedule changes with a tooltip', async ({
+        mount,
+        page,
+    }) => {
+        const scenario = plantedGrowingWithOperationHistoryScenario();
+        const operation = scenario.operationHistoryItems?.[0];
+
+        if (!operation) {
+            throw new Error('Expected operation history item.');
+        }
+
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={{
+                    ...scenario,
+                    operationHistoryItems: [
+                        {
+                            ...operation,
+                            status: 'planned',
+                            scheduledDate: '2026-05-13T00:00:00.000Z',
+                            scheduledAt: '2026-05-12T00:00:00.000Z',
+                            completedAt: null,
+                            verifiedAt: null,
+                            imageUrls: [],
+                            completionNotes: null,
+                            statusHistory: [
+                                {
+                                    status: 'new',
+                                    changedAt: '2026-05-12T00:00:00.000Z',
+                                },
+                                {
+                                    status: 'planned',
+                                    changedAt: '2026-05-12T00:00:00.000Z',
+                                },
+                            ],
+                        },
+                    ],
+                }}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
+
+        const scheduleButton = dialog.getByRole('button', {
+            name: '13. svibnja 2026.',
+        });
+        await expect(scheduleButton).toBeDisabled();
+
+        await scheduleButton.locator('xpath=..').hover();
+        await expect(
+            page
+                .getByRole('tooltip')
+                .getByText(
+                    'Datum radnje zakazane za danas više nije moguće promijeniti.',
+                ),
+        ).toBeVisible();
+    });
+
+    test('diary tab shows Zakaži for active operation cards without a scheduled date', async ({
+        mount,
+        page,
+    }) => {
+        const scenario = plantedGrowingWithOperationHistoryScenario();
+        const operation = scenario.operationHistoryItems?.[0];
+
+        if (!operation) {
+            throw new Error('Expected operation history item.');
+        }
+
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={{
+                    ...scenario,
+                    operationHistoryItems: [
+                        {
+                            ...operation,
+                            status: 'planned',
+                            scheduledDate: null,
+                            scheduledAt: null,
+                            completedAt: null,
+                            verifiedAt: null,
+                            imageUrls: [],
+                            completionNotes: null,
+                            statusHistory: [
+                                {
+                                    status: 'new',
+                                    changedAt: '2026-05-12T00:00:00.000Z',
+                                },
+                            ],
+                        },
+                    ],
+                }}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
+        await dialog.getByRole('button', { name: 'Zakaži' }).click();
+
+        await expect(
+            page.getByText('Novi datum', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Spremi' }),
+        ).toBeVisible();
+    });
+
+    test('diary tab shows completed schedule dates as text instead of buttons', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithOperationHistoryScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
+
+        await expect(dialog.getByText('10. svibnja 2026.')).toBeVisible();
+        await expect(
+            dialog.getByRole('button', { name: '10. svibnja 2026.' }),
+        ).toHaveCount(0);
+    });
+
     test('raised bed diary operation history does not overflow the modal', async ({
         mount,
         page,

--- a/packages/game/src/hooks/useRescheduleDiaryEntry.ts
+++ b/packages/game/src/hooks/useRescheduleDiaryEntry.ts
@@ -11,13 +11,13 @@ export type DiaryRescheduleTarget =
           raisedBedId: number | null;
           raisedBedFieldId: number | null;
           positionIndex?: number;
-          scheduledDate: string;
+          scheduledDate?: string | null;
       }
     | {
           type: 'raisedBedFieldPlant';
           raisedBedId: number;
           positionIndex: number;
-          scheduledDate: string;
+          scheduledDate?: string | null;
       };
 
 const mutationKey = ['gardens', 'diary', 'reschedule'];
@@ -82,6 +82,10 @@ export function isDiaryRescheduleTargetEligible(
         return false;
     }
 
+    if (!target.scheduledDate) {
+        return true;
+    }
+
     const scheduledDate = new Date(target.scheduledDate);
     if (Number.isNaN(scheduledDate.getTime())) {
         return false;
@@ -91,6 +95,29 @@ export function isDiaryRescheduleTargetEligible(
         startOfUtcDay(scheduledDate).getTime() >=
         getMinimumRescheduleDate(referenceDate).getTime()
     );
+}
+
+export function getDiaryRescheduleDisabledReason(
+    target: DiaryRescheduleTarget | undefined,
+    referenceDate = new Date(),
+) {
+    if (!target?.scheduledDate) {
+        return null;
+    }
+
+    const scheduledDate = new Date(target.scheduledDate);
+    if (Number.isNaN(scheduledDate.getTime())) {
+        return 'Datum radnje nije ispravan.';
+    }
+
+    if (
+        startOfUtcDay(scheduledDate).getTime() <
+        getMinimumRescheduleDate(referenceDate).getTime()
+    ) {
+        return 'Datum radnje zakazane za danas više nije moguće promijeniti.';
+    }
+
+    return null;
 }
 
 async function rescheduleOperation({

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -44,6 +44,7 @@ import { useOperations } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
 import {
     type DiaryRescheduleTarget,
+    getDiaryRescheduleDisabledReason,
     isDiaryRescheduleTargetEligible,
 } from '../hooks/useRescheduleDiaryEntry';
 import {
@@ -599,7 +600,6 @@ export function getGardenOperationRescheduleTarget(
     garden: CurrentGardenData | null | undefined,
 ): DiaryRescheduleTarget | null {
     if (
-        !operation.scheduledDate ||
         !reschedulableActiveStatuses.has(operation.status) ||
         operation.completedAt ||
         operation.verifiedAt ||
@@ -722,6 +722,71 @@ export function GardenOperationRescheduleAction({
             gardenId={garden.id}
             target={target}
             triggerLabel={triggerLabel}
+        />
+    );
+}
+
+function isFinishedOperation(operation: GardenOperationHudItem) {
+    return Boolean(
+        operation.completedAt ||
+            operation.verifiedAt ||
+            operation.status === 'completed',
+    );
+}
+
+function OperationScheduleText({ label }: { label: string }) {
+    return (
+        <Row spacing={1} className="min-w-0 text-muted-foreground">
+            <Calendar className="size-3.5 shrink-0" />
+            <Typography level="body3" noWrap className="min-w-0">
+                {label}
+            </Typography>
+        </Row>
+    );
+}
+
+export function GardenOperationScheduleAction({
+    entryName,
+    garden,
+    operation,
+    referenceDate,
+}: {
+    entryName: string;
+    garden: CurrentGardenData | null | undefined;
+    operation: GardenOperationHudItem;
+    referenceDate: Date;
+}) {
+    const scheduledDateLabel = formatDate(operation.scheduledDate);
+
+    if (isFinishedOperation(operation)) {
+        return scheduledDateLabel ? (
+            <OperationScheduleText label={scheduledDateLabel} />
+        ) : null;
+    }
+
+    if (!garden) {
+        return scheduledDateLabel ? (
+            <OperationScheduleText label={scheduledDateLabel} />
+        ) : null;
+    }
+
+    const target = getGardenOperationRescheduleTarget(operation, garden);
+    if (!target) {
+        return scheduledDateLabel ? (
+            <OperationScheduleText label={scheduledDateLabel} />
+        ) : null;
+    }
+
+    return (
+        <RaisedBedDiaryRescheduleAction
+            disabledReason={getDiaryRescheduleDisabledReason(
+                target,
+                referenceDate,
+            )}
+            entryName={entryName}
+            gardenId={garden.id}
+            target={target}
+            triggerLabel={scheduledDateLabel ?? 'Zakaži'}
         />
     );
 }
@@ -979,12 +1044,12 @@ function OperationSchedule({
 }) {
     const scheduledDate = formatDate(operation.scheduledDate);
 
-    if (!scheduledDate) {
-        return null;
-    }
-
     if (scheduleAction) {
         return <div className="w-fit max-w-full">{scheduleAction}</div>;
+    }
+
+    if (!scheduledDate) {
+        return null;
     }
 
     return (
@@ -1762,31 +1827,20 @@ export function GardenOperationsHud() {
                                             : undefined;
                                     const operationName =
                                         operationData?.information.label;
-                                    const scheduledDateLabel = formatDate(
-                                        operation.scheduledDate,
-                                    );
                                     const entryName = getActiveOperationName({
                                         operation,
                                         operationName,
                                         plantSortName:
                                             plantSortData?.information.name,
                                     });
-                                    const scheduleAction =
-                                        canRescheduleGardenOperation(
-                                            operation,
-                                            currentGarden,
-                                            referenceDate,
-                                        ) && scheduledDateLabel ? (
-                                            <GardenOperationRescheduleAction
-                                                entryName={entryName}
-                                                garden={currentGarden}
-                                                operation={operation}
-                                                referenceDate={referenceDate}
-                                                triggerLabel={
-                                                    scheduledDateLabel
-                                                }
-                                            />
-                                        ) : undefined;
+                                    const scheduleAction = (
+                                        <GardenOperationScheduleAction
+                                            entryName={entryName}
+                                            garden={currentGarden}
+                                            operation={operation}
+                                            referenceDate={referenceDate}
+                                        />
+                                    );
 
                                     return (
                                         <GardenOperationCard

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -5,6 +5,7 @@ import { Calendar } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
 import { Typography } from '@gredice/ui/Typography';
 import { type FormEvent, type ReactNode, useState } from 'react';
 import {
@@ -15,11 +16,13 @@ import {
 } from '../../hooks/useRescheduleDiaryEntry';
 
 export function RaisedBedDiaryRescheduleAction({
+    disabledReason,
     entryName,
     gardenId,
     target,
-    triggerLabel = 'Prerasporedi',
+    triggerLabel,
 }: {
+    disabledReason?: string | null;
     entryName: string;
     gardenId: number;
     target: DiaryRescheduleTarget;
@@ -29,10 +32,43 @@ export function RaisedBedDiaryRescheduleAction({
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const mutation = useRescheduleDiaryEntry(gardenId);
     const minimumDate = getMinimumDiaryRescheduleDateInput();
-    const defaultDate = formatDiaryRescheduleDateInput(
-        new Date(target.scheduledDate),
-    );
+    const hasScheduledDate = Boolean(target.scheduledDate);
+    const defaultDate = target.scheduledDate
+        ? formatDiaryRescheduleDateInput(new Date(target.scheduledDate))
+        : minimumDate;
     const currentValue = defaultDate >= minimumDate ? defaultDate : minimumDate;
+    const actionLabel =
+        triggerLabel ?? (hasScheduledDate ? 'Prerasporedi' : 'Zakaži');
+    const modalActionLabel = hasScheduledDate ? 'Prerasporedi' : 'Zakaži';
+    const triggerButton = (
+        <Button
+            type="button"
+            size="xs"
+            variant="soft"
+            disabled={Boolean(disabledReason)}
+            startDecorator={<Calendar className="size-3.5 shrink-0" />}
+        >
+            {actionLabel}
+        </Button>
+    );
+
+    if (disabledReason) {
+        return (
+            <Tooltip delayDuration={100}>
+                <TooltipTrigger asChild>
+                    <span
+                        className="inline-flex w-fit max-w-full cursor-not-allowed"
+                        title={disabledReason}
+                    >
+                        {triggerButton}
+                    </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <Typography level="body3">{disabledReason}</Typography>
+                </TooltipContent>
+            </Tooltip>
+        );
+    }
 
     async function handleSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -62,7 +98,7 @@ export function RaisedBedDiaryRescheduleAction({
 
     return (
         <Modal
-            title={`Prerasporedi ${entryName}`}
+            title={`${modalActionLabel} ${entryName}`}
             open={open}
             onOpenChange={(nextOpen) => {
                 setOpen(nextOpen);
@@ -70,23 +106,15 @@ export function RaisedBedDiaryRescheduleAction({
                     setErrorMessage(null);
                 }
             }}
-            trigger={
-                <Button
-                    type="button"
-                    size="xs"
-                    variant="soft"
-                    startDecorator={<Calendar className="size-3.5 shrink-0" />}
-                >
-                    {triggerLabel}
-                </Button>
-            }
+            trigger={triggerButton}
         >
             <form onSubmit={handleSubmit}>
                 <Stack spacing={4}>
                     <Stack spacing={1}>
-                        <Typography level="h5">Prerasporedi</Typography>
+                        <Typography level="h5">{modalActionLabel}</Typography>
                         <Typography level="body2" secondary>
-                            Odaberi novi datum za {entryName}.
+                            Odaberi {hasScheduledDate ? 'novi ' : ''}datum za{' '}
+                            {entryName}.
                         </Typography>
                     </Stack>
 

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -17,10 +17,9 @@ import { useSorts } from '../../hooks/usePlantSorts';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import {
     buildSowingOperationItems,
-    canRescheduleGardenOperation,
     cartPlantSortEntityType,
     GardenOperationCard,
-    GardenOperationRescheduleAction,
+    GardenOperationScheduleAction,
     sortNewestFirst,
 } from '../GardenOperationsHud';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
@@ -295,16 +294,6 @@ export function RaisedBedOperationHistoryList({
                         ? plantSortById.get(operation.entityId)
                         : undefined;
                 const operationName = operationData?.information.label;
-                const scheduledDateLabel = operation.scheduledDate
-                    ? new Date(operation.scheduledDate).toLocaleDateString(
-                          'hr-HR',
-                          {
-                              day: 'numeric',
-                              month: 'long',
-                              year: 'numeric',
-                          },
-                      )
-                    : null;
                 const entryName =
                     operationName ??
                     plantSortData?.information.name ??
@@ -315,21 +304,14 @@ export function RaisedBedOperationHistoryList({
                     (operation.raisedBedFieldId
                         ? fieldPositionById.get(operation.raisedBedFieldId)
                         : undefined);
-                const rescheduleAction =
-                    !disableActions &&
-                    canRescheduleGardenOperation(
-                        operation,
-                        currentGarden,
-                        referenceDate,
-                    ) ? (
-                        <GardenOperationRescheduleAction
-                            entryName={entryName}
-                            garden={currentGarden}
-                            operation={operation}
-                            referenceDate={referenceDate}
-                            triggerLabel={scheduledDateLabel}
-                        />
-                    ) : null;
+                const scheduleAction = !disableActions ? (
+                    <GardenOperationScheduleAction
+                        entryName={entryName}
+                        garden={currentGarden}
+                        operation={operation}
+                        referenceDate={referenceDate}
+                    />
+                ) : undefined;
                 const aiAction =
                     flags.raisedBedImageAI &&
                     !disableActions &&
@@ -375,8 +357,8 @@ export function RaisedBedOperationHistoryList({
                         currentGarden={currentGarden}
                         referenceDate={referenceDate}
                         progressClassName="md:max-w-80"
-                        scheduleAction={rescheduleAction ?? undefined}
                         action={action}
+                        scheduleAction={scheduleAction}
                     />
                 );
             })}

--- a/packages/storage/src/repositories/gardenDiaryRescheduleRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryRescheduleRepo.ts
@@ -68,10 +68,7 @@ function assertExistingScheduledDateCanMove(
     referenceDate: Date,
 ) {
     if (!scheduledDate) {
-        throw new GardenDiaryRescheduleError(
-            'Only scheduled planned items can be rescheduled.',
-            409,
-        );
+        return;
     }
 
     if (!isDiaryRescheduleDateAllowed(scheduledDate, referenceDate)) {

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -64,6 +64,35 @@ async function createScheduledOperation({
     return operationId;
 }
 
+async function createUnscheduledPlannedOperation({
+    accountId,
+    gardenId,
+    raisedBedId,
+}: {
+    accountId: string;
+    gardenId: number;
+    raisedBedId: number;
+}) {
+    const operationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+
+    await createEvent({
+        type: knownEvents.operations.scheduledV1(operationId.toString(), {
+            scheduledDate: new Date(0).toISOString(),
+        }).type,
+        version: 1,
+        aggregateId: operationId.toString(),
+        data: {},
+    });
+
+    return operationId;
+}
+
 async function createScheduledField({
     raisedBedId,
     positionIndex,
@@ -89,6 +118,29 @@ async function createScheduledField({
     );
 }
 
+async function createUnscheduledField({
+    raisedBedId,
+    positionIndex,
+}: {
+    raisedBedId: number;
+    positionIndex: number;
+}) {
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex,
+    });
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(
+            `${raisedBedId.toString()}|${positionIndex.toString()}`,
+            {
+                plantSortId: '101',
+                scheduledDate: null,
+            },
+        ),
+    );
+}
+
 test('rescheduleGardenDiaryOperation moves planned future operations', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
@@ -98,6 +150,31 @@ test('rescheduleGardenDiaryOperation moves planned future operations', async () 
         gardenId,
         raisedBedId,
         scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await rescheduleGardenDiaryOperation({
+        accountId,
+        gardenId,
+        operationId,
+        scheduledDate: '2026-06-05',
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const operation = await getOperationById(operationId);
+    assert.equal(
+        operation.scheduledDate?.toISOString(),
+        '2026-06-05T00:00:00.000Z',
+    );
+});
+
+test('rescheduleGardenDiaryOperation schedules planned operations without a date', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createUnscheduledPlannedOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
     });
 
     await rescheduleGardenDiaryOperation({
@@ -149,6 +226,34 @@ test('rescheduleGardenDiaryRaisedBedField moves planned future sowing', async ()
         raisedBedId,
         positionIndex: 0,
         scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await rescheduleGardenDiaryRaisedBedField({
+        accountId,
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-06',
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.equal(
+        field?.plantScheduledDate?.toISOString(),
+        '2026-06-06T00:00:00.000Z',
+    );
+});
+
+test('rescheduleGardenDiaryRaisedBedField schedules planned sowing without a date', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    await createUnscheduledField({
+        raisedBedId,
+        positionIndex: 0,
     });
 
     await rescheduleGardenDiaryRaisedBedField({


### PR DESCRIPTION
## Summary
- Moves the diary operation schedule control into the top schedule area of operation cards.
- Shows disabled same-day schedule buttons with an explanatory tooltip, shows `Zakaži` for unscheduled planned items, and renders completed schedule dates as icon text.
- Allows planned diary operations/field sowing without an existing date to be scheduled through the existing endpoint.

## Validation
- `pnpm test --filter @gredice/storage -- gardenDiaryRescheduleRepo.node.spec.ts`
- `pnpm typecheck --filter @gredice/game`
- `pnpm --filter @gredice/game exec biome check --write src/hooks/useRescheduleDiaryEntry.ts src/hud/GardenOperationsHud.tsx src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx src/hud/raisedBed/RaisedBedOperationHistoryList.tsx`
- `pnpm --filter garden exec biome check --write tests/raised-bed-field-hud.spec.tsx`
- `pnpm --filter @gredice/storage exec biome check --write src/repositories/gardenDiaryRescheduleRepo.ts tests/gardenDiaryRescheduleRepo.node.spec.ts`
- `pnpm test --filter garden -- raised-bed-field-hud.spec.tsx`