### PR TITLE
[GRE-492] Add photography update visual markers

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -25,6 +25,10 @@ import {
 } from './RaisedBedPlantField';
 import { resolveRaisedBedAgrotextileCoverPositions } from './raisedBedAgrotextileRewards';
 import { resolveRaisedBedHarvestPositions } from './raisedBedHarvestRewards';
+import {
+    type RaisedBedPhotographyMarker,
+    resolveRaisedBedPhotographyMarkers,
+} from './raisedBedPhotographyRewards';
 import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
 import { isWateringRewardVisible } from './raisedBedWateringRewards';
 import {
@@ -317,6 +321,49 @@ function RaisedBedFieldHarvestCrate({
     );
 }
 
+function RaisedBedFieldPhotographyMarker({
+    blockIndex,
+    marker,
+    orientation,
+}: {
+    blockIndex: number;
+    marker: RaisedBedPhotographyMarker;
+    orientation: RaisedBedOrientation;
+}) {
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex: marker.positionIndex,
+        y: -0.61,
+    });
+    const badgeScale = marker.scope === 'raisedBed' ? 1.12 : 1;
+
+    return (
+        <group position={position} scale={badgeScale}>
+            <mesh position={[-0.074, 0.04, 0.074]} renderOrder={7}>
+                <boxGeometry args={[0.108, 0.01, 0.078]} />
+                <meshStandardMaterial color="#f4f1e8" roughness={0.88} />
+            </mesh>
+            <mesh position={[-0.074, 0.047, 0.074]} renderOrder={8}>
+                <boxGeometry args={[0.08, 0.006, 0.048]} />
+                <meshStandardMaterial color="#7aa4b8" roughness={0.9} />
+            </mesh>
+            <mesh position={[-0.1, 0.054, 0.052]} renderOrder={9}>
+                <sphereGeometry args={[0.014, 8, 6]} />
+                <meshStandardMaterial color="#263238" roughness={0.75} />
+            </mesh>
+            <mesh position={[-0.032, 0.061, 0.11]} renderOrder={10}>
+                <sphereGeometry args={[0.018, 8, 6]} />
+                <meshStandardMaterial color="#48a05b" roughness={0.65} />
+            </mesh>
+            <mesh position={[-0.026, 0.079, 0.118]} renderOrder={11}>
+                <coneGeometry args={[0.012, 0.028, 3]} />
+                <meshStandardMaterial color="#48a05b" roughness={0.65} />
+            </mesh>
+        </group>
+    );
+}
+
 export function RaisedBedFields({
     blockId,
     generatedPlantsHandledExternally = false,
@@ -457,6 +504,14 @@ export function RaisedBedFields({
         (positionIndex) => !agrotextileCoverPositionSet.has(positionIndex),
     );
     const harvestPositionSet = new Set(visibleHarvestPositions);
+    const photographyMarkers = raisedBed
+        ? resolveRaisedBedPhotographyMarkers({
+              blockOffset,
+              fields: raisedBed.fields,
+              raisedBedId: raisedBed.id,
+              visualRewards,
+          })
+        : [];
 
     return (
         <>
@@ -556,6 +611,14 @@ export function RaisedBedFields({
                     blockIndex={blockIndex}
                     orientation={orientation}
                     positionIndex={positionIndex}
+                />
+            ))}
+            {photographyMarkers.map((marker) => (
+                <RaisedBedFieldPhotographyMarker
+                    key={`raised-bed-field-photo-${blockId}-${marker.scope}-${marker.positionIndex}-${marker.timestampMs}`}
+                    blockIndex={blockIndex}
+                    marker={marker}
+                    orientation={orientation}
                 />
             ))}
         </>

--- a/packages/game/src/entities/raisedBed/raisedBedPhotographyRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedPhotographyRewards.ts
@@ -1,0 +1,100 @@
+import type { OperationVisualReward } from '../../operationVisualRewards';
+
+type RaisedBedPhotographyFieldInput = {
+    active?: boolean | null;
+    id: number | string;
+    positionIndex: number;
+};
+
+export type RaisedBedPhotographyMarker = {
+    imageCount: number;
+    positionIndex: number;
+    scope: 'field' | 'raisedBed';
+    timestampMs: number;
+};
+
+type ResolveRaisedBedPhotographyMarkersInput = {
+    blockOffset: number;
+    fields: RaisedBedPhotographyFieldInput[];
+    raisedBedId: number;
+    visualRewards: OperationVisualReward[];
+};
+
+function isActivePhotographyReward(
+    reward: OperationVisualReward,
+    raisedBedId: number,
+) {
+    return (
+        reward.active &&
+        reward.family === 'photography' &&
+        reward.imageUrls.length > 0 &&
+        reward.raisedBedId === raisedBedId
+    );
+}
+
+export function resolveRaisedBedPhotographyMarkers({
+    blockOffset,
+    fields,
+    raisedBedId,
+    visualRewards,
+}: ResolveRaisedBedPhotographyMarkersInput): RaisedBedPhotographyMarker[] {
+    const markers: RaisedBedPhotographyMarker[] = [];
+    const raisedBedReward = visualRewards.find(
+        (reward) =>
+            isActivePhotographyReward(reward, raisedBedId) &&
+            reward.scope === 'raisedBed',
+    );
+
+    if (raisedBedReward) {
+        markers.push({
+            imageCount: raisedBedReward.imageUrls.length,
+            positionIndex: 4,
+            scope: 'raisedBed',
+            timestampMs: raisedBedReward.timestampMs,
+        });
+    }
+
+    const fieldRewardsByFieldId = new Map<number, OperationVisualReward>();
+    for (const reward of visualRewards) {
+        if (
+            !isActivePhotographyReward(reward, raisedBedId) ||
+            reward.scope !== 'field' ||
+            reward.raisedBedFieldId == null
+        ) {
+            continue;
+        }
+
+        fieldRewardsByFieldId.set(reward.raisedBedFieldId, reward);
+    }
+
+    for (const field of fields) {
+        if (
+            field.active === false ||
+            typeof field.id !== 'number' ||
+            field.positionIndex < blockOffset ||
+            field.positionIndex >= blockOffset + 9
+        ) {
+            continue;
+        }
+
+        const reward = fieldRewardsByFieldId.get(field.id);
+        if (!reward) {
+            continue;
+        }
+
+        markers.push({
+            imageCount: reward.imageUrls.length,
+            positionIndex: field.positionIndex - blockOffset,
+            scope: 'field',
+            timestampMs: reward.timestampMs,
+        });
+    }
+
+    return markers.sort((a, b) => {
+        if (a.positionIndex !== b.positionIndex) {
+            return a.positionIndex - b.positionIndex;
+        }
+
+        return b.timestampMs - a.timestampMs;
+    });
+}

--- a/packages/game/src/entities/raisedBed/raisedBedPhotographyRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedPhotographyRewards.unit.ts
@@ -12,6 +12,7 @@ function operation(id: number): OperationVisualDefinitionInput {
         id,
         attributes: {
             application: 'raisedBedFull',
+            visualReward: 'photographyUpdate',
         },
         information: {
             description: 'Fotografiranje gredice',

--- a/packages/game/src/entities/raisedBed/raisedBedPhotographyRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedPhotographyRewards.unit.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+    OperationHistoryVisualInput,
+    OperationVisualDefinitionInput,
+} from '../../operationVisualRewards';
+import { resolveOperationVisualRewards } from '../../operationVisualRewards';
+import { resolveRaisedBedPhotographyMarkers } from './raisedBedPhotographyRewards';
+
+function operation(id: number): OperationVisualDefinitionInput {
+    return {
+        id,
+        attributes: {
+            application: 'raisedBedFull',
+        },
+        information: {
+            description: 'Fotografiranje gredice',
+            instructions: '',
+            label: 'Fotografiranje gredice',
+            name: 'raisedBedPhotography',
+            shortDescription: 'Fotografija novog stanja',
+        },
+        slug: 'raised-bed-photography',
+    };
+}
+
+const operations = [operation(1)];
+
+function operationItem(
+    id: number,
+    input: {
+        completedAt: string;
+        imageUrls?: string[];
+        raisedBedFieldId?: number | null;
+        raisedBedId: number;
+    },
+): OperationHistoryVisualInput {
+    return {
+        id,
+        completedAt: input.completedAt,
+        createdAt: input.completedAt,
+        entityId: 1,
+        imageUrls: input.imageUrls ?? ['https://cdn.gredice.com/proof.jpg'],
+        raisedBedFieldId: input.raisedBedFieldId,
+        raisedBedId: input.raisedBedId,
+        status: 'completed',
+        verifiedAt: input.completedAt,
+    };
+}
+
+test('raised-bed photography reward creates a centered proof marker', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        operationItems: [
+            operationItem(101, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                imageUrls: [
+                    'https://cdn.gredice.com/photo-1.jpg',
+                    'https://cdn.gredice.com/photo-2.jpg',
+                ],
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedPhotographyMarkers({
+            blockOffset: 0,
+            fields: [],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [
+            {
+                imageCount: 2,
+                positionIndex: 4,
+                scope: 'raisedBed',
+                timestampMs: Date.parse('2026-06-01T08:00:00.000Z'),
+            },
+        ],
+    );
+});
+
+test('field photography reward creates a marker on the matching field', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        operationItems: [
+            operationItem(201, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                raisedBedFieldId: 51,
+                raisedBedId: 10,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedPhotographyMarkers({
+            blockOffset: 9,
+            fields: [
+                { active: true, id: 50, positionIndex: 9 },
+                { active: true, id: 51, positionIndex: 10 },
+            ],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [
+            {
+                imageCount: 1,
+                positionIndex: 1,
+                scope: 'field',
+                timestampMs: Date.parse('2026-06-01T08:00:00.000Z'),
+            },
+        ],
+    );
+});
+
+test('photography markers require matching raised bed and images', () => {
+    const visualRewards = resolveOperationVisualRewards({
+        operationItems: [
+            operationItem(301, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                imageUrls: [],
+                raisedBedId: 10,
+            }),
+            operationItem(302, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                raisedBedId: 11,
+            }),
+        ],
+        operations,
+    });
+
+    assert.deepStrictEqual(
+        resolveRaisedBedPhotographyMarkers({
+            blockOffset: 0,
+            fields: [{ active: true, id: 50, positionIndex: 0 }],
+            raisedBedId: 10,
+            visualRewards,
+        }),
+        [],
+    );
+});

--- a/packages/game/src/hooks/useGardenOperations.ts
+++ b/packages/game/src/hooks/useGardenOperations.ts
@@ -184,12 +184,14 @@ export function gardenOperationsQueryKey({
 }
 
 export function useGardenOperations({
+    enabled = true,
     includeCompleted,
     pageSize = DEFAULT_PAGE_SIZE,
     raisedBedId,
     raisedBedFieldId,
     positionIndex,
 }: {
+    enabled?: boolean;
     includeCompleted: boolean;
     pageSize?: number;
 } & GardenOperationsScope) {
@@ -225,6 +227,6 @@ export function useGardenOperations({
         },
         initialPageParam: 0,
         getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-        enabled: Boolean(currentGarden?.id),
+        enabled: Boolean(currentGarden?.id) && enabled,
     });
 }

--- a/packages/game/src/hooks/useRaisedBedOperationVisualRewards.ts
+++ b/packages/game/src/hooks/useRaisedBedOperationVisualRewards.ts
@@ -4,6 +4,7 @@ import {
     resolveOperationVisualRewards,
 } from '../operationVisualRewards';
 import type { useCurrentGarden } from './useCurrentGarden';
+import { useGardenOperations } from './useGardenOperations';
 import { useOperations } from './useOperations';
 
 type CurrentGardenData = NonNullable<
@@ -24,6 +25,12 @@ export function useRaisedBedOperationVisualRewards(
     raisedBed: RaisedBedData | null | undefined,
 ) {
     const { data: operations } = useOperations();
+    const history = useGardenOperations({
+        enabled: Boolean(raisedBed),
+        includeCompleted: true,
+        pageSize: 20,
+        raisedBedId: raisedBed?.id,
+    });
 
     return useMemo(() => {
         if (!raisedBed || !operations) {
@@ -32,7 +39,9 @@ export function useRaisedBedOperationVisualRewards(
 
         return resolveOperationVisualRewards({
             appliedOperations: raisedBedAppliedOperationVisualInputs(raisedBed),
+            operationItems:
+                history.data?.pages.flatMap((page) => page.items) ?? [],
             operations,
         });
-    }, [operations, raisedBed]);
+    }, [history.data?.pages, operations, raisedBed]);
 }


### PR DESCRIPTION
## Summary
- include completed raised-bed operation history when resolving visual rewards so photography operations with images can surface in the scene
- resolve latest photography updates into field or raised-bed proof markers
- render a low-poly photo/update badge above the raised-bed field surface without adding a separate proof-photo concept

Linear: https://linear.app/gredice/issue/GRE-492
Stacked on: #3344
Closes #3327

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden build`
- `git diff --check`