### PR TITLE
Add achievements for accepted community edits

### DIFF
--- a/packages/game/src/shared-ui/achievements/AchievementsOverview.tsx
+++ b/packages/game/src/shared-ui/achievements/AchievementsOverview.tsx
@@ -20,6 +20,7 @@ const categoryLabels: Record<string, string> = {
     planting: 'Sadnja',
     watering: 'Zalijevanje',
     harvest: 'Branje',
+    community_editing: 'Sadržaj',
 };
 
 const statusStyles: Record<

--- a/packages/js/src/achievements/definitions.ts
+++ b/packages/js/src/achievements/definitions.ts
@@ -2,7 +2,8 @@ export type AchievementCategory =
     | 'registration'
     | 'planting'
     | 'watering'
-    | 'harvest';
+    | 'harvest'
+    | 'community_editing';
 
 export type AchievementStatus = 'pending' | 'approved' | 'denied';
 
@@ -56,6 +57,16 @@ const harvestThresholds: Array<[threshold: number, reward: number]> = [
     [500, 50_000],
 ];
 
+// TODO: Balance the rewards
+const communityEditingThresholds: Array<[threshold: number, reward: number]> = [
+    [1, 100],
+    [5, 250],
+    [10, 500],
+    [25, 1_000],
+    [50, 2_000],
+    [100, 5_000],
+];
+
 function plantingTitle(threshold: number) {
     if (threshold === 1) {
         return 'Prvo sjeme';
@@ -75,6 +86,23 @@ function harvestTitle(threshold: number) {
         return 'Prva berba';
     }
     return `${threshold} berbi`;
+}
+
+function communityEditingTitle(threshold: number) {
+    switch (threshold) {
+        case 1:
+            return 'Prvi doprinos';
+        case 5:
+            return 'Pouzdani urednik';
+        case 10:
+            return 'Čuvar sadržaja';
+        case 25:
+            return 'Znalac zajednice';
+        case 50:
+            return 'Majstor sadržaja';
+        default:
+            return `${threshold} prihvaćenih izmjena`;
+    }
 }
 
 export const achievementDefinitions: AchievementDefinition[] = [
@@ -114,6 +142,18 @@ export const achievementDefinitions: AchievementDefinition[] = [
         title: harvestTitle(threshold),
         description: `Uberi biljke ${threshold} puta.`,
         sortOrder: 300 + index,
+    })),
+    ...communityEditingThresholds.map(([threshold, reward], index) => ({
+        key: `community_edit_${threshold}`,
+        category: 'community_editing' as const,
+        threshold,
+        rewardSunflowers: reward,
+        title: communityEditingTitle(threshold),
+        description:
+            threshold === 1
+                ? 'Neka tvoj prvi prijedlog izmjene sadržaja bude prihvaćen.'
+                : `Neka ${threshold} tvojih prijedloga izmjene sadržaja bude prihvaćeno.`,
+        sortOrder: 400 + index,
     })),
 ];
 

--- a/packages/storage/src/repositories/achievementsRepo.ts
+++ b/packages/storage/src/repositories/achievementsRepo.ts
@@ -9,6 +9,8 @@ import {
     type AccountSunflowersPayload,
     accountAchievements,
     accounts,
+    accountUsers,
+    communityEditRequests,
     type EntityStandardized,
     earnSunflowers,
     events,
@@ -277,6 +279,164 @@ interface AchievementPlan {
     skipReward?: boolean;
 }
 
+interface CommunityEditAchievementSource {
+    requestId: number;
+    accountId: string;
+    earnedAt: Date;
+}
+
+function addThresholdPlans(input: {
+    plans: AchievementPlan[];
+    existingByAccount: Map<string, Set<string>>;
+    plannedByAccount: Map<string, Set<string>>;
+    accountId: string;
+    count: number;
+    earnedAt: Date;
+    definitions: AchievementDefinition[];
+}) {
+    const existing = input.existingByAccount.get(input.accountId) ?? new Set();
+    const planned = ensureAccountSet(input.plannedByAccount, input.accountId);
+    for (const definition of input.definitions) {
+        const threshold = definition.threshold ?? 0;
+        if (
+            input.count >= threshold &&
+            !existing.has(definition.key) &&
+            !planned.has(definition.key)
+        ) {
+            input.plans.push({
+                accountId: input.accountId,
+                definition,
+                earnedAt: input.earnedAt,
+                progressValue: input.count,
+            });
+            planned.add(definition.key);
+        }
+    }
+}
+
+function addCommunityEditAchievementPlans(input: {
+    sources: CommunityEditAchievementSource[];
+    definitions: AchievementDefinition[];
+    existingByAccount: Map<string, Set<string>>;
+    plannedByAccount: Map<string, Set<string>>;
+    plans: AchievementPlan[];
+}) {
+    const counters = new Map<string, number>();
+    const seenRequestIds = new Set<number>();
+    for (const source of input.sources) {
+        if (seenRequestIds.has(source.requestId)) {
+            continue;
+        }
+        seenRequestIds.add(source.requestId);
+
+        const nextCount = (counters.get(source.accountId) ?? 0) + 1;
+        counters.set(source.accountId, nextCount);
+        addThresholdPlans({
+            plans: input.plans,
+            existingByAccount: input.existingByAccount,
+            plannedByAccount: input.plannedByAccount,
+            accountId: source.accountId,
+            count: nextCount,
+            earnedAt: source.earnedAt,
+            definitions: input.definitions,
+        });
+    }
+}
+
+async function createPlannedAchievements(
+    plans: AchievementPlan[],
+    existingByAccount: Map<string, Set<string>>,
+) {
+    let created = 0;
+    for (const plan of plans) {
+        const result = await createAccountAchievement(
+            plan.accountId,
+            plan.definition.key,
+            {
+                earnedAt: plan.earnedAt,
+                progressValue: plan.progressValue,
+                threshold: plan.definition.threshold ?? null,
+                skipReward: plan.skipReward,
+            },
+        );
+        if (result.created) {
+            created += 1;
+            ensureAccountSet(existingByAccount, plan.accountId).add(
+                plan.definition.key,
+            );
+        }
+    }
+
+    return { created, attempts: plans.length };
+}
+
+export async function evaluateCommunityEditAchievementsForSubmitter(
+    userId: string,
+) {
+    const [primaryAccountUser] = await storage()
+        .select({ accountId: accountUsers.accountId })
+        .from(accountUsers)
+        .where(eq(accountUsers.userId, userId))
+        .orderBy(asc(accountUsers.createdAt), asc(accountUsers.id))
+        .limit(1);
+
+    if (!primaryAccountUser) {
+        return { created: 0, attempts: 0 };
+    }
+
+    const [existingAchievements, appliedRequests] = await Promise.all([
+        storage()
+            .select({ achievementKey: accountAchievements.achievementKey })
+            .from(accountAchievements)
+            .where(
+                eq(accountAchievements.accountId, primaryAccountUser.accountId),
+            ),
+        storage()
+            .select({
+                requestId: communityEditRequests.id,
+                appliedAt: communityEditRequests.appliedAt,
+                reviewedAt: communityEditRequests.reviewedAt,
+                createdAt: communityEditRequests.createdAt,
+            })
+            .from(communityEditRequests)
+            .where(
+                and(
+                    eq(communityEditRequests.submitterUserId, userId),
+                    eq(communityEditRequests.status, 'applied'),
+                ),
+            )
+            .orderBy(
+                asc(communityEditRequests.appliedAt),
+                asc(communityEditRequests.id),
+            ),
+    ]);
+
+    const existingByAccount = new Map<string, Set<string>>();
+    const existingKeys = ensureAccountSet(
+        existingByAccount,
+        primaryAccountUser.accountId,
+    );
+    for (const achievement of existingAchievements) {
+        existingKeys.add(achievement.achievementKey);
+    }
+
+    const plans: AchievementPlan[] = [];
+    addCommunityEditAchievementPlans({
+        sources: appliedRequests.map((request) => ({
+            requestId: request.requestId,
+            accountId: primaryAccountUser.accountId,
+            earnedAt:
+                request.appliedAt ?? request.reviewedAt ?? request.createdAt,
+        })),
+        definitions: getDefinitionsByCategory('community_editing'),
+        existingByAccount,
+        plannedByAccount: new Map(),
+        plans,
+    });
+
+    return createPlannedAchievements(plans, existingByAccount);
+}
+
 function parseRaisedBedId(aggregateId: string) {
     const [raisedBedPart] = aggregateId.split('|');
     const raisedBedId = Number.parseInt(raisedBedPart ?? '', 10);
@@ -319,33 +479,58 @@ function isHarvestOperation(entity: EntityStandardized | null | undefined) {
 }
 
 export async function evaluateAchievements() {
-    const [accountsList, existingAchievements, raisedBedList, operationsList] =
-        await Promise.all([
-            storage()
-                .select({ id: accounts.id, createdAt: accounts.createdAt })
-                .from(accounts),
-            storage()
-                .select({
-                    accountId: accountAchievements.accountId,
-                    achievementKey: accountAchievements.achievementKey,
-                })
-                .from(accountAchievements),
-            storage()
-                .select({
-                    id: raisedBeds.id,
-                    accountId: raisedBeds.accountId,
-                })
-                .from(raisedBeds)
-                .where(isNotNull(raisedBeds.accountId)),
-            storage()
-                .select({
-                    id: operations.id,
-                    accountId: operations.accountId,
-                    entityId: operations.entityId,
-                })
-                .from(operations)
-                .where(eq(operations.isDeleted, false)),
-        ]);
+    const [
+        accountsList,
+        existingAchievements,
+        raisedBedList,
+        operationsList,
+        communityEditAchievementRows,
+    ] = await Promise.all([
+        storage()
+            .select({ id: accounts.id, createdAt: accounts.createdAt })
+            .from(accounts),
+        storage()
+            .select({
+                accountId: accountAchievements.accountId,
+                achievementKey: accountAchievements.achievementKey,
+            })
+            .from(accountAchievements),
+        storage()
+            .select({
+                id: raisedBeds.id,
+                accountId: raisedBeds.accountId,
+            })
+            .from(raisedBeds)
+            .where(isNotNull(raisedBeds.accountId)),
+        storage()
+            .select({
+                id: operations.id,
+                accountId: operations.accountId,
+                entityId: operations.entityId,
+            })
+            .from(operations)
+            .where(eq(operations.isDeleted, false)),
+        storage()
+            .select({
+                requestId: communityEditRequests.id,
+                accountId: accountUsers.accountId,
+                appliedAt: communityEditRequests.appliedAt,
+                reviewedAt: communityEditRequests.reviewedAt,
+                createdAt: communityEditRequests.createdAt,
+            })
+            .from(communityEditRequests)
+            .innerJoin(
+                accountUsers,
+                eq(accountUsers.userId, communityEditRequests.submitterUserId),
+            )
+            .where(eq(communityEditRequests.status, 'applied'))
+            .orderBy(
+                asc(communityEditRequests.appliedAt),
+                asc(communityEditRequests.id),
+                asc(accountUsers.createdAt),
+                asc(accountUsers.id),
+            ),
+    ]);
 
     const existingByAccount = new Map<string, Set<string>>();
     for (const achievement of existingAchievements) {
@@ -378,6 +563,8 @@ export async function evaluateAchievements() {
     const plantingDefinitions = getDefinitionsByCategory('planting');
     const harvestDefinitions = getDefinitionsByCategory('harvest');
     const wateringDefinitions = getDefinitionsByCategory('watering');
+    const communityEditDefinitions =
+        getDefinitionsByCategory('community_editing');
 
     const plantingCounters = new Map<string, number>();
     const harvestCounters = new Map<string, number>();
@@ -498,6 +685,18 @@ export async function evaluateAchievements() {
         }
     }
 
+    addCommunityEditAchievementPlans({
+        sources: communityEditAchievementRows.map((row) => ({
+            requestId: row.requestId,
+            accountId: row.accountId,
+            earnedAt: row.appliedAt ?? row.reviewedAt ?? row.createdAt,
+        })),
+        definitions: communityEditDefinitions,
+        existingByAccount,
+        plannedByAccount,
+        plans,
+    });
+
     const registrationDefinition = definitionForKey('registration');
     const registrationEvents = await storage().query.events.findMany({
         where: and(
@@ -539,25 +738,5 @@ export async function evaluateAchievements() {
         ensureAccountSet(plannedByAccount, account.id).add('registration');
     }
 
-    let created = 0;
-    for (const plan of plans) {
-        const result = await createAccountAchievement(
-            plan.accountId,
-            plan.definition.key,
-            {
-                earnedAt: plan.earnedAt,
-                progressValue: plan.progressValue,
-                threshold: plan.definition.threshold ?? null,
-                skipReward: plan.skipReward,
-            },
-        );
-        if (result.created) {
-            created += 1;
-            ensureAccountSet(existingByAccount, plan.accountId).add(
-                plan.definition.key,
-            );
-        }
-    }
-
-    return { created, attempts: plans.length };
+    return createPlannedAchievements(plans, existingByAccount);
 }

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -16,6 +16,7 @@ import {
     type SelectCommunityEditRequest,
 } from '../schema';
 import { storage } from '../storage';
+import { evaluateCommunityEditAchievementsForSubmitter } from './achievementsRepo';
 import {
     createAttributeValueMutationSideEffects,
     deleteAttributeValue,
@@ -1297,5 +1298,20 @@ export async function approveCommunityEditRequest(input: {
             `Request ${request.id} was not found after applying.`,
         );
     }
+
+    try {
+        await evaluateCommunityEditAchievementsForSubmitter(
+            applied.submitterUserId,
+        );
+    } catch (error) {
+        console.error(
+            'Failed to evaluate community edit achievements after approval',
+            {
+                requestId: applied.id,
+                error,
+            },
+        );
+    }
+
     return applied;
 }

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -2,11 +2,14 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    accountUsers,
     approveCommunityEditRequest,
     CommunityEditRequestError,
+    createAccount,
     createAttributeDefinition,
     createCommunityEditRequest,
     createEntity,
+    getAccountAchievements,
     getCommunityEditableFieldsForEntity,
     getCommunityEditRequest,
     getEntityRaw,
@@ -332,6 +335,76 @@ test('community edit approval applies through attribute mutations and revisions'
                 revision.nextValue === 'Odobreni opis.',
         ),
     );
+});
+
+test('accepted community edit requests count toward content editing achievements', async () => {
+    const data = await fixture();
+    const suffix = randomUUID();
+    const submitterId = `community-achievement-submit-${suffix}`;
+    await storage()
+        .insert(users)
+        .values({
+            id: submitterId,
+            userName: `community-achievement-${suffix}`,
+            displayName: 'Community Achievement Submitter',
+            role: 'user',
+        });
+    const accountId = await createAccount();
+    await storage().insert(accountUsers).values({
+        accountId,
+        userId: submitterId,
+    });
+
+    const plantId = await createPublishedPlant();
+    const [descriptionField] = (
+        await getCommunityEditableFieldsForEntity({
+            entityTypeName: 'plant',
+            entityId: plantId,
+            sectionKey: 'overview',
+        })
+    ).filter((field) => field.fieldKey === 'plant.description');
+    assert.ok(descriptionField);
+
+    const request = await createCommunityEditRequest({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        publicPath: '/biljke/test',
+        sectionKey: 'overview',
+        submitter: {
+            id: submitterId,
+            name: 'Community Achievement Submitter',
+        },
+        changes: [
+            {
+                fieldKey: 'plant.description',
+                baseValueHash: descriptionField.baseValueHash,
+                proposedValue: 'Opis koji donosi postignuće.',
+            },
+        ],
+    });
+
+    const beforeApproval = await getAccountAchievements(accountId);
+    assert.equal(
+        beforeApproval.some(
+            (achievement) => achievement.achievementKey === 'community_edit_1',
+        ),
+        false,
+    );
+
+    const applied = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(applied.status, 'applied');
+
+    const achievements = await getAccountAchievements(accountId);
+    const contentAchievement = achievements.find(
+        (achievement) => achievement.achievementKey === 'community_edit_1',
+    );
+    assert.ok(contentAchievement);
+    assert.equal(contentAchievement.status, 'pending');
+    assert.equal(contentAchievement.progressValue, 1);
+    assert.equal(contentAchievement.threshold, 1);
 });
 
 test('community edit approval rolls back all attribute writes when a later change fails', async () => {


### PR DESCRIPTION
## Summary
- Add a new `community_editing` achievement category with thresholds for accepted community edits.
- Count applied community edit requests toward achievement progress and create the first milestone when a submission is accepted.
- Surface the new category in the achievements overview UI.
- Add a storage regression test covering the approval-to-achievement flow.

## Testing
- `pnpm --filter @gredice/storage test:node communityEditRequestsRepo.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- Scoped Biome checks passed for the touched files.