### PR TITLE
[GRE-493] Document operation visual rewards QA matrix

### DIFF
--- a/apps/garden/app/debug/GameSceneLauncher.tsx
+++ b/apps/garden/app/debug/GameSceneLauncher.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { operationVisualRewardDebugProfile } from '@gredice/game';
 import { useMemo, useState } from 'react';
 
 const MODE_OPTIONS = [
@@ -18,8 +19,24 @@ const QUALITY_OPTIONS = [
     { value: 'high', label: 'High', description: 'Maximum detail' },
 ] as const;
 
+const PROFILE_OPTIONS = [
+    { value: 'default', label: 'Default', description: 'Small demo garden' },
+    { value: 'dense', label: 'Dense', description: '25x25 stress scene' },
+    {
+        value: 'plant-heavy',
+        label: 'Plants',
+        description: 'Dense planted raised beds',
+    },
+    {
+        value: operationVisualRewardDebugProfile,
+        label: 'Rewards',
+        description: 'Operation visual reward matrix',
+    },
+] as const;
+
 type Mode = (typeof MODE_OPTIONS)[number]['value'];
 type Quality = (typeof QUALITY_OPTIONS)[number]['value'];
+type Profile = (typeof PROFILE_OPTIONS)[number]['value'];
 
 const segmentBase =
     'rounded-md border px-3 py-1.5 text-sm font-medium transition-colors';
@@ -128,6 +145,7 @@ function ToggleButton({
 export function GameSceneLauncher() {
     const [mode, setMode] = useState<Mode>('baseline');
     const [quality, setQuality] = useState<Quality>('auto');
+    const [profile, setProfile] = useState<Profile>('default');
     const [details, setDetails] = useState(true);
     const [hud, setHud] = useState(false);
     const [debugHud, setDebugHud] = useState(false);
@@ -140,6 +158,9 @@ export function GameSceneLauncher() {
         }
         if (quality !== 'auto') {
             params.set('quality', quality);
+        }
+        if (profile !== 'default') {
+            params.set('profile', profile);
         }
         if (!details) {
             params.set('details', '0');
@@ -155,7 +176,7 @@ export function GameSceneLauncher() {
         }
         const queryString = params.toString();
         return `/debug/profile/game${queryString ? `?${queryString}` : ''}`;
-    }, [mode, quality, details, hud, debugHud, controls]);
+    }, [mode, quality, profile, details, hud, debugHud, controls]);
 
     return (
         <div className="flex flex-col gap-5 rounded-lg border border-neutral-800 bg-neutral-900 p-5">
@@ -183,6 +204,14 @@ export function GameSceneLauncher() {
                 options={QUALITY_OPTIONS}
                 value={quality}
                 onChange={setQuality}
+            />
+
+            <SegmentedControl
+                label="Garden profile"
+                description="Switch the seeded mock garden data (profile)."
+                options={PROFILE_OPTIONS}
+                value={profile}
+                onChange={setProfile}
             />
 
             <div className="flex flex-col gap-2">

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -40,6 +40,12 @@ const debugGroups = [
                 description:
                     'Mocked garden scene profiles for weather, season, quality, and HUD checks.',
             },
+            {
+                href: '/debug/profile/game?profile=operation-rewards&details=1&quality=medium',
+                title: 'Operation reward matrix',
+                description:
+                    'Before/after mock raised beds for every operation visual reward state.',
+            },
         ],
     },
     {

--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -1,4 +1,10 @@
-import { GameScene, type GameSceneProps } from '@gredice/game';
+import {
+    GameScene,
+    type GameSceneProps,
+    isOperationVisualRewardDebugProfile,
+    operationVisualRewardDebugProfile,
+    operationVisualRewardDebugScenarios,
+} from '@gredice/game';
 
 type GameProfileSearchParams = Promise<
     Record<string, string | string[] | undefined>
@@ -71,7 +77,11 @@ function resolveQuality(value: string | undefined): GameSceneProps['quality'] {
 function resolveMockGardenProfile(
     value: string | undefined,
 ): GameProfileMockGardenProfile {
-    if (value === 'dense' || value === 'plant-heavy') {
+    if (
+        value === 'dense' ||
+        value === operationVisualRewardDebugProfile ||
+        value === 'plant-heavy'
+    ) {
         return value;
     }
 
@@ -176,6 +186,57 @@ function resolveFreezeTime(mode: GameProfileMode) {
     return new Date(2024, 5, 21, 12, 0, 0);
 }
 
+function OperationRewardDebugOverlay() {
+    return (
+        <aside
+            className="pointer-events-auto absolute inset-x-4 bottom-4 max-h-[36vh] overflow-auto rounded-lg border border-neutral-800 bg-neutral-950/90 p-4 text-white shadow-2xl backdrop-blur"
+            data-operation-reward-debug-panel="1"
+        >
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+                <span className="shrink-0 text-base font-semibold">
+                    Operation reward matrix
+                </span>
+                <span className="max-w-3xl text-xs text-neutral-400">
+                    Each operation is resolved from attributes.visualReward and
+                    rendered as before/after beds.
+                </span>
+            </div>
+            <div className="mt-4 grid gap-2 md:grid-cols-3 xl:grid-cols-5">
+                {operationVisualRewardDebugScenarios.map((scenario) => (
+                    <div
+                        key={scenario.kind}
+                        className="rounded-md border border-neutral-800 bg-neutral-900/80 p-3"
+                    >
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm font-semibold">
+                                {scenario.title}
+                            </span>
+                            <code className="rounded bg-neutral-950 px-1.5 py-0.5 font-mono text-[11px] text-neutral-400">
+                                {scenario.kind} #{scenario.operationId}
+                            </code>
+                        </div>
+                        <div className="mt-2 grid gap-2">
+                            {[scenario.before, scenario.after].map((state) => (
+                                <div
+                                    key={`${scenario.kind}-${state.label}`}
+                                    className="rounded border border-neutral-800 bg-neutral-950/70 p-2"
+                                >
+                                    <span className="block text-[11px] font-semibold uppercase text-neutral-500">
+                                        {state.label} bed {state.raisedBedId}
+                                    </span>
+                                    <span className="mt-1 block text-xs text-neutral-300">
+                                        {state.state}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </aside>
+    );
+}
+
 export default async function GameProfilePage({
     searchParams,
 }: {
@@ -184,19 +245,22 @@ export default async function GameProfilePage({
     const params = await searchParams;
     const mode = resolveMode(firstValue(params.mode));
     const renderDetails = firstValue(params.details) !== '0';
+    const showLegend = firstValue(params.legend) !== '0';
     const showHud = firstValue(params.hud) === '1';
     const showDebugHud = firstValue(params.debugHud) === '1';
     const enableControls = firstValue(params.controls) === '1';
     const mockGardenProfile = resolveMockGardenProfile(
         firstValue(params.profile),
     );
+    const isOperationRewardDebug =
+        isOperationVisualRewardDebugProfile(mockGardenProfile);
     const quality = resolveQuality(firstValue(params.quality));
     const weather = resolveWeather(mode);
     const freezeTime = resolveFreezeTime(mode);
 
     return (
         <main
-            className="h-screen w-screen overflow-hidden bg-[#e7e2cc]"
+            className="relative h-screen w-screen overflow-hidden bg-[#e7e2cc]"
             data-game-profile-mode={mode}
             data-game-profile-controls={enableControls ? '1' : '0'}
             data-game-profile-details={renderDetails ? '1' : '0'}
@@ -220,7 +284,11 @@ export default async function GameProfilePage({
                 renderDetails={renderDetails}
                 weather={weather}
                 winterMode={mode === 'snow' ? 'winter' : 'summer'}
+                zoom={isOperationRewardDebug ? 'far' : 'normal'}
             />
+            {isOperationRewardDebug && showLegend ? (
+                <OperationRewardDebugOverlay />
+            ) : null}
         </main>
     );
 }

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -136,9 +136,21 @@ const denseScenarios = [
     },
 ];
 
+const rewardScenarios = [
+    {
+        name: 'game-operation-rewards-matrix-desktop',
+        path: '/debug/profile/game?mode=details&profile=operation-rewards&controls=1&quality=medium&legend=0',
+        viewport: { width: 1440, height: 1200 },
+        dpr: 1,
+        isMobile: false,
+        budget: 'gameRewards',
+    },
+];
+
 const scenarioSets = {
     core: coreScenarios,
     dense: denseScenarios,
+    rewards: rewardScenarios,
 };
 
 const budgets = {
@@ -222,6 +234,14 @@ const budgets = {
         trianglesPerFrame: 7000000,
         jsHeapMb: 520,
     },
+    gameRewards: {
+        p95FrameMs: 1000,
+        maxFrameMs: 1200,
+        longTaskCount: 12,
+        drawCallsPerFrame: 2400,
+        trianglesPerFrame: 6500000,
+        jsHeapMb: 500,
+    },
 };
 
 function parseArgs(argv) {
@@ -234,6 +254,7 @@ function parseArgs(argv) {
             : defaultOutDir,
         sampleMs: Number(process.env.GAME_PROFILE_SAMPLE_MS ?? 5000),
         scenarioSet: process.env.GAME_PROFILE_SCENARIO_SET ?? 'core',
+        screenshots: process.env.GAME_PROFILE_SCREENSHOTS === '1',
         startServer: process.env.GAME_PROFILE_START_SERVER === '1',
         warmupMs: Number(process.env.GAME_PROFILE_WARMUP_MS ?? 5000),
     };
@@ -269,6 +290,9 @@ function parseArgs(argv) {
             case '--scenario-set':
                 options.scenarioSet = next;
                 index += 1;
+                break;
+            case '--screenshots':
+                options.screenshots = true;
                 break;
             case '--start-server':
                 options.startServer = true;
@@ -307,6 +331,7 @@ function printHelp(options) {
             '  --warmup-ms <ms>       Warmup wait after canvas appears. Default: 5000',
             '  --sample-ms <ms>       requestAnimationFrame sample window. Default: 5000',
             `  --scenario-set <set>    core, dense, all, or comma-separated names. Current: ${options.scenarioSet}`,
+            '  --screenshots           Save a PNG screenshot for each scenario.',
             '  --fail-on-budget       Exit non-zero when a budget check fails.',
             '  --help                 Show this help.',
             '',
@@ -315,6 +340,7 @@ function printHelp(options) {
             '  GAME_PROFILE_START_SERVER=1,',
             '  GAME_PROFILE_WARMUP_MS, GAME_PROFILE_SAMPLE_MS,',
             '  GAME_PROFILE_OUT_DIR, GAME_PROFILE_SCENARIO_SET,',
+            '  GAME_PROFILE_SCREENSHOTS=1,',
             '  GAME_PROFILE_FAIL_ON_BUDGET=1',
             '',
         ].join('\n'),
@@ -322,7 +348,7 @@ function printHelp(options) {
 }
 
 function allScenarios() {
-    return [...coreScenarios, ...denseScenarios];
+    return [...coreScenarios, ...denseScenarios, ...rewardScenarios];
 }
 
 function resolveScenarios(scenarioSet) {
@@ -347,7 +373,7 @@ function resolveScenarios(scenarioSet) {
 
         if (!candidates.length) {
             throw new Error(
-                `Unknown scenario set or scenario: ${token}. Use core, dense, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
+                `Unknown scenario set or scenario: ${token}. Use core, dense, rewards, all, or one of: ${knownScenarios.map((scenario) => scenario.name).join(', ')}.`,
             );
         }
 
@@ -857,6 +883,17 @@ async function measureScenario(browser, baseUrl, scenario, options) {
     const after = Object.fromEntries(
         afterMetrics.metrics.map((metric) => [metric.name, metric.value]),
     );
+    const screenshotPath = options.screenshots
+        ? resolve(options.outDir, 'screenshots', `${scenario.name}.png`)
+        : null;
+    if (screenshotPath) {
+        await mkdir(dirname(screenshotPath), { recursive: true });
+        await page.screenshot({
+            path: screenshotPath,
+            animations: 'disabled',
+            fullPage: false,
+        });
+    }
 
     await context.close();
 
@@ -899,6 +936,7 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         },
         runtime,
         sample: roundedSample,
+        screenshotPath,
         url,
         name: scenario.name,
     };
@@ -975,8 +1013,8 @@ function buildMarkdown(report) {
         '',
         `Budget status: ${report.summary.failedScenarios === 0 ? 'pass' : 'fail'}`,
         '',
-        '| Scenario | Mode | Profile | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Overlays/Decor | FPS | p95 | Max | Draw/frame | Triangles/frame | Long tasks | Heap | Budget |',
-        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+        '| Scenario | Mode | Profile | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Overlays/Decor | FPS | p95 | Max | Draw/frame | Triangles/frame | Long tasks | Heap | Budget | Screenshot |',
+        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
     ];
 
     for (const scenario of report.scenarios) {
@@ -995,8 +1033,9 @@ function buildMarkdown(report) {
         const detailCounts = scenario.runtime
             ? `${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0} decor, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}`
             : 'n/a';
+        const screenshot = scenario.screenshotPath ?? 'n/a';
         lines.push(
-            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} |`,
+            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} | ${screenshot} |`,
         );
     }
 

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -128,6 +128,16 @@ async function expectNoHorizontalOverflow(locator: Locator) {
     expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
+async function openSavedAiDiaryEntry(page: Page) {
+    const aiEntry = page.locator('[data-diary-entry]').nth(1);
+
+    await aiEntry
+        .getByRole('button', {
+            name: 'Klikni za prikaz savjeta suncokreta',
+        })
+        .click();
+}
+
 test('raised bed diary entries stay inside a narrow mobile card', async ({
     mount,
     page,
@@ -237,8 +247,7 @@ test('saved AI operation links render as scheduling chips', async ({
         await captureShoppingCartPost(page);
     await mount(<RaisedBedDiaryOverflowStory />);
 
-    const aiEntry = page.locator('[data-diary-entry]').nth(1);
-    await aiEntry.getByRole('button').first().click();
+    await openSavedAiDiaryEntry(page);
 
     const dialog = page.getByRole('dialog');
     const chips = dialog.locator('[data-ai-operation-chip]');
@@ -280,8 +289,7 @@ test('saved AI plant operation chip schedules the targeted field', async ({
         await captureShoppingCartPost(page);
     await mount(<RaisedBedDiaryOverflowStory />);
 
-    const aiEntry = page.locator('[data-diary-entry]').nth(1);
-    await aiEntry.getByRole('button').first().click();
+    await openSavedAiDiaryEntry(page);
 
     const dialog = page.getByRole('dialog');
     await dialog
@@ -317,8 +325,7 @@ test('saved AI operation scheduling failures stay recoverable', async ({
     );
     await mount(<RaisedBedDiaryOverflowStory />);
 
-    const aiEntry = page.locator('[data-diary-entry]').nth(1);
-    await aiEntry.getByRole('button').first().click();
+    await openSavedAiDiaryEntry(page);
 
     const dialog = page.getByRole('dialog');
     await dialog.getByRole('button', { name: 'Malčiranje gredice' }).click();

--- a/docs/operation-visual-rewards-qa-matrix.md
+++ b/docs/operation-visual-rewards-qa-matrix.md
@@ -1,0 +1,52 @@
+# Operation Visual Rewards QA Matrix
+
+This matrix tracks the garden scene before/after reward behavior for completed real operations. It is meant for release review of the operation visual reward stack and should stay aligned with `packages/game/src/operationVisualRewards.ts` plus the raised-bed render helpers under `packages/game/src/entities/raisedBed/`.
+
+## Source Rules
+
+- Completed, confirmed, and pending-verification operation states can create visual rewards.
+- Planned, failed, canceled, and unknown operation states must not create visual rewards.
+- Field-scoped operations affect only the matching raised-bed field.
+- Raised-bed-scoped operations affect the raised bed according to the visual family.
+- Watering uses a darker moist-soil tint only. Do not add small droplets; they do not read well in the low-poly world.
+- Photography updates use the existing photography operation history and its `imageUrls`. Do not introduce a separate proof-photo concept.
+
+## Matrix
+
+| Operation | Before State | After Reward | Scope Checks | Time / Freshness | Automated Coverage |
+| --- | --- | --- | --- | --- | --- |
+| Watering | Dry raised-bed soil. | Darker moist-soil tint. | Field rewards tint only the matching field; raised-bed rewards tint planted fields in the bed. | Visible for 72 hours after the reward timestamp. | `raisedBedWateringRewards.unit.ts`; `RaisedBedFields.tsx`. |
+| Weeding | Admin- or AI-entered weed state on bed or field. | Weeds disappear and the soil reads clean. | Field weeding clears only the matching field; bed state applies to fields without newer field overrides. | Persistent until a newer weed observation is entered. | `raisedBedWeedState.unit.ts`; admin controls in raised-bed edit UI. |
+| Mulch | Bare planting surface. | Straw/mulch layer appears. | Whole-bed mulch covers the bed; field mulch covers the target field and can override older field mulch. | Persistent until a newer matching remove-mulch reward. | `raisedBedMulchVisualRewards.unit.ts`; `raisedBedMulchOperationOrder.unit.ts`. |
+| Remove mulch | Straw/mulch layer exists. | Matching layer is removed and the planting zone is clean. | Field removal does not clear whole-bed mulch; whole-bed removal clears the whole-bed layer. | Persistent until a newer matching mulch reward. | `raisedBedMulchVisualRewards.unit.ts`. |
+| Agrotextile | Exposed bed or field. | Low-poly fabric cover appears and hides plants/weeds under covered positions. | Raised-bed cover marks every local field position; field cover marks the matching active field. | Persistent until a newer matching remove-agrotextile reward. | `raisedBedAgrotextileRewards.unit.ts`; `RaisedBedFields.tsx`. |
+| Remove agrotextile | Covered bed or field. | Cover disappears and plants/planting zone render again. | Field removal preserves covers on other fields; whole-bed removal clears the whole-bed cover. | Persistent until a newer matching agrotextile reward. | `raisedBedAgrotextileRewards.unit.ts`. |
+| Supports | Unsupported plants. | Stakes and tie bands appear beside supported plants. | Raised-bed support marks planted fields; field support marks only the matching planted field. | Persistent visual reward. | `raisedBedSupportRewards.unit.ts`; `RaisedBedFields.tsx`. |
+| Harvest | Ripe plants with produce. | Crate with produce appears; generated plant produce/flowers are reduced for harvested positions. | Field harvest changes only the matching planted field; raised-bed harvest marks planted fields in the current block. | Persistent visual reward. | `raisedBedHarvestRewards.unit.ts`; generated plant batch props. |
+| Photography update | Old garden/photo state. | Photo/update marker appears from latest photography operation images. | Raised-bed photo creates centered marker; field photo creates marker on the matching field. | Source is latest operation history item with images; no separate proof-photo state. | `raisedBedPhotographyRewards.unit.ts`; `useRaisedBedOperationVisualRewards.ts`. |
+
+## Manual Visual Review
+
+Use this pass before rollout or when any row changes:
+
+1. Start the garden app locally or open the preview environment with the full operation visual reward stack.
+2. Review desktop and mobile viewports for each operation family.
+3. Confirm the canvas is nonblank, correctly framed, and controls still work.
+4. Confirm field-scoped rewards do not bleed into neighboring fields.
+5. Confirm removal rewards visibly undo only the matching visual family and scope.
+6. Confirm watering remains readable as moist soil without relying on droplets.
+7. Confirm photography markers point back to existing operation history/photos rather than a new proof-photo workflow.
+
+## Validation Commands
+
+Runtime visual changes in this stack were validated with:
+
+```bash
+pnpm --filter @gredice/game test
+pnpm --filter @gredice/game typecheck
+pnpm --filter @gredice/game lint
+pnpm --filter garden build
+git diff --check
+```
+
+For docs-only updates to this matrix, `git diff --check` is sufficient.

--- a/docs/operation-visual-rewards-qa-matrix.md
+++ b/docs/operation-visual-rewards-qa-matrix.md
@@ -1,29 +1,32 @@
 # Operation Visual Rewards QA Matrix
 
-This matrix tracks the garden scene before/after reward behavior for completed real operations. It is meant for release review of the operation visual reward stack and should stay aligned with `packages/game/src/operationVisualRewards.ts` plus the raised-bed render helpers under `packages/game/src/entities/raisedBed/`.
+This matrix tracks the garden scene before/after reward behavior for completed real operations. It is meant for release review of the operation visual reward stack and should stay aligned with the `attributes.visualReward` operation attribute, `packages/game/src/operationVisualRewards.ts`, and the raised-bed render helpers under `packages/game/src/entities/raisedBed/`.
 
 ## Source Rules
 
 - Completed, confirmed, and pending-verification operation states can create visual rewards.
 - Planned, failed, canceled, and unknown operation states must not create visual rewards.
+- `attributes.visualReward` is the source of truth for reward selection. Supported values are `watering`, `weeding`, `mulch`, `removeMulch`, `agrotextile`, `removeAgrotextile`, `supports`, `harvest`, and `photographyUpdate`.
+- Operation names, labels, stage labels, descriptions, instructions, image paths, and remove/apply wording must not infer visual rewards.
 - Field-scoped operations affect only the matching raised-bed field.
 - Raised-bed-scoped operations affect the raised bed according to the visual family.
 - Watering uses a darker moist-soil tint only. Do not add small droplets; they do not read well in the low-poly world.
 - Photography updates use the existing photography operation history and its `imageUrls`. Do not introduce a separate proof-photo concept.
+- Existing production operation definitions are backfilled by `packages/storage/scripts/upsertOperationVisualRewardAttributes.ts`; future operation changes should be controlled through the operation attribute in admin.
 
 ## Matrix
 
-| Operation | Before State | After Reward | Scope Checks | Time / Freshness | Automated Coverage |
-| --- | --- | --- | --- | --- | --- |
-| Watering | Dry raised-bed soil. | Darker moist-soil tint. | Field rewards tint only the matching field; raised-bed rewards tint planted fields in the bed. | Visible for 72 hours after the reward timestamp. | `raisedBedWateringRewards.unit.ts`; `RaisedBedFields.tsx`. |
-| Weeding | Admin- or AI-entered weed state on bed or field. | Weeds disappear and the soil reads clean. | Field weeding clears only the matching field; bed state applies to fields without newer field overrides. | Persistent until a newer weed observation is entered. | `raisedBedWeedState.unit.ts`; admin controls in raised-bed edit UI. |
-| Mulch | Bare planting surface. | Straw/mulch layer appears. | Whole-bed mulch covers the bed; field mulch covers the target field and can override older field mulch. | Persistent until a newer matching remove-mulch reward. | `raisedBedMulchVisualRewards.unit.ts`; `raisedBedMulchOperationOrder.unit.ts`. |
-| Remove mulch | Straw/mulch layer exists. | Matching layer is removed and the planting zone is clean. | Field removal does not clear whole-bed mulch; whole-bed removal clears the whole-bed layer. | Persistent until a newer matching mulch reward. | `raisedBedMulchVisualRewards.unit.ts`. |
-| Agrotextile | Exposed bed or field. | Low-poly fabric cover appears and hides plants/weeds under covered positions. | Raised-bed cover marks every local field position; field cover marks the matching active field. | Persistent until a newer matching remove-agrotextile reward. | `raisedBedAgrotextileRewards.unit.ts`; `RaisedBedFields.tsx`. |
-| Remove agrotextile | Covered bed or field. | Cover disappears and plants/planting zone render again. | Field removal preserves covers on other fields; whole-bed removal clears the whole-bed cover. | Persistent until a newer matching agrotextile reward. | `raisedBedAgrotextileRewards.unit.ts`. |
-| Supports | Unsupported plants. | Stakes and tie bands appear beside supported plants. | Raised-bed support marks planted fields; field support marks only the matching planted field. | Persistent visual reward. | `raisedBedSupportRewards.unit.ts`; `RaisedBedFields.tsx`. |
-| Harvest | Ripe plants with produce. | Crate with produce appears; generated plant produce/flowers are reduced for harvested positions. | Field harvest changes only the matching planted field; raised-bed harvest marks planted fields in the current block. | Persistent visual reward. | `raisedBedHarvestRewards.unit.ts`; generated plant batch props. |
-| Photography update | Old garden/photo state. | Photo/update marker appears from latest photography operation images. | Raised-bed photo creates centered marker; field photo creates marker on the matching field. | Source is latest operation history item with images; no separate proof-photo state. | `raisedBedPhotographyRewards.unit.ts`; `useRaisedBedOperationVisualRewards.ts`. |
+| Operation | `attributes.visualReward` | Before State | After Reward | Scope Checks | Time / Freshness | Automated Coverage |
+| --- | --- | --- | --- | --- | --- | --- |
+| Watering | `watering` | Dry raised-bed soil. | Darker moist-soil tint. | Field rewards tint only the matching field; raised-bed rewards tint planted fields in the bed. | Visible for 72 hours after the reward timestamp. | `raisedBedWateringRewards.unit.ts`; `RaisedBedFields.tsx`. |
+| Weeding | `weeding` | Admin- or AI-entered weed state on bed or field. | Weeds disappear and the soil reads clean. | Field weeding clears only the matching field; bed state applies to fields without newer field overrides. | Persistent until a newer weed observation is entered. | `raisedBedWeedState.unit.ts`; admin controls in raised-bed edit UI. |
+| Mulch | `mulch` | Bare planting surface. | Straw/mulch layer appears. | Whole-bed mulch covers the bed; field mulch covers the target field and can override older field mulch. | Persistent until a newer matching remove-mulch reward. | `raisedBedMulchVisualRewards.unit.ts`; `raisedBedMulchOperationOrder.unit.ts`. |
+| Remove mulch | `removeMulch` | Straw/mulch layer exists. | Matching layer is removed and the planting zone is clean. | Field removal does not clear whole-bed mulch; whole-bed removal clears the whole-bed layer. | Persistent until a newer matching mulch reward. | `raisedBedMulchVisualRewards.unit.ts`. |
+| Agrotextile | `agrotextile` | Exposed bed or field. | Low-poly fabric cover appears and hides plants/weeds under covered positions. | Raised-bed cover marks every local field position; field cover marks the matching active field. | Persistent until a newer matching remove-agrotextile reward. | `raisedBedAgrotextileRewards.unit.ts`; `RaisedBedFields.tsx`. |
+| Remove agrotextile | `removeAgrotextile` | Covered bed or field. | Cover disappears and plants/planting zone render again. | Field removal preserves covers on other fields; whole-bed removal clears the whole-bed cover. | Persistent until a newer matching agrotextile reward. | `raisedBedAgrotextileRewards.unit.ts`. |
+| Supports | `supports` | Unsupported plants. | Stakes and tie bands appear beside supported plants. | Raised-bed support marks planted fields; field support marks only the matching planted field. | Persistent visual reward. | `raisedBedSupportRewards.unit.ts`; `RaisedBedFields.tsx`. |
+| Harvest | `harvest` | Ripe plants with produce. | Crate with produce appears; generated plant produce/flowers are reduced for harvested positions. | Field harvest changes only the matching planted field; raised-bed harvest marks planted fields in the current block. | Persistent visual reward. | `raisedBedHarvestRewards.unit.ts`; generated plant batch props. |
+| Photography update | `photographyUpdate` | Old garden/photo state. | Photo/update marker appears from latest photography operation images. | Raised-bed photo creates centered marker; field photo creates marker on the matching field. | Source is latest operation history item with images; no separate proof-photo state. | `raisedBedPhotographyRewards.unit.ts`; `useRaisedBedOperationVisualRewards.ts`. |
 
 ## Manual Visual Review
 
@@ -36,6 +39,7 @@ Use this pass before rollout or when any row changes:
 5. Confirm removal rewards visibly undo only the matching visual family and scope.
 6. Confirm watering remains readable as moist soil without relying on droplets.
 7. Confirm photography markers point back to existing operation history/photos rather than a new proof-photo workflow.
+8. Confirm each reviewed operation has the expected `attributes.visualReward` value in admin.
 
 ## Validation Commands
 

--- a/packages/game/src/hooks/useBlockData.ts
+++ b/packages/game/src/hooks/useBlockData.ts
@@ -4,15 +4,17 @@ import { getLocalSandboxBlockData } from '../localSandboxBlockData';
 import { useGameState } from '../useGameState';
 
 export function useBlockData() {
+    const isMock = useGameState((state) => state.isMock);
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
     );
     const isLocalSandbox = localSandboxStorageKey !== null;
+    const useLocalBlockData = isLocalSandbox || isMock;
 
     return useQuery({
-        queryKey: isLocalSandbox ? ['blocks', 'local-sandbox'] : ['blocks'],
+        queryKey: useLocalBlockData ? ['blocks', 'local'] : ['blocks'],
         queryFn: async () => {
-            if (isLocalSandbox) {
+            if (useLocalBlockData) {
                 return getLocalSandboxBlockData();
             }
 

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -10,6 +10,16 @@ import {
     loadLocalSandboxGarden,
     localSandboxGardenId,
 } from '../localSandboxGarden';
+import {
+    isOperationVisualRewardDebugProfile,
+    type OperationVisualRewardDebugBedState,
+    type OperationVisualRewardDebugScenario,
+    operationVisualRewardDebugNewerTimestamp,
+    operationVisualRewardDebugOlderTimestamp,
+    operationVisualRewardDebugOperationIds,
+    operationVisualRewardDebugScenarios,
+    operationVisualRewardDebugTimestamp,
+} from '../operationVisualRewardDebugProfile';
 import type { Stack } from '../types/Stack';
 import {
     type MockGardenProfile,
@@ -323,6 +333,13 @@ const denseMockGardenBounds = {
     min: -12,
 };
 
+const operationRewardDebugGardenBounds = {
+    maxX: 10,
+    maxZ: 8,
+    minX: -8,
+    minZ: -6,
+};
+
 function mockGardenStackPositionKey(x: number, z: number) {
     return `${x}:${z}`;
 }
@@ -414,6 +431,48 @@ function createDenseMockStacks(winterMode: WinterMode): {
     return { stackByPosition, stacks };
 }
 
+function createOperationRewardDebugStacks(winterMode: WinterMode): {
+    stackByPosition: Map<string, Stack>;
+    stacks: Stack[];
+} {
+    const stackByPosition = new Map<string, Stack>();
+    const stacks: Stack[] = [];
+
+    for (
+        let x = operationRewardDebugGardenBounds.minX;
+        x <= operationRewardDebugGardenBounds.maxX;
+        x += 1
+    ) {
+        for (
+            let z = operationRewardDebugGardenBounds.minZ;
+            z <= operationRewardDebugGardenBounds.maxZ;
+            z += 1
+        ) {
+            const groundName =
+                winterMode === 'winter'
+                    ? 'Block_Snow'
+                    : Math.abs(x * 5 + z * 3) % 6 === 0
+                      ? 'Block_Ground'
+                      : 'Block_Grass';
+            const stack: Stack = {
+                position: new Vector3(x, 0, z),
+                blocks: [
+                    {
+                        id: `operation-reward-ground:${x}:${z}`,
+                        name: groundName,
+                        rotation: Math.abs(x + z) % 4,
+                    },
+                ],
+            };
+
+            stacks.push(stack);
+            stackByPosition.set(mockGardenStackPositionKey(x, z), stack);
+        }
+    }
+
+    return { stackByPosition, stacks };
+}
+
 function createProfileRaisedBed(
     id: number,
     blockId: string,
@@ -453,13 +512,13 @@ function addProfileRaisedBedPair({
     stackByPosition: Map<string, Stack>;
     x: number;
     z: number;
-}) {
+}): MockRaisedBed | null {
     const firstStack = stackByPosition.get(mockGardenStackPositionKey(x, z));
     const secondStack = stackByPosition.get(
         mockGardenStackPositionKey(x, z + 1),
     );
     if (!firstStack || !secondStack) {
-        return;
+        return null;
     }
 
     const firstBlockId = `profile-raised-bed:${id}:0`;
@@ -473,7 +532,223 @@ function addProfileRaisedBedPair({
         name: 'Raised_Bed',
         rotation: 0,
     });
-    raisedBeds.push(createProfileRaisedBed(id, firstBlockId, fieldOffset, now));
+    const raisedBed = createProfileRaisedBed(
+        id,
+        firstBlockId,
+        fieldOffset,
+        now,
+    );
+    raisedBeds.push(raisedBed);
+    return raisedBed;
+}
+
+function completedDebugAppliedOperation({
+    completedAt,
+    entityId,
+    id,
+    raisedBedFieldId,
+}: {
+    completedAt: string;
+    entityId: number;
+    id: number;
+    raisedBedFieldId?: number | null;
+}): MockRaisedBed['appliedOperations'][number] {
+    return {
+        id,
+        entityId,
+        raisedBedFieldId: raisedBedFieldId ?? null,
+        status: 'completed',
+        createdAt: completedAt,
+        completedAt,
+        scheduledDate: null,
+    };
+}
+
+function heavyDebugWeedState(
+    observedAt: string,
+    eventId: number,
+): NonNullable<MockRaisedBed['weedState']> {
+    return {
+        level: 'heavy',
+        source: 'admin',
+        observedAt,
+        updatedAt: observedAt,
+        eventId,
+        notes: 'Operation reward debug profile.',
+    };
+}
+
+function applyOperationRewardDebugState({
+    phase,
+    raisedBed,
+    scenario,
+}: {
+    phase: OperationVisualRewardDebugBedState['label'];
+    raisedBed: MockRaisedBed;
+    scenario: OperationVisualRewardDebugScenario;
+}) {
+    const isAfter = phase === 'After';
+    raisedBed.name = `${scenario.title} ${phase.toLowerCase()}`;
+
+    switch (scenario.kind) {
+        case 'watering':
+            if (isAfter) {
+                raisedBed.appliedOperations = [
+                    completedDebugAppliedOperation({
+                        id: 9501,
+                        entityId:
+                            operationVisualRewardDebugOperationIds.watering,
+                        completedAt: operationVisualRewardDebugTimestamp,
+                    }),
+                ];
+            }
+            break;
+        case 'weeding':
+            raisedBed.weedState = heavyDebugWeedState(
+                operationVisualRewardDebugOlderTimestamp,
+                isAfter ? 9504 : 9503,
+            );
+            if (isAfter) {
+                raisedBed.appliedOperations = [
+                    completedDebugAppliedOperation({
+                        id: 9502,
+                        entityId:
+                            operationVisualRewardDebugOperationIds.weeding,
+                        completedAt: operationVisualRewardDebugNewerTimestamp,
+                    }),
+                ];
+            }
+            break;
+        case 'mulch':
+            if (isAfter) {
+                raisedBed.appliedOperations = [
+                    completedDebugAppliedOperation({
+                        id: 9503,
+                        entityId: operationVisualRewardDebugOperationIds.mulch,
+                        completedAt: operationVisualRewardDebugTimestamp,
+                    }),
+                ];
+            }
+            break;
+        case 'removeMulch':
+            raisedBed.appliedOperations = [
+                completedDebugAppliedOperation({
+                    id: 9504,
+                    entityId: operationVisualRewardDebugOperationIds.mulch,
+                    completedAt: operationVisualRewardDebugOlderTimestamp,
+                }),
+                ...(isAfter
+                    ? [
+                          completedDebugAppliedOperation({
+                              id: 9505,
+                              entityId:
+                                  operationVisualRewardDebugOperationIds.removeMulch,
+                              completedAt:
+                                  operationVisualRewardDebugNewerTimestamp,
+                          }),
+                      ]
+                    : []),
+            ];
+            break;
+        case 'agrotextile':
+            if (isAfter) {
+                raisedBed.appliedOperations = [
+                    completedDebugAppliedOperation({
+                        id: 9506,
+                        entityId:
+                            operationVisualRewardDebugOperationIds.agrotextile,
+                        completedAt: operationVisualRewardDebugTimestamp,
+                    }),
+                ];
+            }
+            break;
+        case 'removeAgrotextile':
+            raisedBed.appliedOperations = [
+                completedDebugAppliedOperation({
+                    id: 9507,
+                    entityId:
+                        operationVisualRewardDebugOperationIds.agrotextile,
+                    completedAt: operationVisualRewardDebugOlderTimestamp,
+                }),
+                ...(isAfter
+                    ? [
+                          completedDebugAppliedOperation({
+                              id: 9508,
+                              entityId:
+                                  operationVisualRewardDebugOperationIds.removeAgrotextile,
+                              completedAt:
+                                  operationVisualRewardDebugNewerTimestamp,
+                          }),
+                      ]
+                    : []),
+            ];
+            break;
+        case 'supports':
+            if (isAfter) {
+                raisedBed.appliedOperations = [
+                    completedDebugAppliedOperation({
+                        id: 9509,
+                        entityId:
+                            operationVisualRewardDebugOperationIds.supports,
+                        completedAt: operationVisualRewardDebugTimestamp,
+                    }),
+                ];
+            }
+            break;
+        case 'harvest':
+            if (isAfter) {
+                raisedBed.appliedOperations = [
+                    completedDebugAppliedOperation({
+                        id: 9510,
+                        entityId:
+                            operationVisualRewardDebugOperationIds.harvest,
+                        completedAt: operationVisualRewardDebugTimestamp,
+                    }),
+                ];
+            }
+            break;
+        case 'photographyUpdate':
+            break;
+    }
+}
+
+function addOperationRewardDebugRaisedBed({
+    fieldOffset,
+    now,
+    raisedBeds,
+    stackByPosition,
+    state,
+    scenario,
+    x,
+    z,
+}: {
+    fieldOffset: number;
+    now: string;
+    raisedBeds: useCurrentGardenResponse['raisedBeds'];
+    stackByPosition: Map<string, Stack>;
+    state: OperationVisualRewardDebugBedState;
+    scenario: OperationVisualRewardDebugScenario;
+    x: number;
+    z: number;
+}) {
+    const raisedBed = addProfileRaisedBedPair({
+        fieldOffset,
+        id: state.raisedBedId,
+        now,
+        raisedBeds,
+        stackByPosition,
+        x,
+        z,
+    });
+    if (!raisedBed) {
+        return;
+    }
+
+    applyOperationRewardDebugState({
+        phase: state.label,
+        raisedBed,
+        scenario,
+    });
 }
 
 function denseMockGarden(
@@ -516,10 +791,62 @@ function denseMockGarden(
     };
 }
 
+function operationRewardDebugMockGarden(
+    winterMode: WinterMode,
+): useCurrentGardenResponse {
+    const now = new Date().toISOString();
+    const { stackByPosition, stacks } =
+        createOperationRewardDebugStacks(winterMode);
+    const raisedBeds: useCurrentGardenResponse['raisedBeds'] = [];
+
+    operationVisualRewardDebugScenarios.forEach((scenario, index) => {
+        const row = Math.floor(index / 3);
+        const column = index % 3;
+        const beforeX = -7 + column * 6;
+        const afterX = beforeX + 2;
+        const z = -5 + row * 5;
+
+        addOperationRewardDebugRaisedBed({
+            fieldOffset: scenario.before.raisedBedId * 100,
+            now,
+            raisedBeds,
+            stackByPosition,
+            state: scenario.before,
+            scenario,
+            x: beforeX,
+            z,
+        });
+        addOperationRewardDebugRaisedBed({
+            fieldOffset: scenario.after.raisedBedId * 100,
+            now,
+            raisedBeds,
+            stackByPosition,
+            state: scenario.after,
+            scenario,
+            x: afterX,
+            z,
+        });
+    });
+
+    return {
+        id: 99997,
+        name: 'Operation reward debug garden',
+        isSandbox: false,
+        backgroundPalette: defaultGameBackgroundPaletteKey,
+        stacks,
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds,
+    };
+}
+
 function mockGarden(
     winterMode: WinterMode,
     profile: MockGardenProfile,
 ): useCurrentGardenResponse {
+    if (isOperationVisualRewardDebugProfile(profile)) {
+        return operationRewardDebugMockGarden(winterMode);
+    }
+
     if (profile === 'dense' || profile === 'plant-heavy') {
         return denseMockGarden(winterMode, profile);
     }

--- a/packages/game/src/hooks/useGardenOperations.ts
+++ b/packages/game/src/hooks/useGardenOperations.ts
@@ -1,5 +1,10 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import {
+    isOperationVisualRewardDebugProfile,
+    operationVisualRewardDebugOperationItems,
+} from '../operationVisualRewardDebugProfile';
+import { useGameState } from '../useGameState';
 import { useCurrentGarden } from './useCurrentGarden';
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -57,6 +62,10 @@ type GardenOperationsPage = {
     nextCursor: number | null;
     total: number;
 };
+
+type CurrentGardenData = NonNullable<
+    NonNullable<ReturnType<typeof useCurrentGarden>['data']>
+>;
 
 type GardenOperationItemResponse = Omit<
     GardenOperationItem,
@@ -164,6 +173,7 @@ export function gardenOperationsQueryKey({
     gardenId,
     includeCompleted,
     pageSize,
+    profile,
     raisedBedId,
     raisedBedFieldId,
     positionIndex,
@@ -171,16 +181,105 @@ export function gardenOperationsQueryKey({
     gardenId: number | undefined;
     includeCompleted: boolean;
     pageSize: number;
+    profile?: string | null;
 } & GardenOperationsScope) {
     return [
         'garden-operations',
         gardenId,
+        profile ?? null,
         includeCompleted,
         pageSize,
         raisedBedId ?? null,
         raisedBedFieldId ?? null,
         positionIndex ?? null,
     ] as const;
+}
+
+function fieldIdsForPositionIndex({
+    currentGarden,
+    positionIndex,
+    raisedBedId,
+}: {
+    currentGarden: CurrentGardenData;
+    positionIndex: number;
+    raisedBedId?: number;
+}) {
+    return currentGarden.raisedBeds
+        .filter((raisedBed) =>
+            raisedBedId == null ? true : raisedBed.id === raisedBedId,
+        )
+        .flatMap((raisedBed) =>
+            raisedBed.fields
+                .filter((field) => field.positionIndex === positionIndex)
+                .map((field) => field.id),
+        );
+}
+
+function getOperationVisualRewardDebugOperationsPage({
+    currentGarden,
+    cursor,
+    includeCompleted,
+    pageSize,
+    positionIndex,
+    raisedBedFieldId,
+    raisedBedId,
+}: {
+    currentGarden: CurrentGardenData;
+    cursor: number;
+    includeCompleted: boolean;
+    pageSize: number;
+} & GardenOperationsScope): GardenOperationsPage {
+    if (!includeCompleted) {
+        return {
+            items: [],
+            nextCursor: null,
+            total: 0,
+        };
+    }
+
+    const fieldIds =
+        positionIndex == null
+            ? null
+            : new Set(
+                  fieldIdsForPositionIndex({
+                      currentGarden,
+                      positionIndex,
+                      raisedBedId,
+                  }),
+              );
+    const matchingItems = operationVisualRewardDebugOperationItems.filter(
+        (item) => {
+            if (raisedBedId != null && item.raisedBedId !== raisedBedId) {
+                return false;
+            }
+
+            if (
+                raisedBedFieldId != null &&
+                item.raisedBedFieldId !== raisedBedFieldId
+            ) {
+                return false;
+            }
+
+            if (
+                fieldIds &&
+                (item.raisedBedFieldId == null ||
+                    !fieldIds.has(item.raisedBedFieldId))
+            ) {
+                return false;
+            }
+
+            return true;
+        },
+    );
+    const items = matchingItems.slice(cursor, cursor + pageSize);
+    const nextCursor =
+        cursor + pageSize < matchingItems.length ? cursor + pageSize : null;
+
+    return {
+        items,
+        nextCursor,
+        total: matchingItems.length,
+    };
 }
 
 export function useGardenOperations({
@@ -196,12 +295,17 @@ export function useGardenOperations({
     pageSize?: number;
 } & GardenOperationsScope) {
     const { data: currentGarden } = useCurrentGarden();
+    const isMock = useGameState((state) => state.isMock);
+    const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
+    const isOperationRewardDebug =
+        isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
 
     return useInfiniteQuery({
         queryKey: gardenOperationsQueryKey({
             gardenId: currentGarden?.id,
             includeCompleted,
             pageSize,
+            profile: isOperationRewardDebug ? mockGardenProfile : null,
             raisedBedId,
             raisedBedFieldId,
             positionIndex,
@@ -213,6 +317,18 @@ export function useGardenOperations({
                     nextCursor: null,
                     total: 0,
                 } satisfies GardenOperationsPage;
+            }
+
+            if (isOperationRewardDebug) {
+                return getOperationVisualRewardDebugOperationsPage({
+                    currentGarden,
+                    includeCompleted,
+                    pageSize,
+                    raisedBedId,
+                    raisedBedFieldId,
+                    positionIndex,
+                    cursor: pageParam,
+                });
             }
 
             return getGardenOperationsPage({

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -20,10 +20,9 @@ export function useOperations() {
         isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
 
     return useQuery({
-        queryKey: [
-            'operations',
-            isOperationRewardDebug ? mockGardenProfile : 'directory',
-        ],
+        queryKey: isOperationRewardDebug
+            ? ['operations', mockGardenProfile]
+            : ['operations'],
         queryFn: async () =>
             isOperationRewardDebug
                 ? operationVisualRewardDebugOperationDefinitions

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -4,7 +4,7 @@ import {
     isOperationVisualRewardDebugProfile,
     operationVisualRewardDebugOperationDefinitions,
 } from '../operationVisualRewardDebugProfile';
-import { useGameState } from '../useGameState';
+import { useOptionalGameState } from '../useGameState';
 
 async function getOperations() {
     const operations = await directoriesClient().GET('/entities/operation');
@@ -14,8 +14,11 @@ async function getOperations() {
 }
 
 export function useOperations() {
-    const isMock = useGameState((state) => state.isMock);
-    const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
+    const isMock = useOptionalGameState((state) => state.isMock, false);
+    const mockGardenProfile = useOptionalGameState(
+        (state) => state.mockGardenProfile,
+        'default',
+    );
     const isOperationRewardDebug =
         isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
 

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -1,5 +1,10 @@
 import { directoriesClient } from '@gredice/client';
 import { useQuery } from '@tanstack/react-query';
+import {
+    isOperationVisualRewardDebugProfile,
+    operationVisualRewardDebugOperationDefinitions,
+} from '../operationVisualRewardDebugProfile';
+import { useGameState } from '../useGameState';
 
 async function getOperations() {
     const operations = await directoriesClient().GET('/entities/operation');
@@ -9,9 +14,20 @@ async function getOperations() {
 }
 
 export function useOperations() {
+    const isMock = useGameState((state) => state.isMock);
+    const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
+    const isOperationRewardDebug =
+        isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
+
     return useQuery({
-        queryKey: ['operations'],
-        queryFn: getOperations,
+        queryKey: [
+            'operations',
+            isOperationRewardDebug ? mockGardenProfile : 'directory',
+        ],
+        queryFn: async () =>
+            isOperationRewardDebug
+                ? operationVisualRewardDebugOperationDefinitions
+                : getOperations(),
         staleTime: 1000 * 60 * 60, // 1 hour
     });
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -10,7 +10,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import Image from 'next/image';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode } from 'react';
 import { useGameFlags } from '../../GameFlagsContext';
 import { isDiaryCancelTargetEligible } from '../../hooks/useCancelDiaryEntry';
 import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';
@@ -166,6 +166,47 @@ function diaryEntryActions({
     );
 }
 
+function SavedAiDiaryEntryButton({
+    entry,
+    gardenId,
+}: {
+    entry: DiaryEntry;
+    gardenId: number;
+}) {
+    return (
+        <Modal
+            title={entry.name}
+            className="md:max-w-3xl"
+            trigger={
+                <button
+                    type="button"
+                    className="relative inline-flex h-auto w-fit min-w-0 items-center justify-start gap-2 rounded-md p-0 text-left text-xs font-medium text-primary underline-offset-4 transition-colors hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                    Klikni za prikaz savjeta suncokreta
+                </button>
+            }
+        >
+            <Stack spacing={4}>
+                <DiaryEntryImages
+                    name={entry.name}
+                    imageUrls={entry.imageUrls}
+                />
+                <div className="prose prose-sm max-w-none dark:prose-invert">
+                    <RaisedBedAiOperationMarkdown gardenId={gardenId}>
+                        {entry.description ?? ''}
+                    </RaisedBedAiOperationMarkdown>
+                </div>
+                <Typography
+                    level="body3"
+                    className="text-muted-foreground text-right"
+                >
+                    {entry.timestamp.toLocaleDateString('hr-HR')}
+                </Typography>
+            </Stack>
+        </Modal>
+    );
+}
+
 function DiaryList({
     error,
     gardenId,
@@ -183,229 +224,182 @@ function DiaryList({
     ) => ReactNode;
 }) {
     const aiHistoryByEntryId = relateAiHistory(entries);
-    const [expandedAiEntry, setExpandedAiEntry] = useState<DiaryEntry | null>(
-        null,
-    );
 
     return (
-        <>
-            <List
-                className="w-full max-w-full overflow-x-hidden"
-                data-diary-list
-            >
-                {error && (
-                    <Alert color="danger">
-                        <Typography level="body2">
-                            {
-                                'Došlo je do pogreške prilikom učitavanja dnevnika. Pokušaj ponovno.'
-                            }
-                        </Typography>
-                    </Alert>
-                )}
-                {isLoading && (
-                    <Spinner
-                        loading
-                        loadingLabel="Učitavanje dnevnika..."
-                        className="mx-auto my-8 flex items-center justify-center"
-                    />
-                )}
-                {!isLoading && !entries?.length && (
-                    <ListItem
-                        label={
-                            <Typography level="body2" className="px-2 py-4">
-                                Nema unosa u dnevniku.
-                            </Typography>
+        <List className="w-full max-w-full overflow-x-hidden" data-diary-list>
+            {error && (
+                <Alert color="danger">
+                    <Typography level="body2">
+                        {
+                            'Došlo je do pogreške prilikom učitavanja dnevnika. Pokušaj ponovno.'
                         }
-                    />
-                )}
-                {entries?.map((entry) => {
-                    const aiHistory = aiHistoryByEntryId.get(entry.id);
-                    const entryAction = renderEntryAction?.(entry, aiHistory);
+                    </Typography>
+                </Alert>
+            )}
+            {isLoading && (
+                <Spinner
+                    loading
+                    loadingLabel="Učitavanje dnevnika..."
+                    className="mx-auto my-8 flex items-center justify-center"
+                />
+            )}
+            {!isLoading && !entries?.length && (
+                <ListItem
+                    label={
+                        <Typography level="body2" className="px-2 py-4">
+                            Nema unosa u dnevniku.
+                        </Typography>
+                    }
+                />
+            )}
+            {entries?.map((entry) => {
+                const aiHistory = aiHistoryByEntryId.get(entry.id);
+                const entryAction = renderEntryAction?.(entry, aiHistory);
 
-                    return (
-                        <div
-                            key={entry.id}
-                            className="w-full min-w-0 max-w-full"
-                            data-diary-entry
-                        >
-                            {entry.isMarkdown ? (
-                                <ListItem
-                                    nodeId={entry.id.toString()}
-                                    onSelected={() => setExpandedAiEntry(entry)}
-                                    className="cursor-pointer hover:bg-muted/50 transition-colors max-w-full"
-                                    label={
+                return (
+                    <div
+                        key={entry.id}
+                        className="w-full min-w-0 max-w-full"
+                        data-diary-entry
+                    >
+                        {entry.isMarkdown ? (
+                            <ListItem
+                                className="max-w-full"
+                                label={
+                                    <Row
+                                        spacing={4}
+                                        className="w-full min-w-0 flex-col items-stretch justify-between font-normal sm:flex-row sm:items-start"
+                                    >
                                         <Row
                                             spacing={4}
-                                            className="w-full min-w-0 flex-col items-stretch justify-between font-normal sm:flex-row sm:items-start"
+                                            className="min-w-0 flex-1 items-start"
                                         >
-                                            <Row
-                                                spacing={4}
-                                                className="min-w-0 flex-1 items-start"
+                                            <DiaryEntryImages
+                                                name={entry.name}
+                                                imageUrls={entry.imageUrls}
+                                                className={diaryEntryImagesClassName(
+                                                    entry.imageUrls,
+                                                )}
+                                            />
+                                            <Stack
+                                                className="min-w-0 flex-1"
+                                                data-diary-entry-content
                                             >
-                                                <DiaryEntryImages
-                                                    name={entry.name}
-                                                    imageUrls={entry.imageUrls}
-                                                    className={diaryEntryImagesClassName(
-                                                        entry.imageUrls,
-                                                    )}
-                                                />
-                                                <Stack
-                                                    className="min-w-0 flex-1"
-                                                    data-diary-entry-content
+                                                <Typography
+                                                    level="body1"
+                                                    semiBold
+                                                    className="flex min-w-0 items-center gap-1.5 break-words"
                                                 >
-                                                    <Typography
-                                                        level="body1"
-                                                        semiBold
-                                                        className="flex min-w-0 items-center gap-1.5 break-words"
-                                                    >
-                                                        <Image
-                                                            src="https://cdn.gredice.com/sunflower-large.svg"
-                                                            alt=""
-                                                            width={18}
-                                                            height={18}
-                                                            className="size-[18px] shrink-0"
-                                                        />
-                                                        <span className="min-w-0 break-words">
-                                                            {entry.name}
-                                                        </span>
-                                                    </Typography>
-                                                    <Typography
-                                                        level="body2"
-                                                        className="break-words"
-                                                    >
-                                                        Klikni za prikaz savjeta
-                                                        suncokreta
-                                                    </Typography>
-                                                </Stack>
-                                            </Row>
-                                            <Typography
-                                                level="body2"
-                                                noWrap
-                                                className="shrink-0 self-start sm:self-auto"
+                                                    <Image
+                                                        src="https://cdn.gredice.com/sunflower-large.svg"
+                                                        alt=""
+                                                        width={18}
+                                                        height={18}
+                                                        className="size-[18px] shrink-0"
+                                                    />
+                                                    <span className="min-w-0 break-words">
+                                                        {entry.name}
+                                                    </span>
+                                                </Typography>
+                                                <SavedAiDiaryEntryButton
+                                                    entry={entry}
+                                                    gardenId={gardenId}
+                                                />
+                                            </Stack>
+                                        </Row>
+                                        <Typography
+                                            level="body2"
+                                            noWrap
+                                            className="shrink-0 self-start sm:self-auto"
+                                        >
+                                            {entry.timestamp.toLocaleDateString(
+                                                'hr-HR',
+                                            )}
+                                        </Typography>
+                                    </Row>
+                                }
+                            />
+                        ) : (
+                            <ListItem
+                                className="max-w-full"
+                                label={
+                                    <Row
+                                        spacing={4}
+                                        className="w-full min-w-0 flex-col items-stretch justify-between font-normal sm:flex-row sm:items-start"
+                                    >
+                                        <Row
+                                            spacing={4}
+                                            className="min-w-0 flex-1 items-start"
+                                        >
+                                            <DiaryEntryImages
+                                                name={entry.name}
+                                                imageUrls={entry.imageUrls}
+                                                className={diaryEntryImagesClassName(
+                                                    entry.imageUrls,
+                                                )}
+                                            />
+                                            <Stack
+                                                className="min-w-0 flex-1"
+                                                data-diary-entry-content
                                             >
+                                                <Typography
+                                                    level="body1"
+                                                    semiBold
+                                                    className="break-words"
+                                                >
+                                                    {entry.name}
+                                                </Typography>
+                                                <Typography
+                                                    level="body2"
+                                                    className="break-words"
+                                                >
+                                                    {entry.description}
+                                                </Typography>
+                                                {entryAction && (
+                                                    <div className="mt-2 w-fit max-w-full">
+                                                        {entryAction}
+                                                    </div>
+                                                )}
+                                            </Stack>
+                                        </Row>
+                                        <Stack className="w-full min-w-0 items-start sm:w-auto sm:shrink-0 sm:items-end">
+                                            {entry.status && (
+                                                <Chip
+                                                    color={
+                                                        entry.status === 'Novo'
+                                                            ? 'warning'
+                                                            : entry.status ===
+                                                                'Završeno'
+                                                              ? 'success'
+                                                              : entry.status ===
+                                                                  'Planirano'
+                                                                ? 'info'
+                                                                : entry.status ===
+                                                                        'Neuspješno' ||
+                                                                    entry.status ===
+                                                                        'Otkazano'
+                                                                  ? 'error'
+                                                                  : 'neutral'
+                                                    }
+                                                    className="shrink-0 w-fit max-w-full self-start sm:self-end"
+                                                >
+                                                    {entry.status}
+                                                </Chip>
+                                            )}
+                                            <Typography level="body2" noWrap>
                                                 {entry.timestamp.toLocaleDateString(
                                                     'hr-HR',
                                                 )}
                                             </Typography>
-                                        </Row>
-                                    }
-                                />
-                            ) : (
-                                <ListItem
-                                    className="max-w-full"
-                                    label={
-                                        <Row
-                                            spacing={4}
-                                            className="w-full min-w-0 flex-col items-stretch justify-between font-normal sm:flex-row sm:items-start"
-                                        >
-                                            <Row
-                                                spacing={4}
-                                                className="min-w-0 flex-1 items-start"
-                                            >
-                                                <DiaryEntryImages
-                                                    name={entry.name}
-                                                    imageUrls={entry.imageUrls}
-                                                    className={diaryEntryImagesClassName(
-                                                        entry.imageUrls,
-                                                    )}
-                                                />
-                                                <Stack
-                                                    className="min-w-0 flex-1"
-                                                    data-diary-entry-content
-                                                >
-                                                    <Typography
-                                                        level="body1"
-                                                        semiBold
-                                                        className="break-words"
-                                                    >
-                                                        {entry.name}
-                                                    </Typography>
-                                                    <Typography
-                                                        level="body2"
-                                                        className="break-words"
-                                                    >
-                                                        {entry.description}
-                                                    </Typography>
-                                                    {entryAction && (
-                                                        <div className="mt-2 w-fit max-w-full">
-                                                            {entryAction}
-                                                        </div>
-                                                    )}
-                                                </Stack>
-                                            </Row>
-                                            <Stack className="w-full min-w-0 items-start sm:w-auto sm:shrink-0 sm:items-end">
-                                                {entry.status && (
-                                                    <Chip
-                                                        color={
-                                                            entry.status ===
-                                                            'Novo'
-                                                                ? 'warning'
-                                                                : entry.status ===
-                                                                    'Završeno'
-                                                                  ? 'success'
-                                                                  : entry.status ===
-                                                                      'Planirano'
-                                                                    ? 'info'
-                                                                    : entry.status ===
-                                                                            'Neuspješno' ||
-                                                                        entry.status ===
-                                                                            'Otkazano'
-                                                                      ? 'error'
-                                                                      : 'neutral'
-                                                        }
-                                                        className="shrink-0 w-fit max-w-full self-start sm:self-end"
-                                                    >
-                                                        {entry.status}
-                                                    </Chip>
-                                                )}
-                                                <Typography
-                                                    level="body2"
-                                                    noWrap
-                                                >
-                                                    {entry.timestamp.toLocaleDateString(
-                                                        'hr-HR',
-                                                    )}
-                                                </Typography>
-                                            </Stack>
-                                        </Row>
-                                    }
-                                />
-                            )}
-                        </div>
-                    );
-                })}
-            </List>
-            <Modal
-                open={expandedAiEntry !== null}
-                onOpenChange={(open) => {
-                    if (!open) setExpandedAiEntry(null);
-                }}
-                title={expandedAiEntry?.name ?? 'Savjeti suncokreta'}
-                className="md:max-w-3xl"
-            >
-                {expandedAiEntry && (
-                    <Stack spacing={4}>
-                        <DiaryEntryImages
-                            name={expandedAiEntry.name}
-                            imageUrls={expandedAiEntry.imageUrls}
-                        />
-                        <div className="prose prose-sm max-w-none dark:prose-invert">
-                            <RaisedBedAiOperationMarkdown gardenId={gardenId}>
-                                {expandedAiEntry.description ?? ''}
-                            </RaisedBedAiOperationMarkdown>
-                        </div>
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground text-right"
-                        >
-                            {expandedAiEntry.timestamp.toLocaleDateString(
-                                'hr-HR',
-                            )}
-                        </Typography>
-                    </Stack>
-                )}
-            </Modal>
-        </>
+                                        </Stack>
+                                    </Row>
+                                }
+                            />
+                        )}
+                    </div>
+                );
+            })}
+        </List>
     );
 }
 

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -13,6 +13,15 @@ export {
 } from './hud/raisedBed/featuredOperations';
 export { defaultLocalSandboxStorageKey } from './localSandboxGarden';
 export type {
+    OperationVisualRewardDebugBedState,
+    OperationVisualRewardDebugScenario,
+} from './operationVisualRewardDebugProfile';
+export {
+    isOperationVisualRewardDebugProfile,
+    operationVisualRewardDebugProfile,
+    operationVisualRewardDebugScenarios,
+} from './operationVisualRewardDebugProfile';
+export type {
     AppliedOperationVisualInput,
     OperationHistoryVisualInput,
     OperationVisualDefinitionInput,

--- a/packages/game/src/operationVisualRewardDebugProfile.ts
+++ b/packages/game/src/operationVisualRewardDebugProfile.ts
@@ -1,0 +1,334 @@
+import type { OperationData } from '@gredice/client';
+import type { GardenOperationItem } from './hooks/useGardenOperations';
+import type { OperationVisualRewardKind } from './operationVisualRewards';
+
+export const operationVisualRewardDebugProfile = 'operation-rewards';
+export const operationVisualRewardDebugTimestamp = '2024-06-21T10:00:00.000Z';
+export const operationVisualRewardDebugOlderTimestamp =
+    '2024-06-21T08:00:00.000Z';
+export const operationVisualRewardDebugNewerTimestamp =
+    '2024-06-21T09:30:00.000Z';
+
+export const operationVisualRewardDebugOperationIds = {
+    agrotextile: 9405,
+    harvest: 9408,
+    mulch: 9403,
+    photographyUpdate: 9409,
+    removeAgrotextile: 9406,
+    removeMulch: 9404,
+    supports: 9407,
+    watering: 9401,
+    weeding: 9402,
+} satisfies Record<OperationVisualRewardKind, number>;
+
+export type OperationVisualRewardDebugBedState = {
+    label: 'Before' | 'After';
+    raisedBedId: number;
+    state: string;
+};
+
+export type OperationVisualRewardDebugScenario = {
+    after: OperationVisualRewardDebugBedState;
+    before: OperationVisualRewardDebugBedState;
+    kind: OperationVisualRewardKind;
+    operationId: number;
+    title: string;
+};
+
+export const operationVisualRewardDebugScenarios = [
+    {
+        title: 'Watering',
+        kind: 'watering',
+        operationId: operationVisualRewardDebugOperationIds.watering,
+        before: {
+            label: 'Before',
+            raisedBedId: 101,
+            state: 'Dry baseline soil',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 102,
+            state: 'Moist darkened soil',
+        },
+    },
+    {
+        title: 'Weeding',
+        kind: 'weeding',
+        operationId: operationVisualRewardDebugOperationIds.weeding,
+        before: {
+            label: 'Before',
+            raisedBedId: 103,
+            state: 'Heavy visible weeds',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 104,
+            state: 'Clean soil after weeding',
+        },
+    },
+    {
+        title: 'Mulch',
+        kind: 'mulch',
+        operationId: operationVisualRewardDebugOperationIds.mulch,
+        before: {
+            label: 'Before',
+            raisedBedId: 105,
+            state: 'Bare soil',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 106,
+            state: 'Straw mulch layer',
+        },
+    },
+    {
+        title: 'Remove mulch',
+        kind: 'removeMulch',
+        operationId: operationVisualRewardDebugOperationIds.removeMulch,
+        before: {
+            label: 'Before',
+            raisedBedId: 107,
+            state: 'Existing straw layer',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 108,
+            state: 'Clean planting zone',
+        },
+    },
+    {
+        title: 'Agrotextile',
+        kind: 'agrotextile',
+        operationId: operationVisualRewardDebugOperationIds.agrotextile,
+        before: {
+            label: 'Before',
+            raisedBedId: 109,
+            state: 'Exposed bed',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 110,
+            state: 'Covered protected bed',
+        },
+    },
+    {
+        title: 'Remove agrotextile',
+        kind: 'removeAgrotextile',
+        operationId: operationVisualRewardDebugOperationIds.removeAgrotextile,
+        before: {
+            label: 'Before',
+            raisedBedId: 111,
+            state: 'Covered bed',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 112,
+            state: 'Visible plants again',
+        },
+    },
+    {
+        title: 'Supports',
+        kind: 'supports',
+        operationId: operationVisualRewardDebugOperationIds.supports,
+        before: {
+            label: 'Before',
+            raisedBedId: 113,
+            state: 'Unsupported plants',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 114,
+            state: 'Tied upright plants',
+        },
+    },
+    {
+        title: 'Harvest',
+        kind: 'harvest',
+        operationId: operationVisualRewardDebugOperationIds.harvest,
+        before: {
+            label: 'Before',
+            raisedBedId: 115,
+            state: 'Ripe plants',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 116,
+            state: 'Harvest crate and reduced ripe visuals',
+        },
+    },
+    {
+        title: 'Photo update',
+        kind: 'photographyUpdate',
+        operationId: operationVisualRewardDebugOperationIds.photographyUpdate,
+        before: {
+            label: 'Before',
+            raisedBedId: 117,
+            state: 'Old state without proof marker',
+        },
+        after: {
+            label: 'After',
+            raisedBedId: 118,
+            state: 'New proof photo marker',
+        },
+    },
+] satisfies OperationVisualRewardDebugScenario[];
+
+type OperationVisualRewardDebugOperationData = OperationData & {
+    attributes: OperationData['attributes'] & {
+        visualReward: OperationVisualRewardKind;
+    };
+};
+
+function debugOperation({
+    application,
+    id,
+    kind,
+    label,
+    name,
+}: {
+    application: string;
+    id: number;
+    kind: OperationVisualRewardKind;
+    label: string;
+    name: string;
+}): OperationVisualRewardDebugOperationData {
+    return {
+        id,
+        entityType: { id: 10, name: 'operation', label: 'Radnje' },
+        slug: `debug-${name}`,
+        attributes: {
+            frequency: 'once',
+            stage: {
+                id,
+                information: {
+                    name: 'debug',
+                    label: 'Debug',
+                },
+            },
+            application,
+            deliverable: false,
+            duration: 15,
+            visualReward: kind,
+        },
+        information: {
+            description: `${label} visual reward debug operation.`,
+            shortDescription: `${label} visual reward.`,
+            name,
+            label,
+            instructions: `${label} debug instruction.`,
+        },
+        prices: {
+            perOperation: 0,
+        },
+        image: { cover: { url: '' } },
+        conditions: {
+            completionAttachImages: kind === 'photographyUpdate',
+            completionAttachImagesRequired: kind === 'photographyUpdate',
+            completionAttachNotes: false,
+            completionAttachNotesRequired: false,
+        },
+        createdAt: operationVisualRewardDebugTimestamp,
+        updatedAt: operationVisualRewardDebugTimestamp,
+    };
+}
+
+export const operationVisualRewardDebugOperationDefinitions = [
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.watering,
+        kind: 'watering',
+        name: 'debugWateringReward',
+        label: 'Debug watering reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.weeding,
+        kind: 'weeding',
+        name: 'debugWeedingReward',
+        label: 'Debug weeding reward',
+        application: 'plant',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.mulch,
+        kind: 'mulch',
+        name: 'debugMulchReward',
+        label: 'Debug mulch reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.removeMulch,
+        kind: 'removeMulch',
+        name: 'debugRemoveMulchReward',
+        label: 'Debug remove mulch reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.agrotextile,
+        kind: 'agrotextile',
+        name: 'debugAgrotextileReward',
+        label: 'Debug agrotextile reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.removeAgrotextile,
+        kind: 'removeAgrotextile',
+        name: 'debugRemoveAgrotextileReward',
+        label: 'Debug remove agrotextile reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.supports,
+        kind: 'supports',
+        name: 'debugSupportsReward',
+        label: 'Debug supports reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.harvest,
+        kind: 'harvest',
+        name: 'debugHarvestReward',
+        label: 'Debug harvest reward',
+        application: 'raisedBedFull',
+    }),
+    debugOperation({
+        id: operationVisualRewardDebugOperationIds.photographyUpdate,
+        kind: 'photographyUpdate',
+        name: 'debugPhotographyUpdateReward',
+        label: 'Debug photo update reward',
+        application: 'raisedBedFull',
+    }),
+] satisfies OperationVisualRewardDebugOperationData[];
+
+export const operationVisualRewardDebugOperationItems = [
+    {
+        id: 9601,
+        entityId: operationVisualRewardDebugOperationIds.photographyUpdate,
+        entityTypeName: 'operation',
+        raisedBedId: 118,
+        raisedBedFieldId: null,
+        status: 'completed',
+        createdAt: operationVisualRewardDebugOlderTimestamp,
+        scheduledDate: null,
+        scheduledAt: null,
+        completedAt: operationVisualRewardDebugNewerTimestamp,
+        verifiedAt: operationVisualRewardDebugNewerTimestamp,
+        canceledAt: null,
+        imageUrls: [
+            'https://cdn.gredice.com/debug/operation-reward-proof-1.jpg',
+            'https://cdn.gredice.com/debug/operation-reward-proof-2.jpg',
+        ],
+        completionNotes: 'Debug proof photos for operation reward marker.',
+        targetLabel: 'Raised bed 118',
+        statusHistory: [
+            {
+                status: 'completed',
+                changedAt: operationVisualRewardDebugNewerTimestamp,
+            },
+        ],
+    },
+] satisfies GardenOperationItem[];
+
+export function isOperationVisualRewardDebugProfile(
+    value: string | null | undefined,
+) {
+    return value === operationVisualRewardDebugProfile;
+}

--- a/packages/game/src/operationVisualRewards.unit.ts
+++ b/packages/game/src/operationVisualRewards.unit.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    operationVisualRewardDebugOperationDefinitions,
+    operationVisualRewardDebugScenarios,
+} from './operationVisualRewardDebugProfile';
+import {
     type AppliedOperationVisualInput,
     filterOperationVisualRewards,
     type OperationHistoryVisualInput,
@@ -180,6 +184,38 @@ describe('operation visual reward kind mapping', () => {
                 }),
             ),
             null,
+        );
+    });
+});
+
+describe('operation visual reward debug profile', () => {
+    it('covers every supported reward kind through explicit attributes', () => {
+        const expectedKinds = operationVisualRewardDebugScenarios
+            .map((scenario) => scenario.kind)
+            .sort();
+        const resolvedKinds = operationVisualRewardDebugOperationDefinitions
+            .map(resolveOperationVisualRewardKind)
+            .filter((kind): kind is OperationVisualRewardKind => kind !== null)
+            .sort();
+
+        assert.deepStrictEqual(resolvedKinds, expectedKinds);
+        assert.deepStrictEqual(
+            operationVisualRewardDebugScenarios.map((scenario) => ({
+                after: scenario.after.raisedBedId,
+                before: scenario.before.raisedBedId,
+                kind: scenario.kind,
+                operationId: scenario.operationId,
+            })),
+            operationVisualRewardDebugOperationDefinitions.map((operation) => ({
+                after: operationVisualRewardDebugScenarios.find(
+                    (scenario) => scenario.operationId === operation.id,
+                )?.after.raisedBedId,
+                before: operationVisualRewardDebugScenarios.find(
+                    (scenario) => scenario.operationId === operation.id,
+                )?.before.raisedBedId,
+                kind: resolveOperationVisualRewardKind(operation),
+                operationId: operation.id,
+            })),
         );
     });
 });

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -44,7 +44,11 @@ import {
 } from './utils/weather';
 
 export type WinterMode = 'summer' | 'winter' | 'holiday';
-export type MockGardenProfile = 'default' | 'dense' | 'plant-heavy';
+export type MockGardenProfile =
+    | 'default'
+    | 'dense'
+    | 'operation-rewards'
+    | 'plant-heavy';
 
 export type ActiveDragPreview = {
     source: ActiveDragPreviewTarget;

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -1,5 +1,10 @@
 import type { GameBackgroundPaletteKey } from '@gredice/js/gameBackground';
-import { createContext, useContext, useEffect } from 'react';
+import {
+    createContext,
+    useContext,
+    useEffect,
+    useSyncExternalStore,
+} from 'react';
 import { createStore, useStore } from 'zustand';
 import { createGameAudio, type GameAudio } from './audio/audioMixer';
 import type {
@@ -603,6 +608,7 @@ export function createGameState({
 
 export type GameStateStore = ReturnType<typeof createGameState>;
 export const GameStateContext = createContext<GameStateStore | null>(null);
+const emptySubscribe = () => () => {};
 const pendingStoreDisposals = new WeakMap<
     GameStateStore,
     ReturnType<typeof setTimeout>
@@ -639,4 +645,17 @@ export function useGameState<T>(selector: (state: GameState) => T): T {
     if (!store)
         throw new Error('Missing GameStateContext.Provider in the tree');
     return useStore(store, selector);
+}
+
+export function useOptionalGameState<T>(
+    selector: (state: GameState) => T,
+    fallback: T,
+): T {
+    const store = useContext(GameStateContext);
+
+    return useSyncExternalStore(
+        store?.subscribe ?? emptySubscribe,
+        () => (store ? selector(store.getState()) : fallback),
+        () => fallback,
+    );
 }


### PR DESCRIPTION
## Summary
- add a repo-owned QA matrix for every operation visual reward family
- add `/debug/profile/game?profile=operation-rewards&details=1&quality=medium` with paired before/after raised beds for watering, weeding, mulch, remove mulch, agrotextile, remove agrotextile, supports, harvest, and photo update
- seed the debug profile from explicit `attributes.visualReward` mock operations and mock operation history so it exercises the production resolver contract
- add screenshot capture support and a `rewards` scenario to the game profile script for visual PR attachments
- document the corrections that watering uses moist soil instead of droplets and photography uses existing operation photos

Linear: https://linear.app/gredice/issue/GRE-493
Stacked on: #3345
Closes #3328

## Validation
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game test`
- `pnpm --filter garden lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build`
- `pnpm --filter garden profile:game:start -- --scenario-set rewards --screenshots --warmup-ms 3000 --sample-ms 1000`
- `git diff --check`
