### PR TITLE
[codex] Add admin operation details

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -148,6 +148,8 @@ export async function createOperationAction(formData: FormData) {
         revalidatePath(KnownPages.Garden(operation.gardenId));
     if (operation.raisedBedId)
         revalidatePath(KnownPages.RaisedBed(operation.raisedBedId));
+    revalidatePath(KnownPages.Operations);
+    revalidatePath(KnownPages.Operation(operationId));
     return { success: true };
 }
 
@@ -491,13 +493,7 @@ export async function rescheduleOperationAction(formData: FormData) {
         scheduledDate: newDate.toISOString(),
     });
 
-    revalidatePath(KnownPages.Schedule);
-    if (operation.accountId)
-        revalidatePath(KnownPages.Account(operation.accountId));
-    if (operation.gardenId)
-        revalidatePath(KnownPages.Garden(operation.gardenId));
-    if (operation.raisedBedId)
-        revalidatePath(KnownPages.RaisedBed(operation.raisedBedId));
+    await revalidateOperationPaths(operation);
     return { success: true };
 }
 
@@ -514,13 +510,7 @@ export async function acceptOperationAction(operationId: number) {
     }
     await acceptOperation(operationId);
     await notifyOperationUpdate(operationId, 'approved');
-    revalidatePath(KnownPages.Schedule);
-    if (operation.accountId)
-        revalidatePath(KnownPages.Account(operation.accountId));
-    if (operation.gardenId)
-        revalidatePath(KnownPages.Garden(operation.gardenId));
-    if (operation.raisedBedId)
-        revalidatePath(KnownPages.RaisedBed(operation.raisedBedId));
+    await revalidateOperationPaths(operation);
 }
 
 export async function assignOperationUserAction(
@@ -584,13 +574,7 @@ export async function assignOperationUserAction(
         await notifyOperationAssignedUsers(operationId, newlyAssignedUserIds);
     }
 
-    revalidatePath(KnownPages.Schedule);
-    if (operation.accountId)
-        revalidatePath(KnownPages.Account(operation.accountId));
-    if (operation.gardenId)
-        revalidatePath(KnownPages.Garden(operation.gardenId));
-    if (operation.raisedBedId)
-        revalidatePath(KnownPages.RaisedBed(operation.raisedBedId));
+    await revalidateOperationPaths(operation);
 
     return { success: true };
 }
@@ -603,6 +587,7 @@ async function revalidateOperationPaths(
     revalidatePath(KnownPages.Operation(operation.id));
     if (operation.accountId)
         revalidatePath(KnownPages.Account(operation.accountId));
+    if (operation.farmId) revalidatePath(KnownPages.Farm(operation.farmId));
     if (operation.gardenId)
         revalidatePath(KnownPages.Garden(operation.gardenId));
     if (operation.raisedBedId)
@@ -924,11 +909,5 @@ export async function cancelOperationAction(formData: FormData) {
             : undefined,
     ]);
 
-    revalidatePath(KnownPages.Schedule);
-    if (operation.accountId)
-        revalidatePath(KnownPages.Account(operation.accountId));
-    if (operation.gardenId)
-        revalidatePath(KnownPages.Garden(operation.gardenId));
-    if (operation.raisedBedId)
-        revalidatePath(KnownPages.RaisedBed(operation.raisedBedId));
+    await revalidateOperationPaths(operation);
 }

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -7,6 +7,7 @@ import {
     getRaisedBed,
 } from '@gredice/storage';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
+import { Button } from '@gredice/ui/Button';
 import {
     Card,
     CardContent,
@@ -16,11 +17,13 @@ import {
 } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
 import { ImageGallery } from '@gredice/ui/ImageGallery';
+import { ExternalLink } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import {
@@ -35,11 +38,104 @@ import {
 import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
+import { OperationCancelButton } from '../../../../components/operations/OperationCancelButton';
+import { OperationRescheduleButton } from '../../../../components/operations/OperationRescheduleButton';
 import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
+import { VerifyOperationModal } from '../../schedule/VerifyOperationModal';
 
 export const dynamic = 'force-dynamic';
+
+function operationStatusLabel(status: string) {
+    switch (status) {
+        case 'new':
+            return 'Novo';
+        case 'planned':
+            return 'Planirano';
+        case 'pendingVerification':
+            return 'Čeka verifikaciju';
+        case 'completed':
+            return 'Završeno';
+        case 'failed':
+            return 'Neuspjelo';
+        case 'canceled':
+        case 'cancelled':
+            return 'Otkazano';
+        default:
+            return status;
+    }
+}
+
+function operationStatusColor(status: string) {
+    switch (status) {
+        case 'completed':
+            return 'success';
+        case 'pendingVerification':
+            return 'warning';
+        case 'planned':
+            return 'info';
+        case 'canceled':
+        case 'cancelled':
+            return 'neutral';
+        case 'failed':
+            return 'error';
+        default:
+            return 'warning';
+    }
+}
+
+function operationStatusChip(status: string) {
+    return (
+        <Chip className="w-fit" color={operationStatusColor(status)}>
+            {operationStatusLabel(status)}
+        </Chip>
+    );
+}
+
+function operationDateValue(value: Date | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    return <LocalDateTime time={false}>{value}</LocalDateTime>;
+}
+
+function operationDurationMinutes(operationDetails?: EntityStandardized) {
+    const duration = operationDetails?.attributes?.duration;
+
+    if (typeof duration === 'number' && Number.isFinite(duration)) {
+        return Math.max(0, duration);
+    }
+
+    if (typeof duration === 'string') {
+        const parsed = Number.parseFloat(duration);
+        if (Number.isFinite(parsed)) {
+            return Math.max(0, parsed);
+        }
+    }
+
+    return null;
+}
+
+function completionRequirements(operationDetails?: EntityStandardized) {
+    const conditions = operationDetails?.conditions;
+    const requirements: string[] = [];
+
+    if (conditions?.completionAttachImagesRequired) {
+        requirements.push('Slike obavezne');
+    } else if (conditions?.completionAttachImages) {
+        requirements.push('Slike opcionalne');
+    }
+
+    if (conditions?.completionAttachNotesRequired) {
+        requirements.push('Napomena obavezna');
+    } else if (conditions?.completionAttachNotes) {
+        requirements.push('Napomena opcionalna');
+    }
+
+    return requirements.length > 0 ? requirements.join(', ') : null;
+}
 
 export default async function OperationDetailsPage({
     params,
@@ -58,10 +154,6 @@ export default async function OperationDetailsPage({
     try {
         operation = await getOperationById(operationIdNumber);
     } catch {
-        return notFound();
-    }
-
-    if (!operation.accountId && !operation.farmId) {
         return notFound();
     }
 
@@ -97,265 +189,332 @@ export default async function OperationDetailsPage({
         operationDetails?.information?.label ||
         operationDetails?.information?.name ||
         `Radnja ${operation.id}`;
-    const operationStatusChip = (
-        <Chip
-            className="w-fit"
-            color={
-                operation.status === 'completed'
-                    ? 'success'
-                    : operation.status === 'pendingVerification'
-                      ? 'warning'
-                      : operation.status === 'planned'
-                        ? 'info'
-                        : operation.status === 'canceled'
-                          ? 'neutral'
-                          : 'warning'
-            }
-        >
-            {operation.status === 'pendingVerification'
-                ? 'Čeka verifikaciju'
-                : operation.status}
+    const durationMinutes = operationDurationMinutes(operationDetails);
+    const requirements = completionRequirements(operationDetails);
+    const publicOperationHref = operationDetails?.information?.label
+        ? KnownPages.GrediceOperation(operationDetails.information.label)
+        : KnownPages.GrediceOperations;
+    const assignedUsers =
+        operation.assignedUsers && operation.assignedUsers.length > 0 ? (
+            <Stack spacing={1}>
+                {operation.assignedUsers.map((user) => {
+                    const displayName = user.displayName ?? user.userName;
+
+                    return (
+                        <Row
+                            key={user.id}
+                            className="min-w-0 items-center"
+                            spacing={2}
+                        >
+                            <UserAvatar
+                                avatarUrl={user.avatarUrl}
+                                displayName={displayName}
+                                className="size-6 shrink-0"
+                            />
+                            <span className="min-w-0 truncate">
+                                {displayName}
+                            </span>
+                        </Row>
+                    );
+                })}
+            </Stack>
+        ) : (
+            'Nije dodijeljeno'
+        );
+    const acceptanceChip = operation.isAccepted ? (
+        <Chip className="w-fit" color="success">
+            Potvrđeno
+        </Chip>
+    ) : (
+        <Chip className="w-fit" color="warning">
+            Nije potvrđeno
         </Chip>
     );
-    const propertyItems: EntityDetailsPropertyListItem[] = [
-        { id: 'id', label: 'ID radnje', value: operation.id },
+    const operationAction = {
+        id: operation.id,
+        entityId: operation.entityId,
+        scheduledDate: operation.scheduledDate,
+        status: operation.status,
+    };
+    const operationItems: EntityDetailsPropertyListItem[] = [
+        { id: 'id', label: 'ID radnje', value: operation.id, mono: true },
+        {
+            id: 'entity-id',
+            label: 'ID zapisa',
+            value: operation.entityId,
+            mono: true,
+        },
         {
             id: 'name',
             label: 'Naziv',
             value: operationDetails?.information?.label || operation.entityId,
         },
-        { id: 'status', label: 'Status', value: operationStatusChip },
-        ...(operation.status === 'planned' && operation.scheduledDate
-            ? [
-                  {
-                      id: 'scheduled-at',
-                      label: 'Zakazano',
-                      value: (
-                          <LocalDateTime time={false}>
-                              {operation.scheduledDate}
-                          </LocalDateTime>
-                      ),
-                  },
-              ]
-            : []),
-        ...(operation.status === 'completed'
-            ? [
-                  ...(operation.completedBy
-                      ? [
-                            {
-                                id: 'completed-by',
-                                label: 'Izvršio',
-                                value: operation.completedBy,
-                            },
-                        ]
-                      : []),
-                  ...(operation.completedAt
-                      ? [
-                            {
-                                id: 'completed-at',
-                                label: 'Izvršeno',
-                                value: (
-                                    <LocalDateTime time={false}>
-                                        {operation.completedAt}
-                                    </LocalDateTime>
-                                ),
-                            },
-                        ]
-                      : []),
-                  ...(operation.verifiedBy
-                      ? [
-                            {
-                                id: 'verified-by',
-                                label: 'Verificirao',
-                                value: operation.verifiedBy,
-                            },
-                        ]
-                      : []),
-                  ...(operation.verifiedAt
-                      ? [
-                            {
-                                id: 'verified-at',
-                                label: 'Verificirano',
-                                value: (
-                                    <LocalDateTime time={false}>
-                                        {operation.verifiedAt}
-                                    </LocalDateTime>
-                                ),
-                            },
-                        ]
-                      : []),
-              ]
-            : []),
-        ...(operation.status === 'pendingVerification'
-            ? [
-                  ...(operation.completedBy
-                      ? [
-                            {
-                                id: 'marked-completed-by',
-                                label: 'Označio završeno',
-                                value: operation.completedBy,
-                            },
-                        ]
-                      : []),
-                  ...(operation.completedAt
-                      ? [
-                            {
-                                id: 'marked-completed-at',
-                                label: 'Označeno završeno',
-                                value: (
-                                    <LocalDateTime time={false}>
-                                        {operation.completedAt}
-                                    </LocalDateTime>
-                                ),
-                            },
-                        ]
-                      : []),
-              ]
-            : []),
-        ...(operation.status === 'failed'
-            ? [
-                  ...(operation.error
-                      ? [
-                            {
-                                id: 'error',
-                                label: 'Greška',
-                                value: operation.error,
-                            },
-                        ]
-                      : []),
-                  ...(operation.errorCode
-                      ? [
-                            {
-                                id: 'error-code',
-                                label: 'Kod greške',
-                                value: operation.errorCode,
-                            },
-                        ]
-                      : []),
-              ]
-            : []),
-        ...(operation.status === 'canceled'
-            ? [
-                  ...(operation.canceledBy
-                      ? [
-                            {
-                                id: 'canceled-by',
-                                label: 'Otkazao',
-                                value: operation.canceledBy,
-                            },
-                        ]
-                      : []),
-                  ...(operation.cancelReason
-                      ? [
-                            {
-                                id: 'cancel-reason',
-                                label: 'Razlog otkazivanja',
-                                value: operation.cancelReason,
-                            },
-                        ]
-                      : []),
-                  ...(operation.canceledAt
-                      ? [
-                            {
-                                id: 'canceled-at',
-                                label: 'Otkazano',
-                                value: (
-                                    <LocalDateTime time={false}>
-                                        {operation.canceledAt}
-                                    </LocalDateTime>
-                                ),
-                            },
-                        ]
-                      : []),
-              ]
-            : []),
-        ...(accountUsers && operation.accountId
-            ? [
-                  {
-                      id: 'account-users',
-                      label: 'Korisnici računa',
-                      value: (
-                          <Link href={KnownPages.Account(operation.accountId)}>
-                              {accountUsers}
-                          </Link>
-                      ),
-                  },
-              ]
-            : []),
-        ...(farm
-            ? [
-                  {
-                      id: 'farm',
-                      label: 'Farma',
-                      value: (
-                          <Link href={KnownPages.Farm(farm.id)}>
-                              {farm.name}
-                          </Link>
-                      ),
-                  },
-              ]
-            : []),
-        ...(gardenName && garden
-            ? [
-                  {
-                      id: 'garden',
-                      label: 'Vrt',
-                      value: (
-                          <Link href={KnownPages.Garden(garden.id)}>
-                              {gardenName}
-                          </Link>
-                      ),
-                  },
-              ]
-            : []),
-        ...(raisedBed
-            ? [
-                  {
-                      id: 'raised-bed',
-                      label: 'Gredica',
-                      value: (
-                          <Link href={KnownPages.RaisedBed(raisedBed.id)}>
-                              <RaisedBedLabel
-                                  physicalId={raisedBed.physicalId}
-                              />
-                          </Link>
-                      ),
-                  },
-              ]
-            : []),
-        ...(raisedBedField
-            ? [
-                  {
-                      id: 'raised-bed-field',
-                      label: 'Polje gredice',
-                      value: raisedBedField.positionIndex + 1,
-                  },
-              ]
-            : []),
+        {
+            id: 'entity-type',
+            label: 'Tip zapisa',
+            value: operation.entityTypeName,
+        },
+        {
+            id: 'status',
+            label: 'Status',
+            value: operationStatusChip(operation.status),
+        },
+        {
+            id: 'public-link',
+            label: 'Javni opis',
+            value: (
+                <a
+                    className="inline-flex min-w-0 items-center gap-1 text-primary hover:underline"
+                    href={publicOperationHref}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    <span className="min-w-0 truncate">Otvori</span>
+                    <ExternalLink className="size-3.5 shrink-0" />
+                </a>
+            ),
+        },
+    ];
+    if (durationMinutes !== null) {
+        operationItems.push({
+            id: 'duration',
+            label: 'Trajanje',
+            value: `${durationMinutes} min`,
+        });
+    }
+    if (typeof operationDetails?.prices?.perOperation === 'number') {
+        operationItems.push({
+            id: 'price',
+            label: 'Cijena po radnji',
+            value: operationDetails.prices.perOperation,
+        });
+    }
+    if (requirements) {
+        operationItems.push({
+            id: 'completion-requirements',
+            label: 'Za završetak',
+            value: requirements,
+        });
+    }
+
+    const locationItems: EntityDetailsPropertyListItem[] = [];
+    if (operation.accountId) {
+        locationItems.push({
+            id: 'account',
+            label: 'Račun',
+            value: (
+                <Link href={KnownPages.Account(operation.accountId)}>
+                    {operation.accountId}
+                </Link>
+            ),
+            mono: true,
+        });
+    }
+    if (accountUsers && operation.accountId) {
+        locationItems.push({
+            id: 'account-users',
+            label: 'Korisnici računa',
+            value: (
+                <Link href={KnownPages.Account(operation.accountId)}>
+                    {accountUsers}
+                </Link>
+            ),
+        });
+    }
+    if (farm) {
+        locationItems.push({
+            id: 'farm',
+            label: 'Farma',
+            value: <Link href={KnownPages.Farm(farm.id)}>{farm.name}</Link>,
+        });
+    }
+    if (gardenName && garden) {
+        locationItems.push({
+            id: 'garden',
+            label: 'Vrt',
+            value: (
+                <Link href={KnownPages.Garden(garden.id)}>{gardenName}</Link>
+            ),
+        });
+    }
+    if (raisedBed) {
+        locationItems.push({
+            id: 'raised-bed',
+            label: 'Gredica',
+            value: (
+                <Link href={KnownPages.RaisedBed(raisedBed.id)}>
+                    <RaisedBedLabel physicalId={raisedBed.physicalId} />
+                </Link>
+            ),
+        });
+    }
+    if (raisedBedField) {
+        locationItems.push({
+            id: 'raised-bed-field',
+            label: 'Polje gredice',
+            value: raisedBedField.positionIndex + 1,
+        });
+    }
+    if (locationItems.length === 0) {
+        locationItems.push({
+            id: 'location',
+            label: 'Lokacija',
+            value: 'Nije povezana',
+        });
+    }
+
+    const assignmentItems: EntityDetailsPropertyListItem[] = [
+        { id: 'accepted', label: 'Potvrda', value: acceptanceChip },
+        { id: 'assigned-users', label: 'Dodijeljeno', value: assignedUsers },
+    ];
+    if (operation.assignedBy) {
+        assignmentItems.push({
+            id: 'assigned-by',
+            label: 'Dodijelio',
+            value: operation.assignedBy,
+        });
+    }
+    if (operation.assignedAt) {
+        assignmentItems.push({
+            id: 'assigned-at',
+            label: 'Dodijeljeno',
+            value: operationDateValue(operation.assignedAt),
+        });
+    }
+    assignmentItems.push(
+        {
+            id: 'scheduled-date',
+            label: 'Zakazano za',
+            value:
+                operationDateValue(operation.scheduledDate) ?? 'Nije zakazano',
+        },
+        {
+            id: 'scheduled-at',
+            label: 'Zakazano',
+            value: operationDateValue(operation.scheduledAt),
+        },
         {
             id: 'timestamp',
-            label: 'Datum',
-            value: (
-                <LocalDateTime time={false}>
-                    {operation.timestamp}
-                </LocalDateTime>
-            ),
+            label: 'Datum radnje',
+            value: operationDateValue(operation.timestamp),
         },
         {
             id: 'created-at',
             label: 'Datum stvaranja',
-            value: (
-                <LocalDateTime time={false}>
-                    {operation.createdAt}
-                </LocalDateTime>
-            ),
+            value: operationDateValue(operation.createdAt),
         },
+    );
+
+    const outcomeItems: EntityDetailsPropertyListItem[] = [];
+    if (operation.completedBy) {
+        outcomeItems.push({
+            id: 'completed-by',
+            label:
+                operation.status === 'pendingVerification'
+                    ? 'Označio završeno'
+                    : 'Izvršio',
+            value: operation.completedBy,
+        });
+    }
+    if (operation.completedAt) {
+        outcomeItems.push({
+            id: 'completed-at',
+            label:
+                operation.status === 'pendingVerification'
+                    ? 'Označeno završeno'
+                    : 'Izvršeno',
+            value: operationDateValue(operation.completedAt),
+        });
+    }
+    if (operation.verifiedBy) {
+        outcomeItems.push({
+            id: 'verified-by',
+            label: 'Verificirao',
+            value: operation.verifiedBy,
+        });
+    }
+    if (operation.verifiedAt) {
+        outcomeItems.push({
+            id: 'verified-at',
+            label: 'Verificirano',
+            value: operationDateValue(operation.verifiedAt),
+        });
+    }
+    if (operation.error) {
+        outcomeItems.push({
+            id: 'error',
+            label: 'Greška',
+            value: operation.error,
+        });
+    }
+    if (operation.errorCode) {
+        outcomeItems.push({
+            id: 'error-code',
+            label: 'Kod greške',
+            value: operation.errorCode,
+        });
+    }
+    if (operation.canceledBy) {
+        outcomeItems.push({
+            id: 'canceled-by',
+            label: 'Otkazao',
+            value: operation.canceledBy,
+        });
+    }
+    if (operation.cancelReason) {
+        outcomeItems.push({
+            id: 'cancel-reason',
+            label: 'Razlog otkazivanja',
+            value: operation.cancelReason,
+        });
+    }
+    if (operation.canceledAt) {
+        outcomeItems.push({
+            id: 'canceled-at',
+            label: 'Otkazano',
+            value: operationDateValue(operation.canceledAt),
+        });
+    }
+    if (operation.completionNotes) {
+        outcomeItems.push({
+            id: 'completion-notes',
+            label: 'Napomena',
+            value: (
+                <span className="whitespace-pre-wrap">
+                    {operation.completionNotes}
+                </span>
+            ),
+        });
+    }
+    if (operation.imageUrls && operation.imageUrls.length > 0) {
+        outcomeItems.push({
+            id: 'image-count',
+            label: 'Slike',
+            value: operation.imageUrls.length,
+        });
+    }
+    if (outcomeItems.length === 0) {
+        outcomeItems.push({
+            id: 'outcome',
+            label: 'Ishod',
+            value: 'Još nema završnog zapisa',
+        });
+    }
+
+    const description = operationDetails?.information?.description;
+    const detailSections = [
+        { id: 'operation', title: 'Radnja', items: operationItems },
+        { id: 'location', title: 'Lokacija', items: locationItems },
+        { id: 'assignment', title: 'Plan i dodjela', items: assignmentItems },
+        { id: 'outcome', title: 'Ishod', items: outcomeItems },
     ];
     const propertiesPanel = (
         <EntityDetailsPropertiesPanel>
-            <EntityDetailsPanelCard title="Detalji">
-                <EntityDetailsPropertyList items={propertyItems} />
-            </EntityDetailsPanelCard>
+            {detailSections.map((section) => (
+                <EntityDetailsPanelCard key={section.id} title={section.title}>
+                    <EntityDetailsPropertyList items={section.items} />
+                </EntityDetailsPanelCard>
+            ))}
         </EntityDetailsPropertiesPanel>
     );
 
@@ -377,17 +536,75 @@ export default async function OperationDetailsPage({
                     }
                     actions={
                         <Row className="items-center" spacing={2}>
+                            {operation.status === 'pendingVerification' && (
+                                <VerifyOperationModal
+                                    operationId={operation.id}
+                                    label={operationTitle}
+                                />
+                            )}
+                            <OperationRescheduleButton
+                                operation={operationAction}
+                                operationLabel={operationTitle}
+                            />
+                            <OperationCancelButton
+                                operation={operationAction}
+                                operationLabel={operationTitle}
+                            />
                             <EntityDetailsPropertiesToggle />
                         </Row>
                     }
-                    heading="Detalji radnje"
+                    heading={operationTitle}
                 />
                 <EntityDetailsPropertiesLayout properties={propertiesPanel}>
-                    <Stack spacing={8}>
+                    <Stack spacing={4}>
+                        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                            {detailSections.map((section) => (
+                                <Card
+                                    className="min-w-0 overflow-hidden"
+                                    key={section.id}
+                                >
+                                    <CardHeader>
+                                        <Row
+                                            className="items-center justify-between gap-2"
+                                            spacing={2}
+                                        >
+                                            <CardTitle className="text-lg">
+                                                {section.title}
+                                            </CardTitle>
+                                            {section.id === 'operation' &&
+                                                operationStatusChip(
+                                                    operation.status,
+                                                )}
+                                        </Row>
+                                    </CardHeader>
+                                    <CardContent>
+                                        <EntityDetailsPropertyList
+                                            items={section.items}
+                                        />
+                                    </CardContent>
+                                </Card>
+                            ))}
+                        </div>
+                        {description && (
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle className="text-lg">
+                                        Opis
+                                    </CardTitle>
+                                </CardHeader>
+                                <CardContent>
+                                    <Typography className="whitespace-pre-wrap">
+                                        {description}
+                                    </Typography>
+                                </CardContent>
+                            </Card>
+                        )}
                         {operation.completionNotes && (
                             <Card>
                                 <CardHeader>
-                                    <CardTitle>Napomena završetka</CardTitle>
+                                    <CardTitle className="text-lg">
+                                        Napomena završetka
+                                    </CardTitle>
                                 </CardHeader>
                                 <CardContent>
                                     <Typography className="whitespace-pre-wrap">
@@ -400,7 +617,9 @@ export default async function OperationDetailsPage({
                             operation.imageUrls.length > 0 && (
                                 <Card>
                                     <CardHeader>
-                                        <CardTitle>Slike</CardTitle>
+                                        <CardTitle className="text-lg">
+                                            Slike
+                                        </CardTitle>
                                     </CardHeader>
                                     <CardOverflow>
                                         <Row className="w-full" spacing={4}>
@@ -419,6 +638,13 @@ export default async function OperationDetailsPage({
                                     </CardOverflow>
                                 </Card>
                             )}
+                        <Button
+                            className="w-fit"
+                            href={KnownPages.Operations}
+                            variant="outlined"
+                        >
+                            Natrag na radnje
+                        </Button>
                     </Stack>
                 </EntityDetailsPropertiesLayout>
             </Stack>


### PR DESCRIPTION
## Summary

- Render populated operation detail pages in `apps/app` with visible sections for operation metadata, location, assignment, schedule, and outcome.
- Keep operation details available even when the operation has no account or farm link.
- Add existing verify, reschedule, and cancel controls to the operation detail header.
- Revalidate operation detail and related farm pages after operation mutations so the detail view stays current.

## Impact

Internal admins get a useful `/admin/operations/:id` detail page instead of an empty page when an operation has no completion notes or images.

## Validation

- `pnpm exec biome check --write 'app/admin/operations/[operationId]/page.tsx' 'app/(actions)/operationActions.ts'`
- `pnpm exec biome check 'app/admin/operations/[operationId]/page.tsx' 'app/(actions)/operationActions.ts'`
- `pnpm typecheck --filter app` passed, but only replayed dependent package checks because `apps/app` has no app-level `typecheck` script.
- `pnpm --filter app exec tsc --noEmit --pretty false` was attempted and fails on existing unrelated app/package errors outside the changed operation files.