### PR TITLE
[GRE-487] Clear mulch visuals after removal rewards

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -28,10 +28,11 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { appliedMulchOperationsOldestFirst } from './raisedBedMulchOperationOrder';
 import {
-    appliedMulchOperationsOldestFirst,
-    latestAppliedMulchOperation,
-} from './raisedBedMulchOperationOrder';
+    resolveActiveFieldMulchRewardsByFieldId,
+    resolveActiveRaisedBedMulchReward,
+} from './raisedBedMulchVisualRewards';
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
@@ -42,9 +43,6 @@ type CurrentGardenData = NonNullable<
 >;
 type RaisedBedFieldData =
     CurrentGardenData['raisedBeds'][number]['fields'][number];
-type AppliedRaisedBedOperationData = NonNullable<
-    CurrentGardenData['raisedBeds'][number]['appliedOperations']
->[number];
 
 type RaisedBedDirtGeometryName =
     | 'Raised_Bed_O_2'
@@ -126,7 +124,10 @@ function activePlantCycleStartMs(field: RaisedBedFieldData) {
 }
 
 function isOperationAppliedToActivePlantCycle(
-    operation: AppliedRaisedBedOperationData,
+    operation: {
+        completedAt?: Date | string | null;
+        createdAt?: Date | string | null;
+    },
     field: RaisedBedFieldData,
 ) {
     const operationTimestamp = timestampMs(
@@ -704,6 +705,11 @@ export function RaisedBedMulchOverlays({
         if (placements.length === 0) {
             continue;
         }
+        const activeRaisedBedMulchReward = resolveActiveRaisedBedMulchReward({
+            appliedOperations: raisedBed.appliedOperations ?? [],
+            operations,
+            raisedBedId: raisedBed.id,
+        });
 
         const fullBedCartVisual = cart?.items.find((item) => {
             if (
@@ -721,23 +727,12 @@ export function RaisedBedMulchOverlays({
         const fullBedCartMulch =
             fullBedCartVisual &&
             mulchVisualByOperationId.get(Number(fullBedCartVisual.entityId));
-        const fullBedAppliedMulch = latestAppliedMulchOperation(
-            raisedBed.appliedOperations ?? [],
-            (operation) => {
-                const visual = mulchVisualByOperationId.get(operation.entityId);
-                return Boolean(
-                    visual && isBedMulchApplication(visual.application),
-                );
-            },
-        );
+        const fullBedAppliedMulch =
+            activeRaisedBedMulchReward &&
+            mulchVisualByOperationId.get(activeRaisedBedMulchReward.entityId);
 
         if (fullBedCartMulch || fullBedAppliedMulch) {
-            let visual = fullBedCartMulch;
-            if (!visual && fullBedAppliedMulch) {
-                visual = mulchVisualByOperationId.get(
-                    fullBedAppliedMulch.entityId,
-                );
-            }
+            const visual = fullBedCartMulch || fullBedAppliedMulch;
             if (visual) {
                 const mulchAsset = getMulchAsset(mulchAssets, visual.blockName);
                 if (mulchAsset) {
@@ -770,23 +765,29 @@ export function RaisedBedMulchOverlays({
         }
 
         const fieldMulchByPositionIndex = new Map<number, string>();
+        const appliedFieldMulchRewardsByFieldId =
+            resolveActiveFieldMulchRewardsByFieldId({
+                appliedOperations: raisedBed.appliedOperations ?? [],
+                operations,
+                raisedBedId: raisedBed.id,
+            });
 
-        for (const operation of appliedMulchOperationsOldestFirst(
-            raisedBed.appliedOperations ?? [],
+        for (const reward of appliedMulchOperationsOldestFirst(
+            Array.from(appliedFieldMulchRewardsByFieldId.values()),
         )) {
-            const visual = mulchVisualByOperationId.get(operation.entityId);
+            const visual = mulchVisualByOperationId.get(reward.entityId);
             if (!visual || !isFieldMulchApplication(visual.application)) {
                 continue;
             }
 
             const field = raisedBed.fields.find(
-                (candidate) => candidate.id === operation.raisedBedFieldId,
+                (candidate) => candidate.id === reward.raisedBedFieldId,
             );
             if (!field || !isRaisedBedFieldOccupied(field)) {
                 continue;
             }
 
-            if (!isOperationAppliedToActivePlantCycle(operation, field)) {
+            if (!isOperationAppliedToActivePlantCycle(reward, field)) {
                 continue;
             }
 

--- a/packages/game/src/entities/raisedBed/raisedBedMulchOperationOrder.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchOperationOrder.ts
@@ -1,7 +1,8 @@
 export type AppliedRaisedBedMulchOperationOrderInput = {
     completedAt?: Date | string | null;
     createdAt?: Date | string | null;
-    id: number;
+    id?: number;
+    operationId?: number;
 };
 
 function timestampMs(value: Date | string | null | undefined) {
@@ -35,7 +36,10 @@ function compareAppliedMulchOperationRecency(
         return timestampDiff;
     }
 
-    return left.id - right.id;
+    return (
+        (left.id ?? left.operationId ?? 0) -
+        (right.id ?? right.operationId ?? 0)
+    );
 }
 
 export function appliedMulchOperationsOldestFirst<

--- a/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.ts
@@ -1,0 +1,54 @@
+import {
+    type AppliedOperationVisualInput,
+    type OperationVisualDefinitionInput,
+    type OperationVisualReward,
+    resolveOperationVisualRewards,
+} from '../../operationVisualRewards';
+
+type ResolveRaisedBedMulchVisualRewardsInput = {
+    appliedOperations: AppliedOperationVisualInput[];
+    operations: OperationVisualDefinitionInput[];
+    raisedBedId: number;
+};
+
+function activeMulchRewards({
+    appliedOperations,
+    operations,
+}: ResolveRaisedBedMulchVisualRewardsInput) {
+    return resolveOperationVisualRewards({
+        appliedOperations,
+        operations,
+    }).filter((reward) => reward.family === 'mulch' && reward.active);
+}
+
+export function resolveActiveRaisedBedMulchReward(
+    input: ResolveRaisedBedMulchVisualRewardsInput,
+) {
+    return (
+        activeMulchRewards(input).find(
+            (reward) =>
+                reward.scope === 'raisedBed' &&
+                reward.raisedBedId === input.raisedBedId,
+        ) ?? null
+    );
+}
+
+export function resolveActiveFieldMulchRewardsByFieldId(
+    input: ResolveRaisedBedMulchVisualRewardsInput,
+) {
+    const rewardsByFieldId = new Map<number, OperationVisualReward>();
+
+    for (const reward of activeMulchRewards(input)) {
+        if (
+            reward.scope !== 'field' ||
+            reward.raisedBedId !== input.raisedBedId ||
+            reward.raisedBedFieldId == null
+        ) {
+            continue;
+        }
+
+        rewardsByFieldId.set(reward.raisedBedFieldId, reward);
+    }
+
+    return rewardsByFieldId;
+}

--- a/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+    AppliedOperationVisualInput,
+    OperationVisualDefinitionInput,
+} from '../../operationVisualRewards';
+import {
+    resolveActiveFieldMulchRewardsByFieldId,
+    resolveActiveRaisedBedMulchReward,
+} from './raisedBedMulchVisualRewards';
+
+function operation(
+    id: number,
+    input: {
+        application?: string;
+        label: string;
+        name: string;
+    },
+): OperationVisualDefinitionInput {
+    return {
+        id,
+        attributes: {
+            application: input.application ?? 'raisedBedFull',
+        },
+        information: {
+            description: input.label,
+            instructions: '',
+            label: input.label,
+            name: input.name,
+            shortDescription: input.label,
+        },
+        slug: input.name,
+    };
+}
+
+const operations = [
+    operation(1, {
+        label: 'Malciranje slamom',
+        name: 'mulchStraw',
+    }),
+    operation(2, {
+        label: 'Uklanjanje malca',
+        name: 'removeMulch',
+    }),
+    operation(3, {
+        application: 'plant',
+        label: 'Malciranje biljke',
+        name: 'plantMulch',
+    }),
+    operation(4, {
+        application: 'plant',
+        label: 'Uklanjanje malca s biljke',
+        name: 'removePlantMulch',
+    }),
+];
+
+function applied(
+    id: number,
+    input: {
+        completedAt: string;
+        entityId: number;
+        raisedBedFieldId?: number | null;
+        raisedBedId: number;
+    },
+): AppliedOperationVisualInput {
+    return {
+        id,
+        completedAt: input.completedAt,
+        createdAt: input.completedAt,
+        entityId: input.entityId,
+        raisedBedFieldId: input.raisedBedFieldId,
+        raisedBedId: input.raisedBedId,
+        status: 'completed',
+    };
+}
+
+test('newer remove-mulch reward clears whole-bed mulch', () => {
+    const reward = resolveActiveRaisedBedMulchReward({
+        raisedBedId: 10,
+        operations,
+        appliedOperations: [
+            applied(101, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+            applied(102, {
+                completedAt: '2026-06-02T08:00:00.000Z',
+                entityId: 2,
+                raisedBedId: 10,
+            }),
+        ],
+    });
+
+    assert.equal(reward, null);
+});
+
+test('older remove-mulch reward does not clear newer whole-bed mulch', () => {
+    const reward = resolveActiveRaisedBedMulchReward({
+        raisedBedId: 10,
+        operations,
+        appliedOperations: [
+            applied(201, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 2,
+                raisedBedId: 10,
+            }),
+            applied(202, {
+                completedAt: '2026-06-02T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+        ],
+    });
+
+    assert.equal(reward?.entityId, 1);
+});
+
+test('field remove-mulch reward clears only the matching field', () => {
+    const rewardsByFieldId = resolveActiveFieldMulchRewardsByFieldId({
+        raisedBedId: 10,
+        operations,
+        appliedOperations: [
+            applied(301, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 3,
+                raisedBedFieldId: 50,
+                raisedBedId: 10,
+            }),
+            applied(302, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 3,
+                raisedBedFieldId: 51,
+                raisedBedId: 10,
+            }),
+            applied(303, {
+                completedAt: '2026-06-02T08:00:00.000Z',
+                entityId: 4,
+                raisedBedFieldId: 50,
+                raisedBedId: 10,
+            }),
+        ],
+    });
+
+    assert.equal(rewardsByFieldId.has(50), false);
+    assert.equal(rewardsByFieldId.get(51)?.entityId, 3);
+});

--- a/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import type {
     AppliedOperationVisualInput,
     OperationVisualDefinitionInput,
+    OperationVisualRewardKind,
 } from '../../operationVisualRewards';
 import {
     resolveActiveFieldMulchRewardsByFieldId,
@@ -15,12 +16,14 @@ function operation(
         application?: string;
         label: string;
         name: string;
+        visualReward: OperationVisualRewardKind;
     },
 ): OperationVisualDefinitionInput {
     return {
         id,
         attributes: {
             application: input.application ?? 'raisedBedFull',
+            visualReward: input.visualReward,
         },
         information: {
             description: input.label,
@@ -37,20 +40,24 @@ const operations = [
     operation(1, {
         label: 'Malciranje slamom',
         name: 'mulchStraw',
+        visualReward: 'mulch',
     }),
     operation(2, {
         label: 'Uklanjanje malca',
         name: 'removeMulch',
+        visualReward: 'removeMulch',
     }),
     operation(3, {
         application: 'plant',
         label: 'Malciranje biljke',
         name: 'plantMulch',
+        visualReward: 'mulch',
     }),
     operation(4, {
         application: 'plant',
         label: 'Uklanjanje malca s biljke',
         name: 'removePlantMulch',
+        visualReward: 'removeMulch',
     }),
 ];
 


### PR DESCRIPTION
## Summary
- route applied mulch overlay rendering through the visual reward contract
- suppress whole-bed or field mulch when a newer remove-mulch operation exists at the same scope
- preserve unrelated field and whole-bed scopes, including field removal not clearing whole-bed mulch

Linear: https://linear.app/gredice/issue/GRE-487
Stacked on: #3339
Closes #3322

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`