### PR TITLE
Improve admin greenhouse seedling table

### DIFF
--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -35,6 +35,7 @@ async function revalidateRaisedBedPaths(raisedBed: {
     if (raisedBed.gardenId)
         revalidatePath(KnownPages.Garden(raisedBed.gardenId));
     revalidatePath(KnownPages.RaisedBed(raisedBed.id));
+    revalidatePath(KnownPages.Greenhouse);
 }
 
 async function applyRaisedBedFieldPlantUpdate({

--- a/apps/app/app/admin/greenhouse/SproutedDateQuickAction.tsx
+++ b/apps/app/app/admin/greenhouse/SproutedDateQuickAction.tsx
@@ -2,18 +2,21 @@
 
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
-import { Check } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Popper } from '@gredice/ui/Popper';
 import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useTransition } from 'react';
 import { raisedBedFieldUpdatePlant } from '../../(actions)/raisedBedFieldsActions';
 
 function formatDateInputValue(value: Date | string | null | undefined) {
-    if (!value) {
-        return '';
-    }
-
-    const date = value instanceof Date ? value : new Date(value);
+    const date = value
+        ? value instanceof Date
+            ? value
+            : new Date(value)
+        : new Date();
     if (Number.isNaN(date.getTime())) {
         return '';
     }
@@ -46,19 +49,27 @@ export function SproutedDateQuickAction({
     sproutedDate: Date | null;
 }) {
     const router = useRouter();
+    const [open, setOpen] = useState(false);
     const [selectedDate, setSelectedDate] = useState(
         formatDateInputValue(sproutedDate),
     );
     const [isPending, startTransition] = useTransition();
-    const dateChanged = selectedDate !== formatDateInputValue(sproutedDate);
 
     useEffect(() => {
         setSelectedDate(formatDateInputValue(sproutedDate));
     }, [sproutedDate]);
 
+    function handleOpenChange(nextOpen: boolean) {
+        if (nextOpen) {
+            setSelectedDate(formatDateInputValue(sproutedDate));
+        }
+        setOpen(nextOpen);
+    }
+
     function handleSave() {
         const timestamp = dateInputToTimestamp(selectedDate);
         if (!timestamp) {
+            alert('Odaberi ispravan datum klijanja.');
             return;
         }
 
@@ -70,6 +81,7 @@ export function SproutedDateQuickAction({
                     status: 'sprouted',
                     timestamp,
                 });
+                setOpen(false);
                 router.refresh();
             } catch (error) {
                 console.error('Error updating sprouted date:', error);
@@ -83,29 +95,63 @@ export function SproutedDateQuickAction({
     }
 
     return (
-        <Row spacing={1} className="items-center">
-            <Input
-                aria-label="Datum klijanja"
-                className="h-8 w-36"
-                disabled={isPending}
-                name={`sproutedDate-${raisedBedId}-${positionIndex}`}
-                onChange={(event) => setSelectedDate(event.target.value)}
-                type="date"
-                value={selectedDate}
-            />
-            <Button
-                aria-label="Spremi datum klijanja"
-                color="success"
-                disabled={!selectedDate || isPending || !dateChanged}
-                loading={isPending}
-                onClick={handleSave}
-                size="sm"
-                startDecorator={<Check className="size-4 shrink-0" />}
-                title="Spremi datum klijanja i označi biljku kao proklijalu"
-                variant="outlined"
-            >
-                Spremi
-            </Button>
-        </Row>
+        <Popper
+            open={open}
+            onOpenChange={handleOpenChange}
+            align="start"
+            className="w-72 p-3"
+            side="bottom"
+            trigger={
+                <Button
+                    type="button"
+                    aria-label="Promijeni datum klijanja"
+                    color="neutral"
+                    size="sm"
+                    title="Promijeni datum klijanja"
+                    variant="plain"
+                    className="h-8 px-1 -mx-1"
+                >
+                    {sproutedDate ? (
+                        <LocalDateTime time={false}>
+                            {sproutedDate}
+                        </LocalDateTime>
+                    ) : (
+                        <span className="text-muted-foreground">-</span>
+                    )}
+                </Button>
+            }
+        >
+            <Stack spacing={3}>
+                <Typography level="h5">Datum klijanja</Typography>
+                <Input
+                    fullWidth
+                    aria-label="Datum klijanja"
+                    disabled={isPending}
+                    label="Proklijalo"
+                    name={`sproutedDate-${raisedBedId}-${positionIndex}`}
+                    onChange={(event) => setSelectedDate(event.target.value)}
+                    type="date"
+                    value={selectedDate}
+                />
+                <Row spacing={2} className="justify-end">
+                    <Button
+                        type="button"
+                        disabled={isPending}
+                        onClick={() => setOpen(false)}
+                        variant="plain"
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        type="button"
+                        disabled={!selectedDate || isPending}
+                        loading={isPending}
+                        onClick={handleSave}
+                    >
+                        Spremi
+                    </Button>
+                </Row>
+            </Stack>
+        </Popper>
     );
 }

--- a/apps/app/app/admin/greenhouse/page.tsx
+++ b/apps/app/app/admin/greenhouse/page.tsx
@@ -7,6 +7,7 @@ import {
 import { Card, CardHeader, CardOverflow } from '@gredice/ui/Card';
 import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
@@ -85,20 +86,58 @@ function getStatusColor(status?: string | null): ColorPaletteProp {
 }
 
 function getPlantName(
-    plantSortNameById: Map<number, string>,
+    plantSort: PlantSortData | undefined,
     plantSortId: number,
 ) {
     return (
-        plantSortNameById.get(plantSortId) ?? `Nepoznata sorta #${plantSortId}`
+        plantSort?.information?.name?.trim() ??
+        `Nepoznata sorta #${plantSortId}`
     );
 }
 
-function dateCell(date: Date | undefined | null) {
-    if (!date) {
+function localCalendarDayIndex(date: Date) {
+    const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+    return (
+        Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) /
+        millisecondsPerDay
+    );
+}
+
+function formatDayCount(days: number) {
+    return days === 1 ? '1 dan' : `${days} dana`;
+}
+
+function daysBetweenDates(startDate: Date, endDate: Date) {
+    const difference =
+        localCalendarDayIndex(endDate) - localCalendarDayIndex(startDate);
+
+    return Math.max(0, difference);
+}
+
+function sowingDateCell(
+    sowDate: Date | undefined,
+    sproutedDate: Date | undefined,
+    today: Date,
+) {
+    if (!sowDate) {
         return <span className="text-muted-foreground">-</span>;
     }
 
-    return <LocalDateTime time={false}>{date}</LocalDateTime>;
+    const targetDate = sproutedDate ?? today;
+    const dayCount = daysBetweenDates(sowDate, targetDate);
+    const label = sproutedDate
+        ? `${formatDayCount(dayCount)} do klijanja`
+        : `${formatDayCount(dayCount)} do danas`;
+
+    return (
+        <div className="space-y-0.5">
+            <LocalDateTime time={false}>{sowDate}</LocalDateTime>
+            <div className="text-xs tabular-nums text-muted-foreground">
+                {label}
+            </div>
+        </div>
+    );
 }
 
 function getGreenhouseRaisedBeds(
@@ -170,11 +209,8 @@ export default async function GreenhousePage() {
         getAllRaisedBeds(),
         getEntitiesFormatted<PlantSortData>('plantSort'),
     ]);
-    const plantSortNameById = new Map(
-        (plantSorts ?? []).map((plantSort) => [
-            plantSort.id,
-            plantSort.information?.name?.trim() || `Sorta ${plantSort.id}`,
-        ]),
+    const plantSortById = new Map(
+        (plantSorts ?? []).map((plantSort) => [plantSort.id, plantSort]),
     );
     const greenhouseRaisedBeds = getGreenhouseRaisedBeds(raisedBeds);
 
@@ -188,6 +224,7 @@ export default async function GreenhousePage() {
 
     const transplantingOperationIdsByFieldId =
         await getTransplantingOperationIdsByFieldId(greenhouseRaisedBeds);
+    const today = new Date();
 
     return (
         <Stack spacing={3}>
@@ -221,77 +258,104 @@ export default async function GreenhousePage() {
                                         Polje
                                     </Table.Head>
                                     <Table.Head>Biljka</Table.Head>
+                                    <Table.Head>Status</Table.Head>
                                     <Table.Head>Sijano</Table.Head>
                                     <Table.Head>Proklijalo</Table.Head>
                                     <Table.Head>Presađivanje</Table.Head>
-                                    <Table.Head>Status</Table.Head>
                                 </Table.Row>
                             </Table.Header>
                             <Table.Body>
-                                {raisedBed.fields.map((field) => (
-                                    <Table.Row
-                                        key={`${raisedBed.id}-${field.id}`}
-                                    >
-                                        <Table.Cell className="font-medium">
-                                            {field.positionIndex + 1}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <span className="font-medium">
-                                                {getPlantName(
-                                                    plantSortNameById,
-                                                    field.plantSortId,
+                                {raisedBed.fields.map((field) => {
+                                    const plantSort = plantSortById.get(
+                                        field.plantSortId,
+                                    );
+                                    const plantName = getPlantName(
+                                        plantSort,
+                                        field.plantSortId,
+                                    );
+
+                                    return (
+                                        <Table.Row
+                                            key={`${raisedBed.id}-${field.id}`}
+                                        >
+                                            <Table.Cell className="font-medium">
+                                                {field.positionIndex + 1}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <div className="flex min-w-0 items-center gap-3">
+                                                    <div className="relative size-9 shrink-0 overflow-hidden rounded-md border bg-muted/30">
+                                                        <PlantOrSortImage
+                                                            plantSort={
+                                                                plantSort
+                                                            }
+                                                            alt={plantName}
+                                                            fill
+                                                            className="object-contain"
+                                                            sizes="36px"
+                                                        />
+                                                    </div>
+                                                    <span className="min-w-0 font-medium">
+                                                        {plantName}
+                                                    </span>
+                                                </div>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Chip
+                                                    color={getStatusColor(
+                                                        field.plantStatus,
+                                                    )}
+                                                    size="sm"
+                                                >
+                                                    {statusLabels[
+                                                        field.plantStatus ?? ''
+                                                    ] ??
+                                                        field.plantStatus ??
+                                                        'Nepoznato'}
+                                                </Chip>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {sowingDateCell(
+                                                    field.plantSowDate,
+                                                    field.plantGrowthDate,
+                                                    today,
                                                 )}
-                                            </span>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {dateCell(field.plantSowDate)}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <SproutedDateQuickAction
-                                                raisedBedId={raisedBed.id}
-                                                positionIndex={
-                                                    field.positionIndex
-                                                }
-                                                sproutedDate={
-                                                    field.plantGrowthDate ??
-                                                    null
-                                                }
-                                            />
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {field.plantStatus === 'sprouted' &&
-                                            raisedBed.accountId ? (
-                                                <SeedlingTransplantingQuickAction
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <SproutedDateQuickAction
                                                     raisedBedId={raisedBed.id}
                                                     positionIndex={
                                                         field.positionIndex
                                                     }
-                                                    existingOperationId={
-                                                        transplantingOperationIdsByFieldId.get(
-                                                            field.id,
-                                                        ) ?? null
+                                                    sproutedDate={
+                                                        field.plantGrowthDate ??
+                                                        null
                                                     }
                                                 />
-                                            ) : (
-                                                '-'
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <Chip
-                                                color={getStatusColor(
-                                                    field.plantStatus,
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {field.plantStatus ===
+                                                    'sprouted' &&
+                                                raisedBed.accountId ? (
+                                                    <SeedlingTransplantingQuickAction
+                                                        raisedBedId={
+                                                            raisedBed.id
+                                                        }
+                                                        positionIndex={
+                                                            field.positionIndex
+                                                        }
+                                                        existingOperationId={
+                                                            transplantingOperationIdsByFieldId.get(
+                                                                field.id,
+                                                            ) ?? null
+                                                        }
+                                                    />
+                                                ) : (
+                                                    '-'
                                                 )}
-                                                size="sm"
-                                            >
-                                                {statusLabels[
-                                                    field.plantStatus ?? ''
-                                                ] ??
-                                                    field.plantStatus ??
-                                                    'Nepoznato'}
-                                            </Chip>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                ))}
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    );
+                                })}
                             </Table.Body>
                         </Table>
                     </CardOverflow>


### PR DESCRIPTION
## Summary
- Show plant sort thumbnails next to plant names on the admin greenhouse table.
- Move the status column before sowing and add elapsed-day context under sowing dates.
- Replace direct sprouted-date editing with a plain date trigger that opens a popover containing the date picker and save button.
- Revalidate the greenhouse page after raised-bed plant updates so saved sprouted dates refresh the table.

## Validation
- `pnpm lint --filter app`
- `pnpm build --filter app`
- `git diff --check`
- Browser smoke check opened `http://localhost:3983/admin/greenhouse`; local session stopped at login, with no console errors before auth.