### PR TITLE
Add automation to switch seedling transplant fields to direct sowing

### DIFF
--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -26,6 +26,8 @@ export const automationModuleKeys = {
         'action.queueSeasonalSowingOfferOperations',
     actionUpdateRaisedBedFieldPlantStatus:
         'action.updateRaisedBedFieldPlantStatus',
+    actionUpdateRaisedBedFieldSowingLocation:
+        'action.updateRaisedBedFieldSowingLocation',
     conditionEventDataEquals: 'condition.eventDataEquals',
     conditionOperationMatches: 'condition.operationMatches',
     conditionPlantStatusEquals: 'condition.plantStatusEquals',
@@ -151,6 +153,19 @@ const automationModulePresentations: Record<
         description: 'Upisuje novi status biljke za ciljano polje gredice.',
         fields: {
             targetStatus: { label: 'Ciljani status' },
+        },
+    },
+    [automationModuleKeys.actionUpdateRaisedBedFieldSowingLocation]: {
+        title: 'Ažuriraj lokaciju sijanja',
+        description: 'Upisuje novu lokaciju sijanja za ciljano polje gredice.',
+        fields: {
+            targetSowingLocation: {
+                label: 'Ciljana lokacija',
+                options: {
+                    direct: 'Direktno',
+                    greenhouse: 'Staklenik',
+                },
+            },
         },
     },
     [automationModuleKeys.actionCreatePlantStatusRequestsFromImageAnalysis]: {

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -6,7 +6,7 @@ existing planting flow where a `raisedBedField.plantUpdate` event with
 `data.status = "sowed"` queues seasonal watering operations asynchronously, and
 monthly schedules that can create recurring farm operations. Operation
 completion images can also be reviewed asynchronously for high-confidence plant
-status changes that create pending admin approval requests. Completing the
+status changes that create pending admin approval requests. Verifying the
 seedling transplanting operation also switches the targeted plant from
 greenhouse sowing to direct sowing.
 

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -6,7 +6,9 @@ existing planting flow where a `raisedBedField.plantUpdate` event with
 `data.status = "sowed"` queues seasonal watering operations asynchronously, and
 monthly schedules that can create recurring farm operations. Operation
 completion images can also be reviewed asynchronously for high-confidence plant
-status changes that create pending admin approval requests.
+status changes that create pending admin approval requests. Completing the
+seedling transplanting operation also switches the targeted plant from
+greenhouse sowing to direct sowing.
 
 ## Ownership
 
@@ -90,6 +92,9 @@ MVP modules:
   definition.
 - `action.updateRaisedBedFieldPlantStatus`: writes a
   `raisedBedField.plantUpdate` event for an operation target.
+- `action.updateRaisedBedFieldSowingLocation`: writes a
+  `raisedBedField.plantSchedule` event for an operation target, preserving the
+  scheduled date while changing `sowingLocation`.
 - `action.createPlantStatusRequestsFromImageAnalysis`: reviews hosted
   raised-bed images from operation completion or raised-bed AI analysis events,
   then creates pending plant-status approval requests when the visual evidence

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -119,7 +119,7 @@ export function seedlingTransplantDirectSowingLocationAutomationGraph(): Automat
                 moduleKey: automationModuleKeys.triggerDomainEvent,
                 position: { x: 0, y: 160 },
                 config: {
-                    eventType: knownEventTypes.operations.complete,
+                    eventType: knownEventTypes.operations.verify,
                 },
             },
             {
@@ -128,6 +128,7 @@ export function seedlingTransplantDirectSowingLocationAutomationGraph(): Automat
                 moduleKey: automationModuleKeys.conditionOperationMatches,
                 position: { x: 280, y: 160 },
                 config: {
+                    status: 'completed',
                     entityId: seedlingTransplantingOperationId,
                 },
             },
@@ -190,9 +191,9 @@ export async function ensureDefaultAutomationDefinitions() {
     const seedlingTransplantDirectSowingLocation =
         await upsertAutomationDefinitionByKey({
             key: seedlingTransplantDirectSowingLocationAutomationKey,
-            name: 'Postavi sadnice nakon presađivanja na direktnu sjetvu',
+            name: 'Postavi sadnice nakon potvrde presađivanja na direktnu sjetvu',
             description:
-                'Kada je radnja presađivanja sadnica završena, prebaci lokaciju sijanja ciljane biljke iz staklenika na direktnu sjetvu.',
+                'Kada je radnja presađivanja sadnica potvrđena, prebaci lokaciju sijanja ciljane biljke iz staklenika na direktnu sjetvu.',
             status: 'enabled',
             graph: seedlingTransplantDirectSowingLocationAutomationGraph(),
             metadata: {

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -10,6 +10,10 @@ export const seasonalSowedWateringAutomationKey =
     'default.seasonal-sowed-watering';
 export const operationImagePlantStatusReviewAutomationKey =
     'default.operation-image-plant-status-review';
+export const seedlingTransplantDirectSowingLocationAutomationKey =
+    'default.seedling-transplant-direct-sowing-location';
+
+const seedlingTransplantingOperationId = 593;
 
 export function seasonalSowedWateringAutomationGraph(): AutomationGraph {
     return {
@@ -106,6 +110,53 @@ export function operationImagePlantStatusReviewAutomationGraph(): AutomationGrap
     };
 }
 
+export function seedlingTransplantDirectSowingLocationAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerDomainEvent,
+                position: { x: 0, y: 160 },
+                config: {
+                    eventType: knownEventTypes.operations.complete,
+                },
+            },
+            {
+                id: 'operation-is-seedling-transplant',
+                kind: 'condition',
+                moduleKey: automationModuleKeys.conditionOperationMatches,
+                position: { x: 280, y: 160 },
+                config: {
+                    entityId: seedlingTransplantingOperationId,
+                },
+            },
+            {
+                id: 'set-location-direct',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionUpdateRaisedBedFieldSowingLocation,
+                position: { x: 620, y: 160 },
+                config: {
+                    targetSowingLocation: 'direct',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-operation-match',
+                source: 'trigger',
+                target: 'operation-is-seedling-transplant',
+            },
+            {
+                id: 'operation-match-to-set-location',
+                source: 'operation-is-seedling-transplant',
+                target: 'set-location-direct',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -136,8 +187,24 @@ export async function ensureDefaultAutomationDefinitions() {
             },
         });
 
+    const seedlingTransplantDirectSowingLocation =
+        await upsertAutomationDefinitionByKey({
+            key: seedlingTransplantDirectSowingLocationAutomationKey,
+            name: 'Postavi sadnice nakon presađivanja na direktnu sjetvu',
+            description:
+                'Kada je radnja presađivanja sadnica završena, prebaci lokaciju sijanja ciljane biljke iz staklenika na direktnu sjetvu.',
+            status: 'enabled',
+            graph: seedlingTransplantDirectSowingLocationAutomationGraph(),
+            metadata: {
+                managedBy: 'gredice',
+                defaultAutomation: true,
+                operationEntityId: seedlingTransplantingOperationId,
+            },
+        });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
+        seedlingTransplantDirectSowingLocation,
     };
 }

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -5,6 +5,7 @@ import {
     createEvent,
     knownEvents,
     knownEventTypes,
+    type RaisedBedFieldSowingLocation,
 } from '../repositories/events';
 import { getFarms } from '../repositories/farmsRepo';
 import { getRaisedBed } from '../repositories/gardensRepo';
@@ -41,6 +42,8 @@ const createFarmInventoryOperationsActionKey =
     'action.createFarmInventoryOperations';
 const updateRaisedBedFieldPlantStatusActionKey =
     'action.updateRaisedBedFieldPlantStatus';
+const updateRaisedBedFieldSowingLocationActionKey =
+    'action.updateRaisedBedFieldSowingLocation';
 const createPlantStatusRequestsFromImageAnalysisActionKey =
     'action.createPlantStatusRequestsFromImageAnalysis';
 const logActionKey = 'action.log';
@@ -60,6 +63,8 @@ export const automationModuleKeys = {
     actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
     actionUpdateRaisedBedFieldPlantStatus:
         updateRaisedBedFieldPlantStatusActionKey,
+    actionUpdateRaisedBedFieldSowingLocation:
+        updateRaisedBedFieldSowingLocationActionKey,
     actionCreatePlantStatusRequestsFromImageAnalysis:
         createPlantStatusRequestsFromImageAnalysisActionKey,
     actionLog: logActionKey,
@@ -381,6 +386,12 @@ function parseRaisedBedFieldAggregateId(aggregateId: string) {
     }
 
     return { raisedBedId, positionIndex };
+}
+
+function parseSowingLocation(
+    value: unknown,
+): RaisedBedFieldSowingLocation | null {
+    return value === 'direct' || value === 'greenhouse' ? value : null;
 }
 
 function configFieldsForEventType() {
@@ -1179,6 +1190,107 @@ const updateRaisedBedFieldPlantStatusActionModule: AutomationModule = {
     },
 };
 
+const updateRaisedBedFieldSowingLocationActionModule: AutomationModule = {
+    key: updateRaisedBedFieldSowingLocationActionKey,
+    kind: 'action',
+    title: 'Update sowing location',
+    description:
+        'Writes a raised-bed field sowing location update for the operation target.',
+    category: 'Raised-bed fields',
+    configFields: [
+        {
+            key: 'targetSowingLocation',
+            label: 'Target sowing location',
+            type: 'select',
+            required: true,
+            options: [
+                { value: 'direct', label: 'Direct' },
+                { value: 'greenhouse', label: 'Greenhouse' },
+            ],
+        },
+    ],
+    dryRunSupported: true,
+    mutatesData: true,
+    retryable: true,
+    validateConfig: (config) =>
+        parseSowingLocation(config.targetSowingLocation)
+            ? []
+            : ['targetSowingLocation must be direct or greenhouse.'],
+    execute: async (context, node) => {
+        if (!context.event) {
+            return skip('No source event is available.');
+        }
+
+        const targetSowingLocation = parseSowingLocation(
+            node.config.targetSowingLocation,
+        );
+        if (!targetSowingLocation) {
+            throw new AutomationModuleExecutionError(
+                'Sowing location action is missing targetSowingLocation.',
+                'invalid_config',
+            );
+        }
+
+        const operationId = Number(context.event.aggregateId);
+        if (!Number.isInteger(operationId) || operationId <= 0) {
+            return skip('Source event aggregate is not an operation id.');
+        }
+
+        const operation = await getOperationById(operationId);
+        if (!operation?.raisedBedId || !operation.raisedBedFieldId) {
+            return skip('Operation has no raised-bed field target.', {
+                operationId,
+            });
+        }
+
+        const raisedBed = await getRaisedBed(operation.raisedBedId);
+        const field = raisedBed?.fields.find(
+            (candidate) => candidate.id === operation.raisedBedFieldId,
+        );
+        if (!raisedBed || !field) {
+            return skip('Operation target field was not found.', {
+                operationId,
+                raisedBedId: operation.raisedBedId,
+                raisedBedFieldId: operation.raisedBedFieldId,
+            });
+        }
+
+        if (field.sowingLocation === targetSowingLocation) {
+            return skip('Plant already has the target sowing location.', {
+                targetSowingLocation,
+            });
+        }
+
+        if (context.dryRun) {
+            return success({
+                dryRun: true,
+                raisedBedId: raisedBed.id,
+                positionIndex: field.positionIndex,
+                previousSowingLocation: field.sowingLocation,
+                targetSowingLocation,
+            });
+        }
+
+        await createEvent(
+            knownEvents.raisedBedFields.plantScheduleV1(
+                `${raisedBed.id}|${field.positionIndex}`,
+                {
+                    scheduledDate:
+                        field.plantScheduledDate?.toISOString() ?? null,
+                    sowingLocation: targetSowingLocation,
+                },
+            ),
+        );
+
+        return success({
+            raisedBedId: raisedBed.id,
+            positionIndex: field.positionIndex,
+            previousSowingLocation: field.sowingLocation,
+            targetSowingLocation,
+        });
+    },
+};
+
 const createPlantStatusRequestsFromImageAnalysisActionModule: AutomationModule =
     {
         key: createPlantStatusRequestsFromImageAnalysisActionKey,
@@ -1305,6 +1417,7 @@ export const automationModules = [
     createOperationActionModule,
     createFarmInventoryOperationsActionModule,
     updateRaisedBedFieldPlantStatusActionModule,
+    updateRaisedBedFieldSowingLocationActionModule,
     createPlantStatusRequestsFromImageAnalysisActionModule,
     logActionModule,
 ] as const satisfies readonly AutomationModule[];

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -34,6 +34,7 @@ import {
     processDueAutomationRuns,
     recordAutomationRunStep,
     seasonalSowedWateringAutomationGraph,
+    seedlingTransplantDirectSowingLocationAutomationGraph,
     startAutomationRun,
     storage,
     updateAutomationDefinition,
@@ -801,7 +802,6 @@ test('plant-status automation skips replay when target status already exists', a
     });
     await createEvent(
         knownEvents.operations.completedV1(operationId.toString(), {
-            completedAt: '2026-05-01T08:00:00.000Z',
             completedBy: 'automations-test',
         }),
     );
@@ -900,6 +900,126 @@ test('plant-status automation skips replay when target status already exists', a
     assert.strictEqual(
         (
             await getEvents(knownEventTypes.raisedBedFields.plantUpdate, [
+                fieldAggregateId,
+            ])
+        ).length,
+        1,
+    );
+});
+
+test('seedling transplant automation sets sowing location to direct once', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    const scheduledDate = '2026-04-01T08:00:00.000Z';
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate,
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields[0];
+    assert.ok(field);
+    assert.strictEqual(field.sowingLocation, 'greenhouse');
+
+    const operationId = await createOperation({
+        accountId,
+        entityId: 593,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+    });
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: 'automations-test',
+        }),
+    );
+    const event = await getLatestEvent(
+        knownEventTypes.operations.complete,
+        operationId.toString(),
+    );
+    const graph = seedlingTransplantDirectSowingLocationAutomationGraph();
+    const definition = await createAutomationDefinition({
+        key: 'test.seedling-transplant-direct-location',
+        name: 'Seedling transplant direct location',
+        status: 'enabled',
+        graph,
+    });
+    const input = {
+        eventId: event.id,
+        eventType: event.type,
+        aggregateId: event.aggregateId,
+        data:
+            event.data && typeof event.data === 'object'
+                ? (event.data as Record<string, unknown>)
+                : {},
+    };
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'event',
+        sourceEvent: event,
+        input,
+    });
+    assert.ok(run);
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+
+    assert.strictEqual(result.status, 'succeeded');
+    const updatedRaisedBed = await getRaisedBed(raisedBedId);
+    const updatedField = updatedRaisedBed?.fields.find(
+        (candidate) => candidate.id === field.id,
+    );
+    assert.strictEqual(updatedField?.sowingLocation, 'direct');
+    assert.strictEqual(
+        updatedField?.plantScheduledDate?.toISOString(),
+        scheduledDate,
+    );
+    const scheduleEvents = await getEvents(
+        knownEventTypes.raisedBedFields.plantSchedule,
+        [fieldAggregateId],
+    );
+    assert.strictEqual(scheduleEvents.length, 1);
+    assert.ok(
+        scheduleEvents[0]?.data &&
+            typeof scheduleEvents[0].data === 'object' &&
+            !Array.isArray(scheduleEvents[0].data),
+    );
+    assert.strictEqual(
+        Reflect.get(scheduleEvents[0].data, 'sowingLocation'),
+        'direct',
+    );
+    assert.strictEqual(
+        Reflect.get(scheduleEvents[0].data, 'scheduledDate'),
+        scheduledDate,
+    );
+
+    const replayRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'replay',
+        sourceEvent: event,
+        input,
+    });
+    assert.ok(replayRun);
+    const startedReplay = await startAutomationRun(replayRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedReplay);
+
+    const replayResult = await executeAutomationRun(startedReplay);
+
+    assert.strictEqual(replayResult.status, 'skipped');
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantSchedule, [
                 fieldAggregateId,
             ])
         ).length,

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -907,7 +907,7 @@ test('plant-status automation skips replay when target status already exists', a
     );
 });
 
-test('seedling transplant automation sets sowing location to direct once', async () => {
+test('seedling transplant automation waits for verification before setting sowing location to direct', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
         await createAutomationRaisedBedContext();
@@ -939,7 +939,7 @@ test('seedling transplant automation sets sowing location to direct once', async
             completedBy: 'automations-test',
         }),
     );
-    const event = await getLatestEvent(
+    const completionEvent = await getLatestEvent(
         knownEventTypes.operations.complete,
         operationId.toString(),
     );
@@ -950,20 +950,62 @@ test('seedling transplant automation sets sowing location to direct once', async
         status: 'enabled',
         graph,
     });
-    const input = {
-        eventId: event.id,
-        eventType: event.type,
-        aggregateId: event.aggregateId,
+    const completionInput = {
+        eventId: completionEvent.id,
+        eventType: completionEvent.type,
+        aggregateId: completionEvent.aggregateId,
         data:
-            event.data && typeof event.data === 'object'
-                ? (event.data as Record<string, unknown>)
+            completionEvent.data && typeof completionEvent.data === 'object'
+                ? (completionEvent.data as Record<string, unknown>)
+                : {},
+    };
+    const completionRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'event',
+        sourceEvent: completionEvent,
+        input: completionInput,
+    });
+    assert.ok(completionRun);
+    const startedCompletionRun = await startAutomationRun(completionRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedCompletionRun);
+
+    const completionResult = await executeAutomationRun(startedCompletionRun);
+
+    assert.strictEqual(completionResult.status, 'skipped');
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantSchedule, [
+                fieldAggregateId,
+            ])
+        ).length,
+        0,
+    );
+
+    await createEvent(
+        knownEvents.operations.verifiedV1(operationId.toString(), {
+            verifiedBy: 'automations-test',
+        }),
+    );
+    const verificationEvent = await getLatestEvent(
+        knownEventTypes.operations.verify,
+        operationId.toString(),
+    );
+    const verificationInput = {
+        eventId: verificationEvent.id,
+        eventType: verificationEvent.type,
+        aggregateId: verificationEvent.aggregateId,
+        data:
+            verificationEvent.data && typeof verificationEvent.data === 'object'
+                ? (verificationEvent.data as Record<string, unknown>)
                 : {},
     };
     const run = await createAutomationRun({
         automationDefinition: definition,
         source: 'event',
-        sourceEvent: event,
-        input,
+        sourceEvent: verificationEvent,
+        input: verificationInput,
     });
     assert.ok(run);
     const startedRun = await startAutomationRun(run.id, {
@@ -1005,8 +1047,8 @@ test('seedling transplant automation sets sowing location to direct once', async
     const replayRun = await createAutomationRun({
         automationDefinition: definition,
         source: 'replay',
-        sourceEvent: event,
-        input,
+        sourceEvent: verificationEvent,
+        input: verificationInput,
     });
     assert.ok(replayRun);
     const startedReplay = await startAutomationRun(replayRun.id, {


### PR DESCRIPTION
## Summary
- Added a trusted automation action for updating a raised-bed field's sowing location via `raisedBedField.plantSchedule`.
- Added the default `operation.complete` automation for operation `593` to switch the target plant from greenhouse to direct sowing.
- Updated admin automation labels and docs to cover the new module and workflow.
- Added a storage regression test covering the one-time location change and replay idempotency.

## Testing
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter app`
- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`