### PR TITLE
[codex] Prevent underwater foliage spawning

### DIFF
--- a/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
@@ -17,7 +17,7 @@ import {
     GroundDecorationInstances,
 } from './GroundDecorationInstances';
 import { getBlockSurfaceDecorations } from './getBlockSurfaceDecorations';
-import { resolveGroundDecorationSurface } from './groundDecorationConfig';
+import { getGroundDecorationBlocks } from './groundDecorationBlocks';
 
 const blockSurfaceYOffset = 0.2;
 type GroundBlockDecorationsProps = {
@@ -40,13 +40,8 @@ export function GroundBlockDecorations({
             return [];
         }
 
-        return stacks.flatMap((stack) =>
-            stack.blocks.flatMap((block, blockIndex) => {
-                const surface = resolveGroundDecorationSurface(block.name);
-                if (!surface) {
-                    return [];
-                }
-
+        return getGroundDecorationBlocks(stacks).flatMap(
+            ({ block, blockIndex, stack, surface }) => {
                 const placements = getBlockSurfaceDecorations({
                     block,
                     density,
@@ -67,7 +62,7 @@ export function GroundBlockDecorations({
                         surface,
                     },
                 ];
-            }),
+            },
         );
     }, [density, garden?.id, stacks]);
     const decoratedBlockPreviewKeys = useMemo(

--- a/packages/game/src/entities/groundDecorations/groundDecorationBlocks.ts
+++ b/packages/game/src/entities/groundDecorations/groundDecorationBlocks.ts
@@ -1,0 +1,48 @@
+import type { Block } from '../../types/Block';
+import type { Stack } from '../../types/Stack';
+import { waterBlockName } from '../waterBlockFoam';
+import {
+    type GroundDecorationSurface,
+    resolveGroundDecorationSurface,
+} from './groundDecorationConfig';
+
+export type GroundDecorationBlock = {
+    block: Block;
+    blockIndex: number;
+    stack: Stack;
+    surface: GroundDecorationSurface;
+};
+
+function hasWaterBlockAbove(stack: Stack, blockIndex: number) {
+    for (let index = blockIndex + 1; index < stack.blocks.length; index += 1) {
+        if (stack.blocks[index]?.name === waterBlockName) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function getGroundDecorationBlocks(stacks: Stack[] | undefined) {
+    if (!stacks) {
+        return [] as GroundDecorationBlock[];
+    }
+
+    return stacks.flatMap((stack) =>
+        stack.blocks.flatMap((block, blockIndex) => {
+            const surface = resolveGroundDecorationSurface(block.name);
+            if (!surface || hasWaterBlockAbove(stack, blockIndex)) {
+                return [];
+            }
+
+            return [
+                {
+                    block,
+                    blockIndex,
+                    stack,
+                    surface,
+                },
+            ];
+        }),
+    );
+}

--- a/packages/game/src/entities/groundDecorations/groundDecorationBlocks.unit.ts
+++ b/packages/game/src/entities/groundDecorations/groundDecorationBlocks.unit.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../../types/Block';
+import type { Stack } from '../../types/Stack';
+import { getGroundDecorationBlocks } from './groundDecorationBlocks';
+
+function block(id: string, name: string): Block {
+    return { id, name, rotation: 0 };
+}
+
+function stack(blocks: Block[]): Stack {
+    return {
+        position: new Vector3(0, 0, 0),
+        blocks,
+    };
+}
+
+test('skips grass and sand decoration blocks covered by water', () => {
+    const grass = block('grass-low', 'Block_Grass');
+    const sand = block('sand-middle', 'Block_Sand');
+    const water = block('water-top', 'Block_Water');
+
+    const decorationBlocks = getGroundDecorationBlocks([
+        stack([grass, sand, water]),
+    ]);
+
+    assert.deepEqual(
+        decorationBlocks.map(
+            ({ block: decorationBlock }) => decorationBlock.id,
+        ),
+        [],
+    );
+});
+
+test('keeps grass and sand decoration blocks when water is lower in the stack', () => {
+    const water = block('water-low', 'Block_Water');
+    const grass = block('grass-top', 'Block_Grass');
+    const sand = block('sand-top', 'Block_Sand');
+
+    const decorationBlocks = getGroundDecorationBlocks([
+        stack([water, grass, sand]),
+    ]);
+
+    assert.deepEqual(
+        decorationBlocks.map(
+            ({ block: decorationBlock }) => decorationBlock.id,
+        ),
+        ['grass-top', 'sand-top'],
+    );
+});


### PR DESCRIPTION
## Summary
- Skip grass and sand ground-decoration candidates when a higher block in the same stack is `Block_Water`.
- Add a focused unit test covering water-covered grass/sand and water below a surface block.

## Root cause
The ground-decoration renderer decorated every grass or sand block in a stack without checking whether water was stacked above it, so foliage could appear underwater.

## Validation
- `pnpm --filter @gredice/game exec tsx --test src/entities/groundDecorations/groundDecorationBlocks.unit.ts src/entities/groundDecorations/getBlockSurfaceDecorations.unit.ts`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `git diff --check`