### PR TITLE
[codex] Improve CMS pages list actions

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageCreateDropdownButton.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageCreateDropdownButton.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { ButtonGroup, buttonGroupItemClassName } from '@gredice/ui/ButtonGroup';
+import { Add, Channel, Down, FileText } from '@gredice/ui/icons';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@gredice/ui/Menu';
+import { KnownPages } from '../../../../src/KnownPages';
+
+export function CmsPageCreateDropdownButton() {
+    return (
+        <ButtonGroup legend="Kreiranje CMS stranice" size="md">
+            <Button
+                href={KnownPages.CmsPageCreate}
+                size="md"
+                startDecorator={<Add className="size-4 shrink-0" />}
+                className={buttonGroupItemClassName({
+                    size: 'md',
+                    className: 'rounded-r-none pr-3',
+                })}
+            >
+                Nova stranica
+            </Button>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        type="button"
+                        size="md"
+                        aria-label="Odaberi vrstu CMS stranice"
+                        title="Odaberi vrstu CMS stranice"
+                        className={buttonGroupItemClassName({
+                            iconOnly: true,
+                            size: 'md',
+                            className:
+                                'rounded-l-none border-l border-primary-foreground/20',
+                        })}
+                    >
+                        <Down className="size-4" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                        href={KnownPages.CmsPageCreateTemplate('blog')}
+                        startDecorator={<FileText className="size-4" />}
+                    >
+                        Blog objava
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                        href={KnownPages.CmsPageCreateTemplate('changelog')}
+                        startDecorator={<Channel className="size-4" />}
+                    >
+                        Changelog zapis
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </ButtonGroup>
+    );
+}

--- a/apps/app/app/admin/cms/pages/CmsPagesTable.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPagesTable.tsx
@@ -7,7 +7,41 @@ import { NoDataPlaceholder } from '../../../../components/shared/placeholders/No
 import { KnownPages } from '../../../../src/KnownPages';
 import { CmsPageStateChip } from './CmsPageStateChip';
 
+function publishedAtTime(page: SelectCmsPage) {
+    if (!page.publishedAt) {
+        return null;
+    }
+
+    const time = new Date(page.publishedAt).getTime();
+    return Number.isNaN(time) ? null : time;
+}
+
+function comparePagesByPublishDate(a: SelectCmsPage, b: SelectCmsPage) {
+    const aPublishedAt = publishedAtTime(a);
+    const bPublishedAt = publishedAtTime(b);
+
+    if (aPublishedAt !== null && bPublishedAt !== null) {
+        const publishDateDifference = bPublishedAt - aPublishedAt;
+
+        if (publishDateDifference !== 0) {
+            return publishDateDifference;
+        }
+    }
+
+    if (aPublishedAt !== null) {
+        return -1;
+    }
+
+    if (bPublishedAt !== null) {
+        return 1;
+    }
+
+    return b.id - a.id;
+}
+
 export function CmsPagesTable({ pages }: { pages: SelectCmsPage[] }) {
+    const sortedPages = [...pages].sort(comparePagesByPublishDate);
+
     return (
         <Table>
             <Table.Header>
@@ -25,7 +59,7 @@ export function CmsPagesTable({ pages }: { pages: SelectCmsPage[] }) {
                         </Table.Cell>
                     </Table.Row>
                 )}
-                {pages.map((page) => (
+                {sortedPages.map((page) => (
                     <Table.Row key={page.id}>
                         <Table.Cell>
                             <div className="flex min-w-0 items-center gap-2">

--- a/apps/app/app/admin/cms/pages/page.tsx
+++ b/apps/app/app/admin/cms/pages/page.tsx
@@ -1,12 +1,9 @@
 import { getCmsPages } from '@gredice/storage';
 import { Card, CardOverflow } from '@gredice/ui/Card';
-import { Add } from '@gredice/ui/icons';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
-import Link from 'next/link';
 import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { auth } from '../../../../lib/auth/auth';
-import { KnownPages } from '../../../../src/KnownPages';
+import { CmsPageCreateDropdownButton } from './CmsPageCreateDropdownButton';
 import { CmsPagesTable } from './CmsPagesTable';
 
 export const dynamic = 'force-dynamic';
@@ -18,41 +15,7 @@ export default async function CmsPagesPage() {
 
     return (
         <Stack spacing={4}>
-            <AdminPageHeader
-                actions={
-                    <Row spacing={2} className="flex-wrap justify-end">
-                        <Link href={KnownPages.CmsPageCreate}>
-                            <Row
-                                spacing={2}
-                                className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                            >
-                                <Add className="size-4" />
-                                <span>Nova stranica</span>
-                            </Row>
-                        </Link>
-                        <Link href={KnownPages.CmsPageCreateTemplate('blog')}>
-                            <Row
-                                spacing={2}
-                                className="text-sm font-medium px-3 py-2 rounded-md border bg-background hover:bg-muted transition-colors"
-                            >
-                                <Add className="size-4" />
-                                <span>Blog objava</span>
-                            </Row>
-                        </Link>
-                        <Link
-                            href={KnownPages.CmsPageCreateTemplate('changelog')}
-                        >
-                            <Row
-                                spacing={2}
-                                className="text-sm font-medium px-3 py-2 rounded-md border bg-background hover:bg-muted transition-colors"
-                            >
-                                <Add className="size-4" />
-                                <span>Changelog zapis</span>
-                            </Row>
-                        </Link>
-                    </Row>
-                }
-            />
+            <AdminPageHeader actions={<CmsPageCreateDropdownButton />} />
             <Card>
                 <CardOverflow>
                     <CmsPagesTable pages={pages} />


### PR DESCRIPTION
## Summary

- Sort `/admin/cms/pages` rows by publish date, newest first, with unpublished pages after published pages.
- Replace the three CMS create buttons with a compact split dropdown button: the default action creates a standard page, and the dropdown links to Blog and Changelog templates.

## Validation

- `pnpm lint --filter app`
- `pnpm build --filter app`
- `git diff --check`

## Notes

- `pnpm typecheck --filter app` only ran dependency typechecks because `app` does not expose its own `typecheck` script.
- `pnpm --filter app exec tsc --noEmit --pretty false` currently fails on existing unrelated errors outside the touched CMS page files.