### PR TITLE
[codex] Add image date context to raised-bed AI analysis

### DIFF
--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -413,8 +413,9 @@ async function buildAnalysisMessages({
     positionIndex,
     referenceDate: inputReferenceDate,
 }: AnalysisParams) {
-    const referenceDate =
-        normalizeAnalysisReferenceDate(inputReferenceDate) ?? new Date();
+    const inputReferenceDateValue =
+        normalizeAnalysisReferenceDate(inputReferenceDate);
+    const referenceDate = inputReferenceDateValue ?? new Date();
     const [plantSorts, operations, operationsData, weather] = await Promise.all(
         [
             getEntitiesFormatted<{
@@ -497,6 +498,9 @@ async function buildAnalysisMessages({
     const orientation = raisedBed.orientation ?? 'vertical';
     const nowIso = new Date().toISOString();
     const referenceDateIso = referenceDate.toISOString();
+    const imageDateSource = inputReferenceDateValue
+        ? 'requestReferenceDate'
+        : 'analysisTimeFallback';
     const analyzedPositionLabel =
         typeof positionIndex === 'number'
             ? toPositionLabel(positionIndex)
@@ -515,7 +519,7 @@ async function buildAnalysisMessages({
                 '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
                 '- U JSON kontekstu vrijednost `positionLabel` koristi ovo brojanje (1-bazirano), dok `positionIndex` ostaje 0-bazirana interna oznaka (`positionLabel = positionIndex + 1`).',
                 '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
-                '- Koristi `analysisReferenceDate` i `weather.historical` za vremenske uvjete na dan fotografija. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
+                '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
             ].join('\n'),
         },
         {
@@ -538,6 +542,8 @@ async function buildAnalysisMessages({
                         JSON.stringify(
                             {
                                 currentDate: nowIso,
+                                imageDate: referenceDateIso,
+                                imageDateSource,
                                 analysisReferenceDate: referenceDateIso,
                                 weather,
                                 raisedBed: {

--- a/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
+++ b/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
@@ -64,6 +64,7 @@ type ReviewInput =
           focusPositionIndex?: number;
           operationId?: number;
           raisedBedFieldId?: number | null;
+          referenceDate: Date;
           skippedInvalidImageCount: number;
       }
     | {
@@ -92,6 +93,22 @@ function isoDate(value: Date | string | null | undefined) {
 
     const date = value instanceof Date ? value : new Date(value);
     return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function dateFromValue(value: unknown) {
+    if (!(value instanceof Date) && typeof value !== 'string') {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getReviewReferenceDate(event: AutomationSourceEvent) {
+    return (
+        dateFromValue(event.data.referenceDate) ?? event.createdAt ?? new Date()
+    );
 }
 
 function daysSince(value: Date | string | null | undefined, now = Date.now()) {
@@ -160,6 +177,8 @@ function parseRaisedBedFieldAggregateId(aggregateId: string) {
 async function resolveReviewInput(
     event: AutomationSourceEvent,
 ): Promise<ReviewInput> {
+    const referenceDate = getReviewReferenceDate(event);
+
     if (event.type === knownEventTypes.operations.complete) {
         const operationId = Number(event.aggregateId);
         if (!Number.isInteger(operationId) || operationId <= 0) {
@@ -208,6 +227,7 @@ async function resolveReviewInput(
             imageUrls,
             operationId,
             raisedBedFieldId: operation.raisedBedFieldId,
+            referenceDate,
             skippedInvalidImageCount,
         };
     }
@@ -241,6 +261,7 @@ async function resolveReviewInput(
             source: 'raisedBedAiAnalysis',
             raisedBedId,
             imageUrls,
+            referenceDate,
             skippedInvalidImageCount,
         };
     }
@@ -276,6 +297,7 @@ async function resolveReviewInput(
             raisedBedId: parsed.raisedBedId,
             focusPositionIndex: parsed.positionIndex,
             imageUrls,
+            referenceDate,
             skippedInvalidImageCount,
         };
     }
@@ -357,6 +379,7 @@ async function buildReviewContext(input: ReviewInput & { ok: true }) {
     const focusPositionIndex =
         input.focusPositionIndex ?? operationFocusField?.positionIndex;
     const nowIso = new Date().toISOString();
+    const imageDateIso = input.referenceDate.toISOString();
     const totalFields = raisedBed.fields.length || 18;
     const rows = Math.max(1, Math.ceil(totalFields / RAISED_BED_COLUMNS));
 
@@ -390,11 +413,26 @@ async function buildReviewContext(input: ReviewInput & { ok: true }) {
                 expectedPlantCount: plantsPerField.totalPlants,
                 expectedPlantsPerRow: plantsPerField.plantsPerRow,
                 seedingDistanceCm: seedingDistance,
-                daysFromSowing: daysSince(field.plantSowDate),
-                daysFromGrowth: daysSince(field.plantGrowthDate),
-                daysFromReady: daysSince(field.plantReadyDate),
-                daysFromHarvest: daysSince(field.plantHarvestedDate),
-                daysFromDead: daysSince(field.plantDeadDate),
+                daysFromSowing: daysSince(
+                    field.plantSowDate,
+                    input.referenceDate.getTime(),
+                ),
+                daysFromGrowth: daysSince(
+                    field.plantGrowthDate,
+                    input.referenceDate.getTime(),
+                ),
+                daysFromReady: daysSince(
+                    field.plantReadyDate,
+                    input.referenceDate.getTime(),
+                ),
+                daysFromHarvest: daysSince(
+                    field.plantHarvestedDate,
+                    input.referenceDate.getTime(),
+                ),
+                daysFromDead: daysSince(
+                    field.plantDeadDate,
+                    input.referenceDate.getTime(),
+                ),
                 needsRemoval: Boolean(field.toBeRemoved),
                 isFocusField: field.positionIndex === focusPositionIndex,
                 history: buildFieldHistory(field),
@@ -407,6 +445,7 @@ async function buildReviewContext(input: ReviewInput & { ok: true }) {
         focusPositionIndex,
         promptContext: {
             currentDate: nowIso,
+            imageDate: imageDateIso,
             source: input.source,
             operationId: input.operationId ?? null,
             imageCount: input.imageUrls.length,
@@ -451,6 +490,7 @@ function buildReviewMessages({
                 'Ako je fotografija close-up i polje nije sigurno prepoznatljivo, koristi `focusField` kada postoji. Ako je fotografija cijele gredice, možeš predložiti više polja.',
                 'Polja s `currentLocation: "greenhouse"` ignoriraj osim ako fotografija jasno pokazuje da se ista biljka nalazi u pripadajućem polju gredice.',
                 'Koristi `expectedPlantCount` kao kontekst za to koliko pojedinačnih biljaka ili klica se očekuje u polju.',
+                '`imageDate` je datum fotografija ili izvornog dnevničkog unosa; koristi ga za kontekst polja i vrijednosti `daysFrom*`. `currentDate` je trenutak obrade automatizacije i ne smije promijeniti interpretaciju stanja na starijoj fotografiji.',
                 '',
                 'Raspored polja u slici cijele gredice:',
                 '- Polja su numerirana od donjeg desnog kuta slike.',
@@ -670,7 +710,7 @@ export async function runRaisedBedImagePlantStatusReview({
                 gardenId: context.raisedBed.gardenId,
                 plantSortId: proposal.plantSortId,
                 currentStatus: proposal.currentStatus,
-                effectiveAt: event.createdAt,
+                effectiveAt: input.referenceDate,
                 note: buildApprovalNote({
                     event,
                     proposal,
@@ -697,6 +737,7 @@ export async function runRaisedBedImagePlantStatusReview({
             raisedBedId: input.raisedBedId,
             operationId: input.operationId ?? null,
             focusPositionIndex: context.focusPositionIndex ?? null,
+            imageDate: input.referenceDate.toISOString(),
             imageCount: input.imageUrls.length,
             skippedInvalidImageCount: input.skippedInvalidImageCount,
             model: AI_MODEL,
@@ -743,6 +784,7 @@ export async function previewRaisedBedImagePlantStatusReview(
             raisedBedId: input.raisedBedId,
             operationId: input.operationId ?? null,
             focusPositionIndex: context.focusPositionIndex ?? null,
+            imageDate: input.referenceDate.toISOString(),
             imageCount: input.imageUrls.length,
             skippedInvalidImageCount: input.skippedInvalidImageCount,
             plantedFieldCount: Array.isArray(context.promptContext.fields)

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    type AutomationGraph,
     acceptOperation,
     automationEventCursors,
     automationModuleKeys,
@@ -90,6 +91,39 @@ async function getScheduledFreeWateringDates(
         )
         .map((operation) => operation.scheduledDate?.toISOString())
         .sort();
+}
+
+function raisedBedAiAnalysisImagePlantStatusReviewAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerDomainEvent,
+                position: { x: 0, y: 160 },
+                config: {
+                    eventType: knownEventTypes.raisedBeds.aiAnalysis,
+                },
+            },
+            {
+                id: 'review-plant-statuses',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionCreatePlantStatusRequestsFromImageAnalysis,
+                position: { x: 620, y: 160 },
+                config: {
+                    minConfidence: 0.9,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-action',
+                source: 'trigger',
+                target: 'review-plant-statuses',
+            },
+        ],
+    };
 }
 
 function addUtcDays(date: Date, days: number) {
@@ -904,15 +938,17 @@ test('image plant-status review automation previews operation completion images 
         raisedBedId,
         raisedBedFieldId: field.id,
     });
-    await createEvent(
-        knownEvents.operations.completedV1(operationId.toString(), {
+    const operationImageDate = new Date('2026-05-10T08:00:00.000Z');
+    await createEvent({
+        ...knownEvents.operations.completedV1(operationId.toString(), {
             completedBy: 'automations-test',
             images: [
                 'https://myegtvromcktt2y7.public.blob.vercel-storage.com/operations/test-field.jpg',
                 'https://example.com/not-gredice-storage.jpg',
             ],
         }),
-    );
+        createdAt: operationImageDate,
+    });
     const event = await getLatestEvent(
         knownEventTypes.operations.complete,
         operationId.toString(),
@@ -963,10 +999,98 @@ test('image plant-status review automation previews operation completion images 
     );
     assert.strictEqual(Reflect.get(actionStep.output, 'imageCount'), 1);
     assert.strictEqual(
+        Reflect.get(actionStep.output, 'imageDate'),
+        operationImageDate.toISOString(),
+    );
+    assert.strictEqual(
         Reflect.get(actionStep.output, 'skippedInvalidImageCount'),
         1,
     );
     assert.strictEqual(Reflect.get(actionStep.output, 'plantedFieldCount'), 1);
+});
+
+test('image plant-status review automation uses AI analysis reference date in dry run', async () => {
+    createTestDb();
+    const { accountId, raisedBedId } = await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-04-01T08:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(fieldAggregateId, {
+            status: 'sowed',
+        }),
+    );
+    const imageDate = '2026-05-10T08:00:00.000Z';
+    await createEvent({
+        ...knownEvents.raisedBeds.aiAnalysisV1(raisedBedId.toString(), {
+            markdown: 'AI review',
+            imageUrl:
+                'https://myegtvromcktt2y7.public.blob.vercel-storage.com/operations/test-field.jpg',
+            imageUrls: [
+                'https://myegtvromcktt2y7.public.blob.vercel-storage.com/operations/test-field.jpg',
+            ],
+            model: 'test-model',
+            analyzedAt: '2026-06-05T08:00:00.000Z',
+            referenceDate: imageDate,
+            accountId,
+        }),
+        createdAt: new Date('2026-06-05T08:00:00.000Z'),
+    });
+    const event = await getLatestEvent(
+        knownEventTypes.raisedBeds.aiAnalysis,
+        raisedBedId.toString(),
+    );
+    const definition = await createAutomationDefinition({
+        key: 'test.image-plant-status-review-ai-reference-date',
+        name: 'Image plant status review AI reference date',
+        status: 'enabled',
+        graph: raisedBedAiAnalysisImagePlantStatusReviewAutomationGraph(),
+    });
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'event',
+        sourceEvent: event,
+        dryRun: true,
+        input: {
+            eventId: event.id,
+            eventType: event.type,
+            aggregateId: event.aggregateId,
+            data:
+                event.data && typeof event.data === 'object'
+                    ? (event.data as Record<string, unknown>)
+                    : {},
+        },
+    });
+    assert.ok(run);
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+
+    assert.strictEqual(result.status, 'succeeded');
+    const runWithSteps = await getAutomationRunWithSteps(startedRun.id);
+    const actionStep = runWithSteps?.steps.find(
+        (step) => step.nodeId === 'review-plant-statuses',
+    );
+    assert.strictEqual(actionStep?.status, 'succeeded');
+    assert.ok(
+        actionStep?.output &&
+            typeof actionStep.output === 'object' &&
+            !Array.isArray(actionStep.output),
+    );
+    assert.strictEqual(
+        Reflect.get(actionStep.output, 'source'),
+        'raisedBedAiAnalysis',
+    );
+    assert.strictEqual(Reflect.get(actionStep.output, 'imageDate'), imageDate);
+    assert.strictEqual(Reflect.get(actionStep.output, 'imageCount'), 1);
 });
 
 test('image plant-status review automation skips non-dry runs when AI Gateway credentials are blank', async (t) => {


### PR DESCRIPTION
## Summary
- Add explicit `imageDate` context to raised-bed AI image advice prompts so delayed analysis can distinguish image date from current date.
- Use source image/reference dates in raised-bed image plant-status automation context, `daysFrom*` calculations, dry-run output, and accepted proposal effective dates.
- Cover operation-completion image dates and AI-analysis `referenceDate` events in automation dry-run tests.

## Validation
- `pnpm --filter api exec biome check --write lib/garden/raisedBedAiAnalysisService.ts`
- `pnpm --filter @gredice/storage exec biome check --write src/automations/raisedBedImagePlantStatusAnalysis.ts tests/automationsRepo.node.spec.ts`
- `pnpm --filter api test:node lib/garden/raisedBedAiAnalysisService.node.spec.ts`
- `pnpm --filter @gredice/storage test:node tests/automationsRepo.node.spec.ts`
- `pnpm typecheck --filter api --filter @gredice/storage`
- `git diff --check`

## Notes
- Direct workspace `tsc --noEmit` still reports existing unrelated baseline errors in storage scripts/tests and `api` web push tests; the new automation graph helper type error found during validation was fixed.
