### PR TITLE
Tune game twilight lighting

### DIFF
--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -23,6 +23,7 @@ import { useGameState } from '../useGameState';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
 import type { GameCloudShadowMode } from './gameQuality';
 import { useSceneTimeInvalidation } from './SceneTime';
+import { getVisualDaylightAmount, smoothstep } from './visualDayNight';
 
 const MAX_CLOUDS = 8;
 const CLOUD_ALPHA_TEST = 0.025;
@@ -45,11 +46,6 @@ const CLOUD_RENDER_ORDER = 30;
 const CLOUD_SHADOW_CASTER_BASE_ALPHA_TEST = 0.2;
 const CLOUD_SHADOW_CASTER_HARD_ALPHA_TEST = 0.08;
 const CLOUD_SHADOW_CASTER_SOFT_ALPHA_TEST = 0.02;
-
-function smoothstep(edge0: number, edge1: number, value: number) {
-    const t = Math.min(1, Math.max(0, (value - edge0) / (edge1 - edge0)));
-    return t * t * (3 - 2 * t);
-}
 
 function seededRandom(seed: number) {
     const value = Math.sin(seed * 12.9898) * 43758.5453;
@@ -272,10 +268,7 @@ export function CloudLayer({
         spawnHalfZ: 8,
     });
     const effectiveCloudiness = Math.min(1, cloudy + foggy * 0.35);
-    const daylightVisibility = Math.min(
-        smoothstep(0.18, 0.28, timeOfDay),
-        1 - smoothstep(0.72, 0.82, timeOfDay),
-    );
+    const daylightVisibility = getVisualDaylightAmount(timeOfDay);
     const visibleCloudiness = daylightVisibility * effectiveCloudiness;
 
     const visibleCloudCount =

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -24,11 +24,18 @@ import { ShadowMapController } from './ShadowMapController';
 import Snow from './Snow/Snow';
 import { Stars } from './Stars';
 import { SunMoon } from './SunMoon';
+import {
+    getVisualDaylightAmount,
+    getVisualNightAmount,
+    smoothstep,
+    visualDayNightTimes,
+} from './visualDayNight';
 import { resolveWaterColors } from './waterColors';
 
 const backgroundColorScale = chroma
     .scale([
         '#2D3947',
+        '#6f8cac',
         '#BADDf6',
         '#E7E2CC',
         '#E7E2CC',
@@ -36,7 +43,16 @@ const backgroundColorScale = chroma
         '#6c5b7b',
         '#2D3947',
     ])
-    .domain([0.2, 0.225, 0.25, 0.75, 0.765, 0.785, 0.8]);
+    .domain([
+        visualDayNightTimes.dawnNightEnd,
+        visualDayNightTimes.sunrise,
+        visualDayNightTimes.dayStart - 0.03,
+        visualDayNightTimes.dayStart,
+        visualDayNightTimes.lateDayStart,
+        visualDayNightTimes.sunset,
+        0.84,
+        visualDayNightTimes.nightStart,
+    ]);
 const sunTemperatureScale = chroma
     .scale([
         chroma.temperature(20000),
@@ -46,10 +62,14 @@ const sunTemperatureScale = chroma
         chroma.temperature(2000),
         chroma.temperature(20000),
     ])
-    .domain([0.2, 0.25, 0.775, 0.8]);
-const sunIntensityTimeScale = chroma
-    .scale(['black', 'white', 'white', 'black'])
-    .domain([0.2, 0.225, 0.75, 0.81]);
+    .domain([
+        visualDayNightTimes.dawnNightEnd,
+        visualDayNightTimes.dawnLightEnd,
+        visualDayNightTimes.dayStart,
+        visualDayNightTimes.lateDayStart,
+        visualDayNightTimes.duskNightStart,
+        visualDayNightTimes.nightStart,
+    ]);
 const hemisphereSkyColorScale = chroma
     .scale([
         chroma.temperature(20000),
@@ -59,7 +79,14 @@ const hemisphereSkyColorScale = chroma
         chroma.temperature(2000),
         chroma.temperature(20000),
     ])
-    .domain([0.2, 0.25, 0.3, 0.75, 0.8, 0.85]);
+    .domain([
+        visualDayNightTimes.dawnNightEnd,
+        visualDayNightTimes.dawnLightEnd,
+        visualDayNightTimes.dayStart,
+        visualDayNightTimes.lateDayStart,
+        visualDayNightTimes.duskNightStart,
+        visualDayNightTimes.nightStart,
+    ]);
 
 type WeatherBlendConfig = {
     transitionSeconds: number;
@@ -253,13 +280,6 @@ function useBlendedWeather(
     return blendedWeather;
 }
 
-const STAR_NIGHT_VISIBILITY = {
-    dawnFadeStart: 0.2,
-    dayStart: 0.25,
-    duskStart: 0.75,
-    nightStart: 0.8,
-};
-
 export function timeOfDayToDate(currentTime: Date, timeOfDay: number) {
     const hours = Math.trunc(timeOfDay * 24);
     const minutes = Math.trunc((timeOfDay * 24 - hours) * 60);
@@ -297,18 +317,6 @@ function getSunPosition(
     return altAzToScenePosition(altitude, azimuth);
 }
 
-function smoothstep(edge0: number, edge1: number, value: number) {
-    const t = Math.min(1, Math.max(0, (value - edge0) / (edge1 - edge0)));
-    return t * t * (3 - 2 * t);
-}
-
-function daylightBlend(timeOfDay: number) {
-    return Math.min(
-        smoothstep(0.2, 0.3, timeOfDay),
-        1 - smoothstep(0.72, 0.82, timeOfDay),
-    );
-}
-
 function resolveThemedBackground({
     backgroundPaletteIndex,
     timeOfDay,
@@ -322,7 +330,7 @@ function resolveThemedBackground({
         return null;
     }
 
-    const daylight = daylightBlend(timeOfDay);
+    const daylight = getVisualDaylightAmount(timeOfDay);
 
     return {
         background: chroma
@@ -346,7 +354,7 @@ export function environmentState(
         hemisphereSkyColor: hemisphereSkyColorScale(timeOfDay).rgb(),
     };
     const intensities = {
-        sun: sunIntensityTimeScale(timeOfDay).get('rgb.r') / 255,
+        sun: getVisualDaylightAmount(timeOfDay),
     };
     return { timeOfDay, sunPosition, colors, intensities };
 }
@@ -920,10 +928,9 @@ export function Environment({
     // Handle fog
     const fog = blendedWeather?.foggy ?? 0;
     const fogNear = 170 - fog * 30;
+    const nightVisibility = getVisualNightAmount(timeOfDay);
     const fogColor =
-        timeOfDay > 0.2 && timeOfDay < 0.8
-            ? new Color(0xaaaaaa)
-            : new Color(0x55556a);
+        nightVisibility < 0.5 ? new Color(0xaaaaaa) : new Color(0x55556a);
 
     // Handle rain
     const rain = blendedWeather?.rainy ?? 0;
@@ -958,25 +965,6 @@ export function Environment({
         weatherDisabled,
     ]);
 
-    const dawnVisibility =
-        timeOfDay <= STAR_NIGHT_VISIBILITY.dawnFadeStart
-            ? 1
-            : timeOfDay >= STAR_NIGHT_VISIBILITY.dayStart
-              ? 0
-              : 1 -
-                (timeOfDay - STAR_NIGHT_VISIBILITY.dawnFadeStart) /
-                    (STAR_NIGHT_VISIBILITY.dayStart -
-                        STAR_NIGHT_VISIBILITY.dawnFadeStart);
-    const duskVisibility =
-        timeOfDay <= STAR_NIGHT_VISIBILITY.duskStart
-            ? 0
-            : timeOfDay >= STAR_NIGHT_VISIBILITY.nightStart
-              ? 1
-              : (timeOfDay - STAR_NIGHT_VISIBILITY.duskStart) /
-                (STAR_NIGHT_VISIBILITY.nightStart -
-                    STAR_NIGHT_VISIBILITY.duskStart);
-    const nightVisibility = Math.max(dawnVisibility, duskVisibility);
-
     // Light clouds keep only a few faint bright stars visible, but only at
     // night or during twilight transitions.
     const cloudCover = blendedWeather?.cloudy ?? 1;
@@ -994,10 +982,7 @@ export function Environment({
     const bodyVisibility = weatherDisabled
         ? 1
         : Math.max(0.05, (1 - obstruction) ** 2);
-    const daylightVisibility = Math.min(
-        smoothstep(0.18, 0.28, timeOfDay),
-        1 - smoothstep(0.72, 0.82, timeOfDay),
-    );
+    const daylightVisibility = getVisualDaylightAmount(timeOfDay);
     const shadowVisibility = weatherDisabled
         ? 1
         : Math.max(
@@ -1111,8 +1096,7 @@ export function Environment({
                 (blendedWeather?.rainy ?? 0) * 0.3 +
                 (blendedWeather?.cloudy ?? 0) * 0.2,
         );
-        const nightFactor =
-            0.2 + Math.max(dawnVisibility, duskVisibility) * 0.6;
+        const nightFactor = 0.2 + nightVisibility * 0.6;
         const flashStrength = Math.min(
             1,
             0.35 + stormStrength * 0.45 + nightFactor,
@@ -1154,8 +1138,7 @@ export function Environment({
         blendedWeather?.cloudy,
         blendedWeather?.rainy,
         actualWeather?.thundery,
-        dawnVisibility,
-        duskVisibility,
+        nightVisibility,
         weatherDisabled,
     ]);
 

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -17,6 +17,7 @@ import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useGameState } from '../useGameState';
 import { altAzToScenePosition, timeOfDayToDate } from './Environment';
+import { visualDayNightTimes } from './visualDayNight';
 
 // World-space size of the billboard planes. The visible disc is a fraction of
 // this (see shader), leaving room around the disc for the soft glow to fade to
@@ -101,7 +102,14 @@ const sunColorScale = chroma
         chroma.temperature(3500),
         chroma.temperature(2200),
     ])
-    .domain([0.2, 0.23, 0.28, 0.72, 0.77, 0.8]);
+    .domain([
+        visualDayNightTimes.sunrise,
+        visualDayNightTimes.dawnLightEnd,
+        visualDayNightTimes.dayStart,
+        0.72,
+        visualDayNightTimes.sunset,
+        visualDayNightTimes.nightStart,
+    ]);
 
 function smoothstep(edge0: number, edge1: number, x: number) {
     const t = Math.min(1, Math.max(0, (x - edge0) / (edge1 - edge0)));

--- a/packages/game/src/scene/moonlight.ts
+++ b/packages/game/src/scene/moonlight.ts
@@ -1,14 +1,8 @@
 import SunCalc from 'suncalc';
+import { getVisualNightAmount, smoothstep } from './visualDayNight';
 
 const MOONLESS_NIGHT_LIGHT_SCALE = 0.32;
 const MOONLESS_NIGHT_SKY_SCALE = 0.6;
-
-const NIGHT_VISIBILITY = {
-    dawnFadeStart: 0.2,
-    dayStart: 0.25,
-    duskStart: 0.75,
-    nightStart: 0.8,
-};
 
 const MOON_HORIZON_FADE = {
     start: -0.05,
@@ -19,29 +13,12 @@ function clamp01(value: number) {
     return Math.min(1, Math.max(0, value));
 }
 
-function smoothstep(edge0: number, edge1: number, value: number) {
-    const t = clamp01((value - edge0) / (edge1 - edge0));
-    return t * t * (3 - 2 * t);
-}
-
 function mix(from: number, to: number, amount: number) {
     return from + (to - from) * amount;
 }
 
 export function getNightAmount(timeOfDay: number) {
-    const dawnAmount =
-        1 -
-        smoothstep(
-            NIGHT_VISIBILITY.dawnFadeStart,
-            NIGHT_VISIBILITY.dayStart,
-            timeOfDay,
-        );
-    const duskAmount = smoothstep(
-        NIGHT_VISIBILITY.duskStart,
-        NIGHT_VISIBILITY.nightStart,
-        timeOfDay,
-    );
-    return Math.max(dawnAmount, duskAmount);
+    return getVisualNightAmount(timeOfDay);
 }
 
 export function resolveMoonlitNightScales({

--- a/packages/game/src/scene/moonlight.unit.ts
+++ b/packages/game/src/scene/moonlight.unit.ts
@@ -39,12 +39,21 @@ test('moonlit night scales leave daylight unchanged', () => {
 });
 
 test('night amount blends through dusk', () => {
-    assert.equal(round(getNightAmount(0.75)), 0);
-    assert.equal(round(getNightAmount(0.8)), 1);
+    assert.equal(round(getNightAmount(0.8)), 0);
+    assert.equal(round(getNightAmount(0.88)), 1);
 
-    const twilight = getNightAmount(0.775);
+    const twilight = getNightAmount(0.85);
     assert.ok(twilight > 0);
     assert.ok(twilight < 1);
+});
+
+test('night amount fades before sunrise', () => {
+    assert.equal(round(getNightAmount(0.14)), 1);
+    assert.equal(round(getNightAmount(0.24)), 0);
+
+    const sunrise = getNightAmount(0.2);
+    assert.ok(sunrise > 0);
+    assert.ok(sunrise < 0.5);
 });
 
 test('moonlit night scales clamp moonlight input', () => {

--- a/packages/game/src/scene/visualDayNight.ts
+++ b/packages/game/src/scene/visualDayNight.ts
@@ -1,0 +1,53 @@
+export const visualDayNightTimes = {
+    dawnNightEnd: 0.14,
+    dawnLightStart: 0.16,
+    sunrise: 0.2,
+    dawnLightEnd: 0.24,
+    dayStart: 0.28,
+    lateDayStart: 0.75,
+    sunset: 0.8,
+    duskNightStart: 0.82,
+    nightStart: 0.88,
+};
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+export function smoothstep(edge0: number, edge1: number, value: number) {
+    const t = clamp01((value - edge0) / (edge1 - edge0));
+    return t * t * (3 - 2 * t);
+}
+
+export function getVisualDaylightAmount(timeOfDay: number) {
+    return Math.min(
+        smoothstep(
+            visualDayNightTimes.dawnLightStart,
+            visualDayNightTimes.dayStart,
+            timeOfDay,
+        ),
+        1 -
+            smoothstep(
+                visualDayNightTimes.sunset,
+                visualDayNightTimes.nightStart,
+                timeOfDay,
+            ),
+    );
+}
+
+export function getVisualNightAmount(timeOfDay: number) {
+    const dawnAmount =
+        1 -
+        smoothstep(
+            visualDayNightTimes.dawnNightEnd,
+            visualDayNightTimes.dawnLightEnd,
+            timeOfDay,
+        );
+    const duskAmount = smoothstep(
+        visualDayNightTimes.duskNightStart,
+        visualDayNightTimes.nightStart,
+        timeOfDay,
+    );
+
+    return Math.max(dawnAmount, duskAmount);
+}

--- a/packages/game/src/scene/visualDayNight.unit.ts
+++ b/packages/game/src/scene/visualDayNight.unit.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getVisualDaylightAmount,
+    getVisualNightAmount,
+} from './visualDayNight';
+
+function round(value: number) {
+    return Number(value.toFixed(6));
+}
+
+test('keeps visual daylight through sunset', () => {
+    assert.equal(round(getVisualDaylightAmount(0.79)), 1);
+    assert.equal(round(getVisualDaylightAmount(0.8)), 1);
+    assert.equal(round(getVisualNightAmount(0.8)), 0);
+});
+
+test('fades to night after sunset', () => {
+    const twilightDaylight = getVisualDaylightAmount(0.84);
+    const twilightNight = getVisualNightAmount(0.85);
+
+    assert.ok(twilightDaylight > 0);
+    assert.ok(twilightDaylight < 1);
+    assert.ok(twilightNight > 0);
+    assert.ok(twilightNight < 1);
+    assert.equal(round(getVisualDaylightAmount(0.88)), 0);
+    assert.equal(round(getVisualNightAmount(0.88)), 1);
+});
+
+test('brings in dawn light before sunrise', () => {
+    assert.equal(round(getVisualNightAmount(0.14)), 1);
+    assert.ok(getVisualDaylightAmount(0.2) > 0.2);
+    assert.ok(getVisualNightAmount(0.2) < 0.5);
+    assert.equal(round(getVisualNightAmount(0.24)), 0);
+});

--- a/packages/game/src/sprites/spriteLighting.ts
+++ b/packages/game/src/sprites/spriteLighting.ts
@@ -1,30 +1,16 @@
+import { getVisualDaylightAmount } from '../scene/visualDayNight';
+
 export type SpriteLightingWeather = {
     cloudy: number;
     foggy: number;
     rainy: number;
 };
 
-function getSunlightFactor(timeOfDay: number) {
-    if (timeOfDay <= 0.2 || timeOfDay >= 0.81) {
-        return 0;
-    }
-
-    if (timeOfDay < 0.225) {
-        return (timeOfDay - 0.2) / 0.025;
-    }
-
-    if (timeOfDay <= 0.75) {
-        return 1;
-    }
-
-    return 1 - (timeOfDay - 0.75) / 0.06;
-}
-
 export function getSpriteBrightness(
     timeOfDay: number,
     weather: SpriteLightingWeather | undefined,
 ) {
-    const daylightFactor = getSunlightFactor(timeOfDay);
+    const daylightFactor = getVisualDaylightAmount(timeOfDay);
     const cloudy = weather?.cloudy ?? 0;
     const foggy = weather?.foggy ?? 0;
     const rainy = weather?.rainy ?? 0;


### PR DESCRIPTION
## Summary
- Adds a shared visual day/night curve so the scene stays lit through actual sunset and fades after it.
- Applies the curve to scene lighting, themed backgrounds, clouds, sprite brightness, moonlight/star visibility, fog color, and sun disc color.
- Adds unit coverage for the new twilight daylight/night transitions.

## Validation
- pnpm --filter @gredice/game lint
- pnpm --filter @gredice/game test
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden typecheck
- pnpm --filter www typecheck
- Local visual smoke check on /debug/profile/game at 20:35 mobile and desktop; screenshots saved under /tmp/gredice-twilight-clean-*.png. The API app was not running, so the garden dev server logged expected API proxy ECONNREFUSED noise while the mock scene rendered.