### PR TITLE
Support selecting specific outlet seedlings in the plant picker

### DIFF
--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -14,6 +14,7 @@ import {
     normalizeShoppingCartScheduledDates,
     OutletOfferUnavailableError,
     OutletReservationUnavailableError,
+    releaseOutletReservationForCartItem,
     upsertOrRemoveCartItem,
     upsertOrRemoveCartItemWithOutletReservation,
 } from '@gredice/storage';
@@ -219,7 +220,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         accountId,
                     });
                 } else {
-                    await upsertOrRemoveCartItem(
+                    const cartItemId = await upsertOrRemoveCartItem(
                         id,
                         cartId,
                         entityId,
@@ -232,6 +233,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         currency,
                         forceCreate,
                     );
+                    if (amount > 0 && cartItemId) {
+                        await releaseOutletReservationForCartItem(cartItemId);
+                    }
                 }
             } catch (error) {
                 if (

--- a/apps/garden/tests/PlantPickerTestStory.tsx
+++ b/apps/garden/tests/PlantPickerTestStory.tsx
@@ -2,6 +2,7 @@ import type { PlantData, PlantSortData } from '@gredice/client';
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
+import type { OutletOfferData } from '../../../packages/game/src/hooks/useOutletOffers';
 import { PlantPicker } from '../../../packages/game/src/hud/raisedBed/RaisedBedPlantPicker';
 import {
     createGameState,
@@ -149,6 +150,59 @@ const tomatoSorts = [
     ),
 ];
 
+const tomatoOutletOffers = [
+    {
+        id: 301,
+        plantSort: {
+            id: tomatoSort.id,
+            name: tomatoSort.information.name,
+            description: tomatoSort.information.shortDescription,
+            imageUrl: null,
+            plant: {
+                id: tomatoPlant.id,
+                name: tomatoPlant.information.name,
+            },
+        },
+        sowingDate: '2026-04-01T00:00:00.000Z',
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPrice: 1.2,
+        comparePrice: 1.5,
+        quantity: 2,
+        remainingQuantity: 2,
+        reservedQuantity: 0,
+        soldQuantity: 0,
+        startAt: '2026-05-01T00:00:00.000Z',
+        endAt: '2026-06-01T00:00:00.000Z',
+        url: 'https://www.gredice.test/outlet?offer=301',
+    },
+    {
+        id: 302,
+        plantSort: {
+            id: tomatoSort.id,
+            name: tomatoSort.information.name,
+            description: tomatoSort.information.shortDescription,
+            imageUrl: null,
+            plant: {
+                id: tomatoPlant.id,
+                name: tomatoPlant.information.name,
+            },
+        },
+        sowingDate: '2026-04-15T00:00:00.000Z',
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPrice: 1.3,
+        comparePrice: 1.5,
+        quantity: 3,
+        remainingQuantity: 3,
+        reservedQuantity: 0,
+        soldQuantity: 0,
+        startAt: '2026-05-01T00:00:00.000Z',
+        endAt: '2026-06-15T00:00:00.000Z',
+        url: 'https://www.gredice.test/outlet?offer=302',
+    },
+] satisfies OutletOfferData[];
+
 function createPlantPickerQueryClient() {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
@@ -208,6 +262,7 @@ function createPlantPickerQueryClient() {
     queryClient.setQueryData(['inventory'], {
         items: [],
     });
+    queryClient.setQueryData(['outlet-offers'], tomatoOutletOffers);
     queryClient.setQueryData(['plants'], [tomatoPlant, basilPlant]);
     queryClient.setQueryData(['sorts'], tomatoSorts);
 

--- a/apps/garden/tests/PlantPickerTestStory.tsx
+++ b/apps/garden/tests/PlantPickerTestStory.tsx
@@ -1,7 +1,7 @@
 import type { PlantData, PlantSortData } from '@gredice/client';
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { type PropsWithChildren, useMemo } from 'react';
+import { type PropsWithChildren, useEffect, useMemo } from 'react';
 import type { OutletOfferData } from '../../../packages/game/src/hooks/useOutletOffers';
 import { PlantPicker } from '../../../packages/game/src/hud/raisedBed/RaisedBedPlantPicker';
 import {
@@ -10,6 +10,12 @@ import {
 } from '../../../packages/game/src/useGameState';
 
 const now = '2026-05-13T00:00:00.000Z';
+
+declare global {
+    interface Window {
+        __grediceRemoveOutlet302?: () => void;
+    }
+}
 
 const tomatoPlant = {
     id: 1,
@@ -293,9 +299,33 @@ function PlantPickerTestProviders({ children }: PropsWithChildren) {
     );
 }
 
-export function PlantPickerTestStory() {
+function OutletOfferRefetchTestHook() {
+    const queryClient = ReactQuery.useQueryClient();
+
+    useEffect(() => {
+        window.__grediceRemoveOutlet302 = () => {
+            queryClient.setQueryData(
+                ['outlet-offers'],
+                tomatoOutletOffers.filter((offer) => offer.id !== 302),
+            );
+        };
+
+        return () => {
+            delete window.__grediceRemoveOutlet302;
+        };
+    }, [queryClient]);
+
+    return null;
+}
+
+export function PlantPickerTestStory({
+    showOutletRefetchControl = false,
+}: {
+    showOutletRefetchControl?: boolean;
+} = {}) {
     return (
         <PlantPickerTestProviders>
+            {showOutletRefetchControl ? <OutletOfferRefetchTestHook /> : null}
             <PlantPicker
                 gardenId={1}
                 raisedBedId={1}

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -136,6 +136,43 @@ test('outlet sowing sends the selected outlet offer', async ({
     expect(post.additionalData).toBe(JSON.stringify({ outletOfferId: 302 }));
 });
 
+test('outlet refetch does not replace a missing selected offer', async ({
+    mount,
+    page,
+}) => {
+    await mockShoppingCartPosts(page);
+
+    await mount(<PlantPickerTestStory showOutletRefetchControl />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const sowingMode = page.getByRole('radiogroup', {
+        name: 'Način sijanja',
+    });
+    const laterOutletOffer = sowingMode.getByRole('radio', {
+        name: /Preostalo 3/,
+    });
+    await sowingMode.getByText('Preostalo 3').click();
+    await expect(laterOutletOffer).toBeChecked();
+
+    await page.evaluate(() => window.__grediceRemoveOutlet302?.());
+
+    await expect(
+        page.getByText('Odabrana outlet sadnica više nije dostupna.'),
+    ).toBeVisible();
+    await expect(
+        sowingMode.getByRole('radio', { name: /Preostalo 2/ }),
+    ).not.toBeChecked();
+    await expect(
+        page.getByRole('textbox', { name: 'Datum sijanja' }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: 'Dodaj u košaru' }),
+    ).toBeDisabled();
+});
+
 test('mobile sort step keeps the cart action reachable', async ({
     mount,
     page,

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -1,5 +1,42 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
 import { PlantPickerTestStory } from './PlantPickerTestStory';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+async function mockShoppingCartPosts(page: Page) {
+    const posts: unknown[] = [];
+
+    await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+        if (route.request().method() === 'POST') {
+            posts.push(route.request().postDataJSON());
+            await route.fulfill({
+                body: JSON.stringify({ success: true }),
+                contentType: 'application/json',
+                status: 200,
+            });
+            return;
+        }
+
+        await route.fulfill({
+            body: JSON.stringify({
+                allowPurchase: true,
+                hasDeliverableItems: false,
+                id: 1,
+                items: [],
+                notes: [],
+                total: 0,
+                totalSunflowers: 0,
+            }),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+
+    return posts;
+}
 
 test('plant search keeps keyboard focus while filtering sowing options', async ({
     mount,
@@ -26,6 +63,77 @@ test('plant search keeps keyboard focus while filtering sowing options', async (
     await expect(searchInput).toHaveValue('paradajz');
     await expect(page.getByRole('button', { name: /Rajčica/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /Bosiljak/ })).toHaveCount(0);
+});
+
+test('outlet sorts keep planned sowing selected by default', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const sowingMode = page.getByRole('radiogroup', {
+        name: 'Način sijanja',
+    });
+    await expect(
+        sowingMode.getByRole('radio', { name: /Planirano sijanje/ }),
+    ).toBeChecked();
+    await expect(sowingMode.getByText('Outlet sadnica')).toHaveCount(2);
+    await expect(
+        page.getByRole('textbox', { name: 'Datum sijanja' }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(post.outletOfferId).toBeUndefined();
+    expect(post.entityId).toBe('101');
+});
+
+test('outlet sowing sends the selected outlet offer', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const sowingMode = page.getByRole('radiogroup', {
+        name: 'Način sijanja',
+    });
+    const laterOutletOffer = sowingMode.getByRole('radio', {
+        name: /Preostalo 3/,
+    });
+    await sowingMode.getByText('Preostalo 3').click();
+    await expect(laterOutletOffer).toBeChecked();
+    await expect(
+        page.getByRole('textbox', { name: 'Datum sijanja' }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(post.outletOfferId).toBe(302);
+    expect(post.additionalData).toBe(JSON.stringify({ outletOfferId: 302 }));
 });
 
 test('mobile sort step keeps the cart action reachable', async ({
@@ -80,7 +188,7 @@ test('mobile sort step scrolls the sowing date clear of sticky actions', async (
     await page.getByRole('button', { name: /Rajčica/ }).click();
     await page.getByRole('button', { name: /Cherry rajčica/ }).click();
 
-    const dateInput = page.getByLabel('Datum sijanja');
+    const dateInput = page.getByRole('textbox', { name: 'Datum sijanja' });
     await dateInput.evaluate((element) => {
         let scrollParent = element.parentElement;
         while (scrollParent) {

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -33,8 +33,21 @@ type PlantsSortListProps = {
     search: string;
     flyToShoppingCart?: boolean;
     neighborPlants?: NeighborPlantSummary[];
-    outletOffersBySortId?: Map<number, OutletOfferData>;
+    outletOffersBySortId?: Map<number, OutletOfferData[]>;
 };
+
+const currencyFormatter = new Intl.NumberFormat('hr-HR', {
+    style: 'currency',
+    currency: 'EUR',
+});
+
+function outletOfferBadgeLabel(outletOffers: OutletOfferData[]) {
+    if (outletOffers.length === 1) {
+        return `Outlet ${currencyFormatter.format(outletOffers[0].outletPrice)}`;
+    }
+
+    return `Outlet ${outletOffers.length} ponude`;
+}
 
 function PlantSortListItem({
     sort,
@@ -42,14 +55,14 @@ function PlantSortListItem({
     onChange,
     flyToShoppingCart,
     neighborPlants,
-    outletOffer,
+    outletOffers,
 }: {
     sort: PlantSortData;
     selectedSortId: number | null;
     onChange: (sort: PlantSortData) => void;
     flyToShoppingCart?: boolean;
     neighborPlants: NeighborPlantSummary[];
-    outletOffer?: OutletOfferData;
+    outletOffers?: OutletOfferData[];
 }) {
     const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
     const { track } = useGameAnalytics();
@@ -134,9 +147,9 @@ function PlantSortListItem({
                 className="flex-wrap gap-y-1 px-4"
             >
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    {outletOffer ? (
+                    {outletOffers?.length ? (
                         <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700 dark:bg-green-900/50 dark:text-green-200">
-                            Outlet {outletOffer.outletPrice.toFixed(2)} €
+                            {outletOfferBadgeLabel(outletOffers)}
                         </span>
                     ) : null}
                     {relationshipSignal ? (
@@ -227,7 +240,7 @@ export function PlantsSortList({
                         selectedSortId={selectedSortId}
                         onChange={onChange}
                         neighborPlants={neighborPlants}
-                        outletOffer={outletOffersBySortId?.get(sort.id)}
+                        outletOffers={outletOffersBySortId?.get(sort.id)}
                         flyToShoppingCart={
                             flyToShoppingCart && selectedSortId === sort.id
                         }

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -3,7 +3,7 @@ import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
-import { Close, Left, Search, ShoppingCart } from '@gredice/ui/icons';
+import { Check, Close, Left, Search, ShoppingCart } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { Row } from '@gredice/ui/Row';
@@ -15,6 +15,7 @@ import {
     type ReactElement,
     useId,
     useLayoutEffect,
+    useMemo,
     useRef,
     useState,
 } from 'react';
@@ -23,7 +24,10 @@ import { SegmentedProgress } from '../../controls/components/SegmentedProgress';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useGardens } from '../../hooks/useGardens';
 import { useInventory } from '../../hooks/useInventory';
-import { useOutletOffers } from '../../hooks/useOutletOffers';
+import {
+    type OutletOfferData,
+    useOutletOffers,
+} from '../../hooks/useOutletOffers';
 import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useSandboxPlant } from '../../hooks/useSandboxPlant';
 import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
@@ -58,6 +62,56 @@ export function formatLocalDate(date: Date): string {
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
+}
+
+const outletCurrencyFormatter = new Intl.NumberFormat('hr-HR', {
+    style: 'currency',
+    currency: 'EUR',
+});
+
+const outletDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+});
+
+function outletOfferTimestamp(date: string) {
+    const timestamp = new Date(date).getTime();
+    return Number.isNaN(timestamp) ? Number.POSITIVE_INFINITY : timestamp;
+}
+
+function compareOutletOffers(left: OutletOfferData, right: OutletOfferData) {
+    const sowingDateDifference =
+        outletOfferTimestamp(left.sowingDate) -
+        outletOfferTimestamp(right.sowingDate);
+    if (sowingDateDifference !== 0) {
+        return sowingDateDifference;
+    }
+
+    const priceDifference = left.outletPrice - right.outletPrice;
+    if (priceDifference !== 0) {
+        return priceDifference;
+    }
+
+    return left.id - right.id;
+}
+
+function groupOutletOffersBySortId(outletOffers: OutletOfferData[] = []) {
+    const offersBySortId = new Map<number, OutletOfferData[]>();
+
+    for (const offer of outletOffers) {
+        const sortOffers = offersBySortId.get(offer.plantSort.id);
+        if (sortOffers) {
+            sortOffers.push(offer);
+        } else {
+            offersBySortId.set(offer.plantSort.id, [offer]);
+        }
+    }
+
+    for (const sortOffers of offersBySortId.values()) {
+        sortOffers.sort(compareOutletOffers);
+    }
+
+    return offersBySortId;
 }
 
 type PlantPickerProps = {
@@ -124,8 +178,12 @@ export function PlantPicker({
     const [flyToShoppingCart, setFlyToShoppingCart] = useState(false);
     const [useInventoryItem, setUseInventoryItem] = useState(false);
     const [useOutletOffer, setUseOutletOffer] = useState(false);
+    const [selectedOutletOfferId, setSelectedOutletOfferId] = useState<
+        number | null
+    >(null);
     const [search, setSearch] = useState('');
     const searchInputId = useId();
+    const sowingModeName = useId();
     const shouldRestoreSearchFocusRef = useRef(false);
 
     let currentStep = 0;
@@ -167,12 +225,15 @@ export function PlantPicker({
     function handlePlantSelect(plant: PlantData) {
         setSelectedPlantId(plant.id);
         setSelectedSortId(null);
+        setUseOutletOffer(false);
+        setSelectedOutletOfferId(null);
         resetSearch();
     }
 
     function handleSortSelect(sort: PlantSortData) {
         setSelectedSortId(sort.id);
-        setUseOutletOffer(Boolean(outletOffersBySortId.get(sort.id)));
+        setUseOutletOffer(false);
+        setSelectedOutletOfferId(null);
         setUseInventoryItem(false);
         resetSearch();
     }
@@ -213,6 +274,7 @@ export function PlantPicker({
         setPlantOptions(null);
         setUseInventoryItem(false);
         setUseOutletOffer(false);
+        setSelectedOutletOfferId(null);
         resetSearch();
         await removeFromCart();
     }
@@ -248,6 +310,8 @@ export function PlantPicker({
                 setOpen(false);
                 setSelectedPlantId(null);
                 setSelectedSortId(null);
+                setUseOutletOffer(false);
+                setSelectedOutletOfferId(null);
                 resetSearch();
             }
             return;
@@ -267,6 +331,8 @@ export function PlantPicker({
         ) {
             await removeFromCart(existingItem);
         }
+        const existingItemCanBeUpdated =
+            existingItem?.entityId === selectedSortId.toString();
 
         // Add new item to cart
         track('game_planting_confirmed', {
@@ -279,7 +345,7 @@ export function PlantPicker({
             sort_id: selectedSortId,
             use_inventory: useInventoryItem,
             outlet_offer_id: selectedOutletOffer?.id,
-            use_outlet_offer: useOutletOffer,
+            use_outlet_offer: Boolean(selectedOutletOffer),
         });
         showShoppingCartTransientHub();
         setFlyToShoppingCart(true);
@@ -287,6 +353,7 @@ export function PlantPicker({
             await setCartItem.mutateAsync({
                 entityTypeName: 'plantSort',
                 entityId: selectedSortId?.toString(),
+                id: existingItemCanBeUpdated ? existingItem.id : undefined,
                 amount: 1,
                 gardenId,
                 raisedBedId,
@@ -336,6 +403,7 @@ export function PlantPicker({
         );
         setUseInventoryItem(existingItem?.currency === 'inventory');
         setUseOutletOffer(Boolean(existingItem?.outlet));
+        setSelectedOutletOfferId(existingItem?.outlet?.offerId ?? null);
     }
 
     // Plant options
@@ -365,11 +433,17 @@ export function PlantPicker({
             item.entityTypeName === 'plantSort' &&
             item.entityId === selectedSortId?.toString(),
     )?.amount;
-    const outletOffersBySortId = new Map(
-        (outletOffers ?? []).map((offer) => [offer.plantSort.id, offer]),
+    const outletOffersBySortId = useMemo(
+        () => groupOutletOffersBySortId(outletOffers),
+        [outletOffers],
     );
-    const selectedOutletOffer = selectedSortId
-        ? outletOffersBySortId.get(selectedSortId)
+    const selectedOutletOffers = selectedSortId
+        ? (outletOffersBySortId.get(selectedSortId) ?? [])
+        : [];
+    const selectedOutletOffer = useOutletOffer
+        ? (selectedOutletOffers.find(
+              (offer) => offer.id === selectedOutletOfferId,
+          ) ?? selectedOutletOffers[0])
         : undefined;
     const relationshipBlockCount = getRaisedBedRelationshipBlockCount({
         cartItems: cart?.items,
@@ -412,6 +486,8 @@ export function PlantPicker({
                                 ? () => {
                                       setSelectedPlantId(null);
                                       setSelectedSortId(null);
+                                      setUseOutletOffer(false);
+                                      setSelectedOutletOfferId(null);
                                       resetSearch();
                                   }
                                 : undefined,
@@ -508,41 +584,201 @@ export function PlantPicker({
                                 </Stack>
                             ) : (
                                 <>
-                                    <Row spacing={2} className="flex-wrap">
-                                        {selectedOutletOffer ? (
-                                            <Button
-                                                variant={
-                                                    useOutletOffer
-                                                        ? 'solid'
-                                                        : 'outlined'
-                                                }
-                                                size="sm"
-                                                onClick={() => {
-                                                    track(
-                                                        'game_outlet_offer_toggled',
-                                                        {
-                                                            garden_id: gardenId,
-                                                            outlet_offer_id:
-                                                                selectedOutletOffer.id,
-                                                            position_index:
-                                                                positionIndex,
-                                                            raised_bed_id:
-                                                                raisedBedId,
-                                                            sort_id:
-                                                                selectedSortId,
-                                                            use_outlet_offer:
-                                                                !useOutletOffer,
-                                                        },
-                                                    );
-                                                    setUseOutletOffer(
-                                                        (previous) => !previous,
-                                                    );
-                                                    setUseInventoryItem(false);
-                                                }}
+                                    {selectedOutletOffers.length > 0 ? (
+                                        <Stack spacing={2}>
+                                            <Typography level="body2" semiBold>
+                                                Način sijanja
+                                            </Typography>
+                                            <div
+                                                role="radiogroup"
+                                                aria-label="Način sijanja"
+                                                className="grid gap-2 md:grid-cols-2"
                                             >
-                                                {`Outlet ${selectedOutletOffer.outletPrice.toFixed(2)} € · ${selectedOutletOffer.remainingQuantity} dostupno`}
-                                            </Button>
-                                        ) : null}
+                                                <label
+                                                    className={cx(
+                                                        'block cursor-pointer rounded-lg border p-3 text-left transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+                                                        !useOutletOffer
+                                                            ? 'border-green-500 bg-green-50 text-green-950 dark:border-green-700 dark:bg-green-950/40 dark:text-green-100'
+                                                            : 'border-input bg-card hover:bg-muted',
+                                                    )}
+                                                >
+                                                    <input
+                                                        type="radio"
+                                                        className="sr-only"
+                                                        name={sowingModeName}
+                                                        value="scheduled"
+                                                        checked={
+                                                            !useOutletOffer
+                                                        }
+                                                        onChange={() => {
+                                                            track(
+                                                                'game_outlet_offer_toggled',
+                                                                {
+                                                                    garden_id:
+                                                                        gardenId,
+                                                                    outlet_offer_id:
+                                                                        selectedOutletOffer?.id,
+                                                                    position_index:
+                                                                        positionIndex,
+                                                                    raised_bed_id:
+                                                                        raisedBedId,
+                                                                    sort_id:
+                                                                        selectedSortId,
+                                                                    use_outlet_offer: false,
+                                                                },
+                                                            );
+                                                            setUseOutletOffer(
+                                                                false,
+                                                            );
+                                                            setSelectedOutletOfferId(
+                                                                null,
+                                                            );
+                                                        }}
+                                                    />
+                                                    <Row
+                                                        alignItems="start"
+                                                        justifyContent="space-between"
+                                                        spacing={2}
+                                                    >
+                                                        <Stack
+                                                            spacing={1}
+                                                            className="min-w-0"
+                                                        >
+                                                            <Typography
+                                                                level="body2"
+                                                                semiBold
+                                                            >
+                                                                Planirano
+                                                                sijanje
+                                                            </Typography>
+                                                            <Typography
+                                                                level="body3"
+                                                                secondary
+                                                            >
+                                                                Odaberi termin
+                                                                za novu biljku.
+                                                            </Typography>
+                                                        </Stack>
+                                                        {!useOutletOffer ? (
+                                                            <Check className="size-5 shrink-0" />
+                                                        ) : null}
+                                                    </Row>
+                                                </label>
+                                                {selectedOutletOffers.map(
+                                                    (offer) => {
+                                                        const selected =
+                                                            selectedOutletOffer?.id ===
+                                                            offer.id;
+
+                                                        return (
+                                                            <label
+                                                                key={offer.id}
+                                                                className={cx(
+                                                                    'block cursor-pointer rounded-lg border p-3 text-left transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+                                                                    selected
+                                                                        ? 'border-green-500 bg-green-50 text-green-950 dark:border-green-700 dark:bg-green-950/40 dark:text-green-100'
+                                                                        : 'border-input bg-card hover:bg-muted',
+                                                                )}
+                                                            >
+                                                                <input
+                                                                    type="radio"
+                                                                    className="sr-only"
+                                                                    name={
+                                                                        sowingModeName
+                                                                    }
+                                                                    value={`outlet-${offer.id}`}
+                                                                    checked={
+                                                                        selected
+                                                                    }
+                                                                    onChange={() => {
+                                                                        track(
+                                                                            'game_outlet_offer_toggled',
+                                                                            {
+                                                                                garden_id:
+                                                                                    gardenId,
+                                                                                outlet_offer_id:
+                                                                                    offer.id,
+                                                                                position_index:
+                                                                                    positionIndex,
+                                                                                raised_bed_id:
+                                                                                    raisedBedId,
+                                                                                sort_id:
+                                                                                    selectedSortId,
+                                                                                use_outlet_offer: true,
+                                                                            },
+                                                                        );
+                                                                        setUseOutletOffer(
+                                                                            true,
+                                                                        );
+                                                                        setSelectedOutletOfferId(
+                                                                            offer.id,
+                                                                        );
+                                                                        setUseInventoryItem(
+                                                                            false,
+                                                                        );
+                                                                    }}
+                                                                />
+                                                                <Row
+                                                                    alignItems="start"
+                                                                    justifyContent="space-between"
+                                                                    spacing={2}
+                                                                >
+                                                                    <Stack
+                                                                        spacing={
+                                                                            1
+                                                                        }
+                                                                        className="min-w-0"
+                                                                    >
+                                                                        <Typography
+                                                                            level="body2"
+                                                                            semiBold
+                                                                        >
+                                                                            Outlet
+                                                                            sadnica
+                                                                        </Typography>
+                                                                        <Typography
+                                                                            level="body3"
+                                                                            secondary
+                                                                        >
+                                                                            Sjetva{' '}
+                                                                            {outletDateFormatter.format(
+                                                                                new Date(
+                                                                                    offer.sowingDate,
+                                                                                ),
+                                                                            )}{' '}
+                                                                            ·{' '}
+                                                                            {outletCurrencyFormatter.format(
+                                                                                offer.outletPrice,
+                                                                            )}
+                                                                        </Typography>
+                                                                        <Typography
+                                                                            level="body3"
+                                                                            secondary
+                                                                        >
+                                                                            Preostalo{' '}
+                                                                            {
+                                                                                offer.remainingQuantity
+                                                                            }{' '}
+                                                                            · do{' '}
+                                                                            {outletDateFormatter.format(
+                                                                                new Date(
+                                                                                    offer.endAt,
+                                                                                ),
+                                                                            )}
+                                                                        </Typography>
+                                                                    </Stack>
+                                                                    {selected ? (
+                                                                        <Check className="size-5 shrink-0" />
+                                                                    ) : null}
+                                                                </Row>
+                                                            </label>
+                                                        );
+                                                    },
+                                                )}
+                                            </div>
+                                        </Stack>
+                                    ) : null}
+                                    <Row spacing={2} className="flex-wrap">
                                         <Button
                                             variant={
                                                 availableFromInventory &&
@@ -553,7 +789,7 @@ export function PlantPicker({
                                             size="sm"
                                             disabled={
                                                 !availableFromInventory ||
-                                                useOutletOffer
+                                                Boolean(selectedOutletOffer)
                                             }
                                             startDecorator={
                                                 <BackpackIcon className="size-5 shrink-0" />
@@ -580,12 +816,14 @@ export function PlantPicker({
                                             {`U ruksaku (${availableFromInventory ?? 0})`}
                                         </Button>
                                     </Row>
-                                    {useOutletOffer && selectedOutletOffer ? (
+                                    {selectedOutletOffer ? (
                                         <div className="rounded-lg border border-green-300 bg-green-50 p-3 text-sm text-green-900 dark:border-green-900 dark:bg-green-950/40 dark:text-green-100">
                                             Presadnica je posijana{' '}
-                                            {new Date(
-                                                selectedOutletOffer.sowingDate,
-                                            ).toLocaleDateString('hr-HR')}{' '}
+                                            {outletDateFormatter.format(
+                                                new Date(
+                                                    selectedOutletOffer.sowingDate,
+                                                ),
+                                            )}{' '}
                                             u stakleniku. Rezervacija se čuva
                                             kratko nakon dodavanja u košaru.
                                         </div>
@@ -617,6 +855,9 @@ export function PlantPicker({
                                 className="min-w-0 justify-start whitespace-nowrap px-2 max-[340px]:justify-center md:justify-start"
                                 onClick={() => {
                                     setSelectedPlantId(null);
+                                    setSelectedSortId(null);
+                                    setUseOutletOffer(false);
+                                    setSelectedOutletOfferId(null);
                                     resetSearch();
                                 }}
                                 startDecorator={<Left className="size-5" />}

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -441,10 +441,16 @@ export function PlantPicker({
         ? (outletOffersBySortId.get(selectedSortId) ?? [])
         : [];
     const selectedOutletOffer = useOutletOffer
-        ? (selectedOutletOffers.find(
-              (offer) => offer.id === selectedOutletOfferId,
-          ) ?? selectedOutletOffers[0])
+        ? selectedOutletOfferId
+            ? selectedOutletOffers.find(
+                  (offer) => offer.id === selectedOutletOfferId,
+              )
+            : selectedOutletOffers[0]
         : undefined;
+    const selectedOutletOfferUnavailable =
+        useOutletOffer &&
+        selectedOutletOfferId !== null &&
+        selectedOutletOffer === undefined;
     const relationshipBlockCount = getRaisedBedRelationshipBlockCount({
         cartItems: cart?.items,
         fields: raisedBed?.fields,
@@ -584,7 +590,8 @@ export function PlantPicker({
                                 </Stack>
                             ) : (
                                 <>
-                                    {selectedOutletOffers.length > 0 ? (
+                                    {selectedOutletOffers.length > 0 ||
+                                    selectedOutletOfferUnavailable ? (
                                         <Stack spacing={2}>
                                             <Typography level="body2" semiBold>
                                                 Način sijanja
@@ -617,6 +624,7 @@ export function PlantPicker({
                                                                     garden_id:
                                                                         gardenId,
                                                                     outlet_offer_id:
+                                                                        selectedOutletOfferId ??
                                                                         selectedOutletOffer?.id,
                                                                     position_index:
                                                                         positionIndex,
@@ -776,6 +784,14 @@ export function PlantPicker({
                                                     },
                                                 )}
                                             </div>
+                                            {selectedOutletOfferUnavailable ? (
+                                                <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
+                                                    Odabrana outlet sadnica više
+                                                    nije dostupna. Odaberi drugu
+                                                    outlet sadnicu ili planirano
+                                                    sijanje.
+                                                </div>
+                                            ) : null}
                                         </Stack>
                                     ) : null}
                                     <Row spacing={2} className="flex-wrap">
@@ -789,7 +805,8 @@ export function PlantPicker({
                                             size="sm"
                                             disabled={
                                                 !availableFromInventory ||
-                                                Boolean(selectedOutletOffer)
+                                                Boolean(selectedOutletOffer) ||
+                                                selectedOutletOfferUnavailable
                                             }
                                             startDecorator={
                                                 <BackpackIcon className="size-5 shrink-0" />
@@ -827,7 +844,7 @@ export function PlantPicker({
                                             u stakleniku. Rezervacija se čuva
                                             kratko nakon dodavanja u košaru.
                                         </div>
-                                    ) : (
+                                    ) : selectedOutletOfferUnavailable ? null : (
                                         <Input
                                             type="date"
                                             label="Datum sijanja"
@@ -881,11 +898,16 @@ export function PlantPicker({
                                 <Button
                                     variant="solid"
                                     className="whitespace-nowrap"
-                                    disabled={!selectedSortId}
+                                    disabled={
+                                        !selectedSortId ||
+                                        selectedOutletOfferUnavailable
+                                    }
                                     title={
                                         !selectedSortId
                                             ? 'Odaberi sortu prije potvrde'
-                                            : undefined
+                                            : selectedOutletOfferUnavailable
+                                              ? 'Odabrana outlet sadnica više nije dostupna'
+                                              : undefined
                                     }
                                     loading={
                                         isSandbox


### PR DESCRIPTION
## Summary
- Group outlet offers by plant sort so multiple batches for the same sort remain selectable instead of overwriting each other.
- Keep planned sowing available by default, with explicit outlet batch selection in the plant picker.
- Release held outlet reservations when a cart item is updated back to normal sowing.
- Add regression coverage for default sowing, explicit outlet selection, and multiple outlet batches for one sort.

## Testing
- `pnpm lint --filter @gredice/game`
- `pnpm lint --filter garden`
- `pnpm lint --filter api`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm build --filter garden`
- `pnpm exec playwright test tests/raised-bed-plant-picker.spec.tsx --config playwright.config.ts`
- `git diff --check`