### PR TITLE
Reduce sunflower size and align reward pickup

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -63,7 +63,6 @@ import { findClosestForecastEntry } from '../../../lib/weather/weatherNowContrac
 
 const dailyRewards = [5, 10, 15, 20, 25, 50];
 const DAILY_REWARD_TIME_ZONE = 'Europe/Zagreb';
-const SUNFLOWER_DROP_SPAWN_CHANCE = 0.35;
 const GARDEN_APP_URL =
     process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
 
@@ -539,7 +538,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             const result = await getOrCreateSunflowerDropSpawn({
                 accountId,
-                allowCreate: Math.random() < SUNFLOWER_DROP_SPAWN_CHANCE,
+                allowCreate: true,
                 gardenId,
                 now,
                 sourceBlockId: sourceBlock.id,

--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -63,6 +63,7 @@ import { findClosestForecastEntry } from '../../../lib/weather/weatherNowContrac
 
 const dailyRewards = [5, 10, 15, 20, 25, 50];
 const DAILY_REWARD_TIME_ZONE = 'Europe/Zagreb';
+const SUNFLOWER_DROP_SPAWN_CHANCE = 0.35;
 const GARDEN_APP_URL =
     process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
 
@@ -538,7 +539,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             const result = await getOrCreateSunflowerDropSpawn({
                 accountId,
-                allowCreate: true,
+                allowCreate: Math.random() < SUNFLOWER_DROP_SPAWN_CHANCE,
                 gardenId,
                 now,
                 sourceBlockId: sourceBlock.id,

--- a/packages/game/src/entities/Sunflower.tsx
+++ b/packages/game/src/entities/Sunflower.tsx
@@ -104,7 +104,7 @@ const centerDotNodeNames = [
 
 const headBackNodeName = 'Sunflower_Head_Back' satisfies SunflowerNodeName;
 const centerNodeName = 'Sunflower_Center' satisfies SunflowerNodeName;
-const sunflowerScale = 0.82;
+const sunflowerScale = 0.656;
 const headPivot = [0, 1.33, 0] satisfies [number, number, number];
 const colors = {
     leaf: '#6f8544',

--- a/packages/game/src/entities/SunflowerDropReward.tsx
+++ b/packages/game/src/entities/SunflowerDropReward.tsx
@@ -1,8 +1,8 @@
-import { Image as DreiImage } from '@react-three/drei';
-import type { ThreeEvent } from '@react-three/fiber';
+import { animated, useSpring } from '@react-spring/three';
+import { type ThreeEvent, useFrame } from '@react-three/fiber';
 import Image from 'next/image';
-import { useEffect, useMemo, useState } from 'react';
-import { Vector3 } from 'three';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Group } from 'three';
 import {
     useClaimSunflowerDrop,
     useSunflowerDrop,
@@ -12,10 +12,16 @@ import {
     useAnimateFlyToSunflowersHud,
 } from '../indicators/AnimateFlyTo';
 import { ParticleType, useParticles } from '../particles/ParticleSystem';
-import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import { useStackHeight } from '../utils/getStackHeight';
+import { HoverOutline } from './helpers/HoverOutline';
 import { SunflowerHeadModel } from './Sunflower';
+import {
+    findSunflowerDropPlacement,
+    getSunflowerDropPosition,
+    getSunflowerDropSpawnDelayMs,
+    type SunflowerDropPlacement,
+} from './sunflowerDropRewardCore';
 
 type SunflowerDropGarden = {
     id: number;
@@ -32,35 +38,20 @@ type SunflowerDropSpawn = {
     spawnId: string;
 };
 
-type SunflowerDropPlacement = {
-    block: Block;
-    stack: Stack;
-};
-
 export type SunflowerDropFlyOrigin = { x: number; y: number };
 
-function hashString(value: string) {
-    let hash = 0;
-    for (let index = 0; index < value.length; index += 1) {
-        hash = (hash * 31 + value.charCodeAt(index)) % 100_000;
-    }
-    return hash / 100_000;
-}
+const sunflowerDropLandingHeight = 0.9;
+const sunflowerDropBounceLift = 0.04;
+const sunflowerDropBounceSpeed = 2.1;
+const sunflowerDropBounceScale = 0.025;
+const reducedMotionQuery = '(prefers-reduced-motion: reduce)';
 
-function findSunflowerDropPlacement(
-    stacks: Stack[],
-    sourceBlockId: string,
-): SunflowerDropPlacement | null {
-    for (const stack of stacks) {
-        const block = stack.blocks.find(
-            (candidate) => candidate.id === sourceBlockId,
-        );
-        if (block) {
-            return { block, stack };
-        }
-    }
-
-    return null;
+function prefersReducedMotion() {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia(reducedMotionQuery).matches
+    );
 }
 
 export function SunflowerDropFlyAnimation({
@@ -110,37 +101,78 @@ function SunflowerDropAtPlacement({
 }) {
     const claimSunflowerDrop = useClaimSunflowerDrop();
     const { spawn: spawnParticles } = useParticles();
+    const reduceMotion = useMemo(prefersReducedMotion, []);
+    const rewardRef = useRef<Group>(null);
+    const [hovered, setHovered] = useState(false);
+    const [hasLanded, setHasLanded] = useState(reduceMotion);
     const stackHeight = useStackHeight(placement.stack, placement.block);
     const drop = useMemo(() => {
-        const hash = hashString(spawn.spawnId);
-        const angle = hash * Math.PI * 2;
-        const radius = 0.34 + hashString(`${spawn.spawnId}:radius`) * 0.14;
-        const x = Math.cos(angle) * radius;
-        const z = Math.sin(angle) * radius;
+        return getSunflowerDropPosition({
+            placement,
+            spawnId: spawn.spawnId,
+            stackHeight,
+        });
+    }, [placement, spawn.spawnId, stackHeight]);
+    const [{ dropOffsetY }, landingApi] = useSpring(() => ({
+        config: {
+            mass: 0.15,
+            tension: 170,
+            friction: 13,
+        },
+        dropOffsetY: reduceMotion ? 0 : sunflowerDropLandingHeight,
+    }));
 
-        return {
-            particlePosition: new Vector3(
-                placement.stack.position.x + x,
-                stackHeight + 0.12,
-                placement.stack.position.z + z,
-            ),
-            position: [
-                placement.stack.position.x + x,
-                stackHeight + 0.085,
-                placement.stack.position.z + z,
-            ] satisfies [number, number, number],
-            rotation: [-Math.PI / 2, 0, angle + Math.PI * 0.15] satisfies [
-                number,
-                number,
-                number,
-            ],
+    useEffect(() => {
+        let active = true;
+        setHasLanded(reduceMotion);
+
+        if (reduceMotion) {
+            landingApi.set({ dropOffsetY: 0 });
+            return () => {
+                active = false;
+            };
+        }
+
+        landingApi.set({ dropOffsetY: sunflowerDropLandingHeight });
+        void landingApi.start({
+            dropOffsetY: 0,
+            onRest: () => {
+                if (active) {
+                    setHasLanded(true);
+                }
+            },
+        });
+
+        return () => {
+            active = false;
+            landingApi.stop();
         };
-    }, [
-        placement.stack.position.x,
-        placement.stack.position.z,
-        spawn.spawnId,
-        stackHeight,
-    ]);
+    }, [landingApi, reduceMotion]);
+
+    useFrame(({ clock }) => {
+        const reward = rewardRef.current;
+        if (!reward) {
+            return;
+        }
+
+        if (reduceMotion || !hasLanded) {
+            reward.position.y = 0;
+            reward.scale.setScalar(1);
+            return;
+        }
+
+        const bounce =
+            ((Math.sin(
+                clock.elapsedTime * sunflowerDropBounceSpeed + drop.phase,
+            ) +
+                1) /
+                2) *
+            sunflowerDropBounceLift;
+        reward.position.y = bounce;
+        reward.scale.setScalar(
+            1 + (bounce / sunflowerDropBounceLift) * sunflowerDropBounceScale,
+        );
+    });
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
         event.stopPropagation();
@@ -155,6 +187,7 @@ function SunflowerDropAtPlacement({
 
         claimSunflowerDrop.mutate(spawn.spawnId, {
             onSuccess: () => {
+                setHovered(false);
                 spawnParticles(ParticleType.Leaf, drop.particlePosition, 12);
                 onClaimed(origin);
             },
@@ -162,27 +195,64 @@ function SunflowerDropAtPlacement({
         });
     }
 
+    function handlePointerEnter(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        setHovered(true);
+    }
+
+    function handlePointerLeave(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        setHovered(false);
+    }
+
     return (
-        <group>
-            <SunflowerHeadModel
+        <HoverOutline color="white" hovered={hovered} thickness={7}>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js group uses raycast picking for the collectible model. */}
+            <group
                 onClick={handleClick}
-                position={drop.position}
-                rotation={drop.rotation}
-                scale={0.34}
-            />
-            <DreiImage
-                url="https://cdn.gredice.com/sunflower-large.svg"
-                transparent
-                position={[
-                    drop.position[0],
-                    drop.position[1] + 0.18,
-                    drop.position[2],
-                ]}
-                scale={0.18}
-                raycast={() => null}
-            />
-        </group>
+                onPointerEnter={handlePointerEnter}
+                onPointerLeave={handlePointerLeave}
+            >
+                <animated.group position-y={dropOffsetY}>
+                    <group
+                        position={drop.position}
+                        rotation={drop.rotation}
+                        scale={0.34}
+                    >
+                        <group ref={rewardRef}>
+                            <SunflowerHeadModel />
+                        </group>
+                    </group>
+                </animated.group>
+            </group>
+        </HoverOutline>
     );
+}
+
+function useSunflowerDropSpawnReady({
+    enabled,
+    gardenId,
+}: {
+    enabled: boolean;
+    gardenId: number | null | undefined;
+}) {
+    const [ready, setReady] = useState(false);
+
+    useEffect(() => {
+        setReady(false);
+
+        if (!enabled || gardenId == null || typeof window === 'undefined') {
+            return;
+        }
+
+        const timeoutId = window.setTimeout(() => {
+            setReady(true);
+        }, getSunflowerDropSpawnDelayMs());
+
+        return () => window.clearTimeout(timeoutId);
+    }, [enabled, gardenId]);
+
+    return ready;
 }
 
 export function SunflowerDropReward({
@@ -195,11 +265,12 @@ export function SunflowerDropReward({
     onClaimed?: (origin: SunflowerDropFlyOrigin) => void;
 }) {
     const [claimedSpawnId, setClaimedSpawnId] = useState<string | null>(null);
-    const sunflowerDrop = useSunflowerDrop(
-        garden?.id,
-        enabled && Boolean(garden) && !garden?.isSandbox,
-    );
-    const spawn = sunflowerDrop.data?.spawn ?? null;
+    const spawnReady = useSunflowerDropSpawnReady({
+        enabled: enabled && Boolean(garden) && !garden?.isSandbox,
+        gardenId: garden?.id,
+    });
+    const sunflowerDrop = useSunflowerDrop(garden?.id, spawnReady);
+    const spawn = spawnReady ? (sunflowerDrop.data?.spawn ?? null) : null;
 
     useEffect(() => {
         if (claimedSpawnId && spawn?.spawnId !== claimedSpawnId) {
@@ -216,6 +287,7 @@ export function SunflowerDropReward({
         <>
             {spawn && placement && claimedSpawnId !== spawn.spawnId && (
                 <SunflowerDropAtPlacement
+                    key={spawn.spawnId}
                     onRejected={() => {
                         void sunflowerDrop.refetch();
                     }}

--- a/packages/game/src/entities/sunflowerDropRewardCore.ts
+++ b/packages/game/src/entities/sunflowerDropRewardCore.ts
@@ -1,0 +1,99 @@
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+
+export const SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS = 60 * 1000;
+export const SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS = 5 * 60 * 1000;
+export const SUNFLOWER_DROP_MIN_GROUND_DISTANCE = 0.55;
+export const SUNFLOWER_DROP_MAX_GROUND_DISTANCE = 0.77;
+export const SUNFLOWER_DROP_GROUND_Y_OFFSET = 0.085;
+export const SUNFLOWER_DROP_PARTICLE_Y_OFFSET = 0.12;
+
+export type SunflowerDropPlacement = {
+    block: Block;
+    stack: Stack;
+};
+
+export type SunflowerDropPosition = {
+    particlePosition: Vector3;
+    phase: number;
+    position: [number, number, number];
+    rotation: [number, number, number];
+};
+
+function hashString(value: string) {
+    let hash = 0;
+    for (let index = 0; index < value.length; index += 1) {
+        hash = (hash * 31 + value.charCodeAt(index)) % 100_000;
+    }
+    return hash / 100_000;
+}
+
+function clampUnit(value: number) {
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+    return Math.min(Math.max(value, 0), 1);
+}
+
+export function getSunflowerDropSpawnDelayMs(random = Math.random) {
+    const unitValue = clampUnit(random());
+    return Math.round(
+        SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS +
+            unitValue *
+                (SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS -
+                    SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS),
+    );
+}
+
+export function findSunflowerDropPlacement(
+    stacks: Stack[],
+    sourceBlockId: string,
+): SunflowerDropPlacement | null {
+    for (const stack of stacks) {
+        const block = stack.blocks.find(
+            (candidate) => candidate.id === sourceBlockId,
+        );
+        if (block) {
+            return { block, stack };
+        }
+    }
+
+    return null;
+}
+
+export function getSunflowerDropPosition({
+    placement,
+    spawnId,
+    stackHeight,
+}: {
+    placement: SunflowerDropPlacement;
+    spawnId: string;
+    stackHeight: number;
+}): SunflowerDropPosition {
+    const angle = hashString(spawnId) * Math.PI * 2;
+    const radius =
+        SUNFLOWER_DROP_MIN_GROUND_DISTANCE +
+        hashString(`${spawnId}:radius`) *
+            (SUNFLOWER_DROP_MAX_GROUND_DISTANCE -
+                SUNFLOWER_DROP_MIN_GROUND_DISTANCE);
+    const x = Math.cos(angle) * radius;
+    const z = Math.sin(angle) * radius;
+    const worldX = placement.stack.position.x + x;
+    const worldZ = placement.stack.position.z + z;
+
+    return {
+        particlePosition: new Vector3(
+            worldX,
+            stackHeight + SUNFLOWER_DROP_PARTICLE_Y_OFFSET,
+            worldZ,
+        ),
+        phase: hashString(`${spawnId}:phase`) * Math.PI * 2,
+        position: [
+            worldX,
+            stackHeight + SUNFLOWER_DROP_GROUND_Y_OFFSET,
+            worldZ,
+        ],
+        rotation: [-Math.PI / 2, 0, angle + Math.PI * 0.15],
+    };
+}

--- a/packages/game/src/entities/sunflowerDropRewardCore.unit.ts
+++ b/packages/game/src/entities/sunflowerDropRewardCore.unit.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import {
+    findSunflowerDropPlacement,
+    getSunflowerDropPosition,
+    getSunflowerDropSpawnDelayMs,
+    SUNFLOWER_DROP_GROUND_Y_OFFSET,
+    SUNFLOWER_DROP_MAX_GROUND_DISTANCE,
+    SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS,
+    SUNFLOWER_DROP_MIN_GROUND_DISTANCE,
+    SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS,
+    SUNFLOWER_DROP_PARTICLE_Y_OFFSET,
+} from './sunflowerDropRewardCore';
+
+const sunflowerBlock: Block = {
+    id: 'sunflower-block-1',
+    name: 'Sunflower',
+    rotation: 0,
+};
+
+const sunflowerStack: Stack = {
+    blocks: [sunflowerBlock],
+    position: new Vector3(3, 0, -2),
+};
+
+test('sunflower drop spawn delay is between one and five minutes', () => {
+    assert.equal(
+        getSunflowerDropSpawnDelayMs(() => 0),
+        SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS,
+    );
+    assert.equal(
+        getSunflowerDropSpawnDelayMs(() => 1),
+        SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS,
+    );
+
+    const midpoint = getSunflowerDropSpawnDelayMs(() => 0.5);
+    assert.equal(
+        midpoint,
+        (SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS +
+            SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS) /
+            2,
+    );
+});
+
+test('sunflower drop placement resolves the source sunflower block', () => {
+    assert.deepEqual(
+        findSunflowerDropPlacement([sunflowerStack], sunflowerBlock.id),
+        {
+            block: sunflowerBlock,
+            stack: sunflowerStack,
+        },
+    );
+    assert.equal(findSunflowerDropPlacement([sunflowerStack], 'missing'), null);
+});
+
+test('sunflower drop position lands near the source sunflower on the ground', () => {
+    const stackHeight = 0.8;
+    const drop = getSunflowerDropPosition({
+        placement: {
+            block: sunflowerBlock,
+            stack: sunflowerStack,
+        },
+        spawnId: '7a77a42a-79c7-49f8-a68f-cce2f3b1f9d0',
+        stackHeight,
+    });
+    const offsetX = drop.position[0] - sunflowerStack.position.x;
+    const offsetZ = drop.position[2] - sunflowerStack.position.z;
+    const distance = Math.hypot(offsetX, offsetZ);
+
+    assert.ok(distance >= SUNFLOWER_DROP_MIN_GROUND_DISTANCE);
+    assert.ok(distance <= SUNFLOWER_DROP_MAX_GROUND_DISTANCE);
+    assert.equal(
+        drop.position[1],
+        stackHeight + SUNFLOWER_DROP_GROUND_Y_OFFSET,
+    );
+    assert.equal(
+        drop.particlePosition.y,
+        stackHeight + SUNFLOWER_DROP_PARTICLE_Y_OFFSET,
+    );
+});

--- a/packages/storage/scripts/upsertSunflowerBlockEntity.ts
+++ b/packages/storage/scripts/upsertSunflowerBlockEntity.ts
@@ -20,7 +20,7 @@ const blockName = 'Sunflower';
 const entityTypeName = 'block';
 
 const sunflowerAttributes = {
-    'attributes.height': '1.25',
+    'attributes.height': '1',
     'attributes.stackable': 'false',
     'attributes.type': 'decoration',
     'functions.raisedBed': 'false',


### PR DESCRIPTION
## Summary
- Shrinks the sunflower entity scale by 20% so it sits closer to the tulip size class.
- Lowers the sunflower block height source so stacking and interaction geometry stay aligned with the smaller visual.
- Keeps the sunflower reward pickup flow changes in place: delayed spawn, ground placement, hover outline, and pickup animation.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm lint --filter @gredice/storage`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `git diff --check`