### PR TITLE
[GRE-488] Add agrotextile cover visual

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -23,6 +23,7 @@ import {
     mockPlantPresetLabelsBySortId,
     RaisedBedPlantField,
 } from './RaisedBedPlantField';
+import { resolveRaisedBedAgrotextileCoverPositions } from './raisedBedAgrotextileRewards';
 import { isWateringRewardVisible } from './raisedBedWateringRewards';
 import {
     resolveRaisedBedFieldWeedLevel,
@@ -160,6 +161,68 @@ function RaisedBedFieldWeedClump({
     );
 }
 
+function RaisedBedFieldAgrotextileCover({
+    blockIndex,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y: -0.704,
+    });
+
+    return (
+        <group position={position}>
+            <mesh
+                position={[0, 0.004, 0]}
+                rotation={[-Math.PI / 2, 0, 0]}
+                renderOrder={4}
+            >
+                <planeGeometry args={[0.25, 0.25]} />
+                <meshStandardMaterial
+                    color="#dcd7c6"
+                    depthWrite={false}
+                    opacity={0.76}
+                    polygonOffset
+                    polygonOffsetFactor={-4}
+                    roughness={1}
+                    transparent
+                />
+            </mesh>
+            <mesh position={[0, 0.012, -0.118]} renderOrder={5}>
+                <boxGeometry args={[0.255, 0.008, 0.012]} />
+                <meshStandardMaterial color="#eee9d8" roughness={1} />
+            </mesh>
+            <mesh position={[0, 0.012, 0.118]} renderOrder={5}>
+                <boxGeometry args={[0.255, 0.008, 0.012]} />
+                <meshStandardMaterial color="#eee9d8" roughness={1} />
+            </mesh>
+            <mesh position={[-0.118, 0.012, 0]} renderOrder={5}>
+                <boxGeometry args={[0.012, 0.008, 0.255]} />
+                <meshStandardMaterial color="#eee9d8" roughness={1} />
+            </mesh>
+            <mesh position={[0.118, 0.012, 0]} renderOrder={5}>
+                <boxGeometry args={[0.012, 0.008, 0.255]} />
+                <meshStandardMaterial color="#eee9d8" roughness={1} />
+            </mesh>
+            <mesh position={[0, 0.014, 0]} renderOrder={6}>
+                <boxGeometry args={[0.22, 0.006, 0.008]} />
+                <meshStandardMaterial color="#c9c2ad" roughness={1} />
+            </mesh>
+            <mesh position={[0, 0.015, 0]} renderOrder={6}>
+                <boxGeometry args={[0.008, 0.006, 0.22]} />
+                <meshStandardMaterial color="#c9c2ad" roughness={1} />
+            </mesh>
+        </group>
+    );
+}
+
 export function RaisedBedFields({
     blockId,
     generatedPlantsHandledExternally = false,
@@ -268,6 +331,15 @@ export function RaisedBedFields({
               } => Boolean(visual),
           )
         : [];
+    const agrotextileCoverPositions = raisedBed
+        ? resolveRaisedBedAgrotextileCoverPositions({
+              blockOffset,
+              fields: raisedBed.fields,
+              raisedBedId: raisedBed.id,
+              visualRewards,
+          })
+        : [];
+    const agrotextileCoverPositionSet = new Set(agrotextileCoverPositions);
 
     return (
         <>
@@ -289,17 +361,25 @@ export function RaisedBedFields({
                     />
                 );
             })}
-            {weedFieldVisuals.map((visual) => (
-                <RaisedBedFieldWeedClump
-                    key={`raised-bed-field-weed-${blockId}-${visual.positionIndex}`}
-                    blockIndex={blockIndex}
-                    level={visual.level}
-                    orientation={orientation}
-                    positionIndex={visual.positionIndex}
-                />
-            ))}
+            {weedFieldVisuals.map((visual) =>
+                agrotextileCoverPositionSet.has(visual.positionIndex) ? null : (
+                    <RaisedBedFieldWeedClump
+                        key={`raised-bed-field-weed-${blockId}-${visual.positionIndex}`}
+                        blockIndex={blockIndex}
+                        level={visual.level}
+                        orientation={orientation}
+                        positionIndex={visual.positionIndex}
+                    />
+                ),
+            )}
             {displayedFields.map((field) => {
                 if (!field) return null;
+                const localPositionIndex = field.positionIndex - blockOffset;
+
+                if (agrotextileCoverPositionSet.has(localPositionIndex)) {
+                    return null;
+                }
+
                 if (
                     generatedPlantsHandledExternally &&
                     generatedPlantsEnabled &&
@@ -328,13 +408,21 @@ export function RaisedBedFields({
                         key={field.id}
                         field={{
                             ...field,
-                            positionIndex: field.positionIndex - blockOffset,
+                            positionIndex: localPositionIndex,
                         }}
                         blockIndex={blockIndex}
                         orientation={orientation}
                     />
                 );
             })}
+            {agrotextileCoverPositions.map((positionIndex) => (
+                <RaisedBedFieldAgrotextileCover
+                    key={`raised-bed-field-agrotextile-${blockId}-${positionIndex}`}
+                    blockIndex={blockIndex}
+                    orientation={orientation}
+                    positionIndex={positionIndex}
+                />
+            ))}
         </>
     );
 }

--- a/packages/game/src/entities/raisedBed/raisedBedAgrotextileRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedAgrotextileRewards.ts
@@ -1,0 +1,68 @@
+import type { OperationVisualReward } from '../../operationVisualRewards';
+
+type RaisedBedAgrotextileFieldInput = {
+    active?: boolean | null;
+    id: number | string;
+    positionIndex: number;
+};
+
+type ResolveRaisedBedAgrotextileCoverPositionsInput = {
+    blockOffset: number;
+    fields: RaisedBedAgrotextileFieldInput[];
+    raisedBedId: number;
+    visualRewards: OperationVisualReward[];
+};
+
+function isActiveAgrotextileReward(
+    reward: OperationVisualReward,
+    raisedBedId: number,
+) {
+    return (
+        reward.active &&
+        reward.family === 'agrotextile' &&
+        reward.raisedBedId === raisedBedId
+    );
+}
+
+export function resolveRaisedBedAgrotextileCoverPositions({
+    blockOffset,
+    fields,
+    raisedBedId,
+    visualRewards,
+}: ResolveRaisedBedAgrotextileCoverPositionsInput) {
+    const hasRaisedBedCover = visualRewards.some(
+        (reward) =>
+            isActiveAgrotextileReward(reward, raisedBedId) &&
+            reward.scope === 'raisedBed',
+    );
+
+    if (hasRaisedBedCover) {
+        return Array.from({ length: 9 }, (_, positionIndex) => positionIndex);
+    }
+
+    const coveredFieldIds = new Set(
+        visualRewards
+            .filter(
+                (reward) =>
+                    isActiveAgrotextileReward(reward, raisedBedId) &&
+                    reward.scope === 'field' &&
+                    reward.raisedBedFieldId != null,
+            )
+            .map((reward) => reward.raisedBedFieldId),
+    );
+
+    return Array.from(
+        new Set(
+            fields
+                .filter(
+                    (field) =>
+                        field.active !== false &&
+                        typeof field.id === 'number' &&
+                        coveredFieldIds.has(field.id) &&
+                        field.positionIndex >= blockOffset &&
+                        field.positionIndex < blockOffset + 9,
+                )
+                .map((field) => field.positionIndex - blockOffset),
+        ),
+    ).sort((a, b) => a - b);
+}

--- a/packages/game/src/entities/raisedBed/raisedBedAgrotextileRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedAgrotextileRewards.unit.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+    AppliedOperationVisualInput,
+    OperationVisualDefinitionInput,
+} from '../../operationVisualRewards';
+import { resolveOperationVisualRewards } from '../../operationVisualRewards';
+import { resolveRaisedBedAgrotextileCoverPositions } from './raisedBedAgrotextileRewards';
+
+function operation(
+    id: number,
+    input: {
+        label: string;
+        name: string;
+    },
+): OperationVisualDefinitionInput {
+    return {
+        id,
+        attributes: {
+            application: 'raisedBedFull',
+        },
+        information: {
+            description: input.label,
+            instructions: '',
+            label: input.label,
+            name: input.name,
+            shortDescription: input.label,
+        },
+        slug: input.name,
+    };
+}
+
+const operations = [
+    operation(1, {
+        label: 'Postavljanje agrotekstila',
+        name: 'agrotextileCover',
+    }),
+    operation(2, {
+        label: 'Uklanjanje agrotekstila',
+        name: 'removeAgrotextileCover',
+    }),
+];
+
+function applied(
+    id: number,
+    input: {
+        completedAt: string;
+        entityId: number;
+        raisedBedFieldId?: number | null;
+        raisedBedId: number;
+    },
+): AppliedOperationVisualInput {
+    return {
+        id,
+        completedAt: input.completedAt,
+        createdAt: input.completedAt,
+        entityId: input.entityId,
+        raisedBedFieldId: input.raisedBedFieldId,
+        raisedBedId: input.raisedBedId,
+        status: 'completed',
+    };
+}
+
+test('whole-bed agrotextile cover marks every local field position', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(101, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedAgrotextileCoverPositions({
+            blockOffset: 9,
+            fields: [],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    );
+});
+
+test('field agrotextile cover marks only the matching active field in the current block', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(201, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedFieldId: 50,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedAgrotextileCoverPositions({
+            blockOffset: 9,
+            fields: [
+                { active: true, id: 50, positionIndex: 10 },
+                { active: true, id: 51, positionIndex: 4 },
+                { active: false, id: 52, positionIndex: 11 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [1],
+    );
+});
+
+test('newer remove-agrotextile reward clears field cover visuals', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(301, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedFieldId: 50,
+                raisedBedId: 10,
+            }),
+            applied(302, {
+                completedAt: '2026-06-02T08:00:00.000Z',
+                entityId: 2,
+                raisedBedFieldId: 50,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedAgrotextileCoverPositions({
+            blockOffset: 9,
+            fields: [{ active: true, id: 50, positionIndex: 10 }],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [],
+    );
+});

--- a/packages/game/src/entities/raisedBed/raisedBedAgrotextileRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedAgrotextileRewards.unit.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import type {
     AppliedOperationVisualInput,
     OperationVisualDefinitionInput,
+    OperationVisualRewardKind,
 } from '../../operationVisualRewards';
 import { resolveOperationVisualRewards } from '../../operationVisualRewards';
 import { resolveRaisedBedAgrotextileCoverPositions } from './raisedBedAgrotextileRewards';
@@ -12,12 +13,14 @@ function operation(
     input: {
         label: string;
         name: string;
+        visualReward: OperationVisualRewardKind;
     },
 ): OperationVisualDefinitionInput {
     return {
         id,
         attributes: {
             application: 'raisedBedFull',
+            visualReward: input.visualReward,
         },
         information: {
             description: input.label,
@@ -34,10 +37,12 @@ const operations = [
     operation(1, {
         label: 'Postavljanje agrotekstila',
         name: 'agrotextileCover',
+        visualReward: 'agrotextile',
     }),
     operation(2, {
         label: 'Uklanjanje agrotekstila',
         name: 'removeAgrotextileCover',
+        visualReward: 'removeAgrotextile',
     }),
 ];
 


### PR DESCRIPTION
## Summary
- render active agrotextile rewards as low-poly cover panels across whole raised beds or targeted fields
- hide plants and weed clumps under covered positions so the protected state reads clearly
- add resolver coverage for whole-bed, field, and remove-agrotextile reward behavior

Linear: https://linear.app/gredice/issue/GRE-488
Stacked on: #3340
Closes #3323

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`