### PR TITLE
Fix raised bed details overflow and restore plant status dates

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -211,11 +211,11 @@ export default async function RaisedBedPage({
                         </Alert>
                     )}
                     <div className="grid grid-cols-1 items-stretch gap-4 lg:grid-cols-2">
-                        <Card>
+                        <Card className="min-w-0 overflow-hidden">
                             <CardHeader>
                                 <CardTitle>Polja</CardTitle>
                             </CardHeader>
-                            <CardOverflow className="mt-0">
+                            <CardOverflow className="mt-0 min-w-0 overflow-hidden">
                                 <Suspense>
                                     <RaisedBedFieldsTable
                                         raisedBedId={raisedBed.id}

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -11,7 +11,7 @@ export const raisedBedFieldCardSelectClassName =
     'w-full min-w-0 [&_[role=combobox]]:h-8 [&_[role=combobox]]:min-w-0 [&_[role=combobox]]:gap-1.5 [&_[role=combobox]]:overflow-hidden [&_[role=combobox]]:!bg-background/80 [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:ring-1 [&_[role=combobox]]:ring-border/70 [&_[role=combobox]]:backdrop-blur-md [&_[role=combobox]]:hover:!bg-background/90 [&_[role=combobox]>span]:block [&_[role=combobox]>span]:min-w-0 [&_[role=combobox]>span]:truncate';
 
 export const raisedBedFieldCardButtonClassName =
-    'max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap !bg-background/80 text-foreground ring-1 ring-border/70 backdrop-blur-md hover:!bg-background/90 hover:text-foreground';
+    'max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap !bg-background/80 text-foreground ring-1 ring-border/70 backdrop-blur-md hover:!bg-background/90 hover:text-foreground [&>span]:min-w-0';
 
 export const raisedBedFieldCardChipClassName =
     'min-w-0 max-w-full overflow-hidden backdrop-blur-md';
@@ -23,7 +23,7 @@ export function RaisedBedFieldCardGrid({
     return (
         <div
             className={cx(
-                'grid grid-cols-3 auto-rows-fr gap-0 overflow-hidden rounded-lg border-r border-b',
+                'grid w-full min-w-0 grid-cols-[repeat(3,minmax(0,1fr))] gap-0 overflow-hidden rounded-lg border-r border-b',
                 className,
             )}
         >
@@ -54,11 +54,15 @@ export function RaisedBedFieldCard({
     return (
         <div
             className={cx(
-                'relative flex aspect-[4/3] min-h-48 min-w-0 flex-col overflow-hidden border-l border-t bg-muted/40',
+                'relative flex aspect-[4/3] min-h-40 min-w-0 max-w-full flex-col overflow-hidden border-l border-t bg-muted/40',
                 className,
             )}
         >
-            {image ?? (
+            {image ? (
+                <div className="absolute inset-0 overflow-hidden [&>img]:size-full">
+                    {image}
+                </div>
+            ) : (
                 <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
                     <Typography level="body2">Nema slike</Typography>
                 </div>

--- a/apps/app/components/raised-beds/RaisedBedFieldStatusDateChip.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldStatusDateChip.tsx
@@ -6,16 +6,19 @@ import { Calendar } from '@gredice/ui/icons';
 import { Popper } from '@gredice/ui/Popper';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import { raisedBedFieldUpdatePlant } from '../../app/(actions)/raisedBedFieldsActions';
 import { raisedBedFieldPlantStatusItems } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantStatusSelector';
+import type { RaisedBedFieldDateItem } from './RaisedBedFieldDatesPopover';
 
 type RaisedBedFieldStatusDateChipProps = {
     raisedBedId: number;
     positionIndex: number;
     status: string;
     date: string | null;
+    dateItems?: RaisedBedFieldDateItem[];
     className?: string;
 };
 
@@ -53,16 +56,19 @@ function formatDateInputValue(date: Date) {
     return `${year}-${month}-${day}`;
 }
 
-function formatShortDate(value: string | null) {
+function formatShortDate(value: string | null, fallback = 'Datum') {
     const date = parseDate(value);
     if (!date) {
-        return 'Datum';
+        return fallback;
     }
 
-    return new Intl.DateTimeFormat('hr-HR', {
-        day: '2-digit',
-        month: '2-digit',
-    }).format(date);
+    const currentYear = new Date().getFullYear();
+    const format: Intl.DateTimeFormatOptions =
+        date.getFullYear() === currentYear
+            ? { day: '2-digit', month: '2-digit' }
+            : { day: '2-digit', month: '2-digit', year: 'numeric' };
+
+    return new Intl.DateTimeFormat('hr-HR', format).format(date);
 }
 
 function dateInputToTimestamp(value: string) {
@@ -81,6 +87,7 @@ export function RaisedBedFieldStatusDateChip({
     positionIndex,
     status,
     date,
+    dateItems = [],
     className,
 }: RaisedBedFieldStatusDateChipProps) {
     const [open, setOpen] = useState(false);
@@ -158,7 +165,7 @@ export function RaisedBedFieldStatusDateChip({
             open={open}
             onOpenChange={handleOpenChange}
             align="start"
-            className="w-72 p-3"
+            className="w-80 max-w-[calc(100vw-2rem)] p-3"
             side="bottom"
             trigger={
                 <Button
@@ -199,6 +206,51 @@ export function RaisedBedFieldStatusDateChip({
                     value={selectedDate}
                     onChange={(event) => setSelectedDate(event.target.value)}
                 />
+                {dateItems.length > 0 && (
+                    <div className="rounded-md border bg-muted/20 p-2">
+                        <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-1.5">
+                            {dateItems.map((item) => (
+                                <div
+                                    className="contents"
+                                    key={`${item.key}-${item.label}`}
+                                >
+                                    <Typography
+                                        level="body3"
+                                        className={cx(
+                                            'min-w-0 truncate',
+                                            item.current
+                                                ? 'font-medium text-foreground'
+                                                : 'text-muted-foreground',
+                                        )}
+                                    >
+                                        {item.label}
+                                    </Typography>
+                                    <Typography
+                                        level="body3"
+                                        className={cx(
+                                            'text-right tabular-nums',
+                                            item.current
+                                                ? 'font-medium text-foreground'
+                                                : item.value
+                                                  ? 'text-foreground'
+                                                  : 'text-muted-foreground',
+                                        )}
+                                        title={item.value ?? undefined}
+                                    >
+                                        {item.value
+                                            ? mounted
+                                                ? formatShortDate(
+                                                      item.value,
+                                                      '-',
+                                                  )
+                                                : '...'
+                                            : '-'}
+                                    </Typography>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
                 <Button
                     fullWidth
                     size="sm"

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -388,7 +388,7 @@ function RaisedBedFieldTile({
                 plantSort={sort}
                 alt={plantLabel}
                 fill
-                className="object-cover"
+                className="object-contain"
                 sizes="(min-width: 1536px) 14rem, (min-width: 1280px) 16rem, (min-width: 768px) 18rem, 50vw"
             />
         ) : undefined;
@@ -448,6 +448,7 @@ function RaisedBedFieldTile({
                 positionIndex={positionIndex}
                 status={field.plantStatus}
                 date={dateItems.find((item) => item.current)?.value ?? null}
+                dateItems={dateItems}
                 className={raisedBedFieldCardButtonClassName}
             />
         ) : undefined;


### PR DESCRIPTION
## Summary
- Constrain the raised-bed fields card and its grid so images and field tiles stay inside the `Polja` panel.
- Restore the plant status date list inside the combined state/date popover.
- Tighten the field-card controls so long labels and buttons do not push layout outside their grid tracks.

## Testing
- Storybook field-grid visual check passed in the browser, including a narrow-width screenshot and bounds measurement.
- Storybook typecheck passed.
- `git diff --check` passed.