### PR TITLE
[codex] Add auto CMS preview viewport

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageForm.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageForm.tsx
@@ -47,6 +47,7 @@ import {
     Add,
     ArrowDown,
     ArrowUp,
+    Auto,
     Close,
     Code,
     Delete,
@@ -857,7 +858,7 @@ export function CmsPageForm({
     const [insertAtEnd, setInsertAtEnd] = useState(false);
     const [sectionSearch, setSectionSearch] = useState('');
     const [previewViewport, setPreviewViewport] =
-        useState<CmsPreviewViewport>('desktop');
+        useState<CmsPreviewViewport>('auto');
     const {
         containerRef: previewViewportContainerRef,
         supportedViewports: supportedPreviewViewports,
@@ -1760,6 +1761,19 @@ export function CmsPageForm({
 
     const previewViewportControls = (
         <ButtonGroup legend="Preview viewport" size="sm">
+            <Button
+                type="button"
+                variant={previewViewport === 'auto' ? 'solid' : 'plain'}
+                size="sm"
+                className={buttonGroupItemClassName({ iconOnly: true })}
+                aria-pressed={previewViewport === 'auto'}
+                aria-label="Auto preview"
+                title="Auto preview"
+                disabled={rawMode}
+                onClick={() => setPreviewViewport('auto')}
+            >
+                <Auto className="size-4" />
+            </Button>
             <Button
                 type="button"
                 variant={previewViewport === 'mobile' ? 'solid' : 'plain'}

--- a/apps/app/app/admin/cms/pages/CmsPreviewViewport.ts
+++ b/apps/app/app/admin/cms/pages/CmsPreviewViewport.ts
@@ -2,15 +2,19 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-export type CmsPreviewViewport = 'mobile' | 'tablet' | 'desktop';
+export type CmsPreviewViewport = 'auto' | 'mobile' | 'tablet' | 'desktop';
+
+type CmsFixedPreviewViewport = Exclude<CmsPreviewViewport, 'auto'>;
 
 export const cmsPagePreviewViewportClassNames = {
+    auto: 'max-w-none',
     mobile: 'max-w-sm',
     tablet: 'max-w-2xl',
     desktop: 'max-w-none',
 } satisfies Record<CmsPreviewViewport, string>;
 
 export const cmsSectionInfoPreviewViewportClassNames = {
+    auto: 'max-w-none',
     mobile: 'max-w-[22rem]',
     tablet: 'max-w-[44rem]',
     desktop: 'max-w-[72rem]',
@@ -20,9 +24,9 @@ const cmsPreviewViewportMinWidths = {
     mobile: 0,
     tablet: 704,
     desktop: 1024,
-} satisfies Record<CmsPreviewViewport, number>;
+} satisfies Record<CmsFixedPreviewViewport, number>;
 
-const cmsPreviewViewportFallbackOrder: CmsPreviewViewport[] = [
+const cmsPreviewViewportFallbackOrder: CmsFixedPreviewViewport[] = [
     'desktop',
     'tablet',
     'mobile',
@@ -35,6 +39,7 @@ function supportedCmsPreviewViewports(
 ): CmsPreviewViewportSupport {
     if (availableWidth === undefined) {
         return {
+            auto: true,
             mobile: true,
             tablet: true,
             desktop: true,
@@ -42,6 +47,7 @@ function supportedCmsPreviewViewports(
     }
 
     return {
+        auto: true,
         mobile: true,
         tablet: availableWidth >= cmsPreviewViewportMinWidths.tablet,
         desktop: availableWidth >= cmsPreviewViewportMinWidths.desktop,

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -1,4 +1,5 @@
 export {
+    ALargeSmall as Auto,
     AlertTriangle as Warning,
     ArrowDown,
     ArrowDownLeft,


### PR DESCRIPTION
## Summary

- Add an Auto CMS preview viewport that fills the available editor space while preserving section container constraints.
- Make Auto the default CMS page editor viewport.
- Keep mobile, tablet, and desktop viewport controls available for testing.

## Validation

- `pnpm lint --filter app --filter @gredice/ui`
- `pnpm typecheck --filter app --filter @gredice/ui`
- `pnpm build --filter app`
- `git diff --check`