### PR TITLE
Fix main CI garden and storage tests

### DIFF
--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -598,7 +598,7 @@ export function getGardenOperationRescheduleTarget(
     operation: GardenOperationHudItem,
     garden: CurrentGardenData | null | undefined,
 ): DiaryRescheduleTarget | null {
-    if (nonEditableStatuses.has(operation.status)) {
+    if (isFinishedOperation(operation)) {
         return null;
     }
 
@@ -635,7 +635,7 @@ export function getGardenOperationCancelTarget(
     operation: GardenOperationHudItem,
     garden: CurrentGardenData | null | undefined,
 ): DiaryRescheduleTarget | null {
-    if (nonEditableStatuses.has(operation.status) || !operation.scheduledDate) {
+    if (isFinishedOperation(operation) || !operation.scheduledDate) {
         return null;
     }
 
@@ -799,7 +799,13 @@ export function GardenOperationCancelAction({
 }
 
 function isFinishedOperation(operation: GardenOperationHudItem) {
-    return nonEditableStatuses.has(operation.status);
+    return Boolean(
+        nonEditableStatuses.has(operation.status) ||
+            terminalFailureStatuses.has(operation.status) ||
+            operation.completedAt ||
+            operation.verifiedAt ||
+            operation.canceledAt,
+    );
 }
 
 function OperationScheduleText({ label }: { label: string }) {

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -111,7 +111,7 @@ export function RaisedBedInfo({
                 onValueChange={(value: string) =>
                     setActiveTab(value as RaisedBedTab)
                 }
-                className="flex flex-col"
+                className="flex flex-col pt-2"
             >
                 <div className="flex justify-center">
                     <TabsList className="border w-fit self-center">

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -846,7 +846,9 @@ export async function searchDirectoryEntities({
         rowsByEntityId.set(row.entityId, row);
     }
 
-    const rowsWithPublicUrls: DirectoryEntitySearchRow[] = [];
+    const rowsWithPublicUrls: Array<
+        DirectoryEntitySearchRow & { highPriorityBoost: number }
+    > = [];
     for (const row of rowsByEntityId.values()) {
         const entity = await getEntityRaw(row.entityId);
         if (!entity) {
@@ -860,18 +862,26 @@ export async function searchDirectoryEntities({
 
         const image = await entityImageMetadata(entity);
         const visualKey = await entityVisualKey(entity);
+        const highPriorityBoost = highPrioritySearchBoost(
+            entity,
+            normalizedQuery,
+        );
         rowsWithPublicUrls.push({
             ...row,
             publicUrl,
             imageUrl: image?.url ?? null,
             imageAlt: image?.alt ?? null,
             visualKey,
-            score: row.score + highPrioritySearchBoost(entity, normalizedQuery),
+            score: row.score + highPriorityBoost,
+            highPriorityBoost,
         });
     }
 
     return rowsWithPublicUrls
         .toSorted((a, b) => {
+            if (b.highPriorityBoost !== a.highPriorityBoost) {
+                return b.highPriorityBoost - a.highPriorityBoost;
+            }
             if (b.score !== a.score) {
                 return b.score - a.score;
             }
@@ -880,7 +890,8 @@ export async function searchDirectoryEntities({
             }
             return a.entityId - b.entityId;
         })
-        .slice(requestedOffset, requestedOffset + requestedLimit);
+        .slice(requestedOffset, requestedOffset + requestedLimit)
+        .map(({ highPriorityBoost: _highPriorityBoost, ...row }) => row);
 }
 
 export function publicSearchCategoryForEntityType(entityTypeName: string) {


### PR DESCRIPTION
## Summary

- Restore terminal operation detection in the garden diary HUD so completed, verified, canceled, and terminal-failure operations do not expose reschedule or cancel controls.
- Add explicit tab clearance in the raised bed info drawer so the mobile more action remains above the tab list.
- Make directory entity search reranking deterministic by carrying the high-priority search boost as an internal sort key before returning rows.

## Root Cause

The garden diary failure came from treating only terminal status values as non-editable, while some completed fixtures still carry a non-terminal status with terminal timestamps. The storage failure was caused by Postgres ranking a generic plant document above the canonical plant sort row despite the high-priority match boost.

## Validation

- `pnpm test --filter garden`
- `pnpm --filter @gredice/storage test:node entitySearchRepo.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/storage exec biome check src/repositories/entitySearchRepo.ts`
- `pnpm --filter @gredice/game exec biome check src/hud/GardenOperationsHud.tsx src/hud/raisedBed/RaisedBedInfo.tsx`
- `git diff --check`

Note: local storage replay used the embedded PGlite fallback because Docker Desktop was installed but its daemon was not running.