### PR TITLE
Add AI operation suggestion scheduling chips

### DIFF
--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -425,6 +425,8 @@ async function buildAnalysisMessages({
             getOperations(accountId, gardenId, raisedBed.id),
             getEntitiesFormatted<{
                 id: string;
+                slug?: string;
+                attributes?: { application?: string | null };
                 information?: { label?: string; name?: string };
             }>('operation'),
             buildWeatherContext(referenceDate),
@@ -443,11 +445,33 @@ async function buildAnalysisMessages({
             entity.information?.label ?? entity.information?.name ?? entity.id,
         ]),
     );
-    const availableOperations = operationsData.map((entity) => ({
-        id: entity.id,
-        name:
-            entity.information?.label ?? entity.information?.name ?? entity.id,
-    }));
+    const availableOperations = operationsData.map((entity) => {
+        const application = entity.attributes?.application ?? null;
+        const isRaisedBedOperation =
+            application === 'raisedBedFull' || application === 'raisedBed1m';
+        const isPlantFieldOperation = application === 'plant';
+        const publicOperationUrl = entity.slug
+            ? `https://www.gredice.com/radnje/${entity.slug}`
+            : null;
+
+        return {
+            id: entity.id,
+            name:
+                entity.information?.label ??
+                entity.information?.name ??
+                entity.id,
+            slug: entity.slug ?? null,
+            application,
+            raisedBedOperationUrl:
+                isRaisedBedOperation && publicOperationUrl
+                    ? `${publicOperationUrl}#raisedBedId=${raisedBed.id}`
+                    : null,
+            plantFieldOperationUrlTemplate:
+                isPlantFieldOperation && publicOperationUrl
+                    ? `${publicOperationUrl}#raisedBedId=${raisedBed.id}&positionIndex={positionIndex}`
+                    : null,
+        };
+    });
 
     const plantedFields = raisedBed.fields
         .filter((field) => field.active && field.plantSortId)
@@ -520,6 +544,9 @@ async function buildAnalysisMessages({
                 '- U JSON kontekstu vrijednost `positionLabel` koristi ovo brojanje (1-bazirano), dok `positionIndex` ostaje 0-bazirana interna oznaka (`positionLabel = positionIndex + 1`).',
                 '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
                 '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
+                '- Kada preporučiš konkretnu radnju iz `availableOperations`, napiši je kao markdown poveznicu na apsolutni URL iz `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
+                '- Za radnje nad pojedinom biljkom/poljem koristi hash s 0-baziranim `positionIndex`: `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId}&positionIndex={positionIndex})`. Ne koristi `positionLabel` u URL-u.',
+                '- Koristi samo apsolutne `https://www.gredice.com/radnje/...` URL predloške iz `availableOperations`; ne izmišljaj slugove, ne piši sirovi URL bez markdown oznake i ne dodaj link ako za radnju ne postoji odgovarajući URL predložak.',
             ].join('\n'),
         },
         {

--- a/apps/garden/tests/RaisedBedDiaryStory.tsx
+++ b/apps/garden/tests/RaisedBedDiaryStory.tsx
@@ -3,6 +3,7 @@ import { type PropsWithChildren, useMemo } from 'react';
 import { GameFlagsContext } from '../../../packages/game/src/GameFlagsContext';
 import { RaisedBedDiary } from '../../../packages/game/src/hud/raisedBed/RaisedBedDiary';
 import { Card, CardOverflow } from '../../../packages/ui/src/Card';
+import { buildOperation } from './raisedBedFieldHudScenarios';
 
 const TEST_GARDEN_ID = 1;
 const TEST_RAISED_BED_ID = 101;
@@ -35,6 +36,30 @@ const imageUrls = [
 const longWord =
     'SuperdugacakNazivDnevnickogUnosaBezRazmakaKojiMoraOstatiUnutarListe';
 
+const baseRaisedBedOperation = buildOperation({
+    id: 77,
+    name: 'raised-bed-mulching',
+    label: 'Malčiranje gredice',
+    stageName: 'growth',
+    stageLabel: 'Rast',
+});
+
+const raisedBedOperation = {
+    ...baseRaisedBedOperation,
+    attributes: {
+        ...baseRaisedBedOperation.attributes,
+        application: 'raisedBedFull',
+    },
+};
+
+const plantFieldOperation = buildOperation({
+    id: 88,
+    name: 'plant-watering',
+    label: 'Zalijevanje biljke',
+    stageName: 'growth',
+    stageLabel: 'Rast',
+});
+
 function todayUtcIso() {
     const today = new Date();
     return new Date(
@@ -64,9 +89,9 @@ const diaryEntries: DiaryEntry[] = [
     },
     {
         id: 2,
-        name: 'AI analysis with several images',
+        name: 'AI analysis with operation links',
         description:
-            '## Analysis\n\nThe gallery and text should stay constrained inside the diary row.',
+            '## Analysis\n\nSchedule [Malčiranje gredice](https://www.gredice.com/radnje/mock-raised-bed-mulching#raisedBedId=101) for the full bed and [Zalijevanje biljke](https://www.gredice.com/radnje/mock-plant-watering#raisedBedId=101&positionIndex=5) for the stressed plant.',
         status: null,
         timestamp: new Date('2026-05-12T12:00:00.000Z'),
         imageUrls,
@@ -100,6 +125,19 @@ function createRaisedBedDiaryQueryClient() {
         ['raisedBeds', TEST_RAISED_BED_ID, 'diary'],
         diaryEntries,
     );
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(
+        ['operations'],
+        [raisedBedOperation, plantFieldOperation],
+    );
+    queryClient.setQueryData(['shopping-cart'], {
+        id: 1,
+        items: [],
+        total: 0,
+        totalSunflowers: 0,
+        allowPurchase: true,
+        notes: [],
+    });
 
     return queryClient;
 }

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -1,10 +1,123 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import type { Locator } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { getMinimumDiaryRescheduleDateInput } from '../../../packages/game/src/hooks/useRescheduleDiaryEntry';
 import { RaisedBedDiaryOverflowStory } from './RaisedBedDiaryStory';
 
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const TABLET_VIEWPORT = { width: 1024, height: 768 };
+const TEST_GARDEN_ID = 1;
+const TEST_RAISED_BED_ID = 101;
+
+type ShoppingCartPostPayload = {
+    additionalData?: unknown;
+    amount?: unknown;
+    cartId?: unknown;
+    currency?: unknown;
+    entityId?: unknown;
+    entityTypeName?: unknown;
+    gardenId?: unknown;
+    positionIndex?: unknown;
+    raisedBedId?: unknown;
+};
+
+function isShoppingCartPostPayload(
+    value: unknown,
+): value is ShoppingCartPostPayload {
+    return typeof value === 'object' && value !== null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseScheduledDate(payload: ShoppingCartPostPayload) {
+    expect(typeof payload.additionalData).toBe('string');
+
+    if (typeof payload.additionalData !== 'string') {
+        throw new Error('Scheduled operation data is not a string');
+    }
+
+    const parsed: unknown = JSON.parse(payload.additionalData);
+
+    expect(isRecord(parsed)).toBe(true);
+
+    if (!isRecord(parsed)) {
+        throw new Error('Scheduled operation data is not an object');
+    }
+
+    return parsed.scheduledDate;
+}
+
+async function captureShoppingCartPost(
+    page: Page,
+    {
+        body = { success: true },
+        status = 200,
+    }: { body?: unknown; status?: number } = {},
+) {
+    let resolvePayload: ((payload: unknown) => void) | undefined;
+    const payloadPromise = new Promise<unknown>((resolve) => {
+        resolvePayload = resolve;
+    });
+
+    await page.route('**/*', async (route) => {
+        const request = route.request();
+        if (
+            request.method() !== 'POST' ||
+            !request.url().includes('/shopping-cart')
+        ) {
+            await route.fallback();
+            return;
+        }
+
+        resolvePayload?.(request.postDataJSON());
+        await route.fulfill({
+            body: JSON.stringify(body),
+            contentType: 'application/json',
+            status,
+        });
+    });
+
+    return { payloadPromise };
+}
+
+function expectBaseSchedulingPayload(
+    payload: unknown,
+    {
+        entityId,
+        positionIndex,
+        selectedDate,
+    }: {
+        entityId: string;
+        positionIndex?: number;
+        selectedDate: string;
+    },
+) {
+    expect(isShoppingCartPostPayload(payload)).toBe(true);
+
+    if (!isShoppingCartPostPayload(payload)) {
+        throw new Error('Shopping cart request payload is not an object');
+    }
+
+    expect(payload).toMatchObject({
+        amount: 1,
+        cartId: 1,
+        currency: 'eur',
+        entityId,
+        entityTypeName: 'operation',
+        gardenId: TEST_GARDEN_ID,
+        raisedBedId: TEST_RAISED_BED_ID,
+    });
+    expect(parseScheduledDate(payload)).toBe(
+        new Date(selectedDate).toISOString(),
+    );
+
+    if (typeof positionIndex === 'number') {
+        expect(payload.positionIndex).toBe(positionIndex);
+    } else {
+        expect(payload).not.toHaveProperty('positionIndex');
+    }
+}
 
 async function expectNoHorizontalOverflow(locator: Locator) {
     const overflow = await locator.evaluate((element) => ({
@@ -113,4 +226,125 @@ test('future planned diary entries expose cancel confirmation', async ({
         dialog.getByText('Otkazivanje se ne može poništiti.'),
     ).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Otkaži' })).toBeVisible();
+});
+
+test('saved AI operation links render as scheduling chips', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    const { payloadPromise: scheduledPayload } =
+        await captureShoppingCartPost(page);
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const aiEntry = page.locator('[data-diary-entry]').nth(1);
+    await aiEntry.getByRole('button').first().click();
+
+    const dialog = page.getByRole('dialog');
+    const chips = dialog.locator('[data-ai-operation-chip]');
+    await expect(chips).toHaveCount(2);
+    await expect(
+        dialog.getByRole('button', { name: 'Malčiranje gredice' }),
+    ).toBeVisible();
+    await expect(
+        dialog.getByRole('button', { name: 'Zalijevanje biljke - polje 6' }),
+    ).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Malčiranje gredice' }).click();
+
+    const scheduleDialog = page.getByRole('dialog', {
+        name: 'Zakaži radnju: Malčiranje gredice',
+    });
+    await expect(scheduleDialog.getByText('Zakazivanje radnje')).toBeVisible();
+    await expect(
+        scheduleDialog.getByText('Malčiranje gredice', { exact: true }),
+    ).toBeVisible();
+
+    const selectedDate = await scheduleDialog
+        .getByLabel('Željeni datum radnje')
+        .inputValue();
+    await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
+
+    expectBaseSchedulingPayload(await scheduledPayload, {
+        entityId: '77',
+        selectedDate,
+    });
+});
+
+test('saved AI plant operation chip schedules the targeted field', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    const { payloadPromise: scheduledPayload } =
+        await captureShoppingCartPost(page);
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const aiEntry = page.locator('[data-diary-entry]').nth(1);
+    await aiEntry.getByRole('button').first().click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog
+        .getByRole('button', { name: 'Zalijevanje biljke - polje 6' })
+        .click();
+
+    const scheduleDialog = page.getByRole('dialog', {
+        name: 'Zakaži radnju: Zalijevanje biljke',
+    });
+    const selectedDate = await scheduleDialog
+        .getByLabel('Željeni datum radnje')
+        .inputValue();
+    await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
+
+    expectBaseSchedulingPayload(await scheduledPayload, {
+        entityId: '88',
+        positionIndex: 5,
+        selectedDate,
+    });
+});
+
+test('saved AI operation scheduling failures stay recoverable', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    const { payloadPromise: scheduledPayload } = await captureShoppingCartPost(
+        page,
+        {
+            body: { error: 'Failed to schedule operation' },
+            status: 500,
+        },
+    );
+    await mount(<RaisedBedDiaryOverflowStory />);
+
+    const aiEntry = page.locator('[data-diary-entry]').nth(1);
+    await aiEntry.getByRole('button').first().click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Malčiranje gredice' }).click();
+
+    const scheduleDialog = page.getByRole('dialog', {
+        name: 'Zakaži radnju: Malčiranje gredice',
+    });
+    const selectedDate = await scheduleDialog
+        .getByLabel('Željeni datum radnje')
+        .inputValue();
+    await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
+
+    expectBaseSchedulingPayload(await scheduledPayload, {
+        entityId: '77',
+        selectedDate,
+    });
+    await expect(
+        scheduleDialog.getByText('Zakazivanje nije uspjelo. Pokušaj ponovno.'),
+    ).toBeVisible();
+    await expect(
+        scheduleDialog.getByRole('button', { name: 'Potvrdi' }),
+    ).toBeEnabled();
+    await expect(
+        scheduleDialog.getByRole('button', { name: 'Odustani' }),
+    ).toBeEnabled();
+
+    await scheduleDialog.getByRole('button', { name: 'Odustani' }).click();
+    await expect(scheduleDialog).toBeHidden();
 });

--- a/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
@@ -1,0 +1,241 @@
+import type { OperationData } from '@gredice/client';
+import { Chip } from '@gredice/ui/Chip';
+import { Calendar } from '@gredice/ui/icons';
+import { Children, isValidElement, type ReactNode, useMemo } from 'react';
+import type { Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
+import { useOperations } from '../../hooks/useOperations';
+import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
+import {
+    parseRaisedBedAiOperationHref,
+    type RaisedBedAiOperationLinkTarget,
+} from './raisedBedAiOperationLinks';
+import { OperationScheduleModal } from './shared/OperationScheduleModal';
+
+function getTextContent(node: ReactNode): string {
+    if (typeof node === 'string' || typeof node === 'number') {
+        return String(node);
+    }
+
+    if (Array.isArray(node)) {
+        return node.map(getTextContent).join('');
+    }
+
+    if (isValidElement<{ children?: ReactNode }>(node)) {
+        return getTextContent(node.props.children);
+    }
+
+    return '';
+}
+
+function getFallbackLinkLabel(href: string | undefined): string {
+    if (!href) {
+        return 'Poveznica';
+    }
+
+    try {
+        const url = new URL(href, 'https://www.gredice.com');
+        return `${url.hostname}${url.pathname}${url.search}`;
+    } catch {
+        return href;
+    }
+}
+
+function getOperationLabel(
+    operation: OperationData | undefined,
+    label: string,
+) {
+    return (
+        operation?.information.label ||
+        operation?.information.name ||
+        label ||
+        'Zakaži radnju'
+    );
+}
+
+function getChipDisplayLabel(
+    operation: OperationData,
+    label: string,
+    target: RaisedBedAiOperationLinkTarget,
+) {
+    const operationLabel = getOperationLabel(operation, label);
+
+    return isPlantFieldOperation(operation) &&
+        typeof target.positionIndex === 'number'
+        ? `${operationLabel} - polje ${target.positionIndex + 1}`
+        : operationLabel;
+}
+
+function isRaisedBedOperation(operation: OperationData) {
+    return (
+        operation.attributes.application === 'raisedBedFull' ||
+        operation.attributes.application === 'raisedBed1m'
+    );
+}
+
+function isPlantFieldOperation(operation: OperationData) {
+    return operation.attributes.application === 'plant';
+}
+
+function getTargetLabel(
+    target: RaisedBedAiOperationLinkTarget,
+    operation: OperationData,
+) {
+    const raisedBedLabel = `gredica #${target.raisedBedId}`;
+
+    if (isPlantFieldOperation(operation)) {
+        return typeof target.positionIndex === 'number'
+            ? `${raisedBedLabel}, polje ${target.positionIndex + 1}`
+            : `${raisedBedLabel}, polje nije zadano`;
+    }
+
+    return raisedBedLabel;
+}
+
+function disabledReason(
+    target: RaisedBedAiOperationLinkTarget,
+    operation: OperationData | undefined,
+) {
+    if (!operation) {
+        return 'Radnja iz AI savjeta nije dostupna u katalogu.';
+    }
+
+    if (!isRaisedBedOperation(operation) && !isPlantFieldOperation(operation)) {
+        return 'Ova radnja se ne može zakazati iz savjeta suncokreta.';
+    }
+
+    if (
+        isPlantFieldOperation(operation) &&
+        typeof target.positionIndex !== 'number'
+    ) {
+        return 'AI poveznica ne sadrži indeks polja za radnju nad biljkom.';
+    }
+
+    return null;
+}
+
+function DisabledOperationChip({
+    label,
+    title,
+}: {
+    label: string;
+    title: string;
+}) {
+    return (
+        <Chip
+            color="warning"
+            data-ai-operation-chip
+            disabled
+            size="sm"
+            startDecorator={<Calendar />}
+            title={title}
+            variant="outlined"
+        >
+            {label}
+        </Chip>
+    );
+}
+
+function RaisedBedAiOperationChip({
+    gardenId,
+    label,
+    target,
+}: {
+    gardenId: number;
+    label: string;
+    target: RaisedBedAiOperationLinkTarget;
+}) {
+    const { data: operations } = useOperations();
+    const setShoppingCartItem = useSetShoppingCartItem();
+    const operation = operations?.find(
+        (item) =>
+            (target.operationSlug && item.slug === target.operationSlug) ||
+            (target.operationId && item.id === target.operationId),
+    );
+    const chipLabel = getOperationLabel(operation, label);
+    const reason = disabledReason(target, operation);
+
+    if (!operation || reason) {
+        return <DisabledOperationChip label={chipLabel} title={reason ?? ''} />;
+    }
+
+    const chipDisplayLabel = getChipDisplayLabel(operation, label, target);
+    const targetPositionIndex = isPlantFieldOperation(operation)
+        ? target.positionIndex
+        : undefined;
+    const targetLabel = getTargetLabel(target, operation);
+    const title = `Zakaži radnju: ${chipLabel} (${targetLabel})`;
+
+    return (
+        <OperationScheduleModal
+            operation={operation}
+            onConfirm={async (scheduledDate) => {
+                await setShoppingCartItem.mutateAsync({
+                    amount: 1,
+                    entityId: operation.id.toString(),
+                    entityTypeName: operation.entityType.name,
+                    gardenId,
+                    raisedBedId: target.raisedBedId,
+                    positionIndex: targetPositionIndex,
+                    additionalData: JSON.stringify({
+                        scheduledDate: scheduledDate.toISOString(),
+                    }),
+                    currency: 'eur',
+                });
+            }}
+            trigger={
+                <Chip
+                    color={
+                        isPlantFieldOperation(operation) ? 'success' : 'info'
+                    }
+                    data-ai-operation-chip
+                    size="sm"
+                    startDecorator={<Calendar />}
+                    title={title}
+                    variant="soft"
+                >
+                    {chipDisplayLabel}
+                </Chip>
+            }
+        />
+    );
+}
+
+export function RaisedBedAiOperationMarkdown({
+    children,
+    gardenId,
+}: {
+    children: string;
+    gardenId: number;
+}) {
+    const components = useMemo<Components>(
+        () => ({
+            a: ({ children: linkChildren, href, ...props }) => {
+                const textContent = Children.toArray(linkChildren)
+                    .map(getTextContent)
+                    .join('')
+                    .trim();
+                const target = parseRaisedBedAiOperationHref(href);
+
+                if (target) {
+                    return (
+                        <RaisedBedAiOperationChip
+                            gardenId={gardenId}
+                            label={textContent}
+                            target={target}
+                        />
+                    );
+                }
+
+                return (
+                    <a href={href} {...props}>
+                        {textContent || getFallbackLinkLabel(href)}
+                    </a>
+                );
+            },
+        }),
+        [gardenId],
+    );
+
+    return <ReactMarkdown components={components}>{children}</ReactMarkdown>;
+}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -11,7 +11,6 @@ import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import Image from 'next/image';
 import { type ReactNode, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
 import { useGameFlags } from '../../GameFlagsContext';
 import { isDiaryCancelTargetEligible } from '../../hooks/useCancelDiaryEntry';
 import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
@@ -20,6 +19,7 @@ import {
     type DiaryRescheduleTarget,
     isDiaryRescheduleTargetEligible,
 } from '../../hooks/useRescheduleDiaryEntry';
+import { RaisedBedAiOperationMarkdown } from './RaisedBedAiOperationMarkdown';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
 import { RaisedBedDiaryCancelAction } from './RaisedBedDiaryCancelAction';
 import { RaisedBedDiaryRescheduleAction } from './RaisedBedDiaryRescheduleAction';
@@ -168,11 +168,13 @@ function diaryEntryActions({
 
 function DiaryList({
     error,
+    gardenId,
     isLoading,
     entries,
     renderEntryAction,
 }: {
     error: Error | null;
+    gardenId: number;
     isLoading: boolean;
     entries: DiaryEntry[] | undefined;
     renderEntryAction?: (
@@ -388,9 +390,9 @@ function DiaryList({
                             imageUrls={expandedAiEntry.imageUrls}
                         />
                         <div className="prose prose-sm max-w-none dark:prose-invert">
-                            <ReactMarkdown>
+                            <RaisedBedAiOperationMarkdown gardenId={gardenId}>
                                 {expandedAiEntry.description ?? ''}
-                            </ReactMarkdown>
+                            </RaisedBedAiOperationMarkdown>
                         </div>
                         <Typography
                             level="body3"
@@ -457,6 +459,7 @@ export function RaisedBedFieldDiary({
     return (
         <DiaryList
             error={error}
+            gardenId={gardenId}
             isLoading={isLoading}
             entries={entries}
             renderEntryAction={renderEntryAction}
@@ -506,6 +509,7 @@ export function RaisedBedDiary({
     return (
         <DiaryList
             error={error}
+            gardenId={gardenId}
             isLoading={isLoading}
             entries={entries}
             renderEntryAction={renderEntryAction}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
@@ -6,11 +6,11 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
 import { AiAnalysisRequestError } from '../../hooks/aiAnalysisError';
 import { useRaisedBedAiAnalysis } from '../../hooks/useRaisedBedAiAnalysis';
 import { useRaisedBedFieldAiAnalysis } from '../../hooks/useRaisedBedFieldAiAnalysis';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { RaisedBedAiOperationMarkdown } from './RaisedBedAiOperationMarkdown';
 import styles from './RaisedBedDiaryAiAction.module.css';
 
 type RaisedBedDiaryAiActionProps = {
@@ -433,9 +433,11 @@ export function RaisedBedDiaryAiAction({
                             <div className="min-h-72 rounded-3xl border bg-card p-4 text-card-foreground shadow-xs">
                                 {visibleMarkdown ? (
                                     <div className="prose prose-sm max-w-none dark:prose-invert">
-                                        <ReactMarkdown>
+                                        <RaisedBedAiOperationMarkdown
+                                            gardenId={gardenId}
+                                        >
                                             {visibleMarkdown}
-                                        </ReactMarkdown>
+                                        </RaisedBedAiOperationMarkdown>
                                         {phase === 'typing' && (
                                             <span
                                                 className={`${styles.cursorBlink} ml-0.5 inline-block h-[1.1rem] w-2.5 rounded-full bg-amber-300 align-text-bottom`}

--- a/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.ts
@@ -1,0 +1,118 @@
+const PUBLIC_OPERATION_HOST = 'www.gredice.com';
+const PUBLIC_OPERATION_PATH_PREFIX = '/radnje/';
+const LEGACY_AI_OPERATION_LINK_PATH_PREFIX = '/garden/operation/';
+
+export type RaisedBedAiOperationLinkTarget = {
+    operationId?: number;
+    operationSlug?: string;
+    raisedBedId: number;
+    positionIndex?: number;
+};
+
+function parsePositiveInteger(value: string | null) {
+    if (!value || !/^\d+$/.test(value)) {
+        return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseNonNegativeInteger(value: string | null) {
+    if (!value || !/^\d+$/.test(value)) {
+        return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function buildRaisedBedAiOperationHref({
+    operationSlug,
+    raisedBedId,
+    positionIndex,
+}: RaisedBedAiOperationLinkTarget) {
+    if (!operationSlug) {
+        return null;
+    }
+
+    const hash = new URLSearchParams({
+        raisedBedId: String(raisedBedId),
+    });
+
+    if (typeof positionIndex === 'number') {
+        hash.set('positionIndex', String(positionIndex));
+    }
+
+    return `https://${PUBLIC_OPERATION_HOST}${PUBLIC_OPERATION_PATH_PREFIX}${operationSlug}#${hash.toString()}`;
+}
+
+export function parseRaisedBedAiOperationHref(
+    href: string | undefined,
+): RaisedBedAiOperationLinkTarget | null {
+    if (!href) {
+        return null;
+    }
+
+    let url: URL;
+    try {
+        url = new URL(href, 'https://garden.gredice.local');
+    } catch {
+        return null;
+    }
+
+    const hash = new URLSearchParams(
+        url.hash.startsWith('#') ? url.hash.slice(1) : url.hash,
+    );
+    const raisedBedId = parsePositiveInteger(hash.get('raisedBedId'));
+
+    if (!raisedBedId) {
+        return null;
+    }
+
+    const rawPositionIndex =
+        hash.get('positionIndex') ?? hash.get('plantFieldIndex');
+
+    const positionIndex =
+        rawPositionIndex === null
+            ? undefined
+            : parseNonNegativeInteger(rawPositionIndex);
+    if (positionIndex === null) {
+        return null;
+    }
+
+    if (
+        url.hostname === PUBLIC_OPERATION_HOST &&
+        url.pathname.startsWith(PUBLIC_OPERATION_PATH_PREFIX)
+    ) {
+        const operationSlug = decodeURIComponent(
+            url.pathname
+                .slice(PUBLIC_OPERATION_PATH_PREFIX.length)
+                .replace(/\/$/, ''),
+        );
+
+        if (!operationSlug) {
+            return null;
+        }
+
+        return typeof positionIndex === 'number'
+            ? { operationSlug, raisedBedId, positionIndex }
+            : { operationSlug, raisedBedId };
+    }
+
+    if (url.pathname.startsWith(LEGACY_AI_OPERATION_LINK_PATH_PREFIX)) {
+        const operationId = parsePositiveInteger(
+            url.pathname.slice(LEGACY_AI_OPERATION_LINK_PATH_PREFIX.length),
+        );
+
+        if (!operationId) {
+            return null;
+        }
+
+        return typeof positionIndex === 'number'
+            ? { operationId, raisedBedId, positionIndex }
+            : { operationId, raisedBedId };
+    }
+
+    return null;
+}

--- a/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.unit.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedAiOperationLinks.unit.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    buildRaisedBedAiOperationHref,
+    parseRaisedBedAiOperationHref,
+} from './raisedBedAiOperationLinks';
+
+describe('raised bed AI operation links', () => {
+    it('builds and parses raised-bed operation links', () => {
+        const href = buildRaisedBedAiOperationHref({
+            operationSlug: 'malciranje-gredice',
+            raisedBedId: 101,
+        });
+
+        assert.strictEqual(
+            href,
+            'https://www.gredice.com/radnje/malciranje-gredice#raisedBedId=101',
+        );
+        assert.deepStrictEqual(parseRaisedBedAiOperationHref(href), {
+            operationSlug: 'malciranje-gredice',
+            raisedBedId: 101,
+        });
+    });
+
+    it('builds and parses plant-field operation links', () => {
+        const href = buildRaisedBedAiOperationHref({
+            operationSlug: 'zalijevanje-biljke',
+            raisedBedId: 101,
+            positionIndex: 5,
+        });
+
+        assert.strictEqual(
+            href,
+            'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&positionIndex=5',
+        );
+        assert.deepStrictEqual(parseRaisedBedAiOperationHref(href), {
+            operationSlug: 'zalijevanje-biljke',
+            raisedBedId: 101,
+            positionIndex: 5,
+        });
+    });
+
+    it('accepts plantFieldIndex as a compatibility alias', () => {
+        assert.deepStrictEqual(
+            parseRaisedBedAiOperationHref(
+                'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&plantFieldIndex=5',
+            ),
+            {
+                operationSlug: 'zalijevanje-biljke',
+                raisedBedId: 101,
+                positionIndex: 5,
+            },
+        );
+    });
+
+    it('parses legacy garden operation links', () => {
+        assert.deepStrictEqual(
+            parseRaisedBedAiOperationHref(
+                '/garden/operation/42#raisedBedId=101&positionIndex=5',
+            ),
+            {
+                operationId: 42,
+                raisedBedId: 101,
+                positionIndex: 5,
+            },
+        );
+    });
+
+    it('rejects unrelated or incomplete links', () => {
+        assert.strictEqual(
+            parseRaisedBedAiOperationHref('/radnje/zalijevanje'),
+            null,
+        );
+        assert.strictEqual(
+            parseRaisedBedAiOperationHref(
+                'https://www.gredice.com/radnje/zalijevanje-biljke',
+            ),
+            null,
+        );
+        assert.strictEqual(
+            parseRaisedBedAiOperationHref(
+                'https://www.gredice.com/radnje/zalijevanje-biljke#raisedBedId=101&positionIndex=-1',
+            ),
+            null,
+        );
+    });
+});

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -1,6 +1,7 @@
 import type { OperationData } from '@gredice/client';
 import { formatPrice } from '@gredice/js/currency';
 import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
+import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Input } from '@gredice/ui/Input';
@@ -24,6 +25,7 @@ export function OperationScheduleModal({
 }) {
     const [open, setOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -31,10 +33,16 @@ export function OperationScheduleModal({
         const date = formData.get('scheduledDate') as string;
         if (date) {
             const scheduledDate = new Date(date);
+            setErrorMessage(null);
             setIsLoading(true);
-            await onConfirm(scheduledDate);
-            setOpen(false);
-            setIsLoading(false);
+            try {
+                await onConfirm(scheduledDate);
+                setOpen(false);
+            } catch {
+                setErrorMessage('Zakazivanje nije uspjelo. Pokušaj ponovno.');
+            } finally {
+                setIsLoading(false);
+            }
         }
     }
 
@@ -67,7 +75,12 @@ export function OperationScheduleModal({
             trigger={trigger}
             title={`Zakaži radnju: ${operation.information.label}`}
             open={open}
-            onOpenChange={setOpen}
+            onOpenChange={(nextOpen) => {
+                setOpen(nextOpen);
+                if (!nextOpen) {
+                    setErrorMessage(null);
+                }
+            }}
         >
             <form onSubmit={handleSubmit}>
                 <Stack spacing={4}>
@@ -108,6 +121,13 @@ export function OperationScheduleModal({
                             </Row>
                         </CardContent>
                     </Card>
+                    {errorMessage ? (
+                        <Alert color="danger">
+                            <Typography level="body2">
+                                {errorMessage}
+                            </Typography>
+                        </Alert>
+                    ) : null}
                     <Input
                         type="date"
                         label="Željeni datum radnje"


### PR DESCRIPTION
## Summary
- Instruct raised-bed AI suggestions to use absolute `https://www.gredice.com/radnje/...` markdown operation links with raised-bed and plant-field hash targets.
- Render supported AI operation links as scheduling chips in live and saved raised-bed AI analysis markdown.
- Parse public operation URLs by slug and schedule bed-level or plant-field operations through the existing cart mutation.

## Validation
- `pnpm --filter garden exec biome check --write tests/raised-bed-diary.spec.tsx`
- `pnpm --filter garden exec playwright test tests/raised-bed-diary.spec.tsx`
- `pnpm --filter @gredice/game test -- src/hud/raisedBed/raisedBedAiOperationLinks.unit.ts`
- `pnpm --filter api test:node lib/garden/raisedBedAiAnalysisService.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter api build`
- `pnpm --filter garden build`
- `git diff --check`