### PR TITLE
[GRE-486] Polish applied mulch visual ordering

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -28,6 +28,10 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import {
+    appliedMulchOperationsOldestFirst,
+    latestAppliedMulchOperation,
+} from './raisedBedMulchOperationOrder';
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
@@ -717,7 +721,8 @@ export function RaisedBedMulchOverlays({
         const fullBedCartMulch =
             fullBedCartVisual &&
             mulchVisualByOperationId.get(Number(fullBedCartVisual.entityId));
-        const fullBedAppliedMulch = (raisedBed.appliedOperations ?? []).find(
+        const fullBedAppliedMulch = latestAppliedMulchOperation(
+            raisedBed.appliedOperations ?? [],
             (operation) => {
                 const visual = mulchVisualByOperationId.get(operation.entityId);
                 return Boolean(
@@ -766,7 +771,9 @@ export function RaisedBedMulchOverlays({
 
         const fieldMulchByPositionIndex = new Map<number, string>();
 
-        for (const operation of raisedBed.appliedOperations ?? []) {
+        for (const operation of appliedMulchOperationsOldestFirst(
+            raisedBed.appliedOperations ?? [],
+        )) {
             const visual = mulchVisualByOperationId.get(operation.entityId);
             if (!visual || !isFieldMulchApplication(visual.application)) {
                 continue;

--- a/packages/game/src/entities/raisedBed/raisedBedMulchOperationOrder.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchOperationOrder.ts
@@ -1,0 +1,57 @@
+export type AppliedRaisedBedMulchOperationOrderInput = {
+    completedAt?: Date | string | null;
+    createdAt?: Date | string | null;
+    id: number;
+};
+
+function timestampMs(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const timestamp =
+        value instanceof Date ? value.getTime() : Date.parse(value);
+
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function operationTimestampMs(
+    operation: AppliedRaisedBedMulchOperationOrderInput,
+) {
+    return (
+        timestampMs(operation.completedAt) ??
+        timestampMs(operation.createdAt) ??
+        0
+    );
+}
+
+function compareAppliedMulchOperationRecency(
+    left: AppliedRaisedBedMulchOperationOrderInput,
+    right: AppliedRaisedBedMulchOperationOrderInput,
+) {
+    const timestampDiff =
+        operationTimestampMs(left) - operationTimestampMs(right);
+    if (timestampDiff !== 0) {
+        return timestampDiff;
+    }
+
+    return left.id - right.id;
+}
+
+export function appliedMulchOperationsOldestFirst<
+    T extends AppliedRaisedBedMulchOperationOrderInput,
+>(operations: T[]) {
+    return [...operations].sort(compareAppliedMulchOperationRecency);
+}
+
+export function latestAppliedMulchOperation<
+    T extends AppliedRaisedBedMulchOperationOrderInput,
+>(operations: T[], predicate: (operation: T) => boolean) {
+    return (
+        [...operations]
+            .sort((left, right) =>
+                compareAppliedMulchOperationRecency(right, left),
+            )
+            .find(predicate) ?? null
+    );
+}

--- a/packages/game/src/entities/raisedBed/raisedBedMulchOperationOrder.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchOperationOrder.unit.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+    type AppliedRaisedBedMulchOperationOrderInput,
+    appliedMulchOperationsOldestFirst,
+    latestAppliedMulchOperation,
+} from './raisedBedMulchOperationOrder';
+
+type MulchOperation = AppliedRaisedBedMulchOperationOrderInput & {
+    application: 'plant' | 'raisedBedFull';
+    blockName: string;
+    raisedBedFieldId?: number | null;
+};
+
+test('latestAppliedMulchOperation selects the newest whole-bed mulch visual', () => {
+    const operations: MulchOperation[] = [
+        {
+            id: 1,
+            application: 'raisedBedFull',
+            blockName: 'MulchHey',
+            completedAt: '2026-06-01T08:00:00.000Z',
+        },
+        {
+            id: 2,
+            application: 'plant',
+            blockName: 'MulchWood',
+            completedAt: '2026-06-03T08:00:00.000Z',
+            raisedBedFieldId: 50,
+        },
+        {
+            id: 3,
+            application: 'raisedBedFull',
+            blockName: 'MulchCoconut',
+            completedAt: '2026-06-02T08:00:00.000Z',
+        },
+    ];
+
+    assert.equal(
+        latestAppliedMulchOperation(
+            operations,
+            (operation) => operation.application === 'raisedBedFull',
+        )?.blockName,
+        'MulchCoconut',
+    );
+});
+
+test('appliedMulchOperationsOldestFirst lets newer field mulch override older field mulch', () => {
+    const operations: MulchOperation[] = [
+        {
+            id: 2,
+            application: 'plant',
+            blockName: 'MulchWood',
+            completedAt: '2026-06-02T08:00:00.000Z',
+            raisedBedFieldId: 50,
+        },
+        {
+            id: 1,
+            application: 'plant',
+            blockName: 'MulchHey',
+            completedAt: '2026-06-01T08:00:00.000Z',
+            raisedBedFieldId: 50,
+        },
+        {
+            id: 3,
+            application: 'plant',
+            blockName: 'MulchCoconut',
+            completedAt: '2026-06-03T08:00:00.000Z',
+            raisedBedFieldId: 50,
+        },
+    ];
+    const fieldMulchByFieldId = new Map<number, string>();
+
+    for (const operation of appliedMulchOperationsOldestFirst(operations)) {
+        if (operation.raisedBedFieldId != null) {
+            fieldMulchByFieldId.set(
+                operation.raisedBedFieldId,
+                operation.blockName,
+            );
+        }
+    }
+
+    assert.equal(fieldMulchByFieldId.get(50), 'MulchCoconut');
+});
+
+test('applied mulch ordering falls back to createdAt and operation id', () => {
+    const operations: MulchOperation[] = [
+        {
+            id: 11,
+            application: 'raisedBedFull',
+            blockName: 'MulchWood',
+            createdAt: '2026-06-02T08:00:00.000Z',
+        },
+        {
+            id: 10,
+            application: 'raisedBedFull',
+            blockName: 'MulchHey',
+            createdAt: '2026-06-02T08:00:00.000Z',
+        },
+    ];
+
+    assert.deepEqual(
+        appliedMulchOperationsOldestFirst(operations).map(
+            (operation) => operation.id,
+        ),
+        [10, 11],
+    );
+    assert.equal(latestAppliedMulchOperation(operations, () => true)?.id, 11);
+});


### PR DESCRIPTION
## Summary
- keep the existing raised-bed mulch overlay implementation and asset mapping
- make completed/applied mulch ordering explicit so the newest whole-bed mulch visual wins
- apply field mulch operations oldest-to-newest so newer field mulch visuals override older ones deterministically

Linear: https://linear.app/gredice/issue/GRE-486
Stacked on: #3338
Closes #3321

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`