### PR TITLE
[GRE-483] Add operation visual reward contract

### DIFF
--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -12,6 +12,25 @@ export {
     PLANT_STAGES,
 } from './hud/raisedBed/featuredOperations';
 export { defaultLocalSandboxStorageKey } from './localSandboxGarden';
+export type {
+    AppliedOperationVisualInput,
+    OperationHistoryVisualInput,
+    OperationVisualDefinitionInput,
+    OperationVisualReward,
+    OperationVisualRewardFamily,
+    OperationVisualRewardKind,
+    OperationVisualRewardPolarity,
+    OperationVisualRewardScope,
+    ResolveOperationVisualRewardsInput,
+} from './operationVisualRewards';
+export {
+    filterOperationVisualRewards,
+    getOperationVisualRewardFamily,
+    getOperationVisualRewardPolarity,
+    isAppliedOperationVisualStatus,
+    resolveOperationVisualRewardKind,
+    resolveOperationVisualRewards,
+} from './operationVisualRewards';
 export type { GameQualitySetting, GameQualityTier } from './scene/gameQuality';
 export { resolveSpriteAtlasAssetPaths } from './sprites/resolveSpriteAtlasAssetPaths';
 export { SpriteAtlasBillboard } from './sprites/SpriteAtlasBillboard';

--- a/packages/game/src/operationVisualRewards.ts
+++ b/packages/game/src/operationVisualRewards.ts
@@ -1,0 +1,473 @@
+export type OperationVisualRewardKind =
+    | 'agrotextile'
+    | 'harvest'
+    | 'mulch'
+    | 'photographyUpdate'
+    | 'removeAgrotextile'
+    | 'removeMulch'
+    | 'supports'
+    | 'watering'
+    | 'weeding';
+
+export type OperationVisualRewardFamily =
+    | 'agrotextile'
+    | 'harvest'
+    | 'mulch'
+    | 'photography'
+    | 'supports'
+    | 'watering'
+    | 'weeds';
+
+export type OperationVisualRewardPolarity = 'apply' | 'remove' | 'update';
+
+export type OperationVisualRewardScope = 'field' | 'garden' | 'raisedBed';
+
+export type OperationVisualDefinitionInput = {
+    id: number;
+    slug?: string | null;
+    attributes?: {
+        application?: string | null;
+        stage?: {
+            information?: {
+                label?: string | null;
+                name?: string | null;
+            } | null;
+        } | null;
+    } | null;
+    image?: {
+        cover?: {
+            url?: string | null;
+        } | null;
+    } | null;
+    information?: {
+        description?: string | null;
+        instructions?: string | null;
+        label?: string | null;
+        name?: string | null;
+        shortDescription?: string | null;
+    } | null;
+};
+
+export type AppliedOperationVisualInput = {
+    id: number;
+    entityId: number;
+    raisedBedFieldId?: number | null;
+    raisedBedId?: number | null;
+    status: string;
+    completedAt?: Date | string | null;
+    createdAt?: Date | string | null;
+    scheduledDate?: Date | string | null;
+};
+
+export type OperationHistoryVisualInput = AppliedOperationVisualInput & {
+    canceledAt?: Date | string | null;
+    completionNotes?: string | null;
+    imageUrls?: string[] | null;
+    verifiedAt?: Date | string | null;
+};
+
+export type OperationVisualReward = {
+    active: boolean;
+    completedAt: string | null;
+    createdAt: string | null;
+    entityId: number;
+    family: OperationVisualRewardFamily;
+    imageUrls: string[];
+    kind: OperationVisualRewardKind;
+    operationId: number;
+    polarity: OperationVisualRewardPolarity;
+    raisedBedFieldId: number | null;
+    raisedBedId: number | null;
+    scope: OperationVisualRewardScope;
+    status: string;
+    timestampMs: number;
+    verifiedAt: string | null;
+};
+
+export type ResolveOperationVisualRewardsInput = {
+    appliedOperations?: AppliedOperationVisualInput[];
+    operationItems?: OperationHistoryVisualInput[];
+    operations: OperationVisualDefinitionInput[];
+};
+
+const activeAppliedStatuses = new Set([
+    'completed',
+    'confirmed',
+    'pendingVerification',
+]);
+
+const removalKeywords = [
+    'ciscenje',
+    'makn',
+    'odstran',
+    'remove',
+    'removal',
+    'skid',
+    'uklanj',
+];
+
+const operationKeywordGroups = {
+    agrotextile: [
+        'agro textile',
+        'agrotekstil',
+        'agrotextil',
+        'agrotextile',
+        'agril',
+        'agryl',
+    ],
+    harvest: ['berba', 'branje', 'harvest', 'ubiranje'],
+    mulch: ['hay', 'malc', 'malcir', 'mulch', 'sijeno', 'slama', 'straw'],
+    photography: ['foto', 'fotograf', 'photo', 'photography', 'slika'],
+    supports: [
+        'kolac',
+        'kolci',
+        'potpor',
+        'stake',
+        'staking',
+        'support',
+        'tie',
+        'vezanje',
+        'veziv',
+    ],
+    watering: ['navodnj', 'watering', 'zalijev'],
+    weeds: ['korov', 'plijev', 'pljev', 'weed', 'weeding'],
+};
+
+function normalizeSearchText(value: string | null | undefined) {
+    return (value ?? '')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()
+        .replace(/\s+/g, ' ');
+}
+
+function textIncludesAny(text: string, keywords: string[]) {
+    return keywords.some((keyword) =>
+        text.includes(normalizeSearchText(keyword)),
+    );
+}
+
+function operationSearchText(operation: OperationVisualDefinitionInput) {
+    return normalizeSearchText(
+        [
+            operation.slug,
+            operation.information?.name,
+            operation.information?.label,
+            operation.information?.shortDescription,
+            operation.information?.description,
+            operation.information?.instructions,
+            operation.attributes?.application,
+            operation.attributes?.stage?.information?.name,
+            operation.attributes?.stage?.information?.label,
+            operation.image?.cover?.url,
+        ]
+            .filter((value): value is string => typeof value === 'string')
+            .join(' '),
+    );
+}
+
+function operationStageText(operation: OperationVisualDefinitionInput) {
+    return normalizeSearchText(
+        [
+            operation.attributes?.stage?.information?.name,
+            operation.attributes?.stage?.information?.label,
+        ]
+            .filter((value): value is string => typeof value === 'string')
+            .join(' '),
+    );
+}
+
+function hasRemovalIntent(text: string) {
+    return textIncludesAny(text, removalKeywords);
+}
+
+export function resolveOperationVisualRewardKind(
+    operation: OperationVisualDefinitionInput | undefined,
+): OperationVisualRewardKind | null {
+    if (!operation) {
+        return null;
+    }
+
+    const text = operationSearchText(operation);
+    const stageText = operationStageText(operation);
+    const isRemoval = hasRemovalIntent(text);
+
+    if (textIncludesAny(text, operationKeywordGroups.photography)) {
+        return 'photographyUpdate';
+    }
+
+    if (
+        textIncludesAny(stageText, operationKeywordGroups.watering) ||
+        textIncludesAny(text, operationKeywordGroups.watering)
+    ) {
+        return 'watering';
+    }
+
+    if (
+        textIncludesAny(stageText, operationKeywordGroups.harvest) ||
+        textIncludesAny(text, operationKeywordGroups.harvest)
+    ) {
+        return 'harvest';
+    }
+
+    if (textIncludesAny(text, operationKeywordGroups.agrotextile)) {
+        return isRemoval ? 'removeAgrotextile' : 'agrotextile';
+    }
+
+    if (textIncludesAny(text, operationKeywordGroups.mulch)) {
+        return isRemoval ? 'removeMulch' : 'mulch';
+    }
+
+    if (textIncludesAny(text, operationKeywordGroups.weeds)) {
+        return 'weeding';
+    }
+
+    if (textIncludesAny(text, operationKeywordGroups.supports)) {
+        return 'supports';
+    }
+
+    return null;
+}
+
+export function getOperationVisualRewardFamily(
+    kind: OperationVisualRewardKind,
+): OperationVisualRewardFamily {
+    switch (kind) {
+        case 'agrotextile':
+        case 'removeAgrotextile':
+            return 'agrotextile';
+        case 'harvest':
+            return 'harvest';
+        case 'mulch':
+        case 'removeMulch':
+            return 'mulch';
+        case 'photographyUpdate':
+            return 'photography';
+        case 'supports':
+            return 'supports';
+        case 'watering':
+            return 'watering';
+        case 'weeding':
+            return 'weeds';
+    }
+}
+
+export function getOperationVisualRewardPolarity(
+    kind: OperationVisualRewardKind,
+): OperationVisualRewardPolarity {
+    switch (kind) {
+        case 'photographyUpdate':
+            return 'update';
+        case 'removeAgrotextile':
+        case 'removeMulch':
+        case 'weeding':
+            return 'remove';
+        default:
+            return 'apply';
+    }
+}
+
+function dateToIso(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    const timestamp = date.getTime();
+
+    return Number.isFinite(timestamp) ? date.toISOString() : null;
+}
+
+function dateToTimestamp(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const timestamp =
+        value instanceof Date ? value.getTime() : Date.parse(value);
+
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function operationTimestampMs(
+    operation: AppliedOperationVisualInput | OperationHistoryVisualInput,
+) {
+    return (
+        dateToTimestamp(operation.completedAt) ??
+        ('verifiedAt' in operation
+            ? dateToTimestamp(operation.verifiedAt)
+            : null) ??
+        dateToTimestamp(operation.createdAt) ??
+        dateToTimestamp(operation.scheduledDate) ??
+        0
+    );
+}
+
+function resolveOperationScope(
+    operation: AppliedOperationVisualInput | OperationHistoryVisualInput,
+): OperationVisualRewardScope {
+    if (operation.raisedBedFieldId != null) {
+        return 'field';
+    }
+
+    if (operation.raisedBedId != null) {
+        return 'raisedBed';
+    }
+
+    return 'garden';
+}
+
+function createOperationVisualReward(
+    operation: AppliedOperationVisualInput | OperationHistoryVisualInput,
+    kind: OperationVisualRewardKind,
+): OperationVisualReward {
+    const polarity = getOperationVisualRewardPolarity(kind);
+
+    return {
+        active: polarity !== 'remove',
+        completedAt: dateToIso(operation.completedAt),
+        createdAt: dateToIso(operation.createdAt),
+        entityId: operation.entityId,
+        family: getOperationVisualRewardFamily(kind),
+        imageUrls:
+            'imageUrls' in operation
+                ? Array.from(
+                      new Set(
+                          (operation.imageUrls ?? []).filter(
+                              (url) =>
+                                  typeof url === 'string' && url.length > 0,
+                          ),
+                      ),
+                  )
+                : [],
+        kind,
+        operationId: operation.id,
+        polarity,
+        raisedBedFieldId: operation.raisedBedFieldId ?? null,
+        raisedBedId: operation.raisedBedId ?? null,
+        scope: resolveOperationScope(operation),
+        status: operation.status,
+        timestampMs: operationTimestampMs(operation),
+        verifiedAt:
+            'verifiedAt' in operation ? dateToIso(operation.verifiedAt) : null,
+    };
+}
+
+function rewardConflictKey(reward: OperationVisualReward) {
+    return [
+        reward.scope,
+        reward.raisedBedId ?? 'garden',
+        reward.raisedBedFieldId ?? 'all',
+        reward.family,
+    ].join(':');
+}
+
+function compareRewardRecency(
+    next: OperationVisualReward,
+    current: OperationVisualReward,
+) {
+    if (next.timestampMs !== current.timestampMs) {
+        return next.timestampMs - current.timestampMs;
+    }
+
+    return next.operationId - current.operationId;
+}
+
+function resolveLatestRewards(rewards: OperationVisualReward[]) {
+    const latestByKey = new Map<string, OperationVisualReward>();
+
+    for (const reward of rewards) {
+        const key = rewardConflictKey(reward);
+        const current = latestByKey.get(key);
+
+        if (!current || compareRewardRecency(reward, current) >= 0) {
+            latestByKey.set(key, reward);
+        }
+    }
+
+    return Array.from(latestByKey.values()).sort((a, b) => {
+        const timestampDiff = b.timestampMs - a.timestampMs;
+        return timestampDiff === 0
+            ? b.operationId - a.operationId
+            : timestampDiff;
+    });
+}
+
+export function isAppliedOperationVisualStatus(status: string) {
+    return activeAppliedStatuses.has(status);
+}
+
+export function resolveOperationVisualRewards({
+    appliedOperations = [],
+    operationItems = [],
+    operations,
+}: ResolveOperationVisualRewardsInput) {
+    const operationsById = new Map(
+        operations.map((operation) => [operation.id, operation]),
+    );
+    const rewards: OperationVisualReward[] = [];
+
+    for (const appliedOperation of appliedOperations) {
+        if (!isAppliedOperationVisualStatus(appliedOperation.status)) {
+            continue;
+        }
+
+        const kind = resolveOperationVisualRewardKind(
+            operationsById.get(appliedOperation.entityId),
+        );
+
+        if (!kind || kind === 'photographyUpdate') {
+            continue;
+        }
+
+        rewards.push(createOperationVisualReward(appliedOperation, kind));
+    }
+
+    for (const operationItem of operationItems) {
+        if (!isAppliedOperationVisualStatus(operationItem.status)) {
+            continue;
+        }
+
+        const kind = resolveOperationVisualRewardKind(
+            operationsById.get(operationItem.entityId),
+        );
+
+        if (kind !== 'photographyUpdate' || !operationItem.imageUrls?.length) {
+            continue;
+        }
+
+        rewards.push(createOperationVisualReward(operationItem, kind));
+    }
+
+    return resolveLatestRewards(rewards);
+}
+
+export function filterOperationVisualRewards(
+    rewards: OperationVisualReward[],
+    scope: {
+        raisedBedFieldId?: number | null;
+        raisedBedId?: number | null;
+    },
+) {
+    return rewards.filter((reward) => {
+        if (reward.scope === 'garden') {
+            return true;
+        }
+
+        if (scope.raisedBedFieldId != null) {
+            return (
+                (reward.scope === 'raisedBed' &&
+                    reward.raisedBedId === scope.raisedBedId) ||
+                reward.raisedBedFieldId === scope.raisedBedFieldId
+            );
+        }
+
+        return (
+            reward.scope === 'raisedBed' &&
+            scope.raisedBedId != null &&
+            reward.raisedBedId === scope.raisedBedId
+        );
+    });
+}

--- a/packages/game/src/operationVisualRewards.ts
+++ b/packages/game/src/operationVisualRewards.ts
@@ -33,6 +33,7 @@ export type OperationVisualDefinitionInput = {
                 name?: string | null;
             } | null;
         } | null;
+        visualReward?: string | null;
     } | null;
     image?: {
         cover?: {
@@ -96,91 +97,23 @@ const activeAppliedStatuses = new Set([
     'pendingVerification',
 ]);
 
-const removalKeywords = [
-    'ciscenje',
-    'makn',
-    'odstran',
-    'remove',
-    'removal',
-    'skid',
-    'uklanj',
-];
-
-const operationKeywordGroups = {
-    agrotextile: [
-        'agro textile',
-        'agrotekstil',
-        'agrotextil',
-        'agrotextile',
-        'agril',
-        'agryl',
-    ],
-    harvest: ['berba', 'branje', 'harvest', 'ubiranje'],
-    mulch: ['hay', 'malc', 'malcir', 'mulch', 'sijeno', 'slama', 'straw'],
-    photography: ['foto', 'fotograf', 'photo', 'photography', 'slika'],
-    supports: [
-        'kolac',
-        'kolci',
-        'potpor',
-        'stake',
-        'staking',
-        'support',
-        'tie',
-        'vezanje',
-        'veziv',
-    ],
-    watering: ['navodnj', 'watering', 'zalijev'],
-    weeds: ['korov', 'plijev', 'pljev', 'weed', 'weeding'],
-};
-
-function normalizeSearchText(value: string | null | undefined) {
-    return (value ?? '')
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, ' ')
-        .trim()
-        .replace(/\s+/g, ' ');
-}
-
-function textIncludesAny(text: string, keywords: string[]) {
-    return keywords.some((keyword) =>
-        text.includes(normalizeSearchText(keyword)),
-    );
-}
-
-function operationSearchText(operation: OperationVisualDefinitionInput) {
-    return normalizeSearchText(
-        [
-            operation.slug,
-            operation.information?.name,
-            operation.information?.label,
-            operation.information?.shortDescription,
-            operation.information?.description,
-            operation.information?.instructions,
-            operation.attributes?.application,
-            operation.attributes?.stage?.information?.name,
-            operation.attributes?.stage?.information?.label,
-            operation.image?.cover?.url,
-        ]
-            .filter((value): value is string => typeof value === 'string')
-            .join(' '),
-    );
-}
-
-function operationStageText(operation: OperationVisualDefinitionInput) {
-    return normalizeSearchText(
-        [
-            operation.attributes?.stage?.information?.name,
-            operation.attributes?.stage?.information?.label,
-        ]
-            .filter((value): value is string => typeof value === 'string')
-            .join(' '),
-    );
-}
-
-function hasRemovalIntent(text: string) {
-    return textIncludesAny(text, removalKeywords);
+export function parseOperationVisualRewardKind(
+    value: string | null | undefined,
+): OperationVisualRewardKind | null {
+    switch (value) {
+        case 'agrotextile':
+        case 'harvest':
+        case 'mulch':
+        case 'photographyUpdate':
+        case 'removeAgrotextile':
+        case 'removeMulch':
+        case 'supports':
+        case 'watering':
+        case 'weeding':
+            return value;
+        default:
+            return null;
+    }
 }
 
 export function resolveOperationVisualRewardKind(
@@ -190,45 +123,7 @@ export function resolveOperationVisualRewardKind(
         return null;
     }
 
-    const text = operationSearchText(operation);
-    const stageText = operationStageText(operation);
-    const isRemoval = hasRemovalIntent(text);
-
-    if (textIncludesAny(text, operationKeywordGroups.photography)) {
-        return 'photographyUpdate';
-    }
-
-    if (
-        textIncludesAny(stageText, operationKeywordGroups.watering) ||
-        textIncludesAny(text, operationKeywordGroups.watering)
-    ) {
-        return 'watering';
-    }
-
-    if (
-        textIncludesAny(stageText, operationKeywordGroups.harvest) ||
-        textIncludesAny(text, operationKeywordGroups.harvest)
-    ) {
-        return 'harvest';
-    }
-
-    if (textIncludesAny(text, operationKeywordGroups.agrotextile)) {
-        return isRemoval ? 'removeAgrotextile' : 'agrotextile';
-    }
-
-    if (textIncludesAny(text, operationKeywordGroups.mulch)) {
-        return isRemoval ? 'removeMulch' : 'mulch';
-    }
-
-    if (textIncludesAny(text, operationKeywordGroups.weeds)) {
-        return 'weeding';
-    }
-
-    if (textIncludesAny(text, operationKeywordGroups.supports)) {
-        return 'supports';
-    }
-
-    return null;
+    return parseOperationVisualRewardKind(operation.attributes?.visualReward);
 }
 
 export function getOperationVisualRewardFamily(

--- a/packages/game/src/operationVisualRewards.unit.ts
+++ b/packages/game/src/operationVisualRewards.unit.ts
@@ -5,6 +5,7 @@ import {
     filterOperationVisualRewards,
     type OperationHistoryVisualInput,
     type OperationVisualDefinitionInput,
+    type OperationVisualRewardKind,
     resolveOperationVisualRewardKind,
     resolveOperationVisualRewards,
 } from './operationVisualRewards';
@@ -16,6 +17,7 @@ function operation(
         label: string;
         name: string;
         stage?: string;
+        visualReward?: OperationVisualRewardKind | string | null;
     },
 ): OperationVisualDefinitionInput {
     return {
@@ -28,6 +30,9 @@ function operation(
                     label: input.stage ?? 'maintenance',
                 },
             },
+            ...(input.visualReward !== undefined
+                ? { visualReward: input.visualReward }
+                : {}),
         },
         information: {
             description: input.label,
@@ -45,42 +50,51 @@ const operations = [
         label: 'Zalijevanje gredice',
         name: 'wateringRaisedBed',
         stage: 'watering',
+        visualReward: 'watering',
     }),
     operation(2, {
         label: 'Malčiranje slamom',
         name: 'mulchStraw',
+        visualReward: 'mulch',
     }),
     operation(3, {
         label: 'Uklanjanje malča',
         name: 'removeMulch',
+        visualReward: 'removeMulch',
     }),
     operation(4, {
         label: 'Postavljanje agrotekstila',
         name: 'agrotextileCover',
+        visualReward: 'agrotextile',
     }),
     operation(5, {
         label: 'Uklanjanje agrotekstila',
         name: 'removeAgrotextileCover',
+        visualReward: 'removeAgrotextile',
     }),
     operation(6, {
         application: 'plant',
         label: 'Plijevljenje korova',
         name: 'weeding',
+        visualReward: 'weeding',
     }),
     operation(7, {
         application: 'plant',
         label: 'Postavljanje potpore',
         name: 'plantSupports',
+        visualReward: 'supports',
     }),
     operation(8, {
         application: 'plant',
         label: 'Berba plodova',
         name: 'harvestPlant',
         stage: 'harvest',
+        visualReward: 'harvest',
     }),
     operation(9, {
         label: 'Fotografiranje gredice',
         name: 'raisedBedPhotography',
+        visualReward: 'photographyUpdate',
     }),
 ];
 
@@ -140,6 +154,32 @@ describe('operation visual reward kind mapping', () => {
         assert.strictEqual(
             resolveOperationVisualRewardKind(operations[8]),
             'photographyUpdate',
+        );
+    });
+
+    it('does not infer rewards from operation text without the explicit attribute', () => {
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(
+                operation(10, {
+                    label: 'Zalijevanje gredice',
+                    name: 'wateringRaisedBed',
+                    stage: 'watering',
+                }),
+            ),
+            null,
+        );
+    });
+
+    it('ignores unknown explicit visual reward values', () => {
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(
+                operation(11, {
+                    label: 'Zalijevanje gredice',
+                    name: 'wateringRaisedBed',
+                    visualReward: 'droplets',
+                }),
+            ),
+            null,
         );
     });
 });

--- a/packages/game/src/operationVisualRewards.unit.ts
+++ b/packages/game/src/operationVisualRewards.unit.ts
@@ -1,0 +1,340 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    type AppliedOperationVisualInput,
+    filterOperationVisualRewards,
+    type OperationHistoryVisualInput,
+    type OperationVisualDefinitionInput,
+    resolveOperationVisualRewardKind,
+    resolveOperationVisualRewards,
+} from './operationVisualRewards';
+
+function operation(
+    id: number,
+    input: {
+        application?: string;
+        label: string;
+        name: string;
+        stage?: string;
+    },
+): OperationVisualDefinitionInput {
+    return {
+        id,
+        attributes: {
+            application: input.application ?? 'raisedBedFull',
+            stage: {
+                information: {
+                    name: input.stage ?? 'maintenance',
+                    label: input.stage ?? 'maintenance',
+                },
+            },
+        },
+        information: {
+            description: input.label,
+            instructions: '',
+            label: input.label,
+            name: input.name,
+            shortDescription: input.label,
+        },
+        slug: input.name,
+    };
+}
+
+const operations = [
+    operation(1, {
+        label: 'Zalijevanje gredice',
+        name: 'wateringRaisedBed',
+        stage: 'watering',
+    }),
+    operation(2, {
+        label: 'Malčiranje slamom',
+        name: 'mulchStraw',
+    }),
+    operation(3, {
+        label: 'Uklanjanje malča',
+        name: 'removeMulch',
+    }),
+    operation(4, {
+        label: 'Postavljanje agrotekstila',
+        name: 'agrotextileCover',
+    }),
+    operation(5, {
+        label: 'Uklanjanje agrotekstila',
+        name: 'removeAgrotextileCover',
+    }),
+    operation(6, {
+        application: 'plant',
+        label: 'Plijevljenje korova',
+        name: 'weeding',
+    }),
+    operation(7, {
+        application: 'plant',
+        label: 'Postavljanje potpore',
+        name: 'plantSupports',
+    }),
+    operation(8, {
+        application: 'plant',
+        label: 'Berba plodova',
+        name: 'harvestPlant',
+        stage: 'harvest',
+    }),
+    operation(9, {
+        label: 'Fotografiranje gredice',
+        name: 'raisedBedPhotography',
+    }),
+];
+
+function applied(
+    id: number,
+    input: {
+        completedAt: string;
+        entityId: number;
+        raisedBedFieldId?: number | null;
+        raisedBedId?: number | null;
+        status?: string;
+    },
+): AppliedOperationVisualInput {
+    return {
+        id,
+        completedAt: input.completedAt,
+        createdAt: input.completedAt,
+        entityId: input.entityId,
+        raisedBedFieldId: input.raisedBedFieldId,
+        raisedBedId: input.raisedBedId,
+        status: input.status ?? 'completed',
+    };
+}
+
+describe('operation visual reward kind mapping', () => {
+    it('maps watering to a watering reward without special droplet kind', () => {
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[0]),
+            'watering',
+        );
+    });
+
+    it('maps removal operations to negative visual families', () => {
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[2]),
+            'removeMulch',
+        );
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[4]),
+            'removeAgrotextile',
+        );
+    });
+
+    it('maps known plant and update actions', () => {
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[5]),
+            'weeding',
+        );
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[6]),
+            'supports',
+        );
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[7]),
+            'harvest',
+        );
+        assert.strictEqual(
+            resolveOperationVisualRewardKind(operations[8]),
+            'photographyUpdate',
+        );
+    });
+});
+
+describe('resolveOperationVisualRewards', () => {
+    it('keeps field and raised-bed scopes separate', () => {
+        const rewards = resolveOperationVisualRewards({
+            appliedOperations: [
+                applied(101, {
+                    completedAt: '2026-06-01T08:00:00.000Z',
+                    entityId: 1,
+                    raisedBedId: 10,
+                }),
+                applied(102, {
+                    completedAt: '2026-06-01T09:00:00.000Z',
+                    entityId: 6,
+                    raisedBedFieldId: 500,
+                    raisedBedId: 10,
+                }),
+            ],
+            operations,
+        });
+
+        assert.deepStrictEqual(
+            rewards.map((reward) => ({
+                kind: reward.kind,
+                raisedBedFieldId: reward.raisedBedFieldId,
+                raisedBedId: reward.raisedBedId,
+                scope: reward.scope,
+            })),
+            [
+                {
+                    kind: 'weeding',
+                    raisedBedFieldId: 500,
+                    raisedBedId: 10,
+                    scope: 'field',
+                },
+                {
+                    kind: 'watering',
+                    raisedBedFieldId: null,
+                    raisedBedId: 10,
+                    scope: 'raisedBed',
+                },
+            ],
+        );
+
+        assert.deepStrictEqual(
+            filterOperationVisualRewards(rewards, {
+                raisedBedFieldId: 500,
+                raisedBedId: 10,
+            }).map((reward) => reward.kind),
+            ['weeding', 'watering'],
+        );
+        assert.deepStrictEqual(
+            filterOperationVisualRewards(rewards, {
+                raisedBedId: 10,
+            }).map((reward) => reward.kind),
+            ['watering'],
+        );
+    });
+
+    it('lets newer removal operations override older applied layers at the same scope', () => {
+        const rewards = resolveOperationVisualRewards({
+            appliedOperations: [
+                applied(201, {
+                    completedAt: '2026-06-01T08:00:00.000Z',
+                    entityId: 2,
+                    raisedBedId: 10,
+                }),
+                applied(202, {
+                    completedAt: '2026-06-02T08:00:00.000Z',
+                    entityId: 3,
+                    raisedBedId: 10,
+                }),
+            ],
+            operations,
+        });
+
+        assert.equal(rewards.length, 1);
+        assert.deepStrictEqual(
+            {
+                active: rewards[0]?.active,
+                family: rewards[0]?.family,
+                kind: rewards[0]?.kind,
+                polarity: rewards[0]?.polarity,
+            },
+            {
+                active: false,
+                family: 'mulch',
+                kind: 'removeMulch',
+                polarity: 'remove',
+            },
+        );
+    });
+
+    it('keeps older removal from clearing newer applied layers', () => {
+        const rewards = resolveOperationVisualRewards({
+            appliedOperations: [
+                applied(301, {
+                    completedAt: '2026-06-01T08:00:00.000Z',
+                    entityId: 5,
+                    raisedBedId: 10,
+                }),
+                applied(302, {
+                    completedAt: '2026-06-03T08:00:00.000Z',
+                    entityId: 4,
+                    raisedBedId: 10,
+                }),
+            ],
+            operations,
+        });
+
+        assert.equal(rewards.length, 1);
+        assert.deepStrictEqual(
+            {
+                active: rewards[0]?.active,
+                kind: rewards[0]?.kind,
+                polarity: rewards[0]?.polarity,
+            },
+            {
+                active: true,
+                kind: 'agrotextile',
+                polarity: 'apply',
+            },
+        );
+    });
+
+    it('ignores planned, failed, canceled, and unknown operation states', () => {
+        const rewards = resolveOperationVisualRewards({
+            appliedOperations: [
+                applied(401, {
+                    completedAt: '2026-06-01T08:00:00.000Z',
+                    entityId: 1,
+                    raisedBedId: 10,
+                    status: 'planned',
+                }),
+                applied(402, {
+                    completedAt: '2026-06-01T09:00:00.000Z',
+                    entityId: 1,
+                    raisedBedId: 10,
+                    status: 'failed',
+                }),
+                applied(403, {
+                    completedAt: '2026-06-01T10:00:00.000Z',
+                    entityId: 1,
+                    raisedBedId: 10,
+                    status: 'canceled',
+                }),
+            ],
+            operations,
+        });
+
+        assert.deepStrictEqual(rewards, []);
+    });
+
+    it('uses operation history images for photography updates', () => {
+        const operationItems: OperationHistoryVisualInput[] = [
+            {
+                ...applied(501, {
+                    completedAt: '2026-06-01T08:00:00.000Z',
+                    entityId: 9,
+                    raisedBedId: 10,
+                    status: 'confirmed',
+                }),
+                imageUrls: [
+                    'https://cdn.gredice.com/photo-1.jpg',
+                    'https://cdn.gredice.com/photo-1.jpg',
+                    'https://cdn.gredice.com/photo-2.jpg',
+                ],
+                verifiedAt: null,
+            },
+        ];
+
+        const rewards = resolveOperationVisualRewards({
+            operationItems,
+            operations,
+        });
+
+        assert.equal(rewards.length, 1);
+        assert.deepStrictEqual(
+            {
+                family: rewards[0]?.family,
+                imageUrls: rewards[0]?.imageUrls,
+                kind: rewards[0]?.kind,
+                polarity: rewards[0]?.polarity,
+            },
+            {
+                family: 'photography',
+                imageUrls: [
+                    'https://cdn.gredice.com/photo-1.jpg',
+                    'https://cdn.gredice.com/photo-2.jpg',
+                ],
+                kind: 'photographyUpdate',
+                polarity: 'update',
+            },
+        );
+    });
+});

--- a/packages/storage/scripts/upsertOperationVisualRewardAttributes.ts
+++ b/packages/storage/scripts/upsertOperationVisualRewardAttributes.ts
@@ -1,0 +1,247 @@
+import { and, eq } from 'drizzle-orm';
+import {
+    attributeValues,
+    closeStorage,
+    createAttributeDefinition,
+    entities,
+    getAttributeDefinitions,
+    type SelectAttributeDefinition,
+    storage,
+    updateAttributeDefinition,
+    upsertAttributeValue,
+} from '../src';
+
+type OperationVisualRewardKind =
+    | 'agrotextile'
+    | 'harvest'
+    | 'mulch'
+    | 'photographyUpdate'
+    | 'removeAgrotextile'
+    | 'removeMulch'
+    | 'supports'
+    | 'watering'
+    | 'weeding';
+
+const actor = {
+    id: 'codex',
+    name: 'Codex',
+};
+
+const entityTypeName = 'operation';
+const visualRewardAttribute = {
+    category: 'attributes',
+    dataType: 'text',
+    description:
+        'Controls the exact in-game visual reward a completed operation creates. Supported values: watering, weeding, mulch, removeMulch, agrotextile, removeAgrotextile, supports, harvest, photographyUpdate.',
+    display: false,
+    entityTypeName,
+    label: 'Vizualna nagrada',
+    multiple: false,
+    name: 'visualReward',
+    order: '136',
+    required: false,
+};
+
+const operationVisualRewardAssignments = [
+    { operationName: 'harvest25Mature', visualReward: 'harvest' },
+    { operationName: 'harvest50Mature', visualReward: 'harvest' },
+    { operationName: 'harvestPlant', visualReward: 'harvest' },
+    { operationName: 'harvestAll', visualReward: 'harvest' },
+    { operationName: 'harvestMature', visualReward: 'harvest' },
+    { operationName: 'plantPhoto', visualReward: 'photographyUpdate' },
+    { operationName: 'raisedBedFullPhoto', visualReward: 'photographyUpdate' },
+    { operationName: 'malchStrawPlant', visualReward: 'mulch' },
+    { operationName: 'malchStrawRaisedBed', visualReward: 'mulch' },
+    { operationName: 'setAgrotextileWhite', visualReward: 'agrotextile' },
+    { operationName: 'plantingPlantSupport', visualReward: 'supports' },
+    { operationName: 'growthPlantSupport', visualReward: 'supports' },
+    { operationName: 'watterSurfaceRaisedBed', visualReward: 'watering' },
+    { operationName: 'watteringSystemSprinkler2', visualReward: 'watering' },
+    {
+        operationName: 'removeAgrotextileWhite',
+        visualReward: 'removeAgrotextile',
+    },
+    { operationName: 'pullingWeedsRaisedBed', visualReward: 'weeding' },
+    { operationName: 'pullingWeedsPlant', visualReward: 'weeding' },
+    { operationName: 'removeMalchStrawPlant', visualReward: 'removeMulch' },
+    { operationName: 'removeMalchStrawRaisedBed', visualReward: 'removeMulch' },
+    { operationName: 'supportTying', visualReward: 'supports' },
+    { operationName: 'watterRaisedBed', visualReward: 'watering' },
+] satisfies {
+    operationName: string;
+    visualReward: OperationVisualRewardKind;
+}[];
+
+function attributePath(definition: SelectAttributeDefinition) {
+    return `${definition.category}.${definition.name}`;
+}
+
+async function getOperationDefinitionsByPath() {
+    const definitions = await getAttributeDefinitions(entityTypeName);
+
+    return new Map(
+        definitions.map((definition) => [
+            attributePath(definition),
+            definition,
+        ]),
+    );
+}
+
+async function ensureVisualRewardAttributeDefinition() {
+    const definitionsByPath = await getOperationDefinitionsByPath();
+    const existingDefinition = definitionsByPath.get('attributes.visualReward');
+
+    if (!existingDefinition) {
+        const id = await createAttributeDefinition(visualRewardAttribute);
+        const refreshedDefinitionsByPath =
+            await getOperationDefinitionsByPath();
+        const createdDefinition = refreshedDefinitionsByPath.get(
+            'attributes.visualReward',
+        );
+        if (!createdDefinition || createdDefinition.id !== id) {
+            throw new Error('Failed to create attributes.visualReward.');
+        }
+
+        return createdDefinition;
+    }
+
+    const shouldUpdate =
+        existingDefinition.dataType !== visualRewardAttribute.dataType ||
+        existingDefinition.description !== visualRewardAttribute.description ||
+        existingDefinition.display !== visualRewardAttribute.display ||
+        existingDefinition.label !== visualRewardAttribute.label ||
+        existingDefinition.multiple !== visualRewardAttribute.multiple ||
+        existingDefinition.order !== visualRewardAttribute.order ||
+        existingDefinition.required !== visualRewardAttribute.required;
+
+    if (shouldUpdate) {
+        await updateAttributeDefinition({
+            id: existingDefinition.id,
+            ...visualRewardAttribute,
+        });
+        const refreshedDefinitionsByPath =
+            await getOperationDefinitionsByPath();
+        const updatedDefinition = refreshedDefinitionsByPath.get(
+            'attributes.visualReward',
+        );
+        if (!updatedDefinition) {
+            throw new Error('Failed to update attributes.visualReward.');
+        }
+
+        return updatedDefinition;
+    }
+
+    return existingDefinition;
+}
+
+async function findOperationEntityIdByName({
+    name,
+    nameDefinition,
+}: {
+    name: string;
+    nameDefinition: SelectAttributeDefinition;
+}) {
+    const matches = await storage()
+        .select({ id: entities.id })
+        .from(entities)
+        .innerJoin(attributeValues, eq(attributeValues.entityId, entities.id))
+        .where(
+            and(
+                eq(entities.entityTypeName, entityTypeName),
+                eq(entities.isDeleted, false),
+                eq(attributeValues.isDeleted, false),
+                eq(attributeValues.attributeDefinitionId, nameDefinition.id),
+                eq(attributeValues.value, name),
+            ),
+        )
+        .limit(2);
+
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected exactly one operation named ${name}, found ${matches.length}.`,
+        );
+    }
+
+    return matches[0].id;
+}
+
+async function getExistingAttributeValue({
+    attributeDefinitionId,
+    entityId,
+}: {
+    attributeDefinitionId: number;
+    entityId: number;
+}) {
+    const [existingValue] = await storage()
+        .select({
+            id: attributeValues.id,
+            value: attributeValues.value,
+        })
+        .from(attributeValues)
+        .where(
+            and(
+                eq(attributeValues.entityId, entityId),
+                eq(
+                    attributeValues.attributeDefinitionId,
+                    attributeDefinitionId,
+                ),
+                eq(attributeValues.isDeleted, false),
+            ),
+        )
+        .limit(1);
+
+    return existingValue;
+}
+
+async function main() {
+    const definitionsByPath = await getOperationDefinitionsByPath();
+    const nameDefinition = definitionsByPath.get('information.name');
+    if (!nameDefinition) {
+        throw new Error('Missing operation information.name definition.');
+    }
+
+    const visualRewardDefinition =
+        await ensureVisualRewardAttributeDefinition();
+    let changedValueCount = 0;
+
+    for (const assignment of operationVisualRewardAssignments) {
+        const entityId = await findOperationEntityIdByName({
+            name: assignment.operationName,
+            nameDefinition,
+        });
+        const existingValue = await getExistingAttributeValue({
+            attributeDefinitionId: visualRewardDefinition.id,
+            entityId,
+        });
+
+        if (existingValue?.value === assignment.visualReward) {
+            continue;
+        }
+
+        await upsertAttributeValue(
+            {
+                id: existingValue?.id,
+                attributeDefinitionId: visualRewardDefinition.id,
+                entityId,
+                entityTypeName,
+                order: visualRewardDefinition.order,
+                value: assignment.visualReward,
+            },
+            actor,
+        );
+        changedValueCount += 1;
+    }
+
+    console.log(
+        `Upserted attributes.visualReward definition ${visualRewardDefinition.id}. Updated ${changedValueCount} operation visual reward values.`,
+    );
+}
+
+main()
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await closeStorage();
+    });


### PR DESCRIPTION
## Summary
- Add a typed `@gredice/game` operation visual reward contract and resolver.
- Use explicit `attributes.visualReward` operation values as the source of truth instead of operation names, labels, stages, descriptions, instructions, image paths, or remove/apply wording.
- Add `packages/storage/scripts/upsertOperationVisualRewardAttributes.ts` to create/backfill the operation attribute, and ran it against the pulled DB environment: definition `206`, 21 operation values updated.
- Cover active status filtering, field/raised-bed scope, removal overrides, photography image updates, and missing/unknown visual reward attributes with unit tests.

Linear: https://linear.app/gredice/issue/GRE-483/game-define-applied-action-visual-reward-state-contract
Closes #3318

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/storage lint`
- `pnpm exec tsx --conditions=react-server --env-file=.env ./scripts/upsertOperationVisualRewardAttributes.ts` from `packages/storage`
- `git diff --check`

Note: `pnpm --filter @gredice/storage typecheck` is not available as a package script. Direct `tsc --noEmit --pretty false` for `@gredice/storage` is currently blocked by existing unrelated script/test type errors.