### PR TITLE
Show pending community edit badge in nav

### DIFF
--- a/apps/app/app/admin/community-edits/CommunityEditsFilters.tsx
+++ b/apps/app/app/admin/community-edits/CommunityEditsFilters.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Check, FileText, Hourglass, User } from '@gredice/ui/icons';
+import {
+    type FilterOption,
+    TableFilter,
+} from '../../../components/shared/filters';
+import {
+    AGE_OPTIONS,
+    ageLabel,
+    ENTITY_TYPE_OPTIONS,
+    entityTypeLabel,
+    STATUS_OPTIONS,
+    statusLabel,
+} from './communityEditLabels';
+
+export type CommunityEditSubmitterFilterOption = {
+    value: string;
+    label: string;
+};
+
+type CommunityEditsFiltersProps = {
+    submitters: CommunityEditSubmitterFilterOption[];
+};
+
+const STATUS_FILTER_OPTIONS: FilterOption = {
+    key: 'status',
+    label: 'Status',
+    icon: <Check className="size-4" />,
+    options: [
+        { value: '', label: 'Svi statusi' },
+        ...STATUS_OPTIONS.filter((status) => status !== 'all').map(
+            (status) => ({
+                value: status,
+                label: statusLabel(status),
+            }),
+        ),
+    ],
+};
+
+const ENTITY_TYPE_FILTER_OPTIONS: FilterOption = {
+    key: 'entityType',
+    label: 'Tip zapisa',
+    icon: <FileText className="size-4" />,
+    options: [
+        { value: '', label: 'Svi zapisi' },
+        ...ENTITY_TYPE_OPTIONS.filter((entityType) => entityType !== 'all').map(
+            (entityType) => ({
+                value: entityType,
+                label: entityTypeLabel(entityType),
+            }),
+        ),
+    ],
+};
+
+const AGE_FILTER_OPTIONS: FilterOption = {
+    key: 'age',
+    label: 'Dob',
+    icon: <Hourglass className="size-4" />,
+    options: [
+        { value: '', label: ageLabel('all') },
+        ...AGE_OPTIONS.filter((age) => age !== 'all').map((age) => ({
+            value: age,
+            label: ageLabel(age),
+        })),
+    ],
+};
+
+export function CommunityEditsFilters({
+    submitters,
+}: CommunityEditsFiltersProps) {
+    const submitterFilterOptions: FilterOption = {
+        key: 'submitter',
+        label: 'Pošiljatelj',
+        icon: <User className="size-4" />,
+        options: [{ value: '', label: 'Svi pošiljatelji' }, ...submitters],
+    };
+
+    return (
+        <TableFilter
+            filters={[
+                STATUS_FILTER_OPTIONS,
+                ENTITY_TYPE_FILTER_OPTIONS,
+                AGE_FILTER_OPTIONS,
+                submitterFilterOptions,
+            ]}
+            defaultValues={{
+                status: '',
+                entityType: '',
+                age: '',
+                submitter: '',
+            }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/community-edits/actions.ts
+++ b/apps/app/app/admin/community-edits/actions.ts
@@ -30,6 +30,7 @@ function formNote(formData: FormData) {
 }
 
 async function revalidateCommunityEditAdminPaths(requestId: number) {
+    revalidatePath(KnownPages.Dashboard, 'layout');
     revalidatePath(KnownPages.CommunityEdits);
     revalidatePath(KnownPages.CommunityEdit(requestId));
 }

--- a/apps/app/app/admin/community-edits/communityEditLabels.ts
+++ b/apps/app/app/admin/community-edits/communityEditLabels.ts
@@ -1,0 +1,85 @@
+export const STATUS_OPTIONS = [
+    'all',
+    'pending',
+    'conflicted',
+    'approved',
+    'applied',
+    'rejected',
+    'canceled',
+] as const;
+
+const STATUS_OPTION_VALUES: readonly string[] = STATUS_OPTIONS;
+
+export const ENTITY_TYPE_OPTIONS = [
+    'all',
+    'plant',
+    'plantSort',
+    'operation',
+    'block',
+] as const;
+
+export const AGE_OPTIONS = ['all', 'day', 'week', 'older'] as const;
+
+const AGE_OPTION_VALUES: readonly string[] = AGE_OPTIONS;
+
+export type StatusOption = (typeof STATUS_OPTIONS)[number];
+export type AgeOption = (typeof AGE_OPTIONS)[number];
+
+export function statusLabel(status: StatusOption | string) {
+    switch (status) {
+        case 'all':
+            return 'Svi';
+        case 'pending':
+            return 'Na čekanju';
+        case 'approved':
+            return 'Odobreno';
+        case 'applied':
+            return 'Primijenjeno';
+        case 'rejected':
+            return 'Odbijeno';
+        case 'conflicted':
+            return 'Konflikt';
+        case 'canceled':
+            return 'Otkazano';
+        default:
+            return status;
+    }
+}
+
+export function entityTypeLabel(entityTypeName: string) {
+    switch (entityTypeName) {
+        case 'plant':
+            return 'Biljka';
+        case 'plantSort':
+            return 'Sorta';
+        case 'operation':
+            return 'Radnja';
+        case 'block':
+            return 'Blok';
+        default:
+            return entityTypeName;
+    }
+}
+
+export function isStatusOption(
+    value: string | undefined,
+): value is StatusOption {
+    return typeof value === 'string' && STATUS_OPTION_VALUES.includes(value);
+}
+
+export function isAgeOption(value: string | undefined): value is AgeOption {
+    return typeof value === 'string' && AGE_OPTION_VALUES.includes(value);
+}
+
+export function ageLabel(age: AgeOption) {
+    switch (age) {
+        case 'all':
+            return 'Sva dob';
+        case 'day':
+            return 'Zadnja 24 h';
+        case 'week':
+            return '2-7 dana';
+        case 'older':
+            return 'Starije';
+    }
+}

--- a/apps/app/app/admin/community-edits/page.tsx
+++ b/apps/app/app/admin/community-edits/page.tsx
@@ -90,9 +90,14 @@ function requestMatchesSubmitter(
         'submitterName' | 'submitterEmail' | 'submitterUserId'
     >,
     submitter: string,
+    exactSubmitterIds: ReadonlySet<string>,
 ) {
     if (!submitter) {
         return true;
+    }
+
+    if (exactSubmitterIds.has(submitter)) {
+        return request.submitterUserId === submitter;
     }
 
     const query = submitter.toLowerCase();
@@ -158,15 +163,18 @@ export default async function CommunityEditsPage({
     const selectedAge = isAgeOption(rawAge) ? rawAge : 'all';
 
     const allRequests = await listCommunityEditRequests();
+    const submitterFilterOptions = buildSubmitterFilterOptions(allRequests);
+    const exactSubmitterIds = new Set(
+        submitterFilterOptions.map((option) => option.value),
+    );
     const filteredRequests = allRequests.filter(
         (request) =>
             (selectedStatus === 'all' || request.status === selectedStatus) &&
             (selectedEntityType === 'all' ||
                 request.entityTypeName === selectedEntityType) &&
             requestMatchesAge(request, selectedAge) &&
-            requestMatchesSubmitter(request, submitter),
+            requestMatchesSubmitter(request, submitter, exactSubmitterIds),
     );
-    const submitterFilterOptions = buildSubmitterFilterOptions(allRequests);
 
     return (
         <Stack spacing={4}>

--- a/apps/app/app/admin/community-edits/page.tsx
+++ b/apps/app/app/admin/community-edits/page.tsx
@@ -2,59 +2,48 @@ import {
     type CommunityEditRequestStatus,
     listCommunityEditRequests,
 } from '@gredice/storage';
-import { Button } from '@gredice/ui/Button';
 import { Card, CardOverflow } from '@gredice/ui/Card';
 import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
-import { Input } from '@gredice/ui/Input';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
+import {
+    type CommunityEditSubmitterFilterOption,
+    CommunityEditsFilters,
+} from './CommunityEditsFilters';
+import {
+    type AgeOption,
+    entityTypeLabel,
+    isAgeOption,
+    isStatusOption,
+    statusLabel,
+} from './communityEditLabels';
 
 export const dynamic = 'force-dynamic';
 
-const STATUS_OPTIONS = [
-    'all',
-    'pending',
-    'conflicted',
-    'approved',
-    'applied',
-    'rejected',
-    'canceled',
-] as const;
-
-const ENTITY_TYPE_OPTIONS = ['all', 'plant', 'plantSort', 'operation', 'block'];
-
-const AGE_OPTIONS = ['all', 'day', 'week', 'older'] as const;
-
-type StatusOption = (typeof STATUS_OPTIONS)[number];
-type AgeOption = (typeof AGE_OPTIONS)[number];
 type CommunityEditRequestListItem = Awaited<
     ReturnType<typeof listCommunityEditRequests>
 >[number];
 
-function statusLabel(status: CommunityEditRequestStatus | StatusOption) {
-    switch (status) {
-        case 'all':
-            return 'Svi';
-        case 'pending':
-            return 'Na čekanju';
-        case 'approved':
-            return 'Odobreno';
-        case 'applied':
-            return 'Primijenjeno';
-        case 'rejected':
-            return 'Odbijeno';
-        case 'conflicted':
-            return 'Konflikt';
-        case 'canceled':
-            return 'Otkazano';
-    }
+const REQUEST_STATUS_VALUES: readonly string[] = [
+    'applied',
+    'approved',
+    'canceled',
+    'conflicted',
+    'pending',
+    'rejected',
+];
+
+function isCommunityEditRequestStatus(
+    status: string,
+): status is CommunityEditRequestStatus {
+    return REQUEST_STATUS_VALUES.includes(status);
 }
 
 function statusColor(status: CommunityEditRequestStatus): ColorPaletteProp {
@@ -71,55 +60,6 @@ function statusColor(status: CommunityEditRequestStatus): ColorPaletteProp {
         case 'conflicted':
             return 'error';
     }
-}
-
-function entityTypeLabel(entityTypeName: string) {
-    switch (entityTypeName) {
-        case 'plant':
-            return 'Biljka';
-        case 'plantSort':
-            return 'Sorta';
-        case 'operation':
-            return 'Radnja';
-        case 'block':
-            return 'Blok';
-        default:
-            return entityTypeName;
-    }
-}
-
-function isStatusOption(value: string | undefined): value is StatusOption {
-    return STATUS_OPTIONS.includes(value as StatusOption);
-}
-
-function isAgeOption(value: string | undefined): value is AgeOption {
-    return AGE_OPTIONS.includes(value as AgeOption);
-}
-
-function buildFilterHref(params: {
-    status?: StatusOption;
-    entityType?: string;
-    submitter?: string;
-    age?: AgeOption;
-}) {
-    const search = new URLSearchParams();
-    if (params.status && params.status !== 'all') {
-        search.set('status', params.status);
-    }
-    if (params.entityType && params.entityType !== 'all') {
-        search.set('entityType', params.entityType);
-    }
-    if (params.submitter) {
-        search.set('submitter', params.submitter);
-    }
-    if (params.age && params.age !== 'all') {
-        search.set('age', params.age);
-    }
-
-    const query = search.toString();
-    return query
-        ? `${KnownPages.CommunityEdits}?${query}`
-        : KnownPages.CommunityEdits;
 }
 
 function requestMatchesAge(
@@ -163,17 +103,39 @@ function requestMatchesSubmitter(
     ].some((value) => value?.toLowerCase().includes(query));
 }
 
-function ageLabel(age: AgeOption) {
-    switch (age) {
-        case 'all':
-            return 'Sva dob';
-        case 'day':
-            return 'Zadnja 24 h';
-        case 'week':
-            return '2-7 dana';
-        case 'older':
-            return 'Starije';
+function submitterDisplayName(request: CommunityEditRequestListItem) {
+    return (
+        request.submitter?.displayName ??
+        request.submitterName ??
+        request.submitter?.userName ??
+        request.submitterUserId
+    );
+}
+
+function submitterFilterLabel(request: CommunityEditRequestListItem) {
+    const displayName = submitterDisplayName(request);
+    return request.submitterEmail
+        ? `${displayName} (${request.submitterEmail})`
+        : displayName;
+}
+
+function buildSubmitterFilterOptions(
+    requests: CommunityEditRequestListItem[],
+): CommunityEditSubmitterFilterOption[] {
+    const submittersById = new Map<string, string>();
+    for (const request of requests) {
+        if (!submittersById.has(request.submitterUserId)) {
+            submittersById.set(
+                request.submitterUserId,
+                submitterFilterLabel(request),
+            );
+        }
     }
+
+    return Array.from(submittersById, ([value, label]) => ({
+        value,
+        label,
+    })).sort((left, right) => left.label.localeCompare(right.label, 'hr'));
 }
 
 export default async function CommunityEditsPage({
@@ -204,102 +166,15 @@ export default async function CommunityEditsPage({
             requestMatchesAge(request, selectedAge) &&
             requestMatchesSubmitter(request, submitter),
     );
-    const statusCounts = new Map<CommunityEditRequestStatus, number>();
-    for (const request of allRequests) {
-        statusCounts.set(
-            request.status as CommunityEditRequestStatus,
-            (statusCounts.get(request.status as CommunityEditRequestStatus) ??
-                0) + 1,
-        );
-    }
+    const submitterFilterOptions = buildSubmitterFilterOptions(allRequests);
 
     return (
         <Stack spacing={4}>
-            <Row spacing={2} className="flex-wrap gap-2">
-                <Chip color="primary">{filteredRequests.length}</Chip>
-                <Typography level="body2" className="text-muted-foreground">
-                    Prijedlozi za javni sadržaj direktorija
-                </Typography>
-            </Row>
+            <Typography level="body2" className="text-muted-foreground">
+                Prijedlozi za javni sadržaj direktorija
+            </Typography>
 
-            <Row spacing={2} className="flex-wrap gap-2">
-                {STATUS_OPTIONS.map((status) => {
-                    const isActive = selectedStatus === status;
-                    const count =
-                        status === 'all'
-                            ? allRequests.length
-                            : (statusCounts.get(status) ?? 0);
-                    return (
-                        <Chip
-                            key={status}
-                            color={isActive ? 'primary' : 'neutral'}
-                            href={buildFilterHref({
-                                status,
-                                entityType: selectedEntityType,
-                                submitter,
-                                age: selectedAge,
-                            })}
-                        >
-                            {statusLabel(status)} ({count})
-                        </Chip>
-                    );
-                })}
-            </Row>
-
-            <form action={KnownPages.CommunityEdits}>
-                <Row spacing={2} className="flex-wrap items-end gap-2">
-                    <label className="space-y-1">
-                        <Typography level="body2">Tip zapisa</Typography>
-                        <select
-                            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                            defaultValue={selectedEntityType}
-                            name="entityType"
-                        >
-                            {ENTITY_TYPE_OPTIONS.map((option) => (
-                                <option key={option} value={option}>
-                                    {option === 'all'
-                                        ? 'Svi zapisi'
-                                        : entityTypeLabel(option)}
-                                </option>
-                            ))}
-                        </select>
-                    </label>
-                    <label className="space-y-1">
-                        <Typography level="body2">Dob</Typography>
-                        <select
-                            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                            defaultValue={selectedAge}
-                            name="age"
-                        >
-                            {AGE_OPTIONS.map((option) => (
-                                <option key={option} value={option}>
-                                    {ageLabel(option)}
-                                </option>
-                            ))}
-                        </select>
-                    </label>
-                    <Input
-                        defaultValue={submitter}
-                        fullWidth
-                        label="Pošiljatelj"
-                        name="submitter"
-                        placeholder="Ime, email ili ID"
-                    />
-                    {selectedStatus !== 'all' ? (
-                        <input
-                            name="status"
-                            type="hidden"
-                            value={selectedStatus}
-                        />
-                    ) : null}
-                    <Button type="submit" variant="outlined">
-                        Filtriraj
-                    </Button>
-                    <Button href={KnownPages.CommunityEdits} variant="plain">
-                        Resetiraj
-                    </Button>
-                </Row>
-            </form>
+            <CommunityEditsFilters submitters={submitterFilterOptions} />
 
             <Card>
                 <CardOverflow>
@@ -325,68 +200,113 @@ export default async function CommunityEditsPage({
                                         </Table.Cell>
                                     </Table.Row>
                                 )}
-                                {filteredRequests.map((request) => (
-                                    <Table.Row key={request.id}>
-                                        <Table.Cell>
-                                            <Chip
-                                                color={statusColor(
-                                                    request.status as CommunityEditRequestStatus,
-                                                )}
-                                                size="sm"
-                                                variant="soft"
-                                            >
-                                                {statusLabel(
-                                                    request.status as CommunityEditRequestStatus,
-                                                )}
-                                            </Chip>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Stack spacing={1}>
-                                                <Link
-                                                    href={KnownPages.CommunityEdit(
-                                                        request.id,
+                                {filteredRequests.map((request) => {
+                                    const requestStatus =
+                                        isCommunityEditRequestStatus(
+                                            request.status,
+                                        )
+                                            ? request.status
+                                            : null;
+                                    const displayName =
+                                        submitterDisplayName(request);
+
+                                    return (
+                                        <Table.Row key={request.id}>
+                                            <Table.Cell>
+                                                <Chip
+                                                    color={
+                                                        requestStatus
+                                                            ? statusColor(
+                                                                  requestStatus,
+                                                              )
+                                                            : 'neutral'
+                                                    }
+                                                    size="sm"
+                                                    variant="soft"
+                                                >
+                                                    {statusLabel(
+                                                        request.status,
                                                     )}
-                                                >
-                                                    {entityTypeLabel(
-                                                        request.entityTypeName,
-                                                    )}{' '}
-                                                    #{request.entityId}
-                                                </Link>
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-muted-foreground"
-                                                >
-                                                    {request.sectionKey ??
-                                                        'Cijela stranica'}
-                                                </Typography>
-                                            </Stack>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {request.changes.length}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Stack spacing={1}>
-                                                <Typography level="body2">
-                                                    {request.submitterName ??
-                                                        request.submitterUserId}
-                                                </Typography>
-                                                {request.submitterEmail ? (
+                                                </Chip>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Stack spacing={1}>
+                                                    <Link
+                                                        href={KnownPages.CommunityEdit(
+                                                            request.id,
+                                                        )}
+                                                    >
+                                                        {entityTypeLabel(
+                                                            request.entityTypeName,
+                                                        )}{' '}
+                                                        #{request.entityId}
+                                                    </Link>
                                                     <Typography
                                                         level="body3"
                                                         className="text-muted-foreground"
                                                     >
-                                                        {request.submitterEmail}
+                                                        {request.sectionKey ??
+                                                            'Cijela stranica'}
                                                     </Typography>
-                                                ) : null}
-                                            </Stack>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <LocalDateTime>
-                                                {request.createdAt}
-                                            </LocalDateTime>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                ))}
+                                                </Stack>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Chip
+                                                    color="info"
+                                                    size="sm"
+                                                    variant="soft"
+                                                >
+                                                    {request.changes.length}
+                                                </Chip>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Link
+                                                    href={KnownPages.User(
+                                                        request.submitterUserId,
+                                                    )}
+                                                    className="flex min-w-0 items-center gap-2"
+                                                >
+                                                    <UserAvatar
+                                                        avatarUrl={
+                                                            request.submitter
+                                                                ?.avatarUrl
+                                                        }
+                                                        displayName={
+                                                            displayName
+                                                        }
+                                                        size="sm"
+                                                    />
+                                                    <Stack
+                                                        spacing={0}
+                                                        className="min-w-0"
+                                                    >
+                                                        <Typography
+                                                            level="body2"
+                                                            className="truncate"
+                                                        >
+                                                            {displayName}
+                                                        </Typography>
+                                                        {request.submitterEmail ? (
+                                                            <Typography
+                                                                level="body3"
+                                                                className="truncate text-muted-foreground"
+                                                            >
+                                                                {
+                                                                    request.submitterEmail
+                                                                }
+                                                            </Typography>
+                                                        ) : null}
+                                                    </Stack>
+                                                </Link>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <LocalDateTime>
+                                                    {request.createdAt}
+                                                </LocalDateTime>
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    );
+                                })}
                             </Table.Body>
                         </Table>
                     </div>

--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import {
     getEntityTypesOrganizedByCategories,
     getPendingAchievementsCount,
+    getPendingCommunityEditRequestsCount,
     getSetting,
     SettingsKeys,
 } from '@gredice/storage';
@@ -49,11 +50,13 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
         { categorizedTypes, uncategorizedTypes, shadowTypes },
         pendingAchievementsCount,
         pendingApprovalTasksCount,
+        pendingCommunityEditRequestsCount,
         dashboardQuickActionsSetting,
     ] = await Promise.all([
         getEntityTypesOrganizedByCategories(),
         getPendingAchievementsCount(),
         getPendingAdminApprovalTaskCount(),
+        getPendingCommunityEditRequestsCount(),
         getSetting(SettingsKeys.DashboardQuickActions),
     ]);
 
@@ -86,6 +89,9 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                 shadowTypes={shadowTypes}
                 pendingAchievementsCount={pendingAchievementsCount}
                 pendingApprovalTasksCount={pendingApprovalTasksCount}
+                pendingCommunityEditRequestsCount={
+                    pendingCommunityEditRequestsCount
+                }
                 quickActions={quickActions}
             >
                 <div className="grow bg-secondary/40" data-gredice-admin-shell>

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -237,6 +237,8 @@ export function Nav({
     const pendingAchievementsCount = navContext?.pendingAchievementsCount ?? 0;
     const pendingApprovalTasksCount =
         navContext?.pendingApprovalTasksCount ?? 0;
+    const pendingCommunityEditRequestsCount =
+        navContext?.pendingCommunityEditRequestsCount ?? 0;
     const quickActionBadgeCounts = {
         pendingAchievementsCount,
         pendingApprovalTasksCount,
@@ -301,6 +303,7 @@ export function Nav({
                     label={adminPages.CommunityEdits.label}
                     icon={<Edit className="size-5" />}
                     onClick={onItemClick}
+                    badge={pendingCommunityEditRequestsCount}
                     compact={compact}
                 />
                 {hasDirectoryRecords && (

--- a/apps/app/components/admin/navigation/NavContext.ts
+++ b/apps/app/components/admin/navigation/NavContext.ts
@@ -9,6 +9,7 @@ export type NavContextType = Awaited<
 > & {
     pendingAchievementsCount: number;
     pendingApprovalTasksCount: number;
+    pendingCommunityEditRequestsCount: number;
     quickActions: DashboardQuickActionOption[];
 };
 

--- a/apps/app/components/admin/providers/AdminClientProvider.tsx
+++ b/apps/app/components/admin/providers/AdminClientProvider.tsx
@@ -9,6 +9,7 @@ export function AdminClientProvider({
     shadowTypes,
     pendingAchievementsCount,
     pendingApprovalTasksCount,
+    pendingCommunityEditRequestsCount,
     quickActions,
     children,
 }: {
@@ -17,6 +18,7 @@ export function AdminClientProvider({
     shadowTypes: NavContextType['shadowTypes'];
     pendingAchievementsCount: number;
     pendingApprovalTasksCount: number;
+    pendingCommunityEditRequestsCount: number;
     quickActions: NavContextType['quickActions'];
     children: React.ReactNode;
 }) {
@@ -28,6 +30,7 @@ export function AdminClientProvider({
                 shadowTypes,
                 pendingAchievementsCount,
                 pendingApprovalTasksCount,
+                pendingCommunityEditRequestsCount,
                 quickActions,
             }}
         >

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { createHash } from 'node:crypto';
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, count, desc, eq } from 'drizzle-orm';
 import {
     type CommunityEditableFieldDefinition,
     type CommunityEditControlType,
@@ -909,6 +909,14 @@ export function listCommunityEditRequests(filters?: {
     return storage().query.communityEditRequests.findMany({
         where: conditions.length > 0 ? and(...conditions) : undefined,
         with: {
+            submitter: {
+                columns: {
+                    id: true,
+                    userName: true,
+                    displayName: true,
+                    avatarUrl: true,
+                },
+            },
             changes: {
                 with: {
                     attributeDefinition: true,
@@ -918,6 +926,15 @@ export function listCommunityEditRequests(filters?: {
         },
         orderBy: [desc(communityEditRequests.createdAt)],
     });
+}
+
+export async function getPendingCommunityEditRequestsCount() {
+    const result = await storage()
+        .select({ count: count() })
+        .from(communityEditRequests)
+        .where(eq(communityEditRequests.status, 'pending'));
+
+    return result[0]?.count ?? 0;
 }
 
 export function getCommunityEditRequest(id: number) {


### PR DESCRIPTION
## Summary
- Added a pending-count badge to `Prijedlozi zajednice` in the admin nav.
- Wired the count through the admin layout context and nav provider.
- Added a storage helper that counts pending community edit requests.
- Revalidate the admin layout after community edit actions so the badge stays current.

## Testing
- Focused Biome checks passed for the touched app and storage files.
- `git diff --check` passed.