### PR TITLE
Add approved bulk operation creation toggle

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -340,11 +340,18 @@ export async function bulkCreateOperationsAction(
             : undefined;
         const selectedAssignedUserId =
             getStringFormValue(formData, 'assignedUserId') || undefined;
+        const approveOnCreate =
+            getStringFormValue(formData, 'approve') === 'true';
         const targets = formData
             .getAll('targets')
             .filter((value): value is string => typeof value === 'string');
         if (targets.length === 0) {
             throw new Error('Odaberite barem jednu ciljnu lokaciju.');
+        }
+        if (approveOnCreate && !selectedAssignedUserId) {
+            throw new Error(
+                'Radnje ne mogu biti potvrđene prije nego što korisnik bude dodijeljen.',
+            );
         }
         const parsedTargets = targets.map(parseOperationTarget);
         await assertRaisedBedTargetsAllowNewOperations(parsedTargets);
@@ -431,6 +438,10 @@ export async function bulkCreateOperationsAction(
                 await notifyOperationAssignedUsers(operationId, [
                     selectedAssignedUserId,
                 ]);
+            }
+            if (approveOnCreate) {
+                await acceptOperation(operationId);
+                await notifyOperationUpdate(operationId, 'approved');
             }
             createdCount += 1;
         }

--- a/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
@@ -5,6 +5,7 @@ import { Input } from '@gredice/ui/Input';
 import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { useActionState, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import { getEntities } from '../../../components/shared/attributes/actions/entitiesActions';
@@ -68,6 +69,7 @@ export function BulkOperationCreateModal({
     const [selectedAssignedUserId, setSelectedAssignedUserId] =
         useState(unassignedValue);
     const [selectedTargetsCount, setSelectedTargetsCount] = useState(0);
+    const [approveOnCreate, setApproveOnCreate] = useState(false);
     const [state, formAction] = useActionState(
         bulkCreateOperationsAction,
         null,
@@ -101,6 +103,7 @@ export function BulkOperationCreateModal({
         setSelectedOperationId(null);
         setSelectedAssignedUserId(unassignedValue);
         setSelectedTargetsCount(0);
+        setApproveOnCreate(false);
         formRef.current?.reset();
     }, [state?.success]);
 
@@ -158,6 +161,43 @@ export function BulkOperationCreateModal({
                                 ? ''
                                 : selectedAssignedUserId
                         }
+                    />
+                    <div className="flex items-center justify-between gap-4 rounded-md border border-border bg-muted/30 px-3 py-2">
+                        <span className="text-sm font-medium">
+                            Odobri odmah
+                        </span>
+                        <button
+                            type="button"
+                            role="switch"
+                            aria-checked={approveOnCreate}
+                            aria-label="Odobri odmah"
+                            onClick={() =>
+                                setApproveOnCreate((current) => !current)
+                            }
+                            className={cx(
+                                'relative flex h-6 w-11 shrink-0 items-center rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                                approveOnCreate
+                                    ? 'border-primary/60 bg-primary'
+                                    : 'border-border bg-muted/70 hover:bg-muted',
+                            )}
+                        >
+                            <span
+                                className={cx(
+                                    'inline-block size-5 rounded-full shadow-xs transition-transform',
+                                    approveOnCreate
+                                        ? 'translate-x-5 bg-primary-foreground'
+                                        : 'translate-x-0.5 bg-muted-foreground',
+                                )}
+                            />
+                            <span className="sr-only">
+                                {approveOnCreate ? 'Da' : 'Ne'}
+                            </span>
+                        </button>
+                    </div>
+                    <input
+                        type="hidden"
+                        name="approve"
+                        value={approveOnCreate ? 'true' : ''}
                     />
                     <TargetsSelectionList
                         name="targets"

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -5,6 +5,7 @@ import {
     type DeliveryRequestState,
     getDeliveryRequest,
     getEntityFormatted,
+    getFarm,
     getGarden,
     getNotificationSetting,
     getOperationById,
@@ -151,6 +152,15 @@ async function buildOperationContext(
                         }
                     }
                 }
+            }
+        }
+
+        if (operation.farmId && !farmSlackChannelId) {
+            const farm = await getFarm(operation.farmId);
+            if (farm) {
+                farmName = farm.name ?? farmName;
+                farmId = farm.id;
+                farmSlackChannelId = farm.slackChannelId ?? farmSlackChannelId;
             }
         }
 


### PR DESCRIPTION
## Summary
- add an Odobri odmah switch to the bulk operation create modal
- pass the approve flag through the bulk create action
- mark each created operation accepted and send the approved notification when the switch is enabled

## Testing
- pnpm lint --filter app
- pnpm typecheck --filter app
- git diff --check
- pnpm --filter app exec tsc --noEmit --pretty false (fails on existing unrelated app-wide type errors, including PageProps globals, notification composer types, and generated fiscalization export typing)