### PR TITLE
Prioritize social login options

### DIFF
--- a/apps/app/components/admin/navigation/LoginDialog.tsx
+++ b/apps/app/components/admin/navigation/LoginDialog.tsx
@@ -105,6 +105,28 @@ export function LoginDialog() {
                     <Typography level="h4" component="p">
                         Prijava
                     </Typography>
+                    <Stack spacing={4}>
+                        <Stack spacing={2}>
+                            <FacebookLoginButton
+                                onClick={() => handleOAuthLogin('facebook')}
+                                lastUsed={lastLoginProvider === 'facebook'}
+                            />
+                            <GoogleLoginButton
+                                onClick={() => handleOAuthLogin('google')}
+                                lastUsed={lastLoginProvider === 'google'}
+                            />
+                        </Stack>
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <Divider />
+                            </div>
+                            <div className="relative flex justify-center">
+                                <span className="bg-background px-2 text-xs rounded-xs">
+                                    ili nastavi emailom
+                                </span>
+                            </div>
+                        </div>
+                    </Stack>
                     <form action={submitAction} className="w-full">
                         <Stack spacing={8}>
                             <Stack spacing={2}>
@@ -142,28 +164,6 @@ export function LoginDialog() {
                             )}
                         </Stack>
                     </form>
-                    <Stack spacing={4}>
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <Divider />
-                            </div>
-                            <div className="relative flex justify-center">
-                                <span className="bg-background px-2 text-xs rounded-xs">
-                                    ili nastavi sa
-                                </span>
-                            </div>
-                        </div>
-                        <Stack spacing={2}>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            />
-                            <GoogleLoginButton
-                                onClick={() => handleOAuthLogin('google')}
-                                lastUsed={lastLoginProvider === 'google'}
-                            />
-                        </Stack>
-                    </Stack>
                 </Stack>
             </Modal>
         </div>

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -142,6 +142,28 @@ export function LoginDialog() {
                             svojom farmom.
                         </Typography>
                     </Stack>
+                    <Stack spacing={4}>
+                        <Stack spacing={2}>
+                            <FacebookLoginButton
+                                onClick={() => handleOAuthLogin('facebook')}
+                                lastUsed={lastLoginProvider === 'facebook'}
+                            />
+                            <GoogleLoginButton
+                                onClick={() => handleOAuthLogin('google')}
+                                lastUsed={lastLoginProvider === 'google'}
+                            />
+                        </Stack>
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <Divider />
+                            </div>
+                            <div className="relative flex justify-center">
+                                <span className="bg-background px-2 text-xs rounded-xs">
+                                    ili nastavi emailom
+                                </span>
+                            </div>
+                        </div>
+                    </Stack>
                     <form action={submitAction} className="w-full space-y-4">
                         <Stack spacing={6}>
                             <Stack spacing={2}>
@@ -183,28 +205,6 @@ export function LoginDialog() {
                             )}
                         </Stack>
                     </form>
-                    <Stack spacing={4}>
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <Divider />
-                            </div>
-                            <div className="relative flex justify-center">
-                                <span className="bg-background px-2 text-xs rounded-xs">
-                                    ili nastavi sa
-                                </span>
-                            </div>
-                        </div>
-                        <Stack spacing={2}>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            />
-                            <GoogleLoginButton
-                                onClick={() => handleOAuthLogin('google')}
-                                lastUsed={lastLoginProvider === 'google'}
-                            />
-                        </Stack>
-                    </Stack>
                 </Stack>
             </Modal>
         </div>

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -164,53 +164,6 @@ export default function LoginModal() {
                         </TabsList>
                     </div>
                     <Stack spacing={4}>
-                        <TabsContent value="login" className="mt-4">
-                            <div className="space-y-4 px-1">
-                                <Stack spacing={4}>
-                                    <EmailPasswordForm
-                                        onSubmit={handleLogin}
-                                        submitText="Prijava"
-                                    />
-                                    {error && (
-                                        <Alert color="danger">{error}</Alert>
-                                    )}
-                                </Stack>
-                                <div className="relative">
-                                    <div className="absolute inset-0 flex items-center">
-                                        <Divider />
-                                    </div>
-                                    <div className="relative flex justify-center">
-                                        <span className="bg-background px-2 text-xs rounded-xs">
-                                            ili nastavi sa
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </TabsContent>
-                        <TabsContent value="register" className="mt-4">
-                            <div className="space-y-4 px-1">
-                                <Stack spacing={4}>
-                                    <EmailPasswordForm
-                                        onSubmit={handleRegister}
-                                        submitText="Registriraj se"
-                                        registration
-                                    />
-                                    {error && (
-                                        <Alert color="danger">{error}</Alert>
-                                    )}
-                                </Stack>
-                                <div className="relative">
-                                    <div className="absolute inset-0 flex items-center">
-                                        <Divider />
-                                    </div>
-                                    <div className="relative flex justify-center">
-                                        <span className="bg-background px-2 text-xs rounded-xs">
-                                            ili nastavi sa
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </TabsContent>
                         <Stack spacing={2}>
                             <FacebookLoginButton
                                 onClick={() => handleOAuthLogin('facebook')}
@@ -221,6 +174,43 @@ export default function LoginModal() {
                                 lastUsed={lastLoginProvider === 'google'}
                             />
                         </Stack>
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <Divider />
+                            </div>
+                            <div className="relative flex justify-center">
+                                <span className="bg-background px-2 text-xs rounded-xs">
+                                    ili nastavi emailom
+                                </span>
+                            </div>
+                        </div>
+                        <TabsContent value="login">
+                            <div className="px-1">
+                                <Stack spacing={4}>
+                                    <EmailPasswordForm
+                                        onSubmit={handleLogin}
+                                        submitText="Prijava"
+                                    />
+                                    {error && (
+                                        <Alert color="danger">{error}</Alert>
+                                    )}
+                                </Stack>
+                            </div>
+                        </TabsContent>
+                        <TabsContent value="register">
+                            <div className="px-1">
+                                <Stack spacing={4}>
+                                    <EmailPasswordForm
+                                        onSubmit={handleRegister}
+                                        submitText="Registriraj se"
+                                        registration
+                                    />
+                                    {error && (
+                                        <Alert color="danger">{error}</Alert>
+                                    )}
+                                </Stack>
+                            </div>
+                        </TabsContent>
                     </Stack>
                 </Tabs>
             </Modal>

--- a/packages/ui/src/auth/GoogleLoginButton.tsx
+++ b/packages/ui/src/auth/GoogleLoginButton.tsx
@@ -48,7 +48,7 @@ export function GoogleLoginButton({
                     d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
                 />
             </svg>
-            Prijava Google računom
+            Google prijava
         </Button>
     );
 }


### PR DESCRIPTION
## Summary
- Shorten the shared Google login button copy to "Google prijava".
- Move Facebook and Google login buttons above the email/password forms in garden, farm, and admin login screens.
- Update the divider copy so email login is clearly presented as the secondary option.

## Validation
- `pnpm lint --filter @gredice/ui --filter garden --filter farm --filter app`
- `pnpm typecheck --filter @gredice/ui --filter garden --filter farm --filter app`
- `git diff --check`
- Browser-verified garden, farm, and admin login screens on local dev servers.