### PR TITLE
Add diary operation cancellation across API and HUD

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -10,6 +10,8 @@ import {
     abandonRaisedBed,
     addGardenBoxInventoryItem,
     buildRaisedBedFieldPlantUpdatePayload,
+    cancelGardenDiaryOperation,
+    cancelGardenDiaryRaisedBedField,
     clearSandboxField,
     countAiRequestEventsSince,
     countRaisedBedsByAccount,
@@ -21,6 +23,7 @@ import {
     deleteGardenStack,
     deleteSandboxGardenCompletely,
     GardenBoxInventoryLimitError,
+    GardenDiaryCancelError,
     GardenDiaryRescheduleError,
     getAccount,
     getAccountGardens,
@@ -131,6 +134,20 @@ function getAnalysisReferenceDate(body: AnalyzeImageBody) {
 function diaryRescheduleErrorResponse(
     context: Context,
     error: GardenDiaryRescheduleError,
+) {
+    switch (error.statusCode) {
+        case 400:
+            return context.json({ error: error.message }, 400);
+        case 404:
+            return context.json({ error: error.message }, 404);
+        case 409:
+            return context.json({ error: error.message }, 409);
+    }
+}
+
+function diaryCancelErrorResponse(
+    context: Context,
+    error: GardenDiaryCancelError,
 ) {
     switch (error.statusCode) {
         case 400:
@@ -631,6 +648,61 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 console.error('Error rescheduling diary operation:', error);
                 return context.json(
                     { error: 'Failed to reschedule operation' },
+                    500,
+                );
+            }
+        },
+    )
+    .post(
+        '/:gardenId/operations/:operationId/cancel',
+        describeRoute({
+            description:
+                'Cancel a planned in-game diary operation for the current user and refund sunflowers',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                operationId: z.string(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, operationId } = context.req.valid('param');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            const operationIdNumber = Number.parseInt(operationId, 10);
+
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+            if (Number.isNaN(operationIdNumber)) {
+                return context.json({ error: 'Invalid operation ID' }, 400);
+            }
+
+            const { accountId, userId } = context.get('authContext');
+
+            try {
+                const result = await cancelGardenDiaryOperation({
+                    accountId,
+                    canceledBy: userId,
+                    gardenId: gardenIdNumber,
+                    operationId: operationIdNumber,
+                });
+
+                await notifyOperationUpdate(operationIdNumber, 'canceled', {
+                    canceledBy: userId,
+                    reason: result.reason,
+                });
+
+                return context.json({ refundAmount: result.refundAmount }, 200);
+            } catch (error) {
+                if (error instanceof GardenDiaryCancelError) {
+                    return diaryCancelErrorResponse(context, error);
+                }
+
+                console.error('Error canceling diary operation:', error);
+                return context.json(
+                    { error: 'Failed to cancel operation' },
                     500,
                 );
             }
@@ -2646,6 +2718,63 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 );
                 return context.json(
                     { error: 'Failed to reschedule raised bed field' },
+                    500,
+                );
+            }
+        },
+    )
+    .post(
+        '/:gardenId/raised-beds/:raisedBedId/fields/:positionIndex/cancel',
+        describeRoute({
+            description:
+                'Cancel a planned in-game diary raised-bed field sowing for the current user and refund sunflowers',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                gardenId: z.string(),
+                raisedBedId: z.string(),
+                positionIndex: z.string(),
+            }),
+        ),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { gardenId, raisedBedId, positionIndex } =
+                context.req.valid('param');
+            const gardenIdNumber = Number.parseInt(gardenId, 10);
+            const raisedBedIdNumber = Number.parseInt(raisedBedId, 10);
+            const positionIndexNumber = Number.parseInt(positionIndex, 10);
+
+            if (Number.isNaN(gardenIdNumber)) {
+                return context.json({ error: 'Invalid garden ID' }, 400);
+            }
+            if (Number.isNaN(raisedBedIdNumber)) {
+                return context.json({ error: 'Invalid raised bed ID' }, 400);
+            }
+            if (Number.isNaN(positionIndexNumber) || positionIndexNumber < 0) {
+                return context.json({ error: 'Invalid position index' }, 400);
+            }
+
+            const { accountId, userId } = context.get('authContext');
+
+            try {
+                const result = await cancelGardenDiaryRaisedBedField({
+                    accountId,
+                    canceledBy: userId,
+                    gardenId: gardenIdNumber,
+                    raisedBedId: raisedBedIdNumber,
+                    positionIndex: positionIndexNumber,
+                });
+
+                return context.json({ refundAmount: result.refundAmount }, 200);
+            } catch (error) {
+                if (error instanceof GardenDiaryCancelError) {
+                    return diaryCancelErrorResponse(context, error);
+                }
+
+                console.error('Error canceling diary raised bed field:', error);
+                return context.json(
+                    { error: 'Failed to cancel raised bed field' },
                     500,
                 );
             }

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -25,6 +25,7 @@ import {
     getRaisedBed,
     type InsertOperation,
     knownEvents,
+    unacceptOperation,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import type { EntityStandardized } from '../../lib/@types/EntityStandardized';
@@ -484,6 +485,7 @@ export async function rescheduleOperationAction(formData: FormData) {
             scheduledDate: newDate.toISOString(),
         }),
     );
+    await unacceptOperation(operationId);
 
     await notifyOperationUpdate(operationId, 'rescheduled', {
         scheduledDate: newDate.toISOString(),

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -408,14 +408,21 @@ export async function rescheduleRaisedBedFieldAction(formData: FormData) {
         throw new Error('Field or plant sort not found.');
     }
 
+    const aggregateId = `${raisedBedId}|${positionIndex}`;
+
     await createEvent(
-        knownEvents.raisedBedFields.plantScheduleV1(
-            `${raisedBedId}|${positionIndex}`,
-            {
-                scheduledDate: new Date(scheduledDate).toISOString(),
-            },
-        ),
+        knownEvents.raisedBedFields.plantScheduleV1(aggregateId, {
+            scheduledDate: new Date(scheduledDate).toISOString(),
+        }),
     );
+
+    if (field.plantStatus === 'pendingVerification') {
+        await createEvent(
+            knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+                status: 'planned',
+            }),
+        );
+    }
 
     revalidatePath(KnownPages.Schedule);
     if (raisedBed.accountId)

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -92,3 +92,25 @@ test('future planned diary entries expose the in-game reschedule action', async 
         getMinimumDiaryRescheduleDateInput(),
     );
 });
+
+test('future planned diary entries expose cancel confirmation', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const cancelButtons = page.getByRole('button', {
+        name: 'Otkaži',
+    });
+    await expect(cancelButtons).toHaveCount(1);
+
+    await cancelButtons.first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('Otkaži radnju')).toBeVisible();
+    await expect(
+        dialog.getByText('Otkazivanje se ne može poništiti.'),
+    ).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Otkaži' })).toBeVisible();
+});

--- a/packages/game/src/hooks/useCancelDiaryEntry.ts
+++ b/packages/game/src/hooks/useCancelDiaryEntry.ts
@@ -1,0 +1,193 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { currentAccountKeys } from './useCurrentAccount';
+import { useGardensKeys } from './useGardens';
+import { notificationsQueryKey } from './useNotifications';
+import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
+import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
+import type { DiaryRescheduleTarget } from './useRescheduleDiaryEntry';
+
+export type DiaryCancelTarget = DiaryRescheduleTarget;
+
+const mutationKey = ['gardens', 'diary', 'cancel'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+async function getResponseErrorMessage(response: Response) {
+    const fallbackMessage = 'Otkazivanje nije uspjelo.';
+    const text = await response.text();
+    if (!text.trim()) {
+        return fallbackMessage;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(text);
+        if (
+            isRecord(parsed) &&
+            typeof parsed.error === 'string' &&
+            parsed.error.trim()
+        ) {
+            return parsed.error;
+        }
+    } catch {
+        return text;
+    }
+
+    return fallbackMessage;
+}
+
+function startOfUtcDay(date: Date) {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+}
+
+function getMinimumCancelDate(referenceDate = new Date()) {
+    const tomorrow = startOfUtcDay(referenceDate);
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    return tomorrow;
+}
+
+export function isDiaryCancelTargetEligible(
+    target: DiaryCancelTarget | undefined,
+    referenceDate = new Date(),
+): target is DiaryCancelTarget {
+    if (!target?.scheduledDate) {
+        return false;
+    }
+
+    const scheduledDate = new Date(target.scheduledDate);
+    if (Number.isNaN(scheduledDate.getTime())) {
+        return false;
+    }
+
+    return (
+        startOfUtcDay(scheduledDate).getTime() >=
+        getMinimumCancelDate(referenceDate).getTime()
+    );
+}
+
+export function getDiaryCancelDisabledReason(
+    target: DiaryCancelTarget | undefined,
+    referenceDate = new Date(),
+) {
+    if (!target?.scheduledDate) {
+        return 'Otkazati možeš samo zakazane buduće radnje.';
+    }
+
+    const scheduledDate = new Date(target.scheduledDate);
+    if (Number.isNaN(scheduledDate.getTime())) {
+        return 'Datum radnje nije ispravan.';
+    }
+
+    if (
+        startOfUtcDay(scheduledDate).getTime() <
+        getMinimumCancelDate(referenceDate).getTime()
+    ) {
+        return 'Radnju zakazanu za danas više nije moguće otkazati.';
+    }
+
+    return null;
+}
+
+async function cancelOperation({
+    gardenId,
+    target,
+}: {
+    gardenId: number;
+    target: Extract<DiaryCancelTarget, { type: 'operation' }>;
+}) {
+    const response = await clientAuthenticated().api.gardens[
+        ':gardenId'
+    ].operations[':operationId'].cancel.$post({
+        param: {
+            gardenId: gardenId.toString(),
+            operationId: target.operationId.toString(),
+        },
+    });
+
+    if (response.status !== 200) {
+        throw new Error(await getResponseErrorMessage(response));
+    }
+}
+
+async function cancelRaisedBedFieldPlant({
+    gardenId,
+    target,
+}: {
+    gardenId: number;
+    target: Extract<DiaryCancelTarget, { type: 'raisedBedFieldPlant' }>;
+}) {
+    const response = await clientAuthenticated().api.gardens[':gardenId'][
+        'raised-beds'
+    ][':raisedBedId'].fields[':positionIndex'].cancel.$post({
+        param: {
+            gardenId: gardenId.toString(),
+            raisedBedId: target.raisedBedId.toString(),
+            positionIndex: target.positionIndex.toString(),
+        },
+    });
+
+    if (response.status !== 200) {
+        throw new Error(await getResponseErrorMessage(response));
+    }
+}
+
+export function useCancelDiaryEntry(gardenId: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationKey,
+        mutationFn: (target: DiaryCancelTarget) => {
+            if (target.type === 'operation') {
+                return cancelOperation({ gardenId, target });
+            }
+
+            return cancelRaisedBedFieldPlant({ gardenId, target });
+        },
+        onSuccess: async (_data, target) => {
+            if (target.raisedBedId) {
+                await queryClient.invalidateQueries({
+                    queryKey: raisedBedDiaryQueryKeys.byId(target.raisedBedId),
+                });
+            }
+
+            if (target.type === 'raisedBedFieldPlant') {
+                await queryClient.invalidateQueries({
+                    queryKey: raisedBedFieldDiaryQueryKeys.byId(
+                        target.raisedBedId,
+                        target.positionIndex,
+                    ),
+                });
+            }
+
+            if (
+                target.type === 'operation' &&
+                target.raisedBedId &&
+                typeof target.positionIndex === 'number'
+            ) {
+                await queryClient.invalidateQueries({
+                    queryKey: raisedBedFieldDiaryQueryKeys.byId(
+                        target.raisedBedId,
+                        target.positionIndex,
+                    ),
+                });
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: ['garden-operations', gardenId],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: useGardensKeys,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: currentAccountKeys,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: notificationsQueryKey,
+            });
+        },
+    });
+}

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -124,12 +124,10 @@ const hiddenFromActive = new Set<GardenOperationStatus>([
     'failed',
     'canceled',
 ]);
-const reschedulableActiveStatuses = new Set<GardenOperationStatus>([
-    'planned',
-    'assigned',
-    'confirmed',
+const nonEditableStatuses = new Set<GardenOperationStatus>([
+    'completed',
+    'canceled',
 ]);
-const cancelableActiveStatuses = new Set<GardenOperationStatus>(['planned']);
 const cartOperationEntityType = 'operation' as const;
 export const cartPlantSortEntityType = 'plantSort' as const;
 const plantingOperationLabel = 'Sadnja';
@@ -343,12 +341,7 @@ function getSowingOperationStatus(
         return 'confirmed';
     }
 
-    const hasAssignedUser = hasAssignedSowingUser(entry);
-    if (status === 'planned' && hasAssignedUser) {
-        return 'confirmed';
-    }
-
-    if (hasAssignedUser) {
+    if (hasAssignedSowingUser(entry)) {
         return 'assigned';
     }
 
@@ -605,12 +598,7 @@ export function getGardenOperationRescheduleTarget(
     operation: GardenOperationHudItem,
     garden: CurrentGardenData | null | undefined,
 ): DiaryRescheduleTarget | null {
-    if (
-        !reschedulableActiveStatuses.has(operation.status) ||
-        operation.completedAt ||
-        operation.verifiedAt ||
-        operation.canceledAt
-    ) {
+    if (nonEditableStatuses.has(operation.status)) {
         return null;
     }
 
@@ -647,13 +635,7 @@ export function getGardenOperationCancelTarget(
     operation: GardenOperationHudItem,
     garden: CurrentGardenData | null | undefined,
 ): DiaryRescheduleTarget | null {
-    if (
-        !cancelableActiveStatuses.has(operation.status) ||
-        operation.completedAt ||
-        operation.verifiedAt ||
-        operation.canceledAt ||
-        !operation.scheduledDate
-    ) {
+    if (nonEditableStatuses.has(operation.status) || !operation.scheduledDate) {
         return null;
     }
 
@@ -817,11 +799,7 @@ export function GardenOperationCancelAction({
 }
 
 function isFinishedOperation(operation: GardenOperationHudItem) {
-    return Boolean(
-        operation.completedAt ||
-            operation.verifiedAt ||
-            operation.status === 'completed',
-    );
+    return nonEditableStatuses.has(operation.status);
 }
 
 function OperationScheduleText({ label }: { label: string }) {
@@ -1127,27 +1105,33 @@ function OperationProgress({
 
 function OperationSchedule({
     operation,
+    cancelAction,
     scheduleAction,
 }: {
     operation: GardenOperationItem;
+    cancelAction?: ReactNode;
     scheduleAction?: ReactNode;
 }) {
     const scheduledDate = formatDate(operation.scheduledDate);
-
-    if (scheduleAction) {
-        return <div className="w-fit max-w-full">{scheduleAction}</div>;
-    }
-
-    if (!scheduledDate) {
-        return null;
-    }
-
-    return (
+    const scheduleContent = scheduleAction ? (
+        <div className="w-fit max-w-full">{scheduleAction}</div>
+    ) : scheduledDate ? (
         <Row spacing={1} className="w-fit max-w-full text-muted-foreground">
             <Calendar aria-hidden className="size-3.5 shrink-0" />
             <Typography level="body3" secondary noWrap>
                 {scheduledDate}
             </Typography>
+        </Row>
+    ) : null;
+
+    if (!scheduleContent && !cancelAction) {
+        return null;
+    }
+
+    return (
+        <Row spacing={1} className="w-fit max-w-full items-center">
+            {scheduleContent}
+            {cancelAction}
         </Row>
     );
 }
@@ -1350,6 +1334,7 @@ export function GardenOperationCard({
     currentGarden,
     referenceDate,
     progressClassName,
+    cancelAction,
     scheduleAction,
     action,
 }: {
@@ -1361,6 +1346,7 @@ export function GardenOperationCard({
     currentGarden?: CurrentGardenData | null;
     referenceDate: Date;
     progressClassName?: string;
+    cancelAction?: ReactNode;
     scheduleAction?: ReactNode;
     action?: ReactNode;
 }) {
@@ -1419,6 +1405,7 @@ export function GardenOperationCard({
                     </Stack>
                     <OperationSchedule
                         operation={operation}
+                        cancelAction={cancelAction}
                         scheduleAction={scheduleAction}
                     />
                     <OperationEvidence operation={operation} />
@@ -1966,16 +1953,7 @@ export function GardenOperationsHud() {
                                             currentGarden={currentGarden}
                                             referenceDate={referenceDate}
                                             scheduleAction={scheduleAction}
-                                            action={
-                                                cancelAction ? (
-                                                    <Row
-                                                        spacing={2}
-                                                        className="flex-wrap justify-end"
-                                                    >
-                                                        {cancelAction}
-                                                    </Row>
-                                                ) : undefined
-                                            }
+                                            cancelAction={cancelAction}
                                         />
                                     );
                                 })}

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -33,6 +33,10 @@ import {
 } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { SegmentedProgress } from '../controls/components/SegmentedProgress';
+import {
+    getDiaryCancelDisabledReason,
+    isDiaryCancelTargetEligible,
+} from '../hooks/useCancelDiaryEntry';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import {
     type GardenOperationItem,
@@ -53,6 +57,7 @@ import {
 } from '../hooks/useShoppingCart';
 import { ScrollView } from '../shared-ui/ScrollView';
 import { useShoppingCartOpenParam } from '../useUrlState';
+import { RaisedBedDiaryCancelAction } from './raisedBed/RaisedBedDiaryCancelAction';
 import { RaisedBedDiaryRescheduleAction } from './raisedBed/RaisedBedDiaryRescheduleAction';
 
 type OperationData = NonNullable<
@@ -124,6 +129,7 @@ const reschedulableActiveStatuses = new Set<GardenOperationStatus>([
     'assigned',
     'confirmed',
 ]);
+const cancelableActiveStatuses = new Set<GardenOperationStatus>(['planned']);
 const cartOperationEntityType = 'operation' as const;
 export const cartPlantSortEntityType = 'plantSort' as const;
 const plantingOperationLabel = 'Sadnja';
@@ -637,6 +643,49 @@ export function getGardenOperationRescheduleTarget(
     return null;
 }
 
+export function getGardenOperationCancelTarget(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+): DiaryRescheduleTarget | null {
+    if (
+        !cancelableActiveStatuses.has(operation.status) ||
+        operation.completedAt ||
+        operation.verifiedAt ||
+        operation.canceledAt ||
+        !operation.scheduledDate
+    ) {
+        return null;
+    }
+
+    const positionIndex = getOperationFieldPositionIndex(operation, garden);
+
+    if (operation.entityTypeName === cartOperationEntityType) {
+        return {
+            type: 'operation',
+            operationId: operation.id,
+            raisedBedId: operation.raisedBedId,
+            raisedBedFieldId: operation.raisedBedFieldId,
+            positionIndex,
+            scheduledDate: operation.scheduledDate,
+        };
+    }
+
+    if (
+        operation.entityTypeName === cartPlantSortEntityType &&
+        operation.raisedBedId &&
+        typeof positionIndex === 'number'
+    ) {
+        return {
+            type: 'raisedBedFieldPlant',
+            raisedBedId: operation.raisedBedId,
+            positionIndex,
+            scheduledDate: operation.scheduledDate,
+        };
+    }
+
+    return null;
+}
+
 function getOperationDisplayStatus(
     operation: GardenOperationHudItem,
     referenceDate: Date,
@@ -694,6 +743,17 @@ export function canRescheduleGardenOperation(
     );
 }
 
+export function canCancelGardenOperation(
+    operation: GardenOperationHudItem,
+    garden: CurrentGardenData | null | undefined,
+    referenceDate: Date,
+) {
+    const target = getGardenOperationCancelTarget(operation, garden);
+    return Boolean(
+        target && isDiaryCancelTargetEligible(target, referenceDate),
+    );
+}
+
 export function GardenOperationRescheduleAction({
     entryName,
     garden,
@@ -722,6 +782,36 @@ export function GardenOperationRescheduleAction({
             gardenId={garden.id}
             target={target}
             triggerLabel={triggerLabel}
+        />
+    );
+}
+
+export function GardenOperationCancelAction({
+    entryName,
+    garden,
+    operation,
+    referenceDate,
+}: {
+    entryName: string;
+    garden: CurrentGardenData | null | undefined;
+    operation: GardenOperationHudItem;
+    referenceDate: Date;
+}) {
+    if (!garden) {
+        return null;
+    }
+
+    const target = getGardenOperationCancelTarget(operation, garden);
+    if (!target) {
+        return null;
+    }
+
+    return (
+        <RaisedBedDiaryCancelAction
+            disabledReason={getDiaryCancelDisabledReason(target, referenceDate)}
+            entryName={entryName}
+            gardenId={garden.id}
+            target={target}
         />
     );
 }
@@ -1841,6 +1931,19 @@ export function GardenOperationsHud() {
                                             referenceDate={referenceDate}
                                         />
                                     );
+                                    const cancelTarget =
+                                        getGardenOperationCancelTarget(
+                                            operation,
+                                            currentGarden,
+                                        );
+                                    const cancelAction = cancelTarget ? (
+                                        <GardenOperationCancelAction
+                                            entryName={entryName}
+                                            garden={currentGarden}
+                                            operation={operation}
+                                            referenceDate={referenceDate}
+                                        />
+                                    ) : undefined;
 
                                     return (
                                         <GardenOperationCard
@@ -1863,6 +1966,16 @@ export function GardenOperationsHud() {
                                             currentGarden={currentGarden}
                                             referenceDate={referenceDate}
                                             scheduleAction={scheduleAction}
+                                            action={
+                                                cancelAction ? (
+                                                    <Row
+                                                        spacing={2}
+                                                        className="flex-wrap justify-end"
+                                                    >
+                                                        {cancelAction}
+                                                    </Row>
+                                                ) : undefined
+                                            }
                                         />
                                     );
                                 })}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image';
 import { type ReactNode, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useGameFlags } from '../../GameFlagsContext';
+import { isDiaryCancelTargetEligible } from '../../hooks/useCancelDiaryEntry';
 import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
 import { useRaisedBedFieldDiaryEntries } from '../../hooks/useRaisedBedFieldDiaryEntries';
 import {
@@ -20,6 +21,7 @@ import {
     isDiaryRescheduleTargetEligible,
 } from '../../hooks/useRescheduleDiaryEntry';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
+import { RaisedBedDiaryCancelAction } from './RaisedBedDiaryCancelAction';
 import { RaisedBedDiaryRescheduleAction } from './RaisedBedDiaryRescheduleAction';
 
 type DiaryEntry = {
@@ -143,14 +145,22 @@ function diaryEntryActions({
             target={rescheduleTarget}
         />
     ) : null;
+    const cancelAction = isDiaryCancelTargetEligible(rescheduleTarget) ? (
+        <RaisedBedDiaryCancelAction
+            entryName={entry.name}
+            gardenId={gardenId}
+            target={rescheduleTarget}
+        />
+    ) : null;
 
-    if (!aiAction && !rescheduleAction) {
+    if (!aiAction && !rescheduleAction && !cancelAction) {
         return null;
     }
 
     return (
         <Row spacing={2} className="flex-wrap items-center">
             {rescheduleAction}
+            {cancelAction}
             {aiAction}
         </Row>
     );

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryCancelAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryCancelAction.tsx
@@ -1,0 +1,135 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Close, Warning } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
+import { Typography } from '@gredice/ui/Typography';
+import { type ReactNode, useState } from 'react';
+import {
+    type DiaryCancelTarget,
+    useCancelDiaryEntry,
+} from '../../hooks/useCancelDiaryEntry';
+
+export function RaisedBedDiaryCancelAction({
+    disabledReason,
+    entryName,
+    gardenId,
+    target,
+    triggerLabel = 'Otkaži',
+}: {
+    disabledReason?: string | null;
+    entryName: string;
+    gardenId: number;
+    target: DiaryCancelTarget;
+    triggerLabel?: ReactNode;
+}) {
+    const [open, setOpen] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const mutation = useCancelDiaryEntry(gardenId);
+    const triggerButton = (
+        <Button
+            type="button"
+            size="xs"
+            variant="soft"
+            color="danger"
+            disabled={Boolean(disabledReason)}
+            startDecorator={<Close className="size-3.5 shrink-0" />}
+        >
+            {triggerLabel}
+        </Button>
+    );
+
+    if (disabledReason) {
+        return (
+            <Tooltip delayDuration={100}>
+                <TooltipTrigger asChild>
+                    <span
+                        className="inline-flex w-fit max-w-full cursor-not-allowed"
+                        title={disabledReason}
+                    >
+                        {triggerButton}
+                    </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <Typography level="body3">{disabledReason}</Typography>
+                </TooltipContent>
+            </Tooltip>
+        );
+    }
+
+    async function handleCancel() {
+        setErrorMessage(null);
+
+        try {
+            await mutation.mutateAsync(target);
+            setOpen(false);
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : 'Otkazivanje nije uspjelo.',
+            );
+        }
+    }
+
+    return (
+        <Modal
+            title={`Otkaži ${entryName}`}
+            open={open}
+            onOpenChange={(nextOpen) => {
+                setOpen(nextOpen);
+                if (!nextOpen) {
+                    setErrorMessage(null);
+                }
+            }}
+            trigger={triggerButton}
+        >
+            <Stack spacing={4}>
+                <Stack spacing={1}>
+                    <Typography level="h5">Otkaži radnju</Typography>
+                    <Typography level="body2" secondary>
+                        Otkazat ćeš {entryName}. Suncokreti će se vratiti na
+                        račun, a obavijest će ostati u porukama.
+                    </Typography>
+                </Stack>
+
+                <Alert
+                    color="warning"
+                    startDecorator={<Warning className="size-4 shrink-0" />}
+                >
+                    Otkazivanje se ne može poništiti.
+                </Alert>
+
+                {errorMessage ? (
+                    <Alert color="danger">
+                        <Typography level="body2">{errorMessage}</Typography>
+                    </Alert>
+                ) : null}
+
+                <Row spacing={2} className="justify-end">
+                    <Button
+                        type="button"
+                        variant="plain"
+                        disabled={mutation.isPending}
+                        onClick={() => setOpen(false)}
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="solid"
+                        color="danger"
+                        loading={mutation.isPending}
+                        disabled={mutation.isPending}
+                        startDecorator={<Close className="size-4 shrink-0" />}
+                        onClick={handleCancel}
+                    >
+                        Otkaži
+                    </Button>
+                </Row>
+            </Stack>
+        </Modal>
+    );
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryCancelAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryCancelAction.tsx
@@ -1,5 +1,6 @@
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Close, Warning } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
@@ -28,17 +29,20 @@ export function RaisedBedDiaryCancelAction({
     const [open, setOpen] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const mutation = useCancelDiaryEntry(gardenId);
+    const triggerTitle =
+        typeof triggerLabel === 'string' ? triggerLabel : 'Otkaži';
     const triggerButton = (
-        <Button
+        <IconButton
             type="button"
             size="xs"
-            variant="soft"
+            variant="plain"
             color="danger"
             disabled={Boolean(disabledReason)}
-            startDecorator={<Close className="size-3.5 shrink-0" />}
+            title={triggerTitle}
+            className="h-7 w-7 shrink-0 bg-transparent hover:bg-transparent dark:hover:bg-transparent"
         >
-            {triggerLabel}
-        </Button>
+            <Close className="size-4 shrink-0" />
+        </IconButton>
     );
 
     if (disabledReason) {

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -344,13 +344,11 @@ export function RaisedBedOperationHistoryList({
                             })}
                         />
                     ) : undefined;
-                const action =
-                    cancelAction || aiAction ? (
-                        <Row spacing={2} className="flex-wrap justify-end">
-                            {cancelAction}
-                            {aiAction}
-                        </Row>
-                    ) : undefined;
+                const action = aiAction ? (
+                    <Row spacing={2} className="flex-wrap justify-end">
+                        {aiAction}
+                    </Row>
+                ) : undefined;
 
                 return (
                     <GardenOperationCard
@@ -372,6 +370,7 @@ export function RaisedBedOperationHistoryList({
                         currentGarden={currentGarden}
                         referenceDate={referenceDate}
                         progressClassName="md:max-w-80"
+                        cancelAction={cancelAction}
                         action={action}
                         scheduleAction={scheduleAction}
                     />

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -18,8 +18,10 @@ import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import {
     buildSowingOperationItems,
     cartPlantSortEntityType,
+    GardenOperationCancelAction,
     GardenOperationCard,
     GardenOperationScheduleAction,
+    getGardenOperationCancelTarget,
     sortNewestFirst,
 } from '../GardenOperationsHud';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
@@ -312,6 +314,17 @@ export function RaisedBedOperationHistoryList({
                         referenceDate={referenceDate}
                     />
                 ) : undefined;
+                const cancelTarget = !disableActions
+                    ? getGardenOperationCancelTarget(operation, currentGarden)
+                    : null;
+                const cancelAction = cancelTarget ? (
+                    <GardenOperationCancelAction
+                        entryName={entryName}
+                        garden={currentGarden}
+                        operation={operation}
+                        referenceDate={referenceDate}
+                    />
+                ) : undefined;
                 const aiAction =
                     flags.raisedBedImageAI &&
                     !disableActions &&
@@ -331,11 +344,13 @@ export function RaisedBedOperationHistoryList({
                             })}
                         />
                     ) : undefined;
-                const action = aiAction ? (
-                    <Row spacing={2} className="flex-wrap justify-end">
-                        {aiAction}
-                    </Row>
-                ) : undefined;
+                const action =
+                    cancelAction || aiAction ? (
+                        <Row spacing={2} className="flex-wrap justify-end">
+                            {cancelAction}
+                            {aiAction}
+                        </Row>
+                    ) : undefined;
 
                 return (
                     <GardenOperationCard

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -41,6 +41,7 @@ export * from './repositories/eventsRepo';
 export * from './repositories/farmsRepo';
 export * from './repositories/feedbacksRepo';
 export * from './repositories/fiscalizationRepo';
+export * from './repositories/gardenDiaryCancelRepo';
 export * from './repositories/gardenDiaryRescheduleRepo';
 export * from './repositories/gardensRepo';
 export * from './repositories/harvestTraceLinksRepo';

--- a/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
@@ -1,0 +1,301 @@
+import { isRaisedBedAbandoned } from '@gredice/js/raisedBeds';
+import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
+import type { EntityStandardized } from '../@types/EntityStandardized';
+import { earnSunflowers } from './accountsRepo';
+import { getEntityFormatted } from './entitiesRepo';
+import { createEvent, knownEvents } from './eventsRepo';
+import {
+    getMinimumDiaryRescheduleDate,
+    isReschedulableFieldPlantStatus,
+    startOfUtcDay,
+} from './gardenDiaryRescheduleRepo';
+import { deleteRaisedBedField, getRaisedBed } from './gardensRepo';
+import { createNotification } from './notificationsRepo';
+import { getOperationsByIds } from './operationsRepo';
+
+export type GardenDiaryCancelStatusCode = 400 | 404 | 409;
+
+export class GardenDiaryCancelError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: GardenDiaryCancelStatusCode,
+    ) {
+        super(message);
+        this.name = 'GardenDiaryCancelError';
+    }
+}
+
+const defaultUserCancelReason = 'Korisnik je otkazao.';
+
+function assertScheduledDateCanCancel(
+    scheduledDate: Date | undefined,
+    referenceDate: Date,
+) {
+    if (!scheduledDate) {
+        throw new GardenDiaryCancelError(
+            'Only scheduled future items can be canceled.',
+            409,
+        );
+    }
+
+    if (
+        startOfUtcDay(scheduledDate).getTime() <
+        getMinimumDiaryRescheduleDate(referenceDate).getTime()
+    ) {
+        throw new GardenDiaryCancelError(
+            'Items scheduled for today or earlier cannot be canceled.',
+            409,
+        );
+    }
+}
+
+function calculateSunflowerRefund(price: number | undefined) {
+    return typeof price === 'number' && price > 0
+        ? Math.round(price * 1000)
+        : 0;
+}
+
+async function operationBelongsToGarden({
+    accountId,
+    gardenId,
+    operation,
+}: {
+    accountId: string;
+    gardenId: number;
+    operation: Awaited<ReturnType<typeof getOperationsByIds>>[number];
+}) {
+    if (operation.accountId !== accountId) {
+        return false;
+    }
+
+    if (operation.gardenId === gardenId && !operation.raisedBedId) {
+        return true;
+    }
+
+    if (!operation.raisedBedId) {
+        return operation.gardenId === gardenId;
+    }
+
+    const raisedBed = await getRaisedBed(operation.raisedBedId);
+    return (
+        Boolean(raisedBed) &&
+        raisedBed?.accountId === accountId &&
+        raisedBed.gardenId === gardenId
+    );
+}
+
+function buildRaisedBedNotificationLink(
+    raisedBedName: string | null | undefined,
+    positionIndex: number | null | undefined,
+) {
+    if (!raisedBedName) {
+        return undefined;
+    }
+
+    return getRaisedBedCloseupUrl(
+        raisedBedName,
+        typeof positionIndex === 'number' ? { positionIndex } : undefined,
+    );
+}
+
+export async function cancelGardenDiaryOperation({
+    accountId,
+    canceledBy,
+    gardenId,
+    operationId,
+    reason = defaultUserCancelReason,
+    referenceDate = new Date(),
+}: {
+    accountId: string;
+    canceledBy: string;
+    gardenId: number;
+    operationId: number;
+    reason?: string;
+    referenceDate?: Date;
+}) {
+    const [operation] = await getOperationsByIds([operationId]);
+    if (
+        !operation ||
+        !(await operationBelongsToGarden({ accountId, gardenId, operation }))
+    ) {
+        throw new GardenDiaryCancelError('Operation not found.', 404);
+    }
+
+    if (operation.status !== 'planned') {
+        throw new GardenDiaryCancelError(
+            'Only planned operations can be canceled.',
+            409,
+        );
+    }
+
+    assertScheduledDateCanCancel(operation.scheduledDate, referenceDate);
+
+    const operationData = await getEntityFormatted<EntityStandardized>(
+        operation.entityId,
+    );
+    const refundAmount = calculateSunflowerRefund(
+        operationData?.prices?.perOperation,
+    );
+    const operationLabel =
+        operationData?.information?.label ??
+        operationData?.information?.name ??
+        `Radnja #${operationId.toString()}`;
+    let content = `Radnja **${operationLabel}** je otkazana.`;
+    let linkUrl: string | undefined;
+
+    if (operation.raisedBedId) {
+        const raisedBed = await getRaisedBed(operation.raisedBedId);
+        if (raisedBed) {
+            const positionIndex = operation.raisedBedFieldId
+                ? raisedBed.fields.find(
+                      (field) => field.id === operation.raisedBedFieldId,
+                  )?.positionIndex
+                : null;
+
+            if (typeof positionIndex === 'number') {
+                content = `Radnja **${operationLabel}** na gredici **${raisedBed.name}** za polje **${positionIndex + 1}** je otkazana.`;
+            } else {
+                content = `Radnja **${operationLabel}** na gredici **${raisedBed.name}** je otkazana.`;
+            }
+
+            linkUrl = buildRaisedBedNotificationLink(
+                raisedBed.name,
+                positionIndex,
+            );
+        }
+    }
+
+    if (refundAmount > 0) {
+        content += `\nSredstva su ti vraćena u iznosu od ${refundAmount} 🌻.`;
+    }
+
+    await createEvent(
+        knownEvents.operations.canceledV1(operationId.toString(), {
+            canceledBy,
+            reason,
+        }),
+    );
+
+    await Promise.all([
+        refundAmount > 0
+            ? earnSunflowers(
+                  accountId,
+                  refundAmount,
+                  `refund:operation:${operationId}`,
+              )
+            : Promise.resolve(),
+        createNotification({
+            accountId,
+            gardenId: operation.gardenId ?? gardenId,
+            raisedBedId: operation.raisedBedId,
+            header: 'Radnja je otkazana',
+            content,
+            linkUrl,
+            timestamp: new Date(),
+        }),
+    ]);
+
+    return {
+        operationId,
+        refundAmount,
+        reason,
+    };
+}
+
+export async function cancelGardenDiaryRaisedBedField({
+    accountId,
+    canceledBy,
+    gardenId,
+    positionIndex,
+    raisedBedId,
+    reason = defaultUserCancelReason,
+    referenceDate = new Date(),
+}: {
+    accountId: string;
+    canceledBy: string;
+    gardenId: number;
+    positionIndex: number;
+    raisedBedId: number;
+    reason?: string;
+    referenceDate?: Date;
+}) {
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (
+        !raisedBed ||
+        raisedBed.accountId !== accountId ||
+        raisedBed.gardenId !== gardenId
+    ) {
+        throw new GardenDiaryCancelError('Raised bed not found.', 404);
+    }
+
+    if (isRaisedBedAbandoned(raisedBed.status)) {
+        throw new GardenDiaryCancelError('Raised bed is abandoned.', 409);
+    }
+
+    const field = raisedBed.fields.find(
+        (candidate) =>
+            candidate.positionIndex === positionIndex && candidate.active,
+    );
+    if (!field?.plantSortId) {
+        throw new GardenDiaryCancelError('Plant field not found.', 404);
+    }
+
+    if (!isReschedulableFieldPlantStatus(field.plantStatus)) {
+        throw new GardenDiaryCancelError(
+            'Only planned plant fields can be canceled.',
+            409,
+        );
+    }
+
+    assertScheduledDateCanCancel(field.plantScheduledDate, referenceDate);
+
+    const plantSortData = await getEntityFormatted<EntityStandardized>(
+        field.plantSortId,
+    );
+    const plantName =
+        plantSortData?.information?.name ?? `Biljka #${field.plantSortId}`;
+    const refundAmount = calculateSunflowerRefund(
+        plantSortData?.prices?.perPlant,
+    );
+    let content = `Sijanje biljke **${plantName}** na gredici **${raisedBed.name}** za polje **${positionIndex + 1}** je otkazano.`;
+
+    if (refundAmount > 0) {
+        content += `\nSredstva su ti vraćena u iznosu od ${refundAmount} 🌻.`;
+    }
+
+    await Promise.all([
+        createEvent(
+            knownEvents.raisedBedFields.deletedV1(
+                `${raisedBedId.toString()}|${positionIndex.toString()}`,
+            ),
+        ),
+        deleteRaisedBedField(raisedBedId, positionIndex),
+        refundAmount > 0
+            ? earnSunflowers(
+                  accountId,
+                  refundAmount,
+                  `refund:raisedBedField:${raisedBedId}:${positionIndex}`,
+              )
+            : Promise.resolve(),
+        createNotification({
+            accountId,
+            gardenId,
+            raisedBedId,
+            header: 'Sijanje je otkazano',
+            content,
+            linkUrl: buildRaisedBedNotificationLink(
+                raisedBed.name,
+                positionIndex,
+            ),
+            timestamp: new Date(),
+        }),
+    ]);
+
+    return {
+        canceledBy,
+        positionIndex,
+        raisedBedId,
+        refundAmount,
+        reason,
+    };
+}

--- a/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
@@ -7,6 +7,7 @@ import { createEvent, knownEvents } from './eventsRepo';
 import {
     getMinimumDiaryRescheduleDate,
     isReschedulableFieldPlantStatus,
+    isReschedulableOperationStatus,
     startOfUtcDay,
 } from './gardenDiaryRescheduleRepo';
 import { deleteRaisedBedField, getRaisedBed } from './gardensRepo';
@@ -121,9 +122,9 @@ export async function cancelGardenDiaryOperation({
         throw new GardenDiaryCancelError('Operation not found.', 404);
     }
 
-    if (operation.status !== 'planned') {
+    if (!isReschedulableOperationStatus(operation.status)) {
         throw new GardenDiaryCancelError(
-            'Only planned operations can be canceled.',
+            'Completed or canceled operations cannot be canceled.',
             409,
         );
     }
@@ -242,7 +243,7 @@ export async function cancelGardenDiaryRaisedBedField({
 
     if (!isReschedulableFieldPlantStatus(field.plantStatus)) {
         throw new GardenDiaryCancelError(
-            'Only planned plant fields can be canceled.',
+            'Only unfinished plant fields can be canceled.',
             409,
         );
     }

--- a/packages/storage/src/repositories/gardenDiaryRescheduleRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryRescheduleRepo.ts
@@ -1,7 +1,7 @@
 import { isRaisedBedAbandoned } from '@gredice/js/raisedBeds';
 import { createEvent, knownEvents } from './eventsRepo';
 import { getRaisedBed } from './gardensRepo';
-import { getOperationsByIds } from './operationsRepo';
+import { getOperationsByIds, unacceptOperation } from './operationsRepo';
 
 export type GardenDiaryRescheduleStatusCode = 400 | 404 | 409;
 
@@ -15,7 +15,15 @@ export class GardenDiaryRescheduleError extends Error {
     }
 }
 
-const reschedulableFieldPlantStatuses = new Set(['new', 'planned']);
+const terminalOperationStatuses = new Set(['completed', 'canceled']);
+const reschedulableFieldPlantStatuses = new Set([
+    'new',
+    'planned',
+    'pendingVerification',
+]);
+const fieldPlantStatusesThatNeedReconfirmation = new Set([
+    'pendingVerification',
+]);
 
 export function startOfUtcDay(date: Date) {
     return new Date(
@@ -61,6 +69,16 @@ export function normalizeDiaryRescheduleDate(
 
 export function isReschedulableFieldPlantStatus(status?: string | null) {
     return !status || reschedulableFieldPlantStatuses.has(status);
+}
+
+export function isReschedulableOperationStatus(status?: string | null) {
+    return !status || !terminalOperationStatuses.has(status);
+}
+
+function shouldResetFieldPlantStatusOnReschedule(status?: string | null) {
+    return Boolean(
+        status && fieldPlantStatusesThatNeedReconfirmation.has(status),
+    );
 }
 
 function assertExistingScheduledDateCanMove(
@@ -129,9 +147,9 @@ export async function rescheduleGardenDiaryOperation({
         throw new GardenDiaryRescheduleError('Operation not found.', 404);
     }
 
-    if (operation.status !== 'planned') {
+    if (!isReschedulableOperationStatus(operation.status)) {
         throw new GardenDiaryRescheduleError(
-            'Only planned operations can be rescheduled.',
+            'Completed or canceled operations cannot be rescheduled.',
             409,
         );
     }
@@ -148,6 +166,7 @@ export async function rescheduleGardenDiaryOperation({
             scheduledDate: normalizedDate.toISOString(),
         }),
     );
+    await unacceptOperation(operationId);
 
     return {
         operationId,
@@ -193,7 +212,7 @@ export async function rescheduleGardenDiaryRaisedBedField({
 
     if (!isReschedulableFieldPlantStatus(field.plantStatus)) {
         throw new GardenDiaryRescheduleError(
-            'Only planned plant fields can be rescheduled.',
+            'Only unfinished plant fields can be rescheduled.',
             409,
         );
     }
@@ -205,14 +224,21 @@ export async function rescheduleGardenDiaryRaisedBedField({
         referenceDate,
     );
 
+    const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
+
     await createEvent(
-        knownEvents.raisedBedFields.plantScheduleV1(
-            `${raisedBedId.toString()}|${positionIndex.toString()}`,
-            {
-                scheduledDate: normalizedDate.toISOString(),
-            },
-        ),
+        knownEvents.raisedBedFields.plantScheduleV1(aggregateId, {
+            scheduledDate: normalizedDate.toISOString(),
+        }),
     );
+
+    if (shouldResetFieldPlantStatusOnReschedule(field.plantStatus)) {
+        await createEvent(
+            knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+                status: 'planned',
+            }),
+        );
+    }
 
     return {
         positionIndex,

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -834,7 +834,17 @@ function summarizePlantCycle(
                 assignedBy = data.assignedBy;
             }
 
-            if (
+            if (plantStatus === 'new' || plantStatus === 'planned') {
+                active = true;
+                toBeRemoved = false;
+                stoppedDate = undefined;
+                plantSowDate = undefined;
+                plantGrowthDate = undefined;
+                plantReadyDate = undefined;
+                plantDeadDate = undefined;
+                plantHarvestedDate = undefined;
+                plantRemovedDate = undefined;
+            } else if (
                 plantStatus === 'pendingVerification' ||
                 plantStatus === 'sowed'
             ) {
@@ -2673,7 +2683,17 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                 ) {
                     assignedBy = data.assignedBy;
                 }
-                if (
+                if (plantStatus === 'new' || plantStatus === 'planned') {
+                    active = true;
+                    toBeRemoved = false;
+                    stoppedDate = undefined;
+                    plantSowDate = undefined;
+                    plantGrowthDate = undefined;
+                    plantReadyDate = undefined;
+                    plantDeadDate = undefined;
+                    plantHarvestedDate = undefined;
+                    plantRemovedDate = undefined;
+                } else if (
                     plantStatus === 'pendingVerification' ||
                     plantStatus === 'sowed'
                 ) {

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -247,6 +247,17 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
                     ? new Date(String(data.scheduledDate))
                     : undefined;
                 scheduledAt = event.createdAt;
+                completedAt = undefined;
+                completedBy = undefined;
+                verifiedAt = undefined;
+                verifiedBy = undefined;
+                error = undefined;
+                errorCode = undefined;
+                canceledBy = undefined;
+                canceledAt = undefined;
+                cancelReason = undefined;
+                imageUrls = undefined;
+                completionNotes = undefined;
             }
         }
 
@@ -948,6 +959,14 @@ export async function acceptOperation(id: number) {
     await storage()
         .update(operations)
         .set({ isAccepted: true })
+        .where(eq(operations.id, id));
+    await bustScheduleCache();
+}
+
+export async function unacceptOperation(id: number) {
+    await storage()
+        .update(operations)
+        .set({ isAccepted: false })
         .where(eq(operations.id, id));
     await bustScheduleCache();
 }

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    acceptOperation,
     cancelGardenDiaryOperation,
     cancelGardenDiaryRaisedBedField,
     createAccount,
@@ -318,6 +319,92 @@ test('rescheduleGardenDiaryOperation schedules planned operations without a date
     );
 });
 
+test('rescheduleGardenDiaryOperation returns confirmed operations to planned and keeps assignment', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await createEvent(
+        knownEvents.operations.assignedV1(operationId.toString(), {
+            assignedUserIds: ['farmer-1'],
+            assignedBy: 'admin-1',
+        }),
+    );
+    await acceptOperation(operationId);
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: 'farmer-1',
+            images: ['https://example.com/confirmed.jpg'],
+            notes: 'Potvrđeno za provjeru.',
+        }),
+    );
+
+    await rescheduleGardenDiaryOperation({
+        accountId,
+        gardenId,
+        operationId,
+        scheduledDate: '2026-06-06',
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const operation = await getOperationById(operationId);
+    assert.equal(operation.status, 'planned');
+    assert.equal(
+        operation.scheduledDate?.toISOString(),
+        '2026-06-06T00:00:00.000Z',
+    );
+    assert.deepEqual(operation.assignedUserIds, ['farmer-1']);
+    assert.equal(operation.assignedBy, 'admin-1');
+    assert.equal(operation.isAccepted, false);
+    assert.equal(operation.completedAt, undefined);
+    assert.equal(operation.completedBy, undefined);
+    assert.equal(operation.imageUrls, undefined);
+    assert.equal(operation.completionNotes, undefined);
+});
+
+test('rescheduleGardenDiaryOperation rejects completed operations', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: 'farmer-1',
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.verifiedV1(operationId.toString(), {
+            verifiedBy: 'admin-1',
+        }),
+    );
+
+    await assert.rejects(
+        () =>
+            rescheduleGardenDiaryOperation({
+                accountId,
+                gardenId,
+                operationId,
+                scheduledDate: '2026-06-06',
+                referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+            }),
+        (error) =>
+            error instanceof GardenDiaryRescheduleError &&
+            error.statusCode === 409,
+    );
+});
+
 test('rescheduleGardenDiaryOperation rejects items scheduled for today', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
@@ -401,6 +488,52 @@ test('rescheduleGardenDiaryRaisedBedField schedules planned sowing without a dat
     );
 });
 
+test('rescheduleGardenDiaryRaisedBedField returns confirmed sowing to planned and keeps assignment', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const aggregateId = `${raisedBedId.toString()}|0`;
+    await createScheduledField({
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            assignedUserIds: ['farmer-1'],
+            assignedBy: 'admin-1',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'pendingVerification',
+        }),
+    );
+
+    await rescheduleGardenDiaryRaisedBedField({
+        accountId,
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-06',
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.equal(field?.plantStatus, 'planned');
+    assert.equal(
+        field?.plantScheduledDate?.toISOString(),
+        '2026-06-06T00:00:00.000Z',
+    );
+    assert.deepEqual(field?.assignedUserIds, ['farmer-1']);
+    assert.equal(field?.assignedBy, 'admin-1');
+    assert.equal(field?.plantSowDate, undefined);
+});
+
 test('rescheduleGardenDiaryRaisedBedField rejects today as the new date', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
@@ -464,6 +597,39 @@ test('cancelGardenDiaryOperation cancels future planned operations with refund a
     assert.equal(notifications.length, 1);
     assert.equal(notifications[0]?.header, 'Radnja je otkazana');
     assert.match(notifications[0]?.content ?? '', /2500 🌻/);
+});
+
+test('cancelGardenDiaryOperation cancels future confirmed operations', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const entityId = await createPricedOperationEntity();
+    const operationId = await createScheduledOperation({
+        accountId,
+        entityId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: 'farmer-1',
+        }),
+    );
+
+    const result = await cancelGardenDiaryOperation({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        operationId,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const operation = await getOperationById(operationId);
+    assert.equal(result.refundAmount, 2500);
+    assert.equal(operation.status, 'canceled');
+    assert.equal(operation.canceledBy, 'user-1');
 });
 
 test('cancelGardenDiaryOperation rejects items scheduled for today', async () => {
@@ -533,6 +699,42 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
     assert.equal(notifications.length, 1);
     assert.equal(notifications[0]?.header, 'Sijanje je otkazano');
     assert.match(notifications[0]?.content ?? '', /1500 🌻/);
+});
+
+test('cancelGardenDiaryRaisedBedField removes future confirmed sowing', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const plantSortId = await createPricedPlantSortEntity();
+    const aggregateId = `${raisedBedId.toString()}|0`;
+
+    await createScheduledField({
+        plantSortId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(aggregateId, {
+            status: 'pendingVerification',
+        }),
+    );
+
+    const result = await cancelGardenDiaryRaisedBedField({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.equal(result.refundAmount, 1500);
+    assert.equal(field, undefined);
 });
 
 test('cancelGardenDiaryRaisedBedField rejects sowing scheduled for today', async () => {

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -1,17 +1,28 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    cancelGardenDiaryOperation,
+    cancelGardenDiaryRaisedBedField,
     createAccount,
+    createAttributeDefinition,
+    createEntity,
     createEvent,
     createOperation,
+    GardenDiaryCancelError,
     GardenDiaryRescheduleError,
+    getAttributeDefinitions,
+    getNotificationsByAccount,
     getOperationById,
     getRaisedBed,
     getRaisedBedDiaryEntries,
     getRaisedBedFieldDiaryEntries,
+    getSunflowers,
     knownEvents,
     rescheduleGardenDiaryOperation,
     rescheduleGardenDiaryRaisedBedField,
+    updateEntity,
+    upsertAttributeValue,
+    upsertEntityType,
     upsertRaisedBedField,
 } from '@gredice/storage';
 import {
@@ -36,20 +47,133 @@ async function createDiaryRescheduleContext() {
     };
 }
 
+async function ensureAttributeDefinition({
+    category,
+    dataType,
+    entityTypeName,
+    label,
+    name,
+}: {
+    category: string;
+    dataType: string;
+    entityTypeName: string;
+    label: string;
+    name: string;
+}) {
+    const existing = (await getAttributeDefinitions(entityTypeName)).find(
+        (definition) =>
+            definition.category === category &&
+            definition.name === name &&
+            definition.dataType === dataType,
+    );
+
+    if (existing) {
+        return existing.id;
+    }
+
+    return createAttributeDefinition({
+        category,
+        dataType,
+        entityTypeName,
+        label,
+        name,
+    });
+}
+
+async function createPricedOperationEntity() {
+    await upsertEntityType({
+        name: 'operation',
+        label: 'Radnja',
+    });
+
+    const labelDefinitionId = await ensureAttributeDefinition({
+        category: 'information',
+        dataType: 'text',
+        entityTypeName: 'operation',
+        label: 'Label',
+        name: 'label',
+    });
+    const priceDefinitionId = await ensureAttributeDefinition({
+        category: 'prices',
+        dataType: 'number',
+        entityTypeName: 'operation',
+        label: 'Price per operation',
+        name: 'perOperation',
+    });
+    const entityId = await createEntity('operation');
+
+    await updateEntity({ id: entityId, state: 'published' });
+    await upsertAttributeValue({
+        attributeDefinitionId: labelDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: 'Zalijevanje',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: priceDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: '2.5',
+    });
+
+    return entityId;
+}
+
+async function createPricedPlantSortEntity() {
+    await upsertEntityType({
+        name: 'plantSort',
+        label: 'Sorta biljke',
+    });
+
+    const nameDefinitionId = await ensureAttributeDefinition({
+        category: 'information',
+        dataType: 'text',
+        entityTypeName: 'plantSort',
+        label: 'Name',
+        name: 'name',
+    });
+    const priceDefinitionId = await ensureAttributeDefinition({
+        category: 'prices',
+        dataType: 'number',
+        entityTypeName: 'plantSort',
+        label: 'Price per plant',
+        name: 'perPlant',
+    });
+    const entityId = await createEntity('plantSort');
+
+    await updateEntity({ id: entityId, state: 'published' });
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName: 'plantSort',
+        entityId,
+        value: 'Cherry rajčica',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: priceDefinitionId,
+        entityTypeName: 'plantSort',
+        entityId,
+        value: '1.5',
+    });
+
+    return entityId;
+}
+
 async function createScheduledOperation({
     accountId,
+    entityId = 1,
     gardenId,
     raisedBedId,
     scheduledDate,
 }: {
     accountId: string;
+    entityId?: number;
     gardenId: number;
     raisedBedId: number;
     scheduledDate: string;
 }) {
     const operationId = await createOperation({
         accountId,
-        entityId: 1,
+        entityId,
         entityTypeName: 'operation',
         gardenId,
         raisedBedId,
@@ -94,10 +218,12 @@ async function createUnscheduledPlannedOperation({
 }
 
 async function createScheduledField({
+    plantSortId = 101,
     raisedBedId,
     positionIndex,
     scheduledDate,
 }: {
+    plantSortId?: number;
     raisedBedId: number;
     positionIndex: number;
     scheduledDate: string;
@@ -111,7 +237,7 @@ async function createScheduledField({
         knownEvents.raisedBedFields.plantPlaceV1(
             `${raisedBedId.toString()}|${positionIndex.toString()}`,
             {
-                plantSortId: '101',
+                plantSortId: plantSortId.toString(),
                 scheduledDate,
             },
         ),
@@ -299,6 +425,146 @@ test('rescheduleGardenDiaryRaisedBedField rejects today as the new date', async 
             error instanceof GardenDiaryRescheduleError &&
             error.statusCode === 400,
     );
+});
+
+test('cancelGardenDiaryOperation cancels future planned operations with refund and notification', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const entityId = await createPricedOperationEntity();
+    const operationId = await createScheduledOperation({
+        accountId,
+        entityId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    const result = await cancelGardenDiaryOperation({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        operationId,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const operation = await getOperationById(operationId);
+    const notifications = await getNotificationsByAccount(
+        accountId,
+        false,
+        0,
+        10,
+    );
+
+    assert.equal(result.refundAmount, 2500);
+    assert.equal(operation.status, 'canceled');
+    assert.equal(operation.canceledBy, 'user-1');
+    assert.equal(operation.cancelReason, 'Korisnik je otkazao.');
+    assert.equal(await getSunflowers(accountId), 3500);
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0]?.header, 'Radnja je otkazana');
+    assert.match(notifications[0]?.content ?? '', /2500 🌻/);
+});
+
+test('cancelGardenDiaryOperation rejects items scheduled for today', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const operationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2026-06-03T00:00:00.000Z',
+    });
+
+    await assert.rejects(
+        () =>
+            cancelGardenDiaryOperation({
+                accountId,
+                canceledBy: 'user-1',
+                gardenId,
+                operationId,
+                referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+            }),
+        (error) =>
+            error instanceof GardenDiaryCancelError && error.statusCode === 409,
+    );
+
+    const operation = await getOperationById(operationId);
+    assert.equal(operation.status, 'planned');
+});
+
+test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund and notification', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const plantSortId = await createPricedPlantSortEntity();
+
+    await createScheduledField({
+        plantSortId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    const result = await cancelGardenDiaryRaisedBedField({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    const notifications = await getNotificationsByAccount(
+        accountId,
+        false,
+        0,
+        10,
+    );
+
+    assert.equal(result.refundAmount, 1500);
+    assert.equal(field, undefined);
+    assert.equal(await getSunflowers(accountId), 2500);
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0]?.header, 'Sijanje je otkazano');
+    assert.match(notifications[0]?.content ?? '', /1500 🌻/);
+});
+
+test('cancelGardenDiaryRaisedBedField rejects sowing scheduled for today', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+
+    await createScheduledField({
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-03T00:00:00.000Z',
+    });
+
+    await assert.rejects(
+        () =>
+            cancelGardenDiaryRaisedBedField({
+                accountId,
+                canceledBy: 'user-1',
+                gardenId,
+                raisedBedId,
+                positionIndex: 0,
+                referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+            }),
+        (error) =>
+            error instanceof GardenDiaryCancelError && error.statusCode === 409,
+    );
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.positionIndex === 0,
+    );
+    assert.equal(field?.active, true);
 });
 
 test('diary entries expose operation and field reschedule targets', async () => {


### PR DESCRIPTION
## Summary
- Add API endpoints to cancel planned diary operations and raised-bed sowing entries, including refund handling and error mapping.
- Surface cancel actions in the garden operations HUD and raised-bed diary UI when entries are eligible.
- Add storage repository coverage and UI tests for cancel confirmation and refund behavior.

## Testing
- Unit tests added for cancel repository flows, including success and 409 rejection cases.
- UI testing added for the raised-bed diary cancel confirmation flow.
- Not run (not requested)