### PR TITLE
[GRE-491] Add harvest visual rewards

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -24,6 +24,7 @@ import {
     RaisedBedPlantField,
 } from './RaisedBedPlantField';
 import { resolveRaisedBedAgrotextileCoverPositions } from './raisedBedAgrotextileRewards';
+import { resolveRaisedBedHarvestPositions } from './raisedBedHarvestRewards';
 import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
 import { isWateringRewardVisible } from './raisedBedWateringRewards';
 import {
@@ -262,6 +263,60 @@ function RaisedBedFieldSupportVisual({
     );
 }
 
+function RaisedBedFieldHarvestCrate({
+    blockIndex,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y: -0.714,
+    });
+
+    return (
+        <group position={position}>
+            <mesh castShadow position={[0.072, 0.034, -0.078]} renderOrder={4}>
+                <boxGeometry args={[0.13, 0.055, 0.095]} />
+                <meshStandardMaterial color="#8a5b32" roughness={0.95} />
+            </mesh>
+            <mesh position={[0.072, 0.072, -0.128]} renderOrder={5}>
+                <boxGeometry args={[0.14, 0.018, 0.012]} />
+                <meshStandardMaterial color="#b47a43" roughness={0.95} />
+            </mesh>
+            <mesh position={[0.072, 0.072, -0.028]} renderOrder={5}>
+                <boxGeometry args={[0.14, 0.018, 0.012]} />
+                <meshStandardMaterial color="#b47a43" roughness={0.95} />
+            </mesh>
+            <mesh position={[0.006, 0.074, -0.078]} renderOrder={5}>
+                <boxGeometry args={[0.012, 0.018, 0.105]} />
+                <meshStandardMaterial color="#b47a43" roughness={0.95} />
+            </mesh>
+            <mesh position={[0.138, 0.074, -0.078]} renderOrder={5}>
+                <boxGeometry args={[0.012, 0.018, 0.105]} />
+                <meshStandardMaterial color="#b47a43" roughness={0.95} />
+            </mesh>
+            <mesh position={[0.038, 0.094, -0.078]} renderOrder={6}>
+                <sphereGeometry args={[0.018, 8, 6]} />
+                <meshStandardMaterial color="#bf3f31" roughness={0.8} />
+            </mesh>
+            <mesh position={[0.078, 0.1, -0.098]} renderOrder={6}>
+                <sphereGeometry args={[0.018, 8, 6]} />
+                <meshStandardMaterial color="#e0a12f" roughness={0.8} />
+            </mesh>
+            <mesh position={[0.112, 0.094, -0.064]} renderOrder={6}>
+                <sphereGeometry args={[0.017, 8, 6]} />
+                <meshStandardMaterial color="#5f8c44" roughness={0.8} />
+            </mesh>
+        </group>
+    );
+}
+
 export function RaisedBedFields({
     blockId,
     generatedPlantsHandledExternally = false,
@@ -390,6 +445,18 @@ export function RaisedBedFields({
     const visibleSupportPositions = supportPositions.filter(
         (positionIndex) => !agrotextileCoverPositionSet.has(positionIndex),
     );
+    const harvestPositions = raisedBed
+        ? resolveRaisedBedHarvestPositions({
+              blockOffset,
+              fields: raisedBed.fields,
+              raisedBedId: raisedBed.id,
+              visualRewards,
+          })
+        : [];
+    const visibleHarvestPositions = harvestPositions.filter(
+        (positionIndex) => !agrotextileCoverPositionSet.has(positionIndex),
+    );
+    const harvestPositionSet = new Set(visibleHarvestPositions);
 
     return (
         <>
@@ -458,6 +525,8 @@ export function RaisedBedFields({
                         key={field.id}
                         field={{
                             ...field,
+                            harvestedVisual:
+                                harvestPositionSet.has(localPositionIndex),
                             positionIndex: localPositionIndex,
                         }}
                         blockIndex={blockIndex}
@@ -468,6 +537,14 @@ export function RaisedBedFields({
             {visibleSupportPositions.map((positionIndex) => (
                 <RaisedBedFieldSupportVisual
                     key={`raised-bed-field-support-${blockId}-${positionIndex}`}
+                    blockIndex={blockIndex}
+                    orientation={orientation}
+                    positionIndex={positionIndex}
+                />
+            ))}
+            {visibleHarvestPositions.map((positionIndex) => (
+                <RaisedBedFieldHarvestCrate
+                    key={`raised-bed-field-harvest-${blockId}-${positionIndex}`}
                     blockIndex={blockIndex}
                     orientation={orientation}
                     positionIndex={positionIndex}

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantBatch.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantBatch.tsx
@@ -28,8 +28,11 @@ export interface RaisedBedGeneratedPlantBatchInstance {
 
 interface RaisedBedGeneratedPlantBatchProps {
     definition: PlantDefinition;
+    flowerGrowth?: number;
+    fruitGrowth?: number;
     instances: RaisedBedGeneratedPlantBatchInstance[];
     lodLevel?: PlantLodLevel;
+    showProduce?: boolean;
 }
 
 const ROOT_QUATERNION = new THREE.Quaternion();
@@ -99,8 +102,11 @@ function RaisedBedDetailedPlantBatch({
 
 export function RaisedBedGeneratedPlantBatch({
     definition,
+    flowerGrowth = 1,
+    fruitGrowth = 1,
     instances,
     lodLevel = 'near',
+    showProduce = true,
 }: RaisedBedGeneratedPlantBatchProps) {
     const renderDetailedGeometry = lodLevel === 'near';
     const batchSeed = useMemo(
@@ -155,13 +161,14 @@ export function RaisedBedGeneratedPlantBatch({
                 Math.max(0, instance.generation),
             );
             const plantData = buildPlantRenderData({
-                flowerGrowth: 1,
-                fruitGrowth: 1,
+                flowerGrowth,
+                fruitGrowth,
                 generation: clampedGeneration,
                 lSystemSymbols,
                 plantDefinition: definition,
                 renderDetailedGeometry,
                 seed: instance.seed,
+                showProduce,
             });
             billboards.push({
                 position: instance.position,
@@ -212,7 +219,15 @@ export function RaisedBedGeneratedPlantBatch({
             thorns,
             vegetables,
         } satisfies BatchedPlantRenderData;
-    }, [definition, instances, renderDetailedGeometry, symbols]);
+    }, [
+        definition,
+        flowerGrowth,
+        fruitGrowth,
+        instances,
+        renderDetailedGeometry,
+        showProduce,
+        symbols,
+    ]);
 
     if (!batchedData) {
         return null;

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -38,6 +38,7 @@ export function RaisedBedPlantField({
     blockIndex,
 }: {
     field: {
+        harvestedVisual?: boolean | null;
         positionIndex: number;
         plantSortId: number | null | undefined;
         plantStatus?: string | null;
@@ -46,7 +47,7 @@ export function RaisedBedPlantField({
     orientation: RaisedBedOrientation;
     blockIndex: number;
 }) {
-    const { positionIndex, plantSortId, plantSowDate } = field;
+    const { harvestedVisual, positionIndex, plantSortId, plantSowDate } = field;
     const fieldGroupRef = useRef<Group | null>(null);
     const { data: sortData } = usePlantSort(plantSortId);
     const flags = useGameFlags();
@@ -123,6 +124,9 @@ export function RaisedBedPlantField({
                   growthMultiplier: resolvedPlantPreset.growthMultiplier,
               })
             : 0;
+    const visualPlantGeneration = harvestedVisual
+        ? Math.max(0.8, plantGeneration * 0.7)
+        : plantGeneration;
     const shouldRenderGeneratedPlants =
         Boolean(flags.enablePlantGeneratorFlag || isMock || isSandbox) &&
         Boolean(resolvedPlantPreset) &&
@@ -137,7 +141,7 @@ export function RaisedBedPlantField({
     const approximateFieldPlantHeight = resolvedPlantPreset
         ? getApproximatePlantHeight(
               resolvedPlantPreset.definition,
-              plantGeneration,
+              visualPlantGeneration,
           ) * plantInstanceScale
         : 0.25;
     const fieldLod = usePlantLodState(
@@ -154,7 +158,7 @@ export function RaisedBedPlantField({
         }
 
         return fieldSlots.map((position, index) => ({
-            generation: plantGeneration,
+            generation: visualPlantGeneration,
             position: [position[0], 0.02, position[2]] as const,
             scale: plantInstanceScale,
             seed: `${plantSortId ?? 'sort'}:${positionIndex}:${blockIndex}:${index}`,
@@ -162,11 +166,11 @@ export function RaisedBedPlantField({
     }, [
         blockIndex,
         fieldSlots,
-        plantGeneration,
         plantInstanceScale,
         plantSortId,
         positionIndex,
         resolvedPlantPreset,
+        visualPlantGeneration,
     ]);
 
     const seedColor = plantSowDate ? 'black' : '#6495ED';
@@ -198,8 +202,11 @@ export function RaisedBedPlantField({
                 shouldRenderGeneratedPlants && resolvedPlantPreset ? (
                     <RaisedBedGeneratedPlantBatch
                         definition={resolvedPlantPreset.definition}
+                        flowerGrowth={harvestedVisual ? 0.35 : 1}
+                        fruitGrowth={harvestedVisual ? 0.1 : 1}
                         instances={generatedPlantInstances}
                         lodLevel={fieldLod.level}
+                        showProduce={!harvestedVisual}
                     />
                 ) : (
                     fieldSlots.map((position) => {

--- a/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.ts
@@ -1,0 +1,70 @@
+import type { OperationVisualReward } from '../../operationVisualRewards';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
+
+type RaisedBedHarvestFieldInput = {
+    active?: boolean | null;
+    id: number | string;
+    plantSortId?: number | null;
+    positionIndex: number;
+};
+
+type ResolveRaisedBedHarvestPositionsInput = {
+    blockOffset: number;
+    fields: RaisedBedHarvestFieldInput[];
+    raisedBedId: number;
+    visualRewards: OperationVisualReward[];
+};
+
+function isActiveHarvestReward(
+    reward: OperationVisualReward,
+    raisedBedId: number,
+) {
+    return (
+        reward.active &&
+        reward.family === 'harvest' &&
+        reward.raisedBedId === raisedBedId
+    );
+}
+
+export function resolveRaisedBedHarvestPositions({
+    blockOffset,
+    fields,
+    raisedBedId,
+    visualRewards,
+}: ResolveRaisedBedHarvestPositionsInput) {
+    const hasRaisedBedHarvest = visualRewards.some(
+        (reward) =>
+            isActiveHarvestReward(reward, raisedBedId) &&
+            reward.scope === 'raisedBed',
+    );
+    const harvestedFieldIds = new Set(
+        visualRewards
+            .filter(
+                (reward) =>
+                    isActiveHarvestReward(reward, raisedBedId) &&
+                    reward.scope === 'field' &&
+                    reward.raisedBedFieldId != null,
+            )
+            .map((reward) => reward.raisedBedFieldId),
+    );
+
+    return Array.from(
+        new Set(
+            fields
+                .filter((field) => {
+                    const isHarvested =
+                        hasRaisedBedHarvest ||
+                        (typeof field.id === 'number' &&
+                            harvestedFieldIds.has(field.id));
+
+                    return (
+                        isHarvested &&
+                        isRaisedBedFieldOccupied(field) &&
+                        field.positionIndex >= blockOffset &&
+                        field.positionIndex < blockOffset + 9
+                    );
+                })
+                .map((field) => field.positionIndex - blockOffset),
+        ),
+    ).sort((a, b) => a - b);
+}

--- a/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+    AppliedOperationVisualInput,
+    OperationVisualDefinitionInput,
+} from '../../operationVisualRewards';
+import { resolveOperationVisualRewards } from '../../operationVisualRewards';
+import { resolveRaisedBedHarvestPositions } from './raisedBedHarvestRewards';
+
+function operation(
+    id: number,
+    input: {
+        application?: string;
+        label: string;
+        name: string;
+    },
+): OperationVisualDefinitionInput {
+    return {
+        id,
+        attributes: {
+            application: input.application ?? 'raisedBedFull',
+            stage: {
+                information: {
+                    label: 'harvest',
+                    name: 'harvest',
+                },
+            },
+        },
+        information: {
+            description: input.label,
+            instructions: '',
+            label: input.label,
+            name: input.name,
+            shortDescription: input.label,
+        },
+        slug: input.name,
+    };
+}
+
+const operations = [
+    operation(1, {
+        label: 'Berba gredice',
+        name: 'raisedBedHarvest',
+    }),
+    operation(2, {
+        application: 'plant',
+        label: 'Berba biljke',
+        name: 'plantHarvest',
+    }),
+];
+
+function applied(
+    id: number,
+    input: {
+        completedAt: string;
+        entityId: number;
+        raisedBedFieldId?: number | null;
+        raisedBedId: number;
+    },
+): AppliedOperationVisualInput {
+    return {
+        id,
+        completedAt: input.completedAt,
+        createdAt: input.completedAt,
+        entityId: input.entityId,
+        raisedBedFieldId: input.raisedBedFieldId,
+        raisedBedId: input.raisedBedId,
+        status: 'completed',
+    };
+}
+
+test('raised-bed harvest reward marks planted fields in the current block', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(101, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedHarvestPositions({
+            blockOffset: 9,
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 9 },
+                { active: true, id: 51, plantSortId: null, positionIndex: 10 },
+                {
+                    active: false,
+                    id: 52,
+                    plantSortId: 337,
+                    positionIndex: 11,
+                },
+                { active: true, id: 53, plantSortId: 337, positionIndex: 18 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [0],
+    );
+});
+
+test('field harvest reward marks only the matching planted field', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(201, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 2,
+                raisedBedFieldId: 51,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedHarvestPositions({
+            blockOffset: 9,
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 9 },
+                { active: true, id: 51, plantSortId: 337, positionIndex: 10 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [1],
+    );
+});
+
+test('harvest rewards ignore other raised beds', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        appliedOperations: [
+            applied(301, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 11,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedHarvestPositions({
+            blockOffset: 0,
+            fields: [
+                { active: true, id: 50, plantSortId: 337, positionIndex: 0 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [],
+    );
+});

--- a/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedHarvestRewards.unit.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import type {
     AppliedOperationVisualInput,
     OperationVisualDefinitionInput,
+    OperationVisualRewardKind,
 } from '../../operationVisualRewards';
 import { resolveOperationVisualRewards } from '../../operationVisualRewards';
 import { resolveRaisedBedHarvestPositions } from './raisedBedHarvestRewards';
@@ -13,6 +14,7 @@ function operation(
         application?: string;
         label: string;
         name: string;
+        visualReward: OperationVisualRewardKind;
     },
 ): OperationVisualDefinitionInput {
     return {
@@ -25,6 +27,7 @@ function operation(
                     name: 'harvest',
                 },
             },
+            visualReward: input.visualReward,
         },
         information: {
             description: input.label,
@@ -41,11 +44,13 @@ const operations = [
     operation(1, {
         label: 'Berba gredice',
         name: 'raisedBedHarvest',
+        visualReward: 'harvest',
     }),
     operation(2, {
         application: 'plant',
         label: 'Berba biljke',
         name: 'plantHarvest',
+        visualReward: 'harvest',
     }),
 ];
 


### PR DESCRIPTION
## Summary
- resolve harvest rewards to planted field positions for field and whole-bed scopes
- render a low-poly harvest crate with produce at harvested fields
- reduce harvested plant visuals by lowering generation and suppressing produce/flower growth in generated plant batches

Linear: https://linear.app/gredice/issue/GRE-491
Stacked on: #3343
Closes #3326

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`