### PR TITLE
Align schedule headers and round avatars

### DIFF
--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -344,32 +344,42 @@ export function FarmScheduleOperationsSection({
 
                     return (
                         <Stack key={key} spacing={2}>
-                            <Row
-                                spacing={2}
-                                className="items-center flex-wrap gap-y-1"
-                            >
-                                {physicalId ? (
-                                    <RaisedBedLabel physicalId={physicalId} />
-                                ) : (
-                                    <Typography semiBold>
-                                        Gredica bez fizičkog ID-a
-                                    </Typography>
-                                )}
-                                <Typography
-                                    level="body2"
-                                    className="text-muted-foreground"
+                            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+                                <div className="min-w-0">
+                                    {physicalId ? (
+                                        <RaisedBedLabel
+                                            physicalId={physicalId}
+                                        />
+                                    ) : (
+                                        <Typography
+                                            semiBold
+                                            className="truncate"
+                                        >
+                                            Gredica bez fizičkog ID-a
+                                        </Typography>
+                                    )}
+                                </div>
+                                <Row
+                                    spacing={2}
+                                    className="justify-end text-right"
                                 >
-                                    {dayOperations.length} zadataka
-                                </Typography>
-                                {totalDuration > 0 && (
                                     <Typography
                                         level="body2"
-                                        className="text-muted-foreground"
+                                        className="whitespace-nowrap text-muted-foreground"
                                     >
-                                        Vrijeme: {formatMinutes(totalDuration)}
+                                        {dayOperations.length} zadataka
                                     </Typography>
-                                )}
-                            </Row>
+                                    {totalDuration > 0 && (
+                                        <Typography
+                                            level="body2"
+                                            className="whitespace-nowrap text-muted-foreground"
+                                        >
+                                            Vrijeme:{' '}
+                                            {formatMinutes(totalDuration)}
+                                        </Typography>
+                                    )}
+                                </Row>
+                            </div>
                             <Stack spacing={2}>
                                 {dayOperations.map((operation) => {
                                     const completed = isOperationCompleted(

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -126,32 +126,42 @@ export function FarmSchedulePlantingsSection({
 
                     return (
                         <Stack key={key} spacing={2}>
-                            <Row
-                                spacing={2}
-                                className="items-center flex-wrap gap-y-1"
-                            >
-                                {physicalId ? (
-                                    <RaisedBedLabel physicalId={physicalId} />
-                                ) : (
-                                    <Typography semiBold>
-                                        Gredica bez fizičkog ID-a
-                                    </Typography>
-                                )}
-                                <Typography
-                                    level="body2"
-                                    className="text-muted-foreground"
+                            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+                                <div className="min-w-0">
+                                    {physicalId ? (
+                                        <RaisedBedLabel
+                                            physicalId={physicalId}
+                                        />
+                                    ) : (
+                                        <Typography
+                                            semiBold
+                                            className="truncate"
+                                        >
+                                            Gredica bez fizičkog ID-a
+                                        </Typography>
+                                    )}
+                                </div>
+                                <Row
+                                    spacing={2}
+                                    className="justify-end text-right"
                                 >
-                                    {dayFields.length} sijanja
-                                </Typography>
-                                {totalDuration > 0 && (
                                     <Typography
                                         level="body2"
-                                        className="text-muted-foreground"
+                                        className="whitespace-nowrap text-muted-foreground"
                                     >
-                                        Vrijeme: {formatMinutes(totalDuration)}
+                                        {dayFields.length} sijanja
                                     </Typography>
-                                )}
-                            </Row>
+                                    {totalDuration > 0 && (
+                                        <Typography
+                                            level="body2"
+                                            className="whitespace-nowrap text-muted-foreground"
+                                        >
+                                            Vrijeme:{' '}
+                                            {formatMinutes(totalDuration)}
+                                        </Typography>
+                                    )}
+                                </Row>
+                            </div>
                             <Stack spacing={2}>
                                 {dayFields.map((field) => {
                                     const completed = isFieldCompleted(

--- a/apps/farm/app/schedule/ScheduleDaySummary.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.tsx
@@ -29,13 +29,6 @@ export function ScheduleDaySummary({
     const { scheduledFields, scheduledOperations } = dayData;
 
     const taskCount = scheduledOperations.length + scheduledFields.length;
-    const raisedBedIds = new Set(
-        [
-            ...scheduledOperations.map((op) => op.raisedBedId),
-            ...scheduledFields.map((field) => field.raisedBedId),
-        ].filter(Boolean),
-    );
-    const raisedBedCount = raisedBedIds.size;
 
     const operationDataById = new Map<number, EntityStandardized>();
     if (operationsData) {
@@ -54,9 +47,8 @@ export function ScheduleDaySummary({
         scheduledFields.length * PLANTING_TASK_DURATION_MINUTES;
 
     return (
-        <Row spacing={8} className="flex-wrap gap-y-2">
+        <Row spacing={2}>
             <SummaryItem label="Zadataka" value={taskCount} />
-            <SummaryItem label="Gredica" value={raisedBedCount} />
             {totalMinutes > 0 && (
                 <SummaryItem
                     label="Vrijeme"

--- a/apps/farm/app/schedule/ScheduleDaySummary.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.tsx
@@ -47,7 +47,7 @@ export function ScheduleDaySummary({
         scheduledFields.length * PLANTING_TASK_DURATION_MINUTES;
 
     return (
-        <Row spacing={2}>
+        <Row className="gap-1 sm:gap-2">
             <SummaryItem label="Zadataka" value={taskCount} />
             {totalMinutes > 0 && (
                 <SummaryItem
@@ -67,11 +67,14 @@ function SummaryItem({
     value: string | number;
 }) {
     return (
-        <div className="text-center">
-            <Typography level="body2" semiBold>
+        <div className="text-center leading-tight">
+            <Typography level="body2" semiBold className="text-xs sm:text-sm">
                 {value}
             </Typography>
-            <Typography level="body2" className="text-muted-foreground">
+            <Typography
+                level="body2"
+                className="text-xs text-muted-foreground sm:text-sm"
+            >
                 {label}
             </Typography>
         </div>

--- a/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
@@ -12,8 +12,7 @@ function SummaryItemSkeleton() {
 
 export function ScheduleDaySummarySkeleton() {
     return (
-        <Row spacing={8}>
-            <SummaryItemSkeleton />
+        <Row spacing={2}>
             <SummaryItemSkeleton />
             <SummaryItemSkeleton />
         </Row>

--- a/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
@@ -3,16 +3,16 @@ import { Skeleton } from '@gredice/ui/Skeleton';
 
 function SummaryItemSkeleton() {
     return (
-        <div className="text-center space-y-1">
-            <Skeleton className="mx-auto h-4 w-8" />
-            <Skeleton className="mx-auto h-4 w-14" />
+        <div className="space-y-1 text-center">
+            <Skeleton className="mx-auto h-3 w-6 sm:h-4 sm:w-8" />
+            <Skeleton className="mx-auto h-3 w-10 sm:h-4 sm:w-14" />
         </div>
     );
 }
 
 export function ScheduleDaySummarySkeleton() {
     return (
-        <Row spacing={2}>
+        <Row className="gap-1 sm:gap-2">
             <SummaryItemSkeleton />
             <SummaryItemSkeleton />
         </Row>

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -25,16 +25,17 @@ async function FarmScheduleContent({ date }: { date: Date }) {
     const plantSortsPromise = getFarmSchedulePlantSorts();
 
     return (
-        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
+        <div className="max-w-5xl mx-auto w-full space-y-4 px-2 py-4 sm:p-4">
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2">
+                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
                     <div className="justify-self-start">
-                        <HomeButton />
+                        <HomeButton className="h-8 sm:h-10" />
                     </div>
                     <div className="min-w-0 justify-self-center">
                         <ScheduleDateNavigation
                             date={date}
                             basePath="/schedule"
+                            compact
                         />
                     </div>
                     <div className="min-w-0 justify-self-end">

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -26,20 +26,27 @@ async function FarmScheduleContent({ date }: { date: Date }) {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-                    <div className="flex min-w-0 items-center gap-2">
+            <div className="space-y-2">
+                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2">
+                    <div className="justify-self-start">
                         <HomeButton />
                     </div>
-                    <ScheduleDateNavigation date={date} basePath="/schedule" />
-                </div>
-                <div className="flex min-w-0 flex-col items-start gap-2 sm:items-end">
-                    <Suspense fallback={<ScheduleDaySummarySkeleton />}>
-                        <ScheduleDaySummarySection
-                            dayDataPromise={dayDataPromise}
-                            operationsDataPromise={operationsDataPromise}
+                    <div className="min-w-0 justify-self-center">
+                        <ScheduleDateNavigation
+                            date={date}
+                            basePath="/schedule"
                         />
-                    </Suspense>
+                    </div>
+                    <div className="min-w-0 justify-self-end">
+                        <Suspense fallback={<ScheduleDaySummarySkeleton />}>
+                            <ScheduleDaySummarySection
+                                dayDataPromise={dayDataPromise}
+                                operationsDataPromise={operationsDataPromise}
+                            />
+                        </Suspense>
+                    </div>
+                </div>
+                <div className="flex min-w-0 justify-end">
                     <Suspense fallback={null}>
                         <ScheduleLabelPrintSection
                             dayDataPromise={dayDataPromise}

--- a/apps/farm/components/HomeButton.tsx
+++ b/apps/farm/components/HomeButton.tsx
@@ -2,18 +2,20 @@ import { Button } from '@gredice/ui/Button';
 import { ArrowLeft } from '@gredice/ui/icons';
 
 interface HomeButtonProps {
+    className?: string;
     href?: string;
     title?: string;
 }
 
 export function HomeButton({
+    className,
     href = '/',
     title = 'Povratak na početnu',
 }: HomeButtonProps) {
     return (
         <Button
             aria-label={title}
-            className="aspect-square px-0"
+            className={`aspect-square px-0 ${className ?? ''}`}
             href={href}
             title={title}
             variant="plain"

--- a/packages/ui/src/Avatar/Avatar.tsx
+++ b/packages/ui/src/Avatar/Avatar.tsx
@@ -17,9 +17,9 @@ export type AvatarProps = HTMLAttributes<HTMLDivElement> & {
     );
 
 const sizeClassNames = {
-    sm: 'h-6 min-w-[24px] max-w-[24px] text-xs',
-    md: 'h-9 min-w-[36px] max-w-[36px]',
-    lg: 'h-12 min-w-[48px] max-w-[48px] text-lg',
+    sm: 'size-6 text-xs',
+    md: 'size-9',
+    lg: 'size-12 text-lg',
 };
 
 export function Avatar({

--- a/packages/ui/src/ScheduleDateNavigation/ScheduleDateNavigation.tsx
+++ b/packages/ui/src/ScheduleDateNavigation/ScheduleDateNavigation.tsx
@@ -2,6 +2,7 @@ import { Left, Navigate } from '../icons';
 import { Link } from '../Link';
 import { Row } from '../Row';
 import { Typography } from '../Typography';
+import { cx } from '../utils';
 
 function formatDateParam(date: Date) {
     const year = date.getFullYear();
@@ -28,6 +29,8 @@ export interface ScheduleDateNavigationProps {
     basePath: string;
     /** Name of the query parameter used to carry the selected date. */
     paramName?: string;
+    /** Reduces spacing and text size on narrow schedule headers. */
+    compact?: boolean;
 }
 
 /**
@@ -37,6 +40,7 @@ export interface ScheduleDateNavigationProps {
 export function ScheduleDateNavigation({
     date,
     basePath,
+    compact = false,
     paramName = 'date',
 }: ScheduleDateNavigationProps) {
     const dayOfWeek = new Intl.DateTimeFormat('hr-HR', {
@@ -55,26 +59,53 @@ export function ScheduleDateNavigation({
     const nextHref = buildHref(basePath, paramName, getOffsetDate(date, 1));
 
     return (
-        <Row spacing={2} className="shrink-0">
+        <Row
+            spacing={compact ? undefined : 2}
+            className={cx('shrink-0', compact && 'gap-1 sm:gap-2')}
+        >
             <Link
                 href={prevHref}
                 title="Prethodni dan"
-                className="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                className={cx(
+                    'inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                    compact ? 'p-1 sm:p-2' : 'p-2',
+                )}
             >
                 <Left className="size-4 shrink-0" />
             </Link>
-            <div className="text-center min-w-20">
-                <Typography level="body2" semiBold className="capitalize">
+            <div
+                className={cx(
+                    'text-center',
+                    compact ? 'min-w-16 sm:min-w-20' : 'min-w-20',
+                )}
+            >
+                <Typography
+                    level="body2"
+                    semiBold
+                    className={cx(
+                        'capitalize',
+                        compact && 'text-xs leading-tight sm:text-sm',
+                    )}
+                >
                     {isToday ? 'Danas' : dayOfWeek}
                 </Typography>
-                <Typography level="body2" className="text-muted-foreground">
+                <Typography
+                    level="body2"
+                    className={cx(
+                        'text-muted-foreground',
+                        compact && 'text-xs leading-tight sm:text-sm',
+                    )}
+                >
                     {dateFormatted}
                 </Typography>
             </div>
             <Link
                 href={nextHref}
                 title="Sljedeći dan"
-                className="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                className={cx(
+                    'inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                    compact ? 'p-1 sm:p-2' : 'p-2',
+                )}
             >
                 <Navigate className="size-4 shrink-0" />
             </Link>


### PR DESCRIPTION
## Summary
- Reworked the farm schedule header so the back button, date picker, and summary sit in a three-column layout with the date picker centered.
- Moved per-raised-bed task counts and time to the right side of each raised-bed header in planting and operation sections.
- Removed the raised-bed total from the daily summary and tightened the summary spacing.
- Updated the shared avatar sizing to use square dimensions so `rounded-full` renders true circular avatars.

## Testing
- Not run (not requested).