### PR TITLE
Smanji razmake u karticama radnji na stranicama biljaka

### DIFF
--- a/apps/www/app/biljke/[alias]/InformationSection.tsx
+++ b/apps/www/app/biljke/[alias]/InformationSection.tsx
@@ -165,10 +165,19 @@ export async function InformationSection({
                 {attributeCards}
                 <Stack
                     className={cx(
-                        'border rounded-lg p-2 h-fit',
+                        'relative border rounded-lg px-2 pb-2 pt-3 h-fit',
                         !applicableOperations?.length && 'justify-center',
                     )}
                 >
+                    <Typography
+                        level="body3"
+                        component="span"
+                        semiBold
+                        uppercase
+                        className="absolute -top-2 left-3 bg-background px-1 leading-none"
+                    >
+                        RADNJE
+                    </Typography>
                     {(applicableOperations?.length ?? 0) <= 0 && (
                         <div className="py-4">
                             <NoDataPlaceholder>

--- a/apps/www/app/biljke/[alias]/PlantOperations.tsx
+++ b/apps/www/app/biljke/[alias]/PlantOperations.tsx
@@ -40,13 +40,13 @@ export function PlantOperations({
     });
 
     return (
-        <Stack spacing={2}>
+        <Stack spacing={1}>
             {orderedOperations?.map((operation, operationIndex) => (
                 <div
                     key={operation.information?.name ?? operationIndex}
                     className="grid grid-cols-1 gap-2"
                 >
-                    <OperationCard operation={operation} />
+                    <OperationCard operation={operation} variant="compact" />
                 </div>
             ))}
         </Stack>

--- a/apps/www/app/radnje/OperationCard.tsx
+++ b/apps/www/app/radnje/OperationCard.tsx
@@ -4,6 +4,7 @@ import { OperationImage } from '@gredice/ui/OperationImage';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { KnownPages } from '../../src/KnownPages';
 
 type OperationCardData = Pick<
@@ -11,21 +12,38 @@ type OperationCardData = Pick<
     'attributes' | 'image' | 'information' | 'prices'
 >;
 
-export function OperationCard({ operation }: { operation: OperationCardData }) {
+export function OperationCard({
+    operation,
+    variant = 'default',
+}: {
+    operation: OperationCardData;
+    variant?: 'default' | 'compact';
+}) {
+    const compact = variant === 'compact';
+
     return (
         <Card
             href={KnownPages.Operation(operation.information.label)}
-            className="border-tertiary border-b-4"
+            className={cx('border-tertiary border-b-4', compact && 'p-1')}
         >
-            <CardContent noHeader>
+            <CardContent noHeader className={cx(compact && 'px-2 py-1')}>
                 <Row justifyContent="space-between" spacing={2}>
-                    <Row spacing={4}>
-                        <OperationImage operation={operation} size={72} />
-                        <Stack>
+                    <Row spacing={compact ? 3 : 4} className="min-w-0 flex-1">
+                        <OperationImage
+                            operation={operation}
+                            size={compact ? 48 : 72}
+                        />
+                        <Stack className="min-w-0">
                             <Typography semiBold>
                                 {operation.information.label}
                             </Typography>
-                            <Typography level="body2" className="text-pretty">
+                            <Typography
+                                level="body2"
+                                className={cx(
+                                    'text-pretty',
+                                    compact && 'leading-snug',
+                                )}
+                            >
                                 {operation.information.shortDescription}
                             </Typography>
                         </Stack>


### PR DESCRIPTION
## Summary
- Dodan je `RADNJE` natpis iznad liste radnji na stranicama biljke i sorte.
- Ugrađene kartice radnji su zbijene kroz kompaktni prikaz s manjim okomitim paddingom i manjim razmacima.
- Standardni prikaz kartica radnji ostaje nepromijenjen na stranici s popisom radnji.

## Testing
- Playwright UI provjera na detaljima biljke i sorte u desktop i mobile prikazu.
- Potvrđeno da se `RADNJE` natpis prikazuje i da kompaktne kartice ne stvaraju horizontalni overflow.