### PR TITLE
Add storage deploy migration script

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -18,6 +18,7 @@
         "lint:migrate": "biome migrate --write",
         "db-generate": "drizzle-kit generate",
         "db-push": "tsx --env-file=.env ./src/migrate.ts",
+        "migrate:deploy": "tsx --conditions=react-server ./src/migrate.ts",
         "dev": "drizzle-kit studio",
         "test": "pnpm run test:node",
         "test:db:start": "bash ./tests/startTestDb.sh",


### PR DESCRIPTION
## Summary
- add a dedicated @gredice/storage deploy migration script for Vercel builds
- updated the live Vercel api project Build Command to run the script only for production deployments

## Validation
- git diff --check
- node package.json script assertion
- shell syntax check for the Vercel Build Command

## Notes
- pnpm bootstrap linked Vercel projects and pulled envs; it exited nonzero on unrelated local Docker and /etc/hosts checks.
- Did not trigger a production deploy or run migrations locally.