### PR TITLE
Fix Novosti rewrite host

### DIFF
--- a/apps/www/app/[...slug]/page.tsx
+++ b/apps/www/app/[...slug]/page.tsx
@@ -86,7 +86,7 @@ export async function generateMetadata({
         return {};
     }
     const canonicalPath = page.canonicalPath || `/${page.slug}`;
-    const openGraphImage = page.seoImageUrl || `/${page.slug}/opengraph-image`;
+    const openGraphImage = page.seoImageUrl || `/api/og/cms/${page.slug}`;
     return {
         title: page.metaTitle || page.title,
         description: page.metaDescription || undefined,

--- a/apps/www/app/api/og/cms/[...slug]/route.tsx
+++ b/apps/www/app/api/og/cms/[...slug]/route.tsx
@@ -1,19 +1,18 @@
 import {
     CmsOgImage,
-    cmsOgImageContentType,
     cmsOgImageSize,
 } from '@gredice/ui/cms';
 import { ImageResponse } from 'next/og';
-import { type CmsRoutePage, fetchCmsDirectoryPage } from './cmsPageData';
+import {
+    type CmsRoutePage,
+    fetchCmsDirectoryPage,
+} from '../../../../[...slug]/cmsPageData';
 import {
     hasReservedFirstSegment,
     normalizeCmsRouteSlug,
-} from './cmsPageRouteUtils';
-import { getSourceCmsPageBySlug } from './sourceCmsPages';
+} from '../../../../[...slug]/cmsPageRouteUtils';
+import { getSourceCmsPageBySlug } from '../../../../[...slug]/sourceCmsPages';
 
-export const alt = 'Gredice';
-export const size = cmsOgImageSize;
-export const contentType = cmsOgImageContentType;
 export const dynamic = 'force-dynamic';
 
 function pageOgKind(contentKind: string | null | undefined) {
@@ -39,11 +38,14 @@ async function resolveCmsOgPage(normalizedSlug: string) {
     return sourcePage;
 }
 
-export default async function CmsPageOpenGraphImage({
-    params,
-}: {
-    params: Promise<{ slug: string[] }>;
-}) {
+export async function GET(
+    _request: Request,
+    {
+        params,
+    }: {
+        params: Promise<{ slug: string[] }>;
+    },
+) {
     const { slug } = await params;
     const normalizedSlug = normalizeCmsRouteSlug(slug);
     const page =
@@ -59,7 +61,7 @@ export default async function CmsPageOpenGraphImage({
             title={page?.title ?? 'Gredice'}
         />,
         {
-            ...size,
+            ...cmsOgImageSize,
         },
     );
 }

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -79,7 +79,7 @@ const nextConfig: NextConfig = {
                       'localhost',
                       getAppDevPort(newsApp),
                   )
-                : 'https://news.gredice.com');
+                : 'https://novosti.gredice.com');
 
         return [
             {


### PR DESCRIPTION
## Summary
- Point the www `/novosti` production rewrite at `https://novosti.gredice.com` instead of the non-resolving `news.gredice.com`.
- Move the CMS Open Graph image handler to a valid API route so the www app builds on Next 16.
- Update CMS metadata fallback images to use the new `/api/og/cms/:slug` route.

## Validation
- `pnpm --filter www typecheck`
- `pnpm --filter www build`
- `git diff --check`