### PR TITLE
Add raised bed relationship indicators and layer toggles

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -18,6 +18,7 @@
         "@gredice/js": "workspace:*",
         "@gredice/ui": "workspace:*",
         "@tailwindcss/typography": "0.5.19",
+        "@tanstack/react-query": "5.100.14",
         "@vercel/analytics": "2.0.1",
         "next": "16.2.6",
         "react": "19.2.6",

--- a/apps/storybook/stories/packages/game/hud/RaisedBedField.stories.tsx
+++ b/apps/storybook/stories/packages/game/hud/RaisedBedField.stories.tsx
@@ -1,0 +1,491 @@
+import { GameAnalyticsProvider } from '@gredice/game';
+import { NuqsAdapter } from '@gredice/ui/nuqs';
+import { GameFlagsContext } from '@packages/game/GameFlagsContext';
+import { currentGardenKeys } from '@packages/game/hooks/useCurrentGarden';
+import { queryKey as currentUserQueryKey } from '@packages/game/hooks/useCurrentUser';
+import { useShoppingCartQueryKey } from '@packages/game/hooks/useShoppingCart';
+import { RaisedBedField } from '@packages/game/hud/raisedBed/RaisedBedField';
+import { createGameState, GameStateContext } from '@packages/game/useGameState';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type ReactNode, useRef } from 'react';
+
+const raisedBedId = 1;
+const gardenId = 42;
+const now = new Date('2026-06-03T10:00:00.000Z');
+const msPerDay = 1000 * 60 * 60 * 24;
+const sortIds = {
+    basil: 458,
+    bellPepper: 219,
+    fennel: 276,
+    parsley: 213,
+    tomato: 206,
+} as const;
+const plantIds = {
+    basil: 1001,
+    bellPepper: 1002,
+    fennel: 1003,
+    parsley: 1004,
+    tomato: 1000,
+} as const;
+const plantImageUrls = {
+    basil: 'https://cdn.gredice.com/entity-attributes/0580c848-eda3-4084-9751-75e1ee020fc7-basil-realistic-340.png',
+    bellPepper:
+        'https://cdn.gredice.com/entity-attributes/0f6230a4-ce8b-4a2a-accc-43c102dd910b-pepper-realistic-340.png',
+    fennel: 'https://cdn.gredice.com/entity-attributes/4f63f71a-0b0e-439d-9d66-b69af0a2c316-fennel-realistic-340.png',
+    parsley:
+        'https://cdn.gredice.com/entity-attributes/1d7798f1-9596-4ae7-967a-dd083901463a-parsley-realistic-340.png',
+    tomato: 'https://cdn.gredice.com/entity-attributes/4b222ee1-2411-485c-9732-aab8c7d4a204-tomato-realistic-340.png',
+} as const;
+const sortImageUrls = {
+    basil: plantImageUrls.basil,
+    bellPepper: plantImageUrls.bellPepper,
+    fennel: plantImageUrls.fennel,
+    parsley: plantImageUrls.parsley,
+    tomato: 'https://cdn.gredice.com/entity-attributes/080d17b9-a04d-4e46-940a-a9be31efa20f-santpierre.png',
+} as const;
+const fieldSortLayout = [
+    sortIds.tomato,
+    sortIds.tomato,
+    sortIds.fennel,
+    sortIds.bellPepper,
+    sortIds.bellPepper,
+    sortIds.tomato,
+    sortIds.parsley,
+    sortIds.parsley,
+    sortIds.parsley,
+    sortIds.bellPepper,
+    sortIds.tomato,
+    sortIds.tomato,
+    sortIds.bellPepper,
+    sortIds.parsley,
+    sortIds.parsley,
+    sortIds.basil,
+    sortIds.tomato,
+    sortIds.tomato,
+];
+const fieldHistorySortIds = new Map<number, number[]>([
+    [4, [sortIds.parsley, sortIds.basil, sortIds.tomato]],
+    [10, [sortIds.basil]],
+    [13, [sortIds.tomato, sortIds.bellPepper]],
+]);
+
+function isoDaysAgo(daysAgo: number) {
+    return new Date(now.getTime() - daysAgo * msPerDay).toISOString();
+}
+
+function buildPlantCycle({
+    historyIndex,
+    plantSortId,
+    positionIndex,
+}: {
+    historyIndex: number;
+    plantSortId: number;
+    positionIndex: number;
+}) {
+    const cycleOffset = historyIndex * 34 + positionIndex;
+    const plantSowDate = isoDaysAgo(190 + cycleOffset);
+    const plantGrowthDate = isoDaysAgo(178 + cycleOffset);
+    const plantReadyDate = isoDaysAgo(138 + cycleOffset);
+    const plantHarvestedDate = isoDaysAgo(120 + cycleOffset);
+    const plantRemovedDate = isoDaysAgo(110 + cycleOffset);
+
+    return {
+        active: false,
+        plantPlaceEventId: 1000 + positionIndex * 10 + historyIndex,
+        plantSortId,
+        positionIndex,
+        plantStatus: 'removed',
+        sowingLocation: 'direct',
+        plantScheduledDate: undefined,
+        plantSowDate,
+        plantGrowthDate,
+        plantReadyDate,
+        plantDeadDate: undefined,
+        plantHarvestedDate,
+        plantRemovedDate,
+        startedAt: plantSowDate,
+        endedAt: plantRemovedDate,
+        stoppedDate: plantRemovedDate,
+        toBeRemoved: false,
+        assignedUserId: null,
+        assignedUserIds: [],
+        assignedBy: null,
+        assignedAt: undefined,
+        createdAt: plantSowDate,
+        updatedAt: plantRemovedDate,
+    };
+}
+
+function buildPlant({
+    companions = [],
+    antagonists = [],
+    imageUrl,
+    name,
+    plantId,
+}: {
+    antagonists?: { id: number; name: string }[];
+    companions?: { id: number; name: string }[];
+    imageUrl: string;
+    name: string;
+    plantId: number;
+}) {
+    return {
+        id: plantId,
+        image: {
+            cover: {
+                url: imageUrl,
+            },
+        },
+        images: {
+            cover: {
+                url: imageUrl,
+            },
+        },
+        information: {
+            name,
+        },
+        relationships: {
+            companions,
+            antagonists,
+        },
+        attributes: {
+            germinationWindowMax: 10,
+            germinationWindowMin: 5,
+            growthWindowMax: 80,
+            growthWindowMin: 55,
+            harvestWindowMax: 28,
+            harvestWindowMin: 14,
+        },
+    };
+}
+
+function buildSort({
+    imageUrl,
+    name,
+    plant,
+    sortId,
+}: {
+    imageUrl: string;
+    name: string;
+    plant: ReturnType<typeof buildPlant>;
+    sortId: number;
+}) {
+    return {
+        id: sortId,
+        image: {
+            cover: {
+                url: imageUrl,
+            },
+        },
+        images: {
+            cover: {
+                url: imageUrl,
+            },
+        },
+        information: {
+            name,
+            shortDescription: plant.information.name,
+            plant,
+        },
+        store: {
+            availableInStore: true,
+        },
+    };
+}
+
+function buildSorts() {
+    const tomato = buildPlant({
+        plantId: plantIds.tomato,
+        name: 'Rajčica',
+        imageUrl: plantImageUrls.tomato,
+        companions: [{ id: plantIds.basil, name: 'Bosiljak' }],
+        antagonists: [{ id: plantIds.fennel, name: 'Komorač' }],
+    });
+    const basil = buildPlant({
+        plantId: plantIds.basil,
+        name: 'Bosiljak',
+        imageUrl: plantImageUrls.basil,
+        companions: [
+            { id: plantIds.tomato, name: 'Rajčica' },
+            { id: plantIds.bellPepper, name: 'Paprika' },
+        ],
+    });
+    const bellPepper = buildPlant({
+        plantId: plantIds.bellPepper,
+        name: 'Paprika',
+        imageUrl: plantImageUrls.bellPepper,
+        companions: [{ id: plantIds.basil, name: 'Bosiljak' }],
+        antagonists: [{ id: plantIds.fennel, name: 'Komorač' }],
+    });
+    const fennel = buildPlant({
+        plantId: plantIds.fennel,
+        name: 'Komorač',
+        imageUrl: plantImageUrls.fennel,
+        antagonists: [
+            { id: plantIds.tomato, name: 'Rajčica' },
+            { id: plantIds.bellPepper, name: 'Paprika' },
+        ],
+    });
+    const parsley = buildPlant({
+        plantId: plantIds.parsley,
+        name: 'Peršin',
+        imageUrl: plantImageUrls.parsley,
+    });
+
+    return [
+        buildSort({
+            sortId: sortIds.tomato,
+            name: 'Rajčica Saint Pierre',
+            imageUrl: sortImageUrls.tomato,
+            plant: tomato,
+        }),
+        buildSort({
+            sortId: sortIds.basil,
+            name: 'Bosiljak Italiano Classico',
+            imageUrl: sortImageUrls.basil,
+            plant: basil,
+        }),
+        buildSort({
+            sortId: sortIds.bellPepper,
+            name: 'Paprika Babura',
+            imageUrl: sortImageUrls.bellPepper,
+            plant: bellPepper,
+        }),
+        buildSort({
+            sortId: sortIds.fennel,
+            name: 'Komorač Dragon',
+            imageUrl: sortImageUrls.fennel,
+            plant: fennel,
+        }),
+        buildSort({
+            sortId: sortIds.parsley,
+            name: 'Peršin lisnati',
+            imageUrl: sortImageUrls.parsley,
+            plant: parsley,
+        }),
+    ];
+}
+
+function buildField(positionIndex: number, plantSortId: number) {
+    const plantSowDate = isoDaysAgo(74 + (positionIndex % 4) * 4);
+    const plantGrowthDate = isoDaysAgo(62 + (positionIndex % 3) * 4);
+    const plantCycles = (fieldHistorySortIds.get(positionIndex) ?? []).map(
+        (historyPlantSortId, historyIndex) =>
+            buildPlantCycle({
+                historyIndex,
+                plantSortId: historyPlantSortId,
+                positionIndex,
+            }),
+    );
+
+    return {
+        id: positionIndex + 1,
+        raisedBedId,
+        isDeleted: false,
+        active: true,
+        toBeRemoved: false,
+        stoppedDate: undefined,
+        positionIndex,
+        plantSortId,
+        plantStatus: 'sprouted',
+        sowingLocation: 'direct',
+        plantScheduledDate: undefined,
+        plantSowDate,
+        plantGrowthDate,
+        plantReadyDate: undefined,
+        plantDeadDate: undefined,
+        plantHarvestedDate: undefined,
+        plantRemovedDate: undefined,
+        plantCycles,
+        assignedUserId: null,
+        assignedUserIds: [],
+        assignedBy: null,
+        assignedAt: undefined,
+        createdAt: plantSowDate,
+        updatedAt: plantGrowthDate,
+    };
+}
+
+function buildGarden() {
+    return {
+        id: gardenId,
+        name: 'Storybook vrt',
+        isSandbox: false,
+        farmId: null,
+        location: {
+            lat: 45.739,
+            lon: 16.572,
+        },
+        stacks: [
+            {
+                position: { x: 0, y: 0, z: 0 },
+                blocks: [
+                    {
+                        id: 'ground-1',
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                    {
+                        id: 'raised-bed-1-a',
+                        name: 'Raised_Bed',
+                        rotation: 0,
+                    },
+                ],
+            },
+            {
+                position: { x: 0, y: 0, z: 1 },
+                blocks: [
+                    {
+                        id: 'ground-2',
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                    {
+                        id: 'raised-bed-1-b',
+                        name: 'Raised_Bed',
+                        rotation: 0,
+                    },
+                ],
+            },
+        ],
+        raisedBeds: [
+            {
+                id: raisedBedId,
+                name: 'Sunčano Sunce',
+                blockId: 'raised-bed-1-a',
+                physicalId: 'storybook-raised-bed-1',
+                fields: fieldSortLayout.map((plantSortId, positionIndex) =>
+                    buildField(positionIndex, plantSortId),
+                ),
+                appliedOperations: [],
+                status: 'new',
+                abandonReason: null,
+                updatedAt: now.toISOString(),
+                createdAt: now.toISOString(),
+                isValid: true,
+                orientation: 'horizontal',
+            },
+        ],
+    };
+}
+
+function createQueryClient() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+                staleTime: Number.POSITIVE_INFINITY,
+            },
+        },
+    });
+    const sorts = buildSorts();
+
+    queryClient.setQueryData(['sorts'], sorts);
+    for (const sort of sorts) {
+        queryClient.setQueryData(['plants', 'sorts', sort.id], sort);
+        queryClient.setQueryData(
+            ['plants', sort.information.plant.id, 'sorts'],
+            sorts.filter(
+                (candidate) =>
+                    candidate.information.plant.id ===
+                    sort.information.plant.id,
+            ),
+        );
+    }
+    queryClient.setQueryData(
+        currentGardenKeys('summer', null, 'default'),
+        buildGarden(),
+    );
+    queryClient.setQueryData(useShoppingCartQueryKey, { items: [] });
+    queryClient.setQueryData(currentUserQueryKey.currentUser, {
+        id: 1,
+        name: 'Storybook user',
+    });
+
+    return queryClient;
+}
+
+function RaisedBedStoryProviders({ children }: { children: ReactNode }) {
+    const queryClientRef = useRef<QueryClient | null>(null);
+    const gameStateRef = useRef<ReturnType<typeof createGameState> | null>(
+        null,
+    );
+
+    if (!queryClientRef.current) {
+        queryClientRef.current = createQueryClient();
+    }
+
+    if (!gameStateRef.current) {
+        gameStateRef.current = createGameState({
+            appBaseUrl: '',
+            freezeTime: now,
+            isMock: true,
+            mockGardenProfile: 'default',
+            winterMode: 'summer',
+        });
+    }
+
+    return (
+        <NuqsAdapter>
+            <QueryClientProvider client={queryClientRef.current}>
+                <GameStateContext.Provider value={gameStateRef.current}>
+                    <GameAnalyticsProvider capture={() => undefined}>
+                        <GameFlagsContext.Provider
+                            value={{
+                                enablePlantHistoryFlag: true,
+                            }}
+                        >
+                            {children}
+                        </GameFlagsContext.Provider>
+                    </GameAnalyticsProvider>
+                </GameStateContext.Provider>
+            </QueryClientProvider>
+        </NuqsAdapter>
+    );
+}
+
+function RaisedBedRelationshipDemo() {
+    return (
+        <RaisedBedStoryProviders>
+            <div className="relative min-h-[680px] w-[480px] overflow-hidden bg-[#c7be74]">
+                <div className="absolute -left-16 top-10 h-[560px] w-[260px] rotate-[-8deg] bg-lime-800/40 blur-[2px]" />
+                <div className="absolute bottom-0 left-0 h-32 w-full bg-lime-900/15" />
+                <div className="absolute left-1/2 top-12 h-[570px] w-[300px] -translate-x-1/2 bg-[#b7896e] p-[30px] shadow-lg">
+                    <RaisedBedField
+                        gardenId={gardenId}
+                        raisedBedId={raisedBedId}
+                    />
+                </div>
+            </div>
+        </RaisedBedStoryProviders>
+    );
+}
+
+const meta = {
+    title: 'packages/game/hud/raisedBed/RaisedBedField',
+    component: RaisedBedField,
+    tags: ['autodocs'],
+    args: {
+        gardenId,
+        raisedBedId,
+    },
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'RaisedBedField renders the raised-bed planting grid, including relationship edge indicators for placed plants.',
+            },
+        },
+    },
+} satisfies Meta<typeof RaisedBedField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const RelationshipIndicators: Story = {
+    name: 'Relationship indicators',
+    render: () => <RaisedBedRelationshipDemo />,
+};

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -9,9 +9,12 @@ import {
     useSensors,
 } from '@dnd-kit/core';
 import { rectSwappingStrategy, SortableContext } from '@dnd-kit/sortable';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Heart, History, Lightning } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useAllSorts } from '../../hooks/usePlantSorts';
 import {
     type ShoppingCartItemData,
     useShoppingCart,
@@ -21,9 +24,15 @@ import { isRaisedBedAbandoned } from '../../raisedBedConstants';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import { getPositionIndexFromGrid } from '../../utils/raisedBedOrientation';
+import {
+    getRaisedBedFieldRelationshipIndicators,
+    type RaisedBedFieldRelationshipIndicator as RaisedBedFieldRelationshipIndicatorData,
+    type RaisedBedFieldRelationshipIndicatorDirection,
+} from './plantRelationshipSignals';
 import { RaisedBedFieldAbandoned } from './RaisedBedFieldAbandoned';
 import { RaisedBedFieldInvalidShape } from './RaisedBedFieldInvalidShape';
 import { RaisedBedFieldItem } from './RaisedBedFieldItem';
+import { RaisedBedFieldRelationshipIndicator } from './RaisedBedFieldRelationshipIndicator';
 import { SortableFieldItem } from './SortableFieldItem';
 
 type PendingFieldMove = {
@@ -33,6 +42,41 @@ type PendingFieldMove = {
     sequence: number;
     toPositionIndex: number;
 };
+
+type RaisedBedFieldLayerPreferences = {
+    showPlantHistoryBadges: boolean;
+    showRelationshipIndicators: boolean;
+};
+
+type RaisedBedFieldRelationshipIndicatorLayer =
+    RaisedBedFieldRelationshipIndicatorData & {
+        showBadge: boolean;
+    };
+
+const RAISED_BED_FIELD_LAYER_PREFERENCES_STORAGE_KEY =
+    'gredice:raised-bed-field-layer-preferences';
+const DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES: RaisedBedFieldLayerPreferences =
+    {
+        showPlantHistoryBadges: true,
+        showRelationshipIndicators: true,
+    };
+const OPPOSITE_RELATIONSHIP_DIRECTIONS: Record<
+    RaisedBedFieldRelationshipIndicatorDirection,
+    RaisedBedFieldRelationshipIndicatorDirection
+> = {
+    bottom: 'top',
+    bottomLeft: 'topRight',
+    bottomRight: 'topLeft',
+    left: 'right',
+    right: 'left',
+    top: 'bottom',
+    topLeft: 'bottomRight',
+    topRight: 'bottomLeft',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
 
 function isRaisedBedCartPlantItem(
     item: ShoppingCartItemData,
@@ -48,6 +92,101 @@ function isRaisedBedCartPlantItem(
     );
 }
 
+function readRaisedBedFieldLayerPreferences(): RaisedBedFieldLayerPreferences {
+    if (typeof window === 'undefined') {
+        return DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES;
+    }
+
+    try {
+        const storedValue = window.localStorage.getItem(
+            RAISED_BED_FIELD_LAYER_PREFERENCES_STORAGE_KEY,
+        );
+        if (!storedValue) {
+            return DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES;
+        }
+
+        const parsedValue: unknown = JSON.parse(storedValue);
+        if (!isRecord(parsedValue)) {
+            return DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES;
+        }
+
+        return {
+            showPlantHistoryBadges:
+                typeof parsedValue.showPlantHistoryBadges === 'boolean'
+                    ? parsedValue.showPlantHistoryBadges
+                    : DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES.showPlantHistoryBadges,
+            showRelationshipIndicators:
+                typeof parsedValue.showRelationshipIndicators === 'boolean'
+                    ? parsedValue.showRelationshipIndicators
+                    : DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES.showRelationshipIndicators,
+        };
+    } catch {
+        return DEFAULT_RAISED_BED_FIELD_LAYER_PREFERENCES;
+    }
+}
+
+function writeRaisedBedFieldLayerPreferences(
+    preferences: RaisedBedFieldLayerPreferences,
+) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(
+            RAISED_BED_FIELD_LAYER_PREFERENCES_STORAGE_KEY,
+            JSON.stringify(preferences),
+        );
+    } catch {
+        // Layer visibility is a convenience preference; ignore storage failures.
+    }
+}
+
+function addRelationshipIndicatorLayer(
+    indicatorsByPosition: Map<
+        number,
+        RaisedBedFieldRelationshipIndicatorLayer[]
+    >,
+    indicator: RaisedBedFieldRelationshipIndicatorLayer,
+) {
+    const indicators = indicatorsByPosition.get(indicator.positionIndex) ?? [];
+    indicators.push(indicator);
+    indicatorsByPosition.set(indicator.positionIndex, indicators);
+}
+
+function RaisedBedFieldLayerToggle({
+    children,
+    isPressed,
+    label,
+    onClick,
+    storageName,
+}: {
+    children: ReactNode;
+    isPressed: boolean;
+    label: string;
+    onClick: () => void;
+    storageName: 'history' | 'relationships';
+}) {
+    return (
+        <button
+            aria-label={label}
+            aria-pressed={isPressed}
+            className={cx(
+                'inline-flex size-10 items-center justify-center rounded-md border-2 border-white shadow-md ring-1 ring-black/10 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700',
+                isPressed
+                    ? 'bg-gradient-to-br from-lime-100/90 to-lime-100/80 text-primary hover:text-primary/80 dark:from-lime-200/80 dark:to-lime-200/70 dark:text-primary-foreground dark:hover:text-primary-foreground/80'
+                    : 'bg-white/85 text-lime-950 hover:bg-white',
+            )}
+            data-raised-bed-layer-control={storageName}
+            onClick={onClick}
+            title={label}
+            type="button"
+        >
+            {children}
+        </button>
+    );
+}
+
 export function RaisedBedField({
     gardenId,
     raisedBedId,
@@ -57,6 +196,7 @@ export function RaisedBedField({
 }) {
     const { data: garden } = useCurrentGarden();
     const { data: cart, isLoading: isCartLoading } = useShoppingCart();
+    const { data: allSorts } = useAllSorts();
     const { track } = useGameAnalytics();
     const swapPositions = useSwapShoppingCartPositions();
     const [pendingMove, setPendingMove] = useState<PendingFieldMove | null>(
@@ -65,7 +205,16 @@ export function RaisedBedField({
     const moveSequenceRef = useRef(0);
     const [dropAnimationDisabled, setDropAnimationDisabled] = useState(false);
     const [isHudDialogOpen, setIsHudDialogOpen] = useState(false);
+    const [layerPreferences, setLayerPreferences] = useState(
+        readRaisedBedFieldLayerPreferences,
+    );
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
+    const plantHistoryToggleLabel = layerPreferences.showPlantHistoryBadges
+        ? 'Sakrij prethodne biljke'
+        : 'Prikaži prethodne biljke';
+    const relationshipsToggleLabel = layerPreferences.showRelationshipIndicators
+        ? 'Sakrij dobre i loše susjede'
+        : 'Prikaži dobre i loše susjede';
 
     const sensors = useSensors(
         useSensor(PointerSensor, {
@@ -115,6 +264,10 @@ export function RaisedBedField({
 
         return () => observer.disconnect();
     }, []);
+
+    useEffect(() => {
+        writeRaisedBedFieldLayerPreferences(layerPreferences);
+    }, [layerPreferences]);
 
     // Determine which positions have cart items (draggable)
     const baseCartItemsByPosition = useMemo(() => {
@@ -223,6 +376,33 @@ export function RaisedBedField({
             .filter((field) => isRaisedBedFieldOccupied(field))
             .map((field) => field.positionIndex),
     );
+    const relationshipIndicatorsByPosition = new Map<
+        number,
+        RaisedBedFieldRelationshipIndicatorLayer[]
+    >();
+    if (layerPreferences.showRelationshipIndicators) {
+        for (const indicator of getRaisedBedFieldRelationshipIndicators({
+            blockCount,
+            cartItems: Array.from(cartItemsByPosition.values()),
+            fields: raisedBed.fields,
+            gardenId,
+            raisedBedId,
+            sorts: allSorts,
+        })) {
+            addRelationshipIndicatorLayer(relationshipIndicatorsByPosition, {
+                ...indicator,
+                showBadge: true,
+            });
+            addRelationshipIndicatorLayer(relationshipIndicatorsByPosition, {
+                ...indicator,
+                direction:
+                    OPPOSITE_RELATIONSHIP_DIRECTIONS[indicator.direction],
+                neighborPositionIndex: indicator.positionIndex,
+                positionIndex: indicator.neighborPositionIndex,
+                showBadge: false,
+            });
+        }
+    }
 
     function handleDragEnd(event: DragEndEvent) {
         if (isHudDialogOpen) return;
@@ -281,8 +461,48 @@ export function RaisedBedField({
     const sortableItems = allPositionIndices.map((pos) => pos.toString());
 
     return (
-        <>
-            <div></div>
+        <div className="relative size-full">
+            <div className="absolute -left-12 bottom-0 z-30 flex flex-col gap-2">
+                <RaisedBedFieldLayerToggle
+                    isPressed={layerPreferences.showPlantHistoryBadges}
+                    label={plantHistoryToggleLabel}
+                    onClick={() =>
+                        setLayerPreferences((current) => ({
+                            ...current,
+                            showPlantHistoryBadges:
+                                !current.showPlantHistoryBadges,
+                        }))
+                    }
+                    storageName="history"
+                >
+                    <History aria-hidden className="size-5" />
+                </RaisedBedFieldLayerToggle>
+                <RaisedBedFieldLayerToggle
+                    isPressed={layerPreferences.showRelationshipIndicators}
+                    label={relationshipsToggleLabel}
+                    onClick={() =>
+                        setLayerPreferences((current) => ({
+                            ...current,
+                            showRelationshipIndicators:
+                                !current.showRelationshipIndicators,
+                        }))
+                    }
+                    storageName="relationships"
+                >
+                    <span className="flex items-center justify-center gap-0.5">
+                        <Heart
+                            aria-hidden
+                            className="size-3.5 shrink-0 fill-current"
+                            strokeWidth={3}
+                        />
+                        <Lightning
+                            aria-hidden
+                            className="size-4 shrink-0 fill-current"
+                            strokeWidth={3}
+                        />
+                    </span>
+                </RaisedBedFieldLayerToggle>
+            </div>
             <DndContext
                 id={`raised-bed-field-${gardenId}-${raisedBedId}`}
                 sensors={sensors}
@@ -346,24 +566,46 @@ export function RaisedBedField({
                                                 showHandle={isInCart}
                                             >
                                                 {({ isDragging }) => (
-                                                    <RaisedBedFieldItem
-                                                        cartPlantItem={
-                                                            cartItemsByPosition.get(
-                                                                positionIndex,
-                                                            ) ?? null
-                                                        }
-                                                        gardenId={gardenId}
-                                                        isCartPending={
-                                                            isCartLoading
-                                                        }
-                                                        raisedBedId={
-                                                            raisedBedId
-                                                        }
-                                                        positionIndex={
-                                                            positionIndex
-                                                        }
-                                                        isDragging={isDragging}
-                                                    />
+                                                    <div className="relative size-full">
+                                                        <RaisedBedFieldItem
+                                                            cartPlantItem={
+                                                                cartItemsByPosition.get(
+                                                                    positionIndex,
+                                                                ) ?? null
+                                                            }
+                                                            gardenId={gardenId}
+                                                            isCartPending={
+                                                                isCartLoading
+                                                            }
+                                                            raisedBedId={
+                                                                raisedBedId
+                                                            }
+                                                            showPlantHistoryBadges={
+                                                                layerPreferences.showPlantHistoryBadges
+                                                            }
+                                                            positionIndex={
+                                                                positionIndex
+                                                            }
+                                                            isDragging={
+                                                                isDragging
+                                                            }
+                                                        />
+                                                        {relationshipIndicatorsByPosition
+                                                            .get(positionIndex)
+                                                            ?.map(
+                                                                (indicator) => (
+                                                                    <RaisedBedFieldRelationshipIndicator
+                                                                        key={`${indicator.positionIndex.toString()}-${indicator.neighborPositionIndex.toString()}-${indicator.status}-${indicator.showBadge ? 'badge' : 'connector'}`}
+                                                                        indicator={
+                                                                            indicator
+                                                                        }
+                                                                        showBadge={
+                                                                            indicator.showBadge
+                                                                        }
+                                                                    />
+                                                                ),
+                                                            )}
+                                                    </div>
                                                 )}
                                             </SortableFieldItem>
                                         </div>
@@ -374,6 +616,6 @@ export function RaisedBedField({
                     </div>
                 </SortableContext>
             </DndContext>
-        </>
+        </div>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItem.tsx
@@ -16,6 +16,7 @@ export function RaisedBedFieldItem({
     gardenId,
     isCartPending,
     raisedBedId,
+    showPlantHistoryBadges = true,
     positionIndex,
     isDragging,
 }: {
@@ -23,6 +24,7 @@ export function RaisedBedFieldItem({
     gardenId: number;
     cartPlantItem: ShoppingCartItemData | null;
     isCartPending: boolean;
+    showPlantHistoryBadges?: boolean;
     positionIndex: number;
     isDragging?: boolean;
 }) {
@@ -37,7 +39,8 @@ export function RaisedBedFieldItem({
         raisedBed?.fields,
         positionIndex,
     );
-    const visiblePlantHistory = enablePlantHistoryFlag ? plantHistory : [];
+    const visiblePlantHistory =
+        enablePlantHistoryFlag && showPlantHistoryBadges ? plantHistory : [];
     const hasField = Boolean(field);
     const focusedPositionIndex =
         typeof fieldDetailsParam === 'number' && fieldDetailsParam > 0

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldRelationshipIndicator.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldRelationshipIndicator.tsx
@@ -1,0 +1,171 @@
+import { Heart, Lightning } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
+import type { RaisedBedFieldRelationshipIndicator as RaisedBedFieldRelationshipIndicatorData } from './plantRelationshipSignals';
+
+const directionClassNames: Record<
+    RaisedBedFieldRelationshipIndicatorData['direction'],
+    string
+> = {
+    bottom: 'bottom-0 left-1/2 -translate-x-1/2 translate-y-[calc(50%+2px)]',
+    bottomLeft:
+        'bottom-0 left-0 -translate-x-[calc(50%+2px)] translate-y-[calc(50%+2px)]',
+    bottomRight:
+        'bottom-0 right-0 translate-x-[calc(50%+2px)] translate-y-[calc(50%+2px)]',
+    left: 'left-0 top-1/2 -translate-x-[calc(50%+2px)] -translate-y-1/2',
+    right: 'right-0 top-1/2 translate-x-[calc(50%+2px)] -translate-y-1/2',
+    top: 'left-1/2 top-0 -translate-x-1/2 -translate-y-[calc(50%+2px)]',
+    topLeft:
+        'left-0 top-0 -translate-x-[calc(50%+2px)] -translate-y-[calc(50%+2px)]',
+    topRight:
+        'right-0 top-0 translate-x-[calc(50%+2px)] -translate-y-[calc(50%+2px)]',
+};
+
+const connectorEndPoints: Record<
+    RaisedBedFieldRelationshipIndicatorData['direction'],
+    { x: number; y: number }
+> = {
+    bottom: { x: 50, y: 100 },
+    bottomLeft: { x: 0, y: 100 },
+    bottomRight: { x: 100, y: 100 },
+    left: { x: 0, y: 50 },
+    right: { x: 100, y: 50 },
+    top: { x: 50, y: 0 },
+    topLeft: { x: 0, y: 0 },
+    topRight: { x: 100, y: 0 },
+};
+
+const connectorStartOffsets: Record<
+    RaisedBedFieldRelationshipIndicatorData['direction'],
+    { x: number; y: number }
+> = {
+    bottom: { x: 0, y: 0 },
+    bottomLeft: { x: 0, y: 0 },
+    bottomRight: { x: 0, y: 0 },
+    left: { x: 0, y: 4 },
+    right: { x: 0, y: 4 },
+    top: { x: 0, y: 0 },
+    topLeft: { x: 0, y: 0 },
+    topRight: { x: 4, y: 5 },
+};
+
+function relationshipTitle(indicator: RaisedBedFieldRelationshipIndicatorData) {
+    if (indicator.status === 'companion') {
+        return `Dobri susjedi: ${indicator.companionPlantNames.join(', ')}`;
+    }
+
+    return `Loši susjedi: ${indicator.antagonistPlantNames.join(', ')}`;
+}
+
+function relationshipConnectorPath(
+    direction: RaisedBedFieldRelationshipIndicatorData['direction'],
+) {
+    const center = { x: 50, y: 50 };
+    const end = connectorEndPoints[direction];
+    const baseDeltaX = end.x - center.x;
+    const baseDeltaY = end.y - center.y;
+    const baseLength = Math.hypot(baseDeltaX, baseDeltaY) || 1;
+    const baseUnitX = baseDeltaX / baseLength;
+    const baseUnitY = baseDeltaY / baseLength;
+    const startOffset = connectorStartOffsets[direction];
+    const start = {
+        x: center.x + baseUnitX * 16 + startOffset.x,
+        y: center.y + baseUnitY * 16 + startOffset.y,
+    };
+    const deltaX = end.x - start.x;
+    const deltaY = end.y - start.y;
+    const length = Math.hypot(deltaX, deltaY) || 1;
+    const unitX = deltaX / length;
+    const unitY = deltaY / length;
+    const perpendicularX = -unitY;
+    const perpendicularY = unitX;
+    const startHalfWidth = 3.75;
+    const endHalfWidth = 10.75;
+    const sideCurve = 10;
+    const startCap = {
+        x: start.x - unitX * 4,
+        y: start.y - unitY * 4,
+    };
+    const point = (x: number, y: number) => `${x.toFixed(2)} ${y.toFixed(2)}`;
+    const startLeft = {
+        x: start.x + perpendicularX * startHalfWidth,
+        y: start.y + perpendicularY * startHalfWidth,
+    };
+    const endLeft = {
+        x: end.x + perpendicularX * endHalfWidth,
+        y: end.y + perpendicularY * endHalfWidth,
+    };
+    const endRight = {
+        x: end.x - perpendicularX * endHalfWidth,
+        y: end.y - perpendicularY * endHalfWidth,
+    };
+    const startRight = {
+        x: start.x - perpendicularX * startHalfWidth,
+        y: start.y - perpendicularY * startHalfWidth,
+    };
+
+    return [
+        `M ${point(startLeft.x, startLeft.y)}`,
+        `C ${point(startLeft.x + unitX * sideCurve, startLeft.y + unitY * sideCurve)} ${point(endLeft.x - unitX * sideCurve, endLeft.y - unitY * sideCurve)} ${point(endLeft.x, endLeft.y)}`,
+        `Q ${point(end.x, end.y)} ${point(endRight.x, endRight.y)}`,
+        `C ${point(endRight.x - unitX * sideCurve, endRight.y - unitY * sideCurve)} ${point(startRight.x + unitX * sideCurve, startRight.y + unitY * sideCurve)} ${point(startRight.x, startRight.y)}`,
+        `Q ${point(startCap.x, startCap.y)} ${point(startLeft.x, startLeft.y)}`,
+        'Z',
+    ].join(' ');
+}
+
+export function RaisedBedFieldRelationshipIndicator({
+    indicator,
+    showBadge = true,
+}: {
+    indicator: RaisedBedFieldRelationshipIndicatorData;
+    showBadge?: boolean;
+}) {
+    const title = relationshipTitle(indicator);
+
+    return (
+        <>
+            {/* biome-ignore lint/a11y/noSvgWithoutTitle: Decorative connector; the badge carries the accessible label. */}
+            <svg
+                aria-hidden
+                className="pointer-events-none absolute -inset-0.5 z-10 overflow-visible"
+                focusable="false"
+                preserveAspectRatio="none"
+                viewBox="0 0 100 100"
+            >
+                <path
+                    className="fill-white drop-shadow-sm"
+                    d={relationshipConnectorPath(indicator.direction)}
+                />
+            </svg>
+            {showBadge ? (
+                <div
+                    aria-label={title}
+                    className={cx(
+                        'pointer-events-none absolute z-20 flex size-6 items-center justify-center rounded-full shadow-md ring-1',
+                        directionClassNames[indicator.direction],
+                        indicator.status === 'companion'
+                            ? 'bg-green-500 text-white ring-green-950/20'
+                            : 'bg-red-600 text-white ring-red-950/20',
+                    )}
+                    data-relationship-status={indicator.status}
+                    role="img"
+                    title={title}
+                >
+                    {indicator.status === 'companion' ? (
+                        <Heart
+                            aria-hidden
+                            className="size-3.5 fill-current"
+                            strokeWidth={3}
+                        />
+                    ) : (
+                        <Lightning
+                            aria-hidden
+                            className="size-4 fill-current"
+                            strokeWidth={3}
+                        />
+                    )}
+                </div>
+            ) : null}
+        </>
+    );
+}

--- a/packages/game/src/hud/raisedBed/plantRelationshipSignals.ts
+++ b/packages/game/src/hud/raisedBed/plantRelationshipSignals.ts
@@ -1,7 +1,4 @@
-import {
-    getGridPositionFromIndex,
-    getPositionIndexFromGrid,
-} from '../../utils/raisedBedOrientation';
+import { getPositionIndexFromGrid } from '../../utils/raisedBedOrientation';
 
 export type PlantRelationshipSignalStatus =
     | 'companion'
@@ -37,6 +34,29 @@ export type NeighborPlantSummary = {
     name: string;
 };
 
+export type RaisedBedFieldRelationshipIndicatorDirection =
+    | 'bottom'
+    | 'bottomLeft'
+    | 'bottomRight'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'topLeft'
+    | 'topRight';
+
+export type RaisedBedFieldRelationshipIndicatorStatus =
+    | 'antagonist'
+    | 'companion';
+
+export type RaisedBedFieldRelationshipIndicator = {
+    companionPlantNames: string[];
+    direction: RaisedBedFieldRelationshipIndicatorDirection;
+    antagonistPlantNames: string[];
+    neighborPositionIndex: number;
+    positionIndex: number;
+    status: RaisedBedFieldRelationshipIndicatorStatus;
+};
+
 type RaisedBedFieldLike = {
     active?: boolean | null;
     plantSortId?: number | null;
@@ -55,13 +75,13 @@ type ShoppingCartPlantItemLike = {
 type PlantSortLike = {
     id: number;
     information?: {
-        plant?: {
-            id: number;
-            information?: {
-                name?: string | null;
-            } | null;
-        } | null;
+        plant?: PlantRelationshipCandidateLike | null;
     } | null;
+};
+
+type PositionedPlantSummary = {
+    plant: PlantRelationshipCandidateLike;
+    positionIndex: number;
 };
 
 function uniqueValues<T>(values: T[]) {
@@ -92,6 +112,40 @@ function plantSummaryForSort(
     };
 }
 
+function positionedPlantSummaryForSort(
+    positionIndex: number,
+    sortId: number | null,
+    sortsById: Map<number, PlantSortLike>,
+): PositionedPlantSummary | null {
+    if (sortId === null) {
+        return null;
+    }
+
+    const plant = sortsById.get(sortId)?.information?.plant;
+    if (!plant) {
+        return null;
+    }
+
+    return {
+        plant,
+        positionIndex,
+    };
+}
+
+function plantName(plant: PlantRelationshipCandidateLike) {
+    return plant.information?.name ?? `Biljka #${plant.id}`;
+}
+
+function getRaisedBedLocalVisualGridPosition(positionIndex: number) {
+    const baseRow = Math.floor(positionIndex / 3);
+    const baseCol = positionIndex % 3;
+
+    return {
+        col: 2 - baseCol,
+        row: 2 - baseRow,
+    };
+}
+
 export function getRaisedBedNeighborPositionIndices({
     blockCount = 2,
     positionIndex,
@@ -110,10 +164,8 @@ export function getRaisedBedNeighborPositionIndices({
     }
 
     const localPositionIndex = positionIndex % 9;
-    const localPosition = getGridPositionFromIndex(
-        localPositionIndex,
-        'vertical',
-    );
+    const localPosition =
+        getRaisedBedLocalVisualGridPosition(localPositionIndex);
     const visualBlockIndex = normalizedBlockCount - 1 - blockIndex;
     const visualRow = visualBlockIndex * 3 + localPosition.row;
     const totalRows = normalizedBlockCount * 3;
@@ -152,6 +204,78 @@ export function getRaisedBedNeighborPositionIndices({
     }
 
     return uniqueValues(positions).sort((a, b) => a - b);
+}
+
+function getRaisedBedVisualGridPosition({
+    blockCount,
+    positionIndex,
+}: {
+    blockCount: number;
+    positionIndex: number;
+}) {
+    if (!Number.isInteger(positionIndex) || positionIndex < 0) {
+        return null;
+    }
+
+    const normalizedBlockCount = Math.max(1, Math.floor(blockCount));
+    const blockIndex = Math.floor(positionIndex / 9);
+    if (blockIndex >= normalizedBlockCount) {
+        return null;
+    }
+
+    const localPositionIndex = positionIndex % 9;
+    const localPosition =
+        getRaisedBedLocalVisualGridPosition(localPositionIndex);
+    const visualBlockIndex = normalizedBlockCount - 1 - blockIndex;
+
+    return {
+        col: localPosition.col,
+        row: visualBlockIndex * 3 + localPosition.row,
+    };
+}
+
+function raisedBedRelationshipDirection(
+    rowDelta: number,
+    colDelta: number,
+): RaisedBedFieldRelationshipIndicatorDirection | null {
+    if (rowDelta === -1 && colDelta === -1) return 'topLeft';
+    if (rowDelta === -1 && colDelta === 0) return 'top';
+    if (rowDelta === -1 && colDelta === 1) return 'topRight';
+    if (rowDelta === 0 && colDelta === -1) return 'left';
+    if (rowDelta === 0 && colDelta === 1) return 'right';
+    if (rowDelta === 1 && colDelta === -1) return 'bottomLeft';
+    if (rowDelta === 1 && colDelta === 0) return 'bottom';
+    if (rowDelta === 1 && colDelta === 1) return 'bottomRight';
+
+    return null;
+}
+
+function getRaisedBedRelationshipDirection({
+    blockCount,
+    neighborPositionIndex,
+    positionIndex,
+}: {
+    blockCount: number;
+    neighborPositionIndex: number;
+    positionIndex: number;
+}) {
+    const position = getRaisedBedVisualGridPosition({
+        blockCount,
+        positionIndex,
+    });
+    const neighborPosition = getRaisedBedVisualGridPosition({
+        blockCount,
+        positionIndex: neighborPositionIndex,
+    });
+
+    if (!position || !neighborPosition) {
+        return null;
+    }
+
+    return raisedBedRelationshipDirection(
+        neighborPosition.row - position.row,
+        neighborPosition.col - position.col,
+    );
 }
 
 export function getRaisedBedRelationshipBlockCount({
@@ -243,6 +367,187 @@ export function getNeighborPlantSummaries({
     return Array.from(summariesById.values()).sort((a, b) =>
         a.name.localeCompare(b.name, 'hr-HR'),
     );
+}
+
+function getPositionedPlantSummaries({
+    cartItems,
+    fields,
+    gardenId,
+    raisedBedId,
+    sorts,
+}: {
+    cartItems?: ShoppingCartPlantItemLike[] | null;
+    fields?: RaisedBedFieldLike[] | null;
+    gardenId: number;
+    raisedBedId: number;
+    sorts?: PlantSortLike[] | null;
+}) {
+    const sortsById = new Map((sorts ?? []).map((sort) => [sort.id, sort]));
+    const summariesByPosition = new Map<number, PositionedPlantSummary>();
+
+    for (const field of fields ?? []) {
+        if (!field.active) {
+            continue;
+        }
+
+        const summary = positionedPlantSummaryForSort(
+            field.positionIndex,
+            field.plantSortId ?? null,
+            sortsById,
+        );
+        if (summary) {
+            summariesByPosition.set(field.positionIndex, summary);
+        }
+    }
+
+    for (const item of cartItems ?? []) {
+        if (
+            item.entityTypeName !== 'plantSort' ||
+            item.gardenId !== gardenId ||
+            item.raisedBedId !== raisedBedId ||
+            item.status !== 'new' ||
+            typeof item.positionIndex !== 'number'
+        ) {
+            continue;
+        }
+
+        const summary = positionedPlantSummaryForSort(
+            item.positionIndex,
+            parseEntityId(item.entityId),
+            sortsById,
+        );
+        if (summary) {
+            summariesByPosition.set(item.positionIndex, summary);
+        }
+    }
+
+    return summariesByPosition;
+}
+
+function getPairRelationshipStatus({
+    neighbor,
+    plant,
+}: {
+    neighbor: PositionedPlantSummary;
+    plant: PositionedPlantSummary;
+}) {
+    const plantToNeighbor = getPlantRelationshipSignal({
+        candidate: plant.plant,
+        neighborPlants: [
+            {
+                id: neighbor.plant.id,
+                name: plantName(neighbor.plant),
+            },
+        ],
+    });
+    const neighborToPlant = getPlantRelationshipSignal({
+        candidate: neighbor.plant,
+        neighborPlants: [
+            {
+                id: plant.plant.id,
+                name: plantName(plant.plant),
+            },
+        ],
+    });
+    const companionPlantNames = uniqueValues([
+        ...plantToNeighbor.companionNeighborNames,
+        ...neighborToPlant.companionNeighborNames,
+    ]).sort((a, b) => a.localeCompare(b, 'hr-HR'));
+    const antagonistPlantNames = uniqueValues([
+        ...plantToNeighbor.antagonistNeighborNames,
+        ...neighborToPlant.antagonistNeighborNames,
+    ]).sort((a, b) => a.localeCompare(b, 'hr-HR'));
+
+    if (antagonistPlantNames.length > 0) {
+        return {
+            antagonistPlantNames,
+            companionPlantNames,
+            status: 'antagonist',
+        } satisfies Pick<
+            RaisedBedFieldRelationshipIndicator,
+            'antagonistPlantNames' | 'companionPlantNames' | 'status'
+        >;
+    }
+
+    if (companionPlantNames.length > 0) {
+        return {
+            antagonistPlantNames,
+            companionPlantNames,
+            status: 'companion',
+        } satisfies Pick<
+            RaisedBedFieldRelationshipIndicator,
+            'antagonistPlantNames' | 'companionPlantNames' | 'status'
+        >;
+    }
+
+    return null;
+}
+
+export function getRaisedBedFieldRelationshipIndicators({
+    blockCount,
+    cartItems,
+    fields,
+    gardenId,
+    raisedBedId,
+    sorts,
+}: {
+    blockCount?: number;
+    cartItems?: ShoppingCartPlantItemLike[] | null;
+    fields?: RaisedBedFieldLike[] | null;
+    gardenId: number;
+    raisedBedId: number;
+    sorts?: PlantSortLike[] | null;
+}) {
+    const normalizedBlockCount = Math.max(1, Math.floor(blockCount ?? 2));
+    const plantsByPosition = getPositionedPlantSummaries({
+        cartItems,
+        fields,
+        gardenId,
+        raisedBedId,
+        sorts,
+    });
+    const indicators: RaisedBedFieldRelationshipIndicator[] = [];
+
+    for (const [positionIndex, plant] of plantsByPosition) {
+        const neighborPositionIndices = getRaisedBedNeighborPositionIndices({
+            blockCount: normalizedBlockCount,
+            positionIndex,
+        });
+
+        for (const neighborPositionIndex of neighborPositionIndices) {
+            if (positionIndex > neighborPositionIndex) {
+                continue;
+            }
+
+            const neighbor = plantsByPosition.get(neighborPositionIndex);
+            if (!neighbor) {
+                continue;
+            }
+
+            const direction = getRaisedBedRelationshipDirection({
+                blockCount: normalizedBlockCount,
+                neighborPositionIndex,
+                positionIndex,
+            });
+            const relationship = getPairRelationshipStatus({
+                neighbor,
+                plant,
+            });
+
+            if (!direction || !relationship) {
+                continue;
+            }
+
+            indicators.push({
+                ...relationship,
+                direction,
+                neighborPositionIndex,
+                positionIndex,
+            });
+        }
+    }
+
+    return indicators;
 }
 
 export function getPlantRelationshipSignal({

--- a/packages/game/src/hud/raisedBed/plantRelationshipSignals.unit.ts
+++ b/packages/game/src/hud/raisedBed/plantRelationshipSignals.unit.ts
@@ -4,6 +4,7 @@ import {
     getNeighborPlantSummaries,
     getPlantRelationshipSignal,
     getPlantRelationshipSignalSortScore,
+    getRaisedBedFieldRelationshipIndicators,
     getRaisedBedNeighborPositionIndices,
     getRaisedBedRelationshipBlockCount,
 } from './plantRelationshipSignals';
@@ -122,6 +123,85 @@ describe('getNeighborPlantSummaries', () => {
         assert.deepEqual(neighborPlants, [
             { id: 100, name: 'Bosiljak' },
             { id: 101, name: 'Komorač' },
+        ]);
+    });
+});
+
+describe('getRaisedBedFieldRelationshipIndicators', () => {
+    it('creates edge indicators for companion and antagonist neighbors', () => {
+        const indicators = getRaisedBedFieldRelationshipIndicators({
+            blockCount: 2,
+            gardenId: 1,
+            raisedBedId: 2,
+            fields: [
+                {
+                    active: true,
+                    plantSortId: 10,
+                    positionIndex: 4,
+                },
+                {
+                    active: true,
+                    plantSortId: 11,
+                    positionIndex: 5,
+                },
+                {
+                    active: true,
+                    plantSortId: 12,
+                    positionIndex: 1,
+                },
+            ],
+            sorts: [
+                {
+                    id: 10,
+                    information: {
+                        plant: {
+                            id: 100,
+                            information: { name: 'Rajčica' },
+                            relationships: {
+                                companions: [{ id: 101, name: 'Bosiljak' }],
+                                antagonists: [{ id: 102, name: 'Komorač' }],
+                            },
+                        },
+                    },
+                },
+                {
+                    id: 11,
+                    information: {
+                        plant: {
+                            id: 101,
+                            information: { name: 'Bosiljak' },
+                        },
+                    },
+                },
+                {
+                    id: 12,
+                    information: {
+                        plant: {
+                            id: 102,
+                            information: { name: 'Komorač' },
+                        },
+                    },
+                },
+            ],
+        });
+
+        assert.deepEqual(indicators, [
+            {
+                antagonistPlantNames: [],
+                companionPlantNames: ['Bosiljak'],
+                direction: 'left',
+                neighborPositionIndex: 5,
+                positionIndex: 4,
+                status: 'companion',
+            },
+            {
+                antagonistPlantNames: ['Komorač'],
+                companionPlantNames: [],
+                direction: 'top',
+                neighborPositionIndex: 4,
+                positionIndex: 1,
+                status: 'antagonist',
+            },
         ]);
     });
 });

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -62,6 +62,7 @@ export {
     GripVertical as Drag,
     Hammer,
     Hash,
+    Heart,
     History,
     Home,
     Hourglass,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 0.218.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.4.67
-        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@scalar/api-reference-react':
         specifier: 0.9.41
         version: 0.9.41(axios@1.16.1)(change-case@5.4.4)(jwt-decode@4.0.0)(qrcode@1.5.4)(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
@@ -193,7 +193,7 @@ importers:
         version: 0.4.14
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -353,7 +353,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
       '@zxing/library':
         specifier: 0.23.0
         version: 0.23.0
@@ -404,19 +404,19 @@ importers:
         version: 0.218.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.4.67
-        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vercel/blob':
         specifier: 2.4.0
         version: 2.4.0
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       flags:
         specifier: 4.0.6
-        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       pg:
         specifier: 8.21.0
         version: 8.21.0
@@ -480,7 +480,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3
@@ -510,16 +510,16 @@ importers:
         version: 0.218.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.4.67
-        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       flags:
         specifier: 4.0.6
-        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -574,13 +574,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)
       postcss:
         specifier: 8.5.15
         version: 8.5.15
@@ -654,12 +654,15 @@ importers:
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
+      '@tanstack/react-query':
+        specifier: 5.100.14
+        version: 5.100.14(react@19.2.6)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -684,7 +687,7 @@ importers:
         version: 0.6.0(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       '@storybook/nextjs-vite':
         specifier: 10.4.1
-        version: 10.4.1(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
@@ -729,22 +732,22 @@ importers:
         version: 0.218.0(@opentelemetry/api@1.9.1)
       '@posthog/next':
         specifier: 0.4.67
-        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vercel/toolbar':
         specifier: 0.2.6
-        version: 0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       flags:
         specifier: 4.0.6
-        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)
+        version: 2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -805,7 +808,7 @@ importers:
         version: 0.4.14
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3
@@ -817,7 +820,7 @@ importers:
         version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-sitemap:
         specifier: 4.2.3
-        version: 4.2.3(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))
+        version: 4.2.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))
       postcss:
         specifier: 8.5.15
         version: 8.5.15
@@ -12342,7 +12345,7 @@ snapshots:
       - '@types/react'
       - rxjs
 
-  '@posthog/next@0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@posthog/next@0.4.67(@types/react@19.2.14)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@posthog/core': 1.29.13
       '@posthog/react': 1.9.1(@types/react@19.2.14)(posthog-js@1.376.4)(react@19.2.6)
@@ -13711,18 +13714,18 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/nextjs-vite@10.4.1(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@storybook/nextjs-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@storybook/builder-vite': 10.4.1(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       '@storybook/react-vite': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
       vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -14289,13 +14292,13 @@ snapshots:
     dependencies:
       valibot: 1.4.1(typescript@6.0.3)
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react: 19.2.6
       vue: 3.5.35(typescript@6.0.3)
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react: 19.2.6
@@ -14309,7 +14312,7 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.26.0
 
-  '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vercel/microfrontends@2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@next/env': 16.0.10
       '@types/md5': 2.3.6
@@ -14324,8 +14327,8 @@ snapshots:
       path-to-regexp: 6.3.0
       semver: 7.8.1
     optionalDependencies:
-      '@vercel/analytics': 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      '@vercel/analytics': 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3))
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)
@@ -14336,17 +14339,17 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/toolbar@0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vercel/toolbar@0.2.6(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@tinyhttp/app': 1.3.0
-      '@vercel/microfrontends': 2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vercel/microfrontends': 2.3.2(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6)(vue@3.5.35(typescript@6.0.3)))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       chokidar: 3.6.0
       execa: 5.1.1
       find-up: 5.0.0
       get-port: 5.1.1
       strip-ansi: 6.0.1
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react: 19.2.6
       vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -15859,13 +15862,13 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.10.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -17328,13 +17331,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  next-sitemap@4.2.3(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)):
+  next-sitemap@4.2.3(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -17439,13 +17442,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  nuqs@2.8.9(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6):
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-      react: 19.2.6
-    optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
 
   nuqs@2.8.9(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react@19.2.6):
     dependencies:
@@ -19044,13 +19040,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
       vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)


### PR DESCRIPTION
## Summary
- Add companion and antagonist relationship indicators to raised bed cells, including mirrored connector rendering for paired plants
- Add local-storage-backed raised bed layer toggles for history badges and relationship indicators
- Update the Storybook story and supporting tests/icons to exercise the new UI

## Testing
- `pnpm --filter @gredice/game typecheck`
- Storybook UI verified locally in the browser