### PR TITLE
[GRE-484] Add watering moist soil visual reward

### DIFF
--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -2,6 +2,8 @@ import { animated } from '@react-spring/three';
 import { Vector3 } from 'three';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useRaisedBedOperationVisualRewards } from '../hooks/useRaisedBedOperationVisualRewards';
+import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -14,6 +16,7 @@ import { useGameGLTF } from '../utils/useGameGLTF';
 import { HoverOutline } from './helpers/HoverOutline';
 import { useEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
+import { isWateringRewardVisible } from './raisedBed/raisedBedWateringRewards';
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
@@ -23,6 +26,9 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const currentStackHeight = useStackHeight(stack, block);
     const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
     const { data: garden } = useCurrentGarden();
+    const raisedBed = findRaisedBedByBlockId(garden, block.id);
+    const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
+    const currentTime = useSnapshotTime();
     const hoveredRaisedBed = hoveredBlock
         ? findRaisedBedByBlockId(garden, hoveredBlock.id)
         : null;
@@ -109,6 +115,13 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
         shape1 = 'Raised_Bed_O_1';
         shape2 = 'Raised_Bed_O_2';
     }
+    const dirtShape = shape1 === 'Raised_Bed_O_1' ? shape2 : shape1;
+    const hasRaisedBedWateringReward = visualRewards.some(
+        (reward) =>
+            reward.scope === 'raisedBed' &&
+            reward.raisedBedId === raisedBed?.id &&
+            isWateringRewardVisible(reward, currentTime),
+    );
 
     return (
         <>
@@ -157,6 +170,22 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
                         coverageMultiplier={0.9}
                     />
                     <RainWetOverlay geometry={nodes[shape2].geometry} />
+                    {hasRaisedBedWateringReward && (
+                        <mesh
+                            geometry={nodes[dirtShape].geometry}
+                            renderOrder={1}
+                        >
+                            <meshStandardMaterial
+                                color="#2f241d"
+                                depthWrite={false}
+                                opacity={0.28}
+                                polygonOffset
+                                polygonOffsetFactor={-2}
+                                roughness={1}
+                                transparent
+                            />
+                        </mesh>
+                    )}
                 </animated.group>
             </HoverOutline>
             <group position={raisedBedPosition}>

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -5,8 +5,10 @@ import {
     useCurrentGarden,
     useIsSandboxGarden,
 } from '../../hooks/useCurrentGarden';
+import { useRaisedBedOperationVisualRewards } from '../../hooks/useRaisedBedOperationVisualRewards';
 import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
+import { useSnapshotTime } from '../../hooks/useSnapshotTime';
 import { useGameState } from '../../useGameState';
 import {
     findRaisedBedByBlockId,
@@ -14,9 +16,56 @@ import {
 } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import {
+    getGridPositionFromIndex,
+    type RaisedBedOrientation,
+} from '../../utils/raisedBedOrientation';
+import {
     mockPlantPresetLabelsBySortId,
     RaisedBedPlantField,
 } from './RaisedBedPlantField';
+import { isWateringRewardVisible } from './raisedBedWateringRewards';
+
+function RaisedBedFieldMoistSoilOverlay({
+    blockIndex,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const offsetX =
+        orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
+    const offsetZ =
+        orientation === 'vertical' ? 0.27 : 0.27 + blockIndex * 0.05;
+    const multiplierX = orientation === 'vertical' ? 0.285 : 0.27;
+    const multiplierZ = orientation === 'vertical' ? 0.27 : 0.285;
+    const { row, col } = getGridPositionFromIndex(positionIndex, orientation);
+    const position: [number, number, number] = [
+        col * multiplierX - offsetX,
+        -0.748,
+        (2 - row) * multiplierZ - offsetZ,
+    ];
+
+    return (
+        <mesh
+            position={position}
+            rotation={[-Math.PI / 2, 0, 0]}
+            renderOrder={1}
+        >
+            <planeGeometry args={[0.22, 0.22]} />
+            <meshStandardMaterial
+                color="#2f241d"
+                depthWrite={false}
+                opacity={0.3}
+                polygonOffset
+                polygonOffsetFactor={-2}
+                roughness={1}
+                transparent
+            />
+        </mesh>
+    );
+}
 
 function shouldRenderGeneratedPlantField(field: {
     positionIndex: number;
@@ -49,6 +98,8 @@ export function RaisedBedFields({
     );
     const { data: cart } = useShoppingCart(renderDetails && !isLocalSandbox);
     const raisedBed = findRaisedBedByBlockId(currentGarden, blockId);
+    const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
+    const currentTime = useSnapshotTime();
     const orientation = raisedBed?.orientation ?? 'vertical';
 
     const blockIds =
@@ -95,8 +146,37 @@ export function RaisedBedFields({
         return null;
     }
 
+    const moistFieldIds = new Set(
+        visualRewards
+            .filter(
+                (reward) =>
+                    reward.scope === 'field' &&
+                    reward.raisedBedFieldId != null &&
+                    isWateringRewardVisible(reward, currentTime),
+            )
+            .map((reward) => reward.raisedBedFieldId),
+    );
+
     return (
         <>
+            {displayedFields.map((field) => {
+                if (
+                    !field ||
+                    typeof field.id !== 'number' ||
+                    !moistFieldIds.has(field.id)
+                ) {
+                    return null;
+                }
+
+                return (
+                    <RaisedBedFieldMoistSoilOverlay
+                        key={`raised-bed-field-moist-soil-${field.id}`}
+                        blockIndex={blockIndex}
+                        orientation={orientation}
+                        positionIndex={field.positionIndex - blockOffset}
+                    />
+                );
+            })}
             {displayedFields.map((field) => {
                 if (!field) return null;
                 if (

--- a/packages/game/src/entities/raisedBed/raisedBedWateringRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedWateringRewards.ts
@@ -1,0 +1,22 @@
+import type { OperationVisualReward } from '../../operationVisualRewards';
+
+export const WATERING_REWARD_VISIBLE_MS = 72 * 60 * 60 * 1000;
+
+export function isWateringRewardVisible(
+    reward: OperationVisualReward,
+    currentTime: Date,
+) {
+    if (!reward.active || reward.kind !== 'watering') {
+        return false;
+    }
+
+    const currentTimeMs = currentTime.getTime();
+    const ageMs = currentTimeMs - reward.timestampMs;
+
+    return (
+        Number.isFinite(currentTimeMs) &&
+        Number.isFinite(reward.timestampMs) &&
+        ageMs >= 0 &&
+        ageMs <= WATERING_REWARD_VISIBLE_MS
+    );
+}

--- a/packages/game/src/entities/raisedBed/raisedBedWateringRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedWateringRewards.unit.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { OperationVisualReward } from '../../operationVisualRewards';
+import {
+    isWateringRewardVisible,
+    WATERING_REWARD_VISIBLE_MS,
+} from './raisedBedWateringRewards';
+
+function reward(input: {
+    active?: boolean;
+    kind?: OperationVisualReward['kind'];
+    timestampMs: number;
+}): OperationVisualReward {
+    return {
+        active: input.active ?? true,
+        completedAt: new Date(input.timestampMs).toISOString(),
+        createdAt: new Date(input.timestampMs).toISOString(),
+        entityId: 1,
+        family: 'watering',
+        imageUrls: [],
+        kind: input.kind ?? 'watering',
+        operationId: 1,
+        polarity: 'apply',
+        raisedBedFieldId: null,
+        raisedBedId: 10,
+        scope: 'raisedBed',
+        status: 'completed',
+        timestampMs: input.timestampMs,
+        verifiedAt: null,
+    };
+}
+
+test('watering reward stays visible for the configured duration', () => {
+    const baseTimeMs = Date.parse('2026-06-01T08:00:00.000Z');
+
+    assert.equal(
+        isWateringRewardVisible(
+            reward({ timestampMs: baseTimeMs }),
+            new Date(baseTimeMs + WATERING_REWARD_VISIBLE_MS),
+        ),
+        true,
+    );
+    assert.equal(
+        isWateringRewardVisible(
+            reward({ timestampMs: baseTimeMs }),
+            new Date(baseTimeMs + WATERING_REWARD_VISIBLE_MS + 1),
+        ),
+        false,
+    );
+});
+
+test('watering reward ignores inactive, future, and non-watering rewards', () => {
+    const baseTimeMs = Date.parse('2026-06-01T08:00:00.000Z');
+    const currentTime = new Date(baseTimeMs);
+
+    assert.equal(
+        isWateringRewardVisible(
+            reward({ active: false, timestampMs: baseTimeMs }),
+            currentTime,
+        ),
+        false,
+    );
+    assert.equal(
+        isWateringRewardVisible(
+            reward({ kind: 'mulch', timestampMs: baseTimeMs }),
+            currentTime,
+        ),
+        false,
+    );
+    assert.equal(
+        isWateringRewardVisible(
+            reward({ timestampMs: baseTimeMs + 1 }),
+            currentTime,
+        ),
+        false,
+    );
+});

--- a/packages/game/src/hooks/useRaisedBedOperationVisualRewards.ts
+++ b/packages/game/src/hooks/useRaisedBedOperationVisualRewards.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import {
+    type AppliedOperationVisualInput,
+    resolveOperationVisualRewards,
+} from '../operationVisualRewards';
+import type { useCurrentGarden } from './useCurrentGarden';
+import { useOperations } from './useOperations';
+
+type CurrentGardenData = NonNullable<
+    NonNullable<ReturnType<typeof useCurrentGarden>['data']>
+>;
+type RaisedBedData = CurrentGardenData['raisedBeds'][number];
+
+function raisedBedAppliedOperationVisualInputs(
+    raisedBed: RaisedBedData,
+): AppliedOperationVisualInput[] {
+    return (raisedBed.appliedOperations ?? []).map((operation) => ({
+        ...operation,
+        raisedBedId: raisedBed.id,
+    }));
+}
+
+export function useRaisedBedOperationVisualRewards(
+    raisedBed: RaisedBedData | null | undefined,
+) {
+    const { data: operations } = useOperations();
+
+    return useMemo(() => {
+        if (!raisedBed || !operations) {
+            return [];
+        }
+
+        return resolveOperationVisualRewards({
+            appliedOperations: raisedBedAppliedOperationVisualInputs(raisedBed),
+            operations,
+        });
+    }, [operations, raisedBed]);
+}


### PR DESCRIPTION
## Summary
- Render recent completed watering as a low-poly moist soil tint instead of droplets or particle details.
- Support both raised-bed scoped and field-scoped watering rewards through the operation visual reward contract.
- Keep watering visible for 72 hours after completion and add focused unit coverage for that window.

Linear: https://linear.app/gredice/issue/GRE-484/game-add-watering-reward-dry-soil-to-moist-soil-tint
Stacked on: #3329
Closes #3319

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`