### PR TITLE
Improve dark mode markdown editors and plant relationships

### DIFF
--- a/apps/app/app/admin/communication/inbox/EmailSendForm.tsx
+++ b/apps/app/app/admin/communication/inbox/EmailSendForm.tsx
@@ -11,6 +11,10 @@ import {
 } from '@gredice/ui/Card';
 import { Input } from '@gredice/ui/Input';
 import { Clear, Mail, Send } from '@gredice/ui/icons';
+import {
+    markdownEditorClassNames,
+    markdownEditorContentEditableClassName,
+} from '@gredice/ui/MarkdownEditor';
 import { Typography } from '@gredice/ui/Typography';
 import {
     BlockTypeSelect,
@@ -174,12 +178,13 @@ export function EmailSendForm({ from }: { from: string }) {
                                     }}
                                     placeholder="Unesite poruku..."
                                     className={cx(
-                                        'border rounded-md',
+                                        markdownEditorClassNames,
+                                        'rounded-md border',
                                         pending && 'bg-muted',
-                                        !pending &&
-                                            '[&_.mdxeditor-toolbar]:bg-background [&_.mdxeditor-toolbar]:text-muted-foreground',
                                     )}
-                                    contentEditableClassName="prose prose-p:my-2 prose-sm max-w-none"
+                                    contentEditableClassName={
+                                        markdownEditorContentEditableClassName
+                                    }
                                     plugins={[
                                         headingsPlugin(),
                                         listsPlugin(),

--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "../../../packages/ui/src/MarkdownEditor/MarkdownEditor.css";
 @config "../tailwind.config.ts";
 @source "../../../packages/ui/src";
 

--- a/apps/app/components/shared/attributes/typed/MarkdownInput.tsx
+++ b/apps/app/components/shared/attributes/typed/MarkdownInput.tsx
@@ -1,3 +1,7 @@
+import {
+    markdownEditorClassNames,
+    markdownEditorContentEditableClassName,
+} from '@gredice/ui/MarkdownEditor';
 import { cx } from '@gredice/ui/utils';
 import {
     BlockTypeSelect,
@@ -17,30 +21,20 @@ import {
     toolbarPlugin,
     UndoRedo,
 } from '@mdxeditor/editor';
-import { useTheme } from 'next-themes';
 import { useState } from 'react';
 import type { AttributeInputProps } from '../AttributeInputProps';
 import '@mdxeditor/editor/style.css';
 
 export function MarkdownInput({ value, onChange }: AttributeInputProps) {
-    const { resolvedTheme } = useTheme();
     const [inputValue, setInputValue] = useState<string>(value || '');
     return (
         <div className="overflow-hidden rounded-md border border-input bg-background">
             <MDXEditor
                 placeholder="Nema informacija..."
-                className={cx(
-                    'bg-background text-foreground',
-                    '[&_.mdxeditor-toolbar]:bg-background [&_.mdxeditor-toolbar]:text-muted-foreground',
-                    "[&_[class*='SelectTrigger']]:bg-background",
-                    "[&_[class*='SelectTrigger']]:text-foreground",
-                    "[&_[class*='DropdownContainer']]:bg-background",
-                    "[&_[class*='CodeBlockLanguageSelectContent']]:bg-background",
-                    "[&_[class*='selectItem']]:bg-background",
-                    "[&_[class*='contentEditable']]:bg-background",
-                    resolvedTheme === 'dark' && 'dark-theme',
-                )}
-                contentEditableClassName="prose prose-p:my-2 prose-sm max-w-none bg-background text-foreground"
+                className={cx(markdownEditorClassNames)}
+                contentEditableClassName={
+                    markdownEditorContentEditableClassName
+                }
                 plugins={[
                     headingsPlugin(),
                     listsPlugin(),

--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -12,6 +12,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
+import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { KnownPages } from '../../../src/KnownPages';
 import { getPlantInforationSections } from './getPlantInforationSections';
@@ -21,6 +22,12 @@ import { VerifiedInformationBadge } from './VerifiedInformationBadge';
 type InformationWithAlternativeName = {
     name?: unknown;
     alternativeName?: unknown;
+};
+
+type OverviewEditTarget = {
+    entityTypeName: 'plant' | 'plantSort';
+    entityId: number;
+    publicPath: string;
 };
 
 const alternativeNamesLocale = 'hr-HR';
@@ -51,9 +58,11 @@ function formatAlternativeNames(
 }
 
 export function PlantPageHeader({
+    overviewEditTarget,
     plant,
     sort,
 }: {
+    overviewEditTarget?: OverviewEditTarget;
     plant: PlantData & { isRecommended: boolean | null | undefined };
     sort?: PlantSortData;
 }) {
@@ -209,20 +218,34 @@ export function PlantPageHeader({
                             navigateLabel="Više o gredicama"
                         />
                     </div>
-                    <FeedbackModal
-                        topic={
-                            sort
-                                ? 'www/plants/sorts/information'
-                                : 'www/plants/information'
-                        }
-                        data={{
-                            plantId: plant.id,
-                            plantAlias: plant.information.name,
-                            sortId: sort?.id,
-                            sortAlias: sort?.information.name,
-                        }}
-                        className="self-end group-hover:opacity-100 opacity-0 transition-opacity"
-                    />
+                    <Row
+                        spacing={1}
+                        className="self-end md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100"
+                    >
+                        {overviewEditTarget ? (
+                            <CommunityEditButton
+                                entityTypeName={
+                                    overviewEditTarget.entityTypeName
+                                }
+                                entityId={overviewEditTarget.entityId}
+                                publicPath={overviewEditTarget.publicPath}
+                                sectionKey="overview"
+                            />
+                        ) : null}
+                        <FeedbackModal
+                            topic={
+                                sort
+                                    ? 'www/plants/sorts/information'
+                                    : 'www/plants/information'
+                            }
+                            data={{
+                                plantId: plant.id,
+                                plantAlias: plant.information.name,
+                                sortId: sort?.id,
+                                sortAlias: sort?.information.name,
+                            }}
+                        />
+                    </Row>
                     <Typography level="body2" secondary>
                         Nisi zadovoljan uslugom ili proizvodom? Pogledaj{' '}
                         <Link className="underline" href={KnownPages.Refunds}>

--- a/apps/www/app/biljke/[alias]/PlantRelationshipsSection.tsx
+++ b/apps/www/app/biljke/[alias]/PlantRelationshipsSection.tsx
@@ -1,5 +1,4 @@
 import type { PlantData } from '@gredice/client';
-import { slug } from '@gredice/js/slug';
 import { Card } from '@gredice/ui/Card';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
@@ -33,14 +32,14 @@ function PlantRelationshipCard({
                     height={56}
                     className="rounded-md object-cover"
                 />
-                <Stack spacing={1} className="min-w-0">
-                    <Typography level="h5" className="truncate">
+                <Stack spacing={0} className="min-w-0">
+                    <Typography level="h5" className="truncate leading-tight">
                         {relationship.name}
                     </Typography>
                     {relationship.latinName && (
                         <Typography
                             level="body2"
-                            className="text-gray-500 italic truncate"
+                            className="text-secondary-foreground italic truncate leading-tight"
                         >
                             {relationship.latinName}
                         </Typography>
@@ -72,7 +71,7 @@ function PlantRelationshipGroup({
                 <Typography level="h3" className="text-xl">
                     {title}
                 </Typography>
-                <Typography level="body2" className="text-gray-600">
+                <Typography level="body2" secondary>
                     {description}
                 </Typography>
             </Stack>
@@ -103,13 +102,6 @@ export function PlantRelationshipsSection({
 
     return (
         <Stack spacing={4}>
-            <Typography
-                level="h2"
-                className="text-2xl"
-                id={slug('Biljni susjedi')}
-            >
-                Biljni susjedi
-            </Typography>
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
                 <PlantRelationshipGroup
                     title="Dobri susjedi"

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -132,7 +132,14 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                         { label: plant.information.name },
                     ]}
                 />
-                <PlantPageHeader plant={plant} />
+                <PlantPageHeader
+                    plant={plant}
+                    overviewEditTarget={{
+                        entityTypeName: 'plant',
+                        entityId: plant.id,
+                        publicPath: KnownPages.Plant(alias),
+                    }}
+                />
                 {informationSections
                     .filter((section) => section.avaialble)
                     .map((section) => (

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -6,7 +6,6 @@ import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { RecipeList } from '../../../components/recipes/RecipeList';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
@@ -134,14 +133,6 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                     ]}
                 />
                 <PlantPageHeader plant={plant} />
-                <Row className="justify-end">
-                    <CommunityEditButton
-                        buttonStyle="button"
-                        entityTypeName="plant"
-                        entityId={plant.id}
-                        publicPath={KnownPages.Plant(alias)}
-                    />
-                </Row>
                 {informationSections
                     .filter((section) => section.avaialble)
                     .map((section) => (

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -5,7 +5,6 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { CommunityEditButton } from '../../../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../../../components/shared/feedback/FeedbackModal';
 import { StructuredDataScript } from '../../../../../components/shared/seo/StructuredDataScript';
 import { getPlantSortsData } from '../../../../../lib/plants/getPlantSortsData';
@@ -261,14 +260,6 @@ export default async function PlantSortPage(
                     ]}
                 />
                 <PlantPageHeader plant={basePlantData} sort={sortData} />
-                <Row className="justify-end">
-                    <CommunityEditButton
-                        buttonStyle="button"
-                        entityTypeName="plantSort"
-                        entityId={sortData.id}
-                        publicPath={sortPath}
-                    />
-                </Row>
                 {informationSections
                     .filter((section) => section.avaialble)
                     .map((section) => (

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -259,7 +259,15 @@ export default async function PlantSortPage(
                         { label: sortData.information.name },
                     ]}
                 />
-                <PlantPageHeader plant={basePlantData} sort={sortData} />
+                <PlantPageHeader
+                    plant={basePlantData}
+                    sort={sortData}
+                    overviewEditTarget={{
+                        entityTypeName: 'plantSort',
+                        entityId: sortData.id,
+                        publicPath: sortPath,
+                    }}
+                />
                 {informationSections
                     .filter((section) => section.avaialble)
                     .map((section) => (

--- a/apps/www/app/blokovi/[alias]/page.tsx
+++ b/apps/www/app/blokovi/[alias]/page.tsx
@@ -127,7 +127,16 @@ export default async function BlockPage(props: PageProps<'/blokovi/[alias]'>) {
                         }
                         header={entity.information.label}
                         subHeader={entity.information.shortDescription}
-                    />
+                    >
+                        <Row className="justify-end">
+                            <CommunityEditButton
+                                entityTypeName="block"
+                                entityId={entity.id}
+                                publicPath={blockPath}
+                                sectionKey="overview"
+                            />
+                        </Row>
+                    </PageHeader>
                     <Markdown>{entity.information.fullDescription}</Markdown>
                     <Row className="justify-end">
                         <CommunityEditButton

--- a/apps/www/app/blokovi/[alias]/page.tsx
+++ b/apps/www/app/blokovi/[alias]/page.tsx
@@ -128,14 +128,6 @@ export default async function BlockPage(props: PageProps<'/blokovi/[alias]'>) {
                         header={entity.information.label}
                         subHeader={entity.information.shortDescription}
                     />
-                    <Row className="justify-end">
-                        <CommunityEditButton
-                            buttonStyle="button"
-                            entityTypeName="block"
-                            entityId={entity.id}
-                            publicPath={blockPath}
-                        />
-                    </Row>
                     <Markdown>{entity.information.fullDescription}</Markdown>
                     <Row className="justify-end">
                         <CommunityEditButton

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "../../../packages/ui/src/MarkdownEditor/MarkdownEditor.css";
 @config "../tailwind.config.ts";
 @source "../../../packages/game/src";
 @source "../../../packages/ui/src";

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -109,14 +109,6 @@ export default async function OperationPage(
                         { label: operation.information.label },
                     ]}
                 />
-                <Row className="justify-end">
-                    <CommunityEditButton
-                        buttonStyle="button"
-                        entityTypeName="operation"
-                        entityId={operation.id}
-                        publicPath={operationPath}
-                    />
-                </Row>
                 <PageHeader
                     visual={<OperationImage operation={operation} size={192} />}
                     header={operation.information.label}

--- a/apps/www/components/community-edits/CommunityMarkdownInput.tsx
+++ b/apps/www/components/community-edits/CommunityMarkdownInput.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import {
+    markdownEditorClassNames,
+    markdownEditorContentEditableClassName,
+} from '@gredice/ui/MarkdownEditor';
 import { cx } from '@gredice/ui/utils';
 import {
     BlockTypeSelect,
@@ -19,7 +23,6 @@ import {
     toolbarPlugin,
     UndoRedo,
 } from '@mdxeditor/editor';
-import { useTheme } from 'next-themes';
 import '@mdxeditor/editor/style.css';
 
 export function CommunityMarkdownInput({
@@ -31,23 +34,17 @@ export function CommunityMarkdownInput({
     onChange: (value: string) => void;
     value: string;
 }) {
-    const { resolvedTheme } = useTheme();
-
     return (
         <div className="overflow-hidden rounded-md border border-input bg-background">
             <MDXEditor
                 className={cx(
-                    'bg-background text-foreground',
-                    '[&_.mdxeditor-toolbar]:bg-background [&_.mdxeditor-toolbar]:text-muted-foreground',
-                    "[&_[class*='SelectTrigger']]:bg-background",
-                    "[&_[class*='SelectTrigger']]:text-foreground",
-                    "[&_[class*='DropdownContainer']]:bg-background",
-                    "[&_[class*='CodeBlockLanguageSelectContent']]:bg-background",
-                    "[&_[class*='selectItem']]:bg-background",
-                    "[&_[class*='contentEditable']]:bg-background",
-                    resolvedTheme === 'dark' && 'dark-theme',
+                    markdownEditorClassNames,
+                    "[&_[class*='contentEditable']]:min-h-32",
                 )}
-                contentEditableClassName="prose prose-p:my-2 prose-sm max-w-none min-h-32 bg-background text-foreground"
+                contentEditableClassName={cx(
+                    markdownEditorContentEditableClassName,
+                    'min-h-32',
+                )}
                 markdown={value}
                 onChange={onChange}
                 placeholder="Upiši prijedlog..."

--- a/packages/ui/src/MarkdownEditor/MarkdownEditor.css
+++ b/packages/ui/src/MarkdownEditor/MarkdownEditor.css
@@ -1,0 +1,103 @@
+/* biome-ignore-all lint/complexity/noImportantStyles: MDXEditor loads generated component CSS after app globals, so these integration overrides must win the cascade. */
+
+.gredice-mdx-editor {
+    --accentBase: hsl(var(--background)) !important;
+    --accentBgSubtle: hsl(var(--muted)) !important;
+    --accentBg: hsl(var(--accent)) !important;
+    --accentBgHover: hsl(var(--accent)) !important;
+    --accentBgActive: hsl(var(--accent)) !important;
+    --accentLine: hsl(var(--border)) !important;
+    --accentBorder: hsl(var(--border)) !important;
+    --accentBorderHover: hsl(var(--ring)) !important;
+    --accentSolid: hsl(var(--primary)) !important;
+    --accentSolidHover: hsl(var(--primary)) !important;
+    --accentText: hsl(var(--foreground)) !important;
+    --accentTextContrast: hsl(var(--primary-foreground)) !important;
+    --basePageBg: hsl(var(--background)) !important;
+    --baseBase: hsl(var(--background)) !important;
+    --baseBgSubtle: hsl(var(--muted)) !important;
+    --baseBg: hsl(var(--muted)) !important;
+    --baseBgHover: hsl(var(--accent)) !important;
+    --baseBgActive: hsl(var(--accent)) !important;
+    --baseLine: hsl(var(--border)) !important;
+    --baseBorder: hsl(var(--border)) !important;
+    --baseBorderHover: hsl(var(--muted-foreground)) !important;
+    --baseSolid: hsl(var(--muted-foreground)) !important;
+    --baseSolidHover: hsl(var(--foreground)) !important;
+    --baseText: hsl(var(--muted-foreground)) !important;
+    --baseTextContrast: hsl(var(--foreground)) !important;
+
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+}
+
+.gredice-mdx-editor [class*="contentEditable"],
+.gredice-mdx-editor-content {
+    background-color: hsl(var(--background)) !important;
+    color: hsl(var(--foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="placeholder"] {
+    color: hsl(var(--muted-foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="toolbarRoot"] {
+    background-color: hsl(var(--background)) !important;
+    color: hsl(var(--muted-foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="toolbarRoot"] svg {
+    color: hsl(var(--foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="toolbarRoot"] [role="separator"] {
+    border-left-color: hsl(var(--border)) !important;
+    border-right-color: hsl(var(--background)) !important;
+}
+
+.gredice-mdx-editor [class*="selectTrigger"],
+.gredice-mdx-editor [class*="toolbarButtonSelectTrigger"],
+.gredice-mdx-editor [class*="toolbarNodeKindSelectTrigger"] {
+    background-color: hsl(var(--background)) !important;
+    color: hsl(var(--foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="selectContainer"],
+.gredice-mdx-editor [class*="toolbarButtonDropdownContainer"],
+.gredice-mdx-editor [class*="toolbarCodeBlockLanguageSelectContent"],
+.gredice-mdx-editor [class*="toolbarNodeKindSelectContainer"] {
+    background-color: hsl(var(--popover)) !important;
+    color: hsl(var(--popover-foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="selectItem"],
+.gredice-mdx-editor [class*="toolbarNodeKindSelectItem"] {
+    color: hsl(var(--popover-foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="selectItem"][data-highlighted],
+.gredice-mdx-editor [class*="selectItem"][data-state="checked"],
+.gredice-mdx-editor [class*="toolbarNodeKindSelectItem"][data-highlighted],
+.gredice-mdx-editor [class*="toolbarNodeKindSelectItem"][data-state="checked"] {
+    background-color: hsl(var(--accent)) !important;
+}
+
+.gredice-mdx-editor [class*="toolbarButton"],
+.gredice-mdx-editor [class*="toolbarToggleItem"] {
+    color: hsl(var(--foreground)) !important;
+}
+
+.gredice-mdx-editor [class*="toolbarButton"]:hover,
+.gredice-mdx-editor [class*="toolbarToggleItem"]:hover {
+    background-color: hsl(var(--muted)) !important;
+}
+
+.gredice-mdx-editor [class*="toolbarButton"][data-state="on"],
+.gredice-mdx-editor [class*="toolbarToggleItem"][data-state="on"] {
+    background-color: hsl(var(--accent)) !important;
+}
+
+.gredice-mdx-editor [class*="popoverContent"] {
+    background-color: hsl(var(--popover)) !important;
+    color: hsl(var(--popover-foreground)) !important;
+}

--- a/packages/ui/src/MarkdownEditor/index.ts
+++ b/packages/ui/src/MarkdownEditor/index.ts
@@ -1,0 +1,4 @@
+export const markdownEditorClassNames = 'gredice-mdx-editor';
+
+export const markdownEditorContentEditableClassName =
+    'gredice-mdx-editor-content prose prose-p:my-2 prose-sm max-w-none bg-background text-foreground';


### PR DESCRIPTION
## Summary
- Unify MDX editor styling across app and community edit forms with shared dark-mode tokens.
- Remove the redundant top-level edit buttons from plant, plant sort, operation, and block pages.
- Simplify plant relationships by dropping the duplicate section header and tightening related-plant card spacing and contrast.

## Testing
- Playwright browser smoke check in dark mode for the plant relationships preview, verifying the redundant heading is gone and the text contrast/spacing is correct.
- UI checks and type validation passed on the touched frontend code.