### PR TITLE
[codex] Prevent auto game quality from using low

### DIFF
--- a/packages/game/src/scene/gameQuality.ts
+++ b/packages/game/src/scene/gameQuality.ts
@@ -1,6 +1,7 @@
 'use client';
 
 export type GameQualityTier = 'low' | 'medium' | 'high';
+type GameQualityAutoTier = Exclude<GameQualityTier, 'low'>;
 export type GameQualityProfileTier = GameQualityTier | 'custom';
 export type GameQualitySetting = GameQualityTier | 'auto' | 'custom';
 export type GameCloudShadowMode = 'hard' | 'soft';
@@ -65,6 +66,10 @@ export const gameQualityProfiles = {
 const GAME_QUALITY_SETTING_STORAGE_KEY = 'game-quality-setting';
 const GAME_QUALITY_CUSTOM_PROFILE_STORAGE_KEY = 'game-quality-custom-profile';
 const shadowMapSizeOptions = [1024, 2048, 4096];
+const autoGameQualityTiers = {
+    constrained: 'medium',
+    standard: 'medium',
+} satisfies Record<'constrained' | 'standard', GameQualityAutoTier>;
 let cachedGameQualitySetting: GameQualitySetting | undefined;
 let cachedGameQualityCustomProfile: GameQualityCustomProfile | undefined;
 
@@ -255,9 +260,9 @@ export function getGameQualityAutoProfileMetrics():
 
 function resolveAutoGameQualityTier(
     metrics = getGameQualityAutoProfileMetrics(),
-): GameQualityTier {
+): GameQualityAutoTier {
     if (metrics === undefined) {
-        return 'medium';
+        return autoGameQualityTiers.standard;
     }
 
     if (
@@ -269,10 +274,10 @@ function resolveAutoGameQualityTier(
             metrics.coreCount <= 4 &&
             metrics.dpr > 1.25)
     ) {
-        return 'low';
+        return autoGameQualityTiers.constrained;
     }
 
-    return 'medium';
+    return autoGameQualityTiers.standard;
 }
 
 export function resolveGameQualityProfile(

--- a/packages/game/src/scene/gameQuality.unit.ts
+++ b/packages/game/src/scene/gameQuality.unit.ts
@@ -29,7 +29,11 @@ test('custom quality profile resolves all adjustable fields', () => {
     });
 });
 
-test('auto quality profile can resolve from supplied device metrics', () => {
+test('manual low quality profile resolves the low tier', () => {
+    assert.equal(resolveGameQualityProfile('low'), gameQualityProfiles.low);
+});
+
+test('auto quality profile never resolves low from supplied device metrics', () => {
     assert.equal(
         resolveGameQualityProfile('auto', undefined, {
             coarsePointer: false,
@@ -48,6 +52,6 @@ test('auto quality profile can resolve from supplied device metrics', () => {
             memoryGb: 8,
             narrowViewport: true,
         }),
-        gameQualityProfiles.low,
+        gameQualityProfiles.medium,
     );
 });


### PR DESCRIPTION
## Summary

- prevent automatic game quality resolution from selecting the `low` profile
- keep the manual `low` setting available when explicitly selected
- add unit coverage for both the manual-low and auto-not-low contracts

## Validation

- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `git diff --check`