### PR TITLE
[codex] Publish harvest quality and safety page

### DIFF
--- a/apps/www/app/Footer.tsx
+++ b/apps/www/app/Footer.tsx
@@ -50,6 +50,10 @@ const sectionsData: SectionData[] = [
                         href: KnownPages.DeliverySlots,
                     },
                     { label: 'Česta pitanja', href: KnownPages.FAQ },
+                    {
+                        label: 'Kvaliteta i sigurnost uroda',
+                        href: KnownPages.QualityHarvestSafety,
+                    },
                     { label: 'Kontaktiraj nas', href: KnownPages.Contact },
                     { label: 'O nama', href: KnownPages.AboutUs },
                 ],

--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -11,8 +11,22 @@ import {
     parseCmsPageRenderMode,
     parseCmsSectionData,
 } from './cmsPageRouteUtils';
+import { getSourceCmsPageBySlug } from './sourceCmsPages';
 
 const localCmsPagePreviewSecret = 'local-preview-secret';
+
+type CmsRoutePage = {
+    slug: string;
+    title: string;
+    content: unknown;
+    renderMode?: unknown;
+    renderMaxWidth?: unknown;
+    metaTitle?: string | null;
+    metaDescription?: string | null;
+    metaImageUrl?: string | null;
+    canonicalPath?: string | null;
+    noIndex?: boolean;
+};
 
 function isLocalPreviewHost(hostname: string) {
     return (
@@ -35,6 +49,38 @@ async function cmsPagePreviewSecret() {
     return isLocalPreviewHost(hostname) ? localCmsPagePreviewSecret : null;
 }
 
+async function fetchCmsDirectoryPage({
+    normalizedSlug,
+    previewSecret,
+    suppressFetchError,
+}: {
+    normalizedSlug: string;
+    previewSecret?: string | null;
+    suppressFetchError?: boolean;
+}) {
+    try {
+        return await clientPublic().api.directories.pages[':slug{.+}'].$get({
+            param: { slug: normalizedSlug },
+            query: previewSecret ? { draft: '1' } : {},
+            ...(previewSecret
+                ? {
+                      header: {
+                          'x-preview-secret': previewSecret,
+                      },
+                  }
+                : {}),
+        });
+    } catch (error) {
+        if (!suppressFetchError) {
+            console.error('Failed to fetch CMS page from directories API', {
+                slug: normalizedSlug,
+                error,
+            });
+        }
+        return null;
+    }
+}
+
 export default async function CmsPublishedPageRoute({
     params,
 }: {
@@ -49,26 +95,22 @@ export default async function CmsPublishedPageRoute({
 
     const { isEnabled } = await draftMode();
     const previewSecret = isEnabled ? await cmsPagePreviewSecret() : null;
+    const sourcePage = getSourceCmsPageBySlug(normalizedSlug);
 
-    const response = await clientPublic().api.directories.pages[
-        ':slug{.+}'
-    ].$get({
-        param: { slug: normalizedSlug },
-        query: isEnabled ? { draft: '1' } : {},
-        ...(isEnabled && previewSecret
-            ? {
-                  header: {
-                      'x-preview-secret': previewSecret,
-                  },
-              }
-            : {}),
+    const response = await fetchCmsDirectoryPage({
+        normalizedSlug,
+        previewSecret: isEnabled ? previewSecret : null,
+        suppressFetchError: Boolean(sourcePage),
     });
 
-    if (response.status !== 200) {
+    let page: CmsRoutePage;
+    if (response?.status === 200) {
+        page = await response.json();
+    } else if (sourcePage) {
+        page = sourcePage;
+    } else {
         notFound();
     }
-
-    const page = await response.json();
 
     return (
         <main>
@@ -93,18 +135,20 @@ export async function generateMetadata({
         return {};
     }
 
-    const response = await clientPublic().api.directories.pages[
-        ':slug{.+}'
-    ].$get({
-        param: { slug: normalizedSlug },
-        query: {},
+    const sourcePage = getSourceCmsPageBySlug(normalizedSlug);
+    const response = await fetchCmsDirectoryPage({
+        normalizedSlug,
+        suppressFetchError: Boolean(sourcePage),
     });
 
-    if (response.status !== 200) {
+    let page: CmsRoutePage;
+    if (response?.status === 200) {
+        page = await response.json();
+    } else if (sourcePage) {
+        page = sourcePage;
+    } else {
         return {};
     }
-
-    const page = await response.json();
     const canonicalPath = page.canonicalPath || `/${page.slug}`;
     return {
         title: page.metaTitle || page.title,

--- a/apps/www/app/[...slug]/sourceCmsPages.ts
+++ b/apps/www/app/[...slug]/sourceCmsPages.ts
@@ -1,0 +1,168 @@
+import type {
+    CmsPageRenderMaxWidth,
+    CmsPageRenderMode,
+    SectionData,
+} from '@gredice/ui/cms';
+
+export {
+    QUALITY_HARVEST_SAFETY_LAST_REVIEWED,
+    QUALITY_HARVEST_SAFETY_PATH,
+    QUALITY_HARVEST_SAFETY_SLUG,
+} from '../../src/publicPagePaths.ts';
+
+import {
+    QUALITY_HARVEST_SAFETY_LAST_REVIEWED,
+    QUALITY_HARVEST_SAFETY_PATH,
+    QUALITY_HARVEST_SAFETY_SLUG,
+} from '../../src/publicPagePaths.ts';
+
+export type SourceCmsPage = {
+    slug: string;
+    title: string;
+    content: SectionData[];
+    renderMode: CmsPageRenderMode;
+    renderMaxWidth: CmsPageRenderMaxWidth;
+    state: 'published';
+    publishedAt: string;
+    metaTitle: string;
+    metaDescription: string;
+    metaImageUrl: string | null;
+    canonicalPath: string;
+    noIndex: false;
+    updatedAt: string;
+};
+
+export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
+    slug: QUALITY_HARVEST_SAFETY_SLUG,
+    title: 'Kvaliteta i sigurnost uroda',
+    state: 'published',
+    publishedAt: `${QUALITY_HARVEST_SAFETY_LAST_REVIEWED}T00:00:00.000Z`,
+    updatedAt: `${QUALITY_HARVEST_SAFETY_LAST_REVIEWED}T00:00:00.000Z`,
+    metaTitle: 'Kvaliteta i sigurnost uroda | Gredice',
+    metaDescription:
+        'Kako Gredice prate higijenu, sljedivost, berbu i dostavu svježeg uroda u trenutnom modelu usluge.',
+    metaImageUrl: null,
+    canonicalPath: QUALITY_HARVEST_SAFETY_PATH,
+    noIndex: false,
+    renderMode: 'container',
+    renderMaxWidth: 'lg',
+    content: [
+        {
+            component: 'PageHeader',
+            header: 'Kvaliteta i sigurnost uroda',
+            description:
+                'Kako Gredice prate higijenu, sljedivost, berbu i dostavu svježeg uroda u trenutnom modelu usluge.',
+        },
+        {
+            component: 'TextBlock',
+            tagline: 'Model usluge',
+            header: 'Urod ostaje korisnikov urod',
+            description:
+                'Gredice pružaju uslugu planiranja, uzgoja, njege, berbe i dostave uroda naručitelju. U trenutnom modelu urod ne predstavljamo kao vlastiti gotov prehrambeni proizvod, nego kao svježe ubrano povrće i bilje koje korisnik preuzima i priprema za vlastitu upotrebu.',
+        },
+        {
+            component: 'Feature1',
+            tagline: 'Kontrole',
+            header: 'Što pratimo kroz sezonu',
+            description:
+                'Interni postupci oslanjaju se na dobru poljoprivrednu praksu, dobru higijensku praksu, sljedivost, evidencije, korektivne radnje i načela HACCP-a.',
+            features: [
+                {
+                    header: 'Inputi i materijali',
+                    description:
+                        'Porijeklo sjemena, presadnica, supstrata, gnojiva, alata i drugih materijala koji ulaze u uzgoj.',
+                },
+                {
+                    header: 'Lokacija i voda',
+                    description:
+                        'Stanje gredice, okolni rizici, životinjski tragovi, poplava, navodnjavanje i prikladnost vode za namjenu.',
+                },
+                {
+                    header: 'Higijena i čistoća',
+                    description:
+                        'Higijena osoba koje rukuju urodom te čistoća alata, gajbi, radnih površina i dostavnog prostora.',
+                },
+                {
+                    header: 'Berba i sortiranje',
+                    description:
+                        'Pregled prije berbe, izdvajanje vidljivo oštećenog ili sumnjivog uroda i osnovno sortiranje prije predaje.',
+                },
+                {
+                    header: 'Sljedivost',
+                    description:
+                        'Povezivanje korisnika, gredice, sezone, berbe i dostave kako bi se u slučaju pitanja moglo provjeriti što se dogodilo.',
+                },
+                {
+                    header: 'Odstupanja i prigovori',
+                    description:
+                        'Zapisivanje sumnji, prigovora i korektivnih radnji kada postupak nije proveden kako je planirano.',
+                },
+            ],
+        },
+        {
+            component: 'CalloutBlock',
+            tagline: 'Obvezna napomena',
+            header: 'Svježi urod treba oprati i pripremiti prije konzumacije',
+            description:
+                'Urod je svježe ubrano povrće i bilje. Prije konzumacije korisnik ga treba oprati i pripremiti na uobičajen higijenski način.',
+        },
+        {
+            component: 'MarkdownBlock',
+            markdown:
+                '## Što ova stranica ne tvrdi\n\nNe iznosimo tvrdnju o formalnoj certifikaciji prema HACCP sustavu. Ne predstavljamo urod kao proizvod namijenjen konzumaciji bez pranja i uobičajene pripreme. Ne predstavljamo Gredice kao industrijsku preradu hrane niti kao prodaju vlastitog gotovog prehrambenog proizvoda.\n\nAko se poslovni model promijeni tako da uključuje prodaju, preradu, pakiranje, skladištenje ili distribuciju hrane kao tržišnog proizvoda, prije javne objave i rada u takvom modelu potreban je novi pravni i sanitarni pregled.',
+        },
+        {
+            component: 'Faq1',
+            tagline: 'Pitanja',
+            header: 'Česta pitanja o kvaliteti i sigurnosti',
+            description:
+                'Najkraći odgovori na pitanja o načinu rada, higijeni i granici javnih tvrdnji.',
+            features: [
+                {
+                    header: 'Komunicirate li formalnu HACCP certifikaciju?',
+                    description:
+                        'Ne. Trenutno govorimo o internim postupcima temeljenima na dobroj praksi, sljedivosti, evidencijama, korektivnim radnjama i načelima HACCP-a.',
+                },
+                {
+                    header: 'Znači li to da ne pratite sigurnost uroda?',
+                    description:
+                        'Ne. Pratimo rizike, čistoću, rukovanje, berbu, dostavu i prigovore kako bi se svaka sumnja mogla procijeniti i zapisati.',
+                },
+                {
+                    header: 'Može li se urod jesti bez pranja?',
+                    description:
+                        'Ne komuniciramo takvu tvrdnju. Urod je svježe ubrano povrće i bilje koje korisnik prije konzumacije treba oprati i pripremiti.',
+                },
+                {
+                    header: 'Što radite ako postoji sumnja na problem?',
+                    description:
+                        'Urod se zadržava ili izdvaja dok se situacija ne procijeni. Problem se zapisuje, provodi se korektivna radnja i po potrebi se korisniku daje jasna uputa.',
+                },
+            ],
+        },
+        {
+            component: 'CtaBand',
+            tagline: `Zadnji pregled: ${QUALITY_HARVEST_SAFETY_LAST_REVIEWED}`,
+            header: 'Pitanja o dostavi, pranju ili pripremi uroda?',
+            description:
+                'Odgovori na najčešća pitanja dostupni su na FAQ stranici, a za konkretan urod možeš se javiti podršci.',
+            ctas: [
+                {
+                    label: 'Otvori česta pitanja',
+                    href: '/cesta-pitanja',
+                },
+                {
+                    label: 'Provjeri dostavu',
+                    href: '/dostava',
+                    secondary: true,
+                },
+            ],
+        },
+    ],
+};
+
+export const sourceCmsPages = [qualityHarvestSafetyCmsPage];
+
+export function getSourceCmsPageBySlug(slug: string) {
+    return sourceCmsPages.find((page) => page.slug === slug) ?? null;
+}

--- a/apps/www/app/[...slug]/sourceCmsPages.ts
+++ b/apps/www/app/[...slug]/sourceCmsPages.ts
@@ -68,31 +68,37 @@ export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
                 'Interni postupci oslanjaju se na dobru poljoprivrednu praksu, dobru higijensku praksu, sljedivost, evidencije, korektivne radnje i načela HACCP-a.',
             features: [
                 {
+                    iconName: 'inputs',
                     header: 'Inputi i materijali',
                     description:
                         'Porijeklo sjemena, presadnica, supstrata, gnojiva, alata i drugih materijala koji ulaze u uzgoj.',
                 },
                 {
+                    iconName: 'water',
                     header: 'Lokacija i voda',
                     description:
                         'Stanje gredice, okolni rizici, životinjski tragovi, poplava, navodnjavanje i prikladnost vode za namjenu.',
                 },
                 {
+                    iconName: 'hygiene',
                     header: 'Higijena i čistoća',
                     description:
                         'Higijena osoba koje rukuju urodom te čistoća alata, gajbi, radnih površina i dostavnog prostora.',
                 },
                 {
+                    iconName: 'harvest',
                     header: 'Berba i sortiranje',
                     description:
                         'Pregled prije berbe, izdvajanje vidljivo oštećenog ili sumnjivog uroda i osnovno sortiranje prije predaje.',
                 },
                 {
+                    iconName: 'traceability',
                     header: 'Sljedivost',
                     description:
                         'Povezivanje korisnika, gredice, sezone, berbe i dostave kako bi se u slučaju pitanja moglo provjeriti što se dogodilo.',
                 },
                 {
+                    iconName: 'deviation',
                     header: 'Odstupanja i prigovori',
                     description:
                         'Zapisivanje sumnji, prigovora i korektivnih radnji kada postupak nije proveden kako je planirano.',
@@ -142,7 +148,6 @@ export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
         },
         {
             component: 'CtaBand',
-            tagline: `Zadnji pregled: ${QUALITY_HARVEST_SAFETY_LAST_REVIEWED}`,
             header: 'Pitanja o dostavi, pranju ili pripremi uroda?',
             description:
                 'Odgovori na najčešća pitanja dostupni su na FAQ stranici, a za konkretan urod možeš se javiti podršci.',

--- a/apps/www/app/llms-routes.spec.ts
+++ b/apps/www/app/llms-routes.spec.ts
@@ -20,6 +20,10 @@ async function assertLlmsResponse(response: Response) {
     assert.match(body, /\[Plants\]\(https:\/\/www\.gredice\.com\/biljke\)/);
     assert.match(
         body,
+        /\[Harvest quality and safety\]\(https:\/\/www\.gredice\.com\/kvaliteta-i-sigurnost-uroda\)/,
+    );
+    assert.match(
+        body,
         /\[Privacy policy\]\(https:\/\/www\.gredice\.com\/legalno\/politika-privatnosti\)/,
     );
 }

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -13,6 +13,7 @@ Gredice publishes canonical public information at https://www.gredice.com. Prefe
 - [Recipes](https://www.gredice.com/recepti): Recipe content built from garden produce.
 - [Delivery](https://www.gredice.com/dostava): Delivery options and service information.
 - [Pricing](https://www.gredice.com/cjenik): Current public pricing and plan information.
+- [Harvest quality and safety](https://www.gredice.com/kvaliteta-i-sigurnost-uroda): Public overview of harvest hygiene, traceability, and handling boundaries.
 
 ## Company and Support
 

--- a/apps/www/lib/plants/getFaqData.ts
+++ b/apps/www/lib/plants/getFaqData.ts
@@ -1,5 +1,6 @@
 import { directoriesClient } from '@gredice/client';
 import { cache } from 'react';
+import { mergeQualityHarvestSafetyFaqEntries } from './qualityHarvestSafetyFaq';
 
 export const getFaqData = cache(async () => {
     try {
@@ -10,9 +11,9 @@ export const getFaqData = cache(async () => {
             return [];
         }
 
-        return data ?? [];
+        return mergeQualityHarvestSafetyFaqEntries(data ?? []);
     } catch (error) {
         console.error('Failed to fetch faq data', error);
-        return [];
+        return mergeQualityHarvestSafetyFaqEntries([]);
     }
 });

--- a/apps/www/lib/plants/qualityHarvestSafetyFaq.node.spec.ts
+++ b/apps/www/lib/plants/qualityHarvestSafetyFaq.node.spec.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { FaqData } from '@gredice/client';
+import {
+    mergeQualityHarvestSafetyFaqEntries,
+    qualityHarvestSafetyFaqEntries,
+} from './qualityHarvestSafetyFaq.ts';
+
+const bannedPublicClaimPhrases = [
+    'HACCP certificirani',
+    'HACCP certifikat',
+    'u potpunosti HACCP compliant',
+    'ready-to-eat',
+    'oprano i spremno za jelo',
+];
+
+test('quality harvest safety FAQ entries are category-backed and link to the public page', () => {
+    assert.equal(qualityHarvestSafetyFaqEntries.length, 6);
+
+    for (const entry of qualityHarvestSafetyFaqEntries) {
+        assert.equal(
+            entry.attributes.category.information.label,
+            'Kvaliteta i sigurnost uroda',
+        );
+        assert.match(
+            entry.information.content,
+            /kvaliteta-i-sigurnost-uroda|urod/iu,
+        );
+    }
+});
+
+test('quality harvest safety FAQ fallback does not duplicate live directory entries', () => {
+    const liveEntry = {
+        ...qualityHarvestSafetyFaqEntries[0],
+        id: 4501,
+    } satisfies FaqData;
+
+    const merged = mergeQualityHarvestSafetyFaqEntries([liveEntry]);
+    assert.equal(
+        merged.filter((entry) => entry.slug === liveEntry.slug).length,
+        1,
+    );
+    assert.equal(merged.length, qualityHarvestSafetyFaqEntries.length);
+});
+
+test('quality harvest safety FAQ avoids risky public claim phrases', () => {
+    const serialized = JSON.stringify(qualityHarvestSafetyFaqEntries);
+
+    for (const phrase of bannedPublicClaimPhrases) {
+        assert.equal(
+            serialized.includes(phrase),
+            false,
+            `FAQ content must not include "${phrase}"`,
+        );
+    }
+});

--- a/apps/www/lib/plants/qualityHarvestSafetyFaq.ts
+++ b/apps/www/lib/plants/qualityHarvestSafetyFaq.ts
@@ -1,0 +1,94 @@
+import type { FaqData } from '@gredice/client';
+import { QUALITY_HARVEST_SAFETY_PATH } from '../../src/publicPagePaths.ts';
+
+const category = {
+    id: -451,
+    information: {
+        name: 'kvaliteta-i-sigurnost-uroda',
+        label: 'Kvaliteta i sigurnost uroda',
+    },
+};
+
+const timestamp = '2026-06-03T00:00:00.000Z';
+
+function faqEntry({
+    content,
+    header,
+    id,
+    slug,
+}: {
+    content: string;
+    header: string;
+    id: number;
+    slug: string;
+}): FaqData {
+    return {
+        id,
+        slug,
+        entityType: {
+            id: 2,
+            name: 'faq',
+            label: 'FAQ',
+        },
+        information: {
+            header,
+            content,
+            name: slug,
+        },
+        attributes: {
+            category,
+            tags: ['kvaliteta', 'sigurnost', 'urod'],
+        },
+        createdAt: timestamp,
+        updatedAt: timestamp,
+    };
+}
+
+export const qualityHarvestSafetyFaqEntries: FaqData[] = [
+    faqEntry({
+        id: -45101,
+        slug: 'kvaliteta-haccp-certifikacija',
+        header: 'Komunicirate li formalnu HACCP certifikaciju?',
+        content: `Ne. Gredice u ovom modelu pružaju uslugu planiranja, uzgoja, njege, berbe i dostave korisnikova uroda. Trenutno javno komuniciramo interne postupke temeljene na dobroj praksi, sljedivosti, evidencijama, korektivnim radnjama i načelima HACCP-a. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+    }),
+    faqEntry({
+        id: -45102,
+        slug: 'kvaliteta-pracenje-sigurnosti',
+        header: 'Znači li to da ne pratite sigurnost uroda?',
+        content: `Ne. Pratimo rizike, čistoću, rukovanje, berbu, dostavu i prigovore kako bi se svaka sumnja mogla procijeniti i zapisati. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+    }),
+    faqEntry({
+        id: -45103,
+        slug: 'kvaliteta-dokumentirani-postupci',
+        header: 'Koje postupke imate dokumentirane?',
+        content: `Dokumentirani su postupci za osobnu higijenu, edukaciju, procjenu gredice, vodu, inpute, čišćenje alata i gajbi, berbu, sortiranje, dostavu, sljedivost, prigovore i godišnju reviziju. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+    }),
+    faqEntry({
+        id: -45104,
+        slug: 'kvaliteta-pranje-uroda',
+        header: 'Može li se urod jesti bez pranja?',
+        content: `Ne komuniciramo takvu tvrdnju. Urod je svježe ubrano povrće i bilje koje korisnik prije konzumacije treba oprati i pripremiti na uobičajen higijenski način. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+    }),
+    faqEntry({
+        id: -45105,
+        slug: 'kvaliteta-sumnja-na-problem',
+        header: 'Što radite ako postoji sumnja na problem?',
+        content: `Ako postoji sumnja na kontaminaciju, pogrešnu primjenu sredstva, ulazak životinja, poplavu, prljavu opremu ili izgubljenu sljedivost, urod se zadržava ili izdvaja dok se ne procijeni. Problem se zapisuje i provodi se korektivna radnja. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+    }),
+    faqEntry({
+        id: -45106,
+        slug: 'kvaliteta-promjena-modela',
+        header: 'Što ako se poslovni model promijeni?',
+        content: `Ako model počne uključivati prodaju, preradu, pakiranje, skladištenje ili distribuciju hrane kao tržišnog proizvoda, prije javne objave i rada u tom modelu potrebno je ponovno provjeriti obveze i prilagoditi sustav rada. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+    }),
+];
+
+export function mergeQualityHarvestSafetyFaqEntries(entries: FaqData[]) {
+    const existingSlugs = new Set(entries.map((entry) => entry.slug));
+    return [
+        ...entries,
+        ...qualityHarvestSafetyFaqEntries.filter(
+            (entry) => !existingSlugs.has(entry.slug),
+        ),
+    ];
+}

--- a/apps/www/next-sitemap.config.cjs
+++ b/apps/www/next-sitemap.config.cjs
@@ -20,6 +20,8 @@ function normalizeSitemapPath(path) {
     return search ? `${normalizedPathname}?${search}` : normalizedPathname;
 }
 
+const sourceCmsPagePaths = ['/kvaliteta-i-sigurnost-uroda'];
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
     siteUrl: process.env.SITE_URL || 'https://www.gredice.com',
@@ -43,22 +45,22 @@ module.exports = {
         alternateRefs: config.alternateRefs ?? [],
     }),
     additionalPaths: async (config) => {
+        const sitemapPaths = new Set(sourceCmsPagePaths);
         const baseUrl = process.env.API_URL || 'https://api.gredice.com';
         let response;
         try {
             response = await fetch(`${baseUrl}/api/directories/pages`);
         } catch {
-            return [];
+            return Promise.all(
+                Array.from(sitemapPaths).map((path) =>
+                    config.transform(config, path),
+                ),
+            );
         }
 
-        if (!response.ok) {
-            return [];
-        }
-
-        /** @type {Array<{ slug: string; noIndex?: boolean; state: string; publishedAt?: string | null }>} */
-        const pages = await response.json();
-        const seen = new Set();
-        const sitemapPaths = await Promise.all(
+        if (response.ok) {
+            /** @type {Array<{ slug: string; noIndex?: boolean; state: string; publishedAt?: string | null }>} */
+            const pages = await response.json();
             pages
                 .filter(
                     (page) =>
@@ -67,15 +69,16 @@ module.exports = {
                         !page.noIndex,
                 )
                 .map((page) => `/${page.slug}`)
-                .filter((path) => {
-                    if (seen.has(path)) {
-                        return false;
-                    }
-                    seen.add(path);
-                    return true;
-                })
-                .map((path) => config.transform(config, path)),
+                .forEach((path) => {
+                    sitemapPaths.add(path);
+                });
+        }
+
+        const transformedPaths = await Promise.all(
+            Array.from(sitemapPaths).map((path) =>
+                config.transform(config, path),
+            ),
         );
-        return sitemapPaths.filter(Boolean);
+        return transformedPaths.filter(Boolean);
     },
 };

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -16,6 +16,7 @@
         "test:prepare": "turbo build --filter=www && pnpm run test:prepare:routes",
         "test:prepare:routes": "node --experimental-strip-types ./tests/populate-test-cases.ts",
         "test:run": "playwright test --project=chromium",
+        "test:cms-pages": "node --experimental-strip-types --test ./tests/cmsPages.node.spec.ts ./lib/plants/qualityHarvestSafetyFaq.node.spec.ts",
         "test-ui": "pnpm run test:prepare && playwright test --project=chromium --ui",
         "generate-playwright": "node ./generate/populate-test-cases.js && playwright test --config playwright-generate.config.ts",
         "generate-playwright:blocks": "node ./generate/populate-test-cases.js && playwright test --config playwright-generate.config.ts generate/blocks-snapshots.specgen.tsx",

--- a/apps/www/src/KnownPages.ts
+++ b/apps/www/src/KnownPages.ts
@@ -1,5 +1,6 @@
 import { PublicDirectoryPaths } from '@gredice/directory-types';
 import type { Route } from 'next';
+import { QUALITY_HARVEST_SAFETY_PATH } from './publicPagePaths';
 
 // TODO: Deprecate KnownPages in favor of using route types directly
 export const KnownPages = {
@@ -27,6 +28,7 @@ export const KnownPages = {
     Recipe: (slug: string) => `/recepti/${encodeURIComponent(slug)}` as Route,
     AboutUs: '/o-nama',
     FAQ: PublicDirectoryPaths.FAQ as Route,
+    QualityHarvestSafety: QUALITY_HARVEST_SAFETY_PATH as Route,
     Contact: '/kontakt',
     Pricing: '/cjenik',
     Refunds: '/povrati-i-povrat-novca',

--- a/apps/www/src/publicPagePaths.ts
+++ b/apps/www/src/publicPagePaths.ts
@@ -1,0 +1,3 @@
+export const QUALITY_HARVEST_SAFETY_SLUG = 'kvaliteta-i-sigurnost-uroda';
+export const QUALITY_HARVEST_SAFETY_PATH = `/${QUALITY_HARVEST_SAFETY_SLUG}`;
+export const QUALITY_HARVEST_SAFETY_LAST_REVIEWED = '2026-06-03';

--- a/apps/www/tests/cmsPages.node.spec.ts
+++ b/apps/www/tests/cmsPages.node.spec.ts
@@ -46,6 +46,24 @@ test('quality harvest safety source CMS page has real content sections', () => {
         JSON.stringify(qualityHarvestSafetyCmsPage.content),
         /Svježi urod treba oprati i pripremiti prije konzumacije/u,
     );
+    assert.doesNotMatch(
+        JSON.stringify(qualityHarvestSafetyCmsPage.content),
+        /Zadnji pregled/u,
+    );
+});
+
+test('quality harvest safety control items include CMS feature icons', () => {
+    const controlsSection = qualityHarvestSafetyCmsPage.content.find(
+        (section) => section.component === 'Feature1',
+    );
+
+    assert.ok(controlsSection?.features?.length);
+    assert.equal(controlsSection.features.length, 6);
+    assert.ok(
+        controlsSection.features.every(
+            (feature) => typeof feature.iconName === 'string',
+        ),
+    );
 });
 
 test('quality harvest safety source CMS page avoids risky public claim phrases', () => {

--- a/apps/www/tests/cmsPages.node.spec.ts
+++ b/apps/www/tests/cmsPages.node.spec.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getSourceCmsPageBySlug,
+    QUALITY_HARVEST_SAFETY_PATH,
+    QUALITY_HARVEST_SAFETY_SLUG,
+    qualityHarvestSafetyCmsPage,
+} from '../app/[...slug]/sourceCmsPages.ts';
+
+const bannedPublicClaimPhrases = [
+    'HACCP certificirani',
+    'HACCP certifikat',
+    'u potpunosti HACCP compliant',
+    'ready-to-eat',
+    'oprano i spremno za jelo',
+];
+
+test('quality harvest safety source CMS page is published and canonical', () => {
+    assert.equal(qualityHarvestSafetyCmsPage.slug, QUALITY_HARVEST_SAFETY_SLUG);
+    assert.equal(qualityHarvestSafetyCmsPage.state, 'published');
+    assert.equal(qualityHarvestSafetyCmsPage.noIndex, false);
+    assert.equal(
+        qualityHarvestSafetyCmsPage.canonicalPath,
+        QUALITY_HARVEST_SAFETY_PATH,
+    );
+    assert.ok(qualityHarvestSafetyCmsPage.metaTitle);
+    assert.ok(qualityHarvestSafetyCmsPage.metaDescription.length <= 160);
+    assert.ok(getSourceCmsPageBySlug(QUALITY_HARVEST_SAFETY_SLUG));
+});
+
+test('quality harvest safety source CMS page has real content sections', () => {
+    const components = qualityHarvestSafetyCmsPage.content.map(
+        (section) => section.component,
+    );
+
+    assert.deepEqual(components, [
+        'PageHeader',
+        'TextBlock',
+        'Feature1',
+        'CalloutBlock',
+        'MarkdownBlock',
+        'Faq1',
+        'CtaBand',
+    ]);
+    assert.match(
+        JSON.stringify(qualityHarvestSafetyCmsPage.content),
+        /Svježi urod treba oprati i pripremiti prije konzumacije/u,
+    );
+});
+
+test('quality harvest safety source CMS page avoids risky public claim phrases', () => {
+    const serialized = JSON.stringify(qualityHarvestSafetyCmsPage);
+
+    for (const phrase of bannedPublicClaimPhrases) {
+        assert.equal(
+            serialized.includes(phrase),
+            false,
+            `CMS page content must not include "${phrase}"`,
+        );
+    }
+});

--- a/docs/haccp-process-documentation.md
+++ b/docs/haccp-process-documentation.md
@@ -1,0 +1,113 @@
+# HACCP-aligned process documentation
+
+This note is the repository index for the approved HACCP-aligned source pack
+used by the public quality and harvest-safety website work.
+
+It is internal operating documentation, not a public certificate, legal opinion,
+sanitary inspection report, or replacement for review by the responsible
+Gredice/OPG owner.
+
+## Document control
+
+| Field | Value |
+| --- | --- |
+| Owner | Gredice / OPG |
+| Version | 1.0 |
+| Source creation date | 2026-05-21 |
+| Public claim approval date | 2026-06-03 |
+| Next review date | 2027-06-03 |
+| Current model | Service of planning, growing, caring for, harvesting, and delivering the customer's harvest |
+| Public website route | `/kvaliteta-i-sigurnost-uroda` |
+
+## Source pack
+
+The approved local source pack is named
+`Gredice_HACCP_Documentation_Pack.zip` and contains:
+
+1. `00_Scope_Legal_Boundary_Publication.md`
+2. `01_Process_Map.md`
+3. `02_Hazard_Analysis_Control_Plan.md`
+4. `03_SOP_Library.md`
+5. `04_Forms_Records.md`
+6. `05_Public_Quality_Page_FAQ.md`
+7. `06_Implementation_Checklist_References.md`
+
+The combined source document is
+`Gredice_HACCP_Process_Documentation_Notion.md`.
+
+Use this repository note as the stable implementation reference. Keep the
+detailed SOP library, forms, and operating records in the internal documentation
+system; do not copy them wholesale onto the public website.
+
+## Public claim boundary
+
+Public copy may say that Gredice uses internal procedures based on:
+
+- good agricultural practice;
+- good hygiene practice;
+- traceability;
+- records;
+- corrective actions; and
+- HACCP principles.
+
+Public copy must keep the current service model visible: Gredice supports the
+customer's garden/raised-bed harvest through planning, growing, caring,
+harvesting, and delivery.
+
+Public copy must also include a visible reminder that fresh harvest should be
+washed and prepared before consumption.
+
+See [HACCP-aligned public claim boundary](./haccp-public-claim-boundary.md) for
+the approved wording constraints and review checklist.
+
+## Internal operating scope
+
+The internal documentation covers:
+
+- garden and crop planning for the customer;
+- input sourcing and storage;
+- garden/raised-bed location risk review;
+- soil preparation, sowing, planting, irrigation, and care;
+- approved-use handling of any materials or treatments;
+- pre-harvest inspection;
+- harvest hygiene, basic sorting, and suspicious-harvest isolation;
+- clean temporary containers, handoff, and delivery;
+- season, garden, harvest, delivery, deviation, and complaint records;
+- annual review and corrective actions.
+
+The current model excludes sale of Gredice's own finished food product,
+industrial food processing, retail packaging/declaration, food warehousing as
+market goods, business-to-business distribution as a food product, and claims
+that harvest can be consumed without washing and ordinary preparation.
+
+## Public website contract
+
+The public page and FAQ should:
+
+- describe the quality and safety controls in conservative Croatian copy;
+- avoid exposing private SOP details, internal records, or operational logs;
+- avoid any public wording that implies formal certification, a certificate,
+  full compliance in all activities, industrial processing, or a product that
+  can skip washing and preparation;
+- link users to support or FAQ content for practical questions;
+- show a visible review date based on the public claim approval date.
+
+## Review triggers
+
+Before public wording changes, repeat the owner/legal/sanitary review if Gredice
+introduces any of the following:
+
+- sale of vegetables as Gredice's own market food product;
+- food processing, cutting, peeling, drying, fermenting, juicing, preserving, or
+  similar transformation;
+- retail packaging or declaration;
+- food warehousing as market goods;
+- distribution to shops, restaurants, or other business buyers as a food
+  product;
+- any claim that harvest can be consumed without washing and ordinary
+  preparation;
+- a new formal certification, inspection basis, or legal status that changes the
+  public claim boundary.
+
+Record the review outcome in Linear or the internal documentation system before
+publishing changed public copy.

--- a/packages/ui/src/PageHeader/PageHeaderSection.tsx
+++ b/packages/ui/src/PageHeader/PageHeaderSection.tsx
@@ -26,6 +26,7 @@ export function PageHeaderSection({
         <div className="@container/cms w-full">
             <PageHeader
                 header={typeof header === 'string' ? header : ''}
+                padded
                 responsive="container"
                 subHeader={typeof description === 'string' ? description : null}
                 visual={visual}

--- a/packages/ui/src/cms/CmsSections.tsx
+++ b/packages/ui/src/cms/CmsSections.tsx
@@ -2,6 +2,7 @@ import { slugify } from '@gredice/js/slug';
 import { createElement, type ExoticComponent, type ReactNode } from 'react';
 import { Accordion } from '../Accordion';
 import { Button } from '../Button';
+import { Card } from '../Card';
 import { Container, type ContainerProps } from '../Container';
 import { Divider } from '../Divider';
 import {
@@ -10,8 +11,16 @@ import {
     CompanyGitHub,
     CompanyReddit,
     CompanyX,
+    Droplets,
     Globe,
+    Leaf,
+    Link,
     Mail,
+    MapPin,
+    Security,
+    Sprout,
+    Success,
+    Warning,
 } from '../icons';
 import { Markdown } from '../Markdown';
 import { Stack } from '../Stack';
@@ -73,6 +82,7 @@ export type SectionData = {
     assetUrl?: string;
     assetDarkUrl?: string;
     assetAlt?: string;
+    iconName?: string;
     features?: SectionData[];
     ctas?: {
         label: string;
@@ -307,7 +317,13 @@ export function CmsMediaImage({
     );
 }
 
-function IconName({ name }: { name: string }) {
+function IconName({
+    className = 'size-4',
+    name,
+}: {
+    className?: string;
+    name: string;
+}) {
     const normalized = name.trim().toLowerCase();
 
     if (!normalized) {
@@ -315,21 +331,43 @@ function IconName({ name }: { name: string }) {
     }
 
     switch (normalized) {
+        case 'deviation':
+        case 'warning':
+            return <Warning className={className} />;
+        case 'harvest':
+        case 'sort':
+            return <Success className={className} />;
+        case 'hygiene':
+        case 'security':
+            return <Security className={className} />;
+        case 'inputs':
+        case 'sprout':
+            return <Sprout className={className} />;
+        case 'leaf':
+            return <Leaf className={className} />;
+        case 'location':
+        case 'map-pin':
+            return <MapPin className={className} />;
+        case 'trace':
+        case 'traceability':
+            return <Link className={className} />;
+        case 'water':
+            return <Droplets className={className} />;
         case 'facebook':
-            return <CompanyFacebook className="size-4" />;
+            return <CompanyFacebook className={className} />;
         case 'github':
-            return <CompanyGitHub className="size-4" />;
+            return <CompanyGitHub className={className} />;
         case 'instagram':
         case 'link':
-            return <Globe className="size-4" />;
+            return <Globe className={className} />;
         case 'mail':
-            return <Mail className="size-4" />;
+            return <Mail className={className} />;
         case 'reddit':
-            return <CompanyReddit className="size-4" />;
+            return <CompanyReddit className={className} />;
         case 'whatsapp':
-            return <Comment className="size-4" />;
+            return <Comment className={className} />;
         case 'x':
-            return <CompanyX className="size-4" />;
+            return <CompanyX className={className} />;
         default:
             break;
     }
@@ -382,8 +420,9 @@ function FeatureItem({
     assetUrl,
     description,
     header,
+    iconName,
 }: SectionData) {
-    return (
+    const content = (
         <Stack spacing={4}>
             <AssetBlock
                 asset={asset}
@@ -402,6 +441,19 @@ function FeatureItem({
                 description
             )}
         </Stack>
+    );
+
+    if (!iconName) {
+        return content;
+    }
+
+    return (
+        <div className="flex gap-4">
+            <span className="mt-1 flex size-10 shrink-0 items-center justify-center rounded-md border bg-card text-primary">
+                <IconName className="size-5" name={iconName} />
+            </span>
+            <div className="min-w-0">{content}</div>
+        </div>
     );
 }
 
@@ -861,7 +913,10 @@ export function StepList(props: SectionData) {
                                 {features.map((feature, index) => (
                                     <div
                                         className="rounded-lg border bg-card p-5"
-                                        key={sectionKey(feature) || `step-${index}`}
+                                        key={
+                                            sectionKey(feature) ||
+                                            `step-${index}`
+                                        }
                                     >
                                         <Stack spacing={4}>
                                             <span className="inline-flex size-8 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
@@ -1054,7 +1109,7 @@ export function CalloutBlock(props: SectionData) {
         <CmsSectionContainer>
             <section className="py-8">
                 <CmsSectionContent section={props}>
-                    <div className="rounded-lg border border-primary/20 bg-muted/30 p-5 @[48rem]/cms:p-6">
+                    <Card className="border-primary/20 bg-card p-5 shadow-sm @[48rem]/cms:p-6">
                         <Stack spacing={5}>
                             <DescriptionBlock
                                 description={description}
@@ -1063,7 +1118,7 @@ export function CalloutBlock(props: SectionData) {
                             />
                             <Ctas ctas={ctas} />
                         </Stack>
-                    </div>
+                    </Card>
                 </CmsSectionContent>
             </section>
         </CmsSectionContainer>
@@ -1122,7 +1177,7 @@ export function CtaBand(props: SectionData) {
         <CmsSectionContainer>
             <section className="py-12">
                 <CmsSectionContent section={props}>
-                    <div className="rounded-lg border bg-muted/20 p-6 @[48rem]/cms:p-10">
+                    <Card className="bg-card p-6 shadow-sm @[48rem]/cms:p-10">
                         <div className="grid gap-6 @[64rem]/cms:grid-cols-[minmax(0,1fr)_auto] @[64rem]/cms:items-end">
                             <DescriptionBlock
                                 className="max-w-3xl"
@@ -1132,7 +1187,7 @@ export function CtaBand(props: SectionData) {
                             />
                             <Ctas ctas={ctas} />
                         </div>
-                    </div>
+                    </Card>
                 </CmsSectionContent>
             </section>
         </CmsSectionContainer>


### PR DESCRIPTION
## Summary
- publish the source-defined `/kvaliteta-i-sigurnost-uroda` CMS page with directory API fallback behavior and public claim guardrails
- add harvest quality and HACCP-aligned FAQ fallback entries plus footer, llms.txt, and sitemap discovery
- add the internal HACCP process documentation source of truth and focused regression coverage

## Linear
- GRE-450
- GRE-451
- GRE-452
- GRE-453
- GRE-454

## Validation
- `pnpm lint --filter www`
- `pnpm --filter www test:cms-pages`
- `pnpm --filter www test:llms`
- `pnpm typecheck --filter www`
- `pnpm build --filter www`
- `git diff --check`
- browser smoke check for `/kvaliteta-i-sigurnost-uroda` and `/cesta-pitanja` on desktop and mobile