### PR TITLE
[GRE-485] Add raised bed weed state controls

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -873,6 +873,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         physicalId: raisedBed.physicalId,
                         blockId: raisedBed.blockId,
                         status: raisedBed.status,
+                        weedState: raisedBed.weedState,
                         abandonReason:
                             abandonReasonByRaisedBedId.get(raisedBed.id) ??
                             null,

--- a/apps/app/app/(actions)/raisedBedActions.ts
+++ b/apps/app/app/(actions)/raisedBedActions.ts
@@ -9,6 +9,8 @@ import {
     abandonRaisedBed,
     getRaisedBed,
     mergeRaisedBeds,
+    type RaisedBedWeedStateLevel,
+    setRaisedBedWeedState as setRaisedBedWeedStateInStorage,
     updateRaisedBed,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
@@ -69,6 +71,39 @@ export async function setRaisedBedStatus(
     }
 
     revalidatePath(KnownPages.Sensors);
+}
+
+export async function setRaisedBedWeedState(
+    raisedBedId: number,
+    level: RaisedBedWeedStateLevel,
+) {
+    await auth(['admin']);
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (!raisedBed) {
+        throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
+    }
+
+    if (raisedBed.weedState?.level === level) {
+        return;
+    }
+
+    await setRaisedBedWeedStateInStorage({
+        level,
+        raisedBedId,
+        source: 'admin',
+    });
+
+    revalidatePath(KnownPages.RaisedBed(raisedBedId));
+    revalidatePath(KnownPages.RaisedBeds);
+
+    if (raisedBed.accountId) {
+        revalidatePath(KnownPages.Account(raisedBed.accountId));
+    }
+
+    if (raisedBed.gardenId) {
+        revalidatePath(KnownPages.Garden(raisedBed.gardenId));
+    }
 }
 
 export async function abandonRaisedBedDueToInactivityAction(

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -16,6 +16,8 @@ import {
     knownEvents,
     moveRaisedBedFieldPlantHistory,
     type RaisedBedFieldSowingLocation,
+    type RaisedBedWeedStateLevel,
+    setRaisedBedFieldWeedState as setRaisedBedFieldWeedStateInStorage,
     updateActiveRaisedBedFieldPlantStatusEventCreatedAt,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
@@ -242,6 +244,41 @@ export async function raisedBedFieldUpdatePlant({
         status,
         plantSortId,
         timestamp,
+    });
+
+    await revalidateRaisedBedPaths(raisedBed);
+
+    return { success: true };
+}
+
+export async function setRaisedBedFieldWeedState({
+    level,
+    positionIndex,
+    raisedBedId,
+}: {
+    level: RaisedBedWeedStateLevel;
+    positionIndex: number;
+    raisedBedId: number;
+}) {
+    await auth(['admin']);
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (!raisedBed) {
+        throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
+    }
+
+    const field = raisedBed.fields.find(
+        (item) => item.positionIndex === positionIndex && item.active,
+    );
+    if (field?.weedState?.level === level) {
+        return { success: true };
+    }
+
+    await setRaisedBedFieldWeedStateInStorage({
+        level,
+        positionIndex,
+        raisedBedId,
+        source: 'admin',
     });
 
     await revalidateRaisedBedPaths(raisedBed);

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { RaisedBedWeedStateLevel } from '@gredice/storage';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { setRaisedBedFieldWeedState } from '../../../(actions)/raisedBedFieldsActions';
+import {
+    isRaisedBedWeedStateLevel,
+    RaisedBedWeedStateItems,
+} from './RaisedBedWeedStateItems';
+
+export function RaisedBedFieldWeedStateSelector({
+    className,
+    level,
+    positionIndex,
+    raisedBedId,
+    variant = 'outlined',
+}: {
+    className?: string;
+    level: RaisedBedWeedStateLevel;
+    positionIndex: number;
+    raisedBedId: number;
+    variant?: 'outlined' | 'plain';
+}) {
+    return (
+        <SelectItems
+            className={className}
+            placeholder={`Korov polje ${positionIndex + 1}`}
+            value={level}
+            onValueChange={(newValue) => {
+                if (
+                    !isRaisedBedWeedStateLevel(newValue) ||
+                    newValue === level
+                ) {
+                    return;
+                }
+
+                setRaisedBedFieldWeedState({
+                    level: newValue,
+                    positionIndex,
+                    raisedBedId,
+                });
+            }}
+            items={RaisedBedWeedStateItems}
+            variant={variant}
+        />
+    );
+}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedWeedStateItems.ts
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedWeedStateItems.ts
@@ -1,0 +1,17 @@
+import type { RaisedBedWeedStateLevel } from '@gredice/storage';
+
+export const RaisedBedWeedStateItems: Array<{
+    value: RaisedBedWeedStateLevel;
+    label: string;
+    icon: string;
+}> = [
+    { value: 'none', label: 'Bez korova', icon: 'OK' },
+    { value: 'light', label: 'Lagani korov', icon: '~' },
+    { value: 'heavy', label: 'Jaki korov', icon: '!' },
+];
+
+export function isRaisedBedWeedStateLevel(
+    value: string,
+): value is RaisedBedWeedStateLevel {
+    return RaisedBedWeedStateItems.some((item) => item.value === value);
+}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedWeedStateSelect.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedWeedStateSelect.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { RaisedBedWeedStateLevel } from '@gredice/storage';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { setRaisedBedWeedState } from '../../../(actions)/raisedBedActions';
+import {
+    isRaisedBedWeedStateLevel,
+    RaisedBedWeedStateItems,
+} from './RaisedBedWeedStateItems';
+
+export function RaisedBedWeedStateSelect({
+    raisedBedId,
+    level,
+}: {
+    raisedBedId: number;
+    level: RaisedBedWeedStateLevel;
+}) {
+    return (
+        <SelectItems
+            label="Korov"
+            value={level}
+            onValueChange={(newValue) => {
+                if (
+                    !isRaisedBedWeedStateLevel(newValue) ||
+                    newValue === level
+                ) {
+                    return;
+                }
+
+                setRaisedBedWeedState(raisedBedId, newValue);
+            }}
+            items={RaisedBedWeedStateItems}
+        />
+    );
+}

--- a/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/page.tsx
@@ -35,6 +35,7 @@ import { OperationsTableCard } from './OperationsTableCard';
 import { RaisedBedActionsMenu } from './RaisedBedActionsMenu';
 import { RaisedBedPhysicalIdInput } from './RaisedBedPhysicalIdInput';
 import { RaisedBedStatusSelect } from './RaisedBedStatusSelect';
+import { RaisedBedWeedStateSelect } from './RaisedBedWeedStateSelect';
 
 export const dynamic = 'force-dynamic';
 
@@ -121,6 +122,10 @@ export default async function RaisedBedPage({
                     <RaisedBedStatusSelect
                         raisedBedId={raisedBed.id}
                         status={raisedBed.status}
+                    />
+                    <RaisedBedWeedStateSelect
+                        raisedBedId={raisedBed.id}
+                        level={raisedBed.weedState?.level ?? 'none'}
                     />
                 </Stack>
             </EntityDetailsPanelCard>

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -39,6 +39,7 @@ type RaisedBedFieldCardProps = {
     locationControl?: ReactNode;
     plantSortControl: ReactNode;
     statusControl?: ReactNode;
+    weedControl?: ReactNode;
     className?: string;
 };
 
@@ -49,6 +50,7 @@ export function RaisedBedFieldCard({
     locationControl,
     plantSortControl,
     statusControl,
+    weedControl,
     className,
 }: RaisedBedFieldCardProps) {
     return (
@@ -79,6 +81,7 @@ export function RaisedBedFieldCard({
             )}
             <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-8">
                 <div className="min-w-0">{plantSortControl}</div>
+                {weedControl && <div className="min-w-0">{weedControl}</div>}
                 {statusControl && (
                     <div className="min-w-0">{statusControl}</div>
                 )}

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -8,6 +8,7 @@ import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
 import { RaisedBedFieldLocationSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldLocationSelector';
 import { RaisedBedFieldPlantSortSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldPlantSortSelector';
+import { RaisedBedFieldWeedStateSelector } from '../../app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector';
 import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
 import { MoveRaisedBedFieldPlantModal } from './MoveRaisedBedFieldPlantModal';
 import {
@@ -452,6 +453,15 @@ function RaisedBedFieldTile({
                 className={raisedBedFieldCardButtonClassName}
             />
         ) : undefined;
+    const weedControl = (
+        <RaisedBedFieldWeedStateSelector
+            raisedBedId={raisedBedId}
+            positionIndex={positionIndex}
+            level={field?.weedState?.level ?? 'none'}
+            variant="plain"
+            className={raisedBedFieldCardSelectClassName}
+        />
+    );
 
     return (
         <RaisedBedFieldCard
@@ -461,6 +471,7 @@ function RaisedBedFieldTile({
             historyControl={historyControl}
             plantSortControl={plantSortControl}
             statusControl={statusControl}
+            weedControl={weedControl}
         />
     );
 }

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -24,6 +24,44 @@ import {
     RaisedBedPlantField,
 } from './RaisedBedPlantField';
 import { isWateringRewardVisible } from './raisedBedWateringRewards';
+import {
+    resolveRaisedBedFieldWeedLevel,
+    type VisibleRaisedBedWeedLevel,
+} from './raisedBedWeedState';
+
+const weedBladePlacements = [
+    { id: 'center-left', columnOffset: -0.035, rowOffset: -0.02 },
+    { id: 'center', columnOffset: 0, rowOffset: -0.02 },
+    { id: 'center-right', columnOffset: 0.035, rowOffset: -0.02 },
+    { id: 'back-left', columnOffset: -0.035, rowOffset: 0.02 },
+    { id: 'back', columnOffset: 0, rowOffset: 0.02 },
+    { id: 'back-right', columnOffset: 0.035, rowOffset: 0.02 },
+] as const;
+
+function getRaisedBedFieldSurfacePosition({
+    blockIndex,
+    orientation,
+    positionIndex,
+    y,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+    y: number;
+}) {
+    const offsetX =
+        orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
+    const offsetZ =
+        orientation === 'vertical' ? 0.27 : 0.27 + blockIndex * 0.05;
+    const multiplierX = orientation === 'vertical' ? 0.285 : 0.27;
+    const multiplierZ = orientation === 'vertical' ? 0.27 : 0.285;
+    const { row, col } = getGridPositionFromIndex(positionIndex, orientation);
+    return [
+        col * multiplierX - offsetX,
+        y,
+        (2 - row) * multiplierZ - offsetZ,
+    ] satisfies [number, number, number];
+}
 
 function RaisedBedFieldMoistSoilOverlay({
     blockIndex,
@@ -34,18 +72,12 @@ function RaisedBedFieldMoistSoilOverlay({
     orientation: RaisedBedOrientation;
     positionIndex: number;
 }) {
-    const offsetX =
-        orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
-    const offsetZ =
-        orientation === 'vertical' ? 0.27 : 0.27 + blockIndex * 0.05;
-    const multiplierX = orientation === 'vertical' ? 0.285 : 0.27;
-    const multiplierZ = orientation === 'vertical' ? 0.27 : 0.285;
-    const { row, col } = getGridPositionFromIndex(positionIndex, orientation);
-    const position: [number, number, number] = [
-        col * multiplierX - offsetX,
-        -0.748,
-        (2 - row) * multiplierZ - offsetZ,
-    ];
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y: -0.748,
+    });
 
     return (
         <mesh
@@ -77,6 +109,54 @@ function shouldRenderGeneratedPlantField(field: {
         (field.plantStatus === 'sprouted' ||
             field.plantStatus === 'ready' ||
             field.plantStatus === 'harvested')
+    );
+}
+
+function RaisedBedFieldWeedClump({
+    blockIndex,
+    level,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    level: VisibleRaisedBedWeedLevel;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y: -0.72,
+    });
+    const bladeCount = level === 'heavy' ? 6 : 3;
+
+    return (
+        <group position={position}>
+            {weedBladePlacements
+                .slice(0, bladeCount)
+                .map((placement, index) => {
+                    const height = level === 'heavy' ? 0.16 : 0.12;
+
+                    return (
+                        <mesh
+                            key={placement.id}
+                            position={[
+                                placement.columnOffset,
+                                height / 2,
+                                placement.rowOffset,
+                            ]}
+                            rotation={[0, index * 0.9, 0]}
+                        >
+                            <coneGeometry args={[0.022, height, 4]} />
+                            <meshStandardMaterial
+                                color="#3f6b35"
+                                roughness={1}
+                            />
+                        </mesh>
+                    );
+                })}
+        </group>
     );
 }
 
@@ -156,6 +236,38 @@ export function RaisedBedFields({
             )
             .map((reward) => reward.raisedBedFieldId),
     );
+    const weedFieldVisuals = raisedBed
+        ? Array.from({ length: 9 }, (_, localPositionIndex) => {
+              const positionIndex = blockOffset + localPositionIndex;
+              const field = raisedBed.fields.find(
+                  (candidate) =>
+                      candidate.active &&
+                      candidate.positionIndex === positionIndex,
+              );
+              const weedLevel = resolveRaisedBedFieldWeedLevel({
+                  fieldWeedState: field?.weedState,
+                  raisedBedFieldId:
+                      typeof field?.id === 'number' ? field.id : null,
+                  raisedBedId: raisedBed.id,
+                  raisedBedWeedState: raisedBed.weedState,
+                  visualRewards,
+              });
+
+              return weedLevel
+                  ? {
+                        level: weedLevel,
+                        positionIndex: localPositionIndex,
+                    }
+                  : null;
+          }).filter(
+              (
+                  visual,
+              ): visual is {
+                  level: VisibleRaisedBedWeedLevel;
+                  positionIndex: number;
+              } => Boolean(visual),
+          )
+        : [];
 
     return (
         <>
@@ -177,6 +289,15 @@ export function RaisedBedFields({
                     />
                 );
             })}
+            {weedFieldVisuals.map((visual) => (
+                <RaisedBedFieldWeedClump
+                    key={`raised-bed-field-weed-${blockId}-${visual.positionIndex}`}
+                    blockIndex={blockIndex}
+                    level={visual.level}
+                    orientation={orientation}
+                    positionIndex={visual.positionIndex}
+                />
+            ))}
             {displayedFields.map((field) => {
                 if (!field) return null;
                 if (

--- a/packages/game/src/entities/raisedBed/raisedBedWeedState.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedWeedState.ts
@@ -1,0 +1,115 @@
+import type { OperationVisualReward } from '../../operationVisualRewards';
+
+export type RaisedBedWeedLevel = 'none' | 'light' | 'heavy';
+
+export type RaisedBedWeedStateInput = {
+    level?: string | null;
+    observedAt?: Date | string | null;
+    updatedAt?: Date | string | null;
+};
+
+export type VisibleRaisedBedWeedLevel = Exclude<RaisedBedWeedLevel, 'none'>;
+
+type ResolveRaisedBedFieldWeedLevelInput = {
+    fieldWeedState?: RaisedBedWeedStateInput | null;
+    raisedBedFieldId?: number | null;
+    raisedBedId: number;
+    raisedBedWeedState?: RaisedBedWeedStateInput | null;
+    visualRewards: OperationVisualReward[];
+};
+
+function weedStateTimestampMs(
+    weedState: RaisedBedWeedStateInput | null | undefined,
+) {
+    const value = weedState?.observedAt ?? weedState?.updatedAt;
+    if (!value) {
+        return 0;
+    }
+
+    const timestamp =
+        value instanceof Date ? value.getTime() : Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function isRaisedBedWeedLevel(value: unknown): value is RaisedBedWeedLevel {
+    return value === 'none' || value === 'light' || value === 'heavy';
+}
+
+function visibleWeedLevel(
+    weedState: RaisedBedWeedStateInput | null | undefined,
+): VisibleRaisedBedWeedLevel | null {
+    if (!isRaisedBedWeedLevel(weedState?.level) || weedState.level === 'none') {
+        return null;
+    }
+
+    return weedState.level;
+}
+
+function latestApplicableWeedingTimestampMs({
+    raisedBedFieldId,
+    raisedBedId,
+    visualRewards,
+}: {
+    raisedBedFieldId?: number | null;
+    raisedBedId: number;
+    visualRewards: OperationVisualReward[];
+}) {
+    return visualRewards.reduce((latestTimestampMs, reward) => {
+        if (reward.kind !== 'weeding' || reward.polarity !== 'remove') {
+            return latestTimestampMs;
+        }
+
+        const appliesToRaisedBed =
+            reward.scope === 'raisedBed' && reward.raisedBedId === raisedBedId;
+        const appliesToField =
+            raisedBedFieldId != null &&
+            reward.scope === 'field' &&
+            reward.raisedBedFieldId === raisedBedFieldId;
+
+        if (!appliesToRaisedBed && !appliesToField) {
+            return latestTimestampMs;
+        }
+
+        return Math.max(latestTimestampMs, reward.timestampMs);
+    }, 0);
+}
+
+function latestWeedState(
+    raisedBedWeedState: RaisedBedWeedStateInput | null | undefined,
+    fieldWeedState: RaisedBedWeedStateInput | null | undefined,
+) {
+    if (!raisedBedWeedState) {
+        return fieldWeedState ?? null;
+    }
+    if (!fieldWeedState) {
+        return raisedBedWeedState;
+    }
+
+    return weedStateTimestampMs(fieldWeedState) >=
+        weedStateTimestampMs(raisedBedWeedState)
+        ? fieldWeedState
+        : raisedBedWeedState;
+}
+
+export function resolveRaisedBedFieldWeedLevel({
+    fieldWeedState,
+    raisedBedFieldId,
+    raisedBedId,
+    raisedBedWeedState,
+    visualRewards,
+}: ResolveRaisedBedFieldWeedLevelInput): VisibleRaisedBedWeedLevel | null {
+    const weedState = latestWeedState(raisedBedWeedState, fieldWeedState);
+    const level = visibleWeedLevel(weedState);
+    if (!level) {
+        return null;
+    }
+
+    const weedStateTimestamp = weedStateTimestampMs(weedState);
+    const latestWeedingTimestamp = latestApplicableWeedingTimestampMs({
+        raisedBedFieldId,
+        raisedBedId,
+        visualRewards,
+    });
+
+    return latestWeedingTimestamp >= weedStateTimestamp ? null : level;
+}

--- a/packages/game/src/entities/raisedBed/raisedBedWeedState.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedWeedState.unit.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { OperationVisualReward } from '../../operationVisualRewards';
+import { resolveRaisedBedFieldWeedLevel } from './raisedBedWeedState';
+
+function weedingReward(input: {
+    raisedBedFieldId?: number | null;
+    raisedBedId: number;
+    timestampMs: number;
+}): OperationVisualReward {
+    return {
+        active: false,
+        completedAt: new Date(input.timestampMs).toISOString(),
+        createdAt: new Date(input.timestampMs).toISOString(),
+        entityId: 1,
+        family: 'weeds',
+        imageUrls: [],
+        kind: 'weeding',
+        operationId: 1,
+        polarity: 'remove',
+        raisedBedFieldId: input.raisedBedFieldId ?? null,
+        raisedBedId: input.raisedBedId,
+        scope: input.raisedBedFieldId == null ? 'raisedBed' : 'field',
+        status: 'completed',
+        timestampMs: input.timestampMs,
+        verifiedAt: null,
+    };
+}
+
+test('raised bed weed state is visible for fields without overrides', () => {
+    assert.equal(
+        resolveRaisedBedFieldWeedLevel({
+            raisedBedId: 10,
+            raisedBedFieldId: 50,
+            raisedBedWeedState: {
+                level: 'light',
+                observedAt: '2026-06-01T08:00:00.000Z',
+            },
+            visualRewards: [],
+        }),
+        'light',
+    );
+});
+
+test('newer field clean state overrides raised bed weeds', () => {
+    assert.equal(
+        resolveRaisedBedFieldWeedLevel({
+            raisedBedId: 10,
+            raisedBedFieldId: 50,
+            raisedBedWeedState: {
+                level: 'heavy',
+                observedAt: '2026-06-01T08:00:00.000Z',
+            },
+            fieldWeedState: {
+                level: 'none',
+                observedAt: '2026-06-02T08:00:00.000Z',
+            },
+            visualRewards: [],
+        }),
+        null,
+    );
+});
+
+test('newer weeding reward clears visible weeds', () => {
+    const weedObservedAt = Date.parse('2026-06-01T08:00:00.000Z');
+
+    assert.equal(
+        resolveRaisedBedFieldWeedLevel({
+            raisedBedId: 10,
+            raisedBedFieldId: 50,
+            raisedBedWeedState: {
+                level: 'heavy',
+                observedAt: new Date(weedObservedAt).toISOString(),
+            },
+            visualRewards: [
+                weedingReward({
+                    raisedBedId: 10,
+                    timestampMs: weedObservedAt + 1,
+                }),
+            ],
+        }),
+        null,
+    );
+});
+
+test('older weeding reward does not clear newly observed weeds', () => {
+    const weedObservedAt = Date.parse('2026-06-01T08:00:00.000Z');
+
+    assert.equal(
+        resolveRaisedBedFieldWeedLevel({
+            raisedBedId: 10,
+            raisedBedFieldId: 50,
+            raisedBedWeedState: {
+                level: 'heavy',
+                observedAt: new Date(weedObservedAt).toISOString(),
+            },
+            visualRewards: [
+                weedingReward({
+                    raisedBedId: 10,
+                    timestampMs: weedObservedAt - 1,
+                }),
+            ],
+        }),
+        'heavy',
+    );
+});
+
+test('field weeding only clears the matching field', () => {
+    const weedObservedAt = Date.parse('2026-06-01T08:00:00.000Z');
+    const reward = weedingReward({
+        raisedBedId: 10,
+        raisedBedFieldId: 51,
+        timestampMs: weedObservedAt + 1,
+    });
+
+    assert.equal(
+        resolveRaisedBedFieldWeedLevel({
+            raisedBedId: 10,
+            raisedBedFieldId: 50,
+            raisedBedWeedState: {
+                level: 'light',
+                observedAt: new Date(weedObservedAt).toISOString(),
+            },
+            visualRewards: [reward],
+        }),
+        'light',
+    );
+    assert.equal(
+        resolveRaisedBedFieldWeedLevel({
+            raisedBedId: 10,
+            raisedBedFieldId: 51,
+            raisedBedWeedState: {
+                level: 'light',
+                observedAt: new Date(weedObservedAt).toISOString(),
+            },
+            visualRewards: [reward],
+        }),
+        null,
+    );
+});

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -270,6 +270,7 @@ function mockRaisedBedField(
         plantDeadDate: undefined,
         plantHarvestedDate: undefined,
         plantRemovedDate: undefined,
+        weedState: null,
         plantCycles: [
             {
                 aggregateId: `${raisedBedId.toString()}|${field.positionIndex.toString()}`,
@@ -426,6 +427,7 @@ function createProfileRaisedBed(
         physicalId: `profile-raised-bed:${id}`,
         fields: mockRaisedBedFields(id, fieldOffset),
         appliedOperations: [],
+        weedState: null,
         status: 'new',
         abandonReason: null,
         updatedAt: now,
@@ -538,6 +540,7 @@ function mockGarden(
             physicalId: '42',
             fields: mockRaisedBedFields(1, 0),
             appliedOperations: [],
+            weedState: null,
             status: 'new',
             abandonReason: null,
             updatedAt: now,
@@ -552,6 +555,7 @@ function mockGarden(
             blockId: '8',
             fields: mockRaisedBedFields(2, 100),
             appliedOperations: [],
+            weedState: null,
             status: 'new',
             abandonReason: null,
             updatedAt: now,

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -84,6 +84,9 @@ export type {
     RaisedBedFieldPlantSchedulePayload,
     RaisedBedFieldPlantUpdatePayload,
     RaisedBedFieldSowingLocation,
+    RaisedBedWeedStateLevel,
+    RaisedBedWeedStateSetPayload,
+    RaisedBedWeedStateSource,
     // Receipt
     ReceiptCreatePayload,
     ReceiptFiscalizePayload,

--- a/packages/storage/src/repositories/events/knownEventTypes.ts
+++ b/packages/storage/src/repositories/events/knownEventTypes.ts
@@ -41,6 +41,7 @@ export const knownEventTypes = {
         delete: 'raisedBed.delete',
         abandon: 'raisedBed.abandon',
         aiAnalysis: 'raisedBed.aiAnalysis',
+        weedStateSet: 'raisedBed.weedState.set',
     },
     raisedBedFields: {
         create: 'raisedBedField.create',
@@ -50,6 +51,7 @@ export const knownEventTypes = {
         plantUpdate: 'raisedBedField.plantUpdate',
         plantReplaceSort: 'raisedBedField.plantReplaceSort',
         aiAnalysis: 'raisedBedField.aiAnalysis',
+        weedStateSet: 'raisedBedField.weedState.set',
     },
     operations: {
         assign: 'operation.assign',

--- a/packages/storage/src/repositories/events/knownEvents.ts
+++ b/packages/storage/src/repositories/events/knownEvents.ts
@@ -42,6 +42,7 @@ import type {
     RaisedBedFieldPlantReplaceSortPayload,
     RaisedBedFieldPlantSchedulePayload,
     RaisedBedFieldPlantUpdatePayload,
+    RaisedBedWeedStateSetPayload,
     ReceiptCreatePayload,
     ReceiptFiscalizePayload,
     TransactionCreatePayload,
@@ -257,6 +258,15 @@ export const knownEvents = {
             aggregateId,
             data,
         }),
+        weedStateSetV1: (
+            aggregateId: string,
+            data: RaisedBedWeedStateSetPayload,
+        ) => ({
+            type: knownEventTypes.raisedBeds.weedStateSet,
+            version: 1,
+            aggregateId,
+            data,
+        }),
     },
     raisedBedFields: {
         createdV1: (
@@ -314,6 +324,15 @@ export const knownEvents = {
             data: RaisedBedFieldAiAnalysisPayload,
         ) => ({
             type: knownEventTypes.raisedBedFields.aiAnalysis,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        weedStateSetV1: (
+            aggregateId: string,
+            data: RaisedBedWeedStateSetPayload,
+        ) => ({
+            type: knownEventTypes.raisedBedFields.weedStateSet,
             version: 1,
             aggregateId,
             data,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -167,6 +167,17 @@ export type RaisedBedAbandonPayload = {
     reason?: 'inactivity' | 'user';
 };
 
+export type RaisedBedWeedStateLevel = 'none' | 'light' | 'heavy';
+
+export type RaisedBedWeedStateSource = 'admin' | 'ai';
+
+export type RaisedBedWeedStateSetPayload = {
+    level: RaisedBedWeedStateLevel;
+    source: RaisedBedWeedStateSource;
+    observedAt?: string | null;
+    notes?: string | null;
+};
+
 // ============================================================================
 // Raised bed field event payload types
 // ============================================================================

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -45,6 +45,9 @@ import {
     knownEvents,
     knownEventTypes,
     type RaisedBedFieldSowingLocation,
+    type RaisedBedWeedStateLevel,
+    type RaisedBedWeedStateSetPayload,
+    type RaisedBedWeedStateSource,
     updateEventCreatedAt,
 } from './eventsRepo';
 import { getFarms } from './farmsRepo';
@@ -74,6 +77,15 @@ type RaisedBedFieldPlantCycleEvent = typeof events.$inferSelect;
 export type RaisedBedFieldPlantStatusChange = {
     status: string;
     occurredAt: Date;
+};
+
+export type RaisedBedWeedState = {
+    level: RaisedBedWeedStateLevel;
+    source: RaisedBedWeedStateSource;
+    observedAt: Date;
+    updatedAt: Date;
+    eventId: number;
+    notes?: string | null;
 };
 
 export type RaisedBedFieldPlantCycle = {
@@ -608,6 +620,67 @@ function parseSowingLocation(
     value: unknown,
 ): RaisedBedFieldSowingLocation | undefined {
     return value === 'direct' || value === 'greenhouse' ? value : undefined;
+}
+
+function parseWeedStateLevel(value: unknown): RaisedBedWeedStateLevel | null {
+    switch (value) {
+        case 'none':
+        case 'light':
+        case 'heavy':
+            return value;
+        default:
+            return null;
+    }
+}
+
+function parseWeedStateSource(value: unknown): RaisedBedWeedStateSource {
+    return value === 'ai' ? 'ai' : 'admin';
+}
+
+function parseWeedStateObservedAt(value: unknown, fallbackDate: Date): Date {
+    if (typeof value !== 'string') {
+        return fallbackDate;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? fallbackDate : date;
+}
+
+function weedStateFromEvent(
+    event: RaisedBedFieldPlantCycleEvent,
+): RaisedBedWeedState | null {
+    const data =
+        event.data && typeof event.data === 'object'
+            ? (event.data as Partial<RaisedBedWeedStateSetPayload>)
+            : undefined;
+    const level = parseWeedStateLevel(data?.level);
+    if (!level) {
+        return null;
+    }
+
+    return {
+        level,
+        source: parseWeedStateSource(data?.source),
+        observedAt: parseWeedStateObservedAt(data?.observedAt, event.createdAt),
+        updatedAt: event.createdAt,
+        eventId: event.id,
+        notes: typeof data?.notes === 'string' ? data.notes : null,
+    };
+}
+
+function latestWeedStateFromEvents(
+    weedStateEvents: RaisedBedFieldPlantCycleEvent[],
+) {
+    let weedState: RaisedBedWeedState | null = null;
+
+    for (const event of weedStateEvents) {
+        const nextWeedState = weedStateFromEvent(event);
+        if (nextWeedState) {
+            weedState = nextWeedState;
+        }
+    }
+
+    return weedState;
 }
 
 function splitPlantCycleEvents(
@@ -1590,6 +1663,48 @@ export async function getRaisedBedMetadataByIds(raisedBedIds: number[]) {
         .orderBy(asc(raisedBeds.id));
 }
 
+async function getRaisedBedWeedStatesByIds(raisedBedIds: number[]) {
+    const uniqueRaisedBedIds = Array.from(new Set(raisedBedIds));
+    const weedStatesByRaisedBedId = new Map<number, RaisedBedWeedState>();
+    if (uniqueRaisedBedIds.length === 0) {
+        return weedStatesByRaisedBedId;
+    }
+
+    const weedStateEvents = await getEvents(
+        knownEventTypes.raisedBeds.weedStateSet,
+        uniqueRaisedBedIds.map((raisedBedId) => raisedBedId.toString()),
+        0,
+        100000,
+    );
+
+    const eventsByRaisedBedId = new Map<
+        number,
+        RaisedBedFieldPlantCycleEvent[]
+    >();
+    for (const event of weedStateEvents) {
+        const raisedBedId = Number(event.aggregateId);
+        if (!Number.isInteger(raisedBedId)) {
+            continue;
+        }
+
+        const raisedBedEvents = eventsByRaisedBedId.get(raisedBedId);
+        if (raisedBedEvents) {
+            raisedBedEvents.push(event);
+        } else {
+            eventsByRaisedBedId.set(raisedBedId, [event]);
+        }
+    }
+
+    for (const [raisedBedId, events] of eventsByRaisedBedId) {
+        const weedState = latestWeedStateFromEvents(events);
+        if (weedState) {
+            weedStatesByRaisedBedId.set(raisedBedId, weedState);
+        }
+    }
+
+    return weedStatesByRaisedBedId;
+}
+
 export async function getRaisedBeds(
     gardenId: number,
     filters?: {
@@ -1609,6 +1724,9 @@ export async function getRaisedBeds(
     const beds = await storage().query.raisedBeds.findMany({
         where: and(...whereConditions),
     });
+    const weedStatesByRaisedBedId = await getRaisedBedWeedStatesByIds(
+        beds.map((bed) => bed.id),
+    );
 
     // For each raised bed, fetch and attach fields with event-sourced info
     return Promise.all(
@@ -1617,13 +1735,14 @@ export async function getRaisedBeds(
             return {
                 ...bed,
                 fields,
+                weedState: weedStatesByRaisedBedId.get(bed.id) ?? null,
             };
         }),
     );
 }
 
 export async function getRaisedBed(raisedBedId: number) {
-    const [raisedBed, fields] = await Promise.all([
+    const [raisedBed, fields, weedStatesByRaisedBedId] = await Promise.all([
         storage().query.raisedBeds.findFirst({
             where: and(
                 eq(raisedBeds.id, raisedBedId),
@@ -1631,13 +1750,96 @@ export async function getRaisedBed(raisedBedId: number) {
             ),
         }),
         getRaisedBedFieldsWithEvents(raisedBedId),
+        getRaisedBedWeedStatesByIds([raisedBedId]),
     ]);
     if (!raisedBed) return null;
     // Attach raised bed fields with event-sourced info
     return {
         ...raisedBed,
         fields,
+        weedState: weedStatesByRaisedBedId.get(raisedBed.id) ?? null,
     };
+}
+
+function buildWeedStatePayload({
+    level,
+    observedAt,
+    source,
+}: {
+    level: RaisedBedWeedStateLevel;
+    observedAt?: Date;
+    source: RaisedBedWeedStateSource;
+}): RaisedBedWeedStateSetPayload {
+    return {
+        level,
+        source,
+        observedAt: (observedAt ?? new Date()).toISOString(),
+    };
+}
+
+export async function setRaisedBedWeedState({
+    level,
+    observedAt,
+    raisedBedId,
+    source = 'admin',
+}: {
+    level: RaisedBedWeedStateLevel;
+    observedAt?: Date;
+    raisedBedId: number;
+    source?: RaisedBedWeedStateSource;
+}) {
+    const raisedBed = await storage().query.raisedBeds.findFirst({
+        where: and(
+            eq(raisedBeds.id, raisedBedId),
+            eq(raisedBeds.isDeleted, false),
+        ),
+    });
+    if (!raisedBed) {
+        throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
+    }
+
+    await createEvent(
+        knownEvents.raisedBeds.weedStateSetV1(
+            raisedBedId.toString(),
+            buildWeedStatePayload({ level, observedAt, source }),
+        ),
+    );
+}
+
+export async function setRaisedBedFieldWeedState({
+    level,
+    observedAt,
+    positionIndex,
+    raisedBedId,
+    source = 'admin',
+}: {
+    level: RaisedBedWeedStateLevel;
+    observedAt?: Date;
+    positionIndex: number;
+    raisedBedId: number;
+    source?: RaisedBedWeedStateSource;
+}) {
+    if (!Number.isInteger(positionIndex) || positionIndex < 0) {
+        throw new Error('Field position must be zero or greater.');
+    }
+
+    const raisedBed = await storage().query.raisedBeds.findFirst({
+        where: and(
+            eq(raisedBeds.id, raisedBedId),
+            eq(raisedBeds.isDeleted, false),
+        ),
+    });
+    if (!raisedBed) {
+        throw new Error(`Raised bed with ID ${raisedBedId} not found.`);
+    }
+
+    await upsertRaisedBedField({ raisedBedId, positionIndex });
+    await createEvent(
+        knownEvents.raisedBedFields.weedStateSetV1(
+            `${raisedBedId.toString()}|${positionIndex.toString()}`,
+            buildWeedStatePayload({ level, observedAt, source }),
+        ),
+    );
 }
 
 export async function getRaisedBedFieldPlantCycles(raisedBedId: number) {
@@ -1716,6 +1918,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
             knownEventTypes.raisedBedFields.plantSchedule,
             knownEventTypes.raisedBedFields.plantUpdate,
             knownEventTypes.raisedBedFields.plantReplaceSort,
+            knownEventTypes.raisedBedFields.weedStateSet,
         ],
         fieldAggregateIds,
         0,
@@ -1776,6 +1979,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
         let assignedUserIds: string[] | undefined;
         let assignedBy: string | null | undefined;
         let assignedAt: Date | undefined;
+        let weedState: RaisedBedWeedState | null = null;
 
         for (const event of events) {
             const data = event.data as Record<string, unknown> | undefined;
@@ -1956,6 +2160,12 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
                     plantSortId = parseInt(data.plantSortId, 10);
                 }
             }
+            // Handle weed state updates
+            else if (
+                event.type === knownEventTypes.raisedBedFields.weedStateSet
+            ) {
+                weedState = weedStateFromEvent(event) ?? weedState;
+            }
             // Handle field deletion event
             else if (event.type === knownEventTypes.raisedBedFields.delete) {
                 plantStatus = 'deleted';
@@ -1996,6 +2206,7 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
             assignedUserId,
             assignedBy,
             assignedAt,
+            weedState,
         };
     });
 }


### PR DESCRIPTION
## Summary
- add event-sourced weed state for raised beds and raised-bed fields, with admin controls for whole-bed and per-field state
- serialize weed state through the garden API and render low-poly weed clumps in the garden scene
- clear/suppress weed visuals when a newer completed weeding operation applies to the same raised bed or field

Linear: https://linear.app/gredice/issue/GRE-485
Stacked on: #3337
Closes #3320

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/storage lint`
- `pnpm --filter @gredice/storage test`
- `pnpm --filter app lint`
- `pnpm --filter app build`
- `pnpm --filter api lint`
- `pnpm --filter api build`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build`
- `git diff --check`
- `pnpm exec tsc --noEmit --pretty false -p apps/app/tsconfig.json` fails on existing unrelated type errors outside this change set