### PR TITLE
[codex] Reduce AI plant history context

### DIFF
--- a/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.node.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    buildPastPlantFieldsContext,
     getRaisedBedImageAnalysisWeeklyLimit,
     getWeatherHistoryDayRange,
     normalizeAnalysisReferenceDate,
@@ -28,4 +29,38 @@ test('getWeatherHistoryDayRange resolves the Zagreb local weather day', () => {
     assert.strictEqual(range.date, '2026-05-12');
     assert.strictEqual(range.from.toISOString(), '2026-05-11T22:00:00.000Z');
     assert.strictEqual(range.to.toISOString(), '2026-05-12T21:59:59.999Z');
+});
+
+test('buildPastPlantFieldsContext summarizes only previous plant names', () => {
+    const context = buildPastPlantFieldsContext(
+        [
+            {
+                positionIndex: 0,
+                plantCycles: [
+                    { plantSortId: 101, active: false },
+                    { plantSortId: 102, active: false },
+                    { plantSortId: 101, active: false },
+                    { plantSortId: 103, active: true },
+                ],
+            },
+            {
+                positionIndex: 1,
+                plantCycles: [{ plantSortId: 104, active: true }],
+            },
+        ],
+        new Map([
+            [101, 'Tomato'],
+            [102, 'Lettuce'],
+            [103, 'Basil'],
+            [104, 'Carrot'],
+        ]),
+    );
+
+    assert.deepStrictEqual(context, [
+        {
+            positionIndex: 0,
+            positionLabel: 1,
+            plantNames: ['Tomato', 'Lettuce'],
+        },
+    ]);
 });

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -116,7 +116,17 @@ type RaisedBedAnalysisTarget = {
         sowingLocation?: 'direct' | 'greenhouse' | string | null;
         toBeRemoved?: boolean | null;
         active?: boolean | null;
+        plantCycles?: Array<{
+            plantSortId?: number | string | null;
+            active?: boolean | null;
+        }> | null;
     }>;
+};
+
+export type PastPlantFieldContext = {
+    positionIndex: number;
+    positionLabel: number;
+    plantNames: string[];
 };
 
 type WeatherDayContext = {
@@ -176,6 +186,60 @@ type WeatherContext = {
 
 function toPositionLabel(positionIndex: number) {
     return positionIndex + 1;
+}
+
+function plantSortContextName(
+    plantSortNameById: Map<number, string>,
+    plantSortId: number | string,
+) {
+    const numericPlantSortId = Number(plantSortId);
+
+    return Number.isFinite(numericPlantSortId)
+        ? (plantSortNameById.get(numericPlantSortId) ?? String(plantSortId))
+        : String(plantSortId);
+}
+
+export function buildPastPlantFieldsContext(
+    fields: Array<{
+        positionIndex: number;
+        plantCycles?: Array<{
+            plantSortId?: number | string | null;
+            active?: boolean | null;
+        }> | null;
+    }>,
+    plantSortNameById: Map<number, string>,
+): PastPlantFieldContext[] {
+    return fields
+        .map((field) => {
+            const plantNames: string[] = [];
+            const seenPlantNames = new Set<string>();
+
+            for (const cycle of field.plantCycles ?? []) {
+                if (cycle.active !== false || !cycle.plantSortId) {
+                    continue;
+                }
+
+                const plantName = plantSortContextName(
+                    plantSortNameById,
+                    cycle.plantSortId,
+                );
+                if (seenPlantNames.has(plantName)) {
+                    continue;
+                }
+
+                seenPlantNames.add(plantName);
+                plantNames.push(plantName);
+            }
+
+            return plantNames.length > 0
+                ? {
+                      positionIndex: field.positionIndex,
+                      positionLabel: toPositionLabel(field.positionIndex),
+                      plantNames,
+                  }
+                : null;
+        })
+        .filter((field): field is PastPlantFieldContext => field !== null);
 }
 
 function isCurrentlyGreenhouseSeedling(field: {
@@ -504,6 +568,10 @@ async function buildAnalysisMessages({
                     field.positionIndex === positionIndex,
             };
         });
+    const pastPlantFields = buildPastPlantFieldsContext(
+        raisedBed.fields,
+        plantSortNameById,
+    );
 
     const executedOperations = operations.map((op) => ({
         id: op.id,
@@ -543,6 +611,7 @@ async function buildAnalysisMessages({
                 '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
                 '- U JSON kontekstu vrijednost `positionLabel` koristi ovo brojanje (1-bazirano), dok `positionIndex` ostaje 0-bazirana interna oznaka (`positionLabel = positionIndex + 1`).',
                 '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
+                '- `pastPlantFields` navodi samo nazive biljaka koje su ranije bile u polju; ne sadrži povijest događaja ni datume.',
                 '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
                 '- Kada preporučiš konkretnu radnju iz `availableOperations`, napiši je kao markdown poveznicu na apsolutni URL iz `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
                 '- Za radnje nad pojedinom biljkom/poljem koristi hash s 0-baziranim `positionIndex`: `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId}&positionIndex={positionIndex})`. Ne koristi `positionLabel` u URL-u.',
@@ -589,6 +658,10 @@ async function buildAnalysisMessages({
                                         : null,
                                 imageCount: imageUrls.length,
                                 plantedFields,
+                                pastPlantFields:
+                                    pastPlantFields.length > 0
+                                        ? pastPlantFields
+                                        : undefined,
                                 availableOperations,
                                 executedOperations,
                             },

--- a/packages/storage/src/automations/raisedBedImagePlantContext.ts
+++ b/packages/storage/src/automations/raisedBedImagePlantContext.ts
@@ -1,0 +1,48 @@
+import type { EntityStandardized } from '../@types/EntityStandardized';
+
+function plantSortName(sort: EntityStandardized | undefined, fallback: string) {
+    return sort?.information?.name ?? sort?.information?.label ?? fallback;
+}
+
+function plantSortNameForId(
+    plantSortsById: Map<number, EntityStandardized>,
+    plantSortId: number | string,
+) {
+    const numericPlantSortId = Number(plantSortId);
+
+    return Number.isFinite(numericPlantSortId)
+        ? plantSortName(
+              plantSortsById.get(numericPlantSortId),
+              `Sorta #${plantSortId}`,
+          )
+        : String(plantSortId);
+}
+
+export function buildPreviousPlantNames(
+    field: {
+        plantCycles: Array<{
+            plantSortId?: number | string | null;
+            active?: boolean | null;
+        }>;
+    },
+    plantSortsById: Map<number, EntityStandardized>,
+) {
+    const plantNames: string[] = [];
+    const seenPlantNames = new Set<string>();
+
+    for (const cycle of field.plantCycles) {
+        if (cycle.active !== false || !cycle.plantSortId) {
+            continue;
+        }
+
+        const plantName = plantSortNameForId(plantSortsById, cycle.plantSortId);
+        if (seenPlantNames.has(plantName)) {
+            continue;
+        }
+
+        seenPlantNames.add(plantName);
+        plantNames.push(plantName);
+    }
+
+    return plantNames;
+}

--- a/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
+++ b/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
@@ -14,6 +14,7 @@ import { knownEventTypes } from '../repositories/events';
 import { getRaisedBed } from '../repositories/gardensRepo';
 import { getOperationById } from '../repositories/operationsRepo';
 import type { AutomationJsonObject } from '../schema';
+import { buildPreviousPlantNames } from './raisedBedImagePlantContext';
 import type { AutomationSourceEvent } from './types';
 
 const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.5';
@@ -84,15 +85,6 @@ type AcceptedReviewProposal = ReviewProposal & {
 
 function optionalNumber(value: unknown) {
     return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function isoDate(value: Date | string | null | undefined) {
-    if (!value) {
-        return null;
-    }
-
-    const date = value instanceof Date ? value : new Date(value);
-    return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 function dateFromValue(value: unknown) {
@@ -337,24 +329,6 @@ function plantSeedingDistance(sort: EntityStandardized | undefined) {
     );
 }
 
-function buildFieldHistory(field: RaisedBedFieldForReview) {
-    return field.plantCycles.map((cycle) => ({
-        positionLabel: cycle.positionIndex + 1,
-        plantSortId: cycle.plantSortId ?? null,
-        plantStatus: cycle.plantStatus ?? null,
-        active: cycle.active,
-        startedAt: isoDate(cycle.startedAt),
-        endedAt: isoDate(cycle.endedAt),
-        sowingLocation: cycle.sowingLocation,
-        sowedAt: isoDate(cycle.plantSowDate),
-        sproutedAt: isoDate(cycle.plantGrowthDate),
-        readyAt: isoDate(cycle.plantReadyDate),
-        deadAt: isoDate(cycle.plantDeadDate),
-        harvestedAt: isoDate(cycle.plantHarvestedDate),
-        removedAt: isoDate(cycle.plantRemovedDate),
-    }));
-}
-
 async function buildReviewContext(input: ReviewInput & { ok: true }) {
     const raisedBed = await getRaisedBed(input.raisedBedId);
     if (!raisedBed) {
@@ -390,6 +364,10 @@ async function buildReviewContext(input: ReviewInput & { ok: true }) {
             const seedingDistance = plantSeedingDistance(plantSort);
             const plantsPerField = calculatePlantsPerField(seedingDistance);
             const currentStatus = field.plantStatus ?? null;
+            const previousPlantNames = buildPreviousPlantNames(
+                field,
+                plantSortsById,
+            );
 
             return {
                 id: field.id,
@@ -435,7 +413,9 @@ async function buildReviewContext(input: ReviewInput & { ok: true }) {
                 ),
                 needsRemoval: Boolean(field.toBeRemoved),
                 isFocusField: field.positionIndex === focusPositionIndex,
-                history: buildFieldHistory(field),
+                ...(previousPlantNames.length > 0
+                    ? { previousPlantNames }
+                    : {}),
             };
         });
 
@@ -490,6 +470,7 @@ function buildReviewMessages({
                 'Ako je fotografija close-up i polje nije sigurno prepoznatljivo, koristi `focusField` kada postoji. Ako je fotografija cijele gredice, možeš predložiti više polja.',
                 'Polja s `currentLocation: "greenhouse"` ignoriraj osim ako fotografija jasno pokazuje da se ista biljka nalazi u pripadajućem polju gredice.',
                 'Koristi `expectedPlantCount` kao kontekst za to koliko pojedinačnih biljaka ili klica se očekuje u polju.',
+                '`previousPlantNames` sadrži samo nazive ranijih biljaka u tom polju; ne sadrži povijest događaja, statuse ni datume.',
                 '`imageDate` je datum fotografija ili izvornog dnevničkog unosa; koristi ga za kontekst polja i vrijednosti `daysFrom*`. `currentDate` je trenutak obrade automatizacije i ne smije promijeniti interpretaciju stanja na starijoj fotografiji.',
                 '',
                 'Raspored polja u slici cijele gredice:',

--- a/packages/storage/tests/raisedBedImagePlantStatusAnalysis.node.spec.ts
+++ b/packages/storage/tests/raisedBedImagePlantStatusAnalysis.node.spec.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { EntityStandardized } from '../src/@types/EntityStandardized';
+import { buildPreviousPlantNames } from '../src/automations/raisedBedImagePlantContext';
+
+test('buildPreviousPlantNames returns deduped names for inactive plant cycles', () => {
+    const plantSortsById = new Map<number, EntityStandardized>([
+        [101, { id: 101, information: { name: 'Tomato' } }],
+        [102, { id: 102, information: { label: 'Lettuce' } }],
+        [103, { id: 103, information: { name: 'Basil' } }],
+    ]);
+
+    const names = buildPreviousPlantNames(
+        {
+            plantCycles: [
+                { plantSortId: 101, active: false },
+                { plantSortId: 102, active: false },
+                { plantSortId: 101, active: false },
+                { plantSortId: 103, active: true },
+            ],
+        },
+        plantSortsById,
+    );
+
+    assert.deepStrictEqual(names, ['Tomato', 'Lettuce']);
+});


### PR DESCRIPTION
## Summary

- Compact raised-bed image analysis context so previous plant cycles are sent as plant names only.
- Replace automated image plant-status review field `history` payloads with optional `previousPlantNames`.
- Add focused node tests for the compact context helpers.

## Why

AI suggestions and raised-bed image analysis were receiving too much historical plant-cycle detail. The prompts only need to know which plants were previously present, not every past lifecycle event and date.

## Validation

- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/garden/raisedBedAiAnalysisService.node.spec.ts`
- `pnpm --filter @gredice/storage exec node --import tsx --test --conditions=react-server ./tests/raisedBedImagePlantStatusAnalysis.node.spec.ts`
- `pnpm --filter api exec biome check --write ./lib/garden/raisedBedAiAnalysisService.ts ./lib/garden/raisedBedAiAnalysisService.node.spec.ts`
- `pnpm --filter @gredice/storage exec biome check --write ./src/automations/raisedBedImagePlantStatusAnalysis.ts ./src/automations/raisedBedImagePlantContext.ts ./tests/raisedBedImagePlantStatusAnalysis.node.spec.ts`
- `git diff --check`