### PR TITLE
Add post-transplant watering automation

### DIFF
--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -22,6 +22,8 @@ export const automationModuleKeys = {
     actionCreatePlantStatusRequestsFromImageAnalysis:
         'action.createPlantStatusRequestsFromImageAnalysis',
     actionLog: 'action.log',
+    actionQueuePostTransplantWateringOperations:
+        'action.queuePostTransplantWateringOperations',
     actionQueueSeasonalSowingOfferOperations:
         'action.queueSeasonalSowingOfferOperations',
     actionUpdateRaisedBedFieldPlantStatus:
@@ -122,6 +124,14 @@ const automationModulePresentations: Record<
             'Dodaje trenutačnu sezonsku ponudu besplatnog zalijevanja nakon sjetve.',
         inputDescription:
             'Event `raisedBedField.plantUpdate` s agregatom `raisedBedId|positionIndex`.',
+        outputDescription: 'ID-jevi kreiranih radnji ili razlog preskakanja.',
+    },
+    [automationModuleKeys.actionQueuePostTransplantWateringOperations]: {
+        title: 'Zalijevanja nakon presađivanja',
+        description:
+            'Dodaje 50L zalijevanja za dva dana nakon potvrđenog presađivanja sadnice.',
+        inputDescription:
+            'Event `operation.verify` za radnju presađivanja sadnice s ciljanom gredicom.',
         outputDescription: 'ID-jevi kreiranih radnji ili razlog preskakanja.',
     },
     [automationModuleKeys.actionCreateOperation]: {

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -8,7 +8,9 @@ monthly schedules that can create recurring farm operations. Operation
 completion images can also be reviewed asynchronously for high-confidence plant
 status changes that create pending admin approval requests. Verifying the
 seedling transplanting operation also switches the targeted plant from
-greenhouse sowing to direct sowing.
+greenhouse sowing to direct sowing and queues 50L watering operations for the
+next two days when that raised bed does not already have at least 50L of
+watering scheduled on those days.
 
 ## Ownership
 
@@ -86,6 +88,10 @@ MVP modules:
 - `condition.plantStatusEquals`: checks current raised-bed field plant status.
 - `action.queueSeasonalSowingOfferOperations`: queues seasonal free watering
   operations.
+- `action.queuePostTransplantWateringOperations`: queues 50L raised-bed
+  watering operations for the two days after seedling transplant verification,
+  skipping days where active scheduled watering for that raised bed already
+  totals at least 50L.
 - `action.createOperation`: creates an operation for the event context.
 - `action.createFarmInventoryOperations`: creates accepted, scheduled farm-level
   operations for every active farm from a JSON list in the automation

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -3,6 +3,7 @@ import {
     upsertAutomationDefinitionByKey,
 } from '../repositories/automationsRepo';
 import { knownEventTypes } from '../repositories/events/knownEventTypes';
+import { RAISED_BED_WATERING_50L_OPERATION_ID } from '../repositories/seasonalOffersRepo';
 import type { AutomationGraph } from '../schema';
 import { automationModuleKeys } from './modules';
 
@@ -12,6 +13,8 @@ export const operationImagePlantStatusReviewAutomationKey =
     'default.operation-image-plant-status-review';
 export const seedlingTransplantDirectSowingLocationAutomationKey =
     'default.seedling-transplant-direct-sowing-location';
+export const seedlingTransplantWateringAutomationKey =
+    'default.seedling-transplant-watering';
 
 const seedlingTransplantingOperationId = 593;
 
@@ -158,6 +161,52 @@ export function seedlingTransplantDirectSowingLocationAutomationGraph(): Automat
     };
 }
 
+export function seedlingTransplantWateringAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerDomainEvent,
+                position: { x: 0, y: 160 },
+                config: {
+                    eventType: knownEventTypes.operations.verify,
+                },
+            },
+            {
+                id: 'operation-is-seedling-transplant',
+                kind: 'condition',
+                moduleKey: automationModuleKeys.conditionOperationMatches,
+                position: { x: 280, y: 160 },
+                config: {
+                    status: 'completed',
+                    entityId: seedlingTransplantingOperationId,
+                },
+            },
+            {
+                id: 'queue-transplant-waterings',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionQueuePostTransplantWateringOperations,
+                position: { x: 620, y: 160 },
+                config: {},
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-operation-match',
+                source: 'trigger',
+                target: 'operation-is-seedling-transplant',
+            },
+            {
+                id: 'operation-match-to-waterings',
+                source: 'operation-is-seedling-transplant',
+                target: 'queue-transplant-waterings',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -203,9 +252,25 @@ export async function ensureDefaultAutomationDefinitions() {
             },
         });
 
+    const seedlingTransplantWatering = await upsertAutomationDefinitionByKey({
+        key: seedlingTransplantWateringAutomationKey,
+        name: 'Dodaj zalijevanja nakon potvrde presađivanja sadnice',
+        description:
+            'Kada je radnja presađivanja sadnica potvrđena, dodaj 50L zalijevanje za ciljanu gredicu za sljedeća dva dana ako taj dan već nema barem 50L zalijevanja.',
+        status: 'enabled',
+        graph: seedlingTransplantWateringAutomationGraph(),
+        metadata: {
+            managedBy: 'gredice',
+            defaultAutomation: true,
+            operationEntityId: seedlingTransplantingOperationId,
+            wateringOperationEntityId: RAISED_BED_WATERING_50L_OPERATION_ID,
+        },
+    });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
         seedlingTransplantDirectSowingLocation,
+        seedlingTransplantWatering,
     };
 }

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -15,7 +15,11 @@ import {
     getFarmAcceptedOperationsByScheduleRange,
     getOperationById,
 } from '../repositories/operationsRepo';
-import { queueSeasonalSowingOfferOperations } from '../repositories/seasonalOffersRepo';
+import {
+    queuePostTransplantWateringOperations,
+    queueSeasonalSowingOfferOperations,
+    RAISED_BED_WATERING_50L_OPERATION_ID,
+} from '../repositories/seasonalOffersRepo';
 import type { AutomationGraphNode, AutomationJsonObject } from '../schema';
 import {
     hasRaisedBedImagePlantStatusReviewAiConfig,
@@ -37,6 +41,8 @@ const operationMatchesConditionKey = 'condition.operationMatches';
 const plantStatusEqualsConditionKey = 'condition.plantStatusEquals';
 const queueSeasonalSowingOfferOperationsActionKey =
     'action.queueSeasonalSowingOfferOperations';
+const queuePostTransplantWateringOperationsActionKey =
+    'action.queuePostTransplantWateringOperations';
 const createOperationActionKey = 'action.createOperation';
 const createFarmInventoryOperationsActionKey =
     'action.createFarmInventoryOperations';
@@ -59,6 +65,8 @@ export const automationModuleKeys = {
     conditionPlantStatusEquals: plantStatusEqualsConditionKey,
     actionQueueSeasonalSowingOfferOperations:
         queueSeasonalSowingOfferOperationsActionKey,
+    actionQueuePostTransplantWateringOperations:
+        queuePostTransplantWateringOperationsActionKey,
     actionCreateOperation: createOperationActionKey,
     actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
     actionUpdateRaisedBedFieldPlantStatus:
@@ -793,6 +801,94 @@ const queueSeasonalSowingOfferOperationsActionModule: AutomationModule = {
     },
 };
 
+const queuePostTransplantWateringOperationsActionModule: AutomationModule = {
+    key: queuePostTransplantWateringOperationsActionKey,
+    kind: 'action',
+    title: 'Queue post-transplant watering operations',
+    description:
+        'Queues 50L raised-bed watering operations for the two days after a seedling transplant is verified.',
+    category: 'Operations',
+    configFields: [],
+    inputDescription:
+        'An `operation.verify` event for a seedling transplant operation with a raised-bed target.',
+    outputDescription: 'Created operation ids, or a skip reason.',
+    dryRunSupported: true,
+    mutatesData: true,
+    retryable: true,
+    execute: async (context) => {
+        if (!context.event) {
+            return skip('No source event is available.');
+        }
+
+        const operationId = Number(context.event.aggregateId);
+        if (!Number.isInteger(operationId) || operationId <= 0) {
+            return skip('Source event aggregate is not an operation id.');
+        }
+
+        let operation: Awaited<ReturnType<typeof getOperationById>> | null =
+            null;
+        try {
+            operation = await getOperationById(operationId);
+        } catch {
+            return skip('Operation was not found.', { operationId });
+        }
+
+        if (!operation.raisedBedId) {
+            return skip('Operation has no raised-bed target.', {
+                operationId,
+            });
+        }
+
+        const raisedBed = await getRaisedBed(operation.raisedBedId);
+        if (!raisedBed?.accountId) {
+            return skip('Raised bed or account was not found.', {
+                operationId,
+                raisedBedId: operation.raisedBedId,
+            });
+        }
+
+        const referenceDate = context.event.createdAt ?? new Date();
+        const gardenId = operation.gardenId ?? raisedBed.gardenId ?? undefined;
+
+        if (context.dryRun) {
+            return success({
+                dryRun: true,
+                operationId,
+                accountId: raisedBed.accountId,
+                gardenId: gardenId ?? null,
+                raisedBedId: raisedBed.id,
+                wateringOperationEntityId: RAISED_BED_WATERING_50L_OPERATION_ID,
+                scheduledDates: [1, 2].map((dayOffset) =>
+                    addUtcDays(referenceDate, dayOffset).toISOString(),
+                ),
+            });
+        }
+
+        const createdOperationIds = await queuePostTransplantWateringOperations(
+            {
+                accountId: raisedBed.accountId,
+                ...(gardenId ? { gardenId } : {}),
+                raisedBedId: raisedBed.id,
+                referenceDate,
+            },
+        );
+
+        if (createdOperationIds.length === 0) {
+            return skip('Post-transplant watering operations already exist.', {
+                operationId,
+                raisedBedId: raisedBed.id,
+                wateringOperationEntityId: RAISED_BED_WATERING_50L_OPERATION_ID,
+            });
+        }
+
+        return success({
+            createdOperationIds,
+            createdCount: createdOperationIds.length,
+            wateringOperationEntityId: RAISED_BED_WATERING_50L_OPERATION_ID,
+        });
+    },
+};
+
 const createOperationActionModule: AutomationModule = {
     key: createOperationActionKey,
     kind: 'action',
@@ -1414,6 +1510,7 @@ export const automationModules = [
     operationMatchesConditionModule,
     plantStatusEqualsConditionModule,
     queueSeasonalSowingOfferOperationsActionModule,
+    queuePostTransplantWateringOperationsActionModule,
     createOperationActionModule,
     createFarmInventoryOperationsActionModule,
     updateRaisedBedFieldPlantStatusActionModule,

--- a/packages/storage/src/repositories/seasonalOffersRepo.ts
+++ b/packages/storage/src/repositories/seasonalOffersRepo.ts
@@ -3,6 +3,14 @@ import { createEvent } from './eventsRepo';
 import { createOperation, getOperations } from './operationsRepo';
 
 export const FREE_WATERING_OPERATION_ID = 274;
+export const RAISED_BED_WATERING_50L_OPERATION_ID = 167;
+
+const wateringOperationLitersById = new Map([
+    [FREE_WATERING_OPERATION_ID, 20],
+    [RAISED_BED_WATERING_50L_OPERATION_ID, 50],
+]);
+const postTransplantWateringDays = 2;
+const postTransplantWateringMinExistingLiters = 50;
 
 type SeasonalSowingOffer = {
     freeWaterings: number;
@@ -59,6 +67,29 @@ function getScheduledWateringDayKeys(
     );
 }
 
+function getScheduledWateringLitersByDayKey(
+    operations: Awaited<ReturnType<typeof getOperations>>,
+) {
+    const litersByDayKey = new Map<string, number>();
+
+    for (const operation of operations) {
+        const liters = wateringOperationLitersById.get(operation.entityId);
+        if (
+            !liters ||
+            operation.status === 'canceled' ||
+            operation.status === 'failed' ||
+            !operation.scheduledDate
+        ) {
+            continue;
+        }
+
+        const dayKey = toUtcDayKey(operation.scheduledDate);
+        litersByDayKey.set(dayKey, (litersByDayKey.get(dayKey) ?? 0) + liters);
+    }
+
+    return litersByDayKey;
+}
+
 function addDays(date: Date, days: number) {
     const nextDate = new Date(date);
     nextDate.setUTCDate(nextDate.getUTCDate() + days);
@@ -113,6 +144,65 @@ export async function queueSeasonalSowingOfferOperations({
         );
 
         scheduledWateringDayKeys.add(scheduledDayKey);
+        createdOperationIds.push(operationId);
+    }
+
+    return createdOperationIds;
+}
+
+export async function queuePostTransplantWateringOperations({
+    accountId,
+    gardenId,
+    raisedBedId,
+    referenceDate = new Date(),
+}: {
+    accountId: string;
+    gardenId?: number;
+    raisedBedId: number;
+    referenceDate?: Date;
+}) {
+    const existingOperations = await getOperations(
+        accountId,
+        gardenId,
+        raisedBedId,
+    );
+
+    const scheduledWateringLitersByDayKey =
+        getScheduledWateringLitersByDayKey(existingOperations);
+
+    const createdOperationIds: number[] = [];
+    for (
+        let dayOffset = 1;
+        dayOffset <= postTransplantWateringDays;
+        dayOffset += 1
+    ) {
+        const scheduledDate = addDays(referenceDate, dayOffset);
+        const scheduledDayKey = toUtcDayKey(scheduledDate);
+        if (
+            (scheduledWateringLitersByDayKey.get(scheduledDayKey) ?? 0) >=
+            postTransplantWateringMinExistingLiters
+        ) {
+            continue;
+        }
+
+        const operationId = await createOperation({
+            accountId,
+            entityId: RAISED_BED_WATERING_50L_OPERATION_ID,
+            entityTypeName: 'operation',
+            gardenId,
+            raisedBedId,
+        });
+
+        await createEvent(
+            knownEvents.operations.scheduledV1(operationId.toString(), {
+                scheduledDate: scheduledDate.toISOString(),
+            }),
+        );
+
+        scheduledWateringLitersByDayKey.set(
+            scheduledDayKey,
+            (scheduledWateringLitersByDayKey.get(scheduledDayKey) ?? 0) + 50,
+        );
         createdOperationIds.push(operationId);
     }
 

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -32,9 +32,11 @@ import {
     listEnabledAutomationDefinitionsForEventType,
     operationImagePlantStatusReviewAutomationGraph,
     processDueAutomationRuns,
+    RAISED_BED_WATERING_50L_OPERATION_ID,
     recordAutomationRunStep,
     seasonalSowedWateringAutomationGraph,
     seedlingTransplantDirectSowingLocationAutomationGraph,
+    seedlingTransplantWateringAutomationGraph,
     startAutomationRun,
     storage,
     updateAutomationDefinition,
@@ -82,13 +84,26 @@ async function getScheduledFreeWateringDates(
     gardenId: number,
     raisedBedId: number,
 ) {
+    return getScheduledOperationDates(
+        accountId,
+        gardenId,
+        raisedBedId,
+        FREE_WATERING_OPERATION_ID,
+    );
+}
+
+async function getScheduledOperationDates(
+    accountId: string,
+    gardenId: number,
+    raisedBedId: number,
+    entityId: number,
+) {
     const operations = await getOperations(accountId, gardenId, raisedBedId);
 
     return operations
         .filter(
             (operation) =>
-                operation.entityId === FREE_WATERING_OPERATION_ID &&
-                operation.scheduledDate,
+                operation.entityId === entityId && operation.scheduledDate,
         )
         .map((operation) => operation.scheduledDate?.toISOString())
         .sort();
@@ -1066,6 +1081,150 @@ test('seedling transplant automation waits for verification before setting sowin
             ])
         ).length,
         1,
+    );
+});
+
+test('seedling transplant watering automation queues 50L waterings for the next two days after verification', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-05-15T08:00:00.000Z',
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields[0];
+    assert.ok(field);
+
+    const verificationDate = new Date('2026-06-01T08:00:00.000Z');
+    const firstWateringDate = addUtcDays(verificationDate, 1);
+    const secondWateringDate = addUtcDays(verificationDate, 2);
+    const preexisting50LWateringId = await createOperation({
+        accountId,
+        entityId: RAISED_BED_WATERING_50L_OPERATION_ID,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    await createEvent(
+        knownEvents.operations.scheduledV1(
+            preexisting50LWateringId.toString(),
+            {
+                scheduledDate: firstWateringDate.toISOString(),
+            },
+        ),
+    );
+    const preexisting20LWateringId = await createOperation({
+        accountId,
+        entityId: FREE_WATERING_OPERATION_ID,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    await createEvent(
+        knownEvents.operations.scheduledV1(
+            preexisting20LWateringId.toString(),
+            {
+                scheduledDate: secondWateringDate.toISOString(),
+            },
+        ),
+    );
+
+    const transplantOperationId = await createOperation({
+        accountId,
+        entityId: 593,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+    });
+    await createEvent({
+        ...knownEvents.operations.verifiedV1(transplantOperationId.toString(), {
+            verifiedBy: 'automations-test',
+        }),
+        createdAt: verificationDate,
+    });
+    const event = await getLatestEvent(
+        knownEventTypes.operations.verify,
+        transplantOperationId.toString(),
+    );
+    const graph = seedlingTransplantWateringAutomationGraph();
+    const definition = await createAutomationDefinition({
+        key: 'test.seedling-transplant-waterings',
+        name: 'Seedling transplant waterings',
+        status: 'enabled',
+        graph,
+    });
+    const input = {
+        eventId: event.id,
+        eventType: event.type,
+        aggregateId: event.aggregateId,
+        data:
+            event.data && typeof event.data === 'object'
+                ? (event.data as Record<string, unknown>)
+                : {},
+    };
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'event',
+        sourceEvent: event,
+        input,
+    });
+    assert.ok(run);
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+
+    assert.strictEqual(result.status, 'succeeded');
+    assert.deepStrictEqual(
+        await getScheduledOperationDates(
+            accountId,
+            gardenId,
+            raisedBedId,
+            RAISED_BED_WATERING_50L_OPERATION_ID,
+        ),
+        [firstWateringDate.toISOString(), secondWateringDate.toISOString()],
+    );
+
+    const runWithSteps = await getAutomationRunWithSteps(startedRun.id);
+    assert.ok(runWithSteps);
+    assert.strictEqual(runWithSteps.status, 'succeeded');
+    assert.deepStrictEqual(
+        runWithSteps.steps.map((step) => step.status),
+        ['succeeded', 'succeeded', 'succeeded'],
+    );
+
+    const replayRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'replay',
+        sourceEvent: event,
+        input,
+    });
+    assert.ok(replayRun);
+    const startedReplay = await startAutomationRun(replayRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedReplay);
+
+    const replayResult = await executeAutomationRun(startedReplay);
+
+    assert.strictEqual(replayResult.status, 'skipped');
+    assert.deepStrictEqual(
+        await getScheduledOperationDates(
+            accountId,
+            gardenId,
+            raisedBedId,
+            RAISED_BED_WATERING_50L_OPERATION_ID,
+        ),
+        [firstWateringDate.toISOString(), secondWateringDate.toISOString()],
     );
 });
 


### PR DESCRIPTION
## Summary
- Adds a default automation for verified seedling transplant operations that queues 50L watering for the next two days.
- Skips days that already have at least 50L of scheduled watering for the same raised bed.
- Updates the admin automation labels and workflow docs to reflect the new behavior.
- Covers the flow with storage automation tests, including replay/idempotency and the skip logic for existing watering.

## Testing
- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage --filter app`
- `pnpm build --filter api --filter app`