### PR TITLE
[GRE-490] Add plant support visual rewards

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -24,6 +24,7 @@ import {
     RaisedBedPlantField,
 } from './RaisedBedPlantField';
 import { resolveRaisedBedAgrotextileCoverPositions } from './raisedBedAgrotextileRewards';
+import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
 import { isWateringRewardVisible } from './raisedBedWateringRewards';
 import {
     resolveRaisedBedFieldWeedLevel,
@@ -223,6 +224,44 @@ function RaisedBedFieldAgrotextileCover({
     );
 }
 
+function RaisedBedFieldSupportVisual({
+    blockIndex,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y: -0.724,
+    });
+
+    return (
+        <group position={position}>
+            <mesh castShadow position={[-0.082, 0.24, 0.052]} renderOrder={3}>
+                <cylinderGeometry args={[0.012, 0.014, 0.48, 5]} />
+                <meshStandardMaterial color="#7a4f2b" roughness={0.9} />
+            </mesh>
+            <mesh position={[0.004, 0.285, 0.044]} renderOrder={4}>
+                <boxGeometry args={[0.17, 0.012, 0.01]} />
+                <meshStandardMaterial color="#d8c68e" roughness={1} />
+            </mesh>
+            <mesh position={[0.002, 0.19, 0.018]} renderOrder={4}>
+                <boxGeometry args={[0.145, 0.01, 0.01]} />
+                <meshStandardMaterial color="#d8c68e" roughness={1} />
+            </mesh>
+            <mesh position={[0.054, 0.235, 0.014]} renderOrder={3}>
+                <cylinderGeometry args={[0.007, 0.008, 0.32, 5]} />
+                <meshStandardMaterial color="#5e7a3d" roughness={1} />
+            </mesh>
+        </group>
+    );
+}
+
 export function RaisedBedFields({
     blockId,
     generatedPlantsHandledExternally = false,
@@ -340,6 +379,17 @@ export function RaisedBedFields({
           })
         : [];
     const agrotextileCoverPositionSet = new Set(agrotextileCoverPositions);
+    const supportPositions = raisedBed
+        ? resolveRaisedBedSupportPositions({
+              blockOffset,
+              fields: raisedBed.fields,
+              raisedBedId: raisedBed.id,
+              visualRewards,
+          })
+        : [];
+    const visibleSupportPositions = supportPositions.filter(
+        (positionIndex) => !agrotextileCoverPositionSet.has(positionIndex),
+    );
 
     return (
         <>
@@ -415,6 +465,14 @@ export function RaisedBedFields({
                     />
                 );
             })}
+            {visibleSupportPositions.map((positionIndex) => (
+                <RaisedBedFieldSupportVisual
+                    key={`raised-bed-field-support-${blockId}-${positionIndex}`}
+                    blockIndex={blockIndex}
+                    orientation={orientation}
+                    positionIndex={positionIndex}
+                />
+            ))}
             {agrotextileCoverPositions.map((positionIndex) => (
                 <RaisedBedFieldAgrotextileCover
                     key={`raised-bed-field-agrotextile-${blockId}-${positionIndex}`}

--- a/packages/game/src/entities/raisedBed/raisedBedSupportRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedSupportRewards.ts
@@ -1,0 +1,70 @@
+import type { OperationVisualReward } from '../../operationVisualRewards';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
+
+type RaisedBedSupportFieldInput = {
+    active?: boolean | null;
+    id: number | string;
+    plantSortId?: number | null;
+    positionIndex: number;
+};
+
+type ResolveRaisedBedSupportPositionsInput = {
+    blockOffset: number;
+    fields: RaisedBedSupportFieldInput[];
+    raisedBedId: number;
+    visualRewards: OperationVisualReward[];
+};
+
+function isActiveSupportsReward(
+    reward: OperationVisualReward,
+    raisedBedId: number,
+) {
+    return (
+        reward.active &&
+        reward.family === 'supports' &&
+        reward.raisedBedId === raisedBedId
+    );
+}
+
+export function resolveRaisedBedSupportPositions({
+    blockOffset,
+    fields,
+    raisedBedId,
+    visualRewards,
+}: ResolveRaisedBedSupportPositionsInput) {
+    const hasRaisedBedSupports = visualRewards.some(
+        (reward) =>
+            isActiveSupportsReward(reward, raisedBedId) &&
+            reward.scope === 'raisedBed',
+    );
+    const supportedFieldIds = new Set(
+        visualRewards
+            .filter(
+                (reward) =>
+                    isActiveSupportsReward(reward, raisedBedId) &&
+                    reward.scope === 'field' &&
+                    reward.raisedBedFieldId != null,
+            )
+            .map((reward) => reward.raisedBedFieldId),
+    );
+
+    return Array.from(
+        new Set(
+            fields
+                .filter((field) => {
+                    const isSupported =
+                        hasRaisedBedSupports ||
+                        (typeof field.id === 'number' &&
+                            supportedFieldIds.has(field.id));
+
+                    return (
+                        isSupported &&
+                        isRaisedBedFieldOccupied(field) &&
+                        field.positionIndex >= blockOffset &&
+                        field.positionIndex < blockOffset + 9
+                    );
+                })
+                .map((field) => field.positionIndex - blockOffset),
+        ),
+    ).sort((a, b) => a - b);
+}

--- a/packages/game/src/entities/raisedBed/raisedBedSupportRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedSupportRewards.unit.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+    AppliedOperationVisualInput,
+    OperationVisualDefinitionInput,
+} from '../../operationVisualRewards';
+import { resolveOperationVisualRewards } from '../../operationVisualRewards';
+import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
+
+function operation(
+    id: number,
+    input: {
+        application?: string;
+        label: string;
+        name: string;
+    },
+): OperationVisualDefinitionInput {
+    return {
+        id,
+        attributes: {
+            application: input.application ?? 'raisedBedFull',
+        },
+        information: {
+            description: input.label,
+            instructions: '',
+            label: input.label,
+            name: input.name,
+            shortDescription: input.label,
+        },
+        slug: input.name,
+    };
+}
+
+const operations = [
+    operation(1, {
+        label: 'Postavljanje potpore',
+        name: 'plantSupports',
+    }),
+    operation(2, {
+        application: 'plant',
+        label: 'Vezanje biljke uz kolac',
+        name: 'plantStakeTie',
+    }),
+];
+
+function applied(
+    id: number,
+    input: {
+        completedAt: string;
+        entityId: number;
+        raisedBedFieldId?: number | null;
+        raisedBedId: number;
+    },
+): AppliedOperationVisualInput {
+    return {
+        id,
+        completedAt: input.completedAt,
+        createdAt: input.completedAt,
+        entityId: input.entityId,
+        raisedBedFieldId: input.raisedBedFieldId,
+        raisedBedId: input.raisedBedId,
+        status: 'completed',
+    };
+}
+
+test('raised-bed support reward marks planted fields in the current block', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(101, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedSupportPositions({
+            blockOffset: 9,
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 9 },
+                { active: true, id: 51, plantSortId: null, positionIndex: 10 },
+                {
+                    active: false,
+                    id: 52,
+                    plantSortId: 337,
+                    positionIndex: 11,
+                },
+                { active: true, id: 53, plantSortId: 337, positionIndex: 18 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [0],
+    );
+});
+
+test('field support reward marks only the matching planted field', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(201, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 2,
+                raisedBedFieldId: 51,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedSupportPositions({
+            blockOffset: 9,
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 9 },
+                { active: true, id: 51, plantSortId: 337, positionIndex: 10 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [1],
+    );
+});
+
+test('support rewards ignore other raised beds', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(301, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 11,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedSupportPositions({
+            blockOffset: 0,
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 0 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [],
+    );
+});

--- a/packages/game/src/entities/raisedBed/raisedBedSupportRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedSupportRewards.unit.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import type {
     AppliedOperationVisualInput,
     OperationVisualDefinitionInput,
+    OperationVisualRewardKind,
 } from '../../operationVisualRewards';
 import { resolveOperationVisualRewards } from '../../operationVisualRewards';
 import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
@@ -13,12 +14,14 @@ function operation(
         application?: string;
         label: string;
         name: string;
+        visualReward: OperationVisualRewardKind;
     },
 ): OperationVisualDefinitionInput {
     return {
         id,
         attributes: {
             application: input.application ?? 'raisedBedFull',
+            visualReward: input.visualReward,
         },
         information: {
             description: input.label,
@@ -35,11 +38,13 @@ const operations = [
     operation(1, {
         label: 'Postavljanje potpore',
         name: 'plantSupports',
+        visualReward: 'supports',
     }),
     operation(2, {
         application: 'plant',
         label: 'Vezanje biljke uz kolac',
         name: 'plantStakeTie',
+        visualReward: 'supports',
     }),
 ];
 


### PR DESCRIPTION
## Summary
- resolve active support rewards to planted field positions for whole-bed and field scopes
- render low-poly stakes plus tie bands beside supported plants without touching plant generator internals
- keep support overlays out from under agrotextile-covered positions

Linear: https://linear.app/gredice/issue/GRE-490
Stacked on: #3342
Closes #3325

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`