### PR TITLE
[codex] Reduce outlet offer cache staleness

### DIFF
--- a/apps/api/app/api/[...route]/outletRoutes.ts
+++ b/apps/api/app/api/[...route]/outletRoutes.ts
@@ -13,9 +13,9 @@ import { setCacheControl } from '../../../lib/http/cacheControl';
 
 const outletCacheControl = {
     visibility: 'public',
-    maxAgeSeconds: 30,
-    sharedMaxAgeSeconds: 30,
-    staleWhileRevalidateSeconds: 60,
+    maxAgeSeconds: 0,
+    sharedMaxAgeSeconds: 0,
+    mustRevalidate: true,
 } as const;
 
 function wwwOrigin() {

--- a/apps/www/app/outlet/outletData.ts
+++ b/apps/www/app/outlet/outletData.ts
@@ -28,7 +28,12 @@ export type OutletOffer = {
 
 export async function getOutletOffers() {
     try {
-        const response = await clientPublic().api.outlet.offers.$get();
+        const response = await clientPublic().api.outlet.offers.$get(
+            undefined,
+            {
+                init: { cache: 'no-store' },
+            },
+        );
         if (response.status !== 200) {
             return [];
         }

--- a/apps/www/app/outlet/page.tsx
+++ b/apps/www/app/outlet/page.tsx
@@ -7,7 +7,7 @@ import { KnownPages } from '../../src/KnownPages';
 import { OutletOfferCard } from './OutletOfferCard';
 import { getOutletOffers, outletOfferImage } from './outletData';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
     title: 'Outlet sadnica',

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -23,7 +23,7 @@ import { NewsletterSignUp } from './NewsletterSignUp';
 import { OutletLandingSection } from './outlet/OutletLandingSection';
 import { PlantsShowcase } from './PlantsShowcase';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 const sectionsData: SectionData[] = [
     {

--- a/packages/game/src/hooks/useOutletOffers.ts
+++ b/packages/game/src/hooks/useOutletOffers.ts
@@ -28,7 +28,9 @@ export type OutletOfferData = {
 };
 
 async function getOutletOffers() {
-    const response = await clientPublic().api.outlet.offers.$get();
+    const response = await clientPublic().api.outlet.offers.$get(undefined, {
+        init: { cache: 'no-store' },
+    });
     if (response.status !== 200) {
         throw new Error('Failed to fetch outlet offers');
     }
@@ -38,11 +40,14 @@ async function getOutletOffers() {
 }
 
 export const useOutletOffersQueryKey = ['outlet-offers'];
+const outletOffersRefetchIntervalMs = 15 * 1000;
 
 export function useOutletOffers() {
     return useQuery({
         queryKey: useOutletOffersQueryKey,
         queryFn: getOutletOffers,
-        staleTime: 1000 * 60,
+        staleTime: 0,
+        refetchOnMount: 'always',
+        refetchInterval: outletOffersRefetchIntervalMs,
     });
 }


### PR DESCRIPTION
## Summary
- Make the public outlet page and homepage outlet section dynamic instead of 60-second ISR.
- Fetch public outlet offers with `cache: 'no-store'` on www and in-game clients.
- Tighten Outlet API cache headers to `max-age=0, s-maxage=0, must-revalidate` and reduce React Query staleness with a 15s active-tab refresh.

## Validation
- `pnpm --filter www exec biome check --write app/page.tsx app/outlet/page.tsx app/outlet/outletData.ts`
- `pnpm --filter api exec biome check --write 'app/api/[...route]/outletRoutes.ts'`
- `pnpm --filter @gredice/game exec biome check --write src/hooks/useOutletOffers.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter api build`
- `pnpm --filter www build`
- `pnpm --filter garden typecheck`
- `pnpm --filter api test:node lib/http/cacheControl.node.spec.ts`
- `pnpm --filter garden test:run apps/garden/tests/landing.spec.ts`
- `git diff --check`